### PR TITLE
Some performance optimizations to dockerTools.build{,Layered}Image

### DIFF
--- a/pkgs/build-support/docker/store-path-to-layer.sh
+++ b/pkgs/build-support/docker/store-path-to-layer.sh
@@ -11,37 +11,35 @@ echo "Creating layer #$layerNumber for $@"
 mkdir -p "$layerPath"
 
 # Make sure /nix and /nix/store appear first in the archive.
+#
 # We create the directories here and use them because
 # when there are other things being added to the
 # nix store, tar could fail, saying,
 # "tar: /nix/store: file changed as we read it"
 mkdir -p nix/store
-tar -cf "$layerPath/layer.tar"  \
-    --mtime="@$SOURCE_DATE_EPOCH" \
-    --owner=0 --group=0 \
-    --transform='s,nix,/nix,' \
-    nix
 
-# We change into the /nix/store in order to avoid a similar
-# "file changed as we read it" error as above. Namely,
-# if we use the absolute path of /nix/store/123-pkg
-# and something new is added to the nix store while tar
-# is running, it will detect a change to /nix/store and
-# fail. Instead, if we cd into the nix store and copy
-# the relative nix store path, tar will ignore changes
-# to /nix/store. In order to create the correct structure
-# in the tar file, we transform the relative nix store
-# path to the absolute store path.
-basename -a "$@" |
-  tar -C /nix/store -rpf "$layerPath/layer.tar" \
-    --verbatim-files-from --files-from - \
-    --hard-dereference --sort=name \
-    --mtime="@$SOURCE_DATE_EPOCH" \
-    --owner=0 --group=0 \
-    --transform="flags=rS;s,^,/nix/store/,"
-
-# Compute a checksum of the tarball.
-tarhash=$(tarsum < $layerPath/layer.tar)
+# Then we change into the /nix/store in order to
+# avoid a similar "file changed as we read it" error
+# as above. Namely, if we use the absolute path of
+# /nix/store/123-pkg and something new is added to the nix
+# store while tar is running, it will detect a change to
+# /nix/store and fail. Instead, if we cd into the nix store
+# and copy the relative nix store path, tar will ignore
+# changes to /nix/store. In order to create the correct
+# structure in the tar file, we transform the relative nix
+# store path to the absolute store path.
+tarhash=$(
+  basename -a "$@" |
+    tar -cp nix \
+      -C /nix/store --verbatim-files-from --files-from - \
+      --hard-dereference --sort=name \
+      --mtime="@$SOURCE_DATE_EPOCH" \
+      --owner=0 --group=0 \
+      --transform 's,^nix(/|$),/nix/,' \
+      --transform 's,^[^/],/nix/store/\0,rS' |
+    tee "$layerPath/layer.tar" |
+    tarsum
+)
 
 # Add a 'checksum' field to the JSON, with the value set to the
 # checksum of the tarball.

--- a/pkgs/build-support/docker/store-path-to-layer.sh
+++ b/pkgs/build-support/docker/store-path-to-layer.sh
@@ -32,15 +32,13 @@ tar -cf "$layerPath/layer.tar"  \
 # to /nix/store. In order to create the correct structure
 # in the tar file, we transform the relative nix store
 # path to the absolute store path.
-for storePath in "$@"; do
-  n=$(basename "$storePath")
+basename -a "$@" |
   tar -C /nix/store -rpf "$layerPath/layer.tar" \
-      --hard-dereference --sort=name \
-      --mtime="@$SOURCE_DATE_EPOCH" \
-      --owner=0 --group=0 \
-      --transform="s,$n,/nix/store/$n," \
-      $n
-done
+    --verbatim-files-from --files-from - \
+    --hard-dereference --sort=name \
+    --mtime="@$SOURCE_DATE_EPOCH" \
+    --owner=0 --group=0 \
+    --transform="flags=rS;s,^,/nix/store/,"
 
 # Compute a checksum of the tarball.
 tarhash=$(tarsum < $layerPath/layer.tar)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This PR aims to speed up creation of Docker images using the `dockerTools` utilities by reducing the disk I/O performed while creating layers.

The first commit reduces the number of of `tar -r` invocations, and the second one calculates `tarsum`'s on the fly while creating the tarball. These two changes seem to make the `buildLayeredImage` function almost twice as fast when building large (> 4GB) images when disk I/O is the bottleneck (eg. on cloud machines).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (nix-build release.nix -A tests.docker-tools)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
