### PR TITLE
vhd2vl: init

### DIFF
--- a/pkgs/applications/science/electronics/vhd2vl/default.nix
+++ b/pkgs/applications/science/electronics/vhd2vl/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, fetchFromGitHub
+, bison
+, flex
+, verilog
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vhd2vl";
+  version = "unstable-2018-09-01";
+
+  src = fetchFromGitHub {
+    owner = "ldoolitt";
+    repo = pname;
+    rev = "37e3143395ce4e7d2f2e301e12a538caf52b983c";
+    sha256 = "17va2pil4938j8c93anhy45zzgnvq3k71a7glj02synfrsv6fs8n";
+  };
+
+  nativeBuildInputs = [
+    bison
+    flex
+  ];
+
+  buildInputs = [
+    verilog
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp src/vhd2vl $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "VHDL to Verilog converter";
+    homepage = "https://github.com/ldoolitt/vhd2vl";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ matthuszagh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7242,6 +7242,8 @@ in
 
   verilog = callPackage ../applications/science/electronics/verilog {};
 
+  vhd2vl = callPackage ../applications/science/electronics/vhd2vl { };
+
   video2midi = callPackage ../tools/audio/video2midi {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adds [vhd2vl](https://github.com/ldoolitt/vhd2vl), a vhdl to verilog converter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
