### PR TITLE
vtk: 7.1.1 -> 8.2.0

### DIFF
--- a/pkgs/applications/science/biology/ants/default.nix
+++ b/pkgs/applications/science/biology/ants/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, makeWrapper, itk4, vtk }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, makeWrapper, itk4, vtk_7 }:
 
 stdenv.mkDerivation rec {
   pname    = "ANTs";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake makeWrapper ];
-  buildInputs = [ itk4 vtk ];
+  buildInputs = [ itk4 vtk_7 ];
 
   cmakeFlags = [ "-DANTS_SUPERBUILD=FALSE" "-DUSE_VTK=TRUE" ];
 

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, vtk, darwin }:
+{ stdenv, fetchurl, cmake, vtk_7, darwin }:
 
 stdenv.mkDerivation rec {
   version = "3.0.5";
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
-  buildInputs = [ cmake vtk ] ++ stdenv.lib.optional stdenv.isDarwin [ darwin.apple_sdk.frameworks.ApplicationServices darwin.apple_sdk.frameworks.Cocoa ];
+  buildInputs = [ cmake vtk_7 ] ++ stdenv.lib.optional stdenv.isDarwin [ darwin.apple_sdk.frameworks.ApplicationServices darwin.apple_sdk.frameworks.Cocoa ];
   propagatedBuildInputs = [ ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/itk/4.x.nix
+++ b/pkgs/development/libraries/itk/4.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, libX11, libuuid, xz, vtk }:
+{ stdenv, fetchurl, cmake, libX11, libuuid, xz, vtk_7 }:
 
 stdenv.mkDerivation rec {
   name = "itk-4.13.2";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ cmake xz ];
-  buildInputs = [ libX11 libuuid vtk ];
+  buildInputs = [ libX11 libuuid vtk_7 ];
 
   meta = {
     description = "Insight Segmentation and Registration Toolkit";

--- a/pkgs/development/libraries/itk/default.nix
+++ b/pkgs/development/libraries/itk/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, makeWrapper
-, pkgconfig, libX11, libuuid, xz, vtk, Cocoa }:
+, pkgconfig, libX11, libuuid, xz, vtk_7, Cocoa }:
 
 stdenv.mkDerivation rec {
   pname = "itk";
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ cmake xz makeWrapper ];
-  buildInputs = [ libX11 libuuid vtk ] ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa ];
+  buildInputs = [ libX11 libuuid vtk_7 ] ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa ];
 
   postInstall = ''
     wrapProgram "$out/bin/h5c++" --prefix PATH ":" "${pkgconfig}/bin"

--- a/pkgs/development/libraries/vtk/7.x.nix
+++ b/pkgs/development/libraries/vtk/7.x.nix
@@ -10,8 +10,8 @@ with stdenv.lib;
 
 let
   os = stdenv.lib.optionalString;
-  majorVersion = "8.2";
-  minorVersion = "0";
+  majorVersion = "7.1";
+  minorVersion = "1";
   version = "${majorVersion}.${minorVersion}";
 in
 
@@ -19,13 +19,20 @@ stdenv.mkDerivation rec {
   name = "vtk-${os (qtLib != null) "qvtk-"}${version}";
   src = fetchurl {
     url = "${meta.homepage}files/release/${majorVersion}/VTK-${version}.tar.gz";
-    sha256 = "1fspgp8k0myr6p2a6wkc21ldcswb4bvmb484m12mxgk1a9vxrhrl";
+    sha256 = "0nm7xwwj7rnsxjdv2ssviys8nhci4n9iiiqm2y14s520hl2dsp1d";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://gitlab.kitware.com/vtk/vtk/-/commit/706f1b397df09a27ab8981ab9464547028d0c322.diff";
+      sha256 = "1q3pi5h40g05pzpbqp75xlgzvbfvyw8raza51svmi7d8dlslqybx";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ libtiff ]
-    ++ optionals (qtLib != null) (with qtLib; [ qtbase qtx11extras qttools ])
+    ++ optional (qtLib != null) qtLib
     ++ optionals stdenv.isLinux [ libGLU libGL libX11 xorgproto libXt ]
     ++ optionals stdenv.isDarwin [ xpc Cocoa CoreServices DiskArbitration IOKit
                                    CFNetwork Security ApplicationServices CoreText

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14872,6 +14872,14 @@ in
   vte_290 = callPackage ../development/libraries/vte/2.90.nix { };
 
   vtk = callPackage ../development/libraries/vtk {
+    inherit (darwin) libobjc;
+    inherit (darwin.apple_sdk.libs) xpc;
+    inherit (darwin.apple_sdk.frameworks) Cocoa CoreServices DiskArbitration
+                                          IOKit CFNetwork Security ApplicationServices
+                                          CoreText IOSurface ImageIO OpenGL GLUT;
+  };
+
+  vtk_7 = callPackage ../development/libraries/vtk/7.x.nix {
     stdenv = if stdenv.isDarwin then stdenv else gcc8Stdenv;
     inherit (darwin) libobjc;
     inherit (darwin.apple_sdk.libs) xpc;
@@ -14911,7 +14919,7 @@ in
     });
   };
 
-  vtkWithQt4 = vtk.override { qtLib = qt4; };
+  vtkWithQt5 = vtk.override { qtLib = qt5; };
 
   vxl = callPackage ../development/libraries/vxl {
     libpng = libpng12;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7061,7 +7061,7 @@ in {
 
   visitor = callPackage ../development/python-modules/visitor { };
 
-  vtk = toPythonModule (pkgs.vtk.override {
+  vtk = toPythonModule (pkgs.vtk_7.override {
     inherit (self) python;
     enablePython = true;
   });


### PR DESCRIPTION
- also create vtk_7 as several packages don't build with 8.x:
  - itk5: vtkVersion.h header not found at compile time
  - ants: version in tree (2.2.0) is incompatible with 8.2
  - itk4: ants depends on both vtk and itk4, so use vtk_7
  - gdcm: vtk header issue
  - python3Packages.vtk: Python C API compilation error with Python 3.8

- upgrade vtkWithQt4 -> vtkWithQt5

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

VTK 9 is out and some packages (e.g., Fury, not yet in Nixpkgs) now require 8 or higher.

Resolves #49531.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
4 package marked as broken and skipped:
linuxPackages_hardkernel_4_14.r8125 linuxPackages_hardkernel_4_14.r8168 qes smimesign

13 package built:
cq-editor freecad mirtk opencascade pcl python27Packages.pythonocc-core python37Packages.cadquery python37Packages.pythonocc-core python38Packages.pythonocc-core smesh vtk vtk7 vtkWithQt5
```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
