### PR TITLE
jupyter_client, nbformat, notebook: fix on python2

### DIFF
--- a/pkgs/development/python-modules/jupyter_client/5.nix
+++ b/pkgs/development/python-modules/jupyter_client/5.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, traitlets
+, jupyter_core
+, pyzmq
+, dateutil
+, isPyPy
+, py
+, tornado
+}:
+
+buildPythonPackage rec {
+  pname = "jupyter_client";
+  version = "5.3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "60e6faec1031d63df57f1cc671ed673dced0ed420f4377ea33db37b1c188b910";
+  };
+
+  propagatedBuildInputs = [
+    traitlets
+    jupyter_core
+    pyzmq
+    dateutil
+    tornado
+  ] ++ lib.optional isPyPy py;
+
+  # Circular dependency with ipykernel
+  doCheck = false;
+
+  meta = {
+    description = "Jupyter protocol implementation and client libraries";
+    homepage = "https://jupyter.org/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ fridh ];
+  };
+}

--- a/pkgs/development/python-modules/nbformat/2.nix
+++ b/pkgs/development/python-modules/nbformat/2.nix
@@ -12,11 +12,11 @@
 
 buildPythonPackage rec {
   pname = "nbformat";
-  version = "5.0.4";
+  version = "4.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "562de41fc7f4f481b79ab5d683279bf3a168858268d4387b489b7b02be0b324a";
+    sha256 = "f7494ef0df60766b7cabe0a3651556345a963b74dbc16bc7c18479041170d402";
   };
 
   LC_ALL="en_US.utf8";

--- a/pkgs/development/python-modules/notebook/2.nix
+++ b/pkgs/development/python-modules/notebook/2.nix
@@ -25,11 +25,11 @@
 
 buildPythonPackage rec {
   pname = "notebook";
-  version = "6.0.3";
+  version = "5.7.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "47a9092975c9e7965ada00b9a20f0cf637d001db60d241d479f53c0be117ad48";
+    sha256 = "573e0ae650c5d76b18b6e564ba6d21bf321d00847de1d215b418acb64f056eb8";
   };
 
   LC_ALL = "en_US.utf8";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4180,7 +4180,10 @@ in {
     inherit (pkgs.jsonnet) name src;
   };
 
-  jupyter_client = callPackage ../development/python-modules/jupyter_client { };
+  jupyter_client = if isPy3k then
+    callPackage ../development/python-modules/jupyter_client { }
+  else
+    callPackage ../development/python-modules/jupyter_client/5.nix { };
 
   jupyter_core = callPackage ../development/python-modules/jupyter_core { };
 


### PR DESCRIPTION
#### Motivation for this change

`jupyter_client` dropped python2 support and apparently there were some mixups at the recent python packages update.

CC @FRidh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
