### PR TITLE
python3Packages.wordfreq: 2.2.0 -> 2.3.2

### DIFF
--- a/pkgs/development/python-modules/langcodes/default.nix
+++ b/pkgs/development/python-modules/langcodes/default.nix
@@ -8,16 +8,15 @@
 
 buildPythonPackage rec {
   pname = "langcodes";
-  version = "1.4.1";
+  version = "2.0.0";
+  disabled = pythonOlder "3.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1axdiva2qglsjmnx2ak7i6hm0yhp6kbc4lcsgn8ckwy0nq1z3kr2";
+    sha256 = "0xszgmydymzhb0dhx5qvdn3x5z477ld0paw17lwwhlrxffkq5jxz";
   };
 
   propagatedBuildInputs = [ marisa-trie ];
-
-  disabled = pythonOlder "3.3";
 
   checkInputs = [ nose ];
 

--- a/pkgs/development/python-modules/wordfreq/default.nix
+++ b/pkgs/development/python-modules/wordfreq/default.nix
@@ -11,17 +11,26 @@
 , fetchFromGitHub
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "wordfreq";
-  version = "2.2.0";
+  version = "2.3.2";
+  disabled = pythonOlder "3";
 
    src = fetchFromGitHub {
     owner = "LuminosoInsight";
     repo = "wordfreq";
     # upstream don't tag by version
-    rev = "bc12599010c8181a725ec97d0b3990758a48da36";
-    sha256 = "195794vkzq5wsq3mg1dgfhlnz2f7vi1xajlifq6wkg4lzwyq262m";
+    rev = "v${version}";
+    sha256 = "078657iiksrqzcc2wvwhiilf3xxq5vlinsv0kz03qzqr1qyvbmas";
    };
+
+  propagatedBuildInputs = [ regex langcodes ftfy msgpack mecab-python3 jieba ];
+
+  # patch to relax version requirements for regex
+  # dependency to prevent break in upgrade
+  postPatch = ''
+    substituteInPlace setup.py --replace "regex ==" "regex >="
+  '';
 
   checkInputs = [ pytest ];
 
@@ -29,16 +38,6 @@ buildPythonPackage {
     # These languages require additional dictionaries
     pytest tests -k 'not test_japanese and not test_korean and not test_languages and not test_french_and_related'
   '';
-   
-  propagatedBuildInputs = [ regex langcodes ftfy msgpack mecab-python3 jieba ];
-  
-  # patch to relax version requirements for regex
-  # dependency to prevent break in upgrade
-  postPatch = ''
-    substituteInPlace setup.py --replace "regex ==" "regex >="
-  '';
-    
-  disabled = pythonOlder "3";
 
   meta = with lib; {
     description = "A library for looking up the frequencies of words in many languages, based on many sources of data";


### PR DESCRIPTION
###### Motivation for this change
Noticed it was broken when reviewing another PR

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/86664
1 package failed to build:
python38Packages.wordfreq

3 package built:
python37Packages.langcodes python37Packages.wordfreq python38Packages.langcodes
```