### PR TITLE
[20.03] openshot-qt: 2.4.4 -> 2.5.1

### DIFF
--- a/pkgs/applications/video/openshot-qt/default.nix
+++ b/pkgs/applications/video/openshot-qt/default.nix
@@ -2,25 +2,16 @@
 , doxygen, python3Packages, libopenshot
 , wrapGAppsHook, gtk3 }:
 
-let
-  fixPermissions = fetchpatch rec {
-    url = https://github.com/OpenShot/openshot-qt/pull/2973.patch;
-    sha256 = "037rh0p3k4sdzprlpyb73byjq3qhqk5zd0d4iin6bq602r8bbp0n";
-  };
-in
-
 mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "openshot-qt";
-  version = "2.4.4";
+  version = "2.5.1";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "openshot-qt";
     rev = "v${version}";
-    sha256 = "0mg63v36h7l8kv2sgf6x8c1n3ygddkqqwlciz7ccxpbm4x1idqba";
+    sha256 = "0qc5i0ay6j2wab1whl41sjb71cj02pg6y79drf7asrprq8b2rmfq";
   };
-
-  patches = [ fixPermissions ];
 
   nativeBuildInputs = [ doxygen wrapGAppsHook ];
 
@@ -57,6 +48,5 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
     license = with licenses; gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = with platforms; linux;
-    broken = true;
   };
 }

--- a/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
@@ -3,13 +3,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "libopenshot-audio";
-  version = "0.1.8";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "libopenshot-audio";
     rev = "v${version}";
-    sha256 = "1fvp6nmf30xzkmcznakh8dv5vn9d7nq051pqcqv638hsfppkmcrl";
+    sha256 = "13if0m5mvlqly8gmbhschzb9papkgp3yqivklhb949dhy16m8zgf";
   };
 
   nativeBuildInputs =
@@ -31,6 +31,5 @@ stdenv.mkDerivation rec {
     license = with licenses; gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = with platforms; linux;
-    broken = true;
   };
 }

--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -8,13 +8,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "libopenshot";
-  version = "0.2.3";
+  version = "0.2.5";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "libopenshot";
     rev = "v${version}";
-    sha256 = "0r1qmr8ar5n72603xkj9h065vbpznrqsq88kxxmn9n8djyyvk03k";
+    sha256 = "1mxjkgjmjzgf628y3rscc6rqf55hxgjpmvwxlncfk1216i5xskwp";
   };
 
   patchPhase = ''
@@ -47,6 +47,5 @@ stdenv.mkDerivation rec {
     license = with licenses; gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = with platforms; linux;
-    broken = true;
   };
 }


### PR DESCRIPTION
Port of #83165 to 20.03.

###### Motivation for this change

`openshot-qt` is currently marked as broken

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @AndersonTorres 