### PR TITLE
nixos/shells-environment: Add environment.homeLocalBinInPath

### DIFF
--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -126,6 +126,14 @@ in
       type = types.bool;
     };
 
+    environment.homeLocalBinInPath = mkOption {
+      description = ''
+        Include ~/.local/bin/ in $PATH.
+      '';
+      default = false;
+      type = types.bool;
+    };
+
     environment.binsh = mkOption {
       default = "${config.system.build.binsh}/bin/sh";
       defaultText = "\${config.system.build.binsh}/bin/sh";
@@ -197,6 +205,11 @@ in
         ${optionalString cfg.homeBinInPath ''
           # ~/bin if it exists overrides other bin directories.
           export PATH="$HOME/bin:$PATH"
+        ''}
+
+        ${optionalString cfg.homeLocalBinInPath ''
+          # ~/.local/bin if it exists overrides other bin directories.
+          export PATH="$HOME/.local/bin:$PATH"
         ''}
       '';
 


### PR DESCRIPTION
###### Motivation for this change

`~/.local/bin` is a common place to put arbitrary user scripts that's replacing the old `~/bin`. This commit makes it easy to add that directory to the user's `PATH`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
