### PR TITLE
poezio: add setuptools as propagatedBuildInput

### DIFF
--- a/pkgs/applications/networking/instant-messengers/poezio/default.nix
+++ b/pkgs/applications/networking/instant-messengers/poezio/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonApplication, fetchFromGitHub, pythonOlder
-, pytest, aiodns, slixmpp, pyinotify, potr, mpd2, cffi, pkgconfig }:
+, pytest, aiodns, slixmpp, pyinotify, potr, mpd2, cffi, pkgconfig, setuptools }:
 buildPythonApplication rec {
     pname = "poezio";
     version = "0.12.1";
@@ -7,7 +7,7 @@ buildPythonApplication rec {
     disabled = pythonOlder "3.4";
 
     checkInputs = [ pytest ];
-    propagatedBuildInputs = [ aiodns slixmpp pyinotify potr mpd2 cffi ];
+    propagatedBuildInputs = [ aiodns slixmpp pyinotify potr mpd2 cffi setuptools ];
     nativeBuildInputs = [ pkgconfig ];
 
     src = fetchFromGitHub {


### PR DESCRIPTION
This unbreaks the otherwise-broken package (setuptools is needed for importing pkg_resources).

Presumably this change should also be backported to the 20.03 release--I could add a PR to that branch as well, but figure it's best to sort out a merge to master first.

###### Motivation for this change
Unbreaking broken package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
