### PR TITLE
realsense + examples + udev rules

### DIFF
--- a/nixos/modules/hardware/intel-realsense.nix
+++ b/nixos/modules/hardware/intel-realsense.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  options = {
+    hardware.intel.realsense.enable = mkOption {
+      type = types.boolean;
+      default = false;
+      description = '' Enable (intel) librealsense udev rules '';
+    };
+
+    hardware.intel.realsense.package = mkOption {
+      type = types.package;
+      default = pkgs.librealsenseWithExamples;
+      description = '' use pkgs.librealsense to avoid examples. The examples for instance contain realsense-viewer.'';
+    };
+  };
+
+  config = mkIf (config.hardware.intel.realsense.enable) {
+    environment.systemPackages = [ pkgs.librealsense ];
+    services.udev.packages =     [ pkgs.librealsense ];
+  };
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -47,6 +47,7 @@
   ./hardware/cpu/intel-microcode.nix
   ./hardware/digitalbitbox.nix
   ./hardware/device-tree.nix
+  ./hardware/intel-realsense.nix
   ./hardware/sensor/iio.nix
   ./hardware/ksm.nix
   ./hardware/ledger.nix

--- a/pkgs/development/libraries/librealsense/default.nix
+++ b/pkgs/development/libraries/librealsense/default.nix
@@ -1,4 +1,19 @@
-{ stdenv, fetchFromGitHub, cmake, libusb1, ninja, pkgconfig }:
+{ stdenv, fetchFromGitHub, cmake, libusb1, ninja, pkgconfig, pkgs,
+
+  # The examples for instance contain realsense-viewer.
+  buildExamples ? false, xorg, glfw3, libGLU
+}:
+
+# See ./nixos/modules/hardware/intel-realsense.nix's option to also get udev rules
+# TODO: turn buildExamples into multi output derivation
+
+let exampleDeps = {
+  inherit (xorg) libX11 libXrender libXtst libXdamage libXi libXext libXfixes libXcomposite;
+  inherit glfw3;
+  inherit libGLU;
+};
+
+in
 
 stdenv.mkDerivation rec {
   pname = "librealsense";
@@ -13,9 +28,11 @@ stdenv.mkDerivation rec {
     sha256 = "04macplj3k2sdpf1wdjm6gsghak5dzfhi2pmr47qldh2sy2zz0a3";
   };
 
+  enableParalellBuilding = true;
+
   buildInputs = [
     libusb1
-  ];
+  ] ++ pkgs.lib.optionals buildExamples (builtins.attrValues exampleDeps);
 
   nativeBuildInputs = [
     cmake
@@ -23,7 +40,21 @@ stdenv.mkDerivation rec {
     pkgconfig
   ];
 
-  cmakeFlags = [ "-DBUILD_EXAMPLES=false" ];
+  cmakeFlags = [ ''-DBUILD_EXAMPLES=${if buildExamples then "true" else "false"}'' ];
+
+  # copy udev rules to $out
+  # fix executable paths in udev rules and copy them to $udev_bins_path
+  postInstall = ''
+  cd ..
+  mkdir -p $out/lib/udev/rules.d
+  udev_bins_path=$out/udev-bins
+  mkdir -p $udev_bins_path
+  cp -ra config/{usb-R200-in,usb-R200-in_udev} $udev_bins_path
+  sed -i 's@/bin/bash@/bin/sh@' $udev_bins_path/*
+  chmod +x $udev_bins_path/*
+  cp config/99-realsense-libusb.rules $out/lib/udev/rules.d/99-realsense-libusb.rules
+  sed -i -e "s@/usr/local/bin/\\(usb-R200-in_udev\\|usb-R200-in\\)@$udev_bins_path/\\1@" -e "s@/bin/sh@$(type -p sh)@" $udev_bins_path/* $out/lib/udev/rules.d/99-realsense-libusb.rules
+  '';
 
   meta = with stdenv.lib; {
     description = "A cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300)";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17143,6 +17143,7 @@ in
   libraw1394 = callPackage ../development/libraries/libraw1394 { };
 
   librealsense = callPackage ../development/libraries/librealsense { };
+  librealsenseWithExamples = librealsense.override { buildExamples = true; };
 
   libsass = callPackage ../development/libraries/libsass { };
 


### PR DESCRIPTION
realsense-viewer still complains about udev rules being outdated cause it seems to byte compare with the patched version. But it seems to work.