### PR TITLE
gnomeExtensions.volume-mixer: bring it back and fix it

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/volume-mixer/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/volume-mixer/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-volume-mixer";
-  version = "3.36.6";
+  version = "3.38.0";
 
   src = fetchFromGitHub {
     owner = "aleho";
     repo = "gnome-shell-volume-mixer";
     rev = version;
-    sha256 = "1s80w5csv82hxky33ql734z9df8zkg1r8xmxc9hl759z6rbqml9g";
+    sha256 = "12iqw1ggzqjgnb6pnp32z8d847wx2sbiz5dl316cgmc2pzn9anj5";
   };
 
   patches = [

--- a/pkgs/desktops/gnome-3/extensions/volume-mixer/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/volume-mixer/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, glib, pulseaudio, python3 }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-volume-mixer";
+  version = "3.36.6";
+
+  src = fetchFromGitHub {
+    owner = "aleho";
+    repo = "gnome-shell-volume-mixer";
+    rev = version;
+    sha256 = "1s80w5csv82hxky33ql734z9df8zkg1r8xmxc9hl759z6rbqml9g";
+  };
+
+  patches = [
+    ./find_libpulse.patch
+  ];
+
+  buildInputs = [
+    glib
+    pulseaudio
+    python3
+  ];
+
+  postPatch = ''
+    substituteInPlace ./shell-volume-mixer@derhofbauer.at/pautils/pa.py \
+        --subst-var-by pulseaudio ${pulseaudio}
+  '';
+
+  # Could use the Makefile, but it requires npm...
+  buildPhase = ''
+    glib-compile-schemas --targetdir=${uuid}/schemas ${uuid}/schemas
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp -r ${uuid} $out/share/gnome-shell/extensions/
+  '';
+
+  uuid = "shell-volume-mixer@derhofbauer.at";
+
+  meta = with stdenv.lib; {
+    description = "GNOME Shell Extension allowing separate configuration of PulseAudio devices";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ bjornfor ];
+    homepage = https://github.com/aleho/gnome-shell-volume-mixer;
+  };
+}

--- a/pkgs/desktops/gnome-3/extensions/volume-mixer/find_libpulse.patch
+++ b/pkgs/desktops/gnome-3/extensions/volume-mixer/find_libpulse.patch
@@ -1,0 +1,19 @@
+Find libpulse.so via direct reference.
+
+Author: Bjørn Forsman <bjorn.forsman@gmail.com>
+diff --git a/shell-volume-mixer@derhofbauer.at/pautils/pa.py b/shell-volume-mixer@derhofbauer.at/pautils/pa.py
+index 7d058bd..00edd6a 100644
+--- a/shell-volume-mixer@derhofbauer.at/pautils/pa.py
++++ b/shell-volume-mixer@derhofbauer.at/pautils/pa.py
+@@ -16,9 +16,9 @@
+ from ctypes import *
+ 
+ try:
+-    lib = CDLL('libpulse.so.0')
++    lib = CDLL('@pulseaudio@/lib/libpulse.so.0')
+ except:
+-    lib = CDLL('libpulse.so')
++    lib = CDLL('@pulseaudio@/lib/libpulse.so')
+ 
+ STRING = c_char_p
+ WSTRING = c_wchar_p

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26127,6 +26127,7 @@ in
     tilingnome = callPackage ../desktops/gnome-3/extensions/tilingnome { };
     timepp = callPackage ../desktops/gnome-3/extensions/timepp { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
+    volume-mixer = callPackage ../desktops/gnome-3/extensions/volume-mixer { };
     window-corner-preview = callPackage ../desktops/gnome-3/extensions/window-corner-preview { };
     window-is-ready-remover = callPackage ../desktops/gnome-3/extensions/window-is-ready-remover { };
     workspace-matrix = callPackage ../desktops/gnome-3/extensions/workspace-matrix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Seems like a useful extension.

This reverts commit ee5506c430dc2a6b8267c61ec0cd16570db3e25a.

Further:
* Add it to the gnomeExtensions attrset. (The reason for removing it in
  the first place was because it wasn't registered there.)
* Move from .../volume-mixer.nix to .../volume-mixer/default.nix, to
  align with the other extensions.
* Update to latest version.
* Fix the installPhase.
* Comment that there is a Makefile for this package, but it requires
  npm, so keep the buildPhase unchanged.
* Add missing deps: pulseaudio and python3
* Add a small patch to find pulseaudio.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
