### PR TITLE
networkmanager: 1.22.10 → 1.26.0

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -10,11 +10,11 @@ let
   pythonForDocs = python3.withPackages (pkgs: with pkgs; [ pygobject3 ]);
 in stdenv.mkDerivation rec {
   pname = "network-manager";
-  version = "1.24.0";
+  version = "1.24.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${stdenv.lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "06044fl60bjlj7c6rqqfbm5795h61h6yzp7ch392hzcnm46wwhn3";
+    sha256 = "1cnf0cif0l45wxf823xqri3ly9n0ai3ndxx34qs3yk1m85f0giic";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -10,11 +10,11 @@ let
   pythonForDocs = python3.withPackages (pkgs: with pkgs; [ pygobject3 ]);
 in stdenv.mkDerivation rec {
   pname = "network-manager";
-  version = "1.22.10";
+  version = "1.24.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${stdenv.lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "0xyaizyp3yz6x3pladw3nvl3hf4n5g140zx9jnxfp9qvag0wqa9b";
+    sha256 = "06044fl60bjlj7c6rqqfbm5795h61h6yzp7ch392hzcnm46wwhn3";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];
@@ -41,7 +41,6 @@ in stdenv.mkDerivation rec {
     "-Dcrypto=gnutls"
     "-Dsession_tracking=systemd"
     "-Dmodem_manager=true"
-    "-Dpolkit_agent=true"
     "-Dnmtui=true"
     "-Ddocs=true"
     "-Dtests=no"
@@ -54,7 +53,7 @@ in stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit iputils kmod openconnect ethtool gnused systemd;
+      inherit iputils kmod openconnect ethtool gnused systemd polkit;
       inherit runtimeShell;
     })
 

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -10,11 +10,11 @@ let
   pythonForDocs = python3.withPackages (pkgs: with pkgs; [ pygobject3 ]);
 in stdenv.mkDerivation rec {
   pname = "network-manager";
-  version = "1.24.2";
+  version = "1.26.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${stdenv.lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "1cnf0cif0l45wxf823xqri3ly9n0ai3ndxx34qs3yk1m85f0giic";
+    sha256 = "0isdqwp58d7r92sqsk7l2vlqwy518n8b7c7z94jk9gc1bdmjf8sj";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];
@@ -48,6 +48,8 @@ in stdenv.mkDerivation rec {
     # Allow using iwd when configured to do so
     "-Diwd=true"
     "-Dlibaudit=yes-disabled-by-default"
+    # We don't use firewalld in NixOS
+    "-Dfirewalld_zone=false"
   ];
 
   patches = [

--- a/pkgs/tools/networking/network-manager/fix-install-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-install-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 0af69f35d..9ab239c8a 100644
+index a2d925a7e..5a65cd2fe 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -912,9 +912,9 @@ meson.add_install_script(
+@@ -959,9 +959,9 @@ meson.add_install_script(
    join_paths('tools', 'meson-post-install.sh'),
    nm_datadir,
    nm_bindir,

--- a/pkgs/tools/networking/network-manager/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/clients/common/nm-vpn-helpers.c b/clients/common/nm-vpn-helpers.c
-index ffae5f553..ba1093e4d 100644
+index fbcb06479..f13f32408 100644
 --- a/clients/common/nm-vpn-helpers.c
 +++ b/clients/common/nm-vpn-helpers.c
-@@ -203,10 +203,7 @@ nm_vpn_openconnect_authenticate_helper (const char *host,
+@@ -213,10 +213,7 @@ nm_vpn_openconnect_authenticate_helper (const char *host,
  		NULL,
  	};
  
@@ -40,10 +40,10 @@ index 91ebd9a36..5201a56c3 100644
  ExecStart=@sbindir@/NetworkManager --no-daemon
  Restart=on-failure
 diff --git a/libnm/meson.build b/libnm/meson.build
-index 51ca46d2b..0c04cc216 100644
+index 406766c70..44c158f8a 100644
 --- a/libnm/meson.build
 +++ b/libnm/meson.build
-@@ -261,7 +261,7 @@ if enable_introspection
+@@ -265,7 +265,7 @@ if enable_introspection
      name,
      input: libnm_gir[0],
      output: name,
@@ -52,7 +52,7 @@ index 51ca46d2b..0c04cc216 100644
      depends: libnm_gir,
    )
  
-@@ -270,7 +270,7 @@ if enable_introspection
+@@ -274,7 +274,7 @@ if enable_introspection
      name,
      input: [libnm_gir[0], nm_settings_docs_overrides],
      output: name,
@@ -61,14 +61,27 @@ index 51ca46d2b..0c04cc216 100644
      depends: libnm_gir,
    )
  endif
+diff --git a/meson.build b/meson.build
+index a2d925a7e..23c85f128 100644
+--- a/meson.build
++++ b/meson.build
+@@ -522,7 +522,7 @@ polkit_agent_dep = dependency('polkit-agent-1', version: '>= 0.97', required : f
+ if polkit_agent_dep.found()
+ 	config_h.set_quoted('POLKIT_PACKAGE_PREFIX', polkit_agent_dep.get_pkgconfig_variable('prefix'))
+ else
+-	config_h.set_quoted('POLKIT_PACKAGE_PREFIX', '/usr')
++	config_h.set_quoted('POLKIT_PACKAGE_PREFIX', '@polkit@')
+ endif
+ 
+ 
 diff --git a/src/devices/nm-device.c b/src/devices/nm-device.c
-index e7a4a059a..0a8f8b7c6 100644
+index 44e5183ec..e725845e4 100644
 --- a/src/devices/nm-device.c
 +++ b/src/devices/nm-device.c
-@@ -13179,14 +13179,14 @@ nm_device_start_ip_check (NMDevice *self)
+@@ -13493,14 +13493,14 @@ nm_device_start_ip_check (NMDevice *self)
  			gw = nm_ip4_config_best_default_route_get (priv->ip_config_4);
  			if (gw) {
- 				nm_utils_inet4_ntop (NMP_OBJECT_CAST_IP4_ROUTE (gw)->gateway, buf);
+ 				_nm_utils_inet4_ntop (NMP_OBJECT_CAST_IP4_ROUTE (gw)->gateway, buf);
 -				ping_binary = nm_utils_find_helper ("ping", "/usr/bin/ping", NULL);
 +				ping_binary = "@iputils@/bin/ping";
  				log_domain = LOGD_IP4;
@@ -76,14 +89,14 @@ index e7a4a059a..0a8f8b7c6 100644
  		} else if (priv->ip_config_6 && priv->ip_state_6 == NM_DEVICE_IP_STATE_DONE) {
  			gw = nm_ip6_config_best_default_route_get (priv->ip_config_6);
  			if (gw) {
- 				nm_utils_inet6_ntop (&NMP_OBJECT_CAST_IP6_ROUTE (gw)->gateway, buf);
+ 				_nm_utils_inet6_ntop (&NMP_OBJECT_CAST_IP6_ROUTE (gw)->gateway, buf);
 -				ping_binary = nm_utils_find_helper ("ping6", "/usr/bin/ping6", NULL);
 +				ping_binary = "@iputils@/bin/ping";
  				log_domain = LOGD_IP6;
  			}
  		}
 diff --git a/src/nm-core-utils.c b/src/nm-core-utils.c
-index fb92289f0..c91b27b09 100644
+index 415e1dc41..995eb6ecf 100644
 --- a/src/nm-core-utils.c
 +++ b/src/nm-core-utils.c
 @@ -336,7 +336,7 @@ nm_utils_modprobe (GError **error, gboolean suppress_error_logging, const char *

--- a/pkgs/tools/networking/network-manager/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-paths.patch
@@ -1,5 +1,18 @@
+diff --git a/clients/common/nm-polkit-listener.c b/clients/common/nm-polkit-listener.c
+index ace205e80..f19c1dea0 100644
+--- a/clients/common/nm-polkit-listener.c
++++ b/clients/common/nm-polkit-listener.c
+@@ -552,7 +552,7 @@ begin_authentication (AuthRequest *request)
+ {
+ 	int fd_flags;
+ 	const char *helper_argv[] = {
+-		POLKIT_PACKAGE_PREFIX "/lib/polkit-1/polkit-agent-helper-1",
++		"/run/wrappers/bin/polkit-agent-helper-1",
+ 		request->username,
+ 		NULL,
+ 	};
 diff --git a/clients/common/nm-vpn-helpers.c b/clients/common/nm-vpn-helpers.c
-index fbcb06479..f13f32408 100644
+index 74ff52bb2..638857df4 100644
 --- a/clients/common/nm-vpn-helpers.c
 +++ b/clients/common/nm-vpn-helpers.c
 @@ -213,10 +213,7 @@ nm_vpn_openconnect_authenticate_helper (const char *host,
@@ -40,45 +53,22 @@ index 91ebd9a36..5201a56c3 100644
  ExecStart=@sbindir@/NetworkManager --no-daemon
  Restart=on-failure
 diff --git a/libnm/meson.build b/libnm/meson.build
-index 406766c70..44c158f8a 100644
+index d3991ab19..58f01c666 100644
 --- a/libnm/meson.build
 +++ b/libnm/meson.build
-@@ -265,7 +265,7 @@ if enable_introspection
-     name,
-     input: libnm_gir[0],
-     output: name,
--    command: [generate_setting_docs_env, python.path(), generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT@', '--output', '@OUTPUT@'],
-+    command: [generate_setting_docs_env, generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT@', '--output', '@OUTPUT@'],
-     depends: libnm_gir,
-   )
- 
-@@ -274,7 +274,7 @@ if enable_introspection
-     name,
-     input: [libnm_gir[0], nm_settings_docs_overrides],
-     output: name,
--    command: [generate_setting_docs_env, python.path(), generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT0@', '--overrides', '@INPUT1@', '--output', '@OUTPUT@'],
-+    command: [generate_setting_docs_env, generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT0@', '--overrides', '@INPUT1@', '--output', '@OUTPUT@'],
-     depends: libnm_gir,
-   )
- endif
-diff --git a/meson.build b/meson.build
-index a2d925a7e..23c85f128 100644
---- a/meson.build
-+++ b/meson.build
-@@ -522,7 +522,7 @@ polkit_agent_dep = dependency('polkit-agent-1', version: '>= 0.97', required : f
- if polkit_agent_dep.found()
- 	config_h.set_quoted('POLKIT_PACKAGE_PREFIX', polkit_agent_dep.get_pkgconfig_variable('prefix'))
- else
--	config_h.set_quoted('POLKIT_PACKAGE_PREFIX', '/usr')
-+	config_h.set_quoted('POLKIT_PACKAGE_PREFIX', '@polkit@')
- endif
- 
- 
+@@ -283,7 +283,6 @@ if enable_introspection
+     output: 'nm-settings-docs-gir.xml',
+     command: [
+       generate_setting_docs_env,
+-      python.path(),
+       join_paths(meson.source_root(), 'tools', 'generate-docs-nm-settings-docs-gir.py'),
+       '--lib-path', meson.current_build_dir(),
+       '--gir', '@INPUT@',
 diff --git a/src/devices/nm-device.c b/src/devices/nm-device.c
-index 44e5183ec..e725845e4 100644
+index de09e4807..2755db165 100644
 --- a/src/devices/nm-device.c
 +++ b/src/devices/nm-device.c
-@@ -13493,14 +13493,14 @@ nm_device_start_ip_check (NMDevice *self)
+@@ -13705,14 +13705,14 @@ nm_device_start_ip_check (NMDevice *self)
  			gw = nm_ip4_config_best_default_route_get (priv->ip_config_4);
  			if (gw) {
  				_nm_utils_inet4_ntop (NMP_OBJECT_CAST_IP4_ROUTE (gw)->gateway, buf);
@@ -96,7 +86,7 @@ index 44e5183ec..e725845e4 100644
  			}
  		}
 diff --git a/src/nm-core-utils.c b/src/nm-core-utils.c
-index 415e1dc41..995eb6ecf 100644
+index 3950c3c3a..a9436d75a 100644
 --- a/src/nm-core-utils.c
 +++ b/src/nm-core-utils.c
 @@ -336,7 +336,7 @@ nm_utils_modprobe (GError **error, gboolean suppress_error_logging, const char *


### PR DESCRIPTION
###### Motivation for this change

Finally support for OWE/Enhanced Open.
(Though we'd need hostapd 2.10 for that to work)

https://gitlab.freedesktop.org/NetworkManager/NetworkManager/blob/1.24.0/NEWS

```
=============================================
NetworkManager-1.24
Overview of changes since NetworkManager-1.22
=============================================

* Add support for virtual routing and forwarding (VRF) interfaces.
* Add support for Opportunistic Wireless Encryption mode (OWE) for Wi-Fi networks.
* Add support for 31-bit prefixes on IPv4 point-to-point links according to
  RFC 3021.
* Drop dependencies for libpolkit-agent-1 and libpolkit-gobject-1.
* nmcli:
  - support setting removal via new command
    `nmcli connection modify $CON_NAME remove $setting`.
  - support backslash escape sequences for "vpn.data", "vpn.secrets",
    "bond.options", and "ethernet.s390-options".
* bridge: support new options "bridge.multicast-querier", "bridge.multicast-query-use-ifaddr",
  "bridge.multicast-router", "bridge.vlan-stats-enabled", "bridge.vlan-protocol",
  "bridge.group-address".
* IPv6 SLAAC: add support for "ipv6.ra-timeout" setting
* IPv6 DHCP: add support for "ipv6.dhcp-timeout" setting
* WWAN: NetworkManager now detects if a PIN-protected SIM card has been
  externally unlocked and automatically tries to activate a suitable
  connection on the modem.
* OVS:
  - add support for changing MTU of OVS interfaces.
  - remove length limitation for OVS Bridge, Patches and Interfaces
    (only Patch types) names.
* VPN: accept empty values for VPN data items and secrets.
* All nm-devices now expose the 'HwAddress' property via D-Bus.
* Slave devices now do not get created/activated if master is missing.
* Fixed multiple issues in the internal "nettools" DHCP client.
* Export NM_CAPABILITY_OVS capability on D-Bus and in libnm to
  indicate that the OVS plugin is loaded.
* Fixes for importing WireGuard profiles in nmcli and better handle
  configurations that enable ip4-auto-default-route with an explicit
  gateway.
* Various bug fixes and improvements.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@Phreedom @domenkozar @obadz @worldofpeace