### PR TITLE
squeak: 4.10.2.2614 -> 202003021730

### DIFF
--- a/pkgs/development/compilers/squeak/default.nix
+++ b/pkgs/development/compilers/squeak/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner="OpenSmalltalk";
     repo="opensmalltalk-vm";
     rev="${version}";
-    sha256 = "0bpwbnpy2sb4gylchfx50sha70z36bwgdxraym4vrr93l8pd3dix";
+    sha256 = "0qxnmw5q836m09y7pkii1dwkjsjwa86pyhwxj11hxsf815r15c0v";
   };
 
   buildInputs = [
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
    find . -type f -exec sed -i -e 's/\/usr\/bin\/env/${lib.escape ["/"] coreutils.outPath}\/bin\/env/g' {} \;
    ./scripts/updateSCCSVersions
-   cd build.linux64x64/squeak.cog.spur/build.debug
+   cd build.linux64x64/squeak.cog.spur/build
    printf "\n" | ./mvm
    make
   '';

--- a/pkgs/development/compilers/squeak/default.nix
+++ b/pkgs/development/compilers/squeak/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
    find . -type f -exec sed -i -e 's/\/usr\/bin\/env/${lib.escape ["/"] coreutils.outPath}\/bin\/env/g' {} \;
    ./scripts/updateSCCSVersions
    cd build.linux64x64/squeak.cog.spur/build
+   sed -i -e 's/configure --without-npsqueak/configure --without-npsqueak --disable-dynamicopenssl/g' mvm
    printf "\n" | ./mvm
    make
   '';

--- a/pkgs/development/compilers/squeak/default.nix
+++ b/pkgs/development/compilers/squeak/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner="OpenSmalltalk";
     repo="opensmalltalk-vm";
     rev="${version}";
-    sha256 = "0qxnmw5q836m09y7pkii1dwkjsjwa86pyhwxj11hxsf815r15c0v";
+    sha256 = "1cs0vmza1nq03i5f6w3j6l78j76qwlmc2aakvc10ivmy4vknglmc";
   };
 
   buildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The Squeak package has not been updated for quite some time. I have updated it to use the opensmalltalk repo where the current Squeak development happens.

This is my first substantial contribution. I am happy to receive feedback and improve it. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
