### PR TITLE
gitAndTools.git-fast-export: 190107 -> 200213, fix

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -98,7 +98,7 @@ let
 
   git-fame = callPackage ./git-fame {};
 
-  git-fast-export = callPackage ./fast-export { };
+  git-fast-export = callPackage ./fast-export { mercurial = mercurial_4; };
 
   git-filter-repo = callPackage ./git-filter-repo {
     pythonPackages = python3Packages;

--- a/pkgs/applications/version-management/git-and-tools/fast-export/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/fast-export/default.nix
@@ -1,13 +1,14 @@
-{stdenv, fetchgit, mercurial, makeWrapper}:
+{stdenv, fetchFromGitHub, git, mercurial, makeWrapper}:
 
 stdenv.mkDerivation rec {
   pname = "fast-export";
-  version = "190107";
+  version = "200213";
 
-  src = fetchgit {
-    url = "git://repo.or.cz/fast-export.git";
+  src = fetchFromGitHub {
+    owner = "frej";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "14azfps9jd5anivcvfwflgsvqdyy6gm9jy284kzx2ng9f7871d14";
+    sha256 = "0hzyh66rlawxip4n2pvz7pbs0cq82clqv1d6c7hf60v1drjxw287";
   };
 
   buildInputs = [mercurial.python mercurial makeWrapper];
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
 
     for script in $out/bin/*.sh; do
       wrapProgram $script \
-        --prefix PATH : "${mercurial.python}/bin":$libexec \
+        --prefix PATH : "${git}/bin":"${mercurial.python}/bin":$libexec \
         --prefix PYTHONPATH : "${mercurial}/${mercurial.python.sitePackages}":$sitepackagesPath
     done
   '';


### PR DESCRIPTION
###### Motivation for this change
Turns out this was broken, probably by a mercurial bump to a py3k version. Fixed & bumped (still no py3k support in a released version though). Added an `installCheckPhase` so this doesn't happen again.

Would be good to get a working version of this out (maybe to stable?) what with the bitbucket mercurial shutdown approaching.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
