### PR TITLE
superTuxKart: use assets directly from download

### DIFF
--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -1,9 +1,15 @@
-{ stdenv, fetchFromGitHub, fetchsvn, cmake, pkgconfig
+{ stdenv, fetchFromGitHub, fetchsvn, cmake, pkgconfig, makeWrapper
 , openal, freealut, libGLU, libGL, libvorbis, libogg, gettext, curl, freetype
 , fribidi, libtool, bluez, libjpeg, libpng, zlib, libX11, libXrandr, enet, harfbuzz }:
 
 let
   dir = "stk-code";
+  assets = fetchsvn {
+    url    = "https://svn.code.sf.net/p/supertuxkart/code/stk-assets";
+    rev    = "18212";
+    sha256 = "1dyj8r5rfifhnhayga8w8irkpa99vw57xjmy74cp8xz8g7zvdzqf";
+    name   = "stk-assets";
+  };
 
 in stdenv.mkDerivation rec {
   pname = "supertuxkart";
@@ -17,15 +23,9 @@ in stdenv.mkDerivation rec {
       sha256 = "01vxxl94583ixswzmi4caz8dk64r56pn3zxh7v63zml60yfvxbvp";
       name   = dir;
     })
-    (fetchsvn {
-      url    = "https://svn.code.sf.net/p/supertuxkart/code/stk-assets";
-      rev    = "18212";
-      sha256 = "1dyj8r5rfifhnhayga8w8irkpa99vw57xjmy74cp8xz8g7zvdzqf";
-      name   = "stk-assets";
-    })
   ];
 
-  nativeBuildInputs = [ cmake gettext libtool pkgconfig ];
+  nativeBuildInputs = [ cmake gettext libtool pkgconfig makeWrapper ];
 
   buildInputs = [
     libX11 libXrandr
@@ -38,7 +38,13 @@ in stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DBUILD_RECORDER=OFF"         # libopenglrecorder is not in nixpkgs
     "-DUSE_SYSTEM_ANGELSCRIPT=OFF" # doesn't work with 2.31.2 or 2.32.0
+    "-DCHECK_ASSETS=OFF"
   ];
+
+  # Obtain the assets directly from the fetched store path, to avoid duplicating assets across multiple engine builds
+  preFixup = ''
+    wrapProgram $out/bin/supertuxkart --set-default SUPERTUXKART_ASSETS_DIR "${assets}"
+  '';
 
   sourceRoot = dir;
 


### PR DESCRIPTION
###### Motivation for this change
This saves copying the assets for each stk build, saving 600MiB each once more than one build is there with the same assets.

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
