### PR TITLE
gitqlient: init at 1.1.0

### DIFF
--- a/pkgs/applications/version-management/gitqlient/default.nix
+++ b/pkgs/applications/version-management/gitqlient/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, mkDerivation, fetchFromGitHub
+, qtbase, qmake
+}:
+
+with stdenv.lib;
+
+mkDerivation rec {
+  pname = "GitQlient";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "francescmm";
+    repo = "GitQlient";
+    rev = "v${version}";
+    sha256 = "048mmwx0nv7sb2cpwl1h8wqb4q7dcnkrrmhvq08yznylgdcgkgs1";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ qtbase ];
+  nativeBuildInputs = [ qmake ];
+  installFlags = [ "INSTALL_ROOT=$(out)" ];
+
+  postInstall = ''
+    mv $out/homeless-shelter/GitQlient/bin $out/bin
+  '';
+
+  meta = {
+    homepage = "https://github.com/francescmm/GitQlient";
+    description = "GitQlient: Multi-platform Git client written with Qt";
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3776,6 +3776,8 @@ in
 
   gitaly = callPackage ../applications/version-management/gitlab/gitaly { };
 
+  gitqlient = qt5.callPackage ../applications/version-management/gitqlient { };
+
   gitstats = callPackage ../applications/version-management/gitstats { };
 
   gogs = callPackage ../applications/version-management/gogs { };


### PR DESCRIPTION
###### Motivation for this change
Fixes: #86702.

Seems to build, launch, run okay. Going to test for a bit, maybe wait for the actual 1.1.0 release and then mark this as not-Draft.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
