### PR TITLE
xbill: install desktop file

### DIFF
--- a/pkgs/games/xbill/default.nix
+++ b/pkgs/games/xbill/default.nix
@@ -1,9 +1,10 @@
-{ stdenv, lib, fetchurl, libX11, libXpm, libXt, motif, ... }:
+{ stdenv, lib, makeDesktopItem, copyDesktopItems, fetchurl, libX11, libXpm, libXt, motif, ... }:
 
 stdenv.mkDerivation rec {
   pname = "xbill";
   version = "2.1";
 
+  nativeBuildInputs = [ copyDesktopItems ];
   buildInputs = [ libX11 libXpm libXt motif ];
 
   NIX_CFLAGS_LINK = "-lXpm";
@@ -17,6 +18,19 @@ stdenv.mkDerivation rec {
     url = "http://www.xbill.org/download/${pname}-${version}.tar.gz";
     sha256 = "13b08lli2gvppmvyhy0xs8cbjbkvrn4b87302mx0pxrdrvqzzz8f";
   };
+
+  desktopItems = [ (makeDesktopItem {
+    name = "xbill";
+    exec = "xbill";
+    icon = "xbill";
+    desktopName = "XBill";
+    comment     = "Get rid of those Wingdows viruses!";
+    categories  = "Game;ArcadeGame;";
+  }) ];
+
+  postInstall = ''
+    install -Dm644 pixmaps/icon.xpm $out/share/pixmaps/xbill.xpm
+  '';
 
   meta = with stdenv; {
     description = "Protect a computer network from getting infected";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Right now, xbill is missing from any graphical program menu because we don't ship the desktop file. This pull request fixes this issue. (I took the desktop file from Debian.)

Thank you, @aw, for your work maintaining this lovely oldie!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
