### PR TITLE
ocamlPackages.tyxml: 4.3.0 → 4.4.0; ocamlPackages.eliom: 6.10.1 → 6.12.0

### DIFF
--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -14,11 +14,11 @@ else
 stdenv.mkDerivation rec
 {
   pname = "eliom";
-  version = "6.10.1";
+  version = "6.12.0";
 
   src = fetchzip {
     url = "https://github.com/ocsigen/eliom/archive/${version}.tar.gz";
-    sha256 = "006722wcmhsfhyzv3qbgrrn53fbv9v4i31z52a0pznb6cll45nkm";
+    sha256 = "015jh72v6ch9h9czd8sn5kjz3pv6lsnvvnhdjgrplwj443dn1xp8";
   };
 
   buildInputs = [ ocaml which findlib js_of_ocaml-ocamlbuild js_of_ocaml-ppx_deriving_json opaline

--- a/pkgs/development/ocaml-modules/tyxml/default.nix
+++ b/pkgs/development/ocaml-modules/tyxml/default.nix
@@ -2,11 +2,11 @@
 
 buildDunePackage rec {
   pname = "tyxml";
-  version = "4.3.0";
+  version = "4.4.0";
 
   src = fetchurl {
     url = "https://github.com/ocsigen/tyxml/releases/download/${version}/tyxml-${version}.tbz";
-    sha256 = "1hxzppfvsdls2y8qiwvz31hmffzh2hgglf01am1vzf2f31mxf6vf";
+    sha256 = "0c150h2f4c4id73ickkdqkir3jya66m6c7f5jxlp4caw9bfr8qsi";
   };
 
   propagatedBuildInputs = [ uutf re ];


### PR DESCRIPTION
###### Motivation for this change

Fixes #87057

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
