### PR TITLE
mariadb: 10.3.22 -> 10.4.12

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -61,6 +61,28 @@
       This is to make it possible to use <literal>podman</literal> instead of <literal>docker</literal>.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      MariaDB has been updated to 10.4, MariaDB Galera to 26.4.
+      Before you upgrade, it would be best to take a backup of your database.
+      For MariaDB Galera Cluster, see <link xlink:href="https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104-with-galera-cluster/">Upgrading
+      from MariaDB 10.3 to MariaDB 10.4 with Galera Cluster</link> instead.
+      Before doing the upgrade read <link xlink:href="https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#incompatible-changes-between-103-and-104">Incompatible
+      Changes Between 10.3 and 10.4</link>.
+      After the upgrade you will need to run <literal>mysql_upgrade</literal>.
+      MariaDB 10.4 introduces a number of changes to the authentication process, intended to make things easier and more
+      intuitive. See <link xlink:href="https://mariadb.com/kb/en/authentication-from-mariadb-104/">Authentication from MariaDB 10.4</link>.
+      unix_socket auth plugin does not use a password, and uses the connecting user's UID instead. When a new MariaDB data directory is initialized, two MariaDB users are
+      created and can be used with new unix_socket auth plugin, as well as traditional mysql_native_password plugin: root@localhost and mysql@localhost. To actually use 
+      the traditional mysql_native_password plugin method, one must run the following:
+<programlisting>
+services.mysql.initialScript = pkgs.writeText "mariadb-init.sql" ''
+  ALTER USER root@localhost IDENTIFIED VIA mysql_native_password USING PASSWORD("verysecret");
+'';
+</programlisting>
+      When MariaDB data directory is just upgraded (not initialized), the users are not created or modified.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -320,6 +320,7 @@ in
         log-bin-index = "mysql-bin-${toString cfg.replication.serverId}.index";
         relay-log = "mysql-relay-bin";
         server-id = cfg.replication.serverId;
