### PR TITLE
nixos/resolved: Include dbus alias of resolved unit

### DIFF
--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -144,6 +144,7 @@ in
 
     systemd.additionalUpstreamSystemUnits = [
       "systemd-resolved.service"
+      "dbus-org.freedesktop.resolve1.service"
     ];
 
     systemd.services.systemd-resolved = {


### PR DESCRIPTION
This will make dbus socket activation for it work

Fixes https://github.com/NixOS/nixpkgs/issues/85855

###### Motivation for this change

When `systemd-resolved` is restarted; this would lead to unavailability of DNS lookups.  You're supposed to use DBUS socket activation to buffer resolved requests; such that restarts happen without downtime

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
