### PR TITLE
ior: 3.0.1 -> 3.2.1

### DIFF
--- a/pkgs/tools/system/ior/default.nix
+++ b/pkgs/tools/system/ior/default.nix
@@ -1,27 +1,23 @@
-{ stdenv, fetchurl, openmpi, automake, autoconf, perl }:
+{ stdenv, fetchFromGitHub, openmpi, perl, autoreconfHook }:
 
-let
-  version = "3.0.1";
-  sha256 = "039rh4z3lsj4vqjsqgakk0b7dkrdrkkzj0p1cjikpc9gn36zpghc";
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "ior";
-  inherit version;
+  version = "3.2.1";
 
-  src = fetchurl {
-    url = "https://github.com/LLNL/ior/archive/${version}.tar.gz";
-    inherit sha256;
+  src = fetchFromGitHub {
+    owner = "hpc";
+    repo = pname;
+    rev = version;
+    sha256 = "036cg75c5vq6kijfv8f918vpm9sf1h7lyg6xr9fba7n0dwbbmycv";
   };
 
-  buildInputs = [ openmpi automake autoconf perl ];
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ openmpi perl ];
 
   enableParallelBuilding = true;
 
-  preConfigure = "./bootstrap";
-
   meta = with stdenv.lib; {
-    homepage = "https://www.nersc.gov/users/computational-systems/cori/nersc-8-procurement/trinity-nersc-8-rfp/nersc-8-trinity-benchmarks/ior/";
+    homepage = "https://ior.readthedocs.io/en/latest/";
     description = "Parallel file system I/O performance test";
     license = licenses.gpl2;
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
New upstream release.

cc @bzizou 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
