### PR TITLE
firecracker: 0.20.0 -> 0.21.1

### DIFF
--- a/pkgs/applications/virtualization/firecracker/default.nix
+++ b/pkgs/applications/virtualization/firecracker/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv }:
 
 let
-  version = "0.20.0";
+  version = "0.21.1";
 
   suffix = {
     x86_64-linux  = "x86_64";
@@ -15,13 +15,13 @@ let
   };
 
   firecracker-bin = fetchbin "firecracker" {
-    x86_64-linux  = "073pp4q5dnyr126k8k7qdkqclqx18hj12app4gj2is0413gia8z9";
-    aarch64-linux = "1w5f522imq5dnjrdidnrq7jlwcdrsiz32shv9bh66dhy336sd8qw";
+    x86_64-linux = "0g4fja3bz1fsyz8vj99199yblkn46ygf33ldwd1ssw8f957vbwnb";
+    aarch64-linux = "1qyppcxnh7f42fs4px5rvkk6lza57h2sq9naskvqn5zy4vsvq89s";
   };
 
   jailer-bin = fetchbin "jailer" {
-    x86_64-linux  = "0falk6y9y0pimgav1yg6ydn6wsslz0my01qd9by8ipk3f3776531";
-    aarch64-linux = "1j4x4p4zz1ydvpzbbmxszyqv28qbl4v3hiwdj2f67f1jn1cv9l7z";
+    x86_64-linux = "0x89pfmqci9d3i9fi9b9zm94yr2v7pq7kp3drlb952jkdfj0njyk";
+    aarch64-linux = "03fx9sk88jm23wqm8fraqd1ccfhbqvc310mkfv1f5p2ykhq2ahrk";
   };
 
 in


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update `firecracker` to the latest release.
- https://github.com/firecracker-microvm/firecracker/releases/tag/v0.21.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
