### PR TITLE
jshon: 20160111.2 -> 20170302 + musl build

### DIFF
--- a/pkgs/development/tools/parsing/jshon/default.nix
+++ b/pkgs/development/tools/parsing/jshon/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, jansson }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, jansson }:
 
 stdenv.mkDerivation rec {
   pname = "jshon";
@@ -13,7 +13,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ jansson ];
 
-  patchPhase =
+  patches = [
+    (fetchpatch {
+      # https://github.com/keenerd/jshon/pull/62
+      url = "https://github.com/keenerd/jshon/commit/96b4e9dbf578be7b31f29740b608aa7b34df3318.patch";
+      sha256 = "0kwbn3xb37iqb5y1n8vhzjiwlbg5jmki3f38pzakc24kzc5ksmaa";
+    })
+  ];
+
+  postPatch =
     ''
       substituteInPlace Makefile --replace "/usr/" "/"
     '';

--- a/pkgs/development/tools/parsing/jshon/default.nix
+++ b/pkgs/development/tools/parsing/jshon/default.nix
@@ -1,25 +1,15 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, jansson }:
+{ stdenv, lib, fetchFromGitHub, jansson }:
 
 stdenv.mkDerivation rec {
-  name = "jshon-20160111.2";
-
-  rev = "a61d7f2f85f4627bc3facdf951746f0fd62334b7";
-  sha256 = "1053w7jbl90q3p5y34pi4i8an1ddsjzwaib5cfji75ivamc5wdmh";
+  pname = "jshon";
+  version = "20170302";
 
   src = fetchFromGitHub {
-    inherit rev sha256;
     owner = "keenerd";
     repo = "jshon";
+    rev = "d919aeaece37962251dbe6c1ee50f0028a5c90e4";
+    sha256 = "1x4zfmsjq0l2y994bxkhx3mn5vzjxxr39iib213zjchi9h6yxvnc";
   };
-
-  patches = [
-    # Fix null termination in read_stream.
-    # https://github.com/keenerd/jshon/issues/53
-    (fetchpatch {
-      url = "https://github.com/mbrock/jshon/commit/32288dd186573ceb58164f30be1782d4580466d8.patch";
-      sha256 = "04rss2nprl9nqblc7smq0477n54hm801xgnnmvyzni313i1n6vhl";
-    })
-  ];
 
   buildInputs = [ jansson ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Primary intend is fixing the musl build of `jshon`. The version update is only to simplify the package.

The removed patch is merged in keenerd/jshon@d919aeaece37962251dbe6c1ee50f0028a5c90e4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`

  The only dependent package `hyper-haskell` is currently failing on master.

<details>
  <summary>nix-review log</summary>
  
  ```log
%  nix-review rev HEAD
2 packages updated:
hyper-haskell jshon (20160111.2 → 20170302)

$ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/fabian/.cache/nixpkgs-review/rev-791d76e8c5d55965035e3ef6eb9df9708ee9f222-1/build.nix
builder for '/nix/store/l7ahwszpb1gwkb707qa2i77rd1rnlwgl-hyper-0.1.0.3.drv' failed with exit code 1; last 10 log lines:
    die', called at libraries/Cabal/Cabal/Distribution/Simple/Configure.hs:1022:20 in Cabal-3.0.1.0:Distribution.Simple.Configure
    configureFinalizedPackage, called at libraries/Cabal/Cabal/Distribution/Simple/Configure.hs:475:12 in Cabal-3.0.1.0:Distribution.Simple.Configure
    configure, called at libraries/Cabal/Cabal/Distribution/Simple.hs:625:20 in Cabal-3.0.1.0:Distribution.Simple
    confHook, called at libraries/Cabal/Cabal/Distribution/Simple/UserHooks.hs:65:5 in Cabal-3.0.1.0:Distribution.Simple.UserHooks
    configureAction, called at libraries/Cabal/Cabal/Distribution/Simple.hs:180:19 in Cabal-3.0.1.0:Distribution.Simple
    defaultMainHelper, called at libraries/Cabal/Cabal/Distribution/Simple.hs:116:27 in Cabal-3.0.1.0:Distribution.Simple
    defaultMain, called at Setup.hs:2:8 in main:Main
  Setup: Encountered missing or private dependencies:
  base >=4.6 && <4.13
cannot build derivation '/nix/store/wa7qa3fasv0zndl4nva9naq57k1p2pa6-hyper-extra-0.1.0.3.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/acvpha2gi56aakdfh9jgpb79c3bg9pav-hyper-haskell-server-0.2.1.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/8v9k7n7psklsb0gn266akxrdygrgym2m-ghc-8.8.3-with-packages.drv': 3 dependencies couldn't be built
cannot build derivation '/nix/store/mv9mncjnrll72h6lmq8lw3g8slihmmss-hyper-haskell-server-with-packages-8.8.3.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/2dhvfzz38b3h11h5vxh5b6im8584zajp-hyper-haskell-0.1.0.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/0dnb0arnr6d5z9a24lp41yzypdisrb4x-env.drv': 1 dependencies couldn't be built
[0 built (1 failed)]
error: build of '/nix/store/0dnb0arnr6d5z9a24lp41yzypdisrb4x-env.drv' failed
1 package failed to build:
hyper-haskell

1 package built:
jshon
```
</details>


- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
