### PR TITLE
matomo: 3.13.4 -> 3.13.5

### DIFF
--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -3,16 +3,16 @@
 let
   versions = {
     matomo = {
-      version = "3.13.4";
-      sha256 = "0yd24hn3ajj5bhzv8f5xr6wpgh2ma9zilzbm9c1n225q553scgjw";
+      version = "3.13.5";
+      sha256 = "1b9a9jj86bb3f0093k6sz235iivvvqbcvkjqxwn7c9z7qsmpvbxr";
     };
 
     matomo-beta = {
-      version = "3.13.4";
+      version = "3.13.5";
       # `beta` examples: "b1", "rc1", null
       # TOOD when updating: use null if stable version is >= latest beta or release candidate
       beta = null;
-      sha256 = "0yd24hn3ajj5bhzv8f5xr6wpgh2ma9zilzbm9c1n225q553scgjw";
+      sha256 = "1b9a9jj86bb3f0093k6sz235iivvvqbcvkjqxwn7c9z7qsmpvbxr";
     };
   };
   common = pname: { version, sha256, beta ? null }:


### PR DESCRIPTION
###### Motivation for this change
New release: https://matomo.org/changelog/matomo-3-13-5
Includes a bugfix for rapidly growing database usage, therefore I will propose a backport PR to 20.03 after this got accepted.
The fix is in form of a database upgrade, which however worked flawlesly for me using `nixos.services.matomo`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
