### PR TITLE
nixos/network-interfaces-scripted: fix dhcpcd when mac address set

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -242,11 +242,14 @@ let
           deviceDependency = if (config.boot.isContainer || i.name == "lo")
             then []
             else [ (subsystemDevice i.name) ];
+          dhcpDependency = if i.macAddress == null
+            then []
+            else [ "dhcpcd.service" ];
         in
         nameValuePair "network-link-${i.name}"
         { description = "Link configuration of ${i.name}";
           wantedBy = [ "network-interfaces.target" ];
-          before = [ "network-interfaces.target" ];
+          before = [ "network-interfaces.target" ] ++ dhcpDependency;
           bindsTo = deviceDependency;
           after = [ "network-pre.target" ] ++ deviceDependency;
           path = [ pkgs.iproute ];


### PR DESCRIPTION
Fixes issue #74471 (dhcpcd is started before mac addresses are set)

###### Motivation for this change
I want my NixOS system to boot up with working networking.

###### Things done
I ran this patch against my installation at `20.03` and it corrected the issue.  I attempted to verify against `master` but gave up after several hours of building.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
