### PR TITLE
python3Packages.toggl-cli: relax click version dependency

### DIFF
--- a/pkgs/development/python-modules/toggl-cli/default.nix
+++ b/pkgs/development/python-modules/toggl-cli/default.nix
@@ -19,6 +19,7 @@ buildPythonPackage rec {
    substituteInPlace requirements.txt \
      --replace "pendulum==2.0.4" "pendulum>=2.0.4" \
      --replace "click-completion==0.5.0" "click-completion>=0.5.0" \
+     --replace "click==7.0" "click>=7.0" \
      --replace "pbr==5.1.2" "pbr>=5.1.2" \
      --replace "inquirer==2.5.1" "inquirer>=2.5.1"
   '';


### PR DESCRIPTION
fixes build problem by substituting click==7.0 with click>=7.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
