### PR TITLE
libxcrypt: init at 4.4.16

### DIFF
--- a/pkgs/development/libraries/libxcrypt/default.nix
+++ b/pkgs/development/libraries/libxcrypt/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "libxcrypt";
+  version = "4.4.16";
+
+  src = fetchFromGitHub {
+    owner = "besser82";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256:1yyn33h9f0w4aahknvpqmzxjxzfhqy6g1d8x6x9wlwbpazx98xx7";
+  };
+
+  preConfigure = ''
+    patchShebangs autogen.sh
+    ./autogen.sh
+  '';
+
+  configureFlags = stdenv.lib.optional stdenv.hostPlatform.isx86 "--enable-fat=yes";
+
+  nativeBuildInputs = [ autoconf automake libtool pkg-config ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Modern library for one-way hashing of passwords";
+    homepage = "https://github.com/besser82/libxcrypt";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ leenaars ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13425,6 +13425,8 @@ in
 
   libx86 = callPackage ../development/libraries/libx86 {};
 
+  libxcrypt = callPackage ../development/libraries/libxcrypt { };
+
   libxdg_basedir = callPackage ../development/libraries/libxdg-basedir { };
 
   libxkbcommon = libxkbcommon_8;


### PR DESCRIPTION
##### Motivation for this change

Useful library that is part of many other distros:
https://repology.org/project/libxcrypt/packages

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
