### PR TITLE
libjpeg_turbo: fix race in tests

### DIFF
--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, nasm, enableStatic ? false }:
+{ stdenv, fetchurl, fetchpatch, cmake, nasm, enableStatic ? false }:
 
 stdenv.mkDerivation rec {
 
@@ -11,6 +11,14 @@ stdenv.mkDerivation rec {
   };
 
   patches =
+    [
+      # Fixes race in tests that causes "jpegtran-shared-icc" to fail
+      # https://github.com/libjpeg-turbo/libjpeg-turbo/pull/425
+      (fetchpatch {
+        url = "https://github.com/libjpeg-turbo/libjpeg-turbo/commit/a2291b252de1413a13db61b21863ae7aea0946f3.patch";
+        sha256 = "0nc5vcch5h52gpi07h08zf8br58q8x81q2hv871hrn0dinb53vym";
+      })
+    ] ++
     stdenv.lib.optional (stdenv.hostPlatform.libc or null == "msvcrt")
       ./mingw-boolean.patch;
 


### PR DESCRIPTION
###### Motivation for this change

Fixes:

```
12/151 Test  #46: jpegtran-shared-icc ...............................***Failed    0.03 sec
Premature end of JPEG file
JPEG datastream contains no image

63/151 Test  #47: jpegtran-shared-icc-cmp ...........................***Failed    0.12 sec
Could not obtain MD5 sum: No such file or directory

The following tests FAILED:
         46 - jpegtran-shared-icc (Failed)
         47 - jpegtran-shared-icc-cmp (Failed)
```

Example build: https://hydra.nixos.org/build/117594627


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
