### PR TITLE
compiler-rt: fix build on armv7l

### DIFF
--- a/pkgs/development/compilers/llvm/10/compiler-rt-armv7l.patch
+++ b/pkgs/development/compilers/llvm/10/compiler-rt-armv7l.patch
@@ -1,0 +1,32 @@
+diff -ur compiler-rt-10.0.0.src/cmake/builtin-config-ix.cmake compiler-rt-10.0.0.src-patched/cmake/builtin-config-ix.cmake
+--- compiler-rt-10.0.0.src/cmake/builtin-config-ix.cmake	2020-03-24 00:01:02.000000000 +0900
++++ compiler-rt-10.0.0.src-patched/cmake/builtin-config-ix.cmake	2020-05-10 03:42:00.883450706 +0900
+@@ -24,7 +24,7 @@
+ 
+ 
+ set(ARM64 aarch64)
+-set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k)
++set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k armv7l)
+ set(HEXAGON hexagon)
+ set(X86 i386)
+ set(X86_64 x86_64)
+diff -ur compiler-rt-10.0.0.src/lib/builtins/CMakeLists.txt compiler-rt-10.0.0.src-patched/lib/builtins/CMakeLists.txt
+--- compiler-rt-10.0.0.src/lib/builtins/CMakeLists.txt	2020-03-24 00:01:02.000000000 +0900
++++ compiler-rt-10.0.0.src-patched/lib/builtins/CMakeLists.txt	2020-05-10 03:44:49.468579650 +0900
+@@ -474,6 +474,7 @@
+ set(armv7_SOURCES ${arm_SOURCES})
+ set(armv7s_SOURCES ${arm_SOURCES})
+ set(armv7k_SOURCES ${arm_SOURCES})
++set(armv7l_SOURCES ${arm_SOURCES})
+ set(arm64_SOURCES ${aarch64_SOURCES})
+ 
+ # macho_embedded archs
+@@ -595,7 +596,7 @@
+   foreach (arch ${BUILTIN_SUPPORTED_ARCH})
+     if (CAN_TARGET_${arch})
+       # For ARM archs, exclude any VFP builtins if VFP is not supported
+-      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")
++      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7l|armv7m|armv7em)$")
+         string(REPLACE ";" " " _TARGET_${arch}_CFLAGS "${TARGET_${arch}_CFLAGS}")
+         check_compile_definition(__VFP_FP__ "${CMAKE_C_FLAGS} ${_TARGET_${arch}_CFLAGS}" COMPILER_RT_HAS_${arch}_VFP)
+         if(NOT COMPILER_RT_HAS_${arch}_VFP)

--- a/pkgs/development/compilers/llvm/10/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
     ./find-darwin-sdk-version.patch # don't test for macOS being >= 10.15
+    ./compiler-rt-armv7l.patch
   ];# ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks

--- a/pkgs/development/compilers/llvm/10/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt.nix
@@ -48,8 +48,9 @@ stdenv.mkDerivation rec {
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
     ./find-darwin-sdk-version.patch # don't test for macOS being >= 10.15
-    ./compiler-rt-armv7l.patch
-  ];# ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
+  ]# ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
+    ++ stdenv.lib.optional stdenv.hostPlatform.isAarch32 ./compiler-rt-armv7l.patch;
+
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
   # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra

