### PR TITLE
j: add avxSupport option

### DIFF
--- a/pkgs/development/interpreters/j/default.nix
+++ b/pkgs/development/interpreters/j/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, readline, libedit, bc }:
+{ stdenv, fetchFromGitHub, readline, libedit, bc
+, avxSupport ? false
+}:
 
 stdenv.mkDerivation rec {
   pname = "j";
@@ -19,6 +21,9 @@ stdenv.mkDerivation rec {
     if stdenv.isLinux then "linux" else
     if stdenv.isDarwin then "darwin" else
     "unknown";
+  variant = if stdenv.isx86_64 && avxSupport then "avx" else "";
+
+  j64x="j${bits}${variant}";
 
   doCheck = true;
 
@@ -34,7 +39,7 @@ stdenv.mkDerivation rec {
     patchShebangs .
     sed -i $JLIB/bin/profile.ijs -e "s@'/usr/share/j/.*'@'$out/share/j'@;"
 
-    ./build_all.sh
+    j64x="${j64x}" ./build_all.sh
 
     cp $SOURCE_DIR/bin/${platform}/j${bits}*/* "$JLIB/bin"
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->
Adds an `avxSupport` option to the J package.  For now I've set this to default to `false` since that matches the behaviour prior to this change, and J does seem like the kind of package where you might want AVX support out of the box.  

Personally, I think I'd prefer defaulting to `false` and requiring opt-in for AVX support so that the default build works more widely across machines, but it's not really something I feel strongly about either way.

###### Motivation for this change
Package wouldn't build as-is on non-AVX x86-64 systems.  As is currently, it still doesn't build out of the box, but you can at least straightforwardly set `avxSupport = false` instead of having to override the build step.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
