### PR TITLE
bashCompletion: speed-up test execution by using xdist

### DIFF
--- a/pkgs/shells/bash/bash-completion/default.nix
+++ b/pkgs/shells/bash/bash-completion/default.nix
@@ -30,6 +30,10 @@ stdenv.mkDerivation rec {
     python3Packages.pexpect
     python3Packages.pytest
     bashInteractive
+
+    # use xdist to speed up the test run, just like upstream:
+    # https://github.com/scop/bash-completion/blob/009bf2228c68894629eb6fd17b3dc0f1f6d67615/test/requirements.txt#L4
+    python3Packages.pytest_xdist
   ];
 
   # - ignore test_gcc on ARM because it assumes -march=native
@@ -40,7 +44,7 @@ stdenv.mkDerivation rec {
   # - ignore test_ls because impure logic
   # - ignore test_screen because it assumes vt terminals exist
   checkPhase = ''
-    pytest . \
+    pytest -n $NIX_BUILD_CORES . \
       ${stdenv.lib.optionalString (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isAarch32) "--ignore=test/t/test_gcc.py"} \
       --ignore=test/t/test_chsh.py \
       --ignore=test/t/test_ether_wake.py \


### PR DESCRIPTION
###### Motivation for this change
Currently the tests take an eternity and are also sometimes flaky. By
following upstream in using xdist for parallel test execution we at
least get the feedback cycle down. On my machine that means instead of
running this for ~25min it runs in 1 minute and 10 seconds.

cc maintainers @peti @xfix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
