### PR TITLE
sidequest: 0.10.2 -> 0.10.4, fix file picker

### DIFF
--- a/pkgs/applications/misc/sidequest/default.nix
+++ b/pkgs/applications/misc/sidequest/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, buildFHSUserEnv, makeDesktopItem, makeWrapper, atomEnv, libuuid, at-spi2-atk, icu, openssl, zlib }:
+{ stdenv, lib, fetchurl, buildFHSUserEnv, makeDesktopItem, wrapGAppsHook, atomEnv, libuuid, at-spi2-atk, icu, openssl, zlib, gtk3 }:
 	let
 		pname = "sidequest";
 		version = "0.10.4";
@@ -19,16 +19,17 @@
 				sha256 = "1hd5093rn3y2l3gibzbylwbl0i4zh80a9bf1wb11jfv07x8n93cp";
 			};
 
-			buildInputs = [ makeWrapper ];
+			buildInputs = [ gtk3 ];
+			nativeBuildInputs = [ wrapGAppsHook ];
 
-			buildCommand = ''
+			installPhase = ''
 				mkdir -p "$out/lib/SideQuest" "$out/bin"
-				tar -xJf "$src" -C "$out/lib/SideQuest" --strip-components 1
+				cp -r . "$out/lib/SideQuest"
 
 				ln -s "$out/lib/SideQuest/sidequest" "$out/bin"
+			'';
 
-				fixupPhase
-
+			postFixup = ''
 				# mkdir -p "$out/share/applications"
 				# ln -s "${desktopItem}/share/applications/*" "$out/share/applications"
 

--- a/pkgs/applications/misc/sidequest/default.nix
+++ b/pkgs/applications/misc/sidequest/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, buildFHSUserEnv, makeDesktopItem, makeWrapper, atomEnv, libuuid, at-spi2-atk, icu, openssl, zlib }:
 	let
 		pname = "sidequest";
-		version = "0.10.2";
+		version = "0.10.4";
 
 		desktopItem = makeDesktopItem rec {
 			name = "SideQuest";
@@ -16,7 +16,7 @@
 
 			src = fetchurl {
 				url = "https://github.com/the-expanse/SideQuest/releases/download/v${version}/SideQuest-${version}.tar.xz";
-				sha256 = "1vfxn4gx5b138gj6nk4w3jlp2l56cqpb8hq2kn5mrf4dhjii8n88";
+				sha256 = "1hd5093rn3y2l3gibzbylwbl0i4zh80a9bf1wb11jfv07x8n93cp";
 			};
 
 			buildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
SideQuest 0.10.4 is the final MIT licensed version, with later versions being proprietary. As changing a license to an unfree one is a breaking change, and I'm unsure of nixpkgs's policy on this, I chose to use this version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).