### PR TITLE
Update Haskell package set to LTS 15.11 (plus other fixes)

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -103,8 +103,8 @@ command displays the complete list of available compilers:
 $ nix-env -f "<nixpkgs>" -qaP -A haskell.compiler
 haskell.compiler.ghc8101                 ghc-8.10.1
 haskell.compiler.integer-simple.ghc8101  ghc-8.10.1
-haskell.compiler.ghcHEAD                 ghc-8.11.20200403
-haskell.compiler.integer-simple.ghcHEAD  ghc-8.11.20200403
+haskell.compiler.ghcHEAD                 ghc-8.11.20200505
+haskell.compiler.integer-simple.ghcHEAD  ghc-8.11.20200505
 haskell.compiler.ghc822Binary            ghc-8.2.2-binary
 haskell.compiler.ghc844                  ghc-8.4.4
 haskell.compiler.ghc863Binary            ghc-8.6.3-binary

--- a/pkgs/data/misc/hackage/default.nix
+++ b/pkgs/data/misc/hackage/default.nix
@@ -1,6 +1,6 @@
 { fetchurl }:
 
 fetchurl {
-  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/9d50cd974714cdcfdaabd089923b571a66bae55a.tar.gz";
-  sha256 = "1hv4pxp47850l36ci2ywmc75c95fvdqr3swz9qymy25gd6rbfs9f";
+  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/a734b1438c8379ed3945412538ff4ec49823564c.tar.gz";
+  sha256 = "0y1y818n10fh0qq7cg67p9l293js78fyahk5f6s9w3c21xn9wn8r";
 }

--- a/pkgs/development/compilers/ghc/8.10.1.nix
+++ b/pkgs/development/compilers/ghc/8.10.1.nix
@@ -27,7 +27,7 @@
   # platform). Static libs are always built.
   enableShared ? !stdenv.targetPlatform.isWindows && !stdenv.targetPlatform.useiOSPrebuilt
 
-, # Whetherto build terminfo.
+, # Whether to build terminfo.
   enableTerminfo ? !stdenv.targetPlatform.isWindows
 
 , # What flavour to build. An empty string indicates no

--- a/pkgs/development/compilers/ghc/8.4.4.nix
+++ b/pkgs/development/compilers/ghc/8.4.4.nix
@@ -24,7 +24,7 @@
   # platform). Static libs are always built.
   enableShared ? !stdenv.targetPlatform.isWindows && !stdenv.targetPlatform.useiOSPrebuilt
 
-, # Whetherto build terminfo.
+, # Whether to build terminfo.
   enableTerminfo ? !stdenv.targetPlatform.isWindows
 
 , # What flavour to build. An empty string indicates no

--- a/pkgs/development/compilers/ghc/8.6.5.nix
+++ b/pkgs/development/compilers/ghc/8.6.5.nix
@@ -27,7 +27,7 @@
   # platform). Static libs are always built.
   enableShared ? !stdenv.targetPlatform.isWindows && !stdenv.targetPlatform.useiOSPrebuilt
 
-, # Whetherto build terminfo.
+, # Whether to build terminfo.
   enableTerminfo ? !stdenv.targetPlatform.isWindows
 
 , # What flavour to build. An empty string indicates no

--- a/pkgs/development/compilers/ghc/8.8.2.nix
+++ b/pkgs/development/compilers/ghc/8.8.2.nix
@@ -27,7 +27,7 @@
   # platform). Static libs are always built.
   enableShared ? !stdenv.targetPlatform.isWindows && !stdenv.targetPlatform.useiOSPrebuilt
 
-, # Whetherto build terminfo.
+, # Whether to build terminfo.
   enableTerminfo ? !stdenv.targetPlatform.isWindows
 
 , # What flavour to build. An empty string indicates no

--- a/pkgs/development/compilers/ghc/8.8.3.nix
+++ b/pkgs/development/compilers/ghc/8.8.3.nix
@@ -27,7 +27,7 @@
   # platform). Static libs are always built.
   enableShared ? !stdenv.targetPlatform.isWindows && !stdenv.targetPlatform.useiOSPrebuilt
 
-, # Whetherto build terminfo.
+, # Whether to build terminfo.
   enableTerminfo ? !stdenv.targetPlatform.isWindows
 
 , # What flavour to build. An empty string indicates no

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -35,7 +35,7 @@
 , # Whetherto build terminfo.
   enableTerminfo ? !stdenv.targetPlatform.isWindows
 
-, version ? "8.11.20200403"
+, version ? "8.11.20200505"
 , # What flavour to build. An empty string indicates no
   # specific flavour and falls back to ghc default values.
   ghcFlavour ? stdenv.lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
