### PR TITLE
Add Themix GUI theme designer  (a.k.a. Oomox) packages

### DIFF
--- a/pkgs/applications/misc/themix/default.nix
+++ b/pkgs/applications/misc/themix/default.nix
@@ -5,10 +5,12 @@ rec {
     unwrapped = callPackage ./gui/unwrapped.nix {};
     plugins = with themixPlugins; [
       import-images
+      theme-oomox
     ];
   };
 
   themixPlugins = {
     import-images = callPackage ./import-images {};
+    theme-oomox = callPackage ./theme-oomox {};
   };
 }

--- a/pkgs/applications/misc/themix/default.nix
+++ b/pkgs/applications/misc/themix/default.nix
@@ -6,11 +6,13 @@ rec {
     plugins = with themixPlugins; [
       import-images
       theme-oomox
+      icons-papirus
     ];
   };
 
   themixPlugins = {
     import-images = callPackage ./import-images {};
     theme-oomox = callPackage ./theme-oomox {};
+    icons-papirus = callPackage ./icons-papirus {};
   };
 }

--- a/pkgs/applications/misc/themix/default.nix
+++ b/pkgs/applications/misc/themix/default.nix
@@ -1,0 +1,12 @@
+{ callPackage }:
+
+rec {
+  themix-gui = callPackage ./gui {
+    unwrapped = callPackage ./gui/unwrapped.nix {};
+    plugins = with themixPlugins; [
+    ];
+  };
+
+  themixPlugins = {
+  };
+}

--- a/pkgs/applications/misc/themix/default.nix
+++ b/pkgs/applications/misc/themix/default.nix
@@ -4,9 +4,11 @@ rec {
   themix-gui = callPackage ./gui {
     unwrapped = callPackage ./gui/unwrapped.nix {};
     plugins = with themixPlugins; [
+      import-images
     ];
   };
 
   themixPlugins = {
+    import-images = callPackage ./import-images {};
   };
 }

--- a/pkgs/applications/misc/themix/gui/default.nix
+++ b/pkgs/applications/misc/themix/gui/default.nix
@@ -3,7 +3,7 @@
 let
   unwrappedWithPlugins = symlinkJoin {
     name = unwrapped.name + "-oomox-root";
-    paths = [ unwrapped ] ++ plugins; 
+    paths = [ unwrapped ] ++ plugins;
   };
 in
 

--- a/pkgs/applications/misc/themix/gui/default.nix
+++ b/pkgs/applications/misc/themix/gui/default.nix
@@ -1,0 +1,23 @@
+{ unwrapped, symlinkJoin, plugins ? [] }:
+
+let
+  unwrappedWithPlugins = symlinkJoin {
+    name = unwrapped.name + "-oomox-root";
+    paths = [ unwrapped ] ++ plugins; 
+  };
+in
+
+if builtins.length plugins == 0
+then unwrapped
+else unwrapped.overrideAttrs (old: {
+  name = with old; "${pname}-${version}-with-plugins";
+
+  buildInputs = old.buildInputs ++ plugins;
+
+  preFixup = old.preFixup + ''
+    gappsWrapperArgs+=(
+        --set OOMOX_ROOT "${unwrappedWithPlugins}/opt/oomox"
+        --prefix PATH : "$PATH"
+    )
+  '';
+})

