### PR TITLE
Gnome 3.36.2

### DIFF
--- a/pkgs/applications/misc/orca/default.nix
+++ b/pkgs/applications/misc/orca/default.nix
@@ -35,13 +35,13 @@
 
 buildPythonApplication rec {
   pname = "orca";
-  version = "3.36.1";
+  version = "3.36.2";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "07w3k0f791zd1pj9j6d27k7gk7c6hx112ngrdz18h573df5n9b61";
+    sha256 = "0hxz8wlyjn6w3zqg1p56pwdj0p23d6vynzczklyc6n91dyvma06g";
   };
 
   patches = [

--- a/pkgs/data/documentation/gnome-user-docs/default.nix
+++ b/pkgs/data/documentation/gnome-user-docs/default.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-user-docs";
-  version = "3.36.1";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-docs/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0vnwya5g7fg0jhdrg9drxnx83lhk8qa2nvcrmd1sdfanlz4qfhjf";
+    sha256 = "0n4rbrq5zww6gjjmicyw5hlvzi8azc6m4sisak15snkp6v4f93qr";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/apps/accerciser/default.nix
+++ b/pkgs/desktops/gnome-3/apps/accerciser/default.nix
@@ -17,13 +17,13 @@
 
  python3.pkgs.buildPythonApplication rec {
   name = "accerciser-${version}";
-  version = "3.36.0";
+  version = "3.36.1";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/accerciser/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1iwi7mnayw1f90s439flh0zkgmj4qx10dzgj38nd5f3wvqmhabk3";
+    sha256 = "1ig9zcg8z7yv2c28q0a4q57ckkpmzjsbnancx01rjihrrjbg9ib2";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/apps/evolution/default.nix
@@ -43,11 +43,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution";
-  version = "3.36.1";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1f3cwc05gw75yqficcxns95r96lv7an4aih6d7hng3n3pqfwyfl7";
+    sha256 = "12ii8crp4v4bpdxrc2rkxwdxqz3qjizyfgfrmir9pcyxlg0lh2f5";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/apps/gedit/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gedit/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gedit";
-  version = "3.36.1";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gedit/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "11z3lhc5i3z0gqw0qmprsm4rmvhbbm4gz6wy0f73c73x4bd8xhvd";
+    sha256 = "15s1almlhjlgl3m8lxg6jpzln8jhgdxxjr635a3b7cf58d35b1v8";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
@@ -51,11 +51,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-boxes";
-  version = "3.36.2";
+  version = "3.36.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-boxes/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "01hjlz9hljk2skrwfqxpy3934wjs6figs71sw8bm8g2vnyaqwq7a";
+    sha256 = "18imxv1859gr53z4yay02611p5f1rd2pwnbaq093gmn77l0j9292";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/apps/gnome-calendar/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-calendar/default.nix
@@ -4,13 +4,13 @@
 
 let
   pname = "gnome-calendar";
-  version = "3.36.0";
+  version = "3.36.1";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1cxy4qf83s8w1ys94rcc4ksf7ywi0hkkpfs0szkkip2v8g3j6kq2";
+    sha256 = "0ql3f509bj17riqs0jfpp434s97dzjgkjcd978i4m4y80nq2131v";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/apps/gnome-getting-started-docs/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-getting-started-docs/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-getting-started-docs";
-  version = "3.36.1";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-getting-started-docs/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "09bf9r6brmll14z87ljgivw0nr0nggcgjpbx6lg2835zq36vfmi9";
+    sha256 = "1ihxa9g687rbb4s2gxd2pf726adx98ahq4kfad868swl7a8vi504";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/apps/gnome-maps/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-maps/default.nix
@@ -5,13 +5,13 @@
 
 let
   pname = "gnome-maps";
-  version = "3.36.1";
+  version = "3.36.2";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1yajq2pxd4fbzngwhn92h55rn02psxih8bbdcdxgg66qdbcyychs";
+    sha256 = "114pia3nd8k7j6ll7za7qzv0ggcdvcw6b3w4lppqqrwqvswik8jv";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
@@ -30,13 +30,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gnome-music";
-  version = "3.36.1";
+  version = "3.36.2";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0cn33r9v2raizq1b8s7s0kb506y91iarc0knm0sljcsqs4qgd03v";
+    sha256 = "19c2x7h9gq4kh4995y1qcn5pyry4x04lh5n7md0q33zsxcx43bdb";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/apps/gnome-weather/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-weather/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-weather";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-weather/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "15ahfgqj0rz16y2bdxb7sa4b3b3larg8hn3b41pc5ddnwf9x63zi";
+    sha256 = "11z75ky6xp9hx7lm24xng7ydr20bzh4d6p9sbi9c8ccz2m3fdrk8";
   };
 
   nativeBuildInputs = [ pkgconfig meson ninja wrapGAppsHook python3 ];

--- a/pkgs/desktops/gnome-3/apps/polari/default.nix
+++ b/pkgs/desktops/gnome-3/apps/polari/default.nix
@@ -5,13 +5,13 @@
 
 let
   pname = "polari";
-  version = "3.36.1";
+  version = "3.36.2";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1rmmq74g22qrmsg0mjvpzk5403kkpfw0iznvnwxfqbi0dfkamhn4";
+    sha256 = "12i0gp2kwp0b7af135q32qygkhh2025f74dqbaylfbmzacbdpz5c";
   };
 
   patches = [

--- a/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
+++ b/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
@@ -3,13 +3,13 @@
 
 let
   pname = "dconf-editor";
-  version = "3.36.0";
+  version = "3.36.2";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "14q678bwgmhzmi7565xhhw51y8b0pv3cqh0f411qwzwif1bd1vkj";
+    sha256 = "1iz1ngb26llhqnm2s4p55ysvnav41iv0fx0pbw98k181gy3cikpd";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/eog/default.nix
+++ b/pkgs/desktops/gnome-3/core/eog/default.nix
@@ -4,13 +4,13 @@
 
 let
   pname = "eog";
-  version = "3.36.1";
+  version = "3.36.2";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "15cwghcbx9x1xmv1dwmwcdxplnhf25w6f4dhx8hk6fjymaks2m74";
+    sha256 = "135pw7ifr585grz1rbmynyyrmhd8w880pilg7c4nvq58jl16n1aw";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext itstool wrapGAppsHook libxml2 gobject-introspection python3 ];

