### PR TITLE
ocamlPackages.mdx: 1.5.0 → 1.6.0

### DIFF
--- a/pkgs/development/ocaml-modules/mdx/default.nix
+++ b/pkgs/development/ocaml-modules/mdx/default.nix
@@ -1,19 +1,20 @@
 { lib, fetchurl, buildDunePackage, opaline, ocaml
+, alcotest
 , astring, cmdliner, cppo, fmt, logs, ocaml-migrate-parsetree, ocaml-version, ocaml_lwt, pandoc, re }:
 
 buildDunePackage rec {
   pname = "mdx";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchurl {
-    url = "https://github.com/realworldocaml/mdx/releases/download/1.5.0/mdx-1.5.0.tbz";
-    sha256 = "0g45plf4z7d178gp0bx7842fwbd3m19679yfph3s95da6mrfm3xn";
+    url = "https://github.com/realworldocaml/mdx/releases/download/${version}/mdx-${version}.tbz";
+    sha256 = "18m4ay226dwbgnwp3ia6bfcm033dvp9yby0lbddqn8ak374m2k3b";
   };
 
   nativeBuildInputs = [ cppo ];
   buildInputs = [ cmdliner ];
   propagatedBuildInputs = [ astring fmt logs ocaml-migrate-parsetree ocaml-version re ];
-  checkInputs = lib.optionals doCheck [ ocaml_lwt pandoc ];
+  checkInputs = [ alcotest ocaml_lwt pandoc ];
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.10

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
