### PR TITLE
pantheon.elementary-icon-theme: Fix build with Inkscape 1.0

### DIFF
--- a/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
@@ -1,12 +1,13 @@
 { stdenv
 , fetchFromGitHub
+, fetchpatch
 , pantheon
 , meson
 , python3
 , ninja
 , hicolor-icon-theme
 , gtk3
-, inkscape
+, librsvg
 , xorg
 }:
 
@@ -23,6 +24,15 @@ stdenv.mkDerivation rec {
     sha256 = "1irkjj8xfpgkl5p56xhqa3w2s98b8lav7d1lxxrabdi87cjv3n33";
   };
 
+  patches = [
+    # Use rsvg-convert to fix the Inkscape 1.0 incompatibility.
+    # https://github.com/elementary/icons/pull/888
+    (fetchpatch {
+      url = "https://github.com/elementary/icons/commit/a4f35525fd0eb9e370fb89fb97e7a5d3f8794241.patch";
+      sha256 = "io2Y8RisRPgSNK8GOvtr/67zYZZq4Yi3SJ10xclrO2o=";
+    })
+  ];
+
   passthru = {
     updateScript = pantheon.updateScript {
       attrPath = "pantheon.${pname}";
@@ -31,7 +41,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     gtk3
-    inkscape
+    librsvg
     meson
     ninja
     python3


### PR DESCRIPTION
Use rsvg-convert to fix the Inkscape 1.0 incompatibility.

Cherry-picked from upstream PR: https://github.com/elementary/icons/pull/888

Partial fix for https://github.com/NixOS/nixpkgs/issues/86930

Tested using the following fish invocations (there are minor rendering differences):

```fish
# Copy the data to working directories
set a /nix/store/2jgy87bnqw01l4jh94zx5g62xvd9zlnl-elementary-icon-theme-5.2.0
set b /nix/store/d37faf7xv98p21q7ahcgagiljqchp13k-elementary-icon-theme-5.2.0
set d share/icons/elementary/cursors
mkdir /tmp/{a,b}cur
cp $a/$d/* /tmp/acur
cp $b/$d/* /tmp/bcur

# Xcursor cannot be viewed directly, it seems
# Taken from https://unix.stackexchange.com/questions/241364/convert-xcursor-to-png
cd /tmp/acur
find . ! -name '*.*' -type f -exec xcur2png {} \;
cd /tmp/bcur
find . ! -name '*.*' -type f -exec xcur2png {} \;

# Compare
set a /tmp/acur
set b /tmp/bcur
mkdir /tmp/diffcur
set d .
for f in (cd $a/$d; fd png)
    echo Comparing $f
    compare -compose src $a/$d/$f $b/$d/$f /tmp/diffcur/$f
    # display /tmp/diffcur/$f
end
```

cc @worldofpeace
