### PR TITLE
mpd: add services.mpd.fluidsynth option

### DIFF
--- a/nixos/modules/services/audio/mpd.nix
+++ b/nixos/modules/services/audio/mpd.nix
@@ -21,6 +21,12 @@ let
 
     ${optionalString (cfg.network.listenAddress != "any") ''bind_to_address "${cfg.network.listenAddress}"''}
     ${optionalString (cfg.network.port != 6600)  ''port "${toString cfg.network.port}"''}
+    ${optionalString (cfg.fluidsynth) ''
+      decoder {
+              plugin "fluidsynth"
+              soundfont "${pkgs.soundfont-fluid}/share/soundfonts/FluidR3_GM2-2.sf2"
+      }
+    ''}
 
     ${cfg.extraConfig}
   '';
@@ -131,6 +137,14 @@ in {
         description = ''
           The path to MPD's database. If set to <literal>null</literal> the
           parameter is omitted from the configuration.
+        '';
+      };
+
+      fluidsynth = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If set, add fluidsynth soundfont and configure the plugin.
         '';
       };
     };


### PR DESCRIPTION
###### Motivation for this change

fluidsynth is compiled in but soundfont-fluid needs to be explicitly
pulled in and path configured, an option makes it much simpler to use

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

I tried running `nixos/tests/mpd.nix` but it looks like my hosts' config firewall bled into it? or it doesn't work anymore because of firewall; port 6600 was refused...
```
serverPulseAudio # [   26.809227] refused connection: IN=eth1 OUT= MAC=52:54:00:12:01:03:52:54:00:12:01
:01:08:00 SRC=192.168.1.1 DST=192.168.1.3 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=27402 DF PROTO=TCP SPT=34
152 DPT=6600 WINDOW=64240 RES=0x00 SYN URGP=0
```
Anyway I tested manually via build-vm and it works (both pulling the package and config looked ok with & without new option set)
```
$ cat vm.nix
{ lib, config, ... }:
{
  services.mpd = {
    enable = true;
    fluidsynth = true;
  };
  users.users.root.initialPassword = "root";
}
$ nixos-rebuild -I nixpkgs=/home/asmadeus/nixpkgs/ -I nixos-config=./vm.nix build-vm
...
$ /nix/store/9ljp3igryy56lzk5xf5lvhf24c01ni8p-nixos-vm/bin/run-nixos-vm -serial mon:stdio -nographic
... service running, config ok and file accessible despite
... not having installed it previously on the host
```
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

mpd maintainers @tobim @fpletz @ehmry @astsmtl