### PR TITLE
nicotine-plus: 1.4.1 -> unstable-2020-05-24

### DIFF
--- a/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
+++ b/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
@@ -1,44 +1,116 @@
-{ stdenv, fetchFromGitHub, python27Packages, geoip }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3
+, wrapGAppsHook
+, gobject-introspection
+, gtk3
+, libnotify
+, geoip
 
-with stdenv.lib;
+# Test dependencies
+, xvfb_run
+, gnome3
+}:
 
-python27Packages.buildPythonApplication {
+python3.pkgs.buildPythonApplication {
   pname = "nicotine-plus";
-  version = "1.4.1";
+  version = "unstable-2020-05-24";
 
   src = fetchFromGitHub {
     owner = "Nicotine-Plus";
     repo = "nicotine-plus";
-    rev = "4e057d64184885c63488d4213ade3233bd33e67b";
-    sha256 = "11j2qm67sszfqq730czsr2zmpgkghsb50556ax1vlpm7rw3gm33c";
+    rev = "0f9e4e1c2391196d4070df5851ff48601aceaf7f";
+    hash = "sha256-kSDqoxmX9beqL98tMQylbhCZVMmQy6/oVOyW1xnxFLY=";
   };
 
-  propagatedBuildInputs = with python27Packages; [
-    pygtk
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  # Avoid double-wrapping; see preFixup
+  # and https://nixos.org/nixpkgs/manual/#ssec-gnome-common-issues.
+  dontWrapGApps = true;
+
+  buildInputs = [
+    gobject-introspection
+    gtk3
+    libnotify
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pygobject3
     miniupnpc
     mutagen
-    notify
     (GeoIP.override { inherit geoip; })
   ];
 
-  # Insert real docs directory.
-  # os.getcwd() is not needed
+  checkInputs = [ python3.pkgs.pytest ] ++ lib.optionals (!stdenv.isDarwin) [
+    # The gtk3 package doesn't enable X11 on Darwin, so we can't
+    # use xvfb-run.
+    xvfb_run
+    python3.pkgs.robotframework
+    # Avoid warnings about missing icons.
+    gnome3.defaultIconTheme
+  ];
+
+  # Run setup hooks for installCheckPhase;
+  # see https://github.com/NixOS/nixpkgs/issues/56943.
+  strictDeps = false;
+
   postPatch = ''
-    substituteInPlace ./pynicotine/gtkgui/frame.py \
-      --replace "paths.append(os.getcwd())" "paths.append('"$out"/doc')"
+    # Remove non-free files.
+    sh debian/nicotine-rm-nonfree
+
+    # Find installed files in the appropriate place.
+    # TODO: Move to importlib_resources upstream so this can be removed.
+    find pynicotine -name '*.py' \
+      -exec sed -i "s|sys\.prefix|'$out'|g" {} +
   '';
 
-  postFixup = ''
-    mkdir -p $out/doc/
-    mv ./doc/NicotinePlusGuide $out/doc/
-    mv $out/bin/nicotine $out/bin/nicotine-plus
+  preBuild = ''
+    # Regenerate languages/*/LC_MESSAGES/nicotine.mo files from source.
+    (cd languages; python msgfmtall.py)
+  '';
+
+  postInstall = ''
+    substituteInPlace $out/share/applications/nicotine.desktop \
+      --replace "Exec=nicotine" "Exec=$out/bin/nicotine"
+  '';
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    export PATH="$out/bin:$PATH"
+    export HOME="$(mktemp -d)"
+
+    # These tests should be kept in sync with debian/tests/control to
+    # the extent possible.
+
+    nicotine --version | grep -q 'Nicotine+'
+
+    pytest test/unit
+
+  '' + lib.optionalString (!stdenv.isDarwin) ''
+    xvfb-run -s '-screen 0 1024x768x24' \
+      robot test/integration/nicotine.robot
+
+  '' + ''
+    runHook postInstallCheck
   '';
 
   meta = {
     description = "A graphical client for the SoulSeek peer-to-peer system";
     homepage = "https://www.nicotine-plus.org";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ klntsky ];
-    platforms = platforms.unix;
+    license = [
+      # Main license
+      lib.licenses.gpl3Plus
+      # Per sounds/default/license.txt
+      lib.licenses.cc0
+    ];
+    maintainers = with lib.maintainers; [ klntsky emily ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/miniupnpc/default.nix
+++ b/pkgs/development/python-modules/miniupnpc/default.nix
@@ -1,18 +1,14 @@
-{ stdenv, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, miniupnpc_2 }:
 
 buildPythonPackage rec {
   pname = "miniupnpc";
-  version = "2.0.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0ca94zz7sr2x57j218aypxqcwkr23n8js30f3yrvvqbg929nr93y";
-  };
+  inherit (miniupnpc_2) version src nativeBuildInputs patches doCheck;
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "miniUPnP client";
     homepage = "http://miniupnp.free.fr/";
-    license = licenses.mit;
-    maintainers = with maintainers; [ peterhoeg ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ peterhoeg ];
   };
 }

--- a/pkgs/tools/misc/xvfb-run/default.nix
+++ b/pkgs/tools/misc/xvfb-run/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, makeWrapper, xorgserver, getopt
-, xauth, utillinux, which, fontsConf, gawk, coreutils }:
+, xauth, openssl, which, fontsConf, gawk, coreutils }:
 let
   xvfb_run = fetchurl {
     name = "xvfb-run";
@@ -17,13 +17,15 @@ stdenv.mkDerivation {
 
     chmod a+x $out/bin/xvfb-run
     patchShebangs $out/bin/xvfb-run
+    substituteInPlace $out/bin/xvfb-run \
+      --replace '$(mcookie)' '$(${openssl}/bin/openssl rand -hex 16)'
     wrapProgram $out/bin/xvfb-run \
       --set FONTCONFIG_FILE "${fontsConf}" \
-      --prefix PATH : ${stdenv.lib.makeBinPath [ getopt xorgserver xauth which utillinux gawk coreutils ]}
+      --prefix PATH : ${stdenv.lib.makeBinPath [ getopt xorgserver xauth which gawk coreutils ]}
   '';
 
   meta = with stdenv.lib; {
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.gpl2;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Includes port to Python 3 and GTK+ 3/PyGObject; see https://github.com/Nicotine-Plus/nicotine-plus/pull/106 for details.

This unstable version identifies itself as 1.4.3, and is planned to be released as 2.0.0 after it has had more fixes and testing through the official upstream PPA. The codebase is old and flaky to begin with, and there have been several unrelated bug fixes in the years since the last stable release, so I think it's worth updating to be able to use non-obsolescent versions of the core dependencies, and have nixos-unstable users help shake out any remaining issues with the port.  I verified that searching and downloading seem to work fine.

Drop the rename of the executable to `nicotine-plus`, as the test depends on the executable name and there doesn't seem to be any strong reason to diverge from upstream here (the original Nicotine is long dead). This is technically a breaking change, so it might be best to include a symlink at `$out/bin/nicotine-plus` temporarily.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).