### PR TITLE
bashtop: init at 0.8.23

### DIFF
--- a/pkgs/tools/system/bashtop/default.nix
+++ b/pkgs/tools/system/bashtop/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, fetchFromGitHub
+, bash_5
+, curl
+, lm_sensors
+, procps
+, sysstat
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bashtop";
+  version = "0.8.23";
+
+  src = fetchFromGitHub {
+    owner = "aristocratos";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0y6yxm2vmbz0373cfdl6mjh8vhs0r0wcng82n304klx90qxg3ljp";
+  };
+
+  buildInputs = [ bash_5 curl lm_sensors procps sysstat ];
+
+  dontBuild = true;
+  installPhase = ''
+    install -Dm755 ${pname} $out/bin/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Linux resource monitor";
+    homepage = "https://github.com/aristocratos/bashtop";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ filalex77 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2301,6 +2301,8 @@ in
 
   bareos = callPackage ../tools/backup/bareos { };
 
+  bashtop = callPackage ../tools/system/bashtop { };
+
   bats = callPackage ../development/interpreters/bats { };
 
   bbe = callPackage ../tools/misc/bbe { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/aristocratos/bashtop/releases/tag/v0.8.23

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
