### PR TITLE
giada: 0.16.1 -> 0.16.2.2

### DIFF
--- a/pkgs/applications/audio/giada/default.nix
+++ b/pkgs/applications/audio/giada/default.nix
@@ -1,23 +1,41 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook,
-  fltk, jansson, rtmidi, libsamplerate, libsndfile,
-  jack2, alsaLib, libpulseaudio,
-  libXpm, libXinerama, libXcursor }:
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, fltk
+, jansson
+, rtmidi
+, libsamplerate
+, libsndfile
+, jack2
+, alsaLib
+, libpulseaudio
+, libXpm
+, libXinerama
+, libXcursor
+, catch2
+, nlohmann_json
+}:
 
 stdenv.mkDerivation rec {
   pname = "giada";
-  version = "0.16.1";
+  version = "0.16.2.2";
 
   src = fetchFromGitHub {
     owner = "monocasual";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0b3lhjs6myml5r5saky15523sbc3qr43r9rh047vhsiafmqdvfq1";
+    sha256 = "0rpg5qmw3b76xcra869shb8fwk5wfzpzw216n96hxa5s6k69cm0p";
   };
 
-  configureFlags = [ "--target=linux" ];
+  configureFlags = [
+    "--target=linux"
+    "--enable-system-catch"
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
   ];
+
   buildInputs = [
     fltk
     libsndfile
@@ -30,9 +48,16 @@ stdenv.mkDerivation rec {
     libpulseaudio
     libXinerama
     libXcursor
+    catch2
+    nlohmann_json
   ];
 
-  meta = with lib; {
+  postPatch = ''
+    sed -i 's:"deps/json/single_include/nlohmann/json\.hpp":<nlohmann/json.hpp>:' \
+        src/core/{conf,init,midiMapConf,patch}.cpp
+  '';
+
+  meta = with stdenv.lib; {
     description = "A free, minimal, hardcore audio tool for DJs, live performers and electronic musicians";
     homepage = "https://giadamusic.com/";
     license = licenses.gpl3;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Version update + use system catch and nlohmann_json

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
