### PR TITLE
fix docs example for foldl

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -73,8 +73,8 @@ rec {
        lconcat [ "a" "b" "c" ]
        => "zabc"
        # different types
-       lstrange = foldl (str: int: str + toString (int + 1)) ""
-       strange [ 1 2 3 4 ]
+       lstrange = foldl (str: int: str + toString (int + 1)) "a"
+       lstrange [ 1 2 3 4 ]
        => "a2345"
   */
   foldl = op: nul: list:


### PR DESCRIPTION
#### Motivation for this change

doc example for lib.foldl was incorrect

#### current (broken)
```
nix-repl> lib.foldl (str: int: str + toString (int + 1)) "" [ 1 2 3 4 ]
"2345"
```
#### proposed change (working)
```
nix-repl> lib.foldl (str: int: str + toString (int + 1)) "a" [ 1 2 3 4 ]
"a2345"
```
