### PR TITLE
mxnet: use openblas, fix build

### DIFF
--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake perl ];
 
-  buildInputs = [ opencv3 gtest blas ]
+  buildInputs = [ opencv3 gtest blas.provider ]
               ++ lib.optionals cudaSupport [ cudatoolkit nvidia_x11 ]
               ++ lib.optional cudnnSupport cudnn;
 


### PR DESCRIPTION
###### Motivation for this change
noticed it was failing when reviewing https://github.com/NixOS/nixpkgs/pull/87102

previous failure:
```
builder for '/nix/store/1zcd9mmm3dyyxcr588cszdclrsnjbga1-mxnet-1.6.0.drv' failed with exit code 1; last 10 log lines:
  -- Could not find OpenBLAS lib. Turning OpenBLAS_FOUND off
  CMake Error at cmake/Modules/FindOpenBLAS.cmake:82 (MESSAGE):
    Could not find OpenBLAS
  Call Stack (most recent call first):
    cmake/ChooseBlas.cmake:42 (find_package)
    CMakeLists.txt:310 (include)


  -- Configuring incomplete, errors occurred!
  See also "/build/apache-mxnet-src-1.6.0-incubating/build/CMakeFiles/CMakeOutput.log".
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
