### PR TITLE
[20.03] kubeval: don't build against schema by default

### DIFF
--- a/pkgs/applications/networking/cluster/kubeval/default.nix
+++ b/pkgs/applications/networking/cluster/kubeval/default.nix
@@ -1,26 +1,5 @@
 { stdenv, lib, fetchFromGitHub, buildGoModule, makeWrapper }:
 
-let
-
-  # Cache schema as a package so network calls are not
-  # necessary at runtime, allowing use in package builds
-  schema = stdenv.mkDerivation {
-    name = "kubeval-schema";
-    src = fetchFromGitHub {
-      owner = "instrumenta";
-      repo = "kubernetes-json-schema";
-      rev = "6a498a60dc68c5f6a1cc248f94b5cd1e7241d699";
-      sha256 = "1y9m2ma3n4h7sf2lg788vjw6pkfyi0fa7gzc870faqv326n6x2jr";
-    };
-
-    installPhase = ''
-      mkdir -p $out/kubernetes-json-schema/master
-      cp -R . $out/kubernetes-json-schema/master
-    '';
-   };
-
-in
-
 buildGoModule rec {
   pname = "kubeval";
   version = "0.14.0";
@@ -32,11 +11,7 @@ buildGoModule rec {
     sha256 = "0kpwk7bv36m3i8vavm1pqc8l611c6l9qbagcc64v6r85qig4w5xv";
   };
 
-  buildInputs = [ makeWrapper ];
-
   modSha256 = "0y9x44y3bchi8xg0a6jmp2rmi8dybkl6qlywb6nj1viab1s8dd4y";
-
-  postFixup = "wrapProgram $out/bin/kubeval --set KUBEVAL_SCHEMA_LOCATION file:///${schema}/kubernetes-json-schema/master";
 
   meta = with lib; {
     description = "Validate your Kubernetes configuration files";

--- a/pkgs/applications/networking/cluster/kubeval/default.nix
+++ b/pkgs/applications/networking/cluster/kubeval/default.nix
@@ -19,6 +19,5 @@ buildGoModule rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ nicknovitski ];
     platforms = platforms.all;
-    broken = true;
   };
 }

--- a/pkgs/applications/networking/cluster/kubeval/schema.nix
+++ b/pkgs/applications/networking/cluster/kubeval/schema.nix
@@ -1,0 +1,15 @@
+{ fetchFromGitHub }:
+# To cache schema as a package so network calls are not
+# necessary at runtime, allowing use in package builds you can use the following:
+
+#   KUBEVAL_SCHEMA_LOCATION="file:///${kubeval-schema}";
+(fetchFromGitHub {
+  name = "kubeval-schema";
+  owner = "instrumenta";
+  repo = "kubernetes-json-schema";
+  rev = "6a498a60dc68c5f6a1cc248f94b5cd1e7241d699";
+  sha256 = "1y9m2ma3n4h7sf2lg788vjw6pkfyi0fa7gzc870faqv326n6x2jr";
+}) // {
+  # the schema is huge (> 7GB), we don't get any benefit from building int on hydra
+  meta.hydraPlatforms = [];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19990,6 +19990,8 @@ in
 
   kubeval = callPackage ../applications/networking/cluster/kubeval { };
 
+  kubeval-schema = callPackage ../applications/networking/cluster/kubeval/schema.nix { };
+
   kubernetes = callPackage ../applications/networking/cluster/kubernetes {
     go = buildPackages.go_1_13;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

backport of #82816 to allow kubeval to be un-broken in 20.03.

cc @Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
