### PR TITLE
safety-cli: init at 0.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7688,6 +7688,12 @@
     githubId = 7709;
     name = "Thomaz Leite";
   };
+  thomasdesr = {
+    email = "git@hive.pw";
+    github = "thomasdesr";
+    githubId = 681004;
+    name = "Thomas Desrosiers";
+  };
   ThomasMader = {
     email = "thomas.mader@gmail.com";
     github = "ThomasMader";

--- a/pkgs/development/python-modules/dparse/default.nix
+++ b/pkgs/development/python-modules/dparse/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27, pytest, toml, pyyaml }:
+
+buildPythonPackage rec {
+  pname = "dparse";
+  version = "0.5.1";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a1b5f169102e1c894f9a7d5ccf6f9402a836a5d24be80a986c7ce9eaed78f367";
+  };
+
+  propagatedBuildInputs = [ toml pyyaml ];
+
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    description = "A parser for Python dependency files";
+    homepage = "https://github.com/pyupio/safety";
+    license = licenses.mit;
+    maintainers = with maintainers; [ thomasdesr ];
+  };
+}

--- a/pkgs/development/python-modules/safety/default.nix
+++ b/pkgs/development/python-modules/safety/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildPythonPackage, fetchPypi, requests, dparse, click, setuptools, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "safety";
+  version = "1.9.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "23bf20690d4400edc795836b0c983c2b4cbbb922233108ff925b7dd7750f00c9";
+  };
+
+  propagatedBuildInputs = [ requests dparse click setuptools ];
+
+  # Disable tests depending on online services
+  checkInputs = [ pytestCheckHook ];
+  dontUseSetuptoolsCheck = true;
+  disabledTests = [
+    "test_check_live"
+    "test_check_live_cached"
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  meta = with lib; {
+    description =
+      "Safety checks your installed dependencies for known security vulnerabilities";
+    homepage = "https://github.com/pyupio/safety";
+    license = licenses.mit;
+    maintainers = with maintainers; [ thomasdesr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6414,6 +6414,8 @@ in
 
   safe = callPackage ../tools/security/safe { };
 
+  safety-cli = with python3.pkgs; toPythonApplication safety;
+
   safe-rm = callPackage ../tools/system/safe-rm { };
 
   safeeyes = callPackage ../applications/misc/safeeyes { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2700,6 +2700,8 @@ in {
 
   dpath = callPackage ../development/python-modules/dpath { };
 
+  dparse = callPackage ../development/python-modules/dparse { };
+
   dpkt = callPackage ../development/python-modules/dpkt {};
 
   urllib3 = callPackage ../development/python-modules/urllib3 {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5663,6 +5663,8 @@ in {
 
   safe = callPackage ../development/python-modules/safe { };
 
+  safety = callPackage ../development/python-modules/safety { };
+
   sampledata = callPackage ../development/python-modules/sampledata { };
 
   sasmodels = callPackage ../development/python-modules/sasmodels { };


### PR DESCRIPTION
###### Motivation for this change

Makes it easier to check for known vulnerabilities in a projects' python dependencies

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [n/a] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
