### PR TITLE
bluez: add configuration options to package

### DIFF
--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -11,114 +11,189 @@
 , readline
 , systemd
 , udev
+
+, enableA2dp                        ? false
+, enableAndroid                     ? false
+, enableAutoImageBase               ? false
+, enableAvrcp                       ? false
+, enableBacktrace                   ? false
+, enableBtpclient                   ? false
+, enableClient                      ? false
+, enableCups                        ? true
+, enableDatafiles                   ? false
+, enableDebug                       ? false
+, enableDependencyTracking          ? false
+, enableDeprecated                  ? false
+, enableExperimental                ? true
+, enableExternalEll                 ? false
+, enableHealth                      ? true
+, enableHid                         ? false
+, enableHog                         ? false
+, enableLibrary                     ? true
+, enableLibtoolLock                 ? false
+, enableLogger                      ? false
+, enableMaintainerMode              ? false
+, enableManpages                    ? false
+, enableMesh                        ? true
+, enableMidi                        ? false
+, enableMonitor                     ? false
+, enableNetwork                     ? false
+, enableNfc                         ? true
+, enableObex                        ? false
+, enableOptimization                ? false
+, enablePie                         ? true
+, enableSap                         ? true
+, enableSilentRules                 ? false
+, enableSixaxis                     ? true
+, enableSystemd                     ? false
+, enableTest                        ? false
+, enableTesting                     ? false
+, enableThreads                     ? false
+, enableTools                       ? false
+, enableUdev                        ? false
+, enableWiimote                     ? true
 }:
 