--- a/pkgs/development/compilers/llvm/5/compiler-rt-armv7l.patch
+++ b/pkgs/development/compilers/llvm/5/compiler-rt-armv7l.patch
@@ -1,0 +1,23 @@
+diff -ur compiler-rt-5.0.2.src/cmake/builtin-config-ix.cmake compiler-rt-5.0.2.src-patched/cmake/builtin-config-ix.cmake
+--- compiler-rt-5.0.2.src/cmake/builtin-config-ix.cmake	2017-05-25 00:53:24.000000000 +0900
++++ compiler-rt-5.0.2.src-patched/cmake/builtin-config-ix.cmake	2020-05-10 03:24:24.937433155 +0900
+@@ -24,7 +24,7 @@
+ 
+ 
+ set(ARM64 aarch64)
+-set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k)
++set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k armv7l)
+ set(X86 i386 i686)
+ set(X86_64 x86_64)
+ set(MIPS32 mips mipsel)
+diff -ur compiler-rt-5.0.2.src/lib/builtins/CMakeLists.txt compiler-rt-5.0.2.src-patched/lib/builtins/CMakeLists.txt
+--- compiler-rt-5.0.2.src/lib/builtins/CMakeLists.txt	2017-07-13 04:33:30.000000000 +0900
++++ compiler-rt-5.0.2.src-patched/lib/builtins/CMakeLists.txt	2020-05-10 03:24:45.945075423 +0900
+@@ -444,6 +444,7 @@
+ set(armv7_SOURCES ${arm_SOURCES})
+ set(armv7s_SOURCES ${arm_SOURCES})
+ set(armv7k_SOURCES ${arm_SOURCES})
++set(armv7l_SOURCES ${arm_SOURCES})
+ set(arm64_SOURCES ${aarch64_SOURCES})
+ 
+ # macho_embedded archs

--- a/pkgs/development/compilers/llvm/5/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/5/compiler-rt.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
+    ./compiler-rt-armv7l.patch
   ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
     ++ stdenv.lib.optional (stdenv.hostPlatform.libc == "glibc") ./compiler-rt-sys-ustat.patch;
 

--- a/pkgs/development/compilers/llvm/5/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/5/compiler-rt.nix
@@ -47,9 +47,9 @@ stdenv.mkDerivation {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
-    ./compiler-rt-armv7l.patch
   ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
-    ++ stdenv.lib.optional (stdenv.hostPlatform.libc == "glibc") ./compiler-rt-sys-ustat.patch;
+    ++ stdenv.lib.optional (stdenv.hostPlatform.libc == "glibc") ./compiler-rt-sys-ustat.patch
+    ++ stdenv.lib.optional stdenv.hostPlatform.isAarch32 ./compiler-rt-armv7l.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
   # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra

--- a/pkgs/development/compilers/llvm/6/compiler-rt-armv7l.patch
+++ b/pkgs/development/compilers/llvm/6/compiler-rt-armv7l.patch
@@ -1,0 +1,32 @@
+diff -ur compiler-rt-6.0.1.src/cmake/builtin-config-ix.cmake compiler-rt-6.0.1.src-patched/cmake/builtin-config-ix.cmake
+--- compiler-rt-6.0.1.src/cmake/builtin-config-ix.cmake	2017-12-01 06:04:11.000000000 +0900
++++ compiler-rt-6.0.1.src-patched/cmake/builtin-config-ix.cmake	2020-05-10 03:30:01.939694303 +0900
+@@ -24,7 +24,7 @@
+ 
+ 
+ set(ARM64 aarch64)
+-set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k)
++set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k armv7l)
+ set(X86 i386)
+ set(X86_64 x86_64)
+ set(MIPS32 mips mipsel)
+diff -ur compiler-rt-6.0.1.src/lib/builtins/CMakeLists.txt compiler-rt-6.0.1.src-patched/lib/builtins/CMakeLists.txt
+--- compiler-rt-6.0.1.src/lib/builtins/CMakeLists.txt	2017-12-25 06:11:32.000000000 +0900
++++ compiler-rt-6.0.1.src-patched/lib/builtins/CMakeLists.txt	2020-05-10 03:30:44.814964156 +0900
+@@ -452,6 +452,7 @@
+ set(armv7_SOURCES ${arm_SOURCES})
+ set(armv7s_SOURCES ${arm_SOURCES})
+ set(armv7k_SOURCES ${arm_SOURCES})
++set(armv7l_SOURCES ${arm_SOURCES})
+ set(arm64_SOURCES ${aarch64_SOURCES})
+ 
+ # macho_embedded archs
+@@ -521,7 +522,7 @@
+       set(_arch ${arch})
+       if("${arch}" STREQUAL "armv6m")
+         set(_arch "arm|armv6m")
+-      elseif("${arch}" MATCHES "^(armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")
++      elseif("${arch}" MATCHES "^(armhf|armv7|armv7s|armv7k|armv7l|armv7m|armv7em)$")
+         set(_arch "arm")
+       endif()
+ 

