### PR TITLE
nixos/confinement: add i18n glibcLocales to confined services

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -360,6 +360,16 @@ php.override {
      The default output of <literal>buildGoPackage</literal> is now <literal>$out</literal> instead of <literal>$bin</literal>.
    </para>
    </listitem>
+   <listitem>
+    <para>
+     The <literal>systemd.services._name_.confinement</literal> default
+     packages list now includes <literal>config.i18n.glibcLocales</literal>.
+     In many cases, <literal>pkgs.glibcLocales</literal> got pulled in
+     resulting in subtle bugs; since the default systemd service environment
+     sets <literal>$LOCALE_ARCHIVE</literal> the automatically pulled version
+     was not used.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/tests/systemd-confinement.nix
+++ b/nixos/tests/systemd-confinement.nix
@@ -51,7 +51,8 @@ import ./make-test-python.nix {
               )
         '';
       }
-      { testScript = ''
+      { config.confinement.packages = [ pkgs.perl ];
+        testScript = ''
           with subtest("full confinement with APIVFS"):
               machine.fail(
                   "chroot-exec ls -l /etc",
@@ -59,7 +60,10 @@ import ./make-test-python.nix {
                   "chroot-exec chown 65534 /bin",
               )
               machine.succeed(
-                  'test "$(chroot-exec id -u)" = 0', "chroot-exec chown 0 /bin",
+                  'test "$(chroot-exec id -u)" = 0',
+                  "chroot-exec chown 0 /bin",
+                  # this tests locale works
+                  'test "$(chroot-exec \'${pkgs.perl}/bin/perl -e "printf \\"1\\n\\""\')" = 1',
               )
         '';
       }


### PR DESCRIPTION
###### Motivation for this change

Programs within the chroot will have pkgs.glibcLocale but not the
environment-defined $LOCALE_ARCHIVE, leading to subtle bugs that can be
hard to figure.

Always include i18n locales to avoid thoses, there already is another
locales anyway, and add a test to make sure it works.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
New test fails without patch and works with patch.
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @aszlig 