### PR TITLE
[20.03] vimUtils.vimrcFile: Backport fix packpath order

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -330,9 +330,8 @@ let
         );
       in
       ''
-        set packpath-=~/.vim/after
-        set packpath+=${packDir packages}
-        set packpath+=~/.vim/after
+        set packpath^=${packDir packages}
+        set runtimepath^=${packDir packages}
 
         filetype indent plugin on | syn on
       '');


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This is the backport of #78385. The comments of that PR said it should be backported. Sadly that never happened.

This broke e.g. haskell-vim syntax-highlighting when people upgraded from 19.09 to 20.03.
See: https://github.com/neovimhaskell/haskell-vim/issues/111

My guess is that the problem was introduced into master around 8dccb59bacef6ae1abc2725955aa3296c6160d2a from january. I could be wrong about that, but it definitely worked on 19.09.

So this was broken only for a few weeks. Sadly exactly when the branch-off happened.

@Mic92 @megheaiulian @jonringer 

cc: @emptyflask 