--- a/pkgs/development/compilers/llvm/6/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/6/compiler-rt.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
+    ./compiler-rt-armv7l.patch
   ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks

--- a/pkgs/development/compilers/llvm/6/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/6/compiler-rt.nix
@@ -47,8 +47,8 @@ stdenv.mkDerivation {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
-    ./compiler-rt-armv7l.patch
-  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch;
+  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
+    ++ stdenv.lib.optional stdenv.hostPlatform.isAarch32 ./compiler-rt-armv7l.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
   # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra

--- a/pkgs/development/compilers/llvm/7/compiler-rt-armv7l.patch
+++ b/pkgs/development/compilers/llvm/7/compiler-rt-armv7l.patch
@@ -1,0 +1,38 @@
+diff -ur compiler-rt-7.1.0.src/cmake/builtin-config-ix.cmake compiler-rt-7.1.0.src-patched/cmake/builtin-config-ix.cmake
+--- compiler-rt-7.1.0.src/cmake/builtin-config-ix.cmake	2018-05-25 06:36:27.000000000 +0900
++++ compiler-rt-7.1.0.src-patched/cmake/builtin-config-ix.cmake	2020-05-09 20:26:33.030608692 +0900
+@@ -24,7 +24,7 @@
+ 
+ 
+ set(ARM64 aarch64)
+-set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k)
++set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k armv7l)
+ set(HEXAGON hexagon)
+ set(X86 i386)
+ set(X86_64 x86_64)
+diff -ur compiler-rt-7.1.0.src/lib/builtins/CMakeLists.txt compiler-rt-7.1.0.src-patched/lib/builtins/CMakeLists.txt
+--- compiler-rt-7.1.0.src/lib/builtins/CMakeLists.txt	2018-07-31 03:18:59.000000000 +0900
++++ compiler-rt-7.1.0.src-patched/lib/builtins/CMakeLists.txt	2020-05-09 20:27:38.893409318 +0900
+@@ -453,6 +453,7 @@
+ set(armv7_SOURCES ${arm_SOURCES})
+ set(armv7s_SOURCES ${arm_SOURCES})
+ set(armv7k_SOURCES ${arm_SOURCES})
++set(armv7l_SOURCES ${arm_SOURCES})
+ set(arm64_SOURCES ${aarch64_SOURCES})
+ 
+ # macho_embedded archs
+@@ -563,12 +564,12 @@
+       set(_arch ${arch})
+       if("${arch}" STREQUAL "armv6m")
+         set(_arch "arm|armv6m")
+-      elseif("${arch}" MATCHES "^(armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")
++      elseif("${arch}" MATCHES "^(armhf|armv7|armv7s|armv7k|armv7l|armv7m|armv7em)$")
+         set(_arch "arm")
+       endif()
+ 
+       # For ARM archs, exclude any VFP builtins if VFP is not supported
+-      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")
++      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7l|armv7m|armv7em)$")
+         string(REPLACE ";" " " _TARGET_${arch}_CFLAGS "${TARGET_${arch}_CFLAGS}")
+         check_compile_definition(__VFP_FP__ "${CMAKE_C_FLAGS} ${_TARGET_${arch}_CFLAGS}" COMPILER_RT_HAS_${arch}_VFP)
+         if(NOT COMPILER_RT_HAS_${arch}_VFP)

