### PR TITLE
koreader: init at 2020.09

### DIFF
--- a/pkgs/applications/misc/koreader/default.nix
+++ b/pkgs/applications/misc/koreader/default.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, fetchurl
+, makeWrapper
+, dpkg
+, luajit
+, gtk3-x11
+, SDL2
+, glib
+, noto-fonts
+, nerdfonts }:
+let font-droid = nerdfonts.override { fonts = [ "DroidSansMono" ]; };
+in stdenv.mkDerivation rec {
+  pname = "koreader";
+  version = "2020.09";
+
+  src = fetchurl {
+    url =
+      "https://github.com/koreader/koreader/releases/download/v${version}/koreader-${version}-amd64.deb";
+    sha256 = "12kiw3mw8g8d9fb8ywd4clm2bgblhq2gqcxzadwpmf0wxq7p0v8z";
+  };
+
+  sourceRoot = ".";
+  nativeBuildInputs = [ makeWrapper dpkg ];
+  buildInputs = [ luajit gtk3-x11 SDL2 glib ];
+  unpackCmd = "dpkg-deb -x ${src} .";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R usr/* $out/
+    cp ${luajit}/bin/luajit $out/lib/koreader/luajit
+    find $out -xtype l -delete
+    for i in ${noto-fonts}/share/fonts/truetype/noto/*; do
+        ln -s "$i" $out/lib/koreader/fonts/noto/
+    done
+    ln -s "${font-droid}/share/fonts/opentype/NerdFonts/Droid Sans Mono Nerd Font Complete Mono.otf" $out/lib/koreader/fonts/droid/DroidSansMono.ttf
+    wrapProgram $out/bin/koreader --prefix LD_LIBRARY_PATH : ${
+      stdenv.lib.makeLibraryPath [ gtk3-x11 SDL2 glib ]
+    }
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/koreader/koreader";
+    description =
+      "An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats, running on Cervantes, Kindle, Kobo, PocketBook and Android devices";
+    platforms = intersectLists platforms.x86_64 platforms.linux;
+    license = licenses.agpl3;
+    maintainers = [ maintainers.contrun ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19053,6 +19053,8 @@ in
 
   kopia = callPackage ../tools/backup/kopia { };
 
+  koreader = callPackage ../applications/misc/koreader {};
+
   lato = callPackage ../data/fonts/lato {};
 
   league-of-moveable-type = callPackage ../data/fonts/league-of-moveable-type {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).



I am currently unable to build the binary from source code. Instead, I used the debian package upstream provided. I don't know what is the equivalent platforms for the upstream provide arm package. I only packaged the x86_64 version.