### PR TITLE
nodePackages: init he and escape-string-regexp

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -81,6 +81,7 @@
 , "gtop"
 , "gulp"
 , "gulp-cli"
+, "he"
 , "html-minifier"
 , "htmlhint"
 , "http-server"

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -66,6 +66,7 @@
 , "elm-oracle"
 , "emoj"
 , "emojione"
+, "escape-string-regexp"
 , "eslint"
 , "eslint_d"
 , {"fast-cli": "1.x"}

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -63230,6 +63230,24 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
+  he = nodeEnv.buildNodePackage {
+    name = "he";
+    packageName = "he";
+    version = "1.2.0";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/he/-/he-1.2.0.tgz";
+      sha512 = "F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==";
+    };
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "A robust HTML entities encoder/decoder with full Unicode support.";
+      homepage = "https://mths.be/he";
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
   html-minifier = nodeEnv.buildNodePackage {
     name = "html-minifier";
     packageName = "html-minifier";

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -59655,6 +59655,24 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
+  escape-string-regexp = nodeEnv.buildNodePackage {
+    name = "escape-string-regexp";
+    packageName = "escape-string-regexp";
+    version = "4.0.0";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz";
+      sha512 = "TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==";
+    };
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Escape RegExp special characters";
+      homepage = "https://github.com/sindresorhus/escape-string-regexp#readme";
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
   eslint = nodeEnv.buildNodePackage {
     name = "eslint";
     packageName = "eslint";


### PR DESCRIPTION
These are a prerequisite for building the [Vulkan
documentation](https://github.com/KhronosGroup/Vulkan-Docs). Vulkan-Docs
doesn't come with a well-formed package.json which makes it difficult to
use with node2nix or other tools. Having these packages here makes it
very easy.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).