### PR TITLE
ocamlPackages.torch: init at 0.8

### DIFF
--- a/pkgs/development/ocaml-modules/torch/default.nix
+++ b/pkgs/development/ocaml-modules/torch/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, buildDunePackage
+, fetchFromGitHub
+, cmdliner
+, ctypes
+, npy
+, ocaml-compiler-libs
+, ppx_custom_printf
+, ppx_expect
+, ppx_sexp_conv
+, sexplib
+, stdio
+, pytorch
+}:
+
+buildDunePackage rec {
+  pname = "torch";
+  version = "0.8";
+
+  owner = "LaurentMazare";
+
+  minimumOCamlVersion = "4.07";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo   = "ocaml-${pname}";
+    rev    = version;
+    sha256 = "19w31paj24pns2ahk9j9rgpkb5hpcd41kfaarxrlddww5dl6pxvi";
+  };
+
+  propagatedBuildInputs = [
+    cmdliner
+    ctypes
+    npy
+    ocaml-compiler-libs
+    pytorch
+    pytorch.dev
+    ppx_custom_printf
+    ppx_expect
+    ppx_sexp_conv
+    sexplib
+    stdio
+  ];
+
+  preBuild = ''export LIBTORCH=${pytorch.dev}/'';
+
+  doCheck = true;
+  checkPhase = "dune runtest";
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Ocaml bindings to Pytorch";
+    maintainers = [ maintainers.bcdarwin ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -763,6 +763,10 @@ let
 
     tls = callPackage ../development/ocaml-modules/tls { };
 
+    torch = callPackage ../development/ocaml-modules/torch {
+      inherit (pkgs.python3Packages) pytorch;
+    };
+
     type_conv_108_08_00 = callPackage ../development/ocaml-modules/type_conv/108.08.00.nix { };
     type_conv_109_60_01 = callPackage ../development/ocaml-modules/type_conv/109.60.01.nix { };
     type_conv_112_01_01 = callPackage ../development/ocaml-modules/type_conv/112.01.01.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
