### PR TITLE
exoscale-cli: init at 1.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2038,6 +2038,12 @@
     githubId = 108501;
     name = "David Pflug";
   };
+  dramaturg = {
+    email = "seb@ds.ag";
+    github = "dramaturg";
+    githubId = 472846;
+    name = "Sebastian Krohn";
+  };
   drets = {
     email = "dmitryrets@gmail.com";
     github = "drets";

--- a/pkgs/tools/admin/exoscale-cli/default.nix
+++ b/pkgs/tools/admin/exoscale-cli/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildGo114Package, fetchFromGitHub }:
+
+buildGo114Package rec {
+  pname = "exoscale-cli";
+  version = "1.12.0";
+
+  src = fetchFromGitHub {
+    owner  = "exoscale";
+    repo   = "cli";
+    rev    = "v${version}";
+    sha256 = "04ym7mfv565icj3lmd2nrvq9asawwmmzg09681pj9py61ws56bxr";
+  };
+
+  goPackagePath = "github.com/exoscale/cli";
+  goDeps = ./deps.nix;
+
+  # ensures only the cli binary is built and we don't clutter bin/ with submodules
+  subPackages = [ "." ];
+
+  # we need to rename the resulting binary but can't use buildFlags with -o here
+  # because these are passed to "go install" which does not recognize -o
+  postBuild = ''
+    mv go/bin/cli go/bin/exo
+  '';
+
+  meta = {
+    description = "Command-line tool for everything at Exoscale: compute, storage, dns";
+    homepage    = "https://github.com/exoscale/cli";
+    license     = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [ dramaturg ];
+  };
+}

