### PR TITLE
guile-opengl: fix dynamic loading of libraries

### DIFF
--- a/pkgs/development/guile-modules/guile-opengl/default.nix
+++ b/pkgs/development/guile-modules/guile-opengl/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, guile }:
+{ stdenv
+, fetchurl
+, pkgconfig
+, guile
+, libGL
+, libGLU
+, freeglut
+}:
 
 let
   name = "guile-opengl-${version}";
@@ -10,6 +17,15 @@ in stdenv.mkDerivation {
     url = "mirror://gnu/guile-opengl/${name}.tar.gz";
     sha256 = "13qfx4xh8baryxqrv986l848ygd0piqwm6s2s90pxk9c0m9vklim";
   };
+
+  patchPhase = ''
+    substituteInPlace glx/runtime.scm \
+      --replace '(dynamic-link "libGL")' '(dynamic-link "${libGL}/lib/libGL.so")'
+    substituteInPlace glu/runtime.scm \
+      --replace '(dynamic-link "libGLU")' '(dynamic-link "${libGLU}/lib/libGLU.so")'
+    substituteInPlace glut/runtime.scm \
+      --replace '(dynamic-link "libglut")' '(dynamic-link "${freeglut}/lib/libglut.so")'
+  '';
 
   nativeBuildInputs = [ pkgconfig guile ];
 


### PR DESCRIPTION
This uses the absolute path for libraries when opening them at runtime

https://www.gnu.org/software/guile/manual/html_node/Foreign-Libraries.html#index-dynamic_002dlink

Previously, the libGL, glu and freeglut weren't dependencies, now they are
```
$ nix-store -q --references guile-opengl-new 
/nix/store/d0ahcim3p9dv6b01nnmx5nvx7qggnki3-libGL-1.2.0
/nix/store/cv03ly81aq91d298kjb28ykzm176z3nb-freeglut-3.2.1
/nix/store/h6daxzmqp3q515vy4mxci92y551y5cx1-glu-9.0.1
```
```
$ nix-store -q --references guile-opengl-old 
```

I do wonder if there is a better way we could do this (i.e. doesn't Mac OSX have different file extensions for the libraries)? Perhaps somehow we could make autoconf find the libraries, and use the path it found? (I don't know much about autoconf). But this doesn't actually matter here, as the build platforms are linux only.

Guile-opengl doesn't seem to have any referrers, so I don't think this changes anything. I'm trying to package inspekt3d (https://gitlab.com/kavalogic-inc/inspekt3d/), and spotted this problem.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