--- a/pkgs/development/compilers/llvm/7/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/7/compiler-rt.nix
@@ -47,9 +47,9 @@ stdenv.mkDerivation {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
-    ./compiler-rt-armv7l.patch
   ] ++ stdenv.lib.optional (useLLVM) ./crtbegin-and-end.patch
-    ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch;
+    ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
+    ++ stdenv.lib.optional stdenv.hostPlatform.isAarch32 ./compiler-rt-armv7l.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
   # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra

--- a/pkgs/development/compilers/llvm/7/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/7/compiler-rt.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
+    ./compiler-rt-armv7l.patch
   ] ++ stdenv.lib.optional (useLLVM) ./crtbegin-and-end.patch
     ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch;
 

--- a/pkgs/development/compilers/llvm/8/compiler-rt-armv7l.patch
+++ b/pkgs/development/compilers/llvm/8/compiler-rt-armv7l.patch
@@ -1,0 +1,38 @@
+diff -ur compiler-rt-7.1.0.src/cmake/builtin-config-ix.cmake compiler-rt-7.1.0.src-patched/cmake/builtin-config-ix.cmake
+--- compiler-rt-7.1.0.src/cmake/builtin-config-ix.cmake	2018-05-25 06:36:27.000000000 +0900
++++ compiler-rt-7.1.0.src-patched/cmake/builtin-config-ix.cmake	2020-05-09 20:26:33.030608692 +0900
+@@ -24,7 +24,7 @@
+ 
+ 
+ set(ARM64 aarch64)
+-set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k)
++set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k armv7l)
+ set(HEXAGON hexagon)
+ set(X86 i386)
+ set(X86_64 x86_64)
+diff -ur compiler-rt-7.1.0.src/lib/builtins/CMakeLists.txt compiler-rt-7.1.0.src-patched/lib/builtins/CMakeLists.txt
+--- compiler-rt-7.1.0.src/lib/builtins/CMakeLists.txt	2018-07-31 03:18:59.000000000 +0900
++++ compiler-rt-7.1.0.src-patched/lib/builtins/CMakeLists.txt	2020-05-09 20:27:38.893409318 +0900
+@@ -453,6 +453,7 @@
+ set(armv7_SOURCES ${arm_SOURCES})
+ set(armv7s_SOURCES ${arm_SOURCES})
+ set(armv7k_SOURCES ${arm_SOURCES})
++set(armv7l_SOURCES ${arm_SOURCES})
+ set(arm64_SOURCES ${aarch64_SOURCES})
+ 
+ # macho_embedded archs
+@@ -563,12 +564,12 @@
+       set(_arch ${arch})
+       if("${arch}" STREQUAL "armv6m")
+         set(_arch "arm|armv6m")
+-      elseif("${arch}" MATCHES "^(armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")
++      elseif("${arch}" MATCHES "^(armhf|armv7|armv7s|armv7k|armv7l|armv7m|armv7em)$")
+         set(_arch "arm")
+       endif()
+ 
+       # For ARM archs, exclude any VFP builtins if VFP is not supported
+-      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")
++      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7l|armv7m|armv7em)$")
+         string(REPLACE ";" " " _TARGET_${arch}_CFLAGS "${TARGET_${arch}_CFLAGS}")
+         check_compile_definition(__VFP_FP__ "${CMAKE_C_FLAGS} ${_TARGET_${arch}_CFLAGS}" COMPILER_RT_HAS_${arch}_VFP)
+         if(NOT COMPILER_RT_HAS_${arch}_VFP)

--- a/pkgs/development/compilers/llvm/8/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/8/compiler-rt.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
+    ./compiler-rt-armv7l.patch
   ]# ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
     ++ stdenv.lib.optional (useLLVM) ./crtbegin-and-end.patch;
 

--- a/pkgs/development/compilers/llvm/8/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/8/compiler-rt.nix
@@ -47,9 +47,9 @@ stdenv.mkDerivation {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
-    ./compiler-rt-armv7l.patch
   ]# ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
