### PR TITLE
kitty: 0.17.3 -> 0.17.4

### DIFF
--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -20,14 +20,14 @@
 with python3Packages;
 buildPythonApplication rec {
   pname = "kitty";
-  version = "0.17.3";
+  version = "0.17.4";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "kovidgoyal";
     repo = "kitty";
     rev = "v${version}";
-    sha256 = "1nx8gjavq8kc656ayh3wign1f68b46jbnmy8zyks25wg0p9gid8l";
+    sha256 = "1rbyj84y8r6h7qd6w7cw58v2abspippignj458ihv2m26i4als2x";
   };
 
   buildInputs = [

--- a/pkgs/applications/misc/kitty/library-paths.patch
+++ b/pkgs/applications/misc/kitty/library-paths.patch
@@ -12,21 +12,27 @@
 
 --- a/kitty/desktop.c
 +++ b/kitty/desktop.c
-@@ -30,7 +30,7 @@
- static PyObject*
- init_x11_startup_notification(PyObject UNUSED *self, PyObject *args) {
-     static bool done = false;
--    static const char* libname = "libstartup-notification-1.so";
-+    static const char* libname = "@libstartup_notification@";
-     // some installs are missing the .so symlink, so try the full name
-     static const char* libname2 = "libstartup-notification-1.so.0";
-     static const char* libname3 = "libstartup-notification-1.so.0.0.0";
-@@ -105,7 +105,7 @@ load_libcanberra_functions(void) {
+@@ -34,10 +34,7 @@ init_x11_startup_notification(PyObject UNUSED *self, PyObject *args) {
+         done = true;
  
- static void
- load_libcanberra(void) {
--    static const char* libname = "libcanberra.so";
-+    static const char* libname = "@libcanberra@";
-     // some installs are missing the .so symlink, so try the full name
-     static const char* libname2 = "libcanberra.so.0";
-     static const char* libname3 = "libcanberra.so.0.2.5";
+         const char* libnames[] = {
+-            "libstartup-notification-1.so",
+-            // some installs are missing the .so symlink, so try the full name
+-            "libstartup-notification-1.so.0",
+-            "libstartup-notification-1.so.0.0.0",
++            "@libstartup_notification@",
+             NULL
+         };
+         for (int i = 0; libnames[i]; i++) {
+@@ -113,10 +110,7 @@ load_libcanberra(void) {
+     if (done) return;
+     done = true;
+     const char* libnames[] = {
+-        "libcanberra.so",
+-        // some installs are missing the .so symlink, so try the full name
+-        "libcanberra.so.0",
+-        "libcanberra.so.0.2.5",
++        "@libcanberra@",
+         NULL
+     };
+     for (int i = 0; libnames[i]; i++) {


### PR DESCRIPTION
https://github.com/kovidgoyal/kitty/releases/tag/v0.17.4

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).