### PR TITLE
php: correctly set outputsToInstall after withExtensions.

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -113,7 +113,9 @@ let
                   unwrapped = php;
                   tests = nixosTests.php;
                   inherit (php-packages) packages extensions;
-                  inherit (php) meta;
+                  meta = php.meta // {
+                    outputsToInstall = [ "out" ];
+                  };
                 };
                 paths = [ php ];
                 postBuild = ''


### PR DESCRIPTION
###### Motivation for this change

At the moment, using .withExtensions on a PHP derivation will produce something which can't be used inside an environment.systemPackages array, because meta.outputsToInstall refers to an output which doesn't exist on the final wrapping derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
