### PR TITLE
urserver: init at 3.6.0.745

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -926,6 +926,7 @@
   ./services/x11/gdk-pixbuf.nix
   ./services/x11/imwheel.nix
   ./services/x11/redshift.nix
+  ./services/x11/urserver.nix
   ./services/x11/urxvtd.nix
   ./services/x11/window-managers/awesome.nix
   ./services/x11/window-managers/default.nix

--- a/nixos/modules/services/x11/urserver.nix
+++ b/nixos/modules/services/x11/urserver.nix
@@ -1,0 +1,38 @@
+# urserver service
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.urserver;
+in {
+
+  options.services.urserver.enable = lib.mkEnableOption "urserver";
+
+  config = lib.mkIf cfg.enable {
+
+    networking.firewall = {
+      allowedTCPPorts = [ 9510 9512 ];
+      allowedUDPPorts = [ 9511 9512 ];
+    };
+
+    systemd.user.services.urserver =  {
+      description = ''
+        Server for Unified Remote: The one-and-only remote for your computer.
+      '';
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        Type = "forking";
+        ExecStart = ''
+          ${pkgs.urserver}/bin/urserver --daemon
+        '';
+        ExecStop = ''
+          ${pkgs.procps}/bin/pkill urserver
+        '';
+        RestartSec = 3;
+        Restart = "on-failure";
+      };
+    };
+  };
+
+}

--- a/pkgs/servers/urserver/default.nix
+++ b/pkgs/servers/urserver/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, fetchurl
+, autoPatchelfHook
+, bluez
+, libX11
+, libXtst
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "urserver";
+  version = "3.6.0.745";
+
+  src = fetchurl {
+    url = "https://www.unifiedremote.com/static/builds/server/linux-x64/745/urserver-${version}.tar.gz";
+    sha256 = "1ib9317bg9n4knwnlbrn1wfkyrjalj8js3a6h7zlcl8h8xc0szc8";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    bluez
+    libX11
+    libXtst
+    makeWrapper
+  ];
+
+  installPhase = ''
+    install -m755 -D urserver $out/bin/urserver
+    wrapProgram $out/bin/urserver --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath buildInputs}"
+    cp -r remotes $out/bin/remotes
+    cp -r manager $out/bin/manager
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.unifiedremote.com/";
+    description = "The one-and-only remote for your computer";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ sfrijters ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16772,6 +16772,8 @@ in
     unifiStable;
   unifi = unifiStable;
 
+  urserver = callPackage ../servers/urserver { };
+
   victoriametrics = callPackage ../servers/nosql/victoriametrics { };
 
   virtlyst = libsForQt5.callPackage ../servers/web-apps/virtlyst { };


### PR DESCRIPTION
###### Motivation for this change

Unified Remote is a remote control app for your computer. It requires the 'urserver' to run on the computer so you can control it with your smartphone.

The application itself was tested on both NixOS and Ubuntu, the service only on NixOS.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
