### PR TITLE
[haskell-updates] haskellPackages.hlint: Fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1500,4 +1500,18 @@ self: super: {
     haskell-lsp = self.haskell-lsp_0_19_0_0;
   });
 
+  # stackage right now is not new enough for hlint-3.0
+  ghc-lib-parser-ex_8_10_0_6 = super.ghc-lib-parser-ex_8_10_0_6.override {
+    ghc-lib-parser = self.ghc-lib-parser_8_10_1_20200412;
+  };
+
+  hlint = super.hlint.override {
+    ghc-lib-parser = self.ghc-lib-parser_8_10_1_20200412;
+    ghc-lib-parser-ex = self.ghc-lib-parser-ex_8_10_0_6;
+    extra = self.extra_1_7_1;
+    filepattern = self.filepattern.override {
+      extra = self.extra_1_7_1;
+    };
+  };
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super


### PR DESCRIPTION
###### Motivation for this change

 hlint 3.0 is shiny and new and is very picky in its dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
