### PR TITLE
horizon-eda: init at 1.1.1

### DIFF
--- a/pkgs/applications/science/electronics/horizon-eda/default.nix
+++ b/pkgs/applications/science/electronics/horizon-eda/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkgconfig
+, sqlite
+, libyamlcpp
+, libuuid
+, gnome3
+, epoxy
+, librsvg
+, zeromq
+, cppzmq
+, glm
+, libgit2
+, curl
+, boost
+, python3
+, opencascade
+, libzip
+, podofo
+, wrapGAppsHook
+, coreutils }:
+
+stdenv.mkDerivation rec {
+  pname = "horizon-eda";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "horizon-eda";
+    repo = "horizon";
+    rev = "v${version}";
+    sha256 = "sha256-gfCD//eiW7zmvVSeIVWos34lOTHqef0k96i4lJ1EzSg=";
+  };
+
+  buildInputs = [
+    boost
+    cppzmq
+    curl
+    epoxy
+    glm
+    gnome3.gtkmm
+    libgit2
+    librsvg
+    libuuid
+    libyamlcpp
+    libzip
+    opencascade
+    podofo
+    python3
+    sqlite
+    zeromq
+  ];
+
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+
+  NIX_CFLAGS_COMPILE = "-I${opencascade}/include/oce";
+
+  installPhase = ''
+    make install INSTALL=${coreutils}/bin/install DESTDIR=$out PREFIX=
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "A free EDA software to develop printed circuit boards";
+    homepage = "https://github.com/horizon-eda/horizon";
+    maintainers = with maintainers; [ luz yrashk ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24977,6 +24977,8 @@ in
 
   fped = callPackage ../applications/science/electronics/fped { };
 
+  horizon-eda = callPackage ../applications/science/electronics/horizon-eda {};
+
   # this is a wrapper for kicad.base and kicad.libraries
   kicad = callPackage ../applications/science/electronics/kicad { };
   kicad-small = kicad.override { pname = "kicad-small"; with3d = false; };


### PR DESCRIPTION
Mostly based on #56497 by @Luz

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
