### PR TITLE
lib: add makeOverridableWithName + build*Package overrides

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -101,7 +101,7 @@ let
       noDepEntry fullDepEntry packEntry stringAfter;
     inherit (customisation) overrideDerivation makeOverridable
       callPackageWith callPackagesWith extendDerivation hydraJob
-      makeScope;
+      makeScope makeOverridableWithName;
     inherit (meta) addMetaAttrs dontDistribute setName updateName
       appendToName mapDerivationAttrset setPrio lowPrio lowPrioSet hiPrio
       hiPrioSet;

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -31,9 +31,10 @@
       inherit cargo;
     };
 
-    buildRustPackage = callPackage ../../../build-support/rust {
-      inherit rustc cargo fetchCargoTarball;
-    };
+    buildRustPackage = lib.makeOverridableWithName "overrideRustAttrs"
+      (callPackage ../../../build-support/rust {
+        inherit rustc cargo fetchCargoTarball;
+      });
 
     rustcSrc = callPackage ./rust-src.nix {
       inherit rustc;

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -22,7 +22,7 @@
 , ruby, bundler
 } @ defs:
 
-lib.makeOverridable (
+lib.makeOverridableWithName "overrideRubyGemAttrs" (
 
 { name ? null
 , gemName

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -56,10 +56,11 @@ let
 
   buildLuaApplication = args: buildLuarocksPackage ({namePrefix="";} // args );
 
-  buildLuarocksPackage = with pkgs.lib; makeOverridable(callPackage ../development/interpreters/lua-5/build-lua-package.nix {
-    inherit toLuaModule;
-    inherit lua;
-  });
+  buildLuarocksPackage = lib.makeOverridableWithName "overrideLuarocksAttrs"
+    (callPackage ../development/interpreters/lua-5/build-lua-package.nix {
+      inherit toLuaModule;
+      inherit lua;
+    });
 in
 with self; {
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -36,9 +36,10 @@ let
       };
     });
 
-  buildPerlPackage = callPackage ../development/perl-modules/generic {
-    inherit buildPerl;
-  };
+  buildPerlPackage = stdenv.lib.makeOverridableWithName "overridePerlAttrs"
+    (callPackage ../development/perl-modules/generic {
+      inherit buildPerl;
+    });
 
   # Helper functions for packages that use Module::Build to build.
   buildPerlModule = args:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Improve the extensibility of language specific package builders.

Some of current `build*Package` functions support more overriding capabilities than others:
- `buildPythonPackage` supports overriding packages via `makeOverridable` and `overridePythonAttrs`
- `buildLuarocksPackage` and `buildRubyGem` support overriding packages via `makeOverridable`
- `buildRustPackage` and `buildPerlPackage` supports no overriding

In theory `makeOverridable` should be enough to make a builder function overridable, but in practice this doesn't always work, because another `callPackage` might shadow the wanted `override` function.

`buildPythonPackage` works around this by providing a `overridePythonAttrs` function which is essentially a `override` with a custom name.

###### Things done

This PR adds a `lib.makeOverridableWithName` function, which is just `lib.makeOverridable` with a additional named `override` function.

It also adjusts the `build*Package` functions that I'm familiar with to use the new helper.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
