### PR TITLE
cargo-tarpaulin: init at 0.12.4

### DIFF
--- a/pkgs/development/tools/analysis/cargo-tarpaulin/default.nix
+++ b/pkgs/development/tools/analysis/cargo-tarpaulin/default.nix
@@ -1,0 +1,30 @@
+{ lib, pkgconfig, rustPlatform, fetchFromGitHub, openssl }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-tarpaulin";
+  version = "0.12.4";
+
+  src = fetchFromGitHub {
+    owner = "xd009642";
+    repo = "tarpaulin";
+    rev = "${version}";
+    sha256 = "0y58800n61s8wmpcpgw5vpywznwwbp0d30fz2z0kjx4mpwmva4g4";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+  buildInputs = [ openssl ];
+
+  cargoSha256 = "12hkzq2xn4g5k94kjirjnnz4dddqg7akxnp3qyfkz092vvp25k9z";
+  #checkFlags = [ "--test-threads" "1" ];
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A code coverage tool for Rust projects";
+    homepage = "https://github.com/xd009642/tarpaulin";
+    license = with licenses; [ mit /* or */ asl20 ];
+    maintainers = with maintainers; [ hugoreeves ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9115,6 +9115,7 @@ in
   cargo-release = callPackage ../tools/package-management/cargo-release {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  cargo-tarpaulin = callPackage ../development/tools/analysis/cargo-tarpaulin { };
   cargo-tree = callPackage ../tools/package-management/cargo-tree { };
   cargo-update = callPackage ../tools/package-management/cargo-update { };
 


### PR DESCRIPTION
###### Motivation for this change

Init [cargo-tarpaulin](https://github.com/xd009642/tarpaulin). Tarpaulin is used to calculate line based code coverage of Rust projects. It's a tool in use by multiple prominent rust projects.
Builds and executes successfully on NixOS.
Currently, the cargo test step for the derivation is disabled. `checkPhase = null`. Some of the tests were failing, I believe this issue is due to the incorrect tests being run. It would be appreciated if someone familiar with the nixpkgs rustPlatform could suggest a way to fix this issue with the derivation build.
The result of the build still functions properly, however it would be nice to enable tests so that future updates can be tested thoroughly.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
