### PR TITLE
python: remove isPy33, isPy34

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -23,8 +23,6 @@ with pkgs;
       };
     in rec {
         isPy27 = pythonVersion == "2.7";
-        isPy33 = pythonVersion == "3.3"; # TODO: remove
-        isPy34 = pythonVersion == "3.4"; # TODO: remove
         isPy35 = pythonVersion == "3.5";
         isPy36 = pythonVersion == "3.6";
         isPy37 = pythonVersion == "3.7";

--- a/pkgs/development/python-modules/clikit/default.nix
+++ b/pkgs/development/python-modules/clikit/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi
-, isPy27, isPy34
+, isPy27
 , pylev, pastel, typing, enum34 }:
 
 buildPythonPackage rec {
@@ -13,8 +13,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     pylev pastel
-  ] ++ lib.optional (isPy27 || isPy34) typing
-    ++ lib.optional isPy27 enum34;
+  ] ++ lib.optionals isPy27 [ typing enum34 ];
 
   # The Pypi tarball doesn't include tests, and the GitHub source isn't
   # buildable until we bootstrap poetry, see

--- a/pkgs/development/python-modules/evdev/default.nix
+++ b/pkgs/development/python-modules/evdev/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, isPy34, fetchPypi, linuxHeaders }:
+{ lib, buildPythonPackage, fetchPypi, linuxHeaders }:
 
 buildPythonPackage rec {
   pname = "evdev";
@@ -16,8 +16,6 @@ buildPythonPackage rec {
   '';
 
   doCheck = false;
-
-  disabled = isPy34;  # see http://bugs.python.org/issue21121
 
   meta = with lib; {
     description = "Provides bindings to the generic input event interface in Linux";

--- a/pkgs/development/python-modules/livestreamer/default.nix
+++ b/pkgs/development/python-modules/livestreamer/default.nix
@@ -7,7 +7,6 @@
 , singledispatch
 , futures
 , isPy27
-, isPy33
 }:
 
 buildPythonPackage rec {
@@ -23,8 +22,7 @@ buildPythonPackage rec {
   buildInputs = [ pkgs.makeWrapper ];
 
   propagatedBuildInputs = [ pkgs.rtmpdump pycrypto requests ]
-    ++ stdenv.lib.optionals isPy27 [ singledispatch futures ]
-    ++ stdenv.lib.optionals isPy33 [ singledispatch ];
+    ++ stdenv.lib.optionals isPy27 [ singledispatch futures ];
 
   postInstall = ''
     wrapProgram $out/bin/livestreamer --prefix PATH : ${pkgs.rtmpdump}/bin

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -4,7 +4,6 @@
 , python
 , buildPythonPackage
 , isPy27
-, isPy33
 , isPy3k
 , numpy
 , llvmlite
@@ -26,7 +25,8 @@ buildPythonPackage rec {
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
 
-  propagatedBuildInputs = [numpy llvmlite] ++ stdenv.lib.optional (!isPy3k) funcsigs ++ stdenv.lib.optional (isPy27 || isPy33) singledispatch;
+  propagatedBuildInputs = [numpy llvmlite]
+    ++ stdenv.lib.optionals isPy27 [ funcsigs singledispatch];
 
   # Copy test script into $out and run the test suite.
   checkPhase = ''

--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -1,5 +1,6 @@
 { lib, buildPythonPackage, fetchPypi, callPackage
-, isPy27, isPy34, pythonOlder
+, isPy27
+, pythonOlder
 , cleo
 , requests
 , cachy
@@ -66,8 +67,7 @@ in buildPythonPackage rec {
     pexpect
     keyring
     lockfile
-  ] ++ lib.optionals (isPy27 || isPy34) [ typing pathlib2 glob2 ]
-    ++ lib.optionals isPy27 [ virtualenv functools32 subprocess32 ]
+  ] ++ lib.optionals isPy27 [ typing pathlib2 glob2 virtualenv functools32 subprocess32 ]
     ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   postInstall = ''

--- a/pkgs/development/python-modules/pycairo/default.nix
+++ b/pkgs/development/python-modules/pycairo/default.nix
@@ -1,12 +1,10 @@
-{ lib, fetchFromGitHub, meson, ninja, buildPythonPackage, pytest, pkgconfig, cairo, xlibsWrapper, isPy33, isPy3k }:
+{ lib, fetchFromGitHub, meson, ninja, buildPythonPackage, pytest, pkgconfig, cairo, xlibsWrapper, isPy3k }:
 
 buildPythonPackage rec {
   pname = "pycairo";
   version = "1.18.2";
 
   format = "other";
-
-  disabled = isPy33;
 
   src = fetchFromGitHub {
     owner = "pygobject";

--- a/pkgs/development/python-modules/rencode/default.nix
+++ b/pkgs/development/python-modules/rencode/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , buildPythonPackage
-, isPy33
 , fetchgit
 , cython
 }:
@@ -8,7 +7,6 @@
 buildPythonPackage {
   pname = "rencode";
   version = "git20150810";
-  disabled = isPy33;
 
   src = fetchgit {
     url = "https://github.com/aresch/rencode";

--- a/pkgs/development/python-modules/rig/default.nix
+++ b/pkgs/development/python-modules/rig/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi
-, isPy34, isPy35, isPy27
+, isPy35, isPy27
 , numpy, pytz, six, enum-compat, sentinel
 }:
 
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   # This is the list of officially supported versions. Other versions may work
   # as well.
-  disabled = !(isPy35 || isPy34 || isPy27);
+  disabled = !(isPy27 || isPy35);
 
   # Test Phase is only supported in development sources.
   doCheck = false;

--- a/pkgs/development/python-modules/serpent/default.nix
+++ b/pkgs/development/python-modules/serpent/default.nix
@@ -4,7 +4,6 @@
 , lib
 , python
 , isPy27
-, isPy33
 , enum34
 , attrs
 , pytz
@@ -19,7 +18,7 @@ buildPythonPackage rec {
     sha256 = "1arnckykpkvv2qrp49l1k7q5mr5pisswl0rvdx98x8wsl1n361pk";
   };
 
-  propagatedBuildInputs = lib.optionals (isPy27 || isPy33) [ enum34 ];
+  propagatedBuildInputs = lib.optionals isPy27 [ enum34 ];
 
   checkInputs = [ attrs pytz ];
   checkPhase = ''

--- a/pkgs/development/python-modules/tomlkit/default.nix
+++ b/pkgs/development/python-modules/tomlkit/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, isPy34
+{ lib, buildPythonPackage, fetchPypi, isPy27
 , enum34, functools32, typing
 }:
 
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs =
     lib.optionals isPy27 [ enum34 functools32 ]
-    ++ lib.optional (isPy27 || isPy34) typing;
+    ++ lib.optional isPy27 typing;
 
   # The Pypi tarball doesn't include tests, and the GitHub source isn't
   # buildable until we bootstrap poetry, see

--- a/pkgs/development/python-modules/traits/default.nix
+++ b/pkgs/development/python-modules/traits/default.nix
@@ -4,7 +4,6 @@
 , python
 , pytest
 , numpy
-, isPy33
 }:
 
 buildPythonPackage rec {
@@ -28,7 +27,7 @@ buildPythonPackage rec {
   # https://github.com/enthought/traits/issues/187
   # https://github.com/enthought/traits/pull/188
   # Furthermore, some tests fail due to being in a chroot
-  doCheck = isPy33;
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Explicitly typed attributes for Python";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18,7 +18,7 @@ let
   packages = ( self:
 
 let
-  inherit (python.passthru) isPy27 isPy33 isPy34 isPy35 isPy36 isPy37 isPy38 isPy39 isPy3k isPyPy pythonAtLeast pythonOlder;
+  inherit (python.passthru) isPy27 isPy35 isPy36 isPy37 isPy38 isPy39 isPy3k isPyPy pythonAtLeast pythonOlder;
 
   callPackage = pkgs.newScope self;
 
@@ -100,7 +100,7 @@ let
 
 in {
 
-  inherit (python.passthru) isPy27 isPy33 isPy34 isPy35 isPy36 isPy37 isPy38 isPy39 isPy3k isPyPy pythonAtLeast pythonOlder;
+  inherit (python.passthru) isPy27 isPy35 isPy36 isPy37 isPy38 isPy39 isPy3k isPyPy pythonAtLeast pythonOlder;
   inherit python bootstrapped-pip buildPythonPackage buildPythonApplication;
   inherit fetchPypi callPackage;
   inherit hasPythonModule requiredPythonModules makePythonPath disabledIf;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This PR removes the usage of `isPy33` and `isPy34` which are not used for anything useful anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