--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
-  version = "3.36.1";
+  version = "3.36.2";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "15k7k225jfv5a45hmjk94xq90np2r9f5v8yj0xi3166vvlp2n4hk";
+    sha256 = "0yz9fsnbnnlj2iidd81i9w7d0dhidrzqkixrnfjfdkhnxk7p9qlq";
   };
 
   patches = [

--- a/pkgs/desktops/gnome-3/core/gnome-contacts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-contacts/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-contacts";
-  version = "3.36";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-contacts/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0yvgsfmqm8dxbhay12m20xp6qi9v31wwyv1gz4fx7j4kklhd5jzf";
+    sha256 = "0qb2kgyk6f6wr129a0gzhvpy5wdjpwjbksxyfs6zxv183jl9s73z";
   };
 
   propagatedUserEnvPkgs = [ evolution-data-server ];

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -68,11 +68,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-control-center";
-  version = "3.36.1";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1466swjyw5vjym001qda94x6sisd4xhpyb6vq91grhkyzwf2vqzk";
+    sha256 = "05vqhj5z4w4vaphp541zxxkx6x781m371l2gqnq2vhnnqvqfz9g0";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-initial-setup/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-initial-setup/default.nix
@@ -36,11 +36,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-initial-setup";
-  version = "3.36.1";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1sfn6bdz8snc2qmi3nzb07vlkdhy9s1ipwxxj0v2i36a7n0gv6ci";
+    sha256 = "0mjp2j4smikmr4fa0y8wrw2srlfjahiixzphz3dmc30hx8df92sg";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
@@ -40,11 +40,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-settings-daemon";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-settings-daemon/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0jddz8f2j4ps7csgq9b694h9hjxsyhlimik6rb2f8nbcxhrg0bzs";
+    sha256 = "0jzf2nznpcrjqq7fjwk66kw8a6x87kgbdjidc2msaqmm379xncry";
   };
 
   patches = [

--- a/pkgs/desktops/gnome-3/core/gnome-terminal/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-terminal/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-terminal";
-  version = "3.36.1.1";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-terminal/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0xm3g3kanfhs1q3xh3x58r55v8906806wvqjbg4c2xvdwyhhimzk";
+    sha256 = "0inzmkmxv8xw4px2zjfw7236d08yjcv7znxcjki6dh4pvjivdla1";
   };
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/nautilus/default.nix
+++ b/pkgs/desktops/gnome-3/core/nautilus/default.nix
@@ -32,11 +32,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nautilus";
-  version = "3.36.1.1";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1pkvxyfm2fl06fpyq2jr147hhpc91y4rgdlxlilg7n8ih982y9gr";
+    sha256 = "1yknaz8n0l949sr8j3b7kdm0cm5mx2dp4n4k577m492hk6akqrr6";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/simple-scan/default.nix
+++ b/pkgs/desktops/gnome-3/core/simple-scan/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "simple-scan";
-  version = "3.36.1";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/simple-scan/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0bprm9gfnlrs0k8jvy9pqm1rjq47z5pgahqjjj1i7q2k4a8g09vl";
+    sha256 = "1ya4k63q75w8xwv3vrk1gvbvbpxq876dvnkn3ym1wxzfd29pznxf";
   };
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/devtools/devhelp/default.nix
+++ b/pkgs/desktops/gnome-3/devtools/devhelp/default.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation rec {
   pname = "devhelp";
-  version = "3.36.1";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/devhelp/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0gcakbq2fci6cf5z8lakydqnynasp74djfy53bh7jjmw0a9yry2c";
+    sha256 = "0phcjdxnwgg0a0z9kyidp977jy365pny6bh2qhdyzcpvkqqq8nlb";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/games/four-in-a-row/default.nix
+++ b/pkgs/desktops/gnome-3/games/four-in-a-row/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "four-in-a-row";
-  version = "3.36.0";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/four-in-a-row/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1bl63npcbr5ymka2y06wps612qynxa4hsqlzn7bvwpz2v53pai1z";
+    sha256 = "1pjwaly0f36gn8ashf19b6w1yldmqpa8grdxcyb6h7b0k3bd54z6";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/games/gnome-klotski/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-klotski/default.nix
@@ -5,13 +5,13 @@
 
 let
   pname = "gnome-klotski";
-  version = "3.36.0";
+  version = "3.36.2";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "06gsg3s8hyhhsk11f1ld2anzv1czg1429483gbv9lr2p7fnq7pyy";
+    sha256 = "1w7fp79hc2v98r7ffg57d6na3wwr355gg9jrdd7w2ad362dfg1kw";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/games/gnome-mahjongg/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-mahjongg/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-mahjongg";
-  version = "3.36.1";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-mahjongg/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1a5h55amr0pab36y2iqm6ynv6mmb8al1b92rfk18wzfcfz7mhxzd";
+    sha256 = "15xfp2acqdnn0pcwg5d77dpv758jjyclwb042wm12gg07rbg3s6j";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/games/gnome-taquin/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-taquin/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-taquin";
-  version = "3.36.0";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-taquin/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "16ss2d8s6glb3k0wnb5ihmbqvk9i1yi18wv9hzgxfyhs1rvk496f";
+    sha256 = "0pi8kxici7p3jys8673ib0kigpif4mfkq0zlq48rsibhdqfhrlij";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/games/gnome-tetravex/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-tetravex/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-tetravex";
-  version = "3.36.0";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-tetravex/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1xbd0flh77v3x0dh4dsfspykwb6rwvga7kqwn1fq7gk421mq6n52";
+    sha256 = "0qf6s3gl5qrs5rwsgx0191b0xyknhz2n9whx5i6ma5yw5ikslmq4";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/games/iagno/default.nix
+++ b/pkgs/desktops/gnome-3/games/iagno/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "iagno";
-  version = "3.36.0";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/iagno/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0ysb021mf5sy1ywicys35rn5c9v355rffjrlhxmr3z6yplrljm5b";
+    sha256 = "0hgn2iqvnfiiwm57bir28dz61b1kkp1zh6av8f342q153rxx10g6";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/games/quadrapassel/default.nix
+++ b/pkgs/desktops/gnome-3/games/quadrapassel/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   pname = "quadrapassel";
-  version = "3.36.00";
+  version = "3.36.02";
 
   src = fetchurl {
     url = "mirror://gnome/sources/quadrapassel/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1xk9x1pp71armj47vxja7fsj6gs116kcjkd8xgwf8wi4zr4kgx7g";
+    sha256 = "0c80pzipxricyh4wydffsc94wj6ymnanqr9bg6wdx51hz1mmmilb";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "geary";
-  version = "3.36.1";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "07rhmzznfa4asx5gbmvnfpybd5czy7xmzk75xrk4r1qcnr24ml03";
+    sha256 = "09l2lbcn3ar3scw6iylmdqi1lhpb408iqs6056d0wzx2l9nkmqis";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
@@ -30,7 +30,7 @@
 
 let
   pname = "gnome-flashback";
-  version = "3.36.1";
+  version = "3.36.3";
 
   # From data/sessions/Makefile.am
   requiredComponentsCommon = [
@@ -61,7 +61,7 @@ let
 
     src = fetchurl {
       url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-      sha256 = "16gknn5mj29i8svlncarj92qi0swdlziggxpg9rryqslsy896a2x";
+      sha256 = "19y1a4kq6db6a19basss76l4rypiz0lwr32ajli1ra1d1yj9xfid";
     };
 
     # make .desktop Execs absolute

--- a/pkgs/development/libraries/gjs/default.nix
+++ b/pkgs/development/libraries/gjs/default.nix
@@ -28,11 +28,11 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "gjs";
-  version = "1.64.1";
+  version = "1.64.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0z4qx4s3174b1w5b0slnn6jwpy2c18s4fvx4xii2kflr7s4q7bsm";
+    sha256 = "0ywrsfmkxaw11z83dnmb9yqkn6k3c1mkxw2mv6arbwad6x6q7zqm";
   };
 
   outputs = [ "out" "dev" "installedTests" ];

--- a/pkgs/development/libraries/vte/default.nix
+++ b/pkgs/development/libraries/vte/default.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vte";
-  version = "0.60.1";
+  version = "0.60.2";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1i7h1jvsg115l5djn29n06xsqvygpfagczxy0i9f39zq6dr809ay";
+    sha256 = "19ccbw0yca78h5qcnm8claj4fg1pj68nj1fsjqqfpzhj7w72i81m";
   };
 
   passthru = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


<details> <summary> News </summary>

>  79551b213404c88a7145a0b13e8935f232ff450c: gnome3.quadrapassel: 3.36.00 -> 3.36.02
>  	(https://ftp.gnome.org/pub/GNOME/sources/quadrapassel/3.36/quadrapassel-3.36.02.news)
>
>  	quadrapassel 3.36.2
>  	====================
>  	* Translation updates for Swedish, Czech, Ukrainian, German, French, Romanian and Friulian.
>
>  	Contributors:
>  	Anders Jonsson, Marek Černocký, Yuri Chornoivan, Wolfgang Stöggl, Charles Monzat, Daniel Șerbănescu, Fabio Tomat
>
>  	quadrapassel 3.36.0
>  	====================
>  	* Updates on the following translations: Dutch, Polish, Intalian, Croation,
>
>  	Contributors:
>  	Goran Vidovic, Milo Casagrande, Piotr Drąg, Nathan Follens
>
>
>  4ca4c4e23855f23adbf1176140ebc32ecc99d61d: gnome3.gnome-flashback: 3.36.1 -> 3.36.3
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-flashback/3.36/gnome-flashback-3.36.2.news)
>
>  	Version 3.36.2
>  	==============
>  	- Fix screensaver unlock problems. ([#46](https://gitlab.gnome.org/GNOME/gnome-flashback/issues/46))
>  	- Fix few small memory leaks.
>  	- Fix screenshot saving to clipboard. ([#50](https://gitlab.gnome.org/GNOME/gnome-flashback/issues/50))
>  	- Active desktop icon rename with F2 key. (LP:[#1875703](https://gitlab.gnome.org/GNOME/gnome-flashback/issues/1875703))
>  	- Fix creating new desktop icons. (LP:[#1875317](https://gitlab.gnome.org/GNOME/gnome-flashback/issues/1875317))
>  	- Updated translations.
>
>
>
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-flashback/3.36/gnome-flashback-3.36.3.news)
>  	Version 3.36.3
>  	==============
>  	- Fix enum type generation. ([#52](https://gitlab.gnome.org/GNOME/gnome-flashback/issues/52))
>
>
>  4e63d8b06fc63b1c97fcdfb744a6a5abe3b4b460: gnome3.iagno: 3.36.0 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/iagno/3.36/iagno-3.36.2.news)
>
>  	3.36.2 – April 24, 2020
>  	=============================
>
>  	Moslty a translations release.
>
>  	Translations updated:
>  	  French: Charles Monzat
>  	  German: Christian Kirbach
>  	  Slovenian: Matej Urbančič
>  	  Ukrainian: Yuri Chornoivan
>
>
>  baeb39fbe60b0e4068b0a9ce4e13c8492b14f12c: gnome3.gnome-tetravex: 3.36.0 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-tetravex/3.36/gnome-tetravex-3.36.2.news)
>
>  	GNOME Tetravex 3.36.2
>  	======================
>
>  	Mostly a translations release.
>
>  	Translations updated:
>  	  French: Guillaume Bernard and Charles Monzat
>  	  German: Wolfgang StÃ¶ggl
>  	  Ukrainian: Yuri Chornoivan
>
>
>  2bc0d3328a5f7026483bcbe1875cbd1e00a33b25: gnome3.gnome-taquin: 3.36.0 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-taquin/3.36/gnome-taquin-3.36.2.news)
>
>  	3.36.2 – April 24, 2020
>  	=============================
>
>  	Mostly a translations release.
>
>  	Translations updated:
>  	  German: Wolfgang Stöggl
>  	  Romanian: Daniel Șerbănescu
>  	  Ukrainian: Yuri Chornoivan
>
>
>  9cf1c2972ad07088b6280b77a1ee12ef48f83cfa: gnome3.gnome-mahjongg: 3.36.1 -> 3.36.2
>  	No file describing changes found for group in cluster with “3.36.2”
>  8b1fef089feb63de05e38f8e4bc7fca15ac3301f: gnome3.gnome-klotski: 3.36.0 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-klotski/3.36/gnome-klotski-3.36.2.news)
>
>  	3.36.2 – April 24, 2020
>  	=============================
>
>  	Mostly a translations release.
>
>  	Translations updated:
>  	  German: Wolfgang Stöggl
>  	  Romanian: Daniel Șerbănescu
>  	  Ukrainian: Yuri Chornoivan
>
>
>  9a0d5b0854538ee02f21ce83a3106c8cd1118ae8: gnome3.four-in-a-row: 3.36.0 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/four-in-a-row/3.36/four-in-a-row-3.36.2.news)
>
>  	3.36.2 - April 24, 2020
>  	=============================
>
>  	Just a translations release.
>
>  	Translations updated:
>  	  French: Charles Monzat
>  	  Spanish: Daniel Mustieles
>  	  Swedish: Anders Jonsson
>  	  Ukrainian: Yuri Chornoivan
>
>
>  cbec74d2967b044f4cbf72ef18f101204c94fbb4: gjs: 1.64.1 -> 1.64.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/gjs/1.64/gjs-1.64.2.news)
>
>  	Version 1.64.2
>  	--------------
>
>  	- Closed bugs and merge requests:
>  	  * GList of int not correctly demarshalled on 64-bit big-endian [Philip
>  	    Chimento, Simon McVittie, [#309](https://gitlab.gnome.org/GNOME/gjs/issues/309), [!417](https://gitlab.gnome.org/GNOME/gjs/merge_requests/417), [!419](https://gitlab.gnome.org/GNOME/gjs/merge_requests/419)]
>  	  * Fix template use in GTK4 [Florian MÃ¼llner, [!420](https://gitlab.gnome.org/GNOME/gjs/merge_requests/420)]
>  	  * Don't crash if a callback doesn't return an expected array of values [Marco
>  	    Trevisan, [!405](https://gitlab.gnome.org/GNOME/gjs/merge_requests/405)]
>  	  * Crash passing integer to strv in constructor [Evan Welsh, [#315](https://gitlab.gnome.org/GNOME/gjs/issues/315), [!422](https://gitlab.gnome.org/GNOME/gjs/merge_requests/422)]
>  	  * Skip some tests if GTK can't be initialised [Ross Burton, [!421](https://gitlab.gnome.org/GNOME/gjs/merge_requests/421)]
>
>  	- Various backports:
>  	  * Fix gjs_log_exception() for InternalError [Philip Chimento]
>  	  * Fix signal match mechanism [Philip Chimento]
>
>  	Version 1.58.7
>  	--------------
>
>  	- Various backports:
>  	  * Don't crash if a callback doesn't return an expected array of values [Marco
>  	    Trevisan]
>  	  * GList of int not correctly demarshalled on 64-bit big-endian [Philip
>  	    Chimento, Simon McVittie]
>  	  * Crash passing integer to strv in constructor [Evan Welsh]
>  	  * Ignore format-nonliteral warning [Marco Trevisan]
>
>
>  2b9aa3adae90b0472aa9333de72300a837c77e2e: vte: 0.60.1 -> 0.60.2
>  	No file describing changes found for group in cluster with “0.60.2”
>  97f6ca3d1674bdf1ef79d6b6d20ce233ec56f297: gnome3.geary: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/geary/3.36/geary-3.36.2.news)
>
>  	Version 3.36.2
>  	--------------
>  	Released: 2020-05-03
>
>  	Enhancements included in this release:
>  	 * Client library now installed to private lib sub-directory
>  	 * Allow downstream packagers set their package's version nuber
>  	 * Numerous bug fixes and user interface improvements
>  	 * Numerous user interface translation updates
>
>  	Thanks to all who contributed code fixes and enhancements to this
>  	release:
>  	 * Daniel Kahn Gillmor
>
>  	Thanks also to all who contributed translations, for the user
>  	interface:
>  	 * Asier Sarasua Garmendia (eu)
>  	 * Dušan Kazik (sk)
>  	 * Efstathios Iosifidis (el)
>  	 * Goran Vidović (hr)
>  	 * Jordi Mas (ca)
>  	 * Yuri Chornoivan (uk)
>
>  	And for the user manual:
>  	 * Jordi Mas (ca)
>
>
>  72dd255e5cbdf1fd74b87f85d268811b100fc771: gnome3.devhelp: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/devhelp/3.36/devhelp-3.36.2.news)
>
>  	News in 3.36.2, 2020-04-25
>  	--------------------------
>  	* Fix RTL (right-to-left text locale) bug.
>  	* Translation updates.
>
>
>  9294db094a275eda68d7d68066e8546a7d81766d: simple-scan: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/simple-scan/3.36/simple-scan-3.36.2.news)
>
>  	Overview of changes in simple-scan 3.36.2
>
>  	  * Use higher bit depth on text scans.
>  	  * Fix size of first page on second scan.
>  	  * Don't interrupt scanning if the device is busy.
>  	  * Support saving files to FUSE file systems.
>  	  * Update known USB scanner IDs.
>  	  * Add initial Lexmark printers support.
>  	  * Add ADF duplex support for Brother DS-720.
>  	  * Fix setting source for Epson scanner.
>
>
>  019e91054bf80d12ac0cdada7a72af58b706b191: gnome3.nautilus: 3.36.1.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/nautilus/3.36/nautilus-3.36.2.news)
>
>  	Major changes in 3.36.2:
>  	* Prevent jump to the old scrolling position after changing location (António Fernandes)
>  	* Revert icon emblem fixes in order to prevent performance issues (António Fernandes)
>  	* Fix content type detection when opening files from remote locations (Ondrej Holy)
>
>
>  00926413067f66cea94e51a3e3b1dfb9d40891b1: gnome3.gnome-terminal: 3.36.1.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-terminal/3.36/gnome-terminal-3.36.2.changes)
>
>  	commit be754773e25f7b0f8ccfe0ed4b7e65711bcee1be
>  	Author: Christian Persch <chpe@src.gnome.org>
>  	Date:   Sat Apr 25 22:13:00 2020 +0200
>
>  	    Version 3.36.2
>
>  	 configure.ac | 2 +-
>  	 1 file changed, 1 insertion(+), 1 deletion(-)
>
>  	commit 57ea15c4bdf15247f1d403aa24fb18efe23cd8a7
>  	Author: Christian Persch <chpe@src.gnome.org>
>  	Date:   Sat Apr 25 22:03:12 2020 +0200
>
>  	    Revert "screen: Use clean env when creating new tab"
>
>  	    The patch is correct, but it exposes a deficiency in the desktop
>  	    environment in that the WM/shell's environment contains necessary
>  	    env vars (e.g. ssh-agent variables) that are missing from the
>  	    systemd --user / d-bus activation environment.  The desktop will
>  	    need to update the activation environment, but until that is done,
>  	    reverting the patch will revert gnome-terminal to the previous
>  	    behaviour of effectively using the environment of the client
>  	    of the first terminal created for all new terminals opened via
>  	    new terminal/tab/window.
>
>  	    This reverts commit 9bb94e3aab84ecc4e7733d0ee001ee50256bd273.
>
>  	    https://gitlab.gnome.org/GNOME/gnome-terminal/-/issues/253
>
>  	 src/terminal-screen.c | 11 +++++++----
>  	 1 file changed, 7 insertions(+), 4 deletions(-)
>
>  	commit 5ecb0ac8b0cf97c73b4b18ba74e5a220b420d942
>  	Author: Christian Persch <chpe@src.gnome.org>
>  	Date:   Sat Apr 25 21:59:50 2020 +0200
>
>  	    screen: Fix memdup overrun
>
>  	    The extra element was never accessed.
>
>  	    (cherry picked from commit 5ae5b48b3f71dec024cd523b28f6bd2acbc8ced6)
>
>  	 src/terminal-screen.c | 2 +-
>  	 1 file changed, 1 insertion(+), 1 deletion(-)
>
>  	commit a7ecf5c9df47d12ad2a4799219f485d087718ec3
>  	Author: Christian Persch <chpe@src.gnome.org>
>  	Date:   Sat Apr 25 21:59:50 2020 +0200
>
>  	    server: Fix refcount leak
>
>  	    Ownership of the GDBusMethodInvocation is passed to terminal_receiver_impl_exec,
>  	    and will be released by terminal_receiver_complete_exec. The extra reference
>  	    added to ExecData was leaked, causing the GUnixFDList passed from the client
>  	    (if any) also to be leaked, which meant that its file descriptors were never
>  	    closed, leading to FD exhaustion.
>
>  	    (cherry picked from commit 1554c74da520db6dff65b9dbf4eb2de82b14e76f)
>
>  	 src/terminal-gdbus.c | 2 +-
>  	 1 file changed, 1 insertion(+), 1 deletion(-)
>
>  	commit c6f72400b39525ecd22def77ec117d924cc519fa
>  	Author: Christian Persch <chpe@src.gnome.org>
>  	Date:   Thu Apr 23 23:18:08 2020 +0200
>
>  	    screen: Take a ref to the FD list
>
>  	    (cherry picked from commit dcd77201aade51bab925b8257d79766ca7acd714)
>
>  	 src/terminal-screen.c | 5 ++++-
>  	 1 file changed, 4 insertions(+), 1 deletion(-)
>
>  	commit 717f8d7dd5a1e6b4006429547b0e035e44d0a164
>  	Author: Mathieu Lovato Stumpf Guntz <psychoslave@culture-libre.org>
>  	Date:   Sun Apr 19 11:51:22 2020 +0000
>
>  	    Update Esperanto translation
>
>  	 po/eo.po | 8 +++++---
>  	 1 file changed, 5 insertions(+), 3 deletions(-)
>
>  	commit 930f14e611e438d6ea534442705b49ab343f0f4f
>  	Author: Peniel Vargas <tsuneake.kaemitsu@gmail.com>
>  	Date:   Sat Apr 18 13:54:29 2020 +0000
>
>  	    Update Japanese translation
>
>  	 po/ja.po | 63 +++++++++++++++++++++++++++++++++------------------------------
>  	 1 file changed, 33 insertions(+), 30 deletions(-)
>
>  	commit 98a71e6ffbb2aebaf4c6ae09c5db152d6c12807c
>  	Author: Kristjan SCHMIDT <kristjan.schmidt@googlemail.com>
>  	Date:   Sun Apr 12 07:29:51 2020 +0000
>
>  	    Update Esperanto translation
>
>  	 po/eo.po | 1460 ++++++++++++++++++++++++++++++++++----------------------------
>  	 1 file changed, 803 insertions(+), 657 deletions(-)
>
>  	commit 5d966ab4c56bd82a8f6f68cc8f8922bca373c346
>  	Author: Matej Urbančič <mateju@svn.gnome.org>
>  	Date:   Fri Apr 10 22:21:18 2020 +0200
>
>  	    Updated Slovenian translation
>
>  	 po/sl.po | 1452 +++++++++++++++++++++++++++++++++-----------------------------
>  	 1 file changed, 781 insertions(+), 671 deletions(-)
>
>  	commit 11f0ad63587c3a9671fe7c4c6e49356da401f2de
>  	Author: Christian Persch <chpe@src.gnome.org>
>  	Date:   Thu Apr 9 21:04:32 2020 +0200
>
>  	    client: legacy: Suppress debug message spam
>
>  	    The glib log writer API has a deficiency in that the filtering is
>  	    done in the default log writer, instead of only passing messages
>  	    that pass the filter. This is filed as glib#2087, but until that
>  	    is fixed, apply a simple log level filter to work around it.
>
>  	    Patch by Kim Nguyen <https://gitlab.gnome.org/kim.nguyen>
>
>  	    Fixes: https://gitlab.gnome.org/GNOME/gnome-terminal/-/issues/42
>  	    (cherry picked from commit f84316ec180e9b9515a0914e883a0585f6877c7e)
>
>  	 src/terminal-options.c | 27 ++++++++++++++++++++++++++-
>  	 1 file changed, 26 insertions(+), 1 deletion(-)
>
>  	commit 65372d4590986a60e6a28533350fb78bc39cbee3
>  	Author: Charles Monzat <charles.monzat@free.fr>
>  	Date:   Sun Apr 5 17:24:18 2020 +0000
>
>  	    Update French translation
>
>  	 help/fr/fr.po | 1917 ++++++++++++++++++++++++++++++---------------------------
>  	 1 file changed, 1018 insertions(+), 899 deletions(-)
>
>  	commit e52b8dcc9265756cf5681adb59adbbad277b27a3
>  	Author: Christian Persch <chpe@src.gnome.org>
>  	Date:   Sat Apr 4 18:10:10 2020 +0200
>
>  	    server: systemd: Don't kill all remaining processes in the control group
>
>  	    Use KillMode=process to only kill the main g-t-server process, not every
>  	    application that was launched by gnome-terminal (e.g. firefox via
>  	    gtk_show_uri()).
>
>  	    https://gitlab.gnome.org/GNOME/gnome-terminal/-/issues/242#note_760400
>  	    (cherry picked from commit e456d6d896ece1fa303d56f7f9375521467bde6d)
>
>  	 src/Makefile.am | 3 ++-
>  	 1 file changed, 2 insertions(+), 1 deletion(-)
>
>  	commit 96ed81405692a98eb984dea51f132762e47d7e02
>  	Author: Guillaume Bernard <associations@guillaume-bernard.fr>
>  	Date:   Wed Apr 1 15:45:28 2020 +0000
>
>  	    Update French translation
>
>  	 po/fr.po | 22 +++++++++++-----------
>  	 1 file changed, 11 insertions(+), 11 deletions(-)
>
>  	commit 4dee4102cc07d6d1c416f62a62cc9e709a318aee
>  	Author: Daniel Șerbănescu <daniel@serbanescu.dk>
>  	Date:   Wed Apr 1 01:04:37 2020 +0000
>
>  	    Update Romanian translation
>
>  	 po/ro.po | 5 +++--
>  	 1 file changed, 3 insertions(+), 2 deletions(-)
>
>  	commit f607729cdd692a64c33e5571916f55415fb0aadf
>  	Author: Yosef Or Boczko <yoseforb@gnome.org>
>  	Date:   Tue Mar 31 08:36:10 2020 +0000
>
>  	    Update Hebrew translation
>
>  	 po/he.po | 3076 ++++++++++++++++++++++++++++++++++++--------------------------
>  	 1 file changed, 1793 insertions(+), 1283 deletions(-)
>
>  	commit 80b156322fcb65999e246291769c359ecf5cc41e
>  	Author: Christian Persch <chpe@src.gnome.org>
>  	Date:   Fri Mar 27 23:51:57 2020 +0100
>
>  	    build: Post release version bump
>
>  	 configure.ac | 4 ++--
>  	 1 file changed, 2 insertions(+), 2 deletions(-)
>
>
>  125153a2c9e9581733e343927cfc3afc3b8b525b: gnome3.gnome-settings-daemon: 3.36.0 -> 3.36.1
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-settings-daemon/3.36/gnome-settings-daemon-3.36.1.news)
>
>  	==============
>  	Version 3.36.1
>  	==============
>  	- Translation updates
>  	- CI improvements
>
>  	Media-keys:
>  	- Do not consider sound feedback a reason to inhibit sound
>  	  feedback.
>
>  	Print-notification:
>  	- Fix a minor warning on shutdown
>
>  	Sharing:
>  	- Do not warn after starting/stopping nonexistent services
>
>
>  a8e592dd9f556589a27778e710df94765b67b305: gnome3.gnome-initial-setup: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-initial-setup/3.36/gnome-initial-setup-3.36.2.news)
>
>  	3.36.2
>  	------
>
>  	* Bugs fixed:
>  	 - [!82](https://gitlab.gnome.org/GNOME/gnome-initial-setup/merge_requests/82) keyboard: Nullify pointers if getting layout fails
>
>  	* Translation updates:
>  	 - Hebrew
>  	 - Kurdish, Central
>  	 - Slovak
>
>
>
>  24513d68fd101824867a8170e0b0c23da25b1954: gnome3.gnome-control-center: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-control-center/3.36/gnome-control-center-3.36.2.news)
>
>  	================
>  	Version 3.36.2
>  	================
>
>  	- Updated translations
>
>  	CI
>  	- Update Flatpak libnma, mobile-broadband-provider-info, libhandy build depends
>
>  	Applications
>  	- Fix only connected snap interfaces showing
>
>  	Background
>  	- Allow adding multiple files to backgrounds
>
>  	Printers
>  	- Add whitespace between top right buttons
>
>  	Sharing
>  	- Set label for checkbox properly
>
>  	Sound
>  	- Fix translation of "System Sounds"
>
>  	Info:
>  	- Verify data coming from switcheroo-control
>
>
>  a6882d3838ccfb4bfae30cc0a99e467e9f1e808f: gnome3.gnome-contacts: 3.36 -> 3.36.1
>  	No file describing changes found for group in cluster with “3.36.1”
>  e4fdb2bf064756d44ebd01285ce61eaa7fba2efa: evolution-data-server: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/evolution-data-server/3.36/evolution-data-server-3.36.2.news)
>
>  	Evolution-Data-Server 3.36.2 2020-04-24
>  	---------------------------------------
>
>  	Bug Fixes:
>  		[I#203](https://gitlab.gnome.org/GNOME/evolution-data-server/issues/203) - Google book: Do not use progress callbacks in libgdata sync API (Milan Crha)
>  		[I#204](https://gitlab.gnome.org/GNOME/evolution-data-server/issues/204) - GOA-configured Nextcloud account not appearing (Milan Crha)
>  		[I#206](https://gitlab.gnome.org/GNOME/evolution-data-server/issues/206) - LDAP: Incorrectly converts SExp to LDAP query (Milan Crha)
>
>  	Miscellaneous:
>  		ESourceRegistryWatcher: The 'filter' signal listener should not be required (Milan Crha)
>
>  	Translations:
>  		Goran VidoviÄ‡ (hr)
>  		Fabio Tomat (fur)
>
>
>  988cd6ab79ec3e31a2a61a9977e696e172745702: gnome3.eog: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/eog/3.36/eog-3.36.2.news)
>
>  	Version 3.36.2
>  	--------------
>
>  	Bug fixes:
>  	 [!50](https://gitlab.gnome.org/GNOME/eog/merge_requests/50), help-overlay: Fix next/previous image shortcuts for RTL languages
>  	 [!51](https://gitlab.gnome.org/GNOME/eog/merge_requests/51), appdata: Update to release 3.36.1 (Felipe Borges)
>  	 [!55](https://gitlab.gnome.org/GNOME/eog/merge_requests/55), eog-application.c: Add new shortcut for zoom-normal action (Sabri Ünal)
>  	 [#121](https://gitlab.gnome.org/GNOME/eog/issues/121), Swipe left and swipe right action have the same description
>  	       in Keyboard Shortcuts dialog (Felix Riemann)
>  	 [#124](https://gitlab.gnome.org/GNOME/eog/issues/124), eog 3.36 cannot open HEIF files via gdk-pixbuf loader (Felix Riemann)
>
>  	New and updated translations:
>
>  	- Jordi Mas [ca]
>  	- Fabio Tomat [fur]
>  	- Yosef Or Boczko [he]
>  	- Matej Urbančič [sl]
>  	- Yuri Chornoivan [uk]
>
>  	New and updated manual translations
>
>  	- Jordi Mas [ca]
>  	- Yuri Chornoivan [uk]
>
>
>  d87ecac64a5022e88711f8be05e9c682e0a4ff1b: gnome3.dconf-editor: 3.36.0 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/dconf-editor/3.36/dconf-editor-3.36.2.news)
>
>  	dconf-editor 3.36.2
>  	=====================
>
>  	Some fixes for the now HC theme.
>
>  	Translations updated:
>  	  Latvian: Rūdolfs Mazurs
>  	  Romanian: Daniel Șerbănescu
>  	  Slovak: Peter Mráz
>  	  Ukrainian: Yuri Chornoivan
>
>
>  258274cb309575a2d9a322ffb6c2b3f465fb9db8: gnome3.polari: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/polari/3.36/polari-3.36.2.news)
>
>  	3.36.2 — “I've Seen More Meat in a Vegan Kitchen”
>  	=================================================
>  	* Fix information leak when re-using account IDs [Florian; [#132](https://gitlab.gnome.org/GNOME/polari/issues/132)]
>
>  	Contributors:
>  	  Florian Müllner
>
>  	Translators:
>  	  Cheng-Chia Tseng [zh_TW], Emin Tufan Çetin [tr]
>
>
>  71eef7dbcb53fc19d6b2354dbb6f34c866699f46: gnome3.gnome-weather: 3.36.0 -> 3.36.1
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-weather/3.36/gnome-weather-3.36.1.news)
>
>  	3.36.1
>  	======
>
>  	* Bugs fixed:
>  	  - [#95](https://gitlab.gnome.org/GNOME/gnome-weather/issues/95) Unknown temperature and cloud conditions when using autolocation (Michael Catanzaro)
>
>
>  90a1da2d615deddac7728df20477a4393056031b: gnome3.gnome-music: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-music/3.36/gnome-music-3.36.2.news)
>
>  	Overview of changes in 3.36.2
>  	=============================
>
>  	â€¢ Fix two crashers
>
>  	Bugs fixed:
>  	 Crash on playlist change check ([#382](https://gitlab.gnome.org/GNOME/gnome-music/issues/382))
>  	 Rare crash on some music files ([!701](https://gitlab.gnome.org/GNOME/gnome-music/merge_requests/701))
>
>  	Thanks to our contributors this release:
>  	 Marinus Schraal
>
>  	Translation added:
>  	 Ukranian
>
>  	Updated translations:
>  	 Hebrew
>  	 Slovak
>  	 Russian
>  	 Slovenian
>  	 Chinese (China)
>
>
>  2db8f0eef17baa26ec0652f4b780819b07c84055: gnome3.gnome-maps: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-maps/3.36/gnome-maps-3.36.2.news)
>
>  	3.36.2 - Apr 25, 2020
>  	=========================
>
>  	Changes since 3.36.1
>  	 - Don't reset query points when routing fails (e.g. no public transit provider
>  	   is available) to allow switching mode with the same query
>  	 - Fix a bug not displaying tiles south of the equator when using --local
>  	 - Allow entering DMS coordinates without comma between latitude and logitude
>  	   parts
>
>  	Added/updated/fixed translations
>  	 - Korean
>  	 - Slovenian
>  	 - Chinese (Taiwan)
>
>  	All contributors to this release
>  	Cheng-Chia Tseng <pswo10680@gmail.com>
>  	Jeeyong Um <conr2d@gmail.com>
>  	Marcus Lundblad <ml@update.uu.se>
>  	Matej Urbančič <mateju@svn.gnome.org>
>
>
>  70439110278633be833cffcb0b96e98cd09d7222: gnome3.gnome-getting-started-docs: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-getting-started-docs/3.36/gnome-getting-started-docs-3.36.2.news)
>
>  	==============
>  	Version 3.36.2
>  	==============
>
>  	* Updated translations:
>  	  fa        (Danial Behzadi)
>  	  id        (Andika Triwidada)
>  	  uk        (Yuri Chornoivan)
>
>
>  8a76bc3acd9855667c11bc825665154e6fec732f: gnome3.gnome-calendar: 3.36.0 -> 3.36.1
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-calendar/3.36/gnome-calendar-3.36.1.news)
>
>  	Major changes in 3.36.1:
>  	* Introduce a new engine
>  	* Fix a lot of bugs
>  	* Support webcal:// URLs
>  	* Updated translations
>
>
>  f75a116fc83baefee7d12a876e4968f605ad4e9e: gnome3.gnome-boxes: 3.36.2 -> 3.36.3
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-boxes/3.36/gnome-boxes-3.36.3.news)
>
>  	3.36.3 - Apr 20, 2020
>  	=====================
>
>  	Changes since 3.36.2
>
>  	  - Set the "No KVM Infobar" visibility correctly
>  	  - Build FreeRDP with OPENH264=ON on Flatpak
>  	  - Only store auth credentials when connection succeeds
>  	  - Fix authentication dialog not popping up for retrials
>  	  - Apply disk size changes in the VM creation assistant
>  	  - Don't recreate GraphicsSpice device on startup
>  	  - Added/updated/fixed translations:
>  	    - Chinese (Taiwan)
>  	    - Japanese
>  	    - Italian
>  	    - Indonesian
>
>  	All contributors to this release:
>
>  	Cheng-Chia Tseng <pswo10680@gmail.com>
>  	Federico Bruni <fede@inventati.org>
>  	Felipe Borges <felipeborges@gnome.org>
>  	Kukuh Syafaat <kukuhsyafaat@gnome.org>
>  	Manuel Wassermann <manuel.wassermann97@gmail.com>
>  	Ryuta Fujii <translation@sicklylife.jp>
>
>
>  12d42046443ba4a59ae0b25832cb84664ab403c4: gnome3.gedit: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/gedit/3.36/gedit-3.36.2.news)
>
>  	News in 3.36.2, 2020-04-25
>  	--------------------------
>  	* Misc bug fixes.
>  	* Translation updates.
>
>
>  4d5f2f991d1c4c99203360271d1caf56f53c18a1: gnome3.evolution: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/evolution/3.36/evolution-3.36.2.news)
>
>  	Evolution 3.36.2 2020-04-24
>  	---------------------------
>
>  	Bug Fixes:
>  		[I#870](https://gitlab.gnome.org/GNOME/evolution/issues/870) - e-day-view: Add a gap between adjacent events (Milan Crha)
>
>  	Miscellaneous:
>  		e-shell: Should retry source authenticate after successful trust prompt (Milan Crha)
>  		em-formatter: Remove unneeded attachment-expander button's 'data' attribute (Milan Crha)
>  		Calendar: Correct management of ECalComponentDateTime structures (Milan Crha)
>  		itip-formatter: Eventually linkify Location field (Milan Crha)
>  		EActivityBar: Unset timeout_id without recursive call to g_source_remove() (Milan Crha)
>  		external-editor: Fix a memory leak (Milan Crha)
>  		Flatpak: Switch to 3.36 runtime and change the build order (Milan Crha)
>
>  	Translations:
>  		Yuri Chornoivan (uk)
>  		Goran VidoviÄ‡ (hr)
>  		Anders Jonsson (sv)
>  		Jordi Mas (ca)
>
>
>  23f875a43fe86d0723a7a3720b77a296cd1c5ba1: gnome3.accerciser: 3.36.1 -> 3.36.2
>  	Unable to recognize updated package.
>  3c826679886ca3ff4f03ec2d4ea9556cf88ac07c: gnome-user-docs: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/gnome-user-docs/3.36/gnome-user-docs-3.36.2.news)
>
>  	3.36.2
>  	======
>
>  	* Updates to GNOME Help (Andre Klapper)
>  	* Updates to System Admin Guide (Ondrej Holy)
>  	* Updated translations:
>  	  ca        (Jordi Mas)
>  	  de        (Andre Klapper)
>  	  es        (Andre Klapper)
>  	  fa        (Arash Mousavi, Danial Behzadi)
>  	  fi        (Jiri Grönroos)
>  	  id        (Andika Triwidada)
>  	  pl        (Piotr Drąg)
>
>
>  34e24f5c5f2064130c17966a4ed4b1ae5d15825d: orca: 3.36.1 -> 3.36.2
>  	(https://ftp.gnome.org/pub/GNOME/sources/orca/3.36/orca-3.36.2.news)
>
>  	3.36.2 - 23 April 2020
>
>  	Chromium:
>
>  	 * Fix chattiness issue resulting from failing to consider the prior
>  	   object when generating labelOrName
>
>  	 * Improve responsiveness of text selection in large objects
>
>  	 * Prevent double-speaking of ARIA combobox value
>
>  	 * Don't speak child position for popup menus (it's always 1 of 1)
>
>  	Web:
>
>  	 * Fix bug causing us to present stale value information for ARIA
>  	   range widgets
>
>  	 * Don't present load completed or page summary information if we are
>  	   in focus mode for a valid object
>
>  	 * Don't present loading message from pages which have no URI (fixes
>  	   some chattiness when launching Firefox)
>
>  	 * Work harder to find presentable text for ARIA alert role
>
>  	 * Don't iterate through all children of very complex SVGs (improves
>  	   performance)
>
>  	 * Only present comment role when first entering the comment (chattiness)
>
>  	 * Fix bug causing us to not present text which is directly inside a
>  	   scroll pane
>
>  	 * Fix bug causing us to present stale information in rich-text editors
>
>  	Mouse Review:
>
>  	 * Fix mouse review on some web elements after scrolling
>
>  	General:
>
>  	 * Don't present position in list for comboboxes which lack children
>
>  	 * Fix bug causing us to not present changes in already-focused terminal
>  	   when Orca is launched
>
>  	 * Improve presentation of status bar labels
>
>  	 * Fix bug causing us to not echo text insertions
>
>  	New and updated translations (THANKS EVERYONE!!!):
>
>  	   oc            Occitan               Quentin PAGÈS
>  	   sl            Slovenian             Matej Urbančič
>
>  	=========
>
>


</details>


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
