### PR TITLE
pythonPackages.ipykernel: 5.1.3 -> 5.2.1

### DIFF
--- a/pkgs/development/python-modules/ipykernel/default.nix
+++ b/pkgs/development/python-modules/ipykernel/default.nix
@@ -15,11 +15,11 @@
 
 buildPythonPackage rec {
   pname = "ipykernel";
-  version = "5.1.4";
+  version = "5.2.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7f1f01df22f1229c8879501057877ccaf92a3b01c1d00db708aad5003e5f9238";
+    sha256 = "1a3hr7wx3ywwskr99hgp120dw9ab1vmcaxdixlsbd9bg6ly3fdr9";
   };
 
   propagatedBuildInputs = [ ipython jupyter_client traitlets tornado ];


### PR DESCRIPTION
###### Motivation for this change
Will resolve #87166 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This PR doesn't break anything new (on my machine at least). I think `pythonPackages.qtconsole` is broken and causing failed builds in a lot of packages that use `ipykernel`, but that's a problem for a different PR. 

I see there is a lot of darwin stuff in this expression, I have no way of testing on darwin.

We should still bump `pyzmq` at some point, the `ipykernel` build still whinges about it.