### PR TITLE
pythonPackages.softlayer: disable python2

### DIFF
--- a/pkgs/development/python-modules/softlayer/default.nix
+++ b/pkgs/development/python-modules/softlayer/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, isPy27
 , ptable
 , click
 , requests
@@ -17,6 +18,7 @@
 buildPythonPackage rec {
   pname = "softlayer-python";
   version = "5.8.4";
+  disabled = isPy27;
 
   propagatedBuildInputs = [ ptable click requests prompt_toolkit pygments urllib3 ];
 


### PR DESCRIPTION
###### Motivation for this change
noticed it failing when reviewing #86735

ERROR: Package 'SoftLayer' requires a different Python: 2.7.18 not in '>=3.5'

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
