### PR TITLE
dino: allow newer versions of libsignal-protocol-c

### DIFF
--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -4,6 +4,7 @@
 , xorg, libXdmcp, libxkbcommon
 , libnotify, libsoup, libgee
 , librsvg, libsignal-protocol-c
+, fetchpatch
 , libgcrypt
 , epoxy
 , at-spi2-core
@@ -25,6 +26,15 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1k5cgj5n8s40i71wqdh6m1q0njl45ichfdbbywx9rga5hljz1c54";
   };
+
+  patches = [
+    (fetchpatch {
+      # Allow newer versions of libsignal-protocol-c
+      url = "https://github.com/dino/dino/commit/fbd70ceaac5ebbddfa21a580c61165bf5b861303.patch";
+      sha256 = "0ydpwsmwrzfsry89fsffkfalhki4n1dw99ixjvpiingdrhjmwyl2";
+      excludes = [ "plugins/signal-protocol/libsignal-protocol-c" ];
+    })
+  ];
 
   nativeBuildInputs = [
     vala


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The exact version of libsignal-protocol-c used by dino is hard-coded to 2.3.2 because "libsignal-protocol-c has a history of breaking compatibility on the patch level". This prevents libsignal-protocol-c from being updated in https://github.com/NixOS/nixpkgs/pull/83736. To fix this, I do what the comment in plugins/signal-protocol/CMakeLists.txt recommends and what Arch Linux does (https://git.archlinux.org/svntogit/community.git/tree/trunk/signal-2.3.3.patch?h=packages/dino) and patch the source so that newer versions are allowed. This works fine for Arch Linux and for me.

This is the first time that I added a patch to a package. Did I do it correctly?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
