### PR TITLE
python3Packages.spyder_3: remove broken application

### DIFF
--- a/pkgs/development/python-modules/spyder/3.nix
+++ b/pkgs/development/python-modules/spyder/3.nix
@@ -1,62 +1,38 @@
-{ stdenv, buildPythonPackage, fetchPypi, makeDesktopItem, jedi, pycodestyle,
-  psutil, pyflakes, rope, numpy, scipy, matplotlib, pylint, keyring, numpydoc,
+{ stdenv, buildPythonPackage, fetchFromGitHub, jedi, pycodestyle,
+  psutil, pyflakes, rope, pylint, keyring, numpydoc,
   qtconsole, qtawesome, nbconvert, mccabe, pyopengl, cloudpickle, pygments,
-  spyder-kernels_0_5, qtpy, pyzmq, chardet
-, pyqtwebengine
+  spyder-kernels_0_5, qtpy, pyzmq, chardet, pyqtwebengine
 }:
 
 buildPythonPackage rec {
   pname = "spyder";
   version = "3.3.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1z7qw1h3rhca12ycv8xrzw6z2gf81v0j6lfq9kpwh472w4vk75v1";
+  src = fetchFromGitHub {
+    owner = "spyder-ide";
+    repo = "spyder";
+    rev = "v3.3.6";
+    sha256 = "1sk9xajhzpklk5bcbdhpfhx3gxhyrahsmj9bv2m6kvbqxdlx6bq6";
   };
 
-  nativeBuildInputs = [ pyqtwebengine.wrapQtAppsHook ];
-
   propagatedBuildInputs = [
-    jedi pycodestyle psutil pyflakes rope numpy scipy matplotlib pylint keyring
-    numpydoc qtconsole qtawesome nbconvert mccabe pyopengl cloudpickle spyder-kernels_0_5
+    jedi pycodestyle psutil pyflakes rope pylint keyring numpydoc 
+    qtconsole qtawesome nbconvert mccabe pyopengl cloudpickle spyder-kernels_0_5
     pygments qtpy pyzmq chardet pyqtwebengine
   ];
 
-  # There is no test for spyder
+  # tests fail with a segfault
   doCheck = false;
-
-  desktopItem = makeDesktopItem {
-    name = "Spyder";
-    exec = "spyder";
-    icon = "spyder";
-    comment = "Scientific Python Development Environment";
-    desktopName = "Spyder";
-    genericName = "Python IDE";
-    categories = "Application;Development;Editor;IDE;";
-  };
 
   postPatch = ''
     # remove dependency on pyqtwebengine
-    # this is still part of the pyqt 5.11 version we have in nixpkgs
+    # this is still part of the pyqt 5.13 version we have in nixpkgs
     sed -i /pyqtwebengine/d setup.py
     substituteInPlace setup.py --replace "pyqt5<5.13" "pyqt5"
   '';
 
-  # Create desktop item
-  postInstall = ''
-    mkdir -p $out/share/icons
-    cp spyder/images/spyder.svg $out/share/icons
-    cp -r $desktopItem/share/applications/ $out/share
-  '';
-
-  dontWrapQtApps = true;
-
-  preFixup = ''
-    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
-  '';
-
   meta = with stdenv.lib; {
-    description = "Scientific python development environment";
+    description = "Library providing a scientific python development environment";
     longDescription = ''
       Spyder (previously known as Pydee) is a powerful interactive development
       environment for the Python language with advanced editing, interactive
@@ -65,6 +41,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/spyder-ide/spyder/";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ gebner marcus7070 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
`python3Packages.spyder_3` was failing due to incorrectly defined desktop item:
https://hydra.nixos.org/build/117762361

###### Things done

`python3Packages.spyder_3` should only be used as a library (`python3Packages.spyder` gets made into an application), so I removed all the application stuff from it. This reduced closure size and fixed the build.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Also tested `cq-editor`, which is the only attribute that uses `spyder_3`, and it works fine.

I should probably backport this to 20.03 as well.