### PR TITLE
xp-pen-g430: rename to pentablet-driver & 20190820 -> 1.2.13.1

### DIFF
--- a/pkgs/misc/drivers/pentablet-driver/default.nix
+++ b/pkgs/misc/drivers/pentablet-driver/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchzip, autoPatchelfHook, libusb1, libX11, libXtst, qtbase, wrapQtAppsHook, libglvnd }:
-stdenv.mkDerivation rec {
+{ stdenv, mkDerivation, fetchzip, autoPatchelfHook, libusb1, libX11, libXtst, qtbase, libglvnd }:
+
+mkDerivation rec {
   pname = "pentablet-driver";
-  version = "20190820";
+  version = "1.2.13.1";
 
   src = fetchzip {
-    url = "https://download01.xp-pen.com/file/2019/08/Linux%20Beta%20Driver(${version}).zip";
-    sha256 = "091kfqxxj90pdmwncgfl8ldi70pdhwryh3cls30654983m8cgnby";
-  } + /Linux_Pentablet_V1.3.0.0.tar.gz;
+    url = "https://download01.xp-pen.com/file/2020/04/Linux_Pentablet_V${version}.tar.gz(20200428).zip";
+    sha256 = "1r423hcpi26v82pzl59br1zw5vablikclqsy6mcqi0v5p84hfrdd";
+  } + /Linux_Pentablet_V1.2.13.1.tar.gz;
 
   nativeBuildInputs = [
     autoPatchelfHook
-    wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -24,14 +24,15 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp {Pentablet_Driver,config.xml} "$out"/bin
+    cp Pentablet_Driver $out/bin/pentablet-driver
+    cp config.xml $out/bin/config.xml
   '';
 
   meta = with stdenv.lib; {
     homepage = "https://www.xp-pen.com/download-46.html";
     description = "Driver for XP-PEN Pentablet drawing tablets";
     license = licenses.unfree;
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ ivar ];
   };
 }

--- a/pkgs/misc/drivers/pentablet-driver/default.nix
+++ b/pkgs/misc/drivers/pentablet-driver/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchzip, autoPatchelfHook, libusb1, libX11, libXtst, qtbase, wrapQtAppsHook, libglvnd }:
 stdenv.mkDerivation rec {
-  pname = "xp-pen-G430";
+  pname = "pentablet-driver";
   version = "20190820";
 
   src = fetchzip {
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://www.xp-pen.com/download-46.html";
-    description = "Driver for the XP-PEN G430 drawing tablet";
+    description = "Driver for XP-PEN Pentablet drawing tablets";
     license = licenses.unfree;
     platforms = platforms.linux;
     maintainers = with maintainers; [ ivar ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -535,6 +535,7 @@ mapAliases ({
   winswitch = throw "winswitch has been removed from nixpkgs."; # added 2019-12-10
   wireguard = wireguard-tools; # added 2018-05-19
   morituri = whipper; # added 2018-09-13
+  xp-pen-g430 = pentablet-driver; # added 2020-05-03
   xfceUnstable = xfce4-14; # added 2019-09-17
   xfce4-14 = xfce;
   xfce4-12 = throw "xfce4-12 has been replaced by xfce4-14"; # added 2020-03-14

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26346,7 +26346,7 @@ in
 
   bcompare = libsForQt5.callPackage ../applications/version-management/bcompare {};
 
-  xp-pen-g430 = libsForQt5.callPackage ../misc/drivers/xp-pen-g430 {};
+  pentablet-driver = libsForQt5.callPackage ../misc/drivers/pentablet-driver { };
 
   qmk_firmware = callPackage ../development/misc/qmk_firmware {
     avrgcc = pkgsCross.avr.buildPackages.gcc;


### PR DESCRIPTION
###### Motivation for this change
Renamed the xp-pen-g430 package to pentablet-driver, as i noticed all drivers in this series are exactly the same. Also updated it from 20190820 -> 1.2.13.1.

I'm copying them to `$out/bin` seperately now as to not have the annoying capitalization of the executable. Note that `config.xml` has to be next to the executable for it to start.

Their versioning is a tad confusing but this came out like 5 months later, so I'm sure it's newer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
