### PR TITLE
vips: 8.9.1 -> 8.9.2

### DIFF
--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -12,9 +12,10 @@
 , libjpeg
 , libgsf
 , libexif
+, libheif
 , ApplicationServices
 , python27
-, libpng ? null
+, libpng
 , fetchFromGitHub
 , fetchpatch
 , autoreconfHook
@@ -25,7 +26,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vips";
-  version = "8.9.1";
+  version = "8.9.2";
 
   outputs = [ "bin" "out" "man" "dev" ];
 
@@ -33,22 +34,13 @@ stdenv.mkDerivation rec {
     owner = "libvips";
     repo = "libvips";
     rev = "v${version}";
-    sha256 = "01vgvzlygg3fzpinb0x1rdm2sqvnqxmvxbnlbg73ygdadv3l2s0v";
+    sha256 = "0pgvcp5yjk96izh7kjfprjd9kddx7zqrwwhm8dyalhrwbmj6c2q5";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
     extraPostFetch = ''
       rm -r $out/test/test-suite/images/
     '';
   };
-
-  patches = [
-    # autogen.sh should not run configure
-    # https://github.com/libvips/libvips/pull/1566
-    (fetchpatch {
-      url = "https://github.com/libvips/libvips/commit/97a92e0e6abab652fdf99313b138bfd77d70deb4.patch";
-      sha256 = "0w1sm5wmvfp8svdpk8mz57c1n6zzy3snq0g2f8yxjamv0d2gw2dp";
-    })
-  ];
 
   nativeBuildInputs = [
     pkgconfig
@@ -69,6 +61,8 @@ stdenv.mkDerivation rec {
     libjpeg
     libgsf
     libexif
+    libheif
+    libpng
     python27
     libpng
     expat

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -202,7 +202,34 @@ in
         maintainers = with maintainers; [ javaguirre ] ++ teams.php.members;
       };
     };
+ 
+    phpmd = mkDerivation rec {
+      version = "2.8.2";
+      pname = "phpmd";
 
+      src = pkgs.fetchurl {
+        url = "https://github.com/phpmd/phpmd/releases/download/${version}/phpmd.phar";
+        sha256 = "1i8qgzxniw5d8zjpypalm384y7qfczapfq70xmg129laq6xiqlqb";
+      };
+
+      phases = [ "installPhase" ];
+      buildInputs = [ pkgs.makeWrapper ];
+
+      installPhase = ''
+        mkdir -p $out/bin
+        install -D $src $out/libexec/phpmd/phpmd.phar
+        makeWrapper ${php}/bin/php $out/bin/phpmd \
+          --add-flags "$out/libexec/phpmd/phpmd.phar"
+      '';
+
+      meta = with pkgs.lib; {
+        description = "PHP coding quality analizer";
+        license = licenses.bsd3;
+        homepage = "https://github.com/phpmd/";
+        maintainers = teams.php.members;
+      };
+    };
+ 
     phpstan = mkDerivation rec {
       version = "0.12.19";
       pname = "phpstan";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New version 

Added library deps

###### Things done

Removed old patch
Added libheif, libpng

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
