### PR TITLE
Add python packages: pyensembl and its dependencies, gffutils, pyBigWig

### DIFF
--- a/nixos/modules/services/x11/window-managers/exwm.nix
+++ b/nixos/modules/services/x11/window-managers/exwm.nix
@@ -5,7 +5,7 @@ with lib;
 let
   cfg = config.services.xserver.windowManager.exwm;
   loadScript = pkgs.writeText "emacs-exwm-load" ''
-    (require 'exwm)
+    ${cfg.loadScript}
     ${optionalString cfg.enableDefaultConfig ''
       (require 'exwm-config)
       (exwm-config-default)
@@ -19,6 +19,18 @@ in
   options = {
     services.xserver.windowManager.exwm = {
       enable = mkEnableOption "exwm";
+      loadScript = mkOption {
+        default = "(require 'exwm)";
+        example = literalExample ''
+          (require 'exwm)
+          (exwm-enable)
+        '';
+        description = ''
+          Emacs lisp code to be run after loading the user's init
+          file. If enableDefaultConfig is true, this will be run
+          before loading the default config.
+        '';
+      };
       enableDefaultConfig = mkOption {
         default = true;
         type = lib.types.bool;

--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -110,6 +110,27 @@
   org-mac-link =
     callPackage ./org-mac-link { };
 
+  org-roam = melpaBuild rec {
+    pname = "org-roam";
+    version = "0.1.1";
+    src = pkgs.fetchFromGitHub {
+      owner = "jethrokuan";
+      repo = "org-roam";
+      rev = "v${version}";
+      sha256 = "0srbqx6i21qdb9cn2cx5fk8a4477xflfx0ybfbx95rwcciz20zn6";
+    };
+    recipe = pkgs.writeText "recipe" ''
+      (org-roam
+       :repo "jethrokuan/org-roam"
+       :fetcher github
+       :files ("*.el"))
+    '';
+    packageRequires = [ dash f s async ];
+    meta = {
+      license = gpl3;
+    };
+  };
+
   perl-completion =
     callPackage ./perl-completion { };
 

--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -112,12 +112,12 @@
 
   org-roam = melpaBuild rec {
     pname = "org-roam";
-    version = "0.1.1";
+    version = "0.1.2";
     src = pkgs.fetchFromGitHub {
       owner = "jethrokuan";
       repo = "org-roam";
       rev = "v${version}";
-      sha256 = "0srbqx6i21qdb9cn2cx5fk8a4477xflfx0ybfbx95rwcciz20zn6";
+      sha256 = "1p8bhj09s0iyb3fcjibsl1p61wiac17sn1w7hwm1wqrcydj8h8hx";
     };
     recipe = pkgs.writeText "recipe" ''
       (org-roam

--- a/pkgs/development/python-modules/datacache/default.nix
+++ b/pkgs/development/python-modules/datacache/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pandas, appdirs, progressbar33, requests, typechecks, nose, mock}:
+
+buildPythonPackage rec {
+  version = "1.1.5";
+  pname = "datacache";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b2ca31b2b9d3803a49645ab4f5b30fdd0820e833a81a6952b4ec3a68c8ee24a7";
+  };
+
+  checkInputs = [ ];
+  propagatedBuildInputs = [ pandas appdirs progressbar33 requests typechecks nose mock ];
+
+  checkPhase = ''
+  '';
+
+  # Tests require extra dependencies
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/openvax/datacache";
+    description = "Helpers for transparently downloading datasets";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/gffutils/default.nix
+++ b/pkgs/development/python-modules/gffutils/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pyfaidx, six, argh, argcomplete, simplejson }:
+buildPythonPackage rec {
+  version = "0.10.1";
+  pname = "gffutils";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a8fc39006d7aa353147238160640e2210b168f7849cb99896be3fc9441e351cb";
+  };
+
+  checkInputs = [ ];
+  propagatedBuildInputs = [ pyfaidx six argh argcomplete simplejson ];
+
+  checkPhase = ''
+  '';
+
+  # Tests require extra dependencies
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/daler/gffutils";
+    description = "GFF and GTF file manipulation and interconversion http://daler.github.io/gffutils";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/gtfparse/default.nix
+++ b/pkgs/development/python-modules/gtfparse/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, numpy, pandas }:
+
+buildPythonPackage rec {
+  version = "1.2.0";
+  pname = "gtfparse";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2f27aa2b87eb43d613edabf27f9c11147dc595c8683b440ac1d88e9acdb85873";
+  };
+
+  checkInputs = [ ];
+  propagatedBuildInputs = [ numpy pandas];
+
+  checkPhase = ''
+  '';
+
+  # Tests require extra dependencies
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/openvax/gtfparse";
+    description = " Parsing tools for GTF (gene transfer format) files ";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/memoized-property/default.nix
+++ b/pkgs/development/python-modules/memoized-property/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  version = "1.0.3";
+  pname = "memoized-property";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4be4d0209944b9b9b678dae9d7e312249fe2e6fb8bdc9bdaa1da4de324f0fcf5";
+  };
+
+  checkInputs = [ ];
+  propagatedBuildInputs = [ ];
+
+  checkPhase = ''
+  '';
+
+  # Tests require extra dependencies
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/estebistec/python-memoized-property";
+    description = "A simple python decorator for defining properties that only run their fget function once ";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/pyBigWig/default.nix
+++ b/pkgs/development/python-modules/pyBigWig/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi, numpy, pytest, zlib }:
+buildPythonPackage rec {
+  version = "0.3.17";
+  pname = "pyBigWig";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "41f64f802689ed72e15296a21a4b7abd3904780b2e4f8146fd29098fc836fd94";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ numpy zlib ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  # Tests require extra dependencies
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/deeptools/pyBigWig";
+    description = "A python extension for quick access to bigWig and bigBed files";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/pybedtools/default.nix
+++ b/pkgs/development/python-modules/pybedtools/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchPypi, numpy, pandas, pysam, six,
+  pytest, numpydoc, pathlib, psutil, pyyaml, sphinx, zlib
+}:
+buildPythonPackage rec {
+  version = "0.8.1";
+  pname = "pybedtools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c035e078617f94720eb627e20c91f2377a7bd9158a137872a6ac88f800898593";
+  };
+
+  checkInputs = [ pytest numpydoc pathlib psutil pyyaml sphinx ];
+  propagatedBuildInputs = [ numpy pandas pysam six zlib ];
+
+  checkPhase = ''
+    pytest -v -doctest-modules
+  '';
+
+  # Tests require extra dependencies
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/daler/pybedtools";
+    description = "Python wrapper -- and more -- for Aaron Quinlan's BEDTools (bioinformatics tools) http://daler.github.io/pybedtools";
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/development/python-modules/pyensembl/default.nix
+++ b/pkgs/development/python-modules/pyensembl/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, numpy, pandas, datacache, six, memoized-property, gtfparse, serializable, tinytimer, setuptools }:
+
+buildPythonPackage rec {
+  version = "1.8.5";
+  pname = "pyensembl";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "13dd05aba296e4acadb14de5a974e6f73834452851a36b9237917ae85b3e060f";
+  };
+
+  checkInputs = [ ];
+  propagatedBuildInputs = [ numpy pandas datacache six memoized-property gtfparse serializable tinytimer serializable ];
+
+  checkPhase = ''
+  '';
+
+  # Tests require extra dependencies
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/openvax/pyensembl";
+    description = " Python interface to access reference genome features (such as genes, transcripts, and exons) from Ensembl ";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/scikit-plot/default.nix
+++ b/pkgs/development/python-modules/scikit-plot/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, matplotlib
+, scipy
+, scikitlearn
+, joblib
+, pytest
+, python
+}:
+
+buildPythonPackage rec {
+  version = "0.3.7";
+  pname = "scikit-plot";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2c7948817fd2dc06879cfe3c1fdde56a8e71fa5ac626ffbe79f043650baa6242";
+  };
+
+  buildInputs = [  ];
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ matplotlib scikitlearn scipy joblib ];
+
+  doCheck = false;
+
+  checkPhase = ''
+    pytest scikitplot/tests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/reiinakano/scikit-plot";
+    description = "An intuitive library to add plotting functionality to scikit-learn objects. ";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/serializable/default.nix
+++ b/pkgs/development/python-modules/serializable/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi,
+typechecks, six, simplejson}:
+buildPythonPackage rec {
+  version = "0.2.1";
+  pname = "serializable";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ec604e5df0c1236c06d190043a407495c4412dd6b6fd3b45a8514518173ed961";
+  };
+
+  checkInputs = [ ];
+  propagatedBuildInputs = [ typechecks six simplejson ];
+
+  checkPhase = ''
+  '';
+
+  # Tests require extra dependencies
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/iskandr/serializable";
+    description = "Base class with serialization methods for user-defined Python objects";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/tinytimer/default.nix
+++ b/pkgs/development/python-modules/tinytimer/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  version = "0.0.0";
+  pname = "tinytimer";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6ad13c8f01ab6094e58081a5367ffc4c5831f2d6b29034d2434d8ae106308fa5";
+  };
+
+  checkInputs = [ ];
+  propagatedBuildInputs = [ ];
+
+  checkPhase = ''
+  '';
+
+  # Tests require extra dependencies
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/iskandr/tinytimer";
+    description = "Tiny Python benchmarking library";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/typechecks/default.nix
+++ b/pkgs/development/python-modules/typechecks/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  version = "0.1.0";
+  pname = "typechecks";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7d801a6018f60d2a10aa3debc3af65f590c96c455de67159f39b9b183107c83b";
+  };
+
+  checkInputs = [ ];
+  propagatedBuildInputs = [ ];
+
+  checkPhase = ''
+  '';
+
+  # Tests require extra dependencies
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/openvax/typechecks";
+    description = "Helper functions for runtime type checking";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7362,6 +7362,8 @@ in {
   scikit-plot = callPackage ../development/python-modules/scikit-plot { };
 
   pybedtools = callPackage ../development/python-modules/pybedtools { };
+
+  pyBigWig = callPackage ../development/python-modules/pyBigWig { };
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7343,6 +7343,19 @@ in {
 
   rxv     = callPackage ../development/python-modules/rxv     { };
 
+  typechecks = callPackage ../development/python-modules/typechecks { };
+
+  datacache = callPackage ../development/python-modules/datacache { };
+
+  memoized-property = callPackage ../development/python-modules/memoized-property { };
+
+  gtfparse = callPackage ../development/python-modules/gtfparse { };
+
+  serializable = callPackage ../development/python-modules/serializable { };
+
+  tinytimer = callPackage ../development/python-modules/tinytimer { };
+
+  pyensembl = callPackage ../development/python-modules/pyensembl { };
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7358,6 +7358,8 @@ in {
   pyensembl = callPackage ../development/python-modules/pyensembl { };
 
   gffutils = callPackage ../development/python-modules/gffutils { };
+
+  scikit-plot = callPackage ../development/python-modules/scikit-plot { };
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7360,6 +7360,8 @@ in {
   gffutils = callPackage ../development/python-modules/gffutils { };
 
   scikit-plot = callPackage ../development/python-modules/scikit-plot { };
+
+  pybedtools = callPackage ../development/python-modules/pybedtools { };
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7356,6 +7356,8 @@ in {
   tinytimer = callPackage ../development/python-modules/tinytimer { };
 
   pyensembl = callPackage ../development/python-modules/pyensembl { };
+
+  gffutils = callPackage ../development/python-modules/gffutils { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
##### Motivation for this change

Both pyenseml and gffutils are commonly used python packages (> 100 stars on GitHub), so I added them to nix packages. 

###### Things done

- Built on platform(s)
   - [x] NixOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (only pyensembl has a supplemental binary)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [-] Mostly Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md). I designed the derivations 1:1 to existing ones. 