-    ++ stdenv.lib.optional (useLLVM) ./crtbegin-and-end.patch;
+    ++ stdenv.lib.optional (useLLVM) ./crtbegin-and-end.patch
+    ++ stdenv.lib.optional stdenv.hostPlatform.isAarch32 ./compiler-rt-armv7l.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
   # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra

--- a/pkgs/development/compilers/llvm/9/compiler-rt-armv7l.patch
+++ b/pkgs/development/compilers/llvm/9/compiler-rt-armv7l.patch
@@ -1,0 +1,38 @@
+diff -ur compiler-rt-7.1.0.src/cmake/builtin-config-ix.cmake compiler-rt-7.1.0.src-patched/cmake/builtin-config-ix.cmake
+--- compiler-rt-7.1.0.src/cmake/builtin-config-ix.cmake	2018-05-25 06:36:27.000000000 +0900
++++ compiler-rt-7.1.0.src-patched/cmake/builtin-config-ix.cmake	2020-05-09 20:26:33.030608692 +0900
+@@ -24,7 +24,7 @@
+ 
+ 
+ set(ARM64 aarch64)
+-set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k)
++set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k armv7l)
+ set(HEXAGON hexagon)
+ set(X86 i386)
+ set(X86_64 x86_64)
+diff -ur compiler-rt-7.1.0.src/lib/builtins/CMakeLists.txt compiler-rt-7.1.0.src-patched/lib/builtins/CMakeLists.txt
+--- compiler-rt-7.1.0.src/lib/builtins/CMakeLists.txt	2018-07-31 03:18:59.000000000 +0900
++++ compiler-rt-7.1.0.src-patched/lib/builtins/CMakeLists.txt	2020-05-09 20:27:38.893409318 +0900
+@@ -453,6 +453,7 @@
+ set(armv7_SOURCES ${arm_SOURCES})
+ set(armv7s_SOURCES ${arm_SOURCES})
+ set(armv7k_SOURCES ${arm_SOURCES})
++set(armv7l_SOURCES ${arm_SOURCES})
+ set(arm64_SOURCES ${aarch64_SOURCES})
+ 
+ # macho_embedded archs
+@@ -563,12 +564,12 @@
+       set(_arch ${arch})
+       if("${arch}" STREQUAL "armv6m")
+         set(_arch "arm|armv6m")
+-      elseif("${arch}" MATCHES "^(armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")
++      elseif("${arch}" MATCHES "^(armhf|armv7|armv7s|armv7k|armv7l|armv7m|armv7em)$")
+         set(_arch "arm")
+       endif()
+ 
+       # For ARM archs, exclude any VFP builtins if VFP is not supported
+-      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")
++      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7l|armv7m|armv7em)$")
+         string(REPLACE ";" " " _TARGET_${arch}_CFLAGS "${TARGET_${arch}_CFLAGS}")
+         check_compile_definition(__VFP_FP__ "${CMAKE_C_FLAGS} ${_TARGET_${arch}_CFLAGS}" COMPILER_RT_HAS_${arch}_VFP)
+         if(NOT COMPILER_RT_HAS_${arch}_VFP)

--- a/pkgs/development/compilers/llvm/9/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/9/compiler-rt.nix
@@ -47,8 +47,8 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
-    ./compiler-rt-armv7l.patch
-  ];# ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
+  ]# ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
+    ++ stdenv.lib.optional stdenv.hostPlatform.isAarch32 ./compiler-rt-armv7l.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
   # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra

--- a/pkgs/development/compilers/llvm/9/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/9/compiler-rt.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
+    ./compiler-rt-armv7l.patch
   ];# ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks


### PR DESCRIPTION
###### Motivation for this change

Fixes #87266 - llvmPackages_7.compiler-rt fails to produce output path on armv7l

Still testing the builds, so opening as draft.

See also same change for x86 https://github.com/NixOS/nixpkgs/pull/85945

cc @matthewbauer @Atemu @TravisWhitaker 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
