### PR TITLE
WIP arduino core upgrade.

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
 
     # Deliberately break build.xml's download statement in order to cause
     # an error if anything needed is missing from download.nix.
-    #substituteInPlace build/build.xml --replace "get src" "get error"
+    substituteInPlace build/build.xml --replace "get src" "get error"
 
     cd ./arduino-core && ant
     cd ../build && ant

--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -25,8 +25,8 @@ let
   };
   # Some .so-files are later copied from .jar-s to $HOME, so patch them beforehand
   patchelfInJars =
-       lib.optional (stdenv.hostPlatform.system == "x86_64-linux") {jar = "share/arduino/lib/jssc-2.8.0-arduino3.jar"; file = "libs/linux/libjSSC-2.8_x86_64.so";}
-    ++ lib.optional (stdenv.hostPlatform.system == "i686-linux") {jar = "share/arduino/lib/jssc-2.8.0-arduino3.jar"; file = "libs/linux/libjSSC-2.8_x86.so";}
+       lib.optional (stdenv.hostPlatform.system == "x86_64-linux") {jar = "share/arduino/lib/jssc-2.9.1.jar"; file = "libs/linux/libjSSC-2.9.1_x86_64.so";}
+    ++ lib.optional (stdenv.hostPlatform.system == "i686-linux") {jar = "share/arduino/lib/jssc-2.8.9.1.jar"; file = "libs/linux/libjSSC-2.9.1_x86.so";}
   ;
   # abiVersion 6 is default, but we need 5 for `avrdude_bin` executable
   ncurses5 = ncurses.override { abiVersion = "5"; };
@@ -62,14 +62,14 @@ let
              + stdenv.lib.optionalString (!withGui) "-core";
 in
 stdenv.mkDerivation rec {
-  version = "1.8.9";
+  version = "1.8.12";
   name = "${flavor}-${version}";
 
   src = fetchFromGitHub {
     owner = "arduino";
     repo = "Arduino";
     rev = version;
-    sha256 = "0kblq0bqap2zzkflrj6rmdi8dvqxa28fcwwrc3lfmbz2893ni3w4";
+    sha256 = "0lxkyvsh55biz2q20ba4qabraind5cpxznl41zfq027vl22j6kd2";
   };
 
   teensyduino_version = "147";
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
 
     # Deliberately break build.xml's download statement in order to cause
     # an error if anything needed is missing from download.nix.
-    substituteInPlace build/build.xml --replace "get src" "get error"
+    #substituteInPlace build/build.xml --replace "get src" "get error"
 
     cd ./arduino-core && ant
     cd ../build && ant

--- a/pkgs/development/arduino/arduino-core/downloads.nix
+++ b/pkgs/development/arduino/arduino-core/downloads.nix
@@ -96,20 +96,20 @@
     url = "https://downloads.arduino.cc/liblistSerials/liblistSerials-1.4.2.zip";
     sha256 = "1p58b421k92rbgwfgbihy0d04mby7kfssghpmjb4gk9yix09za3m";
   };
-  "build/WiFi101-Updater-ArduinoIDE-Plugin-0.10.10.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/archive/v0.10.10.zip";
-    sha256 = "1j6xy7ffrapk0brcfknaj72pvmzrf19sks8pm900ad7w897mksmv";
-  };
    "build/libastylej-2.05.1-4.zip" = fetchurl {
     url = "https://downloads.arduino.cc/libastylej-2.05.1-4.zip";
     sha256 = "0q307b85xba7izjh344kqby3qahg3f5zy18gg52sjk1lbkl9i39s";
   };
+  "build/WiFi101-Updater-ArduinoIDE-Plugin-0.10.10.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/archive/v0.10.10.zip";
+    sha256 = "1j6xy7ffrapk0brcfknaj72pvmzrf19sks8pm900ad7w897mksmv";
+  };
 }
 
 // optionalAttrs (system == "x86_64-linux") {