--- a/pkgs/tools/admin/exoscale-cli/deps.nix
+++ b/pkgs/tools/admin/exoscale-cli/deps.nix
@@ -1,0 +1,876 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev = "v0.3.1";
+      sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
+    };
+  }
+  {
+    goPackagePath = "github.com/VividCortex/ewma";
+    fetch = {
+      type = "git";
+      url = "https://github.com/VividCortex/ewma";
+      rev = "v1.1.1";
+      sha256 = "14v2dy5gqchjn7k0sd6cx59ms42v681r6xz7cb1kspp4b28a74rw";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/assert";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/assert";
+      rev = "405dbfeb8e38";
+      sha256 = "1l567pi17k593nrd1qlbmiq8z9jy3qs60px2a16fdpzjsizwqx8l";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/chroma";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/chroma";
+      rev = "v0.6.2";
+      sha256 = "1bcppy1s148iikr78qjm0akahn01ywh83a8pw544prr9yc16jvmz";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/colour";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/colour";
+      rev = "60882d9e2721";
+      sha256 = "0iq566534gbzkd16ixg7fk298wd766821vvs80838yifx9yml5vs";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/gometalinter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/gometalinter";
+      rev = "v2.0.11";
+      sha256 = "08p7bwvhpgizif8qi59m8mm3mcny70x9msbk8m8vjpphsq55wha4";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/kong";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/kong";
+      rev = "v0.1.15";
+      sha256 = "1llxabcdzlb2hard0h931knqkdnyjyz8dp3k0nli0m0mags7l31b";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/repr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/repr";
+      rev = "117648cd9897";
+      sha256 = "05v1rgzdqc8razf702laagrvhvx68xd9yxxmzd3dyz0d6425pdrp";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/units";
+      rev = "2efee857e7cf";
+      sha256 = "1j65b91qb9sbrml9cpabfrcf07wmgzzghrl7809hjjhrmbzri5bl";
+    };
+  }
+  {
+    goPackagePath = "github.com/armon/consul-api";
+    fetch = {
+      type = "git";
+      url = "https://github.com/armon/consul-api";
+      rev = "eb2c6b5be1b6";
+      sha256 = "1j6fdr1sg36qy4n4xjl7brq739fpm5npq98cmvklzjc9qrx98nk9";
+    };
+  }
+  {
+    goPackagePath = "github.com/blang/semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/blang/semver";
+      rev = "v3.5.1";
+      sha256 = "13ws259bwcibkclbr82ilhk6zadm63kxklxhk12wayklj8ghhsmy";
+    };
+  }
+  {
+    goPackagePath = "github.com/cenkalti/backoff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cenkalti/backoff";
+      rev = "v2.0.0";
+      sha256 = "0k4899ifpir6kmfxli8a2xfj5zdh0xb2jd0fq2r38wzd4pk25ipr";
+    };
+  }
+  {
+    goPackagePath = "github.com/chzyer/logex";
+    fetch = {
+      type = "git";
+      url = "https://github.com/chzyer/logex";
+      rev = "v1.1.10";
+      sha256 = "08pbjj3wx9acavlwyr055isa8a5hnmllgdv5k6ra60l5y1brmlq4";
+    };
+  }
+  {
+    goPackagePath = "github.com/chzyer/readline";
+    fetch = {
+      type = "git";
+      url = "https://github.com/chzyer/readline";
+      rev = "2972be24d48e";
+      sha256 = "104q8dazj8yf6b089jjr82fy9h1g80zyyzvp3g8b44a7d8ngjj6r";
+    };
+  }
+  {
+    goPackagePath = "github.com/chzyer/test";
+    fetch = {
+      type = "git";
+      url = "https://github.com/chzyer/test";
+      rev = "a1ea475d72b1";
+      sha256 = "0rns2aqk22i9xsgyap0pq8wi4cfaxsri4d9q6xxhhyma8jjsnj2k";
+    };
+  }
+  {
+    goPackagePath = "github.com/client9/misspell";
+    fetch = {
+      type = "git";
+      url = "https://github.com/client9/misspell";
+      rev = "v0.3.4";
+      sha256 = "1vwf33wsc4la25zk9nylpbp9px3svlmldkm0bha4hp56jws4q9cs";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/etcd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/etcd";
+      rev = "v3.3.10";
+      sha256 = "1x2ii1hj8jraba8rbxz6dmc03y3sjxdnzipdvg6fywnlq1f3l3wl";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/go-etcd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-etcd";
+      rev = "v2.0.0";
+      sha256 = "1xb34hzaa1lkbq5vkzy9vcz6gqwj7hp6cdbvyack2bf28dwn33jj";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/go-semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-semver";
+      rev = "v0.2.0";
+      sha256 = "1gghi5bnqj50hfxhqc1cxmynqmh2yk9ii7ab9gsm75y5cp94ymk0";
+    };
+  }
+  {
+    goPackagePath = "github.com/cpuguy83/go-md2man";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cpuguy83/go-md2man";
+      rev = "v1.0.8";
+      sha256 = "1w22dfdamsq63b5rvalh9k2y7rbwfkkjs7vm9vd4a13h2ql70lg2";
+    };
+  }
+  {
+    goPackagePath = "github.com/cyberdelia/templates";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cyberdelia/templates";
+      rev = "ca7fffd4298c";
+      sha256 = "1miakwci9pz95p0jps4i3pyv5ws713ks1wwir5bzrl0yg8klrgw1";
+    };
+  }
+  {
+    goPackagePath = "github.com/danwakefield/fnmatch";
+    fetch = {
+      type = "git";
+      url = "https://github.com/danwakefield/fnmatch";
+      rev = "cbb64ac3d964";
+      sha256 = "0cbf511ppsa6hf59mdl7nbyn2b2n71y0bpkzbmfkdqjhanqh1lqz";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
+    goPackagePath = "github.com/deepmap/oapi-codegen";
+    fetch = {
+      type = "git";
+      url = "https://github.com/deepmap/oapi-codegen";
+      rev = "ee90a3f9f1ae";
+      sha256 = "199nb6aqhllkk891x24h1jffin1x9fx8jdsav9pbc2ki0z8mlji3";
+    };
+  }
+  {
+    goPackagePath = "github.com/dgrijalva/jwt-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgrijalva/jwt-go";
+      rev = "v3.2.0";
+      sha256 = "08m27vlms74pfy5z79w67f9lk9zkx6a9jd68k3c4msxy75ry36mp";
+    };
+  }
+  {
+    goPackagePath = "github.com/dlclark/regexp2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dlclark/regexp2";
+      rev = "v1.1.6";
+      sha256 = "144s81ndviwhyy20ipxvvfvap8phv5p762glxrz6aqxprkxfarj5";
+    };
+  }
+  {
+    goPackagePath = "github.com/dustin/go-humanize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dustin/go-humanize";
+      rev = "v1.0.0";
+      sha256 = "1kqf1kavdyvjk7f8kx62pnm7fbypn9z1vbf8v2qdh3y7z7a0cbl3";
+    };
+  }
+  {
+    goPackagePath = "github.com/exoscale/egoscale";
+    fetch = {
+      type = "git";
+      url = "https://github.com/exoscale/egoscale";
+      rev = "v0.24.0";
+      sha256 = "1ls7blpmhwqxz9cfjc5799q4047pawfda1v1mhyicjdlp3b1z1zi";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/camelcase";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/camelcase";
+      rev = "v1.0.0";
+      sha256 = "0z7rw6f5j97dkzqya257dqlxf3cm8zl508081gmnr4bsjhkwpz2l";
+    };
+  }
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "github.com/getkin/kin-openapi";
+    fetch = {
+      type = "git";
+      url = "https://github.com/getkin/kin-openapi";
+      rev = "v0.2.0";
+      sha256 = "0slv4k55yiqgv5cv51mvfdcckl95wsbvhvrrpmh4wf7q9rk0jkf6";
+    };
+  }
+  {
+    goPackagePath = "github.com/ghodss/yaml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ghodss/yaml";
+      rev = "v1.0.0";
+      sha256 = "0skwmimpy7hlh7pva2slpcplnm912rp3igs98xnqmn859kwa5v8g";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-chi/chi";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-chi/chi";
+      rev = "v4.0.2";
+      sha256 = "1ay9yxzj60l21h4wayrq9sv5ajaqaryy5yyf27z7v2k4a83b5qr6";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-ini/ini";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ini/ini";
+      rev = "v1.42.0";
+      sha256 = "18ywm8zyv091j1pp5mvx8szl7928chk8lw02br6jy568d7rk4xal";
+    };
+  }
+  {
+    goPackagePath = "github.com/gofrs/uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gofrs/uuid";
+      rev = "v3.2.0";
+      sha256 = "1q63mp7bznhfgyw133c0wc0hpcj1cq9bcf7w1f8r6inkcrils1fz";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/lint";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/lint";
+      rev = "c67002cb31c3";
+      sha256 = "0gymbggskjmphqxqcx4s0vnlcz7mygbix0vhwcwv5r67c0bf6765";
+    };
+  }
+  {
+    goPackagePath = "github.com/golangci/lint-1";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golangci/lint-1";
+      rev = "d2cdd8c08219";
+      sha256 = "0viib12a61338411ng4nnd4na4fscsknghk397jdfn00sigyy4ls";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/shlex";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/shlex";
+      rev = "c34317bd91bf";
+      sha256 = "00qivza4hkllfkar2vpqmyxybi0fwqipgijv61dgapq4xddxdq0r";
+    };
+  }
+  {
+    goPackagePath = "github.com/gopherjs/gopherjs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gopherjs/gopherjs";
+      rev = "d547d1d9531e";
+      sha256 = "0rhgxfh8b3qq4imkw6dmv0hxsmflm9pkax8i7a9z8q464z1ixrz7";
+    };
+  }
+  {
+    goPackagePath = "github.com/gordonklaus/ineffassign";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gordonklaus/ineffassign";
+      rev = "1003c8bd00dc";
+      sha256 = "1rkzqvd3z03vq8q8qi9cghvgggsf02ammj9wq8jvpnx6b2sd16nd";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/hcl";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/hcl";
+      rev = "v1.0.0";
+      sha256 = "0q6ml0qqs0yil76mpn4mdx4lp94id8vbv575qm60jzl1ijcl5i66";
+    };
+  }
+  {
+    goPackagePath = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev = "v1.0.0";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+  {
+    goPackagePath = "github.com/jtolds/gls";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jtolds/gls";
+      rev = "v4.20.0";
+      sha256 = "1k7xd2q2ysv2xsh373qs801v6f359240kx0vrl0ydh7731lngvk6";
+    };
+  }
+  {
+    goPackagePath = "github.com/juju/ansiterm";
+    fetch = {
+      type = "git";
+      url = "https://github.com/juju/ansiterm";
+      rev = "720a0952cc2a";
+      sha256 = "0n6j0y7xhashp8gdkdl0r7vlbkdrkymrzxn9hxrx522k2isggs7h";
+    };
+  }
+  {
+    goPackagePath = "github.com/konsorten/go-windows-terminal-sequences";
+    fetch = {
+      type = "git";
+      url = "https://github.com/konsorten/go-windows-terminal-sequences";
+      rev = "v1.0.1";
+      sha256 = "1lchgf27n276vma6iyxa0v1xds68n2g8lih5lavqnx5x6q5pw2ip";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pretty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pretty";
+      rev = "v0.1.0";
+      sha256 = "18m4pwg2abd0j9cn5v3k2ksk9ig4vlwxmlw9rrglanziv9l967qp";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pty";
+      rev = "v1.1.1";
+      sha256 = "0383f0mb9kqjvncqrfpidsf8y6ns5zlrc91c6a74xpyxjwvzl2y6";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/text";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/text";
+      rev = "v0.1.0";
+      sha256 = "1gm5bsl01apvc84bw06hasawyqm4q84vx1pm32wr9jnd7a8vjgj1";
+    };
+  }
+  {
+    goPackagePath = "github.com/labstack/echo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/labstack/echo";
+      rev = "v4.1.11";
+      sha256 = "0b14vgwzznn7wzyjb98xdmq4wjg16l3y62njiwfz4qsm4pwzk405";
+    };
+  }
+  {
+    goPackagePath = "github.com/labstack/gommon";
+    fetch = {
+      type = "git";
+      url = "https://github.com/labstack/gommon";
+      rev = "v0.3.0";
+      sha256 = "18z7akyzm75p6anm4b8qkqgm4iivx50z07hi5wf50w1pbsvbcdi0";
+    };
+  }
+  {
+    goPackagePath = "github.com/lunixbochs/vtclean";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lunixbochs/vtclean";
+      rev = "2d01aacdc34a";
+      sha256 = "1ss88dyx5hr4imvpg5lixvp0cf7c2qm4x9m8mdgshjpm92g5rqmf";
+    };
+  }
+  {
+    goPackagePath = "github.com/magiconair/properties";
+    fetch = {
+      type = "git";
+      url = "https://github.com/magiconair/properties";
+      rev = "v1.8.0";
+      sha256 = "1a10362wv8a8qwb818wygn2z48lgzch940hvpv81hv8gc747ajxn";
+    };
+  }
+  {
+    goPackagePath = "github.com/manifoldco/promptui";
+    fetch = {
+      type = "git";
+      url = "https://github.com/manifoldco/promptui";
+      rev = "v0.3.2";
+      sha256 = "185h0lqm14l9j0yvdsn9njq7jw3j6x3l21jvvczzbcbbrj44q0pl";
+    };
+  }
+  {
+    goPackagePath = "github.com/matryer/moq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matryer/moq";
+      rev = "6cfb0558e1bd";
+      sha256 = "0x7ss68cvq2aljyw4765iy7divmp8rghpyzlas3nb95qzsfmmpzl";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev = "v0.1.4";
+      sha256 = "1yxcz08kminqr1221zxpibnbzfcgs3fafin0z9zqb3gqvf74jywz";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "v0.0.10";
+      sha256 = "0jf4hwfwd2cpxrlyv0jzcia809q2bjw7y1m3ciaj2s8lj2jqyf6r";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev = "v0.0.3";
+      sha256 = "0lc39b6xrxv7h3v3y1kgz49cgi5qxwlygs715aam6ba35m48yi7g";
+    };
+  }
+  {
+    goPackagePath = "github.com/minio/minio-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/minio/minio-go";
+      rev = "v6.0.44";
+      sha256 = "0sfmd2lf24f7ds16imk63mas6izhjnmprbxad0sil9abvk8r23mk";
+    };
+  }
+  {
+    goPackagePath = "github.com/minio/sha256-simd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/minio/sha256-simd";
+      rev = "v0.1.1";
+      sha256 = "1j0iqsckm97g4l79vd4mc7apbmkdar23jpzqpnpdhwpfd834j8lp";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev = "v1.1.0";
+      sha256 = "0ydzkipf28hwj2bfxqmwlww47khyk6d152xax4bnyh60f4lq3nx1";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/mapstructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/mapstructure";
+      rev = "v1.1.2";
+      sha256 = "03bpv28jz9zhn4947saqwi328ydj7f6g6pf1m2d4m5zdh5jlfkrr";
+    };
+  }
+  {
+    goPackagePath = "github.com/nicksnyder/go-i18n";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nicksnyder/go-i18n";
+      rev = "v1.10.0";
+      sha256 = "1nlvq85c232z5yjs86pxpmkv7hk6gb5pa6j4hhzgdz85adk2ma04";
+    };
+  }
+  {
+    goPackagePath = "github.com/olekukonko/tablewriter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/olekukonko/tablewriter";
+      rev = "be2c049b30cc";
+      sha256 = "1fr996vpmh6v5q13kfgf0fbi0hksxqg0fnbvj2nqhlsyfp5s8f4w";
+    };
+  }
+  {
+    goPackagePath = "github.com/pelletier/go-toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pelletier/go-toml";
+      rev = "v1.2.0";
+      sha256 = "1fjzpcjng60mc3a4b2ql5a00d5gah84wj740dabv9kq67mpg8fxy";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev = "v0.9.1";
+      sha256 = "1761pybhc2kqr6v5fm8faj08x9bql8427yqg6vnfv6nhrasx1mwq";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/russross/blackfriday";
+    fetch = {
+      type = "git";
+      url = "https://github.com/russross/blackfriday";
+      rev = "v1.5.2";
+      sha256 = "0jzbfzcywqcrnym4gxlz6nphmm1grg6wsl4f0r9x384rn83wkj7c";
+    };
+  }
+  {
+    goPackagePath = "github.com/sergi/go-diff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sergi/go-diff";
+      rev = "v1.0.0";
+      sha256 = "0swiazj8wphs2zmk1qgq75xza6m19snif94h2m6fi8dqkwqdl7c7";
+    };
+  }
+  {
+    goPackagePath = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev = "v1.4.2";
+      sha256 = "087k2lxrr9p9dh68yw71d05h5g9p5v26zbwd6j7lghinjfaw334x";
+    };
+  }
+  {
+    goPackagePath = "github.com/smartystreets/assertions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/assertions";
+      rev = "b2de0cb4f26d";
+      sha256 = "1i7ldgavgl35c7gk25p7bvdr282ckng090zr4ch9mk1705akx09y";
+    };
+  }
+  {
+    goPackagePath = "github.com/smartystreets/goconvey";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/goconvey";
+      rev = "68dc04aab96a";
+      sha256 = "1kas5v95fzhr88hg4rjy0vp03y4pzvy3pwwgkfz2yhn5nlj29nk6";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/afero";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/afero";
+      rev = "v1.1.2";
+      sha256 = "0miv4faf5ihjfifb1zv6aia6f6ik7h1s4954kcb8n6ixzhx9ck6k";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cast";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cast";
+      rev = "v1.3.0";
+      sha256 = "0xq1ffqj8y8h7dcnm0m9lfrh0ga7pssnn2c1dnr09chqbpn4bdc5";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev = "v0.0.3";
+      sha256 = "1q1nsx05svyv9fv3fy6xv6gs9ffimkyzsfm49flvl3wnvf1ncrkd";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/jwalterweatherman";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/jwalterweatherman";
+      rev = "v1.0.0";
+      sha256 = "093fmmvavv84pv4q84hav7ph3fmrq87bvspjj899q0qsx37yvdr8";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev = "v1.0.3";
+      sha256 = "1cj3cjm7d3zk0mf1xdybh0jywkbbw7a6yr3y22x9sis31scprswd";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/viper";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/viper";
+      rev = "v1.3.1";
+      sha256 = "1190mg04718r03qriav99sf4kx2n7wdgr8vdni15f74bpbzrdjrl";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.1.1";
+      sha256 = "0iph0qmpyqg4kwv8jsx6a56a7hhqq8swrazv40ycxk9rzr0s8yls";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.4.0";
+      sha256 = "187i5g88sxfy4vxpm7dw1gwv29pa2qaq475lxrdh5livh69wqfjb";
+    };
+  }
+  {
+    goPackagePath = "github.com/tsenart/deadcode";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tsenart/deadcode";
+      rev = "210d2dc333e9";
+      sha256 = "05kif593f4wygnrq2fdjhn7kkcpdmgjnykcila85d0gqlb1f36g0";
+    };
+  }
+  {
+    goPackagePath = "github.com/ugorji/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ugorji/go";
+      rev = "d75b2dcb6bc8";
+      sha256 = "0di1k35gpq9bp958ywranpbskx2vdwlb38s22vl9rybm3wa5g3ps";
+    };
+  }
+  {
+    goPackagePath = "github.com/valyala/bytebufferpool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/valyala/bytebufferpool";
+      rev = "v1.0.0";
+      sha256 = "01lqzjddq6kz9v41nkky7wbgk7f1cw036sa7ldz10d82g5klzl93";
+    };
+  }
+  {
+    goPackagePath = "github.com/valyala/fasttemplate";
+    fetch = {
+      type = "git";
+      url = "https://github.com/valyala/fasttemplate";
+      rev = "v1.1.0";
+      sha256 = "089wm839lqmw9knr3ifbi82iykaybk0zxzp3c02lsh31wax4f8a2";
+    };
+  }
+  {
+    goPackagePath = "github.com/vbauerster/mpb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/vbauerster/mpb";
+      rev = "v4.8.4";
+      sha256 = "0ifz1hp1a5xjxx7x9km5pb0x6p60lcpzwmhnxlg5x4ls6hrs8wd9";
+    };
+  }
+  {
+    goPackagePath = "github.com/xordataexchange/crypt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xordataexchange/crypt";
+      rev = "b2862e3d0a77";
+      sha256 = "04q3856anpzl4gdfgmg7pbp9cx231nkz3ymq2xp27rnmmwhfxr8y";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "e1110fd1c708";
+      sha256 = "0n5n7dzlr87mvk3mbcx400al4pa1i85jbbdhbx4s1rhr0rs3kh9a";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/lint";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/lint";
+      rev = "c67002cb31c3";
+      sha256 = "0gymbggskjmphqxqcx4s0vnlcz7mygbix0vhwcwv5r67c0bf6765";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "2180aed22343";
+      sha256 = "0hl3pgi8rzij5m6alq4xqfvyvidy7jnf5y85031jv4y1bj85r6pl";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "112230192c58";
+      sha256 = "05i2k43j2d0llq768hg5pf3hb2yhfzp9la1w5wp0rsnnzblr0lfn";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "52ab43148777";
+      sha256 = "1kakxbqrb1w2vwg7r1896z68qcx2lfvimsl8cs2niiipbgpi6imx";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.2";
+      sha256 = "0flv9idw0jm5nm8lx25xqanbkqgfiym6619w575p7nrdh0riqwqh";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "a911d9008d1f";
+      sha256 = "118vsliq2a9xfp6rckc310mf9lydfgah6hgiggd88cm3zch4626m";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/xerrors";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/xerrors";
+      rev = "a985d3407aa7";
+      sha256 = "00wzr5w8aadipgc3rkk8f11i41znskfj9ix5nhhaxyg7isrslgcj";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/alecthomas/kingpin.v3-unstable";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/alecthomas/kingpin.v3-unstable";
+      rev = "df19058c872c";
+      sha256 = "0nb6925fixs6brdwpmwi32b38acn1s8dv4g0syjy3kpq0wasljy9";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "788fd7840127";
+      sha256 = "0v3bim0j375z81zrpr5qv42knqs0y2qv2vkjiqi5axvb78slki1a";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/ini.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/ini.v1";
+      rev = "v1.42.0";
+      sha256 = "18ywm8zyv091j1pp5mvx8szl7928chk8lw02br6jy568d7rk4xal";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.2.5";
+      sha256 = "08smz8dfyxp02ha74my9iszqa5qzgl3ksi28ilyp8lqipssiq6fg";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -776,6 +776,8 @@ in
 
   ec2-utils = callPackage ../tools/virtualization/ec2-utils { };
 
+  exoscale-cli = callPackage ../tools/admin/exoscale-cli { };
+
   altermime = callPackage ../tools/networking/altermime {};
 
   alttab = callPackage ../tools/X11/alttab { };


### PR DESCRIPTION

###### Motivation for this change

Add a derivation the Exoscales cli tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
