### PR TITLE
modules/filesystems/zfs: use current kernel

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -22,10 +22,10 @@ let
   kernel = config.boot.kernelPackages;
 
   packages = if config.boot.zfs.enableUnstable then {
-    zfs = kernel.zfsUnstable;
+    zfs = kernel.zfsUnstable.override { kernel = kernel.kernel; };
     zfsUser = pkgs.zfsUnstable;
   } else {
-    zfs = kernel.zfs;
+    zfs = kernel.zfs.override { kernel = kernel.kernel; };
     zfsUser = pkgs.zfs;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The derivation for zfs currently doesn't pull in the same kernel if `boot.kernel.randstructSeed` is set to a non-zero length string resulting in an extra kernel to build while also basically destroying the purpose of setting a randstructSeed, since the kernel used to build zfs would use a different seed.

Using `callPackage` should also work since `kernel` won't be evaluated until the derivation is called, in which case the kernel would've been updated (I believe), but I'm not sure how that should be done without using a let/in block (which probably should be in `all-packages.nix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

[1] https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/all-packages.nix#L16933
