### PR TITLE
pythonPackages.secure: disable for python2, not supported

### DIFF
--- a/pkgs/development/python-modules/secure/default.nix
+++ b/pkgs/development/python-modules/secure/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27
 , maya
 , requests
 }:
@@ -6,6 +6,7 @@
 buildPythonPackage rec {
   version = "0.2.1";
   pname = "secure";
+  disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "typeerror";


### PR DESCRIPTION
###### Motivation for this change
Noticed it was broken reviewing another package

```
Processing ./secure-0.2.1-py2-none-any.whl
ERROR: Package 'secure' requires a different Python: 2.7.18 not in '>=3'
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
