### PR TITLE
[20.03] riot-{desktop,web}: 1.5.15 -> 1.6.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/riot/riot-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "riot-web",
   "productName": "Riot",
   "main": "src/electron-main.js",
-  "version": "1.5.15",
+  "version": "1.6.0",
   "description": "A feature-rich client for Matrix.org",
   "author": "New Vector Ltd.",
   "dependencies": {

--- a/pkgs/applications/networking/instant-messengers/riot/riot-desktop-yarndeps.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-desktop-yarndeps.nix
@@ -610,11 +610,11 @@
       };
     }
     {
-      name = "minimist___minimist_1.2.2.tgz";
+      name = "minimist___minimist_1.2.3.tgz";
       path = fetchurl {
-        name = "minimist___minimist_1.2.2.tgz";
-        url  = "https://registry.yarnpkg.com/minimist/-/minimist-1.2.2.tgz";
-        sha1 = "b00a00230a1108c48c169e69a291aafda3aacd63";
+        name = "minimist___minimist_1.2.3.tgz";
+        url  = "https://registry.yarnpkg.com/minimist/-/minimist-1.2.3.tgz";
+        sha1 = "3db5c0765545ab8637be71f333a104a965a9ca3f";
       };
     }
     {

--- a/pkgs/applications/networking/instant-messengers/riot/riot-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-desktop.nix
@@ -8,12 +8,12 @@
 
 let
   executableName = "riot-desktop";
-  version = "1.5.15";
+  version = "1.6.0";
   riot-web-src = fetchFromGitHub {
     owner = "vector-im";
     repo = "riot-web";
     rev = "v${version}";
-    sha256 = "08yk5is6n9ci1jml0b94a3swdybx01k5klbl30i1b76biyn75m77";
+    sha256 = "16zm6l4c7vkfdlxh6gdw531k5r4v3mb0h66q41h94dvmj79dz2bj";
   };
   electron = electron_7;
 

--- a/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
@@ -12,11 +12,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "riot-web";
-  version = "1.5.15";
+  version = "1.6.0";
 
   src = fetchurl {
     url = "https://github.com/vector-im/riot-web/releases/download/v${version}/riot-v${version}.tar.gz";
-    sha256 = "09a9l1l65m2c4ldycjhnqn0mmblm3j65vc9rcjfkdxqbd6bh86h7";
+    sha256 = "1mm4xk69ya1k3gz6jjhc4njx7b3rp157jmrqsxr5i382zs035ff7";
   };
 
   installPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Backported version 1.6.0 from master, because it introduces device cross-signing support that is needed to cleanly interoperate with the Android and web clients.

No modifications were necessary. Commits applied cleanly.

Looks like this wasn't contributed to master as a PR, but manually pushed around #86919?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
