### PR TITLE
ocamlPackages.ocurl: 0.9.0 → 0.9.1

### DIFF
--- a/pkgs/development/ocaml-modules/ocurl/default.nix
+++ b/pkgs/development/ocaml-modules/ocurl/default.nix
@@ -5,10 +5,10 @@ then throw "ocurl is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  name = "ocurl-0.9.0";
+  name = "ocurl-0.9.1";
   src = fetchurl {
     url = "http://ygrek.org.ua/p/release/ocurl/${name}.tar.gz";
-    sha256 = "0v5qzfazaynjv1xy3ds2z5iz0np5mz8g831l91l1mrqz6fr1ah0f";
+    sha256 = "0n621cxb9012pj280c7821qqsdhypj8qy9qgrah79dkh6a8h2py6";
   };
 
   buildInputs = [ pkgconfig ocaml findlib ncurses ];


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.10

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
