### PR TITLE
ssm-session-manager-plugin: init at 1.1.61.0

### DIFF
--- a/pkgs/applications/networking/cluster/ssm-session-manager-plugin/default.nix
+++ b/pkgs/applications/networking/cluster/ssm-session-manager-plugin/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchurl, autoPatchelfHook, dpkg, awscli }:
+stdenv.mkDerivation rec {
+  pname = "ssm-session-manager-plugin";
+  version = "1.1.61.0";
+
+  src = fetchurl {
+    url =
+      "https://s3.amazonaws.com/session-manager-downloads/plugin/${version}/ubuntu_64bit/session-manager-plugin.deb";
+    sha256 = "0z59irrpwhjjhn379454xyraqs590hij2n6n6k25w5hh8ak7imfl";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg ];
+
+  buildInputs = [ awscli ];
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase =
+    "install -m755 -D usr/local/sessionmanagerplugin/bin/session-manager-plugin $out/bin/session-manager-plugin";
+
+  meta = with lib; {
+    homepage =
+      "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html";
+    description = "Amazon SSM Session Manager Plugin";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ mbaillie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9691,6 +9691,7 @@ in
   spidermonkey = spidermonkey_38;
 
   ssm-agent = callPackage ../applications/networking/cluster/ssm-agent { };
+  ssm-session-manager-plugin = callPackage ../applications/networking/cluster/ssm-session-manager-plugin { };
 
   supercollider = libsForQt5.callPackage ../development/interpreters/supercollider {
     fftw = fftwSinglePrec;


### PR DESCRIPTION
###### Motivation for this change
This PR introduces the AWS SSM Session Manager Plugin, a necessary proprietary binary for client machines wishing to utilise the AWS CLI `aws ssm start-session` subcommand to connect to EC2 instances. An SSM Session is a secure interactive shell proxied via Amazon's APIs. 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