-  "build/arduino-builder-linux64-1.4.4.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/arduino-builder-linux64-1.4.4.tar.bz2";
-    sha256 = "1m5b4rc9i235ra6isqdpjj9llddb5sldkhidb8c4i14mcqbdci1n";
+  "build/arduino-builder-linux64-1.5.2.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduino-builder-linux64-1.5.2.tar.bz2";
+    sha256 = "0wypr9a2cbv9r0ignsr13raw09i3vfc5zvkjxp2xwb7mv35y77z3";
   };
   "build/linux/avr-gcc-5.4.0-atmel3.6.1-arduino2-x86_64-pc-linux-gnu.tar.bz2" = fetchurl {
     url = "https://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-x86_64-pc-linux-gnu.tar.bz2";
@@ -130,9 +130,9 @@
 }
 
 // optionalAttrs (system == "i686-linux") {
-  "build/arduino-builder-linux32-1.4.4.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/arduino-builder-linux32-1.4.4.tar.bz2";
-    sha256 = "0q3i1ba7vh14616d9ligizcz89yadr0skazxbrcq3mvvjqzbifw8";
+  "build/arduino-builder-linux32-1.5.2.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduino-builder-linux32-1.5.2.tar.bz2";
+    sha256 = "1slzw8fzxkqsp2izjisjd1rxxbqkrq6n72jc4frk5z2gdm6zfa0l";
   };
   "build/linux/avr-gcc-5.4.0-atmel3.6.1-arduino2-i686-pc-linux-gnu.tar.bz2" = fetchurl {
     url = "https://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-i686-pc-linux-gnu.tar.bz2";
@@ -148,9 +148,9 @@
   };
 }
 // optionalAttrs (system == "x86_64-darwin") {
-  "build/arduino-builder-macosx-1.4.4.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/arduino-builder-macosx-1.4.4.tar.bz2";
-    sha256 = "1jp5kg32aiw062kcxlv660w38iaprifm8h3g2798izpwyfj0dmwg";
+  "build/arduino-builder-macosx-1.5.1.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduino-builder-macosx-1.5.1.tar.bz2";
+    sha256 = "0iwy083m495mjfxcj173plfac423znv8zknbqk0x2ndp2xfz0yjv";
   };
   "build/macosx/avr-gcc-5.4.0-atmel3.6.1-arduino2-i386-apple-darwin11.tar.bz2" = fetchurl {
     url = "https://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-i386-apple-darwin11.tar.bz2";
@@ -160,15 +160,15 @@
     url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-i386-apple-darwin11.tar.bz2";
     sha256 = "0qsa3sb3f480fm2z75fq14cqddw5hq8w8q0c2a9cw8i7aa8kkl27";
   };
-  "build/macosx/appbundler/appbundler-1.0ea-arduino4.jar.zip" = fetchurl {
-    url = "https://downloads.arduino.cc/appbundler-1.0ea-arduino4.jar.zip";
-    sha256 = "1vz0g98ancfqdf7yx5m3zrxmzb3fwp18zh5lkh2nyl5xlr9m368z";
+  "build/macosx/appbundler/appbundler-1.0ea-arduino5.jar.zip" = fetchurl {
+    url = "https://downloads.arduino.cc/appbundler-1.0ea-arduino5.jar.zip";
+    sha256 = "1ims951z7ajprqms7yd8ll83c79n7krhd9ljw30yn61f6jk46x82";
   };
 }
 // optionalAttrs (system == "armv6l-linux") {
-  "build/arduino-builder-linuxarm-1.4.4.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/arduino-builder-linuxarm-1.4.4.tar.bz2";
-    sha256 = "03bhlhdkg1jx0d3lh9194xgaqsbank9njhlnwy8braa7pw4p58gn";
+  "build/arduino-builder-linuxarm-1.5.2.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduino-builder-linuxarm-1.5.2.tar.bz2";
+    sha256 = "1vs2s5px07jb2sdv83qxkf9lxmsy8j4dm7bn3vpw5dcjqd3qdyww";
   };
   "build/linux/avr-gcc-5.4.0-atmel3.6.1-arduino2-armhf-pc-linux-gnu.tar.bz2" = fetchurl {
     url = "https://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-armhf-pc-linux-gnu.tar.bz2";

--- a/pkgs/development/arduino/arduino-core/downloads.nix
+++ b/pkgs/development/arduino/arduino-core/downloads.nix
@@ -56,9 +56,9 @@
     url = "https://github.com/arduino-libraries/RobotIRremote/archive/2.0.0.zip";
     sha256 = "0j5smap74j8p3wc6k0h73b1skj4gkr7r25jbjh1j1cg052dxri86";
   };
