### PR TITLE
 python.pkgs.scikitlearn: 0.21.3 -> 0.22.2.post1 

### DIFF
--- a/pkgs/development/python-modules/scikitlearn/default.nix
+++ b/pkgs/development/python-modules/scikitlearn/default.nix
@@ -61,6 +61,12 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "A set of python modules for machine learning and data mining";
+    changelog = let
+      major = versions.major version;
+      minor = versions.minor version;
+      dashVer = replaceChars ["."] ["-"] version;
+    in
+      "https://scikit-learn.org/stable/whats_new/v${major}.${minor}.html#version-${dashVer}";
     homepage = "https://scikit-learn.org";
     license = licenses.bsd3;
     maintainers = with maintainers; [ ];

--- a/pkgs/development/python-modules/scikitlearn/default.nix
+++ b/pkgs/development/python-modules/scikitlearn/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "scikit-learn";
-  version = "0.21.3";
+  version = "0.22.2.post1";
   # UnboundLocalError: local variable 'message' referenced before assignment
   disabled = stdenv.isi686;  # https://github.com/scikit-learn/scikit-learn/issues/5534
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "eb9b8ebf59eddd8b96366428238ab27d05a19e89c5516ce294abc35cea75d003";
+    sha256 = "0z81n13dxvd6qwq5lsnzw2machmxbirhdhr73v90fi55ic9qslsp";
   };
 
   buildInputs = [
@@ -40,15 +40,6 @@ buildPythonPackage rec {
     joblib
   ];
   checkInputs = [ pytest ];
-
-  patches = [
-    # Fixes tests by changing threshold of a test-case that broke
-    # with numpy versions >= 1.17. This should be removed for versions > 0.21.2.
-	( fetchpatch {
-	  url = "https://github.com/scikit-learn/scikit-learn/commit/b730befc821caec5b984d9ff3aa7bc4bd7f4d9bb.patch";
-	  sha256 = "0z36m05mv6d494qwq0688rgwa7c4bbnm5s2rcjlrp29fwn3fy1bv";
-	})
-  ];
 
   LC_ALL="en_US.UTF-8";
 


### PR DESCRIPTION
###### Motivation for this change

Surprisingly to me, `scikitlearn` hasn't been updated since November. Since I couldn't find a reason for that, here's the update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
