### PR TITLE
bashcards v0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6640,6 +6640,12 @@
     githubId = 1942810;
     name = "Christian Ulrich";
   };
+  rpearce = {
+    email = "me@robertwpearce.com";
+    github = "rpearce";
+    githubId = 592876;
+    name = "Robert W. Pearce";
+  };
   rprospero = {
     email = "rprospero+nix@gmail.com";
     github = "rprospero";

--- a/pkgs/tools/misc/bashcards/default.nix
+++ b/pkgs/tools/misc/bashcards/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bashcards";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "rpearce";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1zbijbcm9lrqwiax37li0jjqcaxf469wh5d423frain56z1qknxl";
+  };
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/bin $out/share/man/man8
+    cp bashcards.8 $out/share/man/man8/
+    cp bashcards $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Practice flashcards in bash";
+    homepage = "https://github.com/rpearce/bashcards/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ rpearce ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -812,6 +812,8 @@ in
 
   bash-my-aws = callPackage ../tools/admin/bash-my-aws { };
 
+  bashcards = callPackage ../tools/misc/bashcards { };
+
   bcachefs-tools = callPackage ../tools/filesystems/bcachefs-tools { };
 
   bitwarden = callPackage ../tools/security/bitwarden { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adds a bash CLI tool I created to practice flash cards (https://github.com/rpearce/bashcards). This is my first new package submission, so please let me know what I can do better.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

✅  Tested using `nix-env -i bashcards -f path/to/my/nixpkgs` on macOS Catalina

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
