### PR TITLE
krop: install desktop file

### DIFF
--- a/pkgs/applications/graphics/krop/default.nix
+++ b/pkgs/applications/graphics/krop/default.nix
@@ -24,6 +24,10 @@ python3Packages.buildPythonApplication rec {
    "\${qtWrapperArgs[@]}"
   ];
 
+  postInstall = ''
+    install -m666 -Dt $out/share/applications krop.desktop
+  '';
+
   # Disable checks because of interference with older Qt versions // xcb
   doCheck = false;
 


### PR DESCRIPTION
##### Motivation for this change

use krop from a graphical launcher

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
