### PR TITLE
python3Packages.heudiconv: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/heudiconv/default.nix
+++ b/pkgs/development/python-modules/heudiconv/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   checkPhase = "pytest -k 'not test_dlad and not test_monitor' heudiconv/tests";
 
   meta = with stdenv.lib; {
-    homepage = https://heudiconv.readthedocs.io;
+    homepage = "https://heudiconv.readthedocs.io";
     description = "Flexible DICOM converter for organizing imaging data";
     license = licenses.asl20;
     maintainers = with maintainers; [ bcdarwin ];

--- a/pkgs/development/python-modules/heudiconv/default.nix
+++ b/pkgs/development/python-modules/heudiconv/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, pytest
+, mock
+, dcm2niix
+, nibabel
+, pydicom
+, nipype
+, dcmstack
+, etelemetry
+, filelock
+}:
+
+buildPythonPackage rec {
+  version = "0.8.0";
+  pname = "heudiconv";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    #sha256 = "0gzqqa4pzhywdbvks2qjniwhr89sgipl5k7h9hcjs7cagmy9gb05";
+    sha256 = "1r6y93125mc84c09970ifps5xysp8ffp62rwlzili3q2k1m3fh4v";
+  };
+
+  postPatch = ''
+    # doesn't exist as a separate package with Python 3:
+    substituteInPlace heudiconv/info.py --replace "'pathlib'," ""
+  '';
+
+  propagatedBuildInputs = [
+    dcm2niix nibabel pydicom nipype dcmstack etelemetry filelock
+  ];
+
+  checkInputs = [ dcm2niix pytest mock ];
+
+  # test_monitor and test_dlad require 'inotify' and 'datalad' respectively,
+  # and these aren't in Nixpkgs
+  checkPhase = "pytest -k 'not test_dlad and not test_monitor' heudiconv/tests";
+
+  meta = with stdenv.lib; {
+    homepage = https://heudiconv.readthedocs.io;
+    description = "Flexible DICOM converter for organizing imaging data";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2915,6 +2915,8 @@ in {
 
   helpdev = callPackage ../development/python-modules/helpdev { };
 
+  heudiconv = callPackage ../development/python-modules/heudiconv { };
+
   hickle = callPackage ../development/python-modules/hickle { };
 
   hiro = callPackage ../development/python-modules/hiro {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  One of the CLI scripts (`heudiconv_monitor`) is not working.  It is possible to get this to work by adding the `inotify` package (dsoprea/PyInotify) to Nixpkgs, but this fails some tests and so is perhaps not working correctly, and anyway examining the optional vs mandatory dependencies for `heudiconv` and those used only by this script and its tests suggests `heudiconv_monitor` is optional anyway.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
