### PR TITLE
xdg-utils: Dont make lazy default on kde

### DIFF
--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
   # just needed when built from git
   buildInputs = [ libxslt docbook_xml_dtd_412 docbook_xsl xmlto w3m ];
 
+  patches = [ ./dont-make-lazy-default-on-kde.patch ];
+
   postInstall = stdenv.lib.optionalString mimiSupport ''
     cp ${mimisrc}/xdg-open $out/bin/xdg-open
   '' + ''

--- a/pkgs/tools/X11/xdg-utils/dont-make-lazy-default-on-kde.patch
+++ b/pkgs/tools/X11/xdg-utils/dont-make-lazy-default-on-kde.patch
@@ -1,0 +1,38 @@
+From 6f2acdff42170204efc141179ef6b88cc70f41f6 Mon Sep 17 00:00:00 2001
+From: Matthew Bauer <mjbauer95@gmail.com>
+Date: Wed, 6 May 2020 15:43:05 -0500
+Subject: [PATCH] =?UTF-8?q?Don=E2=80=99t=20run=20make=5Flazy=5Fdefault=20o?=
+ =?UTF-8?q?n=20KDE?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+make_lazy_default tries to check what the default application is, but
+KDE has its own concept of default which may not match this. Skipping
+it here avoids annoyingly having KDE and xdg-utils become out-of-sync.
+
+Upstream MR: https://gitlab.freedesktop.org/xdg/xdg-utils/-/merge_requests/25 
+---
+ scripts/xdg-desktop-menu.in | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/xdg-desktop-menu.in b/scripts/xdg-desktop-menu.in
+index 9d837e1..52f1c3d 100644
+--- a/scripts/xdg-desktop-menu.in
++++ b/scripts/xdg-desktop-menu.in
+@@ -609,7 +609,11 @@ for desktop_file in $desktop_files; do
+                 echo "OnlyShowIn=Old;" >> $gnome_dir/$basefile
+             fi
+ 
+-            make_lazy_default "$xdg_dir" "$basefile"
++            detectDE
++
++            if [ "$DE" != "kde" ]; then
++                make_lazy_default "$xdg_dir" "$basefile"
++            fi
+ 
+             umask $save_umask
+             ;;
+-- 
+2.23.3
+

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -612,6 +612,7 @@ mapAliases ({
   xbmc = kodi; # added 2018-04-25
   xbmcPlain = kodiPlain; # added 2018-04-25
   xbmcPlugins = kodiPlugins; # added 2018-04-25
+  xdg-utils = pkgs.xdg_utils; # added 2020-05-06
   xmonad_log_applet_gnome3 = xmonad_log_applet; # added 2018-05-01
   xf86_video_nouveau = xorg.xf86videonouveau; # added 2015-09
   xf86_input_mtrack = throw ("xf86_input_mtrack has been removed from nixpkgs as it hasn't been maintained"


### PR DESCRIPTION
This detection is broken as of kde5, so we need to disable it.

Upstream pr is: https://gitlab.freedesktop.org/xdg/xdg-utils/-/merge_requests/25

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
