### PR TITLE
python-miio: 0.4.8 -> 0.5.0.1

### DIFF
--- a/pkgs/development/python-modules/python-miio/default.nix
+++ b/pkgs/development/python-modules/python-miio/default.nix
@@ -15,11 +15,11 @@
 
 buildPythonPackage rec {
   pname = "python-miio";
-  version = "0.4.8";
+  version = "0.5.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "19423b3386b23d2e0fc94a8f6a358bcfbb44eed05376e33fd434d26d168bd18c";
+    sha256 = "fa9c318256945ad4a8623fdf921ce81c466a7aea18b04a6711efb662f520b195";
   };
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
#### Motivation for this change

Update python-miio.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
