### PR TITLE
ripgrep: 12.0.1 -> 12.1.0

### DIFF
--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -1,9 +1,7 @@
 { stdenv
 , fetchFromGitHub
 , rustPlatform
-, asciidoc
-, docbook_xsl
-, libxslt
+, asciidoctor
 , installShellFiles
 , Security
 , withPCRE2 ? true
@@ -12,20 +10,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "ripgrep";
-  version = "12.0.1";
+  version = "12.1.0";
 
   src = fetchFromGitHub {
     owner = "BurntSushi";
     repo = pname;
     rev = version;
-    sha256 = "1c0v51s05kbg9825n6mvpizhkkgz38wl7hp8f3vzbjfg4i8l8wb0";
+    sha256 = "1vgkk78c25ia9y4q5psrh7xrlbfdn7dz7bc20kci40n8zr0vjwww";
   };
 
-  cargoSha256 = "0i8x2xgri8f8mzrlkc8l2yzcgczl35nw4bmwg09d343mjkmk6d8y";
+  cargoSha256 = "143lnf4yah9ik7v8rphv7gbvr2ckhjpmy8zfgqml1n3fqxiqvxnb";
 
   cargoBuildFlags = stdenv.lib.optional withPCRE2 "--features pcre2";
 
-  nativeBuildInputs = [ asciidoc docbook_xsl libxslt installShellFiles ];
+  nativeBuildInputs = [ asciidoctor installShellFiles ];
   buildInputs = (stdenv.lib.optional withPCRE2 pcre2)
   ++ (stdenv.lib.optional stdenv.isDarwin Security);
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Changelog: https://github.com/BurntSushi/ripgrep/releases/tag/12.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
