### PR TITLE
tbe: fix build

### DIFF
--- a/pkgs/games/the-butterfly-effect/default.nix
+++ b/pkgs/games/the-butterfly-effect/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchgit, qt5, box2d, which, cmake, gettext }:
+{ stdenv, mkDerivation, fetchgit, qt5, box2d, which, cmake, gettext }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "tbe";
   version = "0.9.3.1";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23848,7 +23848,7 @@ in
     lua = lua5_1;
   };
 
-  tbe = callPackage ../games/the-butterfly-effect { };
+  tbe = libsForQt5.callPackage ../games/the-butterfly-effect { };
 
   teetertorture = callPackage ../games/teetertorture { };
 


### PR DESCRIPTION
###### Motivation for this change

Qt5 changes require TBE to be updated to new style

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
