### PR TITLE
Add libgccjit

### DIFF
--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -5,6 +5,7 @@
 , langJava ? false
 , langGo ? false
 , profiledCompiler ? false
+, langJit ? false
 , staticCompiler ? false
 , enableShared ? true
 , enableLTO ? true
@@ -212,6 +213,7 @@ stdenv.mkDerivation ({
       langGo
       langObjC
       langObjCpp
+      langJit
       ;
   };
 

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -5,6 +5,7 @@
 , langJava ? false
 , langGo ? false
 , profiledCompiler ? false
+, langJit ? false
 , staticCompiler ? false
 , enableShared ? true
 , enableLTO ? true
@@ -224,6 +225,7 @@ stdenv.mkDerivation ({
       langGo
       langObjC
       langObjCpp
+      langJit
       ;
   };
 

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -6,6 +6,7 @@
 , langJava ? false
 , langGo ? false
 , profiledCompiler ? false
+, langJit ? false
 , staticCompiler ? false
 , enableShared ? true
 , enableLTO ? true
@@ -126,7 +127,7 @@ stdenv.mkDerivation ({
 
   inherit patches;
 
-  outputs = if langJava || langGo then ["out" "man" "info"]
+  outputs = if langJava || langGo || langJit then ["out" "man" "info"]
     else [ "out" "lib" "man" "info" ];
   setOutputFlags = false;
   NIX_NO_SELF_RPATH = true;
@@ -136,13 +137,9 @@ stdenv.mkDerivation ({
   hardeningDisable = [ "format" "pie" ];
 
   prePatch =
-    (stdenv.lib.optionalString (langJava || langGo) ''
-      export lib=$out
-    '')
-
     # This should kill all the stdinc frameworks that gcc and friends like to
     # insert into default search paths.
-    + stdenv.lib.optionalString hostPlatform.isDarwin ''
+    stdenv.lib.optionalString hostPlatform.isDarwin ''
       substituteInPlace gcc/config/darwin-c.c \
         --replace 'if (stdinc)' 'if (0)'
 
@@ -244,6 +241,7 @@ stdenv.mkDerivation ({
       langGo
       langObjC
       langObjCpp
+      langJit
       ;
   };
 

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -147,10 +147,10 @@ stdenv.mkDerivation ({
         --replace 'if (stdinc)' 'if (0)'
 
       substituteInPlace libgcc/config/t-slibgcc-darwin \
-        --replace "-install_name @shlib_slibdir@/\$(SHLIB_INSTALL_NAME)" "-install_name $lib/lib/\$(SHLIB_INSTALL_NAME)"
+        --replace "-install_name @shlib_slibdir@/\$(SHLIB_INSTALL_NAME)" "-install_name ''${!outputLib}/lib/\$(SHLIB_INSTALL_NAME)"
 
       substituteInPlace libgfortran/configure \
-        --replace "-install_name \\\$rpath/\\\$soname" "-install_name $lib/lib/\\\$soname"
+        --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
     '';
 
   postPatch =

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -105,10 +105,10 @@ stdenv.mkDerivation ({
       --replace 'if (stdinc)' 'if (0)'
 
     substituteInPlace libgcc/config/t-slibgcc-darwin \
-      --replace "-install_name @shlib_slibdir@/\$(SHLIB_INSTALL_NAME)" "-install_name $lib/lib/\$(SHLIB_INSTALL_NAME)"
+      --replace "-install_name @shlib_slibdir@/\$(SHLIB_INSTALL_NAME)" "-install_name ''${!outputLib}/lib/\$(SHLIB_INSTALL_NAME)"
 
     substituteInPlace libgfortran/configure \
-      --replace "-install_name \\\$rpath/\\\$soname" "-install_name $lib/lib/\\\$soname"
+      --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
   '';
 
   postPatch = ''

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -4,6 +4,7 @@
 , langObjCpp ? stdenv.targetPlatform.isDarwin
 , langGo ? false
 , profiledCompiler ? false
+, langJit ? false
 , staticCompiler ? false
 , enableShared ? true
 , enableLTO ? true
@@ -90,7 +91,7 @@ stdenv.mkDerivation ({
 
   inherit patches;
 
-  outputs = [ "out" "lib" "man" "info" ];
+  outputs = [ "out" "man" "info" ] ++ stdenv.lib.optional (!langJit) "lib";
   setOutputFlags = false;
   NIX_NO_SELF_RPATH = true;
 
@@ -206,6 +207,7 @@ stdenv.mkDerivation ({
       langGo
       langObjC
       langObjCpp
+      langJit
       ;
   } ++ optional (targetPlatform.isAarch64) "--enable-fix-cortex-a53-843419"
     ++ optional targetPlatform.isNetBSD "--disable-libcilkrts"

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -4,6 +4,7 @@
 , langObjCpp ? stdenv.targetPlatform.isDarwin
 , langGo ? false
 , profiledCompiler ? false
+, langJit ? false
 , staticCompiler ? false
 , enableShared ? true
 , enableLTO ? true
@@ -82,7 +83,7 @@ stdenv.mkDerivation ({
 
   inherit patches;
 
-  outputs = [ "out" "lib" "man" "info" ];
+  outputs = [ "out" "man" "info" ] ++ stdenv.lib.optional (!langJit) "lib";
   setOutputFlags = false;
   NIX_NO_SELF_RPATH = true;
 
@@ -197,6 +198,7 @@ stdenv.mkDerivation ({
       langGo
       langObjC
       langObjCpp
+      langJit
       ;
   };
 

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -97,10 +97,10 @@ stdenv.mkDerivation ({
       --replace 'if (stdinc)' 'if (0)'
 
     substituteInPlace libgcc/config/t-slibgcc-darwin \
-      --replace "-install_name @shlib_slibdir@/\$(SHLIB_INSTALL_NAME)" "-install_name $lib/lib/\$(SHLIB_INSTALL_NAME)"
+      --replace "-install_name @shlib_slibdir@/\$(SHLIB_INSTALL_NAME)" "-install_name ''${!outputLib}/lib/\$(SHLIB_INSTALL_NAME)"
 
     substituteInPlace libgfortran/configure \
-      --replace "-install_name \\\$rpath/\\\$soname" "-install_name $lib/lib/\\\$soname"
+      --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
   '';
 
   postPatch = ''

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation ({
 
   inherit patches;
 
-  outputs = [ "out" "lib" "man" "info" ];
+  outputs = [ "out" "man" "info" ] ++ lib.optional langJit "lib";
   setOutputFlags = false;
   NIX_NO_SELF_RPATH = true;
 
@@ -100,10 +100,10 @@ stdenv.mkDerivation ({
       --replace 'if (stdinc)' 'if (0)'
 
     substituteInPlace libgcc/config/t-slibgcc-darwin \
-      --replace "-install_name @shlib_slibdir@/\$(SHLIB_INSTALL_NAME)" "-install_name $lib/lib/\$(SHLIB_INSTALL_NAME)"
+      --replace "-install_name @shlib_slibdir@/\$(SHLIB_INSTALL_NAME)" "-install_name ''${!outputLib}/lib/\$(SHLIB_INSTALL_NAME)"
 
     substituteInPlace libgfortran/configure \
-      --replace "-install_name \\\$rpath/\\\$soname" "-install_name $lib/lib/\\\$soname"
+      --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
   '';
 
   postPatch = ''

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -5,6 +5,7 @@
 , langObjCpp ? stdenv.targetPlatform.isDarwin
 , langGo ? false
 , profiledCompiler ? false
+, langJit ? false
 , staticCompiler ? false
 , enableShared ? true
 , enableLTO ? true
@@ -85,7 +86,7 @@ stdenv.mkDerivation ({
 
   inherit patches;
 
-  outputs = [ "out" "man" "info" ] ++ lib.optional langJit "lib";
+  outputs = [ "out" "man" "info" ] ++ stdenv.lib.optional (!langJit) "lib";
   setOutputFlags = false;
   NIX_NO_SELF_RPATH = true;
 
@@ -202,6 +203,7 @@ stdenv.mkDerivation ({
       langGo
       langObjC
       langObjCpp
+      langJit
       ;
   };
 

--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -202,34 +202,34 @@ postConfigure() {
 
 preInstall() {
     mkdir -p "$out/${targetConfig}/lib"
-    mkdir -p "$lib/${targetConfig}/lib"
+    mkdir -p "${!outputLib}/${targetConfig}/lib"
     # Make ‘lib64’ symlinks to ‘lib’.
     if [ -n "$is64bit" -a -z "$enableMultilib" ]; then
         ln -s lib "$out/${targetConfig}/lib64"
-        ln -s lib "$lib/${targetConfig}/lib64"
+        ln -s lib "${!outputLib}/${targetConfig}/lib64"
     fi
 }
 
 
 postInstall() {
-    # Move runtime libraries to $lib.
-    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.so*" "$lib"
-    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.la"  "$lib"
-    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.dylib" "$lib"
-    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.dll.a" "$lib"
-    moveToOutput "share/gcc-*/python" "$lib"
+    # Move runtime libraries to lib output.
+    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.so*" "${!outputLib}"
+    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.la"  "${!outputLib}"
+    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.dylib" "${!outputLib}"
+    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.dll.a" "${!outputLib}"
+    moveToOutput "share/gcc-*/python" "${!outputLib}"
 
-    for i in "$lib/${targetConfig}"/lib/*.{la,py}; do
-        substituteInPlace "$i" --replace "$out" "$lib"
+    for i in "${!outputLib}/${targetConfig}"/lib/*.{la,py}; do
+        substituteInPlace "$i" --replace "$out" "${!outputLib}"
     done
 
     if [ -n "$enableMultilib" ]; then
-        moveToOutput "${targetConfig+$targetConfig/}lib64/lib*.so*" "$lib"
-        moveToOutput "${targetConfig+$targetConfig/}lib64/lib*.la"  "$lib"
-        moveToOutput "${targetConfig+$targetConfig/}lib64/lib*.dylib" "$lib"
+        moveToOutput "${targetConfig+$targetConfig/}lib64/lib*.so*" "${!outputLib}"
+        moveToOutput "${targetConfig+$targetConfig/}lib64/lib*.la"  "${!outputLib}"
+        moveToOutput "${targetConfig+$targetConfig/}lib64/lib*.dylib" "${!outputLib}"
 
-        for i in "$lib/${targetConfig}"/lib64/*.{la,py}; do
-            substituteInPlace "$i" --replace "$out" "$lib"
+        for i in "${!outputLib}/${targetConfig}"/lib64/*.{la,py}; do
+            substituteInPlace "$i" --replace "$out" "${!outputLib}"
         done
     fi
 
@@ -251,10 +251,10 @@ postInstall() {
     fi
 
     if type "install_name_tool"; then
-        for i in "$lib"/lib/*.*.dylib; do
+        for i in "${!outputLib}"/lib/*.*.dylib; do
             install_name_tool -id "$i" "$i" || true
             for old_path in $(otool -L "$i" | grep "$out" | awk '{print $1}'); do
-              new_path=`echo "$old_path" | sed "s,$out,$lib,"`
+              new_path=`echo "$old_path" | sed "s,$out,${!outputLib},"`
               install_name_tool -change "$old_path" "$new_path" "$i" || true
             done
         done

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -20,6 +20,7 @@
 , langGo
 , langObjC
 , langObjCpp
+, langJit
 }:
 
 assert cloog != null -> stdenv.lib.versionOlder version "5";
@@ -121,6 +122,7 @@ let
           ++ lib.optional langObjC     "objc"
           ++ lib.optional langObjCpp   "obj-c++"
           ++ lib.optionals crossDarwin [ "objc" "obj-c++" ]
+          ++ lib.optional langJit      "jit"
           )
         )
       }"
@@ -173,7 +175,7 @@ let
       "--disable-symvers"
       "libat_cv_have_ifunc=no"
       "--disable-gnu-indirect-function"
-    ]
+    ] ++ lib.optional langJit "--enable-host-shared"
   ;
 
 in configureFlags

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8390,6 +8390,16 @@ in
     profiledCompiler = false;
   });
 
+  libgccjit = gcc9.cc.override {
+    name = "libgccjit";
+    langFortran = false;
+    langCC = false;
+    langC = false;
+    profiledCompiler = false;
+    langJit = true;
+    enableLTO = false;
+  };
+
   gcj = gcj6;
   gcj6 = wrapCC (gcc6.cc.override {
     name = "gcj";


### PR DESCRIPTION
libgccjit is a special "language" frontend of gcc which can compile programs. It can be embedded and used as a library, similar to llvm.

This can be used to build gccemacs. For instance:

```
{ pkgs ? import <nixpkgs> {} }:
(pkgs.emacs.override { stdenv = pkgs.gcc9Stdenv; srcRepo = true; }).overrideAttrs (o: {
    src = pkgs.fetchgit {
      url = "https://git.savannah.gnu.org/git/emacs.git";
      rev = "766f4b96ee148adf8f4bbbf5fa4f1c47555d46de";
      sha256 = "sha256-3SJ431AsdurrDESo8HLElGhUzl0eyADIlit/PNV2FR4=";
    };
    LIBRARY_PATH = "${pkgs.lib.getLib pkgs.stdenv.cc.libc}/lib";
    patches = [];
    buildInputs = o.buildInputs or [] ++ [ pkgs.libgccjit ];
    makeFlags = o.makeFlags or [] ++ ["NATIVE_FAST_BOOT=1"];
    configureFlags = o.configureFlags or [] ++ ["--with-nativecomp"];
  })
```

which can be built with `nix-build`.
