### PR TITLE
mlflow-server: support additional packages for other database backends

### DIFF
--- a/pkgs/servers/mlflow-server/default.nix
+++ b/pkgs/servers/mlflow-server/default.nix
@@ -1,4 +1,4 @@
-{lib, python3, writeText}:
+{lib, python3, writeText, additionalPackages ? []}:
 
 let
   py = python3.pkgs;
@@ -10,7 +10,8 @@ py.toPythonApplication
     propagatedBuildInputs = old.propagatedBuildInputs ++ [
       py.boto3
       py.mysqlclient
-    ];
+      py.psycopg2
+    ] ++ additionalPackages;
 
     postPatch = ''
       substituteInPlace mlflow/utils/process.py --replace \


### PR DESCRIPTION
###### Motivation for this change
add postgres backend, make easier for user to add their own preferred.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
