### PR TITLE
fatsort: 1.5.0.456 -> 1.6.2.605

### DIFF
--- a/pkgs/tools/filesystems/fatsort/default.nix
+++ b/pkgs/tools/filesystems/fatsort/default.nix
@@ -1,17 +1,19 @@
 {stdenv, fetchurl, help2man}:
 
 stdenv.mkDerivation rec {
-  version = "1.5.0.456";
+  version = "1.6.2.605";
   pname = "fatsort";
 
   src = fetchurl {
     url = "mirror://sourceforge/fatsort/${pname}-${version}.tar.xz";
-    sha256 = "15fy2m4p9s8cfvnzdcd5ynkc2js0zklkkf34sjxdac7x2iwb8dd8";
+    sha256 = "1dzzsl3a1ampari424vxkma0i87qkbgkgm2169x9xf3az0vgmjh8";
   };
 
   patches = [ ./fatsort-Makefiles.patch ];
 
   buildInputs = [ help2man ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   meta = with stdenv.lib; {
     homepage = "http://fatsort.sourceforge.net/";

--- a/pkgs/tools/filesystems/fatsort/fatsort-Makefiles.patch
+++ b/pkgs/tools/filesystems/fatsort/fatsort-Makefiles.patch
@@ -1,31 +1,34 @@
-diff -uNr fatsort-1.3.365-a/Makefile fatsort-1.3.365-b/Makefile
---- fatsort-1.3.365-a/Makefile	2014-04-08 19:19:36.000000000 +0100
-+++ fatsort-1.3.365-b/Makefile	2014-12-14 18:31:55.982857720 +0000
+diff -uNr fatsort-1.6.2.605.orig/Makefile fatsort-1.6.2.605.new/Makefile
+--- fatsort-1.6.2.605.orig/Makefile	2019-11-16 16:40:27.000000000 +0100
++++ fatsort-1.6.2.605.new/Makefile	2020-05-10 21:34:34.820874026 +0200
 @@ -1,4 +1,5 @@
 -MANDIR=/usr/local/share/man/man1
-+PREFIX=$(out)
++PREFIX?=/usr/local
 +MANDIR=$(PREFIX)/share/man/man1
  
  INSTALL_FLAGS=-m 0755 -p -D
  
-diff -uNr fatsort-1.3.365-a/src/Makefile fatsort-1.3.365-b/src/Makefile
---- fatsort-1.3.365-a/src/Makefile	2014-04-08 19:19:36.000000000 +0100
-+++ fatsort-1.3.365-b/src/Makefile	2014-12-14 18:32:08.282870461 +0000
-@@ -1,3 +1,5 @@
-+PREFIX=$(out)
-+
- CC=gcc
- LD=gcc
- 
-@@ -33,9 +35,9 @@
- 
- # Mac OS X does not have a "/usr/local/sbin"
- ifeq ($(UNAME),Darwin)
--SBINDIR=/usr/local/bin
-+SBINDIR=$(PREFIX)/bin
+diff -uNr fatsort-1.6.2.605.orig/src/Makefile fatsort-1.6.2.605.new/src/Makefile
+--- fatsort-1.6.2.605.orig/src/Makefile	2018-11-17 00:40:59.000000000 +0100
++++ fatsort-1.6.2.605.new/src/Makefile	2020-05-10 21:33:52.053391027 +0200
+@@ -30,7 +30,7 @@
+ 		override CFLAGS += -D __CYGWIN__
+ 		override CFLAGS += -D __LINUX__
+ 		override LDFLAGS += -liconv
+-		SBINDIR=/usr/local/sbin
++		SBINDIR=$(PREFIX)/sbin
+ 	endif
  else
--SBINDIR=/usr/local/sbin
-+SBINDIR=$(PREFIX)/sbin
+ 	ifdef MINGW
+@@ -60,9 +60,9 @@
+ 			# OS X's install does not support the '-D' flag.
+ 			INSTALL_FLAGS=-m 0755 -p
+ 			# Mac OS X does not have a "/usr/local/sbin"
+-			SBINDIR=/usr/local/bin
++			SBINDIR=$(PREFIX)/bin
+ 		else
+-			SBINDIR=/usr/local/sbin
++			SBINDIR=$(PREFIX)/sbin
+ 		endif
+ 	endif
  endif
- 
- OBJ=fatsort.o FAT_fs.o fileio.o endianness.o signal.o entrylist.o errors.o options.o clusterchain.o sort.o misc.o natstrcmp.o stringlist.o


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
New version.

The patch to set PREFIX needed updating to apply. Rewrite it in a way
that allows submitting upstream. That means we don't hardcode
PREFIX=$out inside the patch but allow the PREFIX to be passed to make
at build time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
