### PR TITLE
[20.03] inkscape: 0.92.4 → 0.92.5

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -43,12 +43,6 @@ stdenv.mkDerivation rec {
   # will leave us under ARGMAX.
   strictDeps = true;
 
-  unpackPhase = ''
-    cp $src ${name}.tar.bz2
-    tar xvjf ${name}.tar.bz2 > /dev/null
-    cd ${name}
-  '';
-
   postPatch = ''
     patchShebangs share/extensions
     patchShebangs fix-roff-punct

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -1,21 +1,53 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, perlPackages, libXft
-, libpng, zlib, popt, boehmgc, libxml2, libxslt, glib, gtkmm2
-, glibmm, libsigcxx, lcms, boost, gettext, makeWrapper
-, gsl, gtkspell2, cairo, python2, poppler, imagemagick, libwpg, librevenge
-, libvisio, libcdr, libexif, potrace, cmake
-, librsvg, wrapGAppsHook
+{ stdenv
+, boehmgc
+, boost
+, cairo
+, cmake
+, fetchpatch
+, fetchurl
+, gettext
+, glib
+, glibmm
+, gsl
+, gtkmm2
+, gtkspell2
+, imagemagick
+, lcms
+, libcdr
+, libexif
+, libpng
+, librevenge
+, librsvg
+, libsigcxx
+, libvisio
+, libwpg
+, libXft
+, libxml2
+, libxslt
+, makeWrapper
+, perlPackages
+, pkg-config
+, poppler
+, popt
+, potrace
+, python2
+, wrapGAppsHook
+, zlib
 }:
-
 let
-  python2Env = python2.withPackages(ps: with ps;
-    [ numpy lxml scour ]);
+  python2Env = python2.withPackages
+    (ps: with ps; [
+      numpy
+      lxml
+      scour
+    ]);
 in
-
 stdenv.mkDerivation rec {
-  name = "inkscape-0.92.4";
+  pname = "inkscape";
+  version = "0.92.4";
 
   src = fetchurl {
-    url = "https://media.inkscape.org/dl/resources/file/${name}.tar.bz2";
+    url = "https://media.inkscape.org/dl/resources/file/${pname}-${version}.tar.bz2";
     sha256 = "0pjinhjibfsz1aywdpgpj3k23xrsszpj4a1ya5562dkv2yl2vv2p";
   };
 
@@ -53,19 +85,49 @@ stdenv.mkDerivation rec {
       --replace '"python-interpreter", "python"' '"python-interpreter", "${python2Env}/bin/python"'
   '';
 
-  nativeBuildInputs = [ pkgconfig cmake makeWrapper python2Env wrapGAppsHook ]
-    ++ (with perlPackages; [ perl XMLParser ]);
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    makeWrapper
+    python2Env
+    wrapGAppsHook
+  ] ++ (with perlPackages; [
+    perl
+    XMLParser
+  ]);
+
   buildInputs = [
-    libXft libpng zlib popt boehmgc
-    libxml2 libxslt glib gtkmm2 glibmm libsigcxx lcms boost gettext
-    gsl poppler imagemagick libwpg librevenge
-    libvisio libcdr libexif potrace
-
+    boehmgc
+    boost
+    gettext
+    glib
+    glibmm
+    gsl
+    gtkmm2
+    imagemagick
+    lcms
+    libcdr
+    libexif
+    libpng
+    librevenge
     librsvg # for loading icons
-
-    python2Env perlPackages.perl
-  ] ++ stdenv.lib.optional (!stdenv.isDarwin) gtkspell2
-    ++ stdenv.lib.optional stdenv.isDarwin cairo;
+    libsigcxx
+    libvisio
+    libwpg
+    libXft
+    libxml2
+    libxslt
+    perlPackages.perl
+    poppler
+    popt
+    potrace
+    python2Env
+    zlib
+  ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
+    gtkspell2
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    cairo
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -30,12 +30,12 @@
 , poppler
 , popt
 , potrace
-, python2
+, python3
 , wrapGAppsHook
 , zlib
 }:
 let
-  python2Env = python2.withPackages
+  python3Env = python3.withPackages
     (ps: with ps; [
       numpy
       lxml
@@ -44,30 +44,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "inkscape";
-  version = "0.92.4";
+  version = "0.92.5";
 
   src = fetchurl {
     url = "https://media.inkscape.org/dl/resources/file/${pname}-${version}.tar.bz2";
-    sha256 = "0pjinhjibfsz1aywdpgpj3k23xrsszpj4a1ya5562dkv2yl2vv2p";
+    sha256 = "ge5/aeK9ZKlzQ9g5Wkp6eQWyG4YVZu1eXZF5F41Rmgs=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "inkscape-poppler_0_76_compat.patch";
-      url = "https://gitlab.com/inkscape/inkscape/commit/e831b034746f8dc3c3c1b88372751f6dcb974831.diff";
-      sha256 = "096rdyi6ppjq1h9jwwsm9hb99nggfrfinik8rm23jkn4h2zl01zf";
-    })
-    (fetchpatch {
-      name = "inkscape-poppler_0_82_compat.patch";
-      url = "https://gitlab.com/inkscape/inkscape/commit/835b6bb62be565efab986d5a3f30a672ad56c7eb.patch";
-      sha256 = "02c6sxi2w52b885vr3pgani6kvxp9gdqqk2jgiykkdzv70hhrnm7";
-    })
-    (fetchpatch {
-      name = "inkscape-poppler_0_83_compat.patch";
-      url = "https://gitlab.com/inkscape/inkscape/commit/b5360a807b12d4e8318475ffd0464b84882788b5.patch";
-      sha256 = "1p44rr2q2i3zkd1y1j7xgdcbgx8yvlq6hq92im8s0bkjby6p5cpz";
-    })
-  ];
 
   # Inkscape hits the ARGMAX when linking on macOS. It appears to be
   # CMake’s ARGMAX check doesn’t offer enough padding for NIX_LDFLAGS.
@@ -82,14 +64,14 @@ stdenv.mkDerivation rec {
     # Python is used at run-time to execute scripts, e.g., those from
     # the "Effects" menu.
     substituteInPlace src/extension/implementation/script.cpp \
-      --replace '"python-interpreter", "python"' '"python-interpreter", "${python2Env}/bin/python"'
+      --replace '"python-interpreter", "python"' '"python-interpreter", "${python3Env}/bin/python"'
   '';
 
   nativeBuildInputs = [
     pkg-config
     cmake
     makeWrapper
-    python2Env
+    python3Env
     wrapGAppsHook
   ] ++ (with perlPackages; [
     perl
@@ -121,7 +103,7 @@ stdenv.mkDerivation rec {
     poppler
     popt
     potrace
-    python2Env
+    python3Env
     zlib
   ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
     gtkspell2


### PR DESCRIPTION
Port of #85184 to 20.03. cc/ @jtojnar 

###### Motivation for this change

Inkscape 0.92.4 depends on python 2

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
