### PR TITLE
jftui: 0.2.2 -> 0.3.0

### DIFF
--- a/pkgs/applications/video/jftui/default.nix
+++ b/pkgs/applications/video/jftui/default.nix
@@ -1,32 +1,27 @@
-{ stdenv, fetchFromGitHub, fetchpatch, clang,
-  pkg-config, curl, mpv, yajl }:
+{ stdenv
+, fetchFromGitHub
+, pkg-config
+, curl
+, mpv
+, yajl
+}:
 
 stdenv.mkDerivation rec {
   pname = "jftui";
-  version = "0.2.2";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "Aanok";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0g93w8ahyh2v0cv2fyj5a7v6qyznavwk0dcxx1qw4kczdgmlxnkx";
+    sha256 = "1az737q5i24ylvkx4g3xlq8k48ni91nz5hhbif97g4nlhwl5cqb6";
   };
-
-  patches = [
-    # Remove this patch with next version
-    (fetchpatch {
-      name = "curl-capability-check-fix";
-      url = "https://github.com/Aanok/jftui/commit/d63996b8bc0d2ac4b04c5de4169bc7f8ec9b2a30.patch";
-      sha256 = "1d595mkzgx3carq2cykxpvmf5klgdlyaq94fk9wj8812yswqlsr7";
-    })
-  ];
 
   nativeBuildInputs = [
     pkg-config
   ];
 
   buildInputs = [
-    clang
     curl
     mpv
     yajl


### PR DESCRIPTION
##### Things done

 - Removed patch, no longer needed.
 - Removed clang for no reason other than to simplify, since upstream also removed hardcoded dependency from makefile.
 - nixpkgs-fmt, for good measure.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
