### PR TITLE
Preserve environment variables from the parent image on dockerTools.buildImage

### DIFF
--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -124,6 +124,16 @@ import ./make-test-python.nix ({ pkgs, ... }: {
                 f"docker run --rm  ${examples.layersOrder.imageName} cat /tmp/layer{index}"
             )
 
+    with subtest("Ensure environment variables are correctly inherited"):
+        docker.succeed(
+            "docker load --input='${examples.environmentVariables}'"
+        )
+        out = docker.succeed("docker run --rm ${examples.environmentVariables.imageName} env")
+        env = out.splitlines()
+        assert "FROM_PARENT=true" in env, "envvars from the parent should be preserved"
+        assert "FROM_CHILD=true" in env, "envvars from the child should be preserved"
+        assert "LAST_LAYER=child" in env, "envvars from the child should take priority"
+
     with subtest("Ensure image with only 2 layers can be loaded"):
         docker.succeed(
             "docker load --input='${examples.two-layered-image}'"

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -231,14 +231,41 @@ rec {
     '';
   };
 
-  # 14. Create another layered image, for comparing layers with image 10.
+  # 14. Environment variable inheritance.
+  # Child image should inherit parents environment variables,
+  # optionally overriding them.
+  environmentVariables = let
+    parent = pkgs.dockerTools.buildImage {
+      name = "parent";
+      tag = "latest";
+      config = {
+        Env = [
+          "FROM_PARENT=true"
+          "LAST_LAYER=parent"
+        ];
+      };
+    };
+  in pkgs.dockerTools.buildImage {
+    name = "child";
+    fromImage = parent;
+    tag = "latest";
+    contents = [ pkgs.coreutils ];
+    config = {
+      Env = [
+        "FROM_CHILD=true"
+        "LAST_LAYER=child"
+      ];
+    };
+  };
+
+  # 15. Create another layered image, for comparing layers with image 10.
   another-layered-image = pkgs.dockerTools.buildLayeredImage {
     name = "another-layered-image";
     tag = "latest";
     config.Cmd = [ "${pkgs.hello}/bin/hello" ];
   };
 
-  # 15. Create a layered image with only 2 layers
+  # 16. Create a layered image with only 2 layers
   two-layered-image = pkgs.dockerTools.buildLayeredImage {
     name = "two-layered-image";
     tag = "latest";
@@ -247,7 +274,7 @@ rec {
     maxLayers = 2;
   };
 
-  # 16. Create a layered image with more packages than max layers.
+  # 17. Create a layered image with more packages than max layers.
   # coreutils and hello are part of the same layer
   bulk-layer = pkgs.dockerTools.buildLayeredImage {
     name = "bulk-layer";
@@ -258,7 +285,7 @@ rec {
     maxLayers = 2;
   };
 
-  # 17. Create a "layered" image without nix store layers. This is not
+  # 18. Create a "layered" image without nix store layers. This is not
   # recommended, but can be useful for base images in rare cases.
   no-store-paths = pkgs.dockerTools.buildLayeredImage {
     name = "no-store-paths";


### PR DESCRIPTION
###### Motivation for this change

When building the Docker images with `docker build`, environment variables from the parent is inherited to the child images. This was not the case with `dockerTools.buildImage`, since it discards the parent configuration when building the child image. This behaviour is a bit inconvenient since that pattern is widely used.

This PR fetches the environment variables from the parent image and injects to the childs configuration. I also extended the NixOS tests to test this behaviour.

Still this is less than ideal, since the environment variables is not the only thing which should be inherited from the parents. Cmd, entrypoint, user, working directory, labels, volumes are also inherited, but unfortunately all in slightly different ways; and I think trying to replicate all that behavior will be costly. So, we can currently only handle environment variables and implement the others only when necessary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).