@@ -103,8 +103,8 @@ stdenv.mkDerivation (rec {
 
   src = fetchgit {
     url = "https://gitlab.haskell.org/ghc/ghc.git/";
-    rev = "4291bddaea3148908c55f235ee8978e1d9aa6f20";
-    sha256 = "1gs3mxmsdpsgsp7vnawx8mys0qwg4x2zhfrbciy3wv8nv13ar1af";
+    rev = "40c71c2cf38b4e134d81b7184a4d5e02949ae70c";
+    sha256 = "04h9rcyzm9w3an1z00hjs062dp7dl19b8pkyxjsypr7a2i9dmvkb";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -32,7 +32,7 @@
   # platform). Static libs are always built.
   enableShared ? !stdenv.targetPlatform.isWindows && !stdenv.targetPlatform.useiOSPrebuilt
 
-, # Whetherto build terminfo.
+, # Whether to build terminfo.
   enableTerminfo ? !stdenv.targetPlatform.isWindows
 
 , version ? "8.11.20200505"

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -71,7 +71,7 @@ self: super: {
       name = "git-annex-${super.git-annex.version}-src";
       url = "git://git-annex.branchable.com/";
       rev = "refs/tags/" + super.git-annex.version;
-      sha256 = "1jjw6ar8ddcncwzksyx2xky50sm2jg1zjr7iiqk0vn8qq0fn2gwy";
+      sha256 = "0adw72lw3ygls87w6i7hirf26gz991dkm992jb5f0h5nvy6d44pl";
     };
   }).override {
     dbus = if pkgs.stdenv.isLinux then self.dbus else null;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1501,4 +1501,18 @@ self: super: {
     haskell-lsp = self.haskell-lsp_0_19_0_0;
   });
 
+  # stackage right now is not new enough for hlint-3.0
+  ghc-lib-parser-ex_8_10_0_6 = super.ghc-lib-parser-ex_8_10_0_6.override {
+    ghc-lib-parser = self.ghc-lib-parser_8_10_1_20200412;
+  };
+
+  hlint = super.hlint.override {
+    ghc-lib-parser = self.ghc-lib-parser_8_10_1_20200412;
+    ghc-lib-parser-ex = self.ghc-lib-parser-ex_8_10_0_6;
+    extra = self.extra_1_7_1;
+    filepattern = self.filepattern.override {
+      extra = self.extra_1_7_1;
+    };
+  };
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1489,4 +1489,16 @@ self: super: {
     selective = self.selective_0_4_1;
   };
 
+  # Needed for ghcide
+  haskell-lsp_0_19_0_0 = super.haskell-lsp_0_19_0_0.override {
+    haskell-lsp-types = self.haskell-lsp-types_0_19_0_0;
+  };
+
+  # this will probably need to get updated with every ghcide update,
+  # we need an override because ghcide is tracking haskell-lsp closely.
+  ghcide = dontCheck (super.ghcide.override rec {
+    haskell-lsp-types = self.haskell-lsp-types_0_19_0_0;
+    haskell-lsp = self.haskell-lsp_0_19_0_0;
+  });
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -132,7 +132,6 @@ self: super: {
     url = "https://github.com/haskell-hvr/cabal-plan/pull/55.patch";
     sha256 = "0lhs4vx5qg5ldhnyb9z7k0jmxhmd2f34x4xbwv6vsljs9vr02pd8";
   });
-  dbus = appendPatch super.dbus ./patches/fix-dbus-for-ghc-8.10.x.patch;
 
   # https://github.com/ndmitchell/hlint/issues/959
   hlint = super.hlint.override {

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -138,4 +138,12 @@ self: super: {
     ghc-lib-parser-ex = addBuildDepend super.ghc-lib-parser-ex super.ghc-lib-parser;
   };
 
+  # https://github.com/commercialhaskell/pantry/issues/21
+  pantry = appendPatch super.pantry (pkgs.fetchpatch {
+    name = "add-cabal-3.2.x-support.patch";
+    url = "https://patch-diff.githubusercontent.com/raw/commercialhaskell/pantry/pull/22.patch";
+    sha256 = "198hsfjsy83s7rp71llf05cwa3vkm74g73djg5p4sk4awm9s6vf2";
+    excludes = ["package.yaml"];
+  });
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -133,11 +133,6 @@ self: super: {
     sha256 = "0lhs4vx5qg5ldhnyb9z7k0jmxhmd2f34x4xbwv6vsljs9vr02pd8";
   });
 
