### PR TITLE
cudd: init at 3.0.0

### DIFF
--- a/pkgs/development/libraries/cudd/cudd.patch
+++ b/pkgs/development/libraries/cudd/cudd.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile.am b/Makefile.am
+index 45f216a..39c3c82 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -3,6 +3,9 @@ ACLOCAL_AMFLAGS = -I m4
+ include_HEADERS = cudd/cudd.h
+ if DDDMP
+ include_HEADERS += dddmp/dddmp.h
++include_HEADERS += util/util.h
++include_HEADERS += config.h
++include_HEADERS += mtr/mtr.h
+ endif
+ if OBJ
+ include_HEADERS += cplusplus/cuddObj.hh

--- a/pkgs/development/libraries/cudd/default.nix
+++ b/pkgs/development/libraries/cudd/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "cudd";
+  version = "3.0.0";
+
+  src = fetchurl {
+    url = "https://davidkebo.com/source/cudd_versions/cudd-3.0.0.tar.gz";
+    sha256 = "0sgbgv7ljfr0lwwwrb9wsnav7mw7jmr3k8mygwza15icass6dsdq";
+  };
+
+  configureFlags = [
+    "--enable-dddmp"
+    "--enable-obj"
+  ];
+
+  patches = [
+    ./cudd.patch
+  ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://davidkebo.com/cudd";
+    description = "Binary Decision Diagram (BDD) library";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ chessai ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -881,6 +881,8 @@ in
 
   crc32c = callPackage ../development/libraries/crc32c { };
 
+  cudd = callPackage ../development/libraries/cudd { };
+
   cue = callPackage ../development/tools/cue { };
 
   deltachat-electron = callPackage


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
