### PR TITLE
grisbi: get rid of sha1 + package cleanup

### DIFF
--- a/pkgs/applications/office/grisbi/default.nix
+++ b/pkgs/applications/office/grisbi/default.nix
@@ -1,5 +1,14 @@
-{ fetchurl, stdenv, gtk, pkgconfig, libgsf, libofx, intltool, wrapGAppsHook
-, libsoup, gnome3 }:
+{ fetchurl
+, stdenv
+, gtk
+, pkgconfig
+, libgsf
+, libofx
+, intltool
+, wrapGAppsHook
+, libsoup
+, gnome3
+}:
 
 stdenv.mkDerivation rec {
   pname = "grisbi";
@@ -7,12 +16,18 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/grisbi/${pname}-${version}.tar.bz2";
-    sha1 = "crv3bga72v6fw07wad0nkrgdg4war66j";
+    sha256 = "1piiyyxjsjbw9gcqydvknzxmmfgh8kdqal12ywrxyxih2afwnvbw";
   };
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
-  buildInputs = [ gtk libgsf libofx intltool libsoup
-    gnome3.adwaita-icon-theme ];
+  buildInputs = [
+    gtk
+    libgsf
+    libofx
+    intltool
+    libsoup
+    gnome3.adwaita-icon-theme
+  ];
 
   meta = with stdenv.lib; {
     description = "A personnal accounting application.";
@@ -24,7 +39,7 @@ stdenv.mkDerivation rec {
       management and other information that make Grisbi adapted for
       associations.
     '';
-    homepage = "http://grisbi.org";
+    homepage = "https://grisbi.org";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ layus ];
     platforms = platforms.linux;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Part of https://github.com/NixOS/nixpkgs/issues/77238

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