+        binlog-ignore-db = [ "information_schema" "performance_schema" "mysql" ];
       })
       (mkIf (!isMariaDB) {
         plugin-load-add = optional (cfg.ensureUsers != []) "auth_socket.so";
@@ -445,7 +446,6 @@ in
 
                         ( echo "stop slave;"
                           echo "change master to master_host='${cfg.replication.masterHost}', master_user='${cfg.replication.masterUser}', master_password='${cfg.replication.masterPassword}';"
-                          echo "set global slave_exec_mode='IDEMPOTENT';"
                           echo "start slave;"
                         ) | ${mysql}/bin/mysql -u root -N
                       ''}

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -87,7 +87,6 @@ in
             datadir = /var/lib/mysql
             bind-address = 127.0.0.1
             port = 3336
-            plugin-load-add = auth_socket.so
 
             !includedir /etc/mysql/conf.d/
           ''';
@@ -315,13 +314,15 @@ in
         datadir = cfg.dataDir;
         bind-address = mkIf (cfg.bind != null) cfg.bind;
         port = cfg.port;
-        plugin-load-add = optional (cfg.ensureUsers != []) "auth_socket.so";
       }
       (mkIf (cfg.replication.role == "master" || cfg.replication.role == "slave") {
         log-bin = "mysql-bin-${toString cfg.replication.serverId}";
         log-bin-index = "mysql-bin-${toString cfg.replication.serverId}.index";
         relay-log = "mysql-relay-bin";
         server-id = cfg.replication.serverId;
+      })
+      (mkIf (!isMariaDB) {
+        plugin-load-add = optional (cfg.ensureUsers != []) "auth_socket.so";
       })
     ];
 

--- a/nixos/tests/mysql/mariadb-galera-mariabackup.nix
+++ b/nixos/tests/mysql/mariadb-galera-mariabackup.nix
@@ -55,7 +55,7 @@ in {
           };
           galera = {
             wsrep_on = "ON";
-            wsrep_debug = "OFF";
+            wsrep_debug = "NONE";
             wsrep_retry_autocommit = "3";
             wsrep_provider = "${pkgs.mariadb-galera}/lib/galera/libgalera_smm.so";
             wsrep_cluster_address = "gcomm://";
@@ -102,7 +102,7 @@ in {
           };
           galera = {
             wsrep_on = "ON";
-            wsrep_debug = "OFF";
+            wsrep_debug = "NONE";
             wsrep_retry_autocommit = "3";
             wsrep_provider = "${pkgs.mariadb-galera}/lib/galera/libgalera_smm.so";
             wsrep_cluster_address = "gcomm://galera_01,galera_02,galera_03";
@@ -149,7 +149,7 @@ in {
           };
           galera = {
             wsrep_on = "ON";
-            wsrep_debug = "OFF";
+            wsrep_debug = "NONE";
             wsrep_retry_autocommit = "3";
             wsrep_provider = "${pkgs.mariadb-galera}/lib/galera/libgalera_smm.so";
             wsrep_cluster_address = "gcomm://galera_01,galera_02,galera_03";
@@ -184,17 +184,17 @@ in {
     galera_03.wait_for_unit("mysql")
     galera_03.wait_for_open_port(3306)
     galera_02.succeed(
-        "sudo -u testuser mysql -u root -e 'use testdb; select test_id from db1;' -N | grep 37"
+        "sudo -u testuser mysql -u testuser -e 'use testdb; select test_id from db1;' -N | grep 37"
     )
     galera_02.succeed(
-        "sudo -u testuser mysql -u root -e 'use testdb; create table db2 (test_id INT, PRIMARY KEY (test_id)) ENGINE = InnoDB;'"
+        "sudo -u testuser mysql -u testuser -e 'use testdb; create table db2 (test_id INT, PRIMARY KEY (test_id)) ENGINE = InnoDB;'"
     )
     galera_02.succeed("systemctl stop mysql")
     galera_01.succeed(
         "sudo -u testuser mysql -u testuser -e 'use testdb; insert into db2 values (38);'"
     )
     galera_03.succeed(
-        "sudo -u testuser mysql -u root -e 'use testdb; create table db3 (test_id INT, PRIMARY KEY (test_id)) ENGINE = InnoDB;'"
+        "sudo -u testuser mysql -u testuser -e 'use testdb; create table db3 (test_id INT, PRIMARY KEY (test_id)) ENGINE = InnoDB;'"
     )
     galera_01.succeed(
         "sudo -u testuser mysql -u testuser -e 'use testdb; insert into db3 values (39);'"
@@ -202,22 +202,22 @@ in {
     galera_02.succeed("systemctl start mysql")
     galera_02.wait_for_open_port(3306)
     galera_02.succeed(
-        "sudo -u testuser mysql -u root -e 'show status' -N | grep 'wsrep_cluster_size.*3'"
+        "sudo -u testuser mysql -u testuser -e 'show status' -N | grep 'wsrep_cluster_size.*3'"
     )
     galera_03.succeed(
-        "sudo -u testuser mysql -u root -e 'show status' -N | grep 'wsrep_local_state_comment.*Synced'"
+        "sudo -u testuser mysql -u testuser -e 'show status' -N | grep 'wsrep_local_state_comment.*Synced'"
     )
     galera_01.succeed(
-        "sudo -u testuser mysql -u root -e 'use testdb; select test_id from db3;' -N | grep 39"
+        "sudo -u testuser mysql -u testuser -e 'use testdb; select test_id from db3;' -N | grep 39"
     )
     galera_02.succeed(
-        "sudo -u testuser mysql -u root -e 'use testdb; select test_id from db2;' -N | grep 38"
+        "sudo -u testuser mysql -u testuser -e 'use testdb; select test_id from db2;' -N | grep 38"
     )
     galera_03.succeed(
-        "sudo -u testuser mysql -u root -e 'use testdb; select test_id from db1;' -N | grep 37"
+        "sudo -u testuser mysql -u testuser -e 'use testdb; select test_id from db1;' -N | grep 37"
     )
     galera_01.succeed("sudo -u testuser mysql -u testuser -e 'use testdb; drop table db3;'")
-    galera_02.succeed("sudo -u testuser mysql -u root -e 'use testdb; drop table db2;'")
-    galera_03.succeed("sudo -u testuser mysql -u root -e 'use testdb; drop table db1;'")
+    galera_02.succeed("sudo -u testuser mysql -u testuser -e 'use testdb; drop table db2;'")
+    galera_03.succeed("sudo -u testuser mysql -u testuser -e 'use testdb; drop table db1;'")
   '';
 })

--- a/nixos/tests/mysql/mariadb-galera-mariabackup.nix
+++ b/nixos/tests/mysql/mariadb-galera-mariabackup.nix
@@ -57,7 +57,7 @@ in {
             wsrep_on = "ON";
             wsrep_debug = "OFF";
             wsrep_retry_autocommit = "3";
-            wsrep_provider = "${pkgs.mariadb-galera_25}/lib/galera/libgalera_smm.so";
+            wsrep_provider = "${pkgs.mariadb-galera}/lib/galera/libgalera_smm.so";
             wsrep_cluster_address = "gcomm://";
             wsrep_cluster_name = "galera";
             wsrep_node_address = "192.168.1.1";
@@ -104,7 +104,7 @@ in {
             wsrep_on = "ON";
             wsrep_debug = "OFF";
             wsrep_retry_autocommit = "3";
-            wsrep_provider = "${pkgs.mariadb-galera_25}/lib/galera/libgalera_smm.so";
+            wsrep_provider = "${pkgs.mariadb-galera}/lib/galera/libgalera_smm.so";
             wsrep_cluster_address = "gcomm://galera_01,galera_02,galera_03";
             wsrep_cluster_name = "galera";
             wsrep_node_address = "192.168.1.2";
@@ -151,7 +151,7 @@ in {
             wsrep_on = "ON";
             wsrep_debug = "OFF";
             wsrep_retry_autocommit = "3";
-            wsrep_provider = "${pkgs.mariadb-galera_25}/lib/galera/libgalera_smm.so";
+            wsrep_provider = "${pkgs.mariadb-galera}/lib/galera/libgalera_smm.so";
             wsrep_cluster_address = "gcomm://galera_01,galera_02,galera_03";
             wsrep_cluster_name = "galera";
             wsrep_node_address = "192.168.1.3";

--- a/nixos/tests/mysql/mariadb-galera-rsync.nix
+++ b/nixos/tests/mysql/mariadb-galera-rsync.nix
@@ -51,7 +51,7 @@ in {
           };
           galera = {
             wsrep_on = "ON";
-            wsrep_debug = "OFF";
+            wsrep_debug = "NONE";
             wsrep_retry_autocommit = "3";
             wsrep_provider = "${pkgs.mariadb-galera}/lib/galera/libgalera_smm.so";
             wsrep_cluster_address = "gcomm://";
@@ -97,7 +97,7 @@ in {
           };
           galera = {
             wsrep_on = "ON";
-            wsrep_debug = "OFF";
+            wsrep_debug = "NONE";
             wsrep_retry_autocommit = "3";
             wsrep_provider = "${pkgs.mariadb-galera}/lib/galera/libgalera_smm.so";
             wsrep_cluster_address = "gcomm://galera_04,galera_05,galera_06";
@@ -143,7 +143,7 @@ in {
           };
           galera = {
             wsrep_on = "ON";
-            wsrep_debug = "OFF";
+            wsrep_debug = "NONE";
             wsrep_retry_autocommit = "3";
             wsrep_provider = "${pkgs.mariadb-galera}/lib/galera/libgalera_smm.so";
             wsrep_cluster_address = "gcomm://galera_04,galera_05,galera_06";
@@ -177,17 +177,17 @@ in {
     galera_06.wait_for_unit("mysql")
     galera_06.wait_for_open_port(3306)
     galera_05.succeed(
-        "sudo -u testuser mysql -u root -e 'use testdb; select test_id from db1;' -N | grep 41"
+        "sudo -u testuser mysql -u testuser -e 'use testdb; select test_id from db1;' -N | grep 41"
     )
     galera_05.succeed(
-        "sudo -u testuser mysql -u root -e 'use testdb; create table db2 (test_id INT, PRIMARY KEY (test_id)) ENGINE = InnoDB;'"
+        "sudo -u testuser mysql -u testuser -e 'use testdb; create table db2 (test_id INT, PRIMARY KEY (test_id)) ENGINE = InnoDB;'"
     )
     galera_05.succeed("systemctl stop mysql")
     galera_04.succeed(
         "sudo -u testuser mysql -u testuser -e 'use testdb; insert into db2 values (42);'"
     )
     galera_06.succeed(
-        "sudo -u testuser mysql -u root -e 'use testdb; create table db3 (test_id INT, PRIMARY KEY (test_id)) ENGINE = InnoDB;'"
+        "sudo -u testuser mysql -u testuser -e 'use testdb; create table db3 (test_id INT, PRIMARY KEY (test_id)) ENGINE = InnoDB;'"
     )
     galera_04.succeed(
         "sudo -u testuser mysql -u testuser -e 'use testdb; insert into db3 values (43);'"
@@ -195,22 +195,22 @@ in {
     galera_05.succeed("systemctl start mysql")
     galera_05.wait_for_open_port(3306)
     galera_05.succeed(
-        "sudo -u testuser mysql -u root -e 'show status' -N | grep 'wsrep_cluster_size.*3'"
+        "sudo -u testuser mysql -u testuser -e 'show status' -N | grep 'wsrep_cluster_size.*3'"
     )
     galera_06.succeed(
-        "sudo -u testuser mysql -u root -e 'show status' -N | grep 'wsrep_local_state_comment.*Synced'"
+        "sudo -u testuser mysql -u testuser -e 'show status' -N | grep 'wsrep_local_state_comment.*Synced'"
     )
     galera_04.succeed(
-        "sudo -u testuser mysql -u root -e 'use testdb; select test_id from db3;' -N | grep 43"
+        "sudo -u testuser mysql -u testuser -e 'use testdb; select test_id from db3;' -N | grep 43"
     )
     galera_05.succeed(
-        "sudo -u testuser mysql -u root -e 'use testdb; select test_id from db2;' -N | grep 42"
+        "sudo -u testuser mysql -u testuser -e 'use testdb; select test_id from db2;' -N | grep 42"
     )
     galera_06.succeed(
-        "sudo -u testuser mysql -u root -e 'use testdb; select test_id from db1;' -N | grep 41"
+        "sudo -u testuser mysql -u testuser -e 'use testdb; select test_id from db1;' -N | grep 41"
     )
     galera_04.succeed("sudo -u testuser mysql -u testuser -e 'use testdb; drop table db3;'")
-    galera_05.succeed("sudo -u testuser mysql -u root -e 'use testdb; drop table db2;'")
-    galera_06.succeed("sudo -u testuser mysql -u root -e 'use testdb; drop table db1;'")
+    galera_05.succeed("sudo -u testuser mysql -u testuser -e 'use testdb; drop table db2;'")
+    galera_06.succeed("sudo -u testuser mysql -u testuser -e 'use testdb; drop table db1;'")
   '';
 })

--- a/nixos/tests/mysql/mariadb-galera-rsync.nix
+++ b/nixos/tests/mysql/mariadb-galera-rsync.nix
@@ -53,7 +53,7 @@ in {
             wsrep_on = "ON";
             wsrep_debug = "OFF";
             wsrep_retry_autocommit = "3";
-            wsrep_provider = "${pkgs.mariadb-galera_25}/lib/galera/libgalera_smm.so";
+            wsrep_provider = "${pkgs.mariadb-galera}/lib/galera/libgalera_smm.so";
             wsrep_cluster_address = "gcomm://";
             wsrep_cluster_name = "galera-rsync";
             wsrep_node_address = "192.168.2.1";
@@ -99,7 +99,7 @@ in {
             wsrep_on = "ON";
             wsrep_debug = "OFF";
             wsrep_retry_autocommit = "3";
-            wsrep_provider = "${pkgs.mariadb-galera_25}/lib/galera/libgalera_smm.so";
+            wsrep_provider = "${pkgs.mariadb-galera}/lib/galera/libgalera_smm.so";
             wsrep_cluster_address = "gcomm://galera_04,galera_05,galera_06";
             wsrep_cluster_name = "galera-rsync";
             wsrep_node_address = "192.168.2.2";
@@ -145,7 +145,7 @@ in {
             wsrep_on = "ON";
             wsrep_debug = "OFF";
             wsrep_retry_autocommit = "3";
-            wsrep_provider = "${pkgs.mariadb-galera_25}/lib/galera/libgalera_smm.so";
+            wsrep_provider = "${pkgs.mariadb-galera}/lib/galera/libgalera_smm.so";
             wsrep_cluster_address = "gcomm://galera_04,galera_05,galera_06";
             wsrep_cluster_name = "galera-rsync";
             wsrep_node_address = "192.168.2.3";

--- a/nixos/tests/mysql/mysql-replication.nix
+++ b/nixos/tests/mysql/mysql-replication.nix
@@ -59,7 +59,7 @@ in
     master.wait_for_open_port(3306)
     # Wait for testdb to be fully populated (5 rows).
     master.wait_until_succeeds(
-        "mysql -u root -D testdb -N -B -e 'select count(id) from tests' | grep -q 5"
+        "sudo -u mysql mysql -u mysql -D testdb -N -B -e 'select count(id) from tests' | grep -q 5"
     )
 
     slave1.start()
@@ -71,19 +71,21 @@ in
 
     # wait for replications to finish
     slave1.wait_until_succeeds(
-        "mysql -u root -D testdb -N -B -e 'select count(id) from tests' | grep -q 5"
+        "sudo -u mysql mysql -u mysql -D testdb -N -B -e 'select count(id) from tests' | grep -q 5"
     )
     slave2.wait_until_succeeds(
-        "mysql -u root -D testdb -N -B -e 'select count(id) from tests' | grep -q 5"
+        "sudo -u mysql mysql -u mysql -D testdb -N -B -e 'select count(id) from tests' | grep -q 5"
     )
 
     slave2.succeed("systemctl stop mysql")
-    master.succeed("echo 'insert into testdb.tests values (123, 456);' | mysql -u root -N")
+    master.succeed(
+        "echo 'insert into testdb.tests values (123, 456);' | sudo -u mysql mysql -u mysql -N"
+    )
     slave2.succeed("systemctl start mysql")
     slave2.wait_for_unit("mysql")
     slave2.wait_for_open_port(3306)
     slave2.wait_until_succeeds(
-        "echo 'select * from testdb.tests where Id = 123;' | mysql -u root -N | grep 456"
+        "echo 'select * from testdb.tests where Id = 123;' | sudo -u mysql mysql -u mysql -N | grep 456"
     )
   '';
 })

--- a/pkgs/servers/sql/mariadb/cmake-disable-auth-pam-testing.patch
+++ b/pkgs/servers/sql/mariadb/cmake-disable-auth-pam-testing.patch
@@ -1,0 +1,12 @@
+diff --git a/plugin/auth_pam/CMakeLists.txt b/plugin/auth_pam/CMakeLists.txt
+index a556b870..918a26f9 100644
+--- a/plugin/auth_pam/CMakeLists.txt
++++ b/plugin/auth_pam/CMakeLists.txt
+@@ -22,7 +22,6 @@ IF(HAVE_PAM_APPL_H)
+                    COMPONENT Server)
+   ENDIF()
+   IF(TARGET auth_pam OR TARGET auth_pam_v1)
+-    ADD_SUBDIRECTORY(testing)
+     ADD_LIBRARY(pam_user_map MODULE mapper/pam_user_map.c)
+     TARGET_LINK_LIBRARIES(pam_user_map pam)
+     SET_TARGET_PROPERTIES (pam_user_map PROPERTIES PREFIX "")

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -23,14 +23,14 @@ mariadb = server // {
 };
 
 common = rec { # attributes common to both builds
-  version = "10.3.22";
+  version = "10.4.12";
 
   src = fetchurl {
     urls = [
       "https://downloads.mariadb.org/f/mariadb-${version}/source/mariadb-${version}.tar.gz"
       "https://downloads.mariadb.com/MariaDB/mariadb-${version}/source/mariadb-${version}.tar.gz"
     ];
-    sha256 = "1iyf1hl82nqsci5h327a537rvdrc5qcbrd1v3fc4cxy2pmfha01j";
+    sha256 = "0252b9rxxz1ljjv6ni0wwgy14j8qmmdd2sq0a65dslx2ib9y3wgy";
     name   = "mariadb-${version}.tar.gz";
   };
 
@@ -111,7 +111,6 @@ common = rec { # attributes common to both builds
   };
 
   meta = {
-
     description = "An enhanced, drop-in replacement for MySQL";
     homepage    = "https://mariadb.org/";
     license     = licenses.gpl2;
@@ -161,7 +160,10 @@ server = stdenv.mkDerivation (common // {
     ++ optional stdenv.hostPlatform.isLinux linux-pam
     ++ optional (!stdenv.hostPlatform.isDarwin) mytopEnv;
 
-  patches = common.patches ++ optionals stdenv.hostPlatform.isDarwin [
+  patches = common.patches ++ [
+    # Disable build unused plugin pam_mariadb_mtr.so. See https://jira.mariadb.org/browse/MDEV-21654
+    ./cmake-disable-auth-pam-testing.patch
+  ] ++ optionals stdenv.hostPlatform.isDarwin [
     ./cmake-without-plugin-auth-pam.patch
   ];
 
@@ -198,7 +200,7 @@ server = stdenv.mkDerivation (common // {
 
   postInstall = common.postInstall + ''
     chmod +x "$out"/bin/wsrep_sst_common
-    rm "$out"/bin/{mysql_client_test,mysqltest}
+    rm "$out"/bin/{mariadb-client-test,mariadb-test,mysql_client_test,mysqltest}
     rm -r "$out"/data # Don't need testing data
   '' + optionalString withStorageMroonga ''
     mv "$out"/share/{groonga,groonga-normalizer-mysql} "$out"/share/doc/mysql

--- a/pkgs/servers/sql/mariadb/galera/25.nix
+++ b/pkgs/servers/sql/mariadb/galera/25.nix
@@ -1,6 +1,0 @@
-{ callPackage, ... } @ args:
-
-callPackage ./. (args // {
-  version = "25.3.27";
-  sha256 = "143kzj0fmak1gdww4qkqmmliw8klxm6mwk5531748swlwm6gqr5q";
-})

--- a/pkgs/servers/sql/mariadb/galera/default.nix
+++ b/pkgs/servers/sql/mariadb/galera/default.nix
@@ -1,24 +1,22 @@
 { stdenv, fetchFromGitHub, buildEnv
 , asio, boost, check, openssl, scons
-, version, sha256, ...
 }:
 
 let
-  pname = "mariadb-galera";
   galeraLibs = buildEnv {
     name = "galera-lib-inputs-united";
     paths = [ openssl.out boost check ];
   };
 
-in stdenv.mkDerivation {
-  inherit pname;
-  inherit version;
+in stdenv.mkDerivation rec {
+  pname = "mariadb-galera";
+  version = "26.4.3";
 
   src = fetchFromGitHub {
     owner = "codership";
     repo = "galera";
     rev = "release_${version}";
-    inherit sha256;
+    sha256 = "1r0b4kxgqrivnwm4hprnpscb16v6l6j8cnvk4i8c64fig1ly8g3j";
     fetchSubmodules = true;
   };
 
@@ -40,7 +38,7 @@ in stdenv.mkDerivation {
 
   installPhase = ''
     # copied with modifications from scripts/packages/freebsd.sh
-    GALERA_LICENSE_DIR="$share/licenses/${pname}"
+    GALERA_LICENSE_DIR="$share/licenses/${pname}-${version}"
     install -d $out/{bin,lib/galera,share/doc/galera,$GALERA_LICENSE_DIR}
     install -m 555 "garb/garbd"                       "$out/bin/garbd"
     install -m 444 "libgalera_smm.so"                 "$out/lib/galera/libgalera_smm.so"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15926,12 +15926,14 @@ in
     inherit (darwin) cctools developer_cmds;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
     boost = boost159;
+    protobuf = protobuf3_7;
   };
 
   mysql80 = callPackage ../servers/sql/mysql/8.0.x.nix {
     inherit (darwin) cctools developer_cmds;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
     boost = boost169; # Configure checks for specific version.
+    protobuf = protobuf3_7;
   };
 
   mysql_jdbc = callPackage ../servers/sql/mysql/jdbc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15865,8 +15865,7 @@ in
   mariadb-connector-c = mariadb-connector-c_3_1;
   mariadb-connector-c_3_1 = callPackage ../servers/sql/mariadb/connector-c/3_1.nix { };
 
-  mariadb-galera = mariadb-galera_25;
-  mariadb-galera_25 = callPackage ../servers/sql/mariadb/galera/25.nix {
+  mariadb-galera = callPackage ../servers/sql/mariadb/galera {
     asio = asio_1_10;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Upgrade MariaDB server to 10.4.12

cc @thoughtpolice @flokli @aanderse @dasJ
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
