### PR TITLE
treewide: strip more things in cross

### DIFF
--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -22,10 +22,12 @@ stdenv.mkDerivation rec {
     "ac_cv_linux_vers=2"
   ];
 
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
-
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace " -arch i386" ""
+  '';
+
+  postInstall = ''
+    rm -f $out/lib/libpcap.a
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/readline/6.3.nix
+++ b/pkgs/development/libraries/readline/6.3.nix
@@ -32,10 +32,6 @@ stdenv.mkDerivation {
      in
        import ./readline-6.3-patches.nix patch);
 
-  # Don't run the native `strip' when cross-compiling.
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
-  bash_cv_func_sigsetjmp = if stdenv.isCygwin then "missing" else null;
-
   meta = with stdenv.lib; {
     description = "Library for interactive line editing";
 

--- a/pkgs/development/libraries/readline/7.0.nix
+++ b/pkgs/development/libraries/readline/7.0.nix
@@ -32,10 +32,6 @@ stdenv.mkDerivation rec {
     ]
     ++ upstreamPatches;
 
-  # Don't run the native `strip' when cross-compiling.
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
-  bash_cv_func_sigsetjmp = if stdenv.isCygwin then "missing" else null;
-
   meta = with stdenv.lib; {
     description = "Library for interactive line editing";
 

--- a/pkgs/development/libraries/readline/8.0.nix
+++ b/pkgs/development/libraries/readline/8.0.nix
@@ -32,10 +32,6 @@ stdenv.mkDerivation rec {
     ]
     ++ upstreamPatches;
 
-  # Don't run the native `strip' when cross-compiling.
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
-  bash_cv_func_sigsetjmp = if stdenv.isCygwin then "missing" else null;
-
   meta = with stdenv.lib; {
     description = "Library for interactive line editing";
 

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -26,10 +26,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # Don't run the native `strip' when cross-compiling.  This breaks at least
-  # with `.a' files for MinGW.
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
-
   meta = with stdenv.lib; {
     description = "GNU Libtool, a generic library support script";
     longDescription = ''


### PR DESCRIPTION
Stripping reduces closure sizes. This removes some old places where stripping was disabled.

Touches these packages:

- perl
- libpcap
- readline{...}
- libtool2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
