### PR TITLE
mpd service: remove user/group from conf

### DIFF
--- a/nixos/modules/services/audio/mpd.nix
+++ b/nixos/modules/services/audio/mpd.nix
@@ -18,8 +18,6 @@ let
     ''}
     state_file          "${cfg.dataDir}/state"
     sticker_file        "${cfg.dataDir}/sticker.sql"
-    user                "${cfg.user}"
-    group               "${cfg.group}"
 
     ${optionalString (cfg.network.listenAddress != "any") ''bind_to_address "${cfg.network.listenAddress}"''}
     ${optionalString (cfg.network.port != 6600)  ''port "${toString cfg.network.port}"''}


### PR DESCRIPTION
###### Motivation for this change

The options should not be set as we already change user with service
file, man mpd.conf says "Do not use this option if you start MPD as an
unprivileged user"

The group option actually is not documented at all anymore and probably
no longer exists.

These options get in the way of setting up confinement for the service,
as it would otherwise be pretty straightforward to setup, but even if
mpd is not root it would check the user exists within the chroot which
is more work (need to get nss working):

```
  systemd.services.mpd = {
    serviceConfig.BindPaths = [
      # mpd state dir
      "/var/lib/mpd"
      # notify systemd service started up
      "/run/systemd/notify"
    ];
    serviceConfig.BindReadOnlyPaths = [
      "/path/to/music:/var/lib/mpd/music"
    ];
    # ProtectSystem is not compatible with confinement
    serviceConfig.ProtectSystem = lib.mkForce false;
    confinement = {
      enable = true;
      binSh = null;
      mode = "chroot-only";
    };
  };
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc mpd maintainers @tobim @fpletz @ehmry @astsmtl