-  # https://github.com/ndmitchell/hlint/issues/959
-  hlint = super.hlint.override {
-    ghc-lib-parser-ex = addBuildDepend super.ghc-lib-parser-ex super.ghc-lib-parser;
-  };
-
   # https://github.com/commercialhaskell/pantry/issues/21
   pantry = appendPatch super.pantry (pkgs.fetchpatch {
     name = "add-cabal-3.2.x-support.patch";

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -72,7 +72,7 @@ default-package-overrides:
   # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
   # not yet available in Nixpkgs
   - gi-gdkx11 < 4
-  # LTS Haskell 15.10
+  # LTS Haskell 15.11
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
   - AC-Angle ==1.0
@@ -378,6 +378,8 @@ default-package-overrides:
   - can-i-haz ==0.3.1.0
   - ca-province-codes ==1.0.0.0
   - carray ==0.1.6.8
+  - casa-client ==0.0.1
+  - casa-types ==0.0.1
   - cased ==0.1.0.0
   - case-insensitive ==1.2.1.0
   - cases ==0.1.3.2
@@ -574,7 +576,7 @@ default-package-overrides:
   - data-tree-print ==0.1.0.2
   - dataurl ==0.1.0.0
   - DAV ==1.3.4
-  - dbus ==1.2.13
+  - dbus ==1.2.14
   - debian-build ==0.10.2.0
   - debug-trace-var ==0.2.0
   - dec ==0.0.3
@@ -664,7 +666,7 @@ default-package-overrides:
   - elm-core-sources ==1.0.0
   - elm-export ==0.6.0.1
   - emacs-module ==0.1.1
-  - email-validate ==2.3.2.12
+  - email-validate ==2.3.2.13
   - emojis ==0.1
   - enclosed-exceptions ==1.0.3
   - ENIG ==0.0.1.0
@@ -897,6 +899,7 @@ default-package-overrides:
   - groups ==0.4.1.0
   - guarded-allocation ==0.0.1
   - hackage-db ==2.1.0
+  - hackage-security ==0.6.0.1
   - haddock-library ==1.8.0
   - half ==0.3
   - hamtsolo ==1.0.3
@@ -1073,7 +1076,7 @@ default-package-overrides:
   - hw-fingertree-strict ==0.1.2.0
   - hw-hedgehog ==0.1.1.0
   - hw-hspec-hedgehog ==0.1.1.0
-  - hw-int ==0.0.1.0
+  - hw-int ==0.0.2.0
   - hw-ip ==2.4.2.0
   - hw-json ==1.3.2.0
   - hw-json-simd ==0.1.1.0
@@ -1116,7 +1119,7 @@ default-package-overrides:
   - incremental-parser ==0.4.0.1
   - indents ==0.5.0.1
   - indexed ==0.1.3
-  - indexed-list-literals ==0.2.1.2
+  - indexed-list-literals ==0.2.1.3
   - indexed-profunctors ==0.1
   - infer-license ==0.2.0
   - inflections ==0.4.0.5
@@ -1153,7 +1156,7 @@ default-package-overrides:
   - ip6addr ==1.0.1
   - iproute ==1.7.9
   - IPv6Addr ==1.1.3
-  - ipynb ==0.1
+  - ipynb ==0.1.0.1
   - ipython-kernel ==0.10.1.0
   - irc ==0.6.1.0
   - irc-client ==1.1.1.1
@@ -1167,7 +1170,7 @@ default-package-overrides:
   - ix-shapable ==0.1.0
   - jack ==0.7.1.4
   - jira-wiki-markup ==1.0.0
-  - jose ==0.8.2.0
+  - jose ==0.8.2.1
   - jose-jwt ==0.8.0
   - js-dgtable ==0.5.2
   - js-flot ==0.8.3
@@ -1196,7 +1199,7 @@ default-package-overrides:
   - kind-generics-th ==0.2.1.0
   - kmeans ==0.1.3
   - koofr-client ==1.0.0.3
-  - kubernetes-webhook-haskell ==0.2.0.0
+  - kubernetes-webhook-haskell ==0.2.0.1
   - l10n ==0.1.0.1
   - labels ==0.3.3
   - lackey ==1.0.12
@@ -1209,7 +1212,7 @@ default-package-overrides:
   - language-java ==0.2.9
   - language-javascript ==0.7.1.0
   - language-protobuf ==1.0.1
-  - language-puppet ==1.4.6.2
+  - language-puppet ==1.4.6.3
   - lapack-carray ==0.0.3
   - lapack-comfort-array ==0.0.0.1
   - lapack-ffi ==0.0.2
@@ -1276,6 +1279,7 @@ default-package-overrides:
   - lsp-test ==0.10.2.0
   - lucid ==2.9.12
   - lucid-extras ==0.2.2
+  - lukko ==0.1.1.2
   - lzma ==0.0.0.3
   - lzma-conduit ==1.2.1
   - machines ==0.7
@@ -1508,6 +1512,7 @@ default-package-overrides:
   - pandoc-plot ==0.2.2.0
   - pandoc-pyplot ==2.3.0.1
   - pandoc-types ==1.20
+  - pantry ==0.4.0.1
   - papillon ==0.1.1.1
   - parallel ==3.2.2.0
   - parallel-io ==0.3.3
@@ -1659,8 +1664,8 @@ default-package-overrides:
   - PyF ==0.9.0.1
   - qchas ==1.1.0.1
   - qm-interpolated-string ==0.3.0.0
-  - qrcode-core ==0.9.2
-  - qrcode-juicypixels ==0.8.0
+  - qrcode-core ==0.9.3
+  - qrcode-juicypixels ==0.8.1
   - quadratic-irrational ==0.1.1
   - QuasiText ==0.1.2.6
   - QuickCheck ==2.13.2
@@ -1718,6 +1723,7 @@ default-package-overrides:
   - RefSerialize ==0.4.0
   - regex ==1.1.0.0
   - regex-applicative ==0.3.3.1
+  - regex-applicative-text ==0.1.0.1
   - regex-base ==0.94.0.0
   - regex-compat ==0.95.2.0
   - regex-compat-tdfa ==0.95.1.4
@@ -1751,7 +1757,7 @@ default-package-overrides:
   - rfc1751 ==0.1.2
   - rfc5051 ==0.1.0.4
   - rigel-viz ==0.2.0.0
-  - rio ==0.1.15.0
+  - rio ==0.1.15.1
   - rio-orphans ==0.1.1.0
   - rio-prettyprint ==0.1.0.0
   - roc-id ==0.1.0.0
@@ -1870,7 +1876,7 @@ default-package-overrides:
   - siggy-chardust ==1.0.0
   - signal ==0.1.0.4
   - silently ==1.2.5.1
-  - simple-affine-space ==0.1
+  - simple-affine-space ==0.1.1
   - simple-cabal ==0.1.1
   - simple-cmd ==0.2.1
   - simple-cmd-args ==0.1.6
@@ -1962,6 +1968,7 @@ default-package-overrides:
   - string-combinators ==0.6.0.5
   - string-conv ==0.1.2
   - string-conversions ==0.4.0.1
+  - string-interpolate ==0.2.0.3
   - string-qq ==0.0.4
   - stringsearch ==0.3.6.6
   - string-transform ==1.1.1
@@ -2006,7 +2013,7 @@ default-package-overrides:
   - tasty-dejafu ==2.0.0.1
   - tasty-discover ==4.2.1
   - tasty-expected-failure ==0.11.1.2
-  - tasty-golden ==2.3.3.1
+  - tasty-golden ==2.3.3.2
   - tasty-hedgehog ==1.0.0.2
   - tasty-hspec ==1.1.5.1
   - tasty-hunit ==0.10.0.2

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2397,6 +2397,8 @@ extra-packages:
   - happy <1.19.6                       # newer versions break Agda
   - happy == 1.19.9                     # for purescript
   - haskell-gi-overloading == 0.0       # gi-* packages use this dependency to disable overloading support
+  - haskell-lsp == 0.19.*               # required for ghcide 0.1.0
+  - haskell-lsp-types == 0.19.*         # required for ghcide 0.1.0
   - haskell-src-exts == 1.19.*          # required by hindent and structured-haskell-mode
   - hinotify == 0.3.9                   # for xmonad-0.26: https://github.com/kolmodin/hinotify/issues/29
   - hoogle == 5.0.14                    # required by hie-hoogle
@@ -5072,7 +5074,6 @@ broken-packages:
   - ghci-lib
   - ghci-ng
   - ghci-pretty
-  - ghcide
   - ghcjs-dom-jsffi
   - ghcjs-fetch
   - ghcjs-hplay
@@ -5871,7 +5872,6 @@ broken-packages:
   - hichi
   - hid-examples
   - hidden-char
-  - hie-bios
   - hie-core
   - hieraclus
   - hierarchical-exceptions

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8809,7 +8809,6 @@ broken-packages:
   - relation
   - relational-postgresql8
   - relative-date
-  - releaser
   - relevant-time
   - reload
   - remark

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2700,6 +2700,7 @@ broken-packages:
   - activitypub
   - activitystreams-aeson
   - actor
+  - acts
   - Adaptive
   - Adaptive-Blaisorblade
   - adaptive-containers
@@ -2791,6 +2792,7 @@ broken-packages:
   - amazon-emailer
   - amazon-emailer-client-snap
   - amazon-products
+  - amazonka-dynamodb
   - amby
   - AMI
   - ampersand
@@ -2822,10 +2824,12 @@ broken-packages:
   - anticiv
   - antigate
   - antimirov
+  - antiope-dynamodb
   - antisplice
   - antlr-haskell
   - antlrc
   - anydbm
+  - aop-prelude
   - aosd
   - apart
   - apecs-stm
@@ -2884,6 +2888,7 @@ broken-packages:
   - arguedit
   - ariadne
   - arion
+  - arithmetic-circuits
   - armada
   - armor
   - arpa
@@ -2970,6 +2975,7 @@ broken-packages:
   - authenticate-ldap
   - authinfo-hs
   - authoring
+  - autoapply
   - AutoForms
   - autom
   - automata
@@ -2983,6 +2989,7 @@ broken-packages:
   - avl-static
   - AvlTree
   - avr-shake
+  - avro-piper
   - avwx
   - awesome-prelude
   - awesomium
@@ -3047,6 +3054,7 @@ broken-packages:
   - barrie
   - barrier
   - barrier-monad
+  - base-encoding
   - base-feature-macros
   - base-generics
   - base-io-access
@@ -3151,6 +3159,7 @@ broken-packages:
   - bindings-libg15
   - bindings-librrd
   - bindings-libstemmer
+  - bindings-libusb
   - bindings-libv4l2
   - bindings-linux-videodev2
   - bindings-monetdb-mapi
@@ -3377,6 +3386,7 @@ broken-packages:
   - cabal-dependency-licenses
   - cabal-dev
   - cabal-dir
+  - cabal-fmt
   - cabal-ghc-dynflags
   - cabal-ghci
   - cabal-graphdeps
@@ -3410,6 +3420,7 @@ broken-packages:
   - cabin
   - cabocha
   - cached
+  - cacophony
   - cafeteria-prelude
   - caffegraph
   - cairo-core
@@ -3510,6 +3521,7 @@ broken-packages:
   - cereal-time
   - certificate
   - cf
+  - cfenv
   - cfipu
   - cflp
   - cfopu
@@ -3683,6 +3695,7 @@ broken-packages:
   - collections-api
   - collections-base-instances
   - colonnade
+  - Color
   - color-counter
   - colorless
   - colorless-http-client
@@ -3943,6 +3956,7 @@ broken-packages:
   - cspmchecker
   - cspretty
   - css
+  - css-selectors
   - css-syntax
   - csv-enumerator
   - csv-nptools
@@ -3963,6 +3977,7 @@ broken-packages:
   - curves
   - custom-prelude
   - CV
+  - cv-combinators
   - cypher
   - d-bus
   - d10
@@ -4131,6 +4146,7 @@ broken-packages:
   - demarcate
   - denominate
   - dense-int-set
+  - dependent-hashmap
   - dependent-monoidal-map
   - dependent-state
   - dependent-sum-aeson-orphans
@@ -4170,6 +4186,7 @@ broken-packages:
   - dhall-yaml
   - dhcp-lease-parser
   - dhrun
+  - di-polysemy
   - dia-base
   - dia-functions
   - diagrams-boolean
@@ -4207,6 +4224,7 @@ broken-packages:
   - DigitalOcean
   - digitalocean-kzs
   - digits
+  - digraph
   - dimensional-codata
   - dimensional-tf
   - DimensionalHash
@@ -4411,6 +4429,7 @@ broken-packages:
   - effect-stack
   - effin
   - egison-quote
+  - egison-tutorial
   - ehaskell
   - ehs
   - eibd-client-simple
@@ -4418,6 +4437,7 @@ broken-packages:
   - Eight-Ball-Pool-Hack-Cheats
   - either-unwrap
   - EitherT
+  - ejdb2-binding
   - ekg-bosun
   - ekg-carbon
   - ekg-elastic
@@ -4588,6 +4608,7 @@ broken-packages:
   - extensible-data
   - extensible-effects-concurrent
   - extensible-skeleton
+  - extensions
   - external-sort
   - Extra
   - extract-dependencies
@@ -4644,6 +4665,7 @@ broken-packages:
   - fca
   - fcache
   - fcd
+  - fcf-containers
   - fcg
   - fckeditor
   - fclabels-monadlib
@@ -4715,6 +4737,7 @@ broken-packages:
   - findhttp
   - fingertree-psqueue
   - fingertree-tf
+  - finitary
   - finitary-derive
   - FiniteMap
   - firefly-example
@@ -4829,6 +4852,7 @@ broken-packages:
   - fraction
   - frag
   - Frames-beam
+  - Frames-dsv
   - franchise
   - Frank
   - fraxl
@@ -4912,6 +4936,7 @@ broken-packages:
   - funpat
   - funsat
   - funspection
+  - fused-effects-readline
   - fused-effects-squeal
   - fusion
   - fusion-plugin
@@ -5020,6 +5045,7 @@ broken-packages:
   - ghc-dump-tree
   - ghc-dump-util
   - ghc-dup
+  - ghc-events-analyze
   - ghc-events-parallel
   - ghc-generic-instances
   - ghc-imported-from
@@ -5088,6 +5114,7 @@ broken-packages:
   - git-remote-ipfs
   - git-repair
   - git-sanity
+  - git-vogue
   - gitdo
   - github-backup
   - github-data
@@ -5375,6 +5402,7 @@ broken-packages:
   - hakyll-R
   - hakyll-series
   - hakyll-shortcode
+  - hakyll-shortcut-links
   - hakyll-typescript
   - hal
   - halberd
@@ -5391,6 +5419,7 @@ broken-packages:
   - hamsql
   - hamtmap
   - hamusic
+  - hanabi-dealer
   - handa-gdata
   - handle-like
   - HandlerSocketClient
@@ -6008,6 +6037,7 @@ broken-packages:
   - hoovie
   - hopencc
   - hopencl
+  - HOpenCV
   - hOpenPGP
   - hopenpgp-tools
   - hopfield
@@ -6104,6 +6134,7 @@ broken-packages:
   - hs-rs-notify
   - hs-scrape
   - hs-snowtify
+  - hs-speedscope
   - hs-twitter
   - hs-twitterarchiver
   - hs-vcard
@@ -6338,7 +6369,16 @@ broken-packages:
   - huzzy
   - hvega-theme
   - hVOIDP
+  - hw-all
   - hw-ci-assist
+  - hw-dsv
+  - hw-json
+  - hw-json-lens
+  - hw-json-simd
+  - hw-json-simple-cursor
+  - hw-json-standard-cursor
+  - hw-kafka-avro
+  - hw-simd
   - hwall-auth-iitk
   - hweblib
   - hwhile
@@ -6422,9 +6462,20 @@ broken-packages:
   - ignore
   - igraph
   - igrf
+  - ihaskell
+  - ihaskell-aeson
   - ihaskell-basic
+  - ihaskell-blaze
+  - ihaskell-charts
+  - ihaskell-diagrams
   - ihaskell-display
+  - ihaskell-gnuplot
+  - ihaskell-graphviz
+  - ihaskell-hatex
+  - ihaskell-hvega
   - ihaskell-inline-r
+  - ihaskell-juicypixels
+  - ihaskell-magic
   - ihaskell-parsec
   - ihaskell-plot
   - ihaskell-rlangqq
@@ -6662,6 +6713,7 @@ broken-packages:
   - json-rpc-client
   - json-schema
   - json-sop
+  - json-syntax
   - json-togo
   - json-tokens
   - json-tracer
@@ -6881,6 +6933,9 @@ broken-packages:
   - language-vhdl
   - language-webidl
   - lapack
+  - lapack-carray
+  - lapack-comfort-array
+  - lapack-ffi
   - large-hashable
   - Lastik
   - lat
@@ -6909,6 +6964,7 @@ broken-packages:
   - lda
   - ldap-client
   - ldapply
+  - LDAPv3
   - ldif
   - leaf
   - leaky
@@ -6983,6 +7039,7 @@ broken-packages:
   - libxslt
   - licensor
   - lie
+  - life-sync
   - lifted-base-tf
   - lifted-protolude
   - lifted-stm
@@ -7055,6 +7112,8 @@ broken-packages:
   - liszt
   - lit
   - literals
+  - LiterateMarkdown
+  - little-logger
   - live-sequencer
   - ll-picosat
   - llsd
@@ -7148,6 +7207,7 @@ broken-packages:
   - lsystem
   - ltext
   - ltk
+  - LTS
   - lua-bc
   - luachunk
   - luautils
@@ -7171,6 +7231,7 @@ broken-packages:
   - lz4-conduit
   - lzma-enumerator
   - lzma-streams
+  - lzo
   - maam
   - mac
   - macaroon-shop
@@ -7249,6 +7310,9 @@ broken-packages:
   - marxup
   - masakazu-bot
   - MASMGen
+  - massiv
+  - massiv-io
+  - massiv-test
   - master-plan
   - matchable
   - matchable-th
@@ -7261,6 +7325,7 @@ broken-packages:
   - mathlink
   - matrix-as-xyz
   - matrix-market
+  - matrix-sized
   - matsuri
   - maude
   - maxent
@@ -7342,6 +7407,7 @@ broken-packages:
   - miconix-test
   - micro-recursion-schemes
   - microaeson
+  - microbase
   - microformats2-parser
   - microformats2-types
   - microgroove
@@ -7523,8 +7589,10 @@ broken-packages:
   - ms
   - msgpack
   - msgpack-aeson
+  - msgpack-binary
   - msgpack-idl
   - msgpack-rpc
+  - msgpack-rpc-conduit
   - msh
   - msi-kb-backlit
   - MSQueue
@@ -7536,9 +7604,11 @@ broken-packages:
   - mtl-tf
   - mtlx
   - mtp
+  - mu-avro
   - mu-grpc-client
   - mu-grpc-common
   - mu-grpc-server
+  - mu-kafka
   - mu-protobuf
   - MuCheck
   - MuCheck-Hspec
@@ -7756,6 +7826,7 @@ broken-packages:
   - nix-deploy
   - nix-eval
   - nix-freeze-tree
+  - nix-narinfo
   - nix-tools
   - nixfromnpm
   - nixpkgs-update
@@ -7830,12 +7901,14 @@ broken-packages:
   - ObjectIO
   - objective
   - ocaml-export
+  - ochan
   - octane
   - octohat
   - octopus
   - Octree
   - oculus
   - odbc
+  - odd-jobs
   - OddWord
   - oden-go-packages
   - oeis2
@@ -7875,6 +7948,7 @@ broken-packages:
   - OpenAFP
   - OpenAFP-Utils
   - openapi-petstore
+  - openapi-typed
   - opench-meteo
   - OpenCL
   - OpenCLRaw
@@ -7883,10 +7957,12 @@ broken-packages:
   - opendatatable
   - OpenGLCheck
   - opengles
+  - openid-connect
   - OpenSCAD
   - opensoundcontrol-ht
   - openssh-github-keys
   - openssh-protocol
+  - opentelemetry-extra
   - opentelemetry-http-client
   - opentelemetry-lightstep
   - opentelemetry-wai
@@ -7921,6 +7997,7 @@ broken-packages:
   - orders
   - Ordinary
   - ordrea
+  - oref
   - organize-imports
   - orgmode
   - origami
@@ -7940,6 +8017,7 @@ broken-packages:
   - otp-authenticator
   - ottparse-pretty
   - overload
+  - overloaded
   - overloaded-records
   - overture
   - pack
@@ -8238,6 +8316,7 @@ broken-packages:
   - plugins-multistage
   - plur
   - plural
+  - plzwrk
   - png-file
   - pngload
   - pngload-fixed
@@ -8340,6 +8419,7 @@ broken-packages:
   - prelude-plus
   - preprocess-haskell
   - preprocessor
+  - preql
   - presburger
   - present
   - press
@@ -8351,6 +8431,7 @@ broken-packages:
   - prettyprinter-graphviz
   - prettyprinter-vty
   - preview
+  - prim
   - prim-array
   - prim-ref
   - primes-type
@@ -8852,6 +8933,8 @@ broken-packages:
   - robots-txt
   - roc-cluster
   - roc-cluster-demo
+  - rock
+  - rocksdb-query
   - roku-api
   - rollbar
   - rollbar-hs
@@ -8972,7 +9055,10 @@ broken-packages:
   - scgi
   - schedevr
   - schedule-planner
+  - scheduler
   - schedyield
+  - schema
+  - schemas
   - schematic
   - scholdoc
   - scholdoc-citeproc
@@ -8981,6 +9067,7 @@ broken-packages:
   - sci-ratio
   - SciBaseTypes
   - scidb-hquery
+  - scientific-notation
   - SciFlow
   - SciFlow-drmaa
   - scion
@@ -9191,6 +9278,7 @@ broken-packages:
   - shivers-cfg
   - shoap
   - shopify
+  - shortcut-links
   - shorten-strings
   - ShortestPathProblems
   - show-prettyprint
@@ -9309,9 +9397,11 @@ broken-packages:
   - smsaero
   - smt-lib
   - SmtLib
+  - smtlib2
   - smtlib2-debug
   - smtlib2-pipe
   - smtlib2-quickcheck
+  - smtlib2-timing
   - smtp-mail-ng
   - SMTPClient
   - smtps-gmail
@@ -9559,12 +9649,14 @@ broken-packages:
   - stern-brocot
   - stgi
   - STL
+  - STLinkUSB
   - stm-chunked-queues
   - stm-containers
   - stm-firehose
   - stm-hamt
   - stm-promise
   - stm-stats
+  - STM32-Zombie
   - stmcontrol
   - stochastic
   - StockholmAlignment
@@ -9792,9 +9884,12 @@ broken-packages:
   - telegram-api
   - telegram-bot
   - telegram-bot-simple
+  - telegram-raw-api
+  - telegram-types
   - teleport
   - teleshell
   - tellbot
+  - tempi
   - template-default
   - template-haskell-util
   - template-hsml
@@ -9806,6 +9901,10 @@ broken-packages:
   - tempus
   - tensor
   - tensor-safe
+  - tensorflow
+  - tensorflow-core-ops
+  - tensorflow-logging
+  - tensorflow-ops
   - termbox
   - termbox-banana
   - termbox-bindings
@@ -10085,6 +10184,7 @@ broken-packages:
   - turingMachine
   - turtle-options
   - tweak
+  - tweet-hs
   - twentefp-eventloop-graphics
   - twentefp-eventloop-trees
   - twentefp-graphs
@@ -10137,6 +10237,7 @@ broken-packages:
   - type-tree
   - typeable-th
   - TypeClass
+  - typed-encoding
   - typed-streams
   - typed-wire
   - typedflow
@@ -10249,6 +10350,7 @@ broken-packages:
   - urn
   - urn-random
   - urxml
+  - usb
   - usb-enumerator
   - usb-hid
   - usb-id-database
@@ -10367,6 +10469,7 @@ broken-packages:
   - visual-graphrewrite
   - visual-prof
   - visualize-cbn
+  - vitrea
   - vivid
   - vivid-osc
   - vivid-supercollider
@@ -10549,6 +10652,7 @@ broken-packages:
   - wraxml
   - wrecker
   - wrecker-ui
+  - wreq-patchable
   - wreq-sb
   - wright
   - writer-cps-full
@@ -10559,6 +10663,7 @@ broken-packages:
   - wsdl
   - wsedit
   - wshterm
+  - wstunnel
   - wtk
   - wtk-gtk
   - wu-wei
@@ -10859,3 +10964,5 @@ broken-packages:
   - ztar
   - zuramaru
   - Zwaluw
+  - zxcvbn-dvorak
+  - zxcvbn-hs

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -727,4 +727,7 @@ self: super: builtins.intersectAttrs super {
           --prefix PATH : "${path}"
       '';
     });
+
+  # Tests access homeless-shelter.
+  hie-bios = dontCheck super.hie-bios;
 }

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -48,12 +48,8 @@ in
 , isExecutable ? false, isLibrary ? !isExecutable
 , jailbreak ? false
 , license
