### PR TITLE
pulumi: 1.12.0 -> 2.1.0

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,50 +1,50 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "1.12.0";
+  version = "2.1.0";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.12.0-linux-x64.tar.gz";
-        sha256 = "14j8f43h920k62h8bhywapphhfbj7whb9l6pjmyigld6x2jpr4mc";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.1.0-linux-x64.tar.gz";
+        sha256 = "0d9bmljgf62dhj1z8h71c2pj2cbvf4ghhlbbbh2jcg55i33ks8ih";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v1.5.0-linux-amd64.tar.gz";
-        sha256 = "1vdd5ghlsxqrfd1nrdj7hsl745k8myhxmd3gh1fq6ksa3apnh1ca";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.1.0-linux-amd64.tar.gz";
+        sha256 = "1kf43j1b4wp39sny92dnsy1myn6wb2msli1ydds3yza81srgcfnh";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v2.8.0-linux-amd64.tar.gz";
-        sha256 = "1q34kv41dbmz45s1sg0rqdxp1qlfq0ii0hy9p95lkzd7qj19qrvv";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.3.0-linux-amd64.tar.gz";
+        sha256 = "17anj9pc90hhiknyf2yab7dzvcfbjn1803bl6ld26r701w3h1jqx";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.5.6-linux-amd64.tar.gz";
-        sha256 = "1g5zgkqnzjqfri61p8876czn0ab2n3mjqf1acdyn8kg5q52sd8ix";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.0.0-linux-amd64.tar.gz";
+        sha256 = "0526a4ll1q9v566i313223pnx2pa3qkcjp01l49h5jmgn8qpw1fn";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.24.0-linux-amd64.tar.gz";
-        sha256 = "1fwnad5p1v4bigcr2icgzmxdn1b3x0j8c361546pqzk67vskn9fg";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.2.0-linux-amd64.tar.gz";
+        sha256 = "14ya2sax2yyza3zbxp5a638y81pcbi26hv8k9y8agnjn82bgx8dy";
       }
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.12.0-darwin-x64.tar.gz";
-        sha256 = "1bg6vnxic8fzycgv8q7m1bf8pk2bxvcn0b6lwy7aa2f3kzw70q46";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.1.0-darwin-x64.tar.gz";
+        sha256 = "1d7w32wac2sc0z5i893h66fgyivf4x3mqki649vxkxc3081kpzi9";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v1.5.0-darwin-amd64.tar.gz";
-        sha256 = "1skvfg8s8f81l4yfgm49jca38cx96khk3f9rpq4ywa3r3f450kni";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.1.0-darwin-amd64.tar.gz";
+        sha256 = "1smy1y2pnxnvw8zcs31q9xs80hyqhzawfzcwkkfnyamdrgasxqsi";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v2.8.0-darwin-amd64.tar.gz";
-        sha256 = "0f0gnbiv2gbam5n3ng9j5rbrml0jfv9k402vd4j9ryfkly4grpa9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.3.0-darwin-amd64.tar.gz";
+        sha256 = "03idn1livy9w3izi7qrdgnigx3ayrp8qp2q3m5ik9ffvv2g11962";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.5.6-darwin-amd64.tar.gz";
-        sha256 = "1l610a0bvwrsbqv4s00ghbplwnk11q3c0n3py0l7w0a2mpl8izzd";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.0.0-darwin-amd64.tar.gz";
+        sha256 = "06m6ldqa82w82kjz7pxi0pbk9x02pzsy4x0in8fcq9gsh1p0gka9";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.24.0-darwin-amd64.tar.gz";
-        sha256 = "17qq7w2wk0803y0if7dn3gnxxnfqnb4n2gcil3zgbc4yhqz4py0y";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.2.0-darwin-amd64.tar.gz";
+        sha256 = "0mymvn2355bq9ykvnww0si0imikzxp7mp1yh2scn8kjn2gs4nhgk";
       }
     ];
   };

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-VERSION="1.12.0"
+VERSION="2.1.0"
 
 declare -A plugins
 plugins=(
-    ["aws"]="1.24.0"
-    ["gcp"]="2.8.0"
-    ["random"]="1.5.0"
-    ["kubernetes"]="1.5.6"
+    ["aws"]="2.2.0"
+    ["gcp"]="3.3.0"
+    ["random"]="2.1.0"
+    ["kubernetes"]="2.0.0"
 )
 
 function genMainSrc() {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update pulumi to latest version. Was lagging behind

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @jlesquembre

I updated the plugins, but I'm not sure how they are used. Doesn't pulumi fetch the resources when you need them from a predefined template?