### PR TITLE
[20.03] squid: apply patch for CVE-2020-11945

### DIFF
--- a/pkgs/servers/squid/default.nix
+++ b/pkgs/servers/squid/default.nix
@@ -1,14 +1,23 @@
-{ stdenv, fetchurl, perl, openldap, pam, db, cyrus_sasl, libcap
+{ stdenv, fetchurl, fetchpatch, perl, openldap, pam, db, cyrus_sasl, libcap
 , expat, libxml2, openssl, pkgconfig
 }:
 
 stdenv.mkDerivation rec {
-  name = "squid-4.10";
+  pname = "squid";
+  version = "4.10";
 
   src = fetchurl {
-    url = "http://www.squid-cache.org/Versions/v4/${name}.tar.xz";
+    url = "http://www.squid-cache.org/Versions/v4/${pname}-${version}.tar.xz";
     sha256 = "07sz0adv8nkhy797675bpra7lvdkwjq9isw1ddgylhlazl511w4q";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2020-11945.patch";
+      url = "http://www.squid-cache.org/Versions/v4/changesets/squid-4-eeebf0f37a72a2de08348e85ae34b02c34e9a811.patch";
+      sha256 = "1mdi1camvaa6pmpiypw4zmmc4a4mgqgcvdic5wajysgwsqvbz1f3";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

http://www.squid-cache.org/Advisories/SQUID-2020_4.txt

Fixes: CVE-2020-11945

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@fpletz @7c6f434c 