### PR TITLE
ocamlPackages-wasm: 1.0 -> 1.1

### DIFF
--- a/pkgs/development/ocaml-modules/wasm/default.nix
+++ b/pkgs/development/ocaml-modules/wasm/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     owner = "WebAssembly";
     repo = "spec";
     rev = "v${version}";
-    sha256 = "0r0wj31s2yg4vn4hyw2afc8wp8b0k3q130yiypwq3dlvfxrr70n6";
+    sha256 = "1jsgrjqzsdmm6f5pgd947nikj7pnxx1mqdnz16j7s62rg8x06h7d";
   };
 
   buildInputs = [ ocaml findlib ocamlbuild ];

--- a/pkgs/development/ocaml-modules/wasm/default.nix
+++ b/pkgs/development/ocaml-modules/wasm/default.nix
@@ -7,13 +7,13 @@ else
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-wasm-${version}";
-  version = "1.0";
+  version = "1.1";
 
   src = fetchFromGitHub {
     owner = "WebAssembly";
     repo = "spec";
     rev = "v${version}";
-    sha256 = "0r0wj31s2yg4vn4hyw2afc8wp8b0k3q130yiypwq3dlvfxrr70m6";
+    sha256 = "0r0wj31s2yg4vn4hyw2afc8wp8b0k3q130yiypwq3dlvfxrr70n6";
   };
 
   buildInputs = [ ocaml findlib ocamlbuild ];

--- a/pkgs/development/ocaml-modules/wasm/default.nix
+++ b/pkgs/development/ocaml-modules/wasm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
 
 if !stdenv.lib.versionAtLeast ocaml.version "4.02"
- || stdenv.lib.versionAtLeast ocaml.version "4.08"
+ || stdenv.lib.versionAtLeast ocaml.version "4.10"
 then throw "wasm is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/wasm/default.nix
+++ b/pkgs/development/ocaml-modules/wasm/default.nix
@@ -1,7 +1,6 @@
 { stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
 
 if !stdenv.lib.versionAtLeast ocaml.version "4.02"
- || stdenv.lib.versionAtLeast ocaml.version "4.10"
 then throw "wasm is not available for OCaml ${ocaml.version}"
 else
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

See https://opam.ocaml.org/packages/wasm/wasm.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
