### PR TITLE
oq: 1.0.2 -> 1.1.0, fix build

### DIFF
--- a/pkgs/development/tools/oq/default.nix
+++ b/pkgs/development/tools/oq/default.nix
@@ -14,7 +14,13 @@ crystal.buildCrystalPackage rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ jq libxml2 ];
 
+  format = "crystal";
   crystalBinaries.oq.src = "src/oq_cli.cr";
+
+  preCheck = ''
+    mkdir bin
+    cp oq bin/oq
+  '';
 
   postInstall = ''
     wrapProgram "$out/bin/oq" \

--- a/pkgs/development/tools/oq/default.nix
+++ b/pkgs/development/tools/oq/default.nix
@@ -2,13 +2,13 @@
 
 crystal.buildCrystalPackage rec {
   pname = "oq";
-  version = "1.0.2";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "Blacksmoke16";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0sf6rb5b6g7gzyq11l5868p3a1s5z8432swlpv457bfbbnbg6j6q";
+    sha256 = "1zg4kxpfi3sap4cwp42zg46j5dv0nf926qdqm7k22ncm6jdrgpgw";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Version bumped  1.0.2 -> 1.1.0

Fixes build failure
- Set build format explicitly to `crystal` since buildCrystalPackage thinks it's `make`
- Copy binary to `bin/oq` for tests to run.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