-stdenv.mkDerivation rec {
-  pname = "bluez";
-  version = "5.52";
+let
+  configEnableFlag = flag : ( enabled : if enabled then "--enable-" + flag else "" );
+in
+  stdenv.mkDerivation rec {
+    pname = "bluez";
+    version = "5.53";
 
-  src = fetchurl {
-    url = "mirror://kernel/linux/bluetooth/${pname}-${version}.tar.xz";
-    sha256 = "02jng21lp6fb3c2bh6vf9y7cj4gaxwk29dfc32ncy0lj0gi4q57p";
-  };
+    src = fetchurl {
+      url = "mirror://kernel/linux/bluetooth/${pname}-${version}.tar.xz";
+      sha256 = "1g1qg6dz6hl3csrmz75ixr12lwv836hq3ckb259svvrg62l2vaiq";
+    };
 
-  pythonPath = with python3.pkgs; [
-    dbus-python
-    pygobject3
-    recursivePthLoader
-  ];
+    pythonPath = with python3.pkgs; [
+      dbus-python
+      pygobject3
+      recursivePthLoader
+    ];
 
-  buildInputs = [
-    alsaLib
-    dbus
-    glib
-    json_c
-    libical
-    python3
-    readline
-    udev
-  ];
+    buildInputs = [
+      alsaLib
+      dbus
+      glib
+      json_c
+      libical
+      python3
+      readline
+      udev
+    ];
 
-  nativeBuildInputs = [
-    pkgconfig
-    python3.pkgs.wrapPython
-  ];
+    nativeBuildInputs = [
+      pkgconfig
+      python3.pkgs.wrapPython
+    ];
 
-  outputs = [ "out" "dev" "test" ];
+    outputs = [ "out" "dev" "test" ];
 
-  postPatch = ''
-    substituteInPlace tools/hid2hci.rules \
-      --replace /sbin/udevadm ${systemd}/bin/udevadm \
-      --replace "hid2hci " "$out/lib/udev/hid2hci "
-  '';
+    postPatch = ''
+      substituteInPlace tools/hid2hci.rules \
+        --replace /sbin/udevadm ${systemd}/bin/udevadm \
+        --replace "hid2hci " "$out/lib/udev/hid2hci "
 
-  configureFlags = [
-    "--localstatedir=/var"
-    "--enable-library"
-    "--enable-cups"
-    "--enable-pie"
-    "--with-dbusconfdir=${placeholder "out"}/share"
-    "--with-dbussystembusdir=${placeholder "out"}/share/dbus-1/system-services"
-    "--with-dbussessionbusdir=${placeholder "out"}/share/dbus-1/services"
-    "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
-    "--with-systemduserunitdir=${placeholder "out"}/etc/systemd/user"
-    "--with-udevdir=${placeholder "out"}/lib/udev"
-    "--enable-health"
-    "--enable-mesh"
-    "--enable-midi"
-    "--enable-nfc"
-    "--enable-sap"
-    "--enable-sixaxis"
-    "--enable-wiimote"
-  ];
+      mkdir -p $out/var/lib
+    '';
 
-  # Work around `make install' trying to create /var/lib/bluetooth.
-  installFlags = [ "statedir=$(TMPDIR)/var/lib/bluetooth" ];
+    configureFlags = [
+      "--localstatedir=/var"
+      "--with-dbusconfdir=${placeholder "out"}/share"
+      "--with-dbussystembusdir=${placeholder "out"}/share/dbus-1/system-services"
+      "--with-dbussessionbusdir=${placeholder "out"}/share/dbus-1/services"
+      "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
+      "--with-systemduserunitdir=${placeholder "out"}/etc/systemd/user"
+      "--with-udevdir=${placeholder "out"}/lib/udev"
+      
+      (configEnableFlag "a2dp"                enableA2dp)
+      (configEnableFlag "android"             enableAndroid)
+      (configEnableFlag "avrcp"               enableAvrcp)
+      (configEnableFlag "backtrace"           enableBacktrace)
+      (configEnableFlag "btpclient"           enableBtpclient)
+      (configEnableFlag "client"              enableClient)
+      (configEnableFlag "cups"                enableCups)
+      (configEnableFlag "datafiles"           enableDatafiles)
+      (configEnableFlag "debug"               enableDebug)
+      (configEnableFlag "dependency-tracking" enableDependencyTracking)
+      (configEnableFlag "deprecated"          enableDeprecated)
+      (configEnableFlag "experimental"        enableExperimental)
+      (configEnableFlag "external-ell"        enableExternalEll)
+      (configEnableFlag "health"              enableHealth)
+      (configEnableFlag "hid"                 enableHid)
+      (configEnableFlag "hog"                 enableHog)
+      (configEnableFlag "library"             enableLibrary)
+      (configEnableFlag "libtool-lock"        enableLibtoolLock)
+      (configEnableFlag "logger"              enableLogger)
+      (configEnableFlag "maintainer-mode"     enableMaintainerMode)
+      (configEnableFlag "manpages"            enableManpages)
+      (configEnableFlag "mesh"                enableMesh)
+      (configEnableFlag "midi"                enableMidi)
+      (configEnableFlag "monitor"             enableMonitor)
+      (configEnableFlag "network"             enableNetwork)
+      (configEnableFlag "nfc"                 enableNfc)
+      (configEnableFlag "obex"                enableObex)
+      (configEnableFlag "optimization"        enableOptimization)
+      (configEnableFlag "pie"                 enablePie)
+      (configEnableFlag "sap"                 enableSap)
+      (configEnableFlag "silent-rules"        enableSilentRules)
+      (configEnableFlag "sixaxis"             enableSixaxis)
+      (configEnableFlag "systemd"             enableSystemd)
+      (configEnableFlag "testing"             enableTesting)
+      (configEnableFlag "threads"             enableThreads)
+      (configEnableFlag "tools"               enableTools)
+      (configEnableFlag "udev"                enableUdev)
+      (configEnableFlag "wiimote"             enableWiimote)
+    ];
 
-  makeFlags = [ "rulesdir=${placeholder "out"}/lib/udev/rules.d" ];
+    # Work around `make install' trying to create /var/lib/bluetooth.
+    installFlags = [ "statedir=$out/var/lib/bluetooth" ];
 
-  doCheck = stdenv.hostPlatform.isx86_64;
+    makeFlags = [ "rulesdir=${placeholder "out"}/lib/udev/rules.d" ];
 
-  postInstall = ''
-    mkdir -p $test/{bin,test}
-    cp -a test $test
-    pushd $test/test
-    for a in \
-            simple-agent \
-            test-adapter \
-            test-device \
-            test-thermometer \
-            list-devices \
-            monitor-bluetooth \
-            ; do
-      ln -s ../test/$a $test/bin/bluez-$a
-    done
-    popd
-    wrapPythonProgramsIn $test/test "$test/test $pythonPath"
+    doCheck = stdenv.hostPlatform.isx86_64;
 
-    # for bluez4 compatibility for NixOS
-    mkdir $out/sbin
-    ln -s ../libexec/bluetooth/bluetoothd $out/sbin/bluetoothd
-    ln -s ../libexec/bluetooth/obexd $out/sbin/obexd
+    postInstall = ''
+      mkdir -p $test/{bin,test}
+      cp -a test $test
+      pushd $test/test
+      for a in \
+              simple-agent \
+              test-adapter \
+              test-device \
+              test-thermometer \
+              list-devices \
+              monitor-bluetooth \
+              ; do
+        ln -s ../test/$a $test/bin/bluez-$a
+      done
+      popd
+      wrapPythonProgramsIn $test/test "$test/test $pythonPath"
 
-    # Add extra configuration
-    mkdir $out/etc/bluetooth
-    ln -s /etc/bluetooth/main.conf $out/etc/bluetooth/main.conf
+      # for bluez4 compatibility for NixOS
+      mkdir $out/sbin
+      ln -s ../libexec/bluetooth/bluetoothd $out/sbin/bluetoothd
+      ln -s ../libexec/bluetooth/obexd $out/sbin/obexd
 
-    # Add missing tools, ref https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/bluez
-    for files in `find tools/ -type f -perm -755`; do
-      filename=$(basename $files)
-      install -Dm755 tools/$filename $out/bin/$filename
-    done
-  '';
+      # Add extra configuration
+      mkdir $out/etc/bluetooth
+      ln -s /etc/bluetooth/main.conf $out/etc/bluetooth/main.conf
 
-  enableParallelBuilding = true;
+      # Add missing tools, ref https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/bluez
+      for files in `find tools/ -type f -perm -755`; do
+        filename=$(basename $files)
+        install -Dm755 tools/$filename $out/bin/$filename
+      done
+    '';
 
-  meta = with stdenv.lib; {
-    description = "Bluetooth support for Linux";
-    homepage = http://www.bluez.org/;
-    license = with licenses; [ gpl2 lgpl21 ];
-    platforms = platforms.linux;
-    repositories.git = https://git.kernel.org/pub/scm/bluetooth/bluez.git;
-  };
-}
+    enableParallelBuilding = true;
+
+    meta = with stdenv.lib; {
+      description = "Bluetooth support for Linux";
+      homepage = "http://www.bluez.org/";
+      license = with licenses; [ gpl2 lgpl21 ];
+      platforms = platforms.linux;
+      repositories.git = https://git.kernel.org/pub/scm/bluetooth/bluez.git;
+    };
+  }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I wanted to be able to enable the deprecated tools

###### Things done
Added configuration options to the `bluez` package

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- ? Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
