### PR TITLE
podman: fix wrapper

### DIFF
--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -54,5 +54,6 @@ buildGoPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ marsam ] ++ teams.podman.members;
     platforms = platforms.unix;
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/applications/virtualization/podman/wrapper.nix
+++ b/pkgs/applications/virtualization/podman/wrapper.nix
@@ -43,12 +43,7 @@ in runCommand podman.name {
   ];
 
 } ''
-  # Symlink everything but $out from podman-unwrapped
-  ${
-    lib.concatMapStringsSep "\n"
-    (o: "ln -s ${podman.${o}} ${placeholder o}")
-    (builtins.filter (o: o != "out")
-    podman.outputs)}
+  ln -s ${podman.man} $man
 
   mkdir -p $out/bin
   ln -s ${podman-unwrapped}/share $out/share


### PR DESCRIPTION
https://hydra.nixos.org/jobset/nixpkgs/trunk/jobs-tab?filter=podman

The wrapper is failing on hydra, some of the changes from https://github.com/NixOS/nixpkgs/pull/86830 seem to have been lost when staging-next was merged.

cc @adisbladis 