### PR TITLE
betterdiscordctl: init at 1.7.0

### DIFF
--- a/pkgs/tools/misc/betterdiscordctl/default.nix
+++ b/pkgs/tools/misc/betterdiscordctl/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  pname = "betterdiscordctl";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "bb010g";
+    repo = "betterdiscordctl";
+    rev = "v${version}";
+    sha256 = "0qpmm5l8jhm7k0kqblc0bnr9fl4b6z8iddhjar03bb4kqgr962fa";
+  };
+
+  patches = [
+    (fetchpatch { # Required till https://github.com/bb010g/betterdiscordctl/pull/67 is merged upstream.
+      url = "https://github.com/bb010g/betterdiscordctl/pull/67/commits/f1c7170fc2626d9aec4d244977b5a73c401aa1d4.patch";
+      sha256 = "003zqd9ljb9h674sjwjvvdfs7q4cw0p1ydg3lax132vb4vz9k0zi";
+    })
+  ];
+
+  preBuild = "sed -i 's/^nix=$/&yes/g;s/^DISABLE_UPGRADE=$/&yes/g' ./betterdiscordctl";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/doc/betterdiscordctl
+    install -Dm744 betterdiscordctl $out/bin/betterdiscordctl
+    install -Dm644 README.md $out/share/doc/betterdiscordctl/README.md
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/bb010g/betterdiscordctl";
+    description = "A utility for managing BetterDiscord on Linux";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ivar bb010g ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -756,6 +756,8 @@ in
 
   berglas = callPackage ../tools/admin/berglas/default.nix { };
 
+  betterdiscordctl = callPackage ../tools/misc/betterdiscordctl { };
+
   brakeman = callPackage ../development/tools/analysis/brakeman { };
 
   brewtarget = libsForQt5.callPackage ../applications/misc/brewtarget { } ;


### PR DESCRIPTION
###### Motivation for this change
Adds [betterdiscordctl](https://github.com/bb010g/betterdiscordctl), a pretty useful tool for customizing Discord. Tested with stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
