### PR TITLE
nixos/nsswitch cleanup nss modules

### DIFF
--- a/nixos/modules/config/ldap.nix
+++ b/nixos/modules/config/ldap.nix
@@ -244,6 +244,10 @@ in
       if cfg.daemon.enable then nss_pam_ldapd else nss_ldap
     );
 
+    system.nssDatabases.group = optional cfg.nsswitch "ldap";
+    system.nssDatabases.passwd = optional cfg.nsswitch "ldap";
+    system.nssDatabases.shadow = optional cfg.nsswitch "ldap";
+
     users = mkIf cfg.daemon.enable {
       groups.nslcd = {
         gid = config.ids.gids.nslcd;

--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -9,15 +9,12 @@ let
   # only with nscd up and running we can load NSS modules that are not integrated in NSS
   canLoadExternalModules = config.services.nscd.enable;
   # XXX Move these to their respective modules
-  nssmdns = canLoadExternalModules && config.services.avahi.nssmdns;
   nsswins = canLoadExternalModules && config.services.samba.nsswins;
 
   hostArray = mkMerge [
     (mkBefore [ "files" ])
-    (mkIf nssmdns [ "mdns_minimal [NOTFOUND=return]" ])
     (mkIf nsswins [ "wins" ])
     (mkAfter [ "dns" ])
-    (mkIf nssmdns (mkOrder 1501 [ "mdns" ])) # 1501 to ensure it's after dns
   ];
 
 in {

--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -11,7 +11,6 @@ let
   # XXX Move these to their respective modules
   nssmdns = canLoadExternalModules && config.services.avahi.nssmdns;
   nsswins = canLoadExternalModules && config.services.samba.nsswins;
-  ldap = canLoadExternalModules && (config.users.ldap.enable && config.users.ldap.nsswitch);
 
   hostArray = mkMerge [
     (mkBefore [ "files" ])
@@ -19,16 +18,6 @@ let
     (mkIf nsswins [ "wins" ])
     (mkAfter [ "dns" ])
     (mkIf nssmdns (mkOrder 1501 [ "mdns" ])) # 1501 to ensure it's after dns
-  ];
-
-  passwdArray = mkMerge [
-    (mkBefore [ "files" ])
-    (mkIf ldap [ "ldap" ])
-  ];
-
-  shadowArray = mkMerge [
-    (mkBefore [ "files" ])
-    (mkIf ldap [ "ldap" ])
   ];
 
 in {
@@ -145,9 +134,9 @@ in {
     '';
 
     system.nssDatabases = {
-      passwd = passwdArray;
-      group = passwdArray;
-      shadow = shadowArray;
+      passwd = mkBefore [ "files" ];
+      group = mkBefore [ "files" ];
+      shadow = mkBefore [ "files" ];
       hosts = hostArray;
       services = mkBefore [ "files" ];
     };

--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -99,7 +99,7 @@ with lib;
         # If disabling nscd is really necessary, it's still possible to opt out
         # by forcing config.system.nssModules to [].
         assertion = config.system.nssModules.path != "" -> config.services.nscd.enable;
-        message = "Loading NSS modules from path ${config.system.nssModules.path} requires nscd being enabled.";
+        message = "Loading NSS modules from system.nssModules (${config.system.nssModules.path}), requires services.nscd.enable being set to true.";
       }
     ];
 

--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -95,7 +95,9 @@ with lib;
   config = {
     assertions = [
       {
-        # generic catch if the NixOS module adding to nssModules does not prevent it with specific message.
+        # Prevent users from disabling nscd, with nssModules being set.
+        # If disabling nscd is really necessary, it's still possible to opt out
+        # by forcing config.system.nssModules to [].
         assertion = config.system.nssModules.path != "" -> config.services.nscd.enable;
         message = "Loading NSS modules from path ${config.system.nssModules.path} requires nscd being enabled.";
       }

--- a/nixos/modules/security/google_oslogin.nix
+++ b/nixos/modules/security/google_oslogin.nix
@@ -50,6 +50,7 @@ in
     # enable the nss module, so user lookups etc. work
     system.nssModules = [ package ];
     system.nssDatabases.passwd = [ "cache_oslogin" "oslogin" ];
+    system.nssDatabases.group = [ "cache_oslogin" "oslogin" ];
 
     # Ugly: sshd refuses to start if a store path is given because /nix/store is group-writable.
     # So indirect by a symlink.

--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -76,9 +76,10 @@ in {
 
       system.nssModules = optional cfg.enable pkgs.sssd;
       system.nssDatabases = {
+        group = [ "sss" ];
         passwd = [ "sss" ];
-        shadow = [ "sss" ];
         services = [ "sss" ];
+        shadow = [ "sss" ];
       };
       services.dbus.packages = [ pkgs.sssd ];
     })

--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -69,7 +69,7 @@ in {
         mode = "0400";
       };
 
-      system.nssModules = optional cfg.enable pkgs.sssd;
+      system.nssModules = pkgs.sssd;
       system.nssDatabases = {
         group = [ "sss" ];
         passwd = [ "sss" ];

--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -42,11 +42,6 @@ in {
   };
   config = mkMerge [
     (mkIf cfg.enable {
-      assertions = singleton {
-        assertion = nscd.enable;
-        message = "nscd must be enabled through `services.nscd.enable` for SSSD to work.";
-      };
-
       systemd.services.sssd = {
         description = "System Security Services Daemon";
         wantedBy    = [ "multi-user.target" ];

--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -224,6 +224,7 @@ in
       (mkIf cfg.enable {
 
         system.nssModules = optional cfg.nsswins samba;
+        system.nssDatabases.hosts = optional cfg.nsswins "wins";
 
         systemd = {
           targets.samba = {

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -238,6 +238,10 @@ in
     users.groups.avahi = {};
 
     system.nssModules = optional cfg.nssmdns pkgs.nssmdns;
+    system.nssDatabases.hosts = optionals cfg.nssmdns (mkMerge [
+      [ "mdns_minimal [NOTFOUND=return]" ]
+      (mkOrder 1501 [ "mdns" ]) # 1501 to ensure it's after dns
+    ]);
 
     environment.systemPackages = [ pkgs.avahi ];
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -848,6 +848,10 @@ in
         [ "mymachines" ]
         (mkAfter [ "systemd" ])
       ]);
+      group = (mkMerge [
+        [ "mymachines" ]
+        (mkAfter [ "systemd" ])
+      ]);
     };
 
     environment.systemPackages = [ systemd ];

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -829,16 +829,8 @@ in
 
     system.build.units = cfg.units;
 
-    # Systemd provides various NSS modules to look up dynamic users, locally
-    # configured IP adresses and local container hostnames.
-    # On NixOS, these can only be passed to the NSS system via nscd (and its
-    # LD_LIBRARY_PATH), which is why it's usually a very good idea to have nscd
-    # enabled (also see the config.nscd.enable description).
-    # While there is already an assertion in place complaining loudly about
-    # having nssModules configured and nscd disabled, for some reason we still
-    # check for nscd being enabled before adding to nssModules.
-    system.nssModules = optional config.services.nscd.enable systemd.out;
-    system.nssDatabases = mkIf config.services.nscd.enable {
+    system.nssModules = [ systemd.out ];
+    system.nssDatabases = {
       hosts = (mkMerge [
         [ "mymachines" ]
         (mkOrder 1600 [ "myhostname" ] # 1600 to ensure it's always the last


### PR DESCRIPTION
This moves the remaining NSS modules to their corresponding modules, and contains some follow-up fixes, where we missed adding to the `group` database (as the `passwdArray` was used both for `system.nssDatabases.passed` and `system.nssDatabases.group`).

It also removes the conditional loading of systemd nss modules, as requested in https://github.com/NixOS/nixpkgs/pull/86940#discussion_r420122114.

closes #86350.

###### Motivation for this change
#86350

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
