### PR TITLE
[haskell-updates] hackagePackages.neuron: Fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1515,4 +1515,8 @@ self: super: {
     };
   };
 
+  # hasn‘t bumped upper bounds
+  # upstream: https://github.com/obsidiansystems/which/pull/6
+  which = doJailbreak super.which;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2732,7 +2732,6 @@ broken-packages:
   - aeson-diff-generic
   - aeson-filthy
   - aeson-flowtyped
-  - aeson-gadt-th
   - aeson-injector
   - aeson-iproute
   - aeson-native
@@ -7799,7 +7798,6 @@ broken-packages:
   - neural
   - neural-network-blashs
   - neural-network-hmatrix
-  - neuron
   - newhope
   - newports
   - newsletter
@@ -8893,7 +8891,6 @@ broken-packages:
   - rhine
   - rhine-gloss
   - rhythm-game-tutorial
-  - rib
   - ribbit
   - RichConditional
   - ridley
@@ -10599,7 +10596,6 @@ broken-packages:
   - wheb-mongo
   - wheb-redis
   - wheb-strapped
-  - which
   - while-lang-parser
   - whim
   - whiskers

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -730,4 +730,24 @@ self: super: builtins.intersectAttrs super {
 
   # Tests access homeless-shelter.
   hie-bios = dontCheck super.hie-bios;
+
+  # Compiling the readme throws errors and has no purpose in nixpkgs
+  aeson-gadt-th =
+    disableCabalFlag (doJailbreak (super.aeson-gadt-th)) "build-readme";
+
+  neuron = overrideCabal (super.neuron) (drv: {
+    # neuron expects the neuron-search script to be in PATH at built-time.
+    buildTools = [ pkgs.makeWrapper ];
+    preConfigure = ''
+      mkdir -p $out/bin
+      cp src-bash/neuron-search $out/bin/neuron-search
+      chmod +x $out/bin/neuron-search
+      wrapProgram $out/bin/neuron-search --prefix 'PATH' ':' ${
+        with pkgs;
+        lib.makeBinPath [ fzf ripgrep gawk bat findutils envsubst ]
+      }
+      PATH=$PATH:$out/bin
+    '';
+  });
+
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

**WARNING:** Do not merge, right now this uses a tarball from my personal server, not upstream, as a proof of concept.

###### Motivation for this change

I am trying to get the nice `neuron` app to build.

It is building, but I had to employ weird workarounds.

1. The hackage package is not containing everything needed to actually compile, so pulling the source again from github. This is probably something we should fix on upstream in future releases.
2. The program includes a nix-generate shell script at compiletime. I don‘t know how to do this nicely in nixpkgs without relying on IFD. Would be very open to suggestions.
3. Right now the git version is not set during the build process. That is not a problem, but generated html outputs (UNKNOWN) were normally a git commit id would be.

I will contact upstream regarding all three points.

###### Things to be done

- [x] Add extra-sources on upstream
- [x] Change bash-script to not use IFD on upstream
- [ ] New upstream release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
