### PR TITLE
abseil-cpp: 20191119 -> 20200225.2; or-tools: 7.5 -> 7.6

### DIFF
--- a/pkgs/development/libraries/abseil-cpp/default.nix
+++ b/pkgs/development/libraries/abseil-cpp/default.nix
@@ -2,15 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "abseil-cpp";
-  date = "20191119";
-  rev = "8ba96a8244bbe334d09542e92d566673a65c1f78";
-  version = "${date}-${rev}";
+  version = "20200225.2";
 
   src = fetchFromGitHub {
     owner = "abseil";
     repo = "abseil-cpp";
-    rev = rev;
-    sha256 = "089bvlspgdgi40fham20qy1m97gr1jh5k5czz49dincpd18j6inb";
+    rev = version;
+    sha256 = "0dwxg54pv6ihphbia0iw65r64whd7v8nm4wwhcz219642cgpv54y";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -19,6 +17,7 @@ stdenv.mkDerivation rec {
     description = "An open-source collection of C++ code designed to augment the C++ standard library";
     homepage = "https://abseil.io/";
     license = licenses.asl20;
+    platforms = platforms.all;
     maintainers = [ maintainers.andersk ];
   };
 }

--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -8,13 +8,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "or-tools";
-  version = "7.5";
+  version = "7.6";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "or-tools";
     rev = "v${version}";
-    sha256 = "1p9jwdwzcsaa58ap912hdf2w27vna3xl9g4lh6kjskddwi8l3wac";
+    sha256 = "0605q3y7vh7x7m9azrbkx44blq12zrab6v28b9wmpcn1lmykbw1b";
   };
 
   # The original build system uses cmake which does things like pull


### PR DESCRIPTION
###### Motivation for this change

Replaces #84149 and #86709. These are together because or-tools upstream depends on a specific version of abseil, which fortunately is now the current LTS release of abseil rather than a random Git commit.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
