### PR TITLE
improve robustness of various Rust packages (part 2)

### DIFF
--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -100,7 +100,7 @@ rustPlatform.buildRustPackage rec {
   '' + (
     if stdenv.isDarwin then ''
       mkdir $out/Applications
-      cp -r target/release/osx/Alacritty.app $out/Applications/Alacritty.app
+      cp -r $releaseDir/osx/Alacritty.app $out/Applications/Alacritty.app
     '' else ''
       install -D extra/linux/Alacritty.desktop -t $out/share/applications/
       install -D extra/logo/alacritty-term.svg $out/share/icons/hicolor/scalable/apps/Alacritty.svg

--- a/pkgs/tools/nix/cached-nix-shell/default.nix
+++ b/pkgs/tools/nix/cached-nix-shell/default.nix
@@ -34,7 +34,7 @@ in rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     mkdir -p $out/lib $out/share/cached-nix-shell $out/share/man/man1 $out/var/empty
-    cp target/release/build/cached-nix-shell-*/out/trace-nix.so $out/lib
+    cp $releaseDir/build/cached-nix-shell-*/out/trace-nix.so $out/lib
     cp rcfile.sh $out/share/cached-nix-shell/rcfile.sh
     cp cached-nix-shell.1 $out/share/man/man1
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I noticed I missed a couple in #82982.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
