### PR TITLE
linode-cli: Fix sha256 hash for openapi spec

### DIFF
--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -13,8 +13,8 @@
 let
 
   spec = fetchurl {
-    url = "https://developers.linode.com/api/docs/v4/openapi.yaml";
-    sha256 = "1l2fahdcmv7sp1qkwr5nv2vls8fypvlybwylqfzhyjmn7jqkw4hq";
+    url = "https://raw.githubusercontent.com/linode/linode-api-docs/v4.63.1/openapi.yaml";
+    sha256 = "03ngzbq24zazfqmfd7xjmxixkcb9vv1jgamplsj633j7sjj708s0";
   };
 
 in


### PR DESCRIPTION
Replaced the has for the openapi spec with a working hash, as
attempting to install linode-cli was failing, with the following
message:

hash mismatch in fixed-output derivation '/nix/store/px3cdbcb84bvw6xslr1k6hszyxpdis6j-openapi.yaml':
  wanted: sha256:1l2fahdcmv7sp1qkwr5nv2vls8fypvlybwylqfzhyjmn7jqkw4hq
  got:    sha256:03ngzbq24zazfqmfd7xjmxixkcb9vv1jgamplsj633j7sjj708s0
cannot build derivation '/nix/store/49xrq47id66kwszyaqg1qapknc3i8mmx-linode-cli-2.14.1.drv': 1 dependencies couldn't be built

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Wanting to be able to install linode-cli properly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
