### PR TITLE
libaec: init at 1.0.4; zopfli: include all headers

### DIFF
--- a/pkgs/development/libraries/libaec/default.nix
+++ b/pkgs/development/libraries/libaec/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitLab
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libaec";
+  version  = "1.0.4";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.dkrz.de";
+    owner = "k202009";
+    repo = "libaec";
+    rev = "v${version}";
+    sha256 = "1rpma89i35ahbalaqz82y201syxni7jkf9892jlyyrhhrvlnm4l2";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://gitlab.dkrz.de/k202009/libaec";
+    description = "Adaptive Entropy Coding library";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/tools/compression/zopfli/default.nix
+++ b/pkgs/tools/compression/zopfli/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     install -Dm444 -t $out/share/doc/zopfli ../README*
+    cp $src/src/zopfli/*.h $dev/include/
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12418,6 +12418,8 @@ in
 
   libacr38u = callPackage ../tools/security/libacr38u { };
 
+  libaec = callPackage ../development/libraries/libaec { };
+
   libagar = callPackage ../development/libraries/libagar { };
   libagar_test = callPackage ../development/libraries/libagar/libagar_test.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
Add/fix imagecodecs dependencies

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
