### PR TITLE
nottetris2: init at 2.0

### DIFF
--- a/pkgs/games/nottetris2/default.nix
+++ b/pkgs/games/nottetris2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, zip, love_0_7, lua, makeWrapper, makeDesktopItem }:
+{ stdenv, fetchFromGitHub, zip, love_0_7, makeWrapper, makeDesktopItem }:
 
 let
   pname = "nottetris2";
@@ -25,8 +25,8 @@ stdenv.mkDerivation {
     sha256 = "17iabh6rr8jim70n96rbhif4xq02g2kppscm8l339yqx6mhb64hs";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ lua love_0_7 zip ];
+  nativeBuildInputs = [ zip ];
+  buildInputs = [ love_0_7 makeWrapper ];
 
   phases = [ "unpackPhase" "installPhase" ];
 

--- a/pkgs/games/nottetris2/default.nix
+++ b/pkgs/games/nottetris2/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation {
     description = "It's like Tetris, but it's not";
     platforms = platforms.linux;
     license = licenses.wtfpl;
+    maintainers = with maintainers; [ yorickvp ];
     downloadPage = "https://stabyourself.net/nottetris2/";
   };
 

--- a/pkgs/games/nottetris2/default.nix
+++ b/pkgs/games/nottetris2/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, zip, love_0_7, lua, makeWrapper, makeDesktopItem }:
+
+let
+  pname = "nottetris2";
+  version = "2.0";
+
+  desktopItem = makeDesktopItem {
+    name = "nottetris2";
+    exec = pname;
+    comment = "It's like tetris, but it's not";
+    desktopName = "nottetris2";
+    genericName = "nottetris2";
+    categories = "Game";
+  };
+
+in
+
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "Stabyourself";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "17iabh6rr8jim70n96rbhif4xq02g2kppscm8l339yqx6mhb64hs";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ lua love_0_7 zip ];
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase =
+  ''
+    mkdir -p $out/bin $out/share/games/lovegames $out/share/applications
+    zip -9 -r ${pname}.love ./*
+    mv ${pname}.love $out/share/games/lovegames/${pname}.love
+    makeWrapper ${love_0_7}/bin/love $out/bin/${pname} --add-flags $out/share/games/lovegames/${pname}.love
+    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+    chmod +x $out/bin/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "It's like Tetris, but it's not";
+    platforms = platforms.linux;
+    license = licenses.wtfpl;
+    downloadPage = "https://stabyourself.net/nottetris2/";
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23617,6 +23617,8 @@ in
 
   newtonwars = callPackage ../games/newtonwars { };
 
+  nottetris2 = callPackage ../games/nottetris2 { };
+
   nudoku = callPackage ../games/nudoku { };
 
   nxengine-evo = callPackage ../games/nxengine-evo { };


### PR DESCRIPTION
###### Motivation for this change
I want to play this game

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