-  "build/SpacebrewYun-1.0.1.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/SpacebrewYun/archive/1.0.1.zip";
-    sha256 = "1zs6ymlzw66bglrm0x6d3cvr52q85c8rlm525x0wags111xx3s90";
+  "build/SpacebrewYun-1.0.2.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/SpacebrewYun/archive/1.0.2.zip";
+    sha256 = "1d8smmsx12qhf2ldvmi93h48cvdyz4id5gd68cvf076wfyv6dks8";
   };
   "build/Temboo-1.2.1.zip" = fetchurl {
     url = "https://github.com/arduino-libraries/Temboo/archive/1.2.1.zip";
@@ -69,28 +69,28 @@
     sha256 = "1dflfrg38f0312nxn6wkkgq1ql4hx3y9kplalix6mkqmzwrdvna4";
   };
   "build/Mouse-1.0.1.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/Mouse/archive/1.0.1.zip";
+    url = "https://github.com/arduino- libraries/Mouse/archive/1.0.1.zip";
     sha256 = "106jjqxzpf5lrs9akwvamqsblj5w2fb7vd0wafm9ihsikingiypr";
   };
   "build/Keyboard-1.0.2.zip" = fetchurl {
     url = "https://github.com/arduino-libraries/Keyboard/archive/1.0.2.zip";
     sha256 = "17yfj95r1i7fb87q4krmxmaq07b4x2xf8cjngrj5imj68wgjck53";
   };
-  "build/SD-1.2.3.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/SD/archive/1.2.3.zip";
-    sha256 = "0i5hb5hmrsrhfgxx8w7zzrfrkc751vs63vhxrj6qvwazhfcdpjw2";
+  "build/SD-1.2.4.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/SD/archive/1.2.4.zip";
+    sha256 = "123g9px9nqcrsx696wqwzjd5s4hr55nxgfz95b7ws3v007i1f3fz";
   };
-  "build/Servo-1.1.3.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/Servo/archive/1.1.3.zip";
-    sha256 = "1m019a75cdn1fg0cwlzbahmaqvg8sgzr6v1812rd7rjh8ismiah6";
+  "build/Servo-1.1.6.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Servo/archive/1.1.6.zip";
+    sha256 = "1z9k9lxzj5d3f8h9hy86f4k5wgfr2a9zcvjh76qmpvv6clcv3js3";
   };
   "build/LiquidCrystal-1.0.7.zip" = fetchurl {
     url = "https://github.com/arduino-libraries/LiquidCrystal/archive/1.0.7.zip";
     sha256 = "1wrxrqz3n4yrj9j1a2b7pdd7a1rlyi974ra7crv5amjng8817x9n";
   };
-  "build/Adafruit_Circuit_Playground-1.8.1.zip" = fetchurl {
-    url = "https://github.com/Adafruit/Adafruit_CircuitPlayground/archive/1.8.1.zip";
-    sha256 = "1fl24px4c42f6shpb3livwsxgpj866yy285274qrj4m1zl07f18q";
+  "build/Adafruit_Circuit_Playground-1.10.4.zip" = fetchurl {
+    url = "https://github.com/adafruit/Adafruit_CircuitPlayground/archive/1.10.4.zip";
+    sha256 = "194az5pxxzs0wg4ng7w0zqrdw93qdyv02y0q2yy57dr4kwfrm6nl";
   };
   "build/libastylej-2.05.1-4.zip" = fetchurl {
     url = "https://downloads.arduino.cc/libastylej-2.05.1-4.zip";
@@ -99,10 +99,6 @@
   "build/liblistSerials-1.4.2.zip" = fetchurl {
     url = "https://downloads.arduino.cc/liblistSerials/liblistSerials-1.4.2.zip";
     sha256 = "1p58b421k92rbgwfgbihy0d04mby7kfssghpmjb4gk9yix09za3m";
-  };
-  "build/shared/WiFi101-Updater-ArduinoIDE-Plugin-0.10.6.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/releases/download/v0.10.6/WiFi101-Updater-ArduinoIDE-Plugin-0.10.6.zip";
-    sha256 = "1k23xyr5dmr60y8hb9x24wrgd4mfgvrzky621p6fvawn5xbdq8a3";
   };
 }
 // optionalAttrs (system == "x86_64-linux") {
