### PR TITLE
python3Packages.dicom2nifti: init at 2.2.8

### DIFF
--- a/pkgs/development/python-modules/dicom2nifti/default.nix
+++ b/pkgs/development/python-modules/dicom2nifti/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, gdcm
+, nose
+, nibabel
+, numpy
+, pydicom
+, scipy
+}:
+
+buildPythonPackage rec {
+  pname = "dicom2nifti";
+  version = "2.2.8";
+  disabled = isPy27;
+
+  # no tests in PyPI dist
+  src = fetchFromGitHub {
+    owner = "icometrix";
+    repo = pname;
+    rev = version;
+    sha256 = "1qi2map6f4pa1l8wsif7ff7rhja6ynrjlm7w306dzvi9l25mia34";
+  };
+
+  propagatedBuildInputs = [ gdcm nibabel numpy pydicom scipy ];
+
+  checkInputs = [ nose gdcm ];
+  checkPhase = "nosetests tests";
+
+  meta = with lib; {
+    homepage = "https://github.com/icometrix/dicom2nifti";
+    description = "Library for converting dicom files to nifti";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -676,6 +676,8 @@ in {
 
   dftfit = callPackage ../development/python-modules/dftfit { };
 
+  dicom2nifti = callPackage ../development/python-modules/dicom2nifti { };
+
   discid = callPackage ../development/python-modules/discid { };
 
   discordpy = callPackage ../development/python-modules/discordpy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
