### PR TITLE
podman: Don't symlink the $bin output

### DIFF
--- a/nixos/modules/virtualisation/podman.nix
+++ b/nixos/modules/virtualisation/podman.nix
@@ -8,13 +8,11 @@ let
 
   # Provides a fake "docker" binary mapping to podman
   dockerCompat = pkgs.runCommandNoCC "${podmanPackage.pname}-docker-compat-${podmanPackage.version}" {
-    outputs = [ "out" "bin" "man" ];
+    outputs = [ "out" "man" ];
     inherit (podmanPackage) meta;
   } ''
-    mkdir $out
-
-    mkdir -p $bin/bin
-    ln -s ${podmanPackage.bin}/bin/podman $bin/bin/docker
+    mkdir -p $out/bin
+    ln -s ${podmanPackage}/bin/podman $out/bin/docker
 
     mkdir -p $man/share/man/man1
     for f in ${podmanPackage.man}/share/man/man1/*; do

--- a/pkgs/applications/virtualization/podman/wrapper.nix
+++ b/pkgs/applications/virtualization/podman/wrapper.nix
@@ -34,15 +34,15 @@ in runCommand podman.name {
   ];
 
 } ''
-  # Symlink everything but $bin from podman-unwrapped
+  # Symlink everything but $out from podman-unwrapped
   ${
     lib.concatMapStringsSep "\n"
     (o: "ln -s ${podman.${o}} ${placeholder o}")
-    (builtins.filter (o: o != "bin")
+    (builtins.filter (o: o != "out")
     podman.outputs)}
 
-  mkdir -p $bin/bin
-  ln -s ${podman-unwrapped}/share $bin/share
-  makeWrapper ${podman-unwrapped}/bin/podman $bin/bin/podman \
+  mkdir -p $out/bin
+  ln -s ${podman-unwrapped}/share $out/share
+  makeWrapper ${podman-unwrapped}/bin/podman $out/bin/podman \
     --prefix PATH : ${binPath}
 ''

--- a/pkgs/applications/virtualization/podman/wrapper.nix
+++ b/pkgs/applications/virtualization/podman/wrapper.nix
@@ -27,30 +27,23 @@ let
     iptables
   ] ++ extraPackages);
 
-  outputs = [
-    "out"
-    "man"
-  ];
-
 in runCommand podman.name {
   name = "${podman.pname}-wrapper-${podman.version}";
   inherit (podman) pname version;
 
   meta = builtins.removeAttrs podman.meta [ "outputsToInstall" ];
 
-  inherit outputs;
+  outputs = [
+    "out"
+    "man"
+  ];
 
   nativeBuildInputs = [
     makeWrapper
   ];
 
 } ''
-  # Symlink everything but $out from podman-unwrapped
-  ${
-    lib.concatMapStringsSep "\n"
-    (o: "ln -s ${podman.${o}} ${placeholder o}")
-    (builtins.filter (o: o != "out")
-    outputs)}
+  ln -s ${podman.man} $man
 
   mkdir -p $out/bin
   ln -s ${podman-unwrapped}/share $out/share

--- a/pkgs/applications/virtualization/podman/wrapper.nix
+++ b/pkgs/applications/virtualization/podman/wrapper.nix
@@ -27,8 +27,19 @@ let
     iptables
   ] ++ extraPackages);
 
+  outputs = [
+    "out"
+    "man"
+  ];
+
 in runCommand podman.name {
-  inherit (podman) name pname version meta outputs;
+  name = "${podman.pname}-wrapper-${podman.version}";
+  inherit (podman) pname version;
+
+  meta = builtins.removeAttrs podman.meta [ "outputsToInstall" ];
+
+  inherit outputs;
+
   nativeBuildInputs = [
     makeWrapper
   ];
@@ -39,7 +50,7 @@ in runCommand podman.name {
     lib.concatMapStringsSep "\n"
     (o: "ln -s ${podman.${o}} ${placeholder o}")
     (builtins.filter (o: o != "out")
-    podman.outputs)}
+    outputs)}
 
   mkdir -p $out/bin
   ln -s ${podman-unwrapped}/share $out/share


### PR DESCRIPTION
###### Motivation for this change
If we do it propagates and ends up in $PATH inside nix-shell

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
