### PR TITLE
dstask: init at 0.18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7326,6 +7326,12 @@
     githubId = 1181362;
     name = "Stefan Junker";
   };
+  stianlagstad = {
+    email = "stianlagstad@gmail.com";
+    github = "stianlagstad";
+    githubId = 4340859;
+    name = "Stian Lågstad";
+  };
   StijnDW = {
     email = "stekke@airmail.cc";
     github = "StijnDW";

--- a/pkgs/applications/misc/dstask/default.nix
+++ b/pkgs/applications/misc/dstask/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "dstask";
+  version = "0.18";
+
+  src = fetchFromGitHub {
+    owner = "naggie";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "16z5zlfj955pzsj0l58835slvpchdaq2vbyx2fjzi6y9xn1z2nd1";
+  };
+
+  # Set vendorSha256 to null because dstask vendors its dependencies (meaning
+  # that third party dependencies are stored in the repository).
+  #
+  # Ref <https://github.com/NixOS/nixpkgs/pull/87383#issuecomment-633204382>
+  # and <https://github.com/NixOS/nixpkgs/blob/d4226e3a4b5fcf988027147164e86665d382bbfa/pkgs/development/go-modules/generic/default.nix#L18>
+  vendorSha256 = null;
+
+  # The ldflags reduce the executable size by stripping some debug stuff.
+  # The other variables are set so that the output of dstask version shows the
+  # git ref and the release version from github.
+  # Ref <https://github.com/NixOS/nixpkgs/pull/87383#discussion_r432097657>
+  buildFlagsArray = [ ''
+    -ldflags=-w -s
+    -X "github.com/naggie/dstask.VERSION=${version}"
+    -X "github.com/naggie/dstask.GIT_COMMIT=v${version}"
+  '' ];
+
+  subPackages = [ "cmd/dstask.go" ];
+
+  meta = with stdenv.lib; {
+    description = "Command line todo list with super-reliable git sync";
+    homepage = src.meta.homepage;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stianlagstad foxit64 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22072,6 +22072,8 @@ in
 
   taskwarrior = callPackage ../applications/misc/taskwarrior { };
 
+  dstask = callPackage ../applications/misc/dstask { };
+
   tasksh = callPackage ../applications/misc/tasksh { };
 
   taskserver = callPackage ../servers/misc/taskserver { };


### PR DESCRIPTION
###### Motivation for this change

I'd like to still use https://github.com/naggie/dstask after switching from Ubuntu to NixOS.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
