### PR TITLE
deluge: fix running the Gtk UI

### DIFF
--- a/pkgs/applications/networking/p2p/deluge/2/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/2/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, intltool, libtorrentRasterbar, pythonPackages
-, gtk3, gobject-introspection, librsvg, wrapGAppsHook }:
+, gtk3, glib, gobject-introspection, librsvg, wrapGAppsHook }:
 
 pythonPackages.buildPythonPackage rec {
   pname = "deluge";
@@ -18,7 +18,7 @@ pythonPackages.buildPythonPackage rec {
     gtk3 gobject-introspection librsvg
   ];
 
-  nativeBuildInputs = [ intltool wrapGAppsHook ];
+  nativeBuildInputs = [ intltool wrapGAppsHook glib ];
 
   checkInputs = with pythonPackages; [
     pytest /* pytest-twisted */ pytestcov mock


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

At the moment, runing `deluge` with the deluge package installed returns
"No GSettings schemas are installed on the system".

After this patch, XDG_DATA_DIRS includes the gsettings-desktop-schemas,
which means the program actually manages to launch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
