### PR TITLE
libusb1: fix enableSystemd=false build

### DIFF
--- a/pkgs/development/libraries/libusb1/default.nix
+++ b/pkgs/development/libraries/libusb1/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     sha256 = "0mxbpg01kgbk5nh6524b0m4xk7ywkyzmc3yhi5asqcsd3rbhjj98";
   };
 
-  outputs = [ "out" "dev" ]; # get rid of propagating systemd closure
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   propagatedBuildInputs =
@@ -30,8 +30,6 @@ stdenv.mkDerivation rec {
     stdenv.lib.optionals stdenv.isDarwin [ libobjc IOKit ];
 
   dontDisableStatic = withStatic;
-
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
 
   configureFlags = stdenv.lib.optional (!enableSystemd) "--disable-udev";
 


### PR DESCRIPTION
###### Motivation for this change

Without `--disable-udev` the build tries to use `udev` by default, which fails when `systemd` is not in `buildInputs`.

This also removes some old workarounds, which are fixed by upstream already and don't affect the build anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS `nix build -f . pkgsMusl.libusb1 pkgsStatic.libusb1 libusb1`
   - [x] macOS `nix build '(with import ./. { system = "x86_64-darwin"; }; libusb1)'`
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
