### PR TITLE
obs-studio-plugins.input-overlay: init at 5.0.0

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -6,6 +6,8 @@
 # - Add plugin to it's own directory (because of future patches).
 
 {
+  input-overlay = qt6Packages.callPackage ./input-overlay.nix { };
+
   looking-glass-obs = callPackage ./looking-glass-obs.nix { };
 
   obs-backgroundremoval = callPackage ./obs-backgroundremoval { };

--- a/pkgs/applications/video/obs-studio/plugins/input-overlay.nix
+++ b/pkgs/applications/video/obs-studio/plugins/input-overlay.nix
@@ -1,0 +1,47 @@
+{ stdenv, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, obs-studio
+, libuiohook
+, qtbase
+, xorg
+, libxkbcommon
+, libxkbfile
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-input-overlay";
+  version = "5.0.0";
+  src = fetchFromGitHub {
+    owner = "univrsal";
+    repo = "input-overlay";
+    rev = "v${version}";
+    sha256 = "sha256-kpVAvQpBU8TxHAFcx/ok67++4MHh5saoRHJc5XpY4YQ=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    obs-studio libuiohook qtbase
+    xorg.libX11 xorg.libXau xorg.libXdmcp xorg.libXtst xorg.libXext
+    xorg.libXi xorg.libXt xorg.libXinerama libxkbcommon libxkbfile
+  ];
+
+  postInstall = ''
+    mkdir $out/lib $out/share
+    mv $out/obs-plugins/64bit $out/lib/obs-plugins
+    rm -rf $out/obs-plugins
+    mv $out/data $out/share/obs
+  '';
+
+  dontWrapQtApps = true;
+
+  meta = with lib; {
+    description = "Show keyboard, gamepad and mouse input on stream ";
+    homepage = "https://github.com/univrsal/input-overlay";
+    maintainers = with maintainers; [ glittershark ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

OBS plugin for displaying keyboard inputs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS (just libuiohook, not obs-input-overlay, because obs-studio itself isn't supported on darwin)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
