### PR TITLE
nixos/hostapd: country selection, CRDA, logging

### DIFF
--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -21,6 +21,7 @@ let
     hw_mode=${cfg.hwMode}
     channel=${toString cfg.channel}
     ${optionalString (cfg.countryCode != null) ''country_code=${cfg.countryCode}''}
+    ${optionalString (cfg.countryCode != null) ''ieee80211d=1''}
 
     # logging (debug level)
     logger_syslog=-1
@@ -167,7 +168,10 @@ in
           Set as needed to indicate country in which device is operating.
           This can limit available channels and transmit power.
           These two octets are used as the first two octets of the Country String
-          (dot11CountryString)
+          (dot11CountryString).
+          If set this enables IEEE 802.11d. This advertises the countryCode and
+          the set of allowed channels and transmit power levels based on the
+          regulatory limits.
         '';
       };
 

--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -24,9 +24,9 @@ let
 
     # logging (debug level)
     logger_syslog=-1
-    logger_syslog_level=2
+    logger_syslog_level=${toString cfg.logLevel}
     logger_stdout=-1
-    logger_stdout_level=2
+    logger_stdout_level=${toString cfg.logLevel}
 
     ctrl_interface=/run/hostapd
     ctrl_interface_group=${cfg.group}
@@ -142,6 +142,19 @@ in
           passphrase to associate with this access point.
           Warning: This passphrase will get put into a world-readable file in
           the Nix store!
+        '';
+      };
+
+      logLevel = mkOption {
+        default = 2;
+        type = types.int;
+        description = ''
+          Levels (minimum value for logged events):
+          0 = verbose debugging
+          1 = debugging
+          2 = informational messages
+          3 = notification
+          4 = warning
         '';
       };
 

--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -164,6 +164,8 @@ in
 
     environment.systemPackages =  [ pkgs.hostapd ];
 
+    services.udev.packages = [ pkgs.crda ];
+
     systemd.services.hostapd =
       { description = "hostapd wireless AP";
 

--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -20,6 +20,7 @@ let
     ssid=${cfg.ssid}
     hw_mode=${cfg.hwMode}
     channel=${toString cfg.channel}
+    ${optionalString (cfg.countryCode != null) ''country_code=${cfg.countryCode}''}
 
     # logging (debug level)
     logger_syslog=-1
@@ -144,6 +145,19 @@ in
         '';
       };
 
+      countryCode = mkOption {
+        default = null;
+        example = "US";
+        type = with types; nullOr str;
+        description = ''
+          Country code (ISO/IEC 3166-1). Used to set regulatory domain.
+          Set as needed to indicate country in which device is operating.
+          This can limit available channels and transmit power.
+          These two octets are used as the first two octets of the Country String
+          (dot11CountryString)
+        '';
+      };
+
       extraConfig = mkOption {
         default = "";
         example = ''
@@ -164,7 +178,7 @@ in
 
     environment.systemPackages =  [ pkgs.hostapd ];
 
-    services.udev.packages = [ pkgs.crda ];
+    services.udev.packages = optional (cfg.countryCode != null) [ pkgs.crda ];
 
     systemd.services.hostapd =
       { description = "hostapd wireless AP";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add to the hostapd module:

* add a country code option to unlock channels not allowed by default

* enable CRDA (needed for the country code to work)

* configurable log level

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Am I supposed to cc the pkg maintainers? @Phreedom @NinjaTrappeur 