### PR TITLE
write: init at 209

### DIFF
--- a/pkgs/applications/editors/write/default.nix
+++ b/pkgs/applications/editors/write/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, fetchurl
+, autoPatchelfHook
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  version = "209";
+  pname = "write-${version}";
+
+  src = fetchurl {
+    url = "www.styluslabs.com/write/write209.tar.gz";
+    sha256 = "1p6glp4vdpwl8hmhypayc4cvs3j9jfmjfhhrgqm2xkgl5bfbv2qd";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp Write $out/bin/
+  '';
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    autoPatchelfHook
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "www.styluslabs.com";
+    description = "Write is a word processor for handwriting";
+    license = licenses.unfree;
+    maintainers = with maintainers; [
+      olynch
+    ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22701,6 +22701,8 @@ in
       );
   };
 
+  write = qt5.callPackage ../applications/editors/write { };
+
   wsjtx = qt5.callPackage ../applications/radio/wsjtx { };
 
   wxhexeditor = callPackage ../applications/editors/wxhexeditor {


### PR DESCRIPTION
###### Motivation for this change
Added write, a word processor for handwriting

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
