### PR TITLE
left4gore: Init at 2.3

### DIFF
--- a/pkgs/games/left4gore/default.nix
+++ b/pkgs/games/left4gore/default.nix
@@ -1,0 +1,48 @@
+{ stdenvNoCC, lib, fetchurl, buildFHSUserEnv }:
+
+let
+  version = "2.3";
+
+  # Unwrapped package, for putting into the FHS env
+  left4gore-unwrapped = stdenvNoCC.mkDerivation {
+    pname = "left4gore-unwrapped";
+    inherit version;
+
+    src = fetchurl {
+      url = "http://www.left4gore.com/dist/left4gore-${version}-linux.tar.gz";
+      sha256 = "1n57nh32ybn6kirn8djh0nsjx6m84c0jfi1x8r4w2qr0qky3z7p0";
+    };
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp left4gore $out/bin
+    '';
+  };
+
+  # FHS env, as patchelf will not work
+  env = buildFHSUserEnv {
+    name = "left4gore-env-${version}";
+    targetPkgs = _: [ left4gore-unwrapped ];
+    runScript = "left4gore";
+  };
+
+in stdenvNoCC.mkDerivation {
+  pname = "left4gore";
+  inherit version;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    ln -s ${env}/bin/* $out/bin/left4gore
+  '';
+
+  meta = with lib; {
+    homepage = "http://www.left4gore.com";
+    description = "Memory patcher which adds the gore back into Left 4 Dead 2";
+    license = licenses.unfree; # Probably the best choice
+    maintainers = with maintainers; [ das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24740,6 +24740,8 @@ in
 
   legendary-gl = python38Packages.callPackage ../games/legendary-gl { };
 
+  left4gore-bin = callPackage ../games/left4gore { };
+
   lgogdownloader = callPackage ../games/lgogdownloader { };
 
   liberal-crime-squad = callPackage ../games/liberal-crime-squad { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Doesn't work that easily on NixOS due to yama.
Works when quitting steam and launching `left4gore -2`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
