### PR TITLE
gnomeExtensions.window-is-ready-remover unstable-2020-03-25 -> 1.02

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/window-is-ready-remover/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/window-is-ready-remover/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-window-is-ready-remover";
-  version = "unstable-2020-03-25";
+  version = "1.02";
 
   src = fetchFromGitHub {
     owner = "nunofarruca";
     repo = "WindowIsReady_Remover";
-    rev = "a9f9b3a060a6ba8eec71332f39dc2569b6e93761";
-    sha256 = "0l6cg9kz2plbvsqhgwfajknzw9yv3mg9gxdbsk147gbh2arnp6v3";
+    rev = "v${version}";
+    sha256 = "1xaf95gn0if44avvkjxyf8fl29y28idn9shnrks0m9k67jcwv8ns";
   };
 
   uuid = "windowIsReady_Remover@nunofarruca@gmail.com";
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "GNOME Shell extension removing window is ready notification";
     homepage = "https://github.com/nunofarruca/WindowIsReady_Remover";
-    license = licenses.unfree;
+    license = licenses.asl20;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upstream added license and started to use tags.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