--- a/pkgs/applications/misc/themix/gui/oomox_root.patch
+++ b/pkgs/applications/misc/themix/gui/oomox_root.patch
@@ -1,0 +1,15 @@
+diff --git a/oomox_gui/config.py b/oomox_gui/config.py
+index 4bfd874c..5a43b3dd 100644
+--- a/oomox_gui/config.py
++++ b/oomox_gui/config.py
+@@ -3,7 +3,9 @@ import os
+ 
+ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+ 
+-OOMOX_ROOT_DIR = os.path.abspath(os.path.join(SCRIPT_DIR, "../"))
++OOMOX_ROOT_DIR = os.getenv("OOMOX_ROOT")
++if not OOMOX_ROOT_DIR:
++    OOMOX_ROOT_DIR = os.path.abspath(os.path.join(SCRIPT_DIR, "../"))
+ 
+ COLORS_DIR = os.path.join(
+     OOMOX_ROOT_DIR, "colors/"

--- a/pkgs/applications/misc/themix/gui/unwrapped.nix
+++ b/pkgs/applications/misc/themix/gui/unwrapped.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "themix-gui";
-  version = "1.13.2.1";
+  version = "1.13.3";
 
   src = fetchFromGitHub {
     owner = "themix-project";
     repo = "oomox";
     rev = version;
-    sha256 = "07lq5bmhbpnf9nqsn6krfgc1inyzpmmzwkmckjajghg44mhcwvvi";
+    sha256 = "0j45cb34vsxx4azjidbrv5pm65asgmrzksl07b0xik5c3hvc2ksr";
   };
 
   patches = [ ./oomox_root.patch ];

--- a/pkgs/applications/misc/themix/gui/unwrapped.nix
+++ b/pkgs/applications/misc/themix/gui/unwrapped.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, wrapGAppsHook, python3, gettext
+{ lib, stdenv, fetchFromGitHub, wrapGAppsHook, python3, gettext
 , gtk3, gobject-introspection, hicolor-icon-theme
 }:
 

--- a/pkgs/applications/misc/themix/gui/unwrapped.nix
+++ b/pkgs/applications/misc/themix/gui/unwrapped.nix
@@ -1,0 +1,67 @@
+{ stdenv, fetchFromGitHub, wrapGAppsHook, python3, gettext
+, gtk3, gobject-introspection, hicolor-icon-theme
+}:
+
+stdenv.mkDerivation rec {
+  pname = "themix-gui";
+  version = "1.13.2.1";
+
+  src = fetchFromGitHub {
+    owner = "themix-project";
+    repo = "oomox";
+    rev = version;
+    sha256 = "07lq5bmhbpnf9nqsn6krfgc1inyzpmmzwkmckjajghg44mhcwvvi";
+  };
+
+  patches = [ ./oomox_root.patch ];
+
+  postPatch = ''
+    patchShebangs .
+
+    for bin in packaging/bin/*; do
+        sed -i "$bin" -e "s@\(/opt/oomox/\)@$out\1@"
+        sed -i "$bin" -e "s@exec \(python3\)@exec ${python3}/bin/\1@"
+    done
+
+    # No need to remove .git* in git submodules
+    sed -i Makefile -e '/$(RM) -r .\+\.git\*/d'
+  '';
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  buildInputs = [ python3 ] ++ (with python3.pkgs; [
+    pygobject3
+  ]) ++ [
+    gettext gtk3 gobject-introspection hicolor-icon-theme
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    python -O -m compileall oomox_gui
+    runHook postBuild
+  '';
+
+  # No tests
+  doCheck = false; 
+
+  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+
+  installTargets = "install_gui";
+
+  postInstall = ''
+    sed -i "$out/share/applications/com.github.themix_project.Oomox.desktop" \
+        -e "s@Exec=\(oomox-gui\)@Exec=$out/bin/\1@"
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix PYTHONPATH : "$PYTHONPATH")
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Plugin-based theme designer GUI for desktop/console environments";
+    inherit (src.meta) homepage;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ mnacamura ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/themix/gui/unwrapped.nix
+++ b/pkgs/applications/misc/themix/gui/unwrapped.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Plugin-based theme designer GUI for desktop/console environments";
     homepage = "https://github.com/themix-project/oomox";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ mnacamura ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/themix/gui/unwrapped.nix
+++ b/pkgs/applications/misc/themix/gui/unwrapped.nix
@@ -29,11 +29,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ wrapGAppsHook ];
 
-  buildInputs = [ python3 ] ++ (with python3.pkgs; [
-    pygobject3
-  ]) ++ [
-    gettext gtk3 gobject-introspection hicolor-icon-theme
-  ];
+  buildInputs = [ python3 gettext gtk3 gobject-introspection hicolor-icon-theme ]
+    ++ (with python3.pkgs; [ pygobject3 ]);
 
   buildPhase = ''
     runHook preBuild
@@ -57,9 +54,9 @@ stdenv.mkDerivation rec {
     gappsWrapperArgs+=(--prefix PYTHONPATH : "$PYTHONPATH")
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Plugin-based theme designer GUI for desktop/console environments";
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/themix-project/oomox";
     license = licenses.gpl3;
     maintainers = with maintainers; [ mnacamura ];
     platforms = platforms.linux;

--- a/pkgs/applications/misc/themix/gui/unwrapped.nix
+++ b/pkgs/applications/misc/themix/gui/unwrapped.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   '';
 
   # No tests
-  doCheck = false; 
+  doCheck = false;
 
   installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
 

--- a/pkgs/applications/misc/themix/icons-papirus/default.nix
+++ b/pkgs/applications/misc/themix/icons-papirus/default.nix
@@ -2,7 +2,6 @@
 
 stdenv.mkDerivation rec {
   pname = "themix-icons-papirus";
-
   inherit (themix-gui) version src;
 
   patches = [
@@ -38,12 +37,7 @@ stdenv.mkDerivation rec {
 
   installTargets = "install_icons_papirus";
 
-  meta = {
+  meta = themix-gui.meta // {
     description = "Papirus icons plugin for Themix GUI designer";
-    inherit (themix-gui.meta)
-    homepage
-    license
-    maintainers
-    platforms;
   };
 }

--- a/pkgs/applications/misc/themix/icons-papirus/default.nix
+++ b/pkgs/applications/misc/themix/icons-papirus/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, themix-gui, python3, papirus-icon-theme }:
+
+stdenv.mkDerivation rec {
+  pname = "themix-icons-papirus";
+
+  inherit (themix-gui) version src;
+
+  patches = [
+    # themix-gui generates customized theme by `cp -r` theme skeleton to
+    # working directory and modifying it. As the skeleton is in nix store and
+    # not writable, the copied one is not modifiable.
+    ./writable.patch
+  ];
+
+  postPatch = ''
+    patchShebangs plugins/icons_papirus
+
+    # No need to remove .git*
+    sed -i Makefile -e '/$(RM) -r .\+\.git\*/d'
+
+    # Fix original Papirus icon path
+    sed -i plugins/icons_papirus/change_color.sh \
+        -e 's@$root/papirus-icon-theme@${papirus-icon-theme.src}@'
+  '';
+
+  nativeBuildInputs = [ python3 ];
+
+  buildPhase = ''
+    runHook preBuild
+    python -O -m compileall plugins/icons_papirus
+    runHook postBuild
+  '';
+
+  # No tests
+  doCheck = false; 
+
+  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+
+  installTargets = "install_icons_papirus";
+
+  meta = {
+    description = "Papirus icons plugin for Themix GUI designer";
+    inherit (themix-gui.meta)
+    homepage
+    license
+    maintainers
+    platforms;
+  };
+}

--- a/pkgs/applications/misc/themix/icons-papirus/default.nix
+++ b/pkgs/applications/misc/themix/icons-papirus/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   # No tests
-  doCheck = false; 
+  doCheck = false;
 
   installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
 

--- a/pkgs/applications/misc/themix/icons-papirus/writable.patch
+++ b/pkgs/applications/misc/themix/icons-papirus/writable.patch
@@ -1,0 +1,12 @@
+diff --git a/plugins/icons_papirus/change_color.sh b/plugins/icons_papirus/change_color.sh
+index ecbc1e6a..b286fa0c 100755
+--- a/plugins/icons_papirus/change_color.sh
++++ b/plugins/icons_papirus/change_color.sh
+@@ -114,6 +114,7 @@ dark_stroke_fallback="$(darker "$ICONS_COLOR" 56)"
+ 
+ echo ":: Copying theme template..."
+ cp -R "$root/papirus-icon-theme/Papirus" "$tmp_dir/"
++chmod -R +w "$tmp_dir/Papirus"
+ echo "== Template was copied to $tmp_dir"
+ 
+ 

--- a/pkgs/applications/misc/themix/import-images/default.nix
+++ b/pkgs/applications/misc/themix/import-images/default.nix
@@ -5,10 +5,6 @@
 # , enableHaishoku ? false
 }:
 
-let
-  inherit (stdenv.lib) optionals;
-in
-
 stdenv.mkDerivation rec {
   pname = "themix-import-images";
 
@@ -29,12 +25,7 @@ stdenv.mkDerivation rec {
 
   installTargets = "install_import_images";
 
-  meta = {
+  meta = themix-gui.meta // {
     description = "Plugin for Themix GUI designer to get color palettes from images";
-    inherit (themix-gui.meta)
-    homepage
-    license
-    maintainers
-    platforms;
   };
 }

--- a/pkgs/applications/misc/themix/import-images/default.nix
+++ b/pkgs/applications/misc/themix/import-images/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, themix-gui, python3
+# TODO: These optional python packages are not available in nixpkgs.
+# , enableColorthief ? false
+# , enableColorz ? false
+# , enableHaishoku ? false
+}:
+
+let
+  inherit (stdenv.lib) optionals;
+in
+
+stdenv.mkDerivation rec {
+  pname = "themix-import-images";
+
+  inherit (themix-gui) version src;
+
+  propagatedBuildInputs = with python3.pkgs; [ pillow ];
+
+  buildPhase = ''
+    runHook preBuild
+    python -O -m compileall plugins/import_pil
+    runHook postBuild
+  '';
+
+  # No tests
+  doCheck = false;
+
+  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+
+  installTargets = "install_import_images";
+
+  meta = {
+    description = "Plugin for Themix GUI designer to get color palettes from images";
+    inherit (themix-gui.meta)
+    homepage
+    license
+    maintainers
+    platforms;
+  };
+}

--- a/pkgs/applications/misc/themix/import-images/default.nix
+++ b/pkgs/applications/misc/themix/import-images/default.nix
@@ -1,18 +1,11 @@
-{ lib, stdenv, themix-gui, python3
-, enableColorthief ? true
-, enableColorz ? true
-, enableHaishoku ? true
-}:
+{ lib, stdenv, themix-gui, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "themix-import-images";
 
   inherit (themix-gui) version src;
 
-  propagatedBuildInputs = with python3.pkgs; [ pillow ]
-    ++ lib.optionals enableColorthief [ colorthief ]
-    ++ lib.optionals enableColorz [ colorz ]
-    ++ lib.optionals enableHaishoku [ haishoku ];
+  propagatedBuildInputs = with python3.pkgs; [ pillow colorthief colorz haishoku ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/applications/misc/themix/import-images/default.nix
+++ b/pkgs/applications/misc/themix/import-images/default.nix
@@ -1,8 +1,7 @@
-{ stdenv, themix-gui, python3
-# TODO: These optional python packages are not available in nixpkgs.
-# , enableColorthief ? false
-# , enableColorz ? false
-# , enableHaishoku ? false
+{ lib, stdenv, themix-gui, python3
+, enableColorthief ? true
+, enableColorz ? true
+, enableHaishoku ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -10,7 +9,10 @@ stdenv.mkDerivation rec {
 
   inherit (themix-gui) version src;
 
-  propagatedBuildInputs = with python3.pkgs; [ pillow ];
+  propagatedBuildInputs = with python3.pkgs; [ pillow ]
+    ++ lib.optionals enableColorthief [ colorthief ]
+    ++ lib.optionals enableColorz [ colorz ]
+    ++ lib.optionals enableHaishoku [ haishoku ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/applications/misc/themix/theme-oomox/default.nix
+++ b/pkgs/applications/misc/themix/theme-oomox/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   '';
 
   # No tests
-  doCheck = false; 
+  doCheck = false;
 
   makefile = "Makefile_oomox_plugin";
 

--- a/pkgs/applications/misc/themix/theme-oomox/default.nix
+++ b/pkgs/applications/misc/themix/theme-oomox/default.nix
@@ -1,19 +1,29 @@
 { stdenv, fetchFromGitHub, python3, bc, sassc, glib, libxml2, gdk-pixbuf
 , gtk-engine-murrine
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
   pname = "themix-theme-oomox";
-  version = "1.12";
+  version = "1.12.r2.g0db28619";
 
   src = fetchFromGitHub {
     owner = "themix-project";
     repo = "oomox-gtk-theme";
-    rev = version;
-    sha256 = "015yj9hl283dsgphkva441r1fr580wiyssm4s2x4xfjprqksxg8w";
+    rev = "e0d729510791b4797e80610b73b5beea07673b10";
+    sha256 = "1i0pj3hwpxcrwrx1y1yf9xxp38zcaljh7f8na3z3k77f1pldch27";
   };
 
   patches = [
+    (let
+       rev = "b695fcb8d303f804c53d85ad7d6396b0cd2b29b4";
+       sha256 = "0696bvj8pddf34pnljkxbnl2za6ah80a5rmjj89qjs122xg50n0d";
+     in
+     fetchpatch {
+       url = "https://github.com/themix-project/oomox-gtk-theme/commit/${rev}.patch";
+       inherit sha256;
+     })
+
     # themix-gui generates customized theme by `cp -r` theme skeleton to
     # working directory and modifying it. As the skeleton is in nix store and
     # not writable, the copied one is not modifiable.

--- a/pkgs/applications/misc/themix/theme-oomox/default.nix
+++ b/pkgs/applications/misc/themix/theme-oomox/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Oomox theme plugin for Themix GUI designer";
     homepage = "https://github.com/themix-project/oomox";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ mnacamura ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/themix/theme-oomox/default.nix
+++ b/pkgs/applications/misc/themix/theme-oomox/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, python3, bc, sassc, glib, libxml2, gdk-pixbuf
+{ lib, stdenv, fetchFromGitHub, python3, bc, sassc, glib, librsvg, gdk-pixbuf
 , gtk-engine-murrine
 , fetchpatch
 }:
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ python3 ];
 
-  propagatedBuildInputs = [ bc sassc glib libxml2 gdk-pixbuf ];
+  propagatedBuildInputs = [ bc sassc glib librsvg gdk-pixbuf ];
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 

--- a/pkgs/applications/misc/themix/theme-oomox/default.nix
+++ b/pkgs/applications/misc/themix/theme-oomox/default.nix
@@ -48,12 +48,12 @@ stdenv.mkDerivation rec {
   installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
 
   postInstall = ''
-    cp -r __pycache__ "$out/opt/oomox/plugins/theme_oomox"/
+    cp -r __pycache__ $out/opt/oomox/plugins/theme_oomox/
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Oomox theme plugin for Themix GUI designer";
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/themix-project/oomox";
     license = licenses.gpl3;
     maintainers = with maintainers; [ mnacamura ];
     platforms = platforms.linux;

--- a/pkgs/applications/misc/themix/theme-oomox/default.nix
+++ b/pkgs/applications/misc/themix/theme-oomox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3, bc, sassc, glib, libxml2, gdk-pixbuf
+{ lib, stdenv, fetchFromGitHub, python3, bc, sassc, glib, libxml2, gdk-pixbuf
 , gtk-engine-murrine
 , fetchpatch
 }:

--- a/pkgs/applications/misc/themix/theme-oomox/default.nix
+++ b/pkgs/applications/misc/themix/theme-oomox/default.nix
@@ -15,13 +15,9 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (let
-       rev = "b695fcb8d303f804c53d85ad7d6396b0cd2b29b4";
-       sha256 = "0696bvj8pddf34pnljkxbnl2za6ah80a5rmjj89qjs122xg50n0d";
-     in
      fetchpatch {
-       url = "https://github.com/themix-project/oomox-gtk-theme/commit/${rev}.patch";
-       inherit sha256;
+       url = "https://github.com/themix-project/oomox-gtk-theme/commit/b695fcb8d303f804c53d85ad7d6396b0cd2b29b4.patch";
+       sha256 = "0696bvj8pddf34pnljkxbnl2za6ah80a5rmjj89qjs122xg50n0d";
      })
 
     # themix-gui generates customized theme by `cp -r` theme skeleton to

--- a/pkgs/applications/misc/themix/theme-oomox/default.nix
+++ b/pkgs/applications/misc/themix/theme-oomox/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-     fetchpatch {
+     (fetchpatch {
        url = "https://github.com/themix-project/oomox-gtk-theme/commit/b695fcb8d303f804c53d85ad7d6396b0cd2b29b4.patch";
        sha256 = "0696bvj8pddf34pnljkxbnl2za6ah80a5rmjj89qjs122xg50n0d";
      })

--- a/pkgs/applications/misc/themix/theme-oomox/default.nix
+++ b/pkgs/applications/misc/themix/theme-oomox/default.nix
@@ -43,7 +43,9 @@ stdenv.mkDerivation rec {
   # No tests
   doCheck = false; 
 
-  installFlags = [ "-f Makefile_oomox_plugin" "DESTDIR=$(out)" "PREFIX=" ];
+  makefile = "Makefile_oomox_plugin";
+
+  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
 
   postInstall = ''
     cp -r __pycache__ "$out/opt/oomox/plugins/theme_oomox"/

--- a/pkgs/applications/misc/themix/theme-oomox/default.nix
+++ b/pkgs/applications/misc/themix/theme-oomox/default.nix
@@ -1,0 +1,59 @@
+{ stdenv, fetchFromGitHub, python3, bc, sassc, glib, libxml2, gdk-pixbuf
+, gtk-engine-murrine
+}:
+
+stdenv.mkDerivation rec {
+  pname = "themix-theme-oomox";
+  version = "1.12";
+
+  src = fetchFromGitHub {
+    owner = "themix-project";
+    repo = "oomox-gtk-theme";
+    rev = version;
+    sha256 = "015yj9hl283dsgphkva441r1fr580wiyssm4s2x4xfjprqksxg8w";
+  };
+
+  patches = [
+    # themix-gui generates customized theme by `cp -r` theme skeleton to
+    # working directory and modifying it. As the skeleton is in nix store and
+    # not writable, the copied one is not modifiable.
+    ./writable.patch
+  ];
+
+  postPatch = ''
+    patchShebangs .
+
+    for bin in packaging/bin/*; do
+        sed -i "$bin" -e "s@\(/opt/oomox/\)@$out\1@"
+    done
+  '';
+
+  nativeBuildInputs = [ python3 ];
+
+  propagatedBuildInputs = [ bc sassc glib libxml2 gdk-pixbuf ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  buildPhase = ''
+    runHook preBuild
+    python -O -m compileall .
+    runHook postBuild
+  '';
+
+  # No tests
+  doCheck = false; 
+
+  installFlags = [ "-f Makefile_oomox_plugin" "DESTDIR=$(out)" "PREFIX=" ];
+
+  postInstall = ''
+    cp -r __pycache__ "$out/opt/oomox/plugins/theme_oomox"/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Oomox theme plugin for Themix GUI designer";
+    inherit (src.meta) homepage;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ mnacamura ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/themix/theme-oomox/writable.patch
+++ b/pkgs/applications/misc/themix/theme-oomox/writable.patch
@@ -1,0 +1,15 @@
+diff --git a/change_color.sh b/change_color.sh
+index f1c72574..39155b07 100755
+--- a/change_color.sh
++++ b/change_color.sh
+@@ -209,8 +209,10 @@ rm -fr "$DEST_PATH"
+ mkdir -p "$DEST_PATH"
+ echo -e "\nBuilding theme at $DEST_PATH\n"
+ cp -r "$SRC_PATH/src/index.theme" "$DEST_PATH"
++chmod +w "$DEST_PATH/index.theme"
+ for FILEPATH in "${PATHLIST[@]}"; do
+ 	cp -r "$SRC_PATH/$FILEPATH" "$DEST_PATH"
++	chmod -R +w "$DEST_PATH/$(basename $FILEPATH)"
+ done
+ 
+ 

--- a/pkgs/development/python-modules/colorthief/default.nix
+++ b/pkgs/development/python-modules/colorthief/default.nix
@@ -11,6 +11,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pillow ];
 
+  # No tests
+  doCheck = false;
+  pythonImportsCheck = [ "colorthief" ];
+
   meta = with lib; {
     description = "Module for grabbing the color palette from an image";
     homepage = "https://github.com/fengsp/color-thief-py";

--- a/pkgs/development/python-modules/colorthief/default.nix
+++ b/pkgs/development/python-modules/colorthief/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi, pillow }:
+
+buildPythonPackage rec {
+  pname = "colorthief";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08bjsmmkihyksms2vgndslln02rvw56lkxz28d39qrnxbg4v1707";
+  };
+
+  propagatedBuildInputs = [ pillow ];
+
+  meta = with lib; {
+    description = "Module for grabbing the color palette from an image";
+    homepage = "https://github.com/fengsp/color-thief-py";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ mnacamura ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/colorz/default.nix
+++ b/pkgs/development/python-modules/colorz/default.nix
@@ -11,6 +11,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pillow scipy ];
 
+  # No tests
+  doCheck = false;
+  pythonImportsCheck = [ "colorz" ];
+
   meta = with lib; {
     description = "Python color scheme generator";
     homepage = "https://github.com/metakirby5/colorz";

--- a/pkgs/development/python-modules/colorz/default.nix
+++ b/pkgs/development/python-modules/colorz/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi, pillow, scipy }:
+
+buildPythonPackage rec {
+  pname = "colorz";
+  version = "1.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ghd90lgplf051fs5n5bb42zffd3fqpgzkbv6bhjw7r8jqwgcky0";
+  };
+
+  propagatedBuildInputs = [ pillow scipy ];
+
+  meta = with lib; {
+    description = "Python color scheme generator";
+    homepage = "https://github.com/metakirby5/colorz";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mnacamura ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/haishoku/default.nix
+++ b/pkgs/development/python-modules/haishoku/default.nix
@@ -11,6 +11,11 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pillow ];
 
+  # WARNING: Testing via this command is deprecated and will be removed in a future version. Users
+  # looking for a generic test entry point independent of test runner are encouraged to use tox
+  doCheck = false;
+  pythonImportsCheck = [ "haishoku" ];
+
   meta = with lib; {
     description = "Tool for grabbing dominant color palette from images";
     homepage = "https://github.com/LanceGin/haishoku";

--- a/pkgs/development/python-modules/haishoku/default.nix
+++ b/pkgs/development/python-modules/haishoku/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi, pillow }:
+
+buildPythonPackage rec {
+  pname = "haishoku";
+  version = "1.1.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1m6bzxlm4pfdpjr827k1zy9ym3qn411lpw5wiaqq2q2q0d6a3fg4";
+  };
+
+  propagatedBuildInputs = [ pillow ];
+
+  meta = with lib; {
+    description = "Tool for grabbing dominant color palette from images";
+    homepage = "https://github.com/LanceGin/haishoku";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mnacamura ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30577,6 +30577,10 @@ in
 
   terranix = callPackage ../applications/networking/cluster/terranix {};
 
+  inherit (callPackage ../applications/misc/themix {})
+  themix-gui
+  themixPlugins;
+
   tilt = callPackage ../applications/networking/cluster/tilt {};
 
   timeular = callPackage ../applications/office/timeular {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30578,8 +30578,8 @@ in
   terranix = callPackage ../applications/networking/cluster/terranix {};
 
   inherit (callPackage ../applications/misc/themix {})
-  themix-gui
-  themixPlugins;
+    themix-gui
+    themixPlugins;
 
   tilt = callPackage ../applications/networking/cluster/tilt {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1463,6 +1463,10 @@ in {
 
   colorspacious = callPackage ../development/python-modules/colorspacious { };
 
+  colorthief = callPackage ../development/python-modules/colorthief { };
+
+  colorz = callPackage ../development/python-modules/colorz { };
+
   colour = callPackage ../development/python-modules/colour { };
 
   commandparse = callPackage ../development/python-modules/commandparse { };
@@ -2972,6 +2976,8 @@ in {
   hachoir = callPackage ../development/python-modules/hachoir { };
 
   ha-ffmpeg = callPackage ../development/python-modules/ha-ffmpeg { };
+
+  haishoku = callPackage ../development/python-modules/haishoku { };
 
   halo = callPackage ../development/python-modules/halo { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Themix GUI theme desiner (Oomox) is a great tool for customizing desktop themes and console color palettes. <s>It's packaged in a number of distros: Arch, Debian, Ubuntu, CentOS, Fedora, etc. Why not in Nixpkgs?</s>AUR and COPR have it. deb package is provided by the Themix project.

Themix has a number of plugins but I would like to keep this PL minimal: It ships only import-image, theme-oomox, and icons-papirus plugins.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
