### PR TITLE
shadow: add runtime-shell.patch for cross-compilation

### DIFF
--- a/pkgs/os-specific/linux/shadow/default.nix
+++ b/pkgs/os-specific/linux/shadow/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, nixosTests, fetchpatch, fetchFromGitHub, autoreconfHook, libxslt
-, libxml2 , docbook_xml_dtd_45, docbook_xsl, itstool, flex, bison
+, libxml2 , docbook_xml_dtd_45, docbook_xsl, itstool, flex, bison, runtimeShell
 , pam ? null, glibcCross ? null
 }:
 
@@ -38,7 +38,10 @@ stdenv.mkDerivation rec {
       # Obtain XML resources from XML catalog (patch adapted from gtk-doc)
       ./respect-xml-catalog-files-var.patch
       dots_in_usernames
+      ./runtime-shell.patch
     ];
+
+  RUNTIME_SHELL = runtimeShell;
 
   # The nix daemon often forbids even creating set[ug]id files.
   postPatch =
@@ -76,6 +79,8 @@ stdenv.mkDerivation rec {
       mkdir -p $su/bin
       mv $out/bin/su $su/bin
     '';
+
+  disallowedReferences = lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) stdenv.shellPackage;
 
   meta = with lib; {
     homepage = "https://github.com/shadow-maint";

--- a/pkgs/os-specific/linux/shadow/runtime-shell.patch
+++ b/pkgs/os-specific/linux/shadow/runtime-shell.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index e4c6aaec..03883ad7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -682,7 +682,7 @@ if test "$enable_utmpx" = "yes"; then
+ 	          [Define if utmpx should be used])
+ fi
+ 
+-AC_DEFINE_UNQUOTED(SHELL, ["$SHELL"], [The default shell.])
++AC_DEFINE_UNQUOTED(SHELL, ["$RUNTIME_SHELL"], [The runtime shell.])
+ 
+ AM_GNU_GETTEXT_VERSION(0.16)
+ AM_GNU_GETTEXT([external], [need-ngettext])


### PR DESCRIPTION
This gets the right shell in the closure.

By default, shadow wants to pull in the bash we are building it with,
while we would prefer it used the runtime bash.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
