### PR TITLE
nco: Patch hardcoded paths cp and mv

### DIFF
--- a/pkgs/development/libraries/nco/default.nix
+++ b/pkgs/development/libraries/nco/default.nix
@@ -1,17 +1,24 @@
-{ stdenv, fetchzip, netcdf, netcdfcxx4, gsl, udunits, antlr, which, curl, flex }:
+{ stdenv, fetchzip, netcdf, netcdfcxx4, gsl, udunits, antlr, which, curl, flex, coreutils }:
 
 stdenv.mkDerivation rec {
   version = "4.9.2";
   pname = "nco";
 
   nativeBuildInputs = [ flex which ];
-  buildInputs = [ netcdf netcdfcxx4 gsl udunits antlr curl ];
+  buildInputs = [ netcdf netcdfcxx4 gsl udunits antlr curl coreutils ];
 
   src = fetchzip {
     url = "https://github.com/nco/nco/archive/${version}.tar.gz";
     sha256 = "0nip9dmdx3d5nc30bz1d2w9his1dph136l53r160aa3bmb29xwqn";
   };
 
+  prePatch = ''
+    substituteInPlace src/nco/nco_fl_utl.c \
+      --replace "/bin/cp" "${coreutils}/bin/cp"
+    substituteInPlace src/nco/nco_fl_utl.c \
+      --replace "/bin/mv" "${coreutils}/bin/mv"
+  '';
+  
   meta = {
     description = "NetCDF Operator toolkit";
     longDescription = "The NCO (netCDF Operator) toolkit manipulates and analyzes data stored in netCDF-accessible formats, including DAP, HDF4, and HDF5";


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Commit b83ed3efe81525302469a3052982f41393a616e0 in the nco source
repo, hard-coded the paths to cp and mv, so as to point to their FHS
locations, which resulted in ncrename throwing a "file not found"
error when invoked outside of an FHS sandbox.


###### Things done

This nixpkgs commit patches the src/nco_fl_utl.c to instead point the
associated nixpkgs.coreutils locations. The hard-coded paths actually
occur in a number of other locations, but this is enough to quash the
error w/ ncrename (and presumably the other CLI nco tooling, although
this isn't tested).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
