### PR TITLE
nix-build-uncached: init at 0.1.1

### DIFF
--- a/pkgs/development/tools/misc/nix-build-uncached/default.nix
+++ b/pkgs/development/tools/misc/nix-build-uncached/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoModule, fetchFromGitHub, nix, makeWrapper }:
+
+buildGoModule rec {
+  pname = "nix-build-uncached";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "nix-build-uncached";
+    rev = "v${version}";
+    sha256 = "0jkpg3ab56lg2kdms9w9ka9ba89py3ajksjsi1rd3iqi74zz2mmh";
+  };
+
+  goPackagePath = "github.com/Mic92/nix-build-uncached";
+  vendorSha256 = null;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/nix-build-uncached \
+      --prefix PATH ":" ${lib.makeBinPath [ nix ]}
+  '';
+
+  meta = with lib; {
+    description = "A CI friendly wrapper around nix-build";
+    license = licenses.mit;
+    homepage = "https://github.com/Mic92/nix-build-uncached";
+    maintainers = [ maintainers.mic92 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10668,6 +10668,8 @@ in
     pythonPackages = python3Packages;
   };
 
+  nix-build-uncached = callPackage ../development/tools/misc/nix-build-uncached { };
+
   nexus = callPackage ../development/tools/repository-managers/nexus { };
 
   nwjs = callPackage ../development/tools/nwjs {


### PR DESCRIPTION
###### Motivation for this change

`nix-build-uncached` is "A CI friendly wrapper around nix-build."

cc: @Mic92

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
