### PR TITLE
vpn-slice: init at 0.14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3466,6 +3466,12 @@
     }];
     name = "Jiri Daněk";
   };
+  jdbaldry = {
+    email = "jack.baldry@grafana.com";
+    github = "jdbaldry";
+    githubId = 4599384;
+    name = "Jack Baldry";
+  };
   jdehaas = {
     email = "qqlq@nullptr.club";
     github = "jeroendehaas";

--- a/pkgs/tools/networking/vpn-slice/default.nix
+++ b/pkgs/tools/networking/vpn-slice/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonApplication, python3Packages, fetchFromGitHub }:
+
+buildPythonApplication rec {
+  pname = "vpn-slice";
+  version = "0.14";
+
+  src = fetchFromGitHub {
+    owner = "dlenski";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1z2mdl3arzl95zrj4ir57f762gcimmmq5nk91j679cshxz4snxyr";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ setproctitle dnspython ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/dlenski/vpn-slice";
+    description =
+      "vpnc-script replacement for easy and secure split-tunnel VPN setup";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jdbaldry ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7293,6 +7293,8 @@ in
 
   vpnc = callPackage ../tools/networking/vpnc { };
 
+  vpn-slice = python3Packages.callPackage ../tools/networking/vpn-slice { };
+
   vp = callPackage ../applications/misc/vp {
     # Enable next line for console graphics. Note that
     # it requires `sixel` enabled terminals such as mlterm


### PR DESCRIPTION
As a NixOS beginner, I would appreciate any guidance on the following:

In order to work, vpn-slice edits the systems /etc/hosts file which is read-only by default on NixOS. As the changes are temporary (only needed during operation of the split tunnel), I was happy to add write permissions to the host file using `environment.etc.hosts.mode = "0644";` as I feel like it wasn't against the spirit of declarative system configuration.

Would you recommend a different approach?

##### Motivation for this change
Python tool for convenient configuration of a split tunnel VPN

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