-# We cannot enable -j<n> parallelism for libraries because GHC is far more
-# likely to generate a non-determistic library ID in that case. Further
-# details are at <https://github.com/peti/ghc-library-id-bug>.
-#
-# Currently disabled for aarch64. See https://ghc.haskell.org/trac/ghc/ticket/15449.
-, enableParallelBuilding ? ((stdenv.lib.versionOlder "7.8" ghc.version && !isLibrary) || stdenv.lib.versionOlder "8.0.1" ghc.version) && !(stdenv.buildPlatform.isAarch64)
+  # aarch64 sometimes crashes for -jn with n>1: https://ghc.haskell.org/trac/ghc/ticket/15449
+, enableParallelBuilding ? !stdenv.buildPlatform.isAarch64
 , maintainers ? []
 , doCoverage ? false
 , doHaddock ? !(ghc.isHaLVM or false)
@@ -82,7 +78,7 @@ in
   # same package in the (recursive) dependencies of the package being
   # built. Will delay failures, if any, to compile time.
   allowInconsistentDependencies ? false
-, maxBuildCores ? 4 # GHC usually suffers beyond -j4. https://ghc.haskell.org/trac/ghc/ticket/9221
+, maxBuildCores ? 16 # more cores usually don't improve performance: https://ghc.haskell.org/trac/ghc/ticket/9221
 , # If set to true, this builds a pre-linked .o file for this Haskell library.
   # This can make it slightly faster to load this library into GHCi, but takes
   # extra disk space and compile time.
@@ -181,6 +177,8 @@ let
     (optionalString enableHsc2hsViaAsm "--hsc2hs-option=--via-asm")
   ];
 
+  parallelBuildingFlags = "-j$NIX_BUILD_CORES" + optionalString stdenv.isLinux " +RTS -A64M -RTS";
+
   crossCabalFlagsString =
     stdenv.lib.optionalString isCross (" " + stdenv.lib.concatStringsSep " " crossCabalFlags);
 
@@ -199,7 +197,7 @@ let
     "--package-db=$packageConfDir"
     (optionalString (enableSharedExecutables && stdenv.isLinux) "--ghc-option=-optl=-Wl,-rpath=$out/lib/${ghc.name}/${pname}-${version}")
     (optionalString (enableSharedExecutables && stdenv.isDarwin) "--ghc-option=-optl=-Wl,-headerpad_max_install_names")
-    (optionalString enableParallelBuilding "--ghc-option=-j$NIX_BUILD_CORES")
+    (optionalString enableParallelBuilding "--ghc-options=${parallelBuildingFlags}")
     (optionalString useCpphs "--with-cpphs=${cpphs}/bin/cpphs --ghc-options=-cpp --ghc-options=-pgmP${cpphs}/bin/cpphs --ghc-options=-optP--cpp")
     (enableFeature (enableDeadCodeElimination && !stdenv.hostPlatform.isAarch32 && !stdenv.hostPlatform.isAarch64 && (versionAtLeast "8.0.1" ghc.version)) "split-objs")
     (enableFeature enableLibraryProfiling "library-profiling")
@@ -227,9 +225,9 @@ let
 
   setupCompileFlags = [
     (optionalString (!coreSetup) "-${nativePackageDbFlag}=$setupPackageConfDir")
-    (optionalString (isGhcjs || isHaLVM || versionOlder "7.8" ghc.version) "-j$NIX_BUILD_CORES")
-    # https://github.com/haskell/cabal/issues/2398
-    (optionalString (versionOlder "7.10" ghc.version && !isHaLVM) "-threaded")
+    (optionalString enableParallelBuilding (parallelBuildingFlags))
+    "-threaded"       # https://github.com/haskell/cabal/issues/2398
+    "-rtsopts"        # allow us to pass RTS flags to the generated Setup executable
   ];
 
   isHaskellPkg = x: x ? isHaskellLibrary;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -77,8 +77,8 @@ in {
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
       bootPkgs = packages.ghc883; # no binary yet
       inherit (buildPackages.python3Packages) sphinx;
-      buildLlvmPackages = buildPackages.llvmPackages_9;
-      llvmPackages = pkgs.llvmPackages_9;
+      buildLlvmPackages = buildPackages.llvmPackages_10;
+      llvmPackages = pkgs.llvmPackages_10;
       libffi = pkgs.libffi;
     };
     ghcjs = compiler.ghcjs86;


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2020-05-08 [20:00 CET](http://www.thetimezoneconverter.com/?t=20:00&tz=Berlin). You can watch this live on Twitch at https://www.twitch.tv/peti343. In addition to the chat features offered by Twitch, there is also a voice conference at https://discord.gg/YTEa3XR that viewers can use to chat with me and with each other.

## TODO

- [x] Add ghcOptions flag to ghcWithPackages wrapper: https://github.com/NixOS/nixpkgs/pull/86948
- [x] Update `all-cabal-hashes` reference.
- [ ] Split-out a minimal `nix` docker image: https://github.com/NixOS/docker/pull/13