### PR TITLE
nix-direnv: init at 1.0.0

### DIFF
--- a/pkgs/tools/misc/nix-direnv/default.nix
+++ b/pkgs/tools/misc/nix-direnv/default.nix
@@ -21,7 +21,9 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    runHook preInstall
     install -m500 -D direnvrc $out/share/nix-direnv/direnvrc
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/nix-direnv/default.nix
+++ b/pkgs/tools/misc/nix-direnv/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub, gnugrep, nix }:
+
+stdenv.mkDerivation rec {
+  pname = "nix-direnv";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = "nix-direnv";
+    rev = "${version}";
+    sha256 = "1lwmg6mn3lf7s0345v53zadxn9v0x8z6pcbj90v5dx3pgrq41gs8";
+  };
+
+  # Substitute instead of wrapping because the resulting file is
+  # getting sourced, not executed:
+  postPatch = ''
+    substituteInPlace direnvrc \
+      --replace "grep" "${gnugrep}/bin/grep" \
+      --replace "nix-shell" "${nix}/bin/nix-shell" \
+      --replace "nix-instantiate" "${nix}/bin/nix-instantiate"
+  '';
+
+  installPhase = ''
+    install -m500 -D direnvrc $out/share/nix-direnv/direnvrc
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A fast, persistent use_nix implementation for direnv";
+    homepage    = "https://github.com/nix-community/nix-direnv";
+    license     = licenses.mit;
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/nix-direnv/default.nix
+++ b/pkgs/tools/misc/nix-direnv/default.nix
@@ -31,5 +31,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://github.com/nix-community/nix-direnv";
     license     = licenses.mit;
     platforms   = platforms.unix;
+    maintainers = with maintainers; [ mic92 ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2058,6 +2058,8 @@ in
 
   nfstrace = callPackage ../tools/networking/nfstrace { };
 
+  nix-direnv = callPackage ../tools/misc/nix-direnv { };
+
   nixpkgs-pytools = with python3.pkgs; toPythonApplication nixpkgs-pytools;
 
   noteshrink = callPackage ../tools/misc/noteshrink { };


### PR DESCRIPTION
#### Motivation for this change

Add [nix-direnv](https://github.com/nix-community/nix-direnv), a fast, persistent use_nix implementation for [direnv](https://github.com/direnv/direnv/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @Mic92 