### PR TITLE
opencv: rename and default to opencv4

### DIFF
--- a/pkgs/applications/audio/faust/faust2jack.nix
+++ b/pkgs/applications/audio/faust/faust2jack.nix
@@ -2,7 +2,7 @@
 , gtk2
 , jack2Full
 , alsaLib
-, opencv
+, opencv2
 , libsndfile
 }:
 
@@ -20,7 +20,7 @@ faust.wrapWithBuildEnv {
     gtk2
     jack2Full
     alsaLib
-    opencv
+    opencv2
     libsndfile
   ];
 

--- a/pkgs/applications/audio/faust/faust2jaqt.nix
+++ b/pkgs/applications/audio/faust/faust2jaqt.nix
@@ -1,6 +1,6 @@
 { faust
 , jack2Full
-, opencv
+, opencv2
 , qt4
 , libsndfile
 , which
@@ -17,7 +17,7 @@ faust.wrapWithBuildEnv {
 
   propagatedBuildInputs = [
     jack2Full
-    opencv
+    opencv2
     qt4
     libsndfile
     which

--- a/pkgs/applications/gis/saga/default.nix
+++ b/pkgs/applications/gis/saga/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, gdal, wxGTK30, proj, libiodbc, lzma,
-  libharu, opencv, vigra, postgresql, Cocoa,
+  libharu, opencv2, vigra, postgresql, Cocoa,
   unixODBC , poppler, hdf4, hdf5, netcdf, sqlite, qhull, giflib }:
 
 stdenv.mkDerivation {
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
 
   # See https://groups.google.com/forum/#!topic/nix-devel/h_vSzEJAPXs
   # for why the have additional buildInputs on darwin
-  buildInputs = [ gdal wxGTK30 proj libharu opencv vigra postgresql libiodbc lzma
+  buildInputs = [ gdal wxGTK30 proj libharu opencv2 vigra postgresql libiodbc lzma
                   qhull giflib ]
                 ++ stdenv.lib.optionals stdenv.isDarwin
                   [ Cocoa unixODBC poppler hdf4.out hdf5 netcdf sqlite ];

--- a/pkgs/applications/science/math/mathematica/10.nix
+++ b/pkgs/applications/science/math/mathematica/10.nix
@@ -8,7 +8,7 @@
 , gcc
 , glib
 , ncurses
-, opencv
+, opencv2
 , openssl
 , unixODBC
 , xorg
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     gcc.libc
     glib
     ncurses
-    opencv
+    opencv2
     openssl
     unixODBC
     libxml2

--- a/pkgs/applications/science/math/mathematica/11.nix
+++ b/pkgs/applications/science/math/mathematica/11.nix
@@ -10,7 +10,7 @@
 , gcc
 , glib
 , ncurses
-, opencv
+, opencv2
 , openssl
 , unixODBC
 , xkeyboard_config
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     gcc.libc
     glib
     ncurses
-    opencv
+    opencv2
     openssl
     unixODBC
     xkeyboard_config

--- a/pkgs/applications/science/math/mathematica/9.nix
+++ b/pkgs/applications/science/math/mathematica/9.nix
@@ -8,7 +8,7 @@
 , gcc
 , glib
 , ncurses
-, opencv
+, opencv2
 , openssl
 , unixODBC
 , xorg
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     gcc.libc
     glib
     ncurses
-    opencv
+    opencv2
     openssl
     unixODBC
   ] ++ (with xorg; [

--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -11,7 +11,7 @@
 , glib
 , libssh2
 , ncurses
-, opencv
+, opencv2
 , openssl
 , unixODBC
 , xkeyboard_config
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     glib
     libssh2
     ncurses
-    opencv
+    opencv2
     openssl
     stdenv.cc.cc.lib
     unixODBC

--- a/pkgs/applications/video/p2pvc/default.nix
+++ b/pkgs/applications/video/p2pvc/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, pkgconfig, fetchFromGitHub, opencv, ncurses, portaudio }:
+{ stdenv, pkgconfig, fetchFromGitHub, opencv2, ncurses, portaudio }:
 
 stdenv.mkDerivation {
   name = "p2pvc";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ opencv ncurses portaudio ];
+  buildInputs = [ opencv2 ncurses portaudio ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/graphics/pfstools/default.nix
+++ b/pkgs/tools/graphics/pfstools/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, cmake, pkgconfig, darwin
 , openexr, zlib, imagemagick, libGLU, libGL, freeglut, fftwFloat
-, fftw, gsl, libexif, perl, opencv, qt5, netpbm
+, fftw, gsl, libexif, perl, opencv2, qt5, netpbm
 }:
 
 stdenv.mkDerivation rec {
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [
     openexr zlib imagemagick fftwFloat
-    fftw gsl libexif perl opencv qt5.qtbase netpbm
+    fftw gsl libexif perl opencv2 qt5.qtbase netpbm
   ] ++ (if stdenv.isDarwin then (with darwin.apple_sdk.frameworks; [
     OpenGL GLUT
   ]) else [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13798,7 +13798,7 @@ in
 
   openct = callPackage ../development/libraries/openct { };
 
-  opencv = callPackage ../development/libraries/opencv {
+  opencv2 = callPackage ../development/libraries/opencv {
     inherit (darwin.apple_sdk.frameworks) Cocoa QTKit;
   };
 
@@ -13813,6 +13813,8 @@ in
   opencv4 = callPackage ../development/libraries/opencv/4.x.nix {
     inherit (darwin.apple_sdk.frameworks) AVFoundation Cocoa VideoDecodeAcceleration;
   };
+
+  opencv = opencv4;
 
   openexr = callPackage ../development/libraries/openexr { };
 


### PR DESCRIPTION
###### Motivation for this change

Make opencv4 the default and make sure all packages that depend on it built with it. The general goal is to reduce closure size for users of packages which can use the latest opencv. See https://discourse.nixos.org/t/nixpkgs-policy-regarding-libraries-available-in-multiple-versions/7026/2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` (used ofborg)
  - [x] faust2jack-unstable (uses `opencv2` explicitly now)
  - [x] faust2jaqt-unstable (uses `opencv2` explicitly now)
  - [x] Tambura (a dependency of fast2jaqt which hasn't really changed it's inputs)
  - [x] ffmpeg-full
  - [x] frei0r-plugins
  - [x] handbrake
  - [x] hydron-unstable
  - [x] kdenlive
  - [x] liquidsoap-full
  - [x] manim
  - [x] mathematica (uses `opencv2` explicitly now (I can't test it since it's unfree))
  - [x] meguca-unstable (already broken)
  - [x] mlt
  - [x] olive-editor
  - [x] libsForQt5.openbr (already broken)
  - [x] openmvs-unstable (already broken)
  - [x] p2pvc (uses `opencv2` explicitly now)
  - [x] pfstools (uses `opencv2` explicitly now)
  - [x] printrun
  - [x] python2.7-gym
  - [x] python2.7-pydub
  - [x] python2.7-pyglet
  - [x] python2.7-pytmx
  - [x] python2.7-remotecv (already broken)
  - [x] python3.7-baselines
  - [x] python3.7-gym
  - [x] python3.7-moderngl_window
  - [x] python3.7-pydub
  - [x] python3.7-pyglet
  - [x] python3.7-pytmx
  - [x] python3.7-rl-coach (already fails to build on [hydra as well](https://hydra.nixos.org/build/118101610/log/tail))
  - [x] python3.7-roboschool
  - [x] python3.8-gym
  - [x] python3.8-moderngl_window
  - [x] python3.8-pydub
  - [x] python3.8-pyglet
  - [x] python3.8-pytmx
  - [x] python3.8-roboschool
  - [x] retroshare (broken anyway)
  - [x] saga (uses `opencv2` explicitly now)
  - [x] seeks (broken anyway)
  - [x] shotcut
  - [x] soundkonverter
  - [x] synfigstudio (already broken)
  - [x] yafaray-core
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).