### PR TITLE
perlPackages: make package set extensible

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -1,5 +1,13 @@
-{ config, lib, stdenv, fetchurl, pkgs, buildPackages, callPackage
-, enableThreading ? true, coreutils, makeWrapper
+{ buildPackages
+, callPackage
+, coreutils
+, enableThreading ? true
+, fetchurl
+, lib
+, makeWrapper
+, packageOverrides ? (self: super: { })
+, pkgs
+, stdenv
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -111,9 +119,9 @@ let
     passthru = rec {
       interpreter = "${perl}/bin/perl";
       libPrefix = "lib/perl5/site_perl";
-      pkgs = callPackage ../../../top-level/perl-packages.nix {
+      pkgs = callPackage ../../perl-modules {
         inherit perl buildPerl;
-        overrides = config.perlPackageOverrides or (p: {}); # TODO: (self: super: {}) like in python
+        overrides = packageOverrides;
       };
       buildEnv = callPackage ./wrapper.nix {
         inherit perl;

--- a/pkgs/development/perl-modules/default.nix
+++ b/pkgs/development/perl-modules/default.nix
@@ -1,0 +1,24 @@
+# inspired by pkgs/development/lua-modules/default.nix
+{ buildPerl
+, callPackage
+, config
+, lib
+, overrides ? (self: super: { })
+, perl
+, pkgs
+}:
+
+with lib;
+let
+  initialPackages = (
+    callPackage ../../top-level/perl-packages.nix {
+      inherit perl pkgs buildPerl;
+    }
+  );
+  configOverrides = self: super:
+    (config.perlPackageOverrides or (pkgs: { })) pkgs;
+in
+makeExtensible
+  (extends overrides
+    (extends configOverrides
+      initialPackages))

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8,16 +8,16 @@
 { config
 , stdenv, lib, buildPackages, pkgs
 , fetchurl, fetchgit, fetchpatch, fetchFromGitHub
-, perl, overrides, buildPerl, shortenPerlShebang
+, perl, buildPerl, shortenPerlShebang
 }:
 
 # cpan2nix assumes that perl-packages.nix will be used only with perl 5.30.3 or above
 assert lib.versionAtLeast perl.version "5.30.3";
 let
   inherit (lib) maintainers teams;
-  self = _self // (overrides pkgs);
-  _self = with self; {
+  packages = (self:
 
+with self; {
   inherit perl;
   perlPackages = self;
 
@@ -23601,4 +23601,5 @@ let
   SubExporterUtil = self.SubExporter;
   version = self.Version;
 
-}; in self
+});
+in packages


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add the same overriding capabilities to the `perlPackages` set that `pythonPackages` and `luaPackages` already have.

###### Things done

It uses the same `packageOverrides` argument that `pythonPackages` and `luaPackages` also use and keeps the old `config.perlPackageOverrides` method.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
