### PR TITLE
libfm: fix duplicate inclusion of libfm-extra

### DIFF
--- a/pkgs/development/libraries/libfm/default.nix
+++ b/pkgs/development/libraries/libfm/default.nix
@@ -28,6 +28,11 @@ stdenv.mkDerivation rec {
     "sysconfdir=${placeholder "out"}/etc"
   ];
 
+  # libfm-extra is pulled in by menu-cache and thus leads to a collision for libfm
+  postInstall = optional (!extraOnly) ''
+     rm $out/lib/libfm-extra.so $out/lib/libfm-extra.so.* $out/lib/libfm-extra.la $out/lib/pkgconfig/libfm-extra.pc
+  '';
+
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`libfm-extra` is pulled in implicitly when `libfm` is built. Remove duplicate files.

```
collision between `/nix/store/cas1jifhs1k2hdrs3mczpfs67x8f9wjf-libfm-extra-1.3.1/lib/libfm-extra.so' and `/nix/store/k88h4xr33adf9kw12pfjgp6lwnr4wxyr-libfm-1.3.1/lib/libfm-extra.so'
collision between `/nix/store/cas1jifhs1k2hdrs3mczpfs67x8f9wjf-libfm-extra-1.3.1/lib/libfm-extra.la' and `/nix/store/k88h4xr33adf9kw12pfjgp6lwnr4wxyr-libfm-1.3.1/lib/libfm-extra.la'
collision between `/nix/store/cas1jifhs1k2hdrs3mczpfs67x8f9wjf-libfm-extra-1.3.1/lib/libfm-extra.so.4.1.2' and `/nix/store/k88h4xr33adf9kw12pfjgp6lwnr4wxyr-libfm-1.3.1/lib/libfm-extra.so.4.1.2'
collision between `/nix/store/cas1jifhs1k2hdrs3mczpfs67x8f9wjf-libfm-extra-1.3.1/lib/libfm-extra.so.4' and `/nix/store/k88h4xr33adf9kw12pfjgp6lwnr4wxyr-libfm-1.3.1/lib/libfm-extra.so.4'
collision between `/nix/store/cas1jifhs1k2hdrs3mczpfs67x8f9wjf-libfm-extra-1.3.1/lib/pkgconfig/libfm-extra.pc' and `/nix/store/k88h4xr33adf9kw12pfjgp6lwnr4wxyr-libfm-1.3.1/lib/pkgconfig/libfm-extra.pc'

nix why-depends nixpkgs.pcmanfm nixpkgs.libfm-extra
/nix/store/ccs0xsvqhiishcd0acs2plikci1fcz2g-pcmanfm-1.3.1
╚═══bin/.pcmanfm-wrapped: …p-harfbuzz-2.6.4/lib:/nix/store/pm5k7dx68jwpbv0cv4wzk3zcika0x2pj-libfm-1.3.1/lib:/nix/store/9hy6…
    => /nix/store/pm5k7dx68jwpbv0cv4wzk3zcika0x2pj-libfm-1.3.1
    ╚═══bin/libfm-pref-apps: …p-harfbuzz-2.6.4/lib:/nix/store/8ls43gqsslh8ky0qr524cnwy7wwh9zbi-menu-cache-1.1.0/lib:/nix/store…
        => /nix/store/8ls43gqsslh8ky0qr524cnwy7wwh9zbi-menu-cache-1.1.0
        ╚═══libexec/menu-cache/menu-cache-gen: …LIBC_2.7.GLIBC_2.3.4./nix/store/cas1jifhs1k2hdrs3mczpfs67x8f9wjf-libfm-extra-1.3.1/lib:/nix/stor…
            => /nix/store/cas1jifhs1k2hdrs3mczpfs67x8f9wjf-libfm-extra-1.3.1
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [X] compiled and tested pcmanfm
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after) 
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
