### PR TITLE
arcanist: Fix on darwin

### DIFF
--- a/pkgs/development/tools/misc/arcanist/default.nix
+++ b/pkgs/development/tools/misc/arcanist/default.nix
@@ -42,10 +42,12 @@ stdenv.mkDerivation {
     mkdir -p $out/bin $out/libexec
     cp -R libphutil $out/libexec/libphutil
     cp -R arcanist  $out/libexec/arcanist
-
-    ln -s $out/libexec/arcanist/bin/arc $out/bin
-    wrapProgram $out/bin/arc \
-      --prefix PATH : "${php}/bin"
+    ${if stdenv.isDarwin then ''
+        echo "#! $shell -e" > $out/bin/arc
+        echo "exec ${php}/bin/php $out/libexec/arcanist/scripts/arcanist.php "'"$@"' >> $out/bin/arc
+        chmod +x $out/bin/arc''
+      else ''
+        ln -s $out/libexec/arcanist/scripts/arcanist.php $out/bin/arc''}
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
With recent work done on the PHP packaging, the PHP executable is by default a wrapper script. Darwin doesn't like scripts in the shebang of another script, so we have to wrap `arcanist`, feeding the script as an argument to PHP instead. See #86881 and #23018.

I haven't thoroughly tested this, since I don't use arcanist. Can someone who does make sure it actually works? :) The executable runs, but I don't know if all commands work as expected...

cc @purcell 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
