### PR TITLE
irods: 4.2.2 -> 4.2.7 + fixed + use fetchFromGitHub

### DIFF
--- a/pkgs/tools/filesystems/irods/common.nix
+++ b/pkgs/tools/filesystems/irods/common.nix
@@ -1,4 +1,4 @@
-{ stdenv, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp, boost, jansson, zeromq, openssl, pam, libiodbc, kerberos, gcc, libcxx, which }:
+{ stdenv, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp, boost, jansson, zeromq, openssl, pam, libiodbc, kerberos, gcc, libcxx, which, catch2 }:
 
 # Common attributes of irods packages
 
@@ -7,7 +7,7 @@ with stdenv;
 {
   enableParallelBuilding = true;
 
-  buildInputs = [ bzip2 zlib autoconf automake cmake gnumake help2man texinfo libtool cppzmq libarchive avro-cpp jansson zeromq openssl pam libiodbc kerberos gcc boost libcxx which ];
+  buildInputs = [ bzip2 zlib autoconf automake cmake gnumake help2man texinfo libtool cppzmq libarchive avro-cpp jansson zeromq openssl pam libiodbc kerberos gcc boost libcxx which catch2 ];
 
   cmakeFlags = [
     "-DIRODS_EXTERNALS_FULLPATH_CLANG=${stdenv.cc}"
@@ -18,6 +18,7 @@ with stdenv;
     "-DIRODS_EXTERNALS_FULLPATH_JANSSON=${jansson}"
     "-DIRODS_EXTERNALS_FULLPATH_ZMQ=${zeromq}"
     "-DIRODS_EXTERNALS_FULLPATH_CPPZMQ=${cppzmq}"
+    "-DIRODS_EXTERNALS_FULLPATH_CATCH2=${catch2}"
     "-DIRODS_LINUX_DISTRIBUTION_NAME=nix"
     "-DIRODS_LINUX_DISTRIBUTION_VERSION_MAJOR=${builtins.nixVersion}"
     "-DCPACK_GENERATOR=TGZ"

--- a/pkgs/tools/filesystems/irods/default.nix
+++ b/pkgs/tools/filesystems/irods/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp_llvm, boost, jansson, zeromq, openssl , pam, libiodbc, kerberos, gcc, libcxx, which }:
+{ stdenv, fetchFromGitHub, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp_llvm, boost, jansson, zeromq, openssl , pam, libiodbc, kerberos, gcc, libcxx, which, catch2 }:
 
 with stdenv;
 
@@ -10,19 +10,21 @@ let
     inherit stdenv bzip2 zlib autoconf automake cmake gnumake
             help2man texinfo libtool cppzmq libarchive jansson
             zeromq openssl pam libiodbc kerberos gcc libcxx
-            boost avro-cpp which;
+            boost avro-cpp which catch2;
   };
 in rec {
 
   # irods: libs and server package
   irods = stdenv.mkDerivation (common // rec {
-    version = "4.2.2";
-    prefix = "irods";
-    name = "${prefix}-${version}";
+    version = "4.2.7";
+    pname = "irods";
 
-    src = fetchurl {
-      url = "https://github.com/irods/irods/releases/download/${version}/irods-${version}.tar.gz";
-      sha256 = "0b89hs7sizwrs2ja7jl521byiwb58g297p0p7zg5frxmv4ig8dw7";
+    src = fetchFromGitHub {
+      owner = "irods";
+      repo = "irods";
+      rev = version;
+      sha256 = "1pd4l42z4igzf0l8xbp7yz0nhzsv47ziv5qj8q1hh6pfhmwlzp9s";
+      fetchSubmodules = true;
     };
 
     # Patches:
@@ -41,6 +43,10 @@ in rec {
       substituteInPlace cmake/runtime_library.cmake --replace "DESTINATION usr/lib" "DESTINATION lib"
       substituteInPlace cmake/development_library.cmake --replace "DESTINATION usr/lib" "DESTINATION lib"
       substituteInPlace cmake/development_library.cmake --replace "DESTINATION usr/include" "DESTINATION include"
+      for file in unit_tests/cmake/test_config/*.cmake
+      do
+        substituteInPlace $file --replace "CATCH2}/include" "CATCH2}/include/catch2"
+      done
       export cmakeFlags="$cmakeFlags
         -DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,$out/lib
         -DCMAKE_MODULE_LINKER_FLAGS=-Wl,-rpath,$out/lib
@@ -59,12 +65,17 @@ in rec {
 
   # icommands (CLI) package, depends on the irods package
   irods-icommands = stdenv.mkDerivation (common // rec {
-     version = "4.2.2";
-     name = "irods-icommands-${version}";
-     src = fetchurl {
-       url = "https://github.com/irods/irods_client_icommands/archive/${version}.tar.gz";
-       sha256 = "15zcxrx0q5c3rli3snd0b2q4i0hs3zzcrbpnibbhsip855qvs77h";
+     version = "4.2.7";
+     pname = "irods-icommands";
+
+     src = fetchFromGitHub {
+       owner = "irods";
+       repo = "irods_client_icommands";
+       rev = version;
+       sha256 = "08hqrc9iaw0y9rrrcknnl5mzbcrsvqc39pwvm62fipl3vnfqryli";
      };
+
+     patches = [ ./zmqcpp-deprecated-send_recv.patch ];
 
      buildInputs = common.buildInputs ++ [ irods ];
 
@@ -84,7 +95,6 @@ in rec {
        description = common.meta.description + " CLI clients";
        longDescription = common.meta.longDescription + ''
          This package provides the CLI clients, called 'icommands'.'';
-       broken = true;
      };
   });
 }

--- a/pkgs/tools/filesystems/irods/zmqcpp-deprecated-send_recv.patch
+++ b/pkgs/tools/filesystems/irods/zmqcpp-deprecated-send_recv.patch
@@ -1,0 +1,21 @@
+diff -r -u source/src/irods-grid.cpp source.new/src/irods-grid.cpp
+--- source/src/irods-grid.cpp	1970-01-01 01:00:01.000000000 +0100
++++ source.new/src/irods-grid.cpp	2020-05-05 16:34:35.566464346 +0200
+@@ -412,7 +412,7 @@
+             data_to_send.data(),
+             data_to_send.size() );
+         try {
+-            if (!zmq_skt.send(req)) {
++            if (!zmq_skt.send( req, zmq::send_flags::dontwait )) {
+                 std::cerr << "ZeroMQ encountered an error sending a message.\n";
+                 return errno;
+             }
+@@ -426,7 +426,7 @@
+         zmq::message_t rep;
+         // wait for the server reponse
+         try {
+-            if (!zmq_skt.recv( &rep )) {
++            if (!zmq_skt.recv( rep, zmq::recv_flags::dontwait )) {
+                 std::cerr << "ZeroMQ encountered an error receiving a message.\n";
+                 return errno;
+             }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

We are currently upgrading our irods storage infrastructure and we need this version of the irods clients.
We also noticed that this package was marked as broken. It needed some fixes regarding zmq, some new dependencies and was also not using fetchFromGithub which is now the recommended and efficient way to get sources from github releases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
