### PR TITLE
glusterfs: fix snapshots

### DIFF
--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -81,17 +81,17 @@ stdenv.mkDerivation
       --replace '/bin/mount' '${utillinux}/bin/mount'
   '';
 
-   # Note that the VERSION file is something that is present in release tarballs
-   # but not in git tags (at least not as of writing in v3.10.1).
-   # That's why we have to create it.
-   # Without this, gluster (at least 3.10.1) will fail very late and cryptically,
-   # for example when setting up geo-replication, with a message like
-   #   Staging of operation 'Volume Geo-replication Create' failed on localhost : Unable to fetch master volume details. Please check the master cluster and master volume.
-   # What happens here is that the gverify.sh script tries to compare the versions,
-   # but fails when the version is empty.
-   # See upstream GlusterFS bug https://bugzilla.redhat.com/show_bug.cgi?id=1452705
-   preConfigure = ''
-     echo "v${s.version}" > VERSION
+  # Note that the VERSION file is something that is present in release tarballs
+  # but not in git tags (at least not as of writing in v3.10.1).
+  # That's why we have to create it.
+  # Without this, gluster (at least 3.10.1) will fail very late and cryptically,
+  # for example when setting up geo-replication, with a message like
+  #   Staging of operation 'Volume Geo-replication Create' failed on localhost : Unable to fetch master volume details. Please check the master cluster and master volume.
+  # What happens here is that the gverify.sh script tries to compare the versions,
+  # but fails when the version is empty.
+  # See upstream GlusterFS bug https://bugzilla.redhat.com/show_bug.cgi?id=1452705
+  preConfigure = ''
+    echo "v${s.version}" > VERSION
     ./autogen.sh
     export PYTHON=${python3}/bin/python
     '';

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -73,6 +73,12 @@ stdenv.mkDerivation
 
   postPatch = ''
     sed -e '/chmod u+s/d' -i contrib/fuse-util/Makefile.am
+    substituteInPlace libglusterfs/src/glusterfs/lvm-defaults.h \
+      --replace '/sbin/' '${lvm2}/bin/'
+    substituteInPlace libglusterfs/src/glusterfs/compat.h \
+      --replace '/bin/umount' '${utillinux}/bin/umount'
+    substituteInPlace contrib/fuse-lib/mount-gluster-compat.h \
+      --replace '/bin/mount' '${utillinux}/bin/mount'
   '';
 
    # Note that the VERSION file is something that is present in release tarballs


### PR DESCRIPTION
###### Motivation for this change
Snapshots were not working.

There might be a more elegant way to fixing this than replacing strings in headers, but this works.

cc @nh2 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
