### PR TITLE
 python3Packages.pytest: 5.3.5 -> 5.4.1 

### DIFF
--- a/pkgs/development/python-modules/pytest-asyncio/default.nix
+++ b/pkgs/development/python-modules/pytest-asyncio/default.nix
@@ -1,13 +1,13 @@
 { stdenv, buildPythonPackage, fetchPypi, pytest, isPy3k, isPy35, async_generator }:
 buildPythonPackage rec {
   pname = "pytest-asyncio";
-  version = "0.10.0";
+  version = "0.12.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9fac5100fd716cbecf6ef89233e8590a4ad61d729d1732e0a96b84182df1daaf";
+    sha256 = "1lpb1q297rly685yl23mni3mmv6vmyx3qsv5ccj1vh8bvkrx4ns7";
   };
 
   buildInputs = [ pytest ]

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -1,9 +1,25 @@
-{ stdenv, buildPythonPackage, pythonOlder, fetchPypi, attrs, hypothesis, py
-, setuptools_scm, setuptools, six, pluggy, funcsigs, isPy3k, more-itertools
-, atomicwrites, mock, writeText, pathlib2, wcwidth, packaging, isPyPy, python
+{ stdenv, buildPythonPackage, pythonOlder, fetchPypi, isPy3k, isPyPy
+, atomicwrites
+, attrs
+, funcsigs
+, hypothesis
+, mock
+, more-itertools
+, packaging
+, pathlib2
+, pluggy
+, py
+, pygments
+, python
+, setuptools
+, setuptools_scm
+, six
+, wcwidth
+, writeText
 }:
+
 buildPythonPackage rec {
-  version = "5.3.5";
+  version = "5.4.1";
   pname = "pytest";
 
   disabled = !isPy3k;
@@ -15,10 +31,10 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d";
+    sha256 = "0w7r0pl1rkzpvb7k3926zcc9brd071zc8b1r3wymz05qfmqf7pc4";
   };
 
-  checkInputs = [ hypothesis mock ];
+  checkInputs = [ hypothesis mock pygments ];
   nativeBuildInputs = [ setuptools_scm ];
   propagatedBuildInputs = [ attrs py setuptools six pluggy more-itertools atomicwrites wcwidth packaging ]
     ++ stdenv.lib.optionals (pythonOlder "3.6") [ pathlib2 ];

--- a/pkgs/development/python-modules/sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "SQLAlchemy";
-  version = "1.3.13";
+  version = "1.3.16";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "64a7b71846db6423807e96820993fa12a03b89127d278290ca25c0b11ed7b4fb";
+    sha256 = "0w1xfy7j1h0dyfwk6zc6lfbv2m77lmxk7g17sbgpi08bq0kf293j";
   };
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change
attempt at  #83675 again, this time giving a month for the ecosystem to adjust.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
