### PR TITLE
frozen-bubble: install desktop file

### DIFF
--- a/pkgs/games/frozen-bubble/default.nix
+++ b/pkgs/games/frozen-bubble/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, perlPackages, pkg-config, SDL, SDL_mixer, SDL_Pango, glib }:
+{ lib, makeDesktopItem, copyDesktopItems, fetchurl, perlPackages, pkgconfig, SDL, SDL_mixer, SDL_Pango, glib }:
 
 perlPackages.buildPerlModule {
   pname = "frozen-bubble";
@@ -10,16 +10,31 @@ perlPackages.buildPerlModule {
   };
   patches = [ ./fix-compilation.patch ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkgconfig copyDesktopItems ];
 
   buildInputs =  [ glib SDL SDL_mixer SDL_Pango perlPackages.SDL perlPackages.FileSlurp ];
   propagatedBuildInputs = with perlPackages; [ AlienSDL CompressBzip2 FileShareDir FileWhich IPCSystemSimple LocaleMaketextLexicon ];
 
   perlPreHook = "export LD=$CC";
 
-  meta = {
+  desktopItems = [ (makeDesktopItem {
+    name = "frozen-bubble";
+    exec = "frozen-bubble";
+    icon = "frozen-bubble";
+    desktopName = "Frozen Bubble";
+    comment     = "Pop out the bubbles!";
+    categories  = "Game;ArcadeGame;";
+  }) ];
+
+  postInstall = ''
+    for size in 16x16 32x32 48x48 64x64; do
+      install -Dm644 share/icons/frozen-bubble-icon-$size.png $out/share/icons/hicolor/$size/apps/frozen-bubble.png
+    done
+  '';
+
+  meta = with lib; {
     description = "Puzzle with Bubbles";
-    license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ puckipedia ];
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ puckipedia ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Thank you, @puckipedia, for maintaining Frozen Bubble in nixpkgs! This pull request just adds a desktop file (lifted from Debian) together with appropriate icons (which are already part of the upstream package).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
