### PR TITLE
libcello: 0.9.2 -> 2.1.0

### DIFF
--- a/pkgs/development/libraries/libcello/default.nix
+++ b/pkgs/development/libraries/libcello/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libcello-${version}";
+  pname = "libcello";
   version = "2.1.0";
 
   src = fetchurl {

--- a/pkgs/development/libraries/libcello/default.nix
+++ b/pkgs/development/libraries/libcello/default.nix
@@ -1,17 +1,21 @@
-{stdenv, fetchurl}:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libcello-0.9.2";
+  name = "libcello-${version}";
+  version = "2.1.0";
 
   src = fetchurl {
-    url = "http://libcello.org/static/${name}.tar.gz";
-    sha256 = "cd82639cb9b133119fd89a77a5a505a55ea5fcc8decfc53bee0725358ec8bad0";
+    url = "http://libcello.org/static/libCello-${version}.tar.gz";
+    sha256 = "0a1b2x5ni07vd9ridnl7zv7h2s32070wsphjy94qr066b99gdb29";
   };
+
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = {
     homepage = "http://libcello.org/";
     description = "Higher level programming in C";
     license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.MostAwesomeDude ];
     platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

libcello became much more usable with this major version bump several years ago. The library had a new release recently and that's what I've packaged here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
