### PR TITLE
btrfs-heatmap: init at v8; incl. python.pkgs.btrfs

### DIFF
--- a/pkgs/development/python-modules/btrfs/default.nix
+++ b/pkgs/development/python-modules/btrfs/default.nix
@@ -1,0 +1,22 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "btrfs";
+  version = "11";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1w92sj47wy53ygz725xr613k32pk5khi0g9lrpp6img871241hrx";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Inspect btrfs filesystems";
+    homepage = "https://github.com/knorrie/python-btrfs";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.evils ];
+  };
+}

--- a/pkgs/tools/filesystems/btrfs-heatmap/default.nix
+++ b/pkgs/tools/filesystems/btrfs-heatmap/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, lib
+, fetchFromGitHub
+, python3
+, installShellFiles
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "btrfs-heatmap";
+  version = "8";
+
+  src = fetchFromGitHub {
+    owner = "knorrie";
+    repo = "btrfs-heatmap";
+    rev = "v${version}";
+    sha256 = "035frvk3s7g18y81srssvm550nfq7jylr7w60nvixidxvrc0yrnh";
+  };
+
+  # man page is currently only in the debian branch
+  # https://github.com/knorrie/btrfs-heatmap/issues/11
+  msrc = fetchurl {
+    url = "https://raw.githubusercontent.com/knorrie/btrfs-heatmap/45d844e12d7f5842ebb99e65d7b968a5e1a89066/debian/man/btrfs-heatmap.8";
+    sha256 = "1md7xc426sc8lq4w29gjd6gv7vjqhcwrqqcr6z39kihvi04d5f6q";
+  };
+
+  buildInputs = [ python3 ];
+  nativeBuildInputs = [ python3.pkgs.wrapPython installShellFiles ];
+
+  outputs = [ "out" "man" ];
+
+  installPhase = ''
+    install -Dm 0755 heatmap.py $out/sbin/btrfs-heatmap
+    installManPage ${msrc}
+
+    buildPythonPath ${python3.pkgs.btrfs}
+    patchPythonScript $out/sbin/btrfs-heatmap
+  '';
+
+  meta = with lib; {
+    description = "Visualize the layout of a mounted btrfs";
+    homepage = "https://github.com/knorrie/btrfs-heatmap";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.evils ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -860,6 +860,8 @@ in
 
   boulder = callPackage ../tools/admin/boulder { };
 
+  btrfs-heatmap = callPackage ../tools/filesystems/btrfs-heatmap { };
+
   buildbot = with python3Packages; toPythonApplication buildbot;
   buildbot-ui = with python3Packages; toPythonApplication buildbot-ui;
   buildbot-full = with python3Packages; toPythonApplication buildbot-full;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -557,6 +557,8 @@ in {
 
   browsermob-proxy = disabledIf isPy3k (callPackage ../development/python-modules/browsermob-proxy {});
 
+  btrfs = callPackage ../development/python-modules/btrfs { };
+
   bt_proximity = callPackage ../development/python-modules/bt-proximity { };
 
   bugseverywhere = throw "bugseverywhere has been removed: Abandoned by upstream."; # Added 2019-11-27


### PR DESCRIPTION
###### Motivation for this change
pretty pictures
![cruft](https://user-images.githubusercontent.com/30512529/81026192-8dd5af80-8e79-11ea-919d-01277dcb1f1a.png)


###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `/nix/store/icvlas78f6xanwl8fv4fsf9g0932gm91-btrfs-heatmap-8-1	  106812480`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