@@ -122,9 +118,9 @@
     url = "https://downloads.arduino.cc/tools/arduinoOTA-1.2.1-linux_amd64.tar.bz2";
     sha256 = "1ya834p2cqjj8k1ad3yxcnzd4bcgrlqsqsli9brq1138ac6k30jv";
   };
-  "build/avr-1.6.23.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/cores/avr-1.6.23.tar.bz2";
-    sha256 = "1al449r8hcdck7f4y295g7q388qvbn6qhk2zqdvws9kg4mzqsq8q";
+  "build/avr-1.8.2.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/cores/avr-1.8.2.tar.bz2";
+    sha256 = "06zl8fwphknd0qdx87fcr1003gid1yqsazaj674mm9widqfd84v2";
   };
 }
 // optionalAttrs (system == "i686-linux") {

--- a/pkgs/development/arduino/arduino-core/downloads.nix
+++ b/pkgs/development/arduino/arduino-core/downloads.nix
@@ -69,7 +69,7 @@
     sha256 = "1dflfrg38f0312nxn6wkkgq1ql4hx3y9kplalix6mkqmzwrdvna4";
   };
   "build/Mouse-1.0.1.zip" = fetchurl {
-    url = "https://github.com/arduino- libraries/Mouse/archive/1.0.1.zip";
+    url = "https://github.com/arduino-libraries/Mouse/archive/1.0.1.zip";
     sha256 = "106jjqxzpf5lrs9akwvamqsblj5w2fb7vd0wafm9ihsikingiypr";
   };
   "build/Keyboard-1.0.2.zip" = fetchurl {
@@ -92,15 +92,20 @@
     url = "https://github.com/adafruit/Adafruit_CircuitPlayground/archive/1.10.4.zip";
     sha256 = "194az5pxxzs0wg4ng7w0zqrdw93qdyv02y0q2yy57dr4kwfrm6nl";
   };
-  "build/libastylej-2.05.1-4.zip" = fetchurl {
-    url = "https://downloads.arduino.cc/libastylej-2.05.1-4.zip";
-    sha256 = "0q307b85xba7izjh344kqby3qahg3f5zy18gg52sjk1lbkl9i39s";
-  };
   "build/liblistSerials-1.4.2.zip" = fetchurl {
     url = "https://downloads.arduino.cc/liblistSerials/liblistSerials-1.4.2.zip";
     sha256 = "1p58b421k92rbgwfgbihy0d04mby7kfssghpmjb4gk9yix09za3m";
   };
+  "build/WiFi101-Updater-ArduinoIDE-Plugin-0.10.10.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/archive/v0.10.10.zip";
+    sha256 = "1j6xy7ffrapk0brcfknaj72pvmzrf19sks8pm900ad7w897mksmv";
+  };
+   "build/libastylej-2.05.1-4.zip" = fetchurl {
+    url = "https://downloads.arduino.cc/libastylej-2.05.1-4.zip";
+    sha256 = "0q307b85xba7izjh344kqby3qahg3f5zy18gg52sjk1lbkl9i39s";
+  };
 }
+
 // optionalAttrs (system == "x86_64-linux") {
   "build/arduino-builder-linux64-1.4.4.tar.bz2" = fetchurl {
     url = "https://downloads.arduino.cc/tools/arduino-builder-linux64-1.4.4.tar.bz2";
@@ -123,6 +128,7 @@
     sha256 = "06zl8fwphknd0qdx87fcr1003gid1yqsazaj674mm9widqfd84v2";
   };
 }
+
 // optionalAttrs (system == "i686-linux") {
   "build/arduino-builder-linux32-1.4.4.tar.bz2" = fetchurl {
     url = "https://downloads.arduino.cc/tools/arduino-builder-linux32-1.4.4.tar.bz2";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I would like to upgrade to latest arduino IDE but it still complains about missing libraries...

`BUILD FAILED
/build/source/build/build.xml:134: The following error occurred while executing this line:
/build/source/build/build.xml:638: The following error occurred while executing this line:
/build/source/build/build.xml:220: The following error occurred while executing this line:
/build/source/build/build.xml:887: Could not find file /build/source/build/shared/WiFi101-Updater-ArduinoIDE-Plugin-0.10.10.zip to generate checksum for.`

@cc bjornfor gazally bergey binarin worldofpeace
    robberer matthewbauer
    pSuborbekk jwiegley Ericson2314 witchof0x20 domenkozar cko auntieNeo abbradar

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
