### PR TITLE
nixos/gdk-pixbuf.nix: don’t set GDK_PIXBUF_MODULE_FILE in cross

### DIFF
--- a/nixos/modules/services/x11/gdk-pixbuf.nix
+++ b/nixos/modules/services/x11/gdk-pixbuf.nix
@@ -37,7 +37,7 @@ in
   # If there is any package configured in modulePackages, we generate the
   # loaders.cache based on that and set the environment variable
   # GDK_PIXBUF_MODULE_FILE to point to it.
-  config = mkIf (cfg.modulePackages != [] || pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform) {
+  config = mkIf (cfg.modulePackages != []) {
     environment.variables = {
       GDK_PIXBUF_MODULE_FILE = "${loadersCache}";
     };


### PR DESCRIPTION
From 6c5983a291530f040deb97881e80cca373a5b29e, this should not be
necessary for gdk-pixbuf to work correctly.
