### PR TITLE
mu: allow configuring the BatchSize

### DIFF
--- a/pkgs/tools/networking/mu/default.nix
+++ b/pkgs/tools/networking/mu/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, sqlite, pkgconfig, autoreconfHook, pmccabe
 , xapian, glib, gmime3, texinfo , emacs, guile
 , gtk3, webkitgtk, libsoup, icu
-, withMug ? false }:
+, withMug ? false
+, batchSize ? null }:
 
 stdenv.mkDerivation rec {
   pname = "mu";
@@ -13,6 +14,11 @@ stdenv.mkDerivation rec {
     rev    = version;
     sha256 = "1i9chd8ks1q4g5pyscsir6pw4kahkx3k8ckzbi8j3gr6jz1qzzsg";
   };
+
+  postPatch = stdenv.lib.optionalString (batchSize != null) ''
+    sed -i lib/mu-store.cc --regexp-extended \
+      -e 's@(constexpr auto BatchSize).*@\1 = ${toString batchSize};@'
+  '';
 
   buildInputs = [
     sqlite xapian glib gmime3 texinfo emacs guile libsoup icu


### PR DESCRIPTION
###### Motivation for this change

mu can in some scenarios use quite a bit of memory and no longer
supports a runtime parameter to adjust the memory use.

This change allows one to override the batch size if needed.

With few reverse dependencies, it shouldn't be an issue to compile this
locally but by default we don't change anything and stick to upstream.

ref: https://github.com/djcb/mu/issues/1653

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).