### PR TITLE
Python packageOverrides improvements

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -38,7 +38,7 @@ with pkgs;
         pkgs = pythonPackages;
         interpreter = "${self}/bin/${executable}";
         inherit executable implementation libPrefix pythonVersion sitePackages;
-        inherit sourceVersion;
+        inherit sourceVersion packageOverrides;
         pythonAtLeast = lib.versionAtLeast pythonVersion;
         pythonOlder = lib.versionOlder pythonVersion;
         inherit hasDistutilsCxxPatch pythonForBuild;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17,7 +17,11 @@ with pkgs.lib;
 let
   packages = ( self:
 
+let unoverriddenPython = python; in
+
 let
+  python = unoverriddenPython.override { packageOverrides = overrides; };
+
   inherit (python.passthru) isPy27 isPy35 isPy36 isPy37 isPy38 isPy39 isPy3k isPyPy pythonAtLeast pythonOlder;
 
   callPackage = pkgs.newScope self;


### PR DESCRIPTION
Between these two changes, complex uses of packageOverrides become a lot more tolerable (even if they’re still not pleasant). Explanations in commit messages.