### PR TITLE
mari0: init at 1.6.2

### DIFF
--- a/pkgs/games/mari0/default.nix
+++ b/pkgs/games/mari0/default.nix
@@ -16,7 +16,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "${pname}-${version}";
+  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "Stabyourself";

--- a/pkgs/games/mari0/default.nix
+++ b/pkgs/games/mari0/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
     description = "Crossover between Super Mario Bros. and Portal";
     platforms = platforms.linux;
     license = licenses.mit;
-    downloadPage = http://stabyourself.net/mari0/;
+    downloadPage = "https://stabyourself.net/mari0/";
   };
 
 }

--- a/pkgs/games/mari0/default.nix
+++ b/pkgs/games/mari0/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, zip, love_11, lua, makeWrapper, makeDesktopItem }:
+
+let
+  pname = "mari0";
+  version = "1.6.2";
+
+  desktopItem = makeDesktopItem {
+    name = "mari0";
+    exec = pname;
+    comment = "Crossover between Super Mario Bros. and Portal";
+    desktopName = "mari0";
+    genericName = "mari0";
+    categories = "Game";
+  };
+
+in
+
+stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "Stabyourself";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "1zqaq4w599scsjvy1rsb21fd2r8j3srx9vym4ir9bh666dp36gxa";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ lua love_11 zip ];
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase =
+  ''
+    mkdir -p $out/bin $out/share/games/lovegames $out/share/applications
+    zip -9 -r ${pname}.love ./*
+    mv ${pname}.love $out/share/games/lovegames/${pname}.love
+    makeWrapper ${love_11}/bin/love $out/bin/${pname} --add-flags $out/share/games/lovegames/${pname}.love
+    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+    chmod +x $out/bin/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Crossover between Super Mario Bros. and Portal";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    downloadPage = http://stabyourself.net/mari0/;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23558,6 +23558,8 @@ in
     gtk = gtk2;
   };
 
+  mari0 = callPackage ../games/mari0 { };
+
   mars = callPackage ../games/mars { };
 
   megaglest = callPackage ../games/megaglest {};


### PR DESCRIPTION
###### Motivation for this change
I want to play the game.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
