### PR TITLE
qimgv: 0.9 -> 0.9.1

### DIFF
--- a/pkgs/applications/graphics/qimgv/default.nix
+++ b/pkgs/applications/graphics/qimgv/default.nix
@@ -16,24 +16,14 @@
 
 mkDerivation rec {
   pname = "qimgv";
-  version = "0.9";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "easymodo";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1yynjk47gjf2kjfb0ak4blxpb5irgqc1k59z726lwjd6gvg689fl";
+    sha256 = "0b2hddps969gjim2r9a22zaxmnzp600av2zz6icq66ksfrx1rpac";
   };
-
-  patches = [
-    # QtAtomicInt's `storeRelaxed` was introduced in Qt 5.14, while nixpkgs only
-    # has Qt 5.12. This appears to be the only instance of Qt 5.12
-    # incompatibility, and will be fixed in the next release.
-    (fetchpatch {
-      url = "https://github.com/easymodo/qimgv/commit/a39d6086ceb9445d2c16943e0719096a99920bf8.patch";
-      sha256 = "1z3ngv6i316hrdcdzig4jg6bcdbgfxjaxvm2jcfcw2dnfbfiq47s";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
https://github.com/easymodo/qimgv/compare/v0.9...v0.9.1

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
