### PR TITLE
apt-cacher-ng: 3.2 → 3.5

### DIFF
--- a/pkgs/servers/http/apt-cacher-ng/default.nix
+++ b/pkgs/servers/http/apt-cacher-ng/default.nix
@@ -4,6 +4,7 @@
 , doxygen
 , fetchurl
 , fuse
+, libevent
 , lzma
 , openssl
 , pkgconfig
@@ -14,15 +15,15 @@
 
 stdenv.mkDerivation rec {
   pname = "apt-cacher-ng";
-  version = "3.2";
+  version = "3.5";
 
   src = fetchurl {
     url = "http://ftp.debian.org/debian/pool/main/a/apt-cacher-ng/apt-cacher-ng_${version}.orig.tar.xz";
-    sha256 = "1kas5xq44rx33pczhrz05dsdhjaavxdmcs5h1ygfi76bpqvyhpa0";
+    sha256 = "0h76n02nnpg7ir9247qrxb8p4d4p282nh13zrv5bb9sfm12pril2";
   };
 
   nativeBuildInputs = [ cmake doxygen pkgconfig ];
-  buildInputs = [ bzip2 fuse lzma openssl systemd tcp_wrappers zlib ];
+  buildInputs = [ bzip2 fuse libevent lzma openssl systemd tcp_wrappers zlib ];
 
   meta = with stdenv.lib; {
     description = "A caching proxy specialized for linux distribution files";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes: CVE-2017-7443, CVE-2020-5202

- https://broken.sh/issues/CVE-2017-7443
- https://broken.sh/issues/CVE-2020-5202

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
