### PR TITLE
nixos/systemd: move systemd-provided NSS modules to systemd module

### DIFF
--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -14,14 +14,12 @@ let
   nssmdns = canLoadExternalModules && config.services.avahi.nssmdns;
   nsswins = canLoadExternalModules && config.services.samba.nsswins;
   ldap = canLoadExternalModules && (config.users.ldap.enable && config.users.ldap.nsswitch);
-  resolved = canLoadExternalModules && config.services.resolved.enable;
 
   hostArray = mkMerge [
     (mkBefore [ "files" ])
     (mkIf mymachines [ "mymachines" ])
     (mkIf nssmdns [ "mdns_minimal [NOTFOUND=return]" ])
     (mkIf nsswins [ "wins" ])
-    (mkIf resolved [ "resolve [!UNAVAIL=return]" ])
     (mkAfter [ "dns" ])
     (mkIf nssmdns (mkOrder 1501 [ "mdns" ])) # 1501 to ensure it's after dns
     (mkIf myhostname (mkOrder 1600 [ "myhostname" ])) # 1600 to ensure it's always the last
@@ -133,11 +131,6 @@ in {
         # generic catch if the NixOS module adding to nssModules does not prevent it with specific message.
         assertion = config.system.nssModules.path != "" -> canLoadExternalModules;
         message = "Loading NSS modules from path ${config.system.nssModules.path} requires nscd being enabled.";
-      }
-      {
-        # resolved does not need to add to nssModules, therefore needs an extra assertion
-        assertion = resolved -> canLoadExternalModules;
-        message = "Loading systemd-resolved's nss-resolve NSS module requires nscd being enabled.";
       }
     ];
 

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -138,6 +138,10 @@ in
 
     users.users.resolved.group = "systemd-resolve";
 
+    # add resolve to nss hosts database if enabled and nscd enabled
+    # system.nssModules is configured in nixos/modules/system/boot/systemd.nix
+    system.nssDatabases.hosts = optional config.services.nscd.enable "resolve [!UNAVAIL=return]";
+
     systemd.additionalUpstreamSystemUnits = [
       "systemd-resolved.service"
     ];


### PR DESCRIPTION
###### Motivation for this change
#86350

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
