### PR TITLE
stdenv-darwin: now with 50% less LLVM!

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -307,7 +307,7 @@ in rec {
       inherit
         gnumake gzip gnused bzip2 gawk ed xz patch bash python3
         ncurses libffi zlib gmp pcre gnugrep
-        coreutils findutils diffutils patchutils ninja;
+        coreutils findutils diffutils patchutils ninja libxml2;
 
       # Hack to make sure we don't link ncurses in bootstrap tools. The proper
       # solution is to avoid passing -L/nix-store/...-bootstrap-tools/lib,
@@ -321,7 +321,7 @@ in rec {
       llvmPackages_7 = super.llvmPackages_7 // (let
         tools = super.llvmPackages_7.tools.extend (llvmSelf: _: {
           clang-unwrapped = llvmPackages_7.clang-unwrapped.override { llvm = llvmSelf.llvm; };
-          llvm = llvmPackages_7.llvm.override { libxml2 = self.darwin.libxml2-nopython; };
+          llvm = llvmPackages_7.llvm.override { inherit libxml2; };
         });
         libraries = super.llvmPackages_7.libraries.extend (llvmSelf: _: {
           inherit (llvmPackages_7) libcxx libcxxabi compiler-rt;
@@ -332,9 +332,8 @@ in rec {
         inherit (darwin) dyld Libsystem libiconv locale;
 
         cctools = super.darwin.cctools.override { enableTapiSupport = false; };
-        libxml2-nopython = super.libxml2.override { pythonSupport = false; };
         CF = super.darwin.CF.override {
-          libxml2 = libxml2-nopython;
+          inherit libxml2;
           python3 = prevStage.python3;
         };
       };
@@ -419,9 +418,9 @@ in rec {
       gnugrep llvmPackages.clang-unwrapped llvmPackages.clang-unwrapped.lib patch pcre.out gettext
       binutils.bintools darwin.binutils darwin.binutils.bintools
       curl.out openssl.out libssh2.out nghttp2.lib libkrb5
-      cc.expand-response-params
+      cc.expand-response-params libxml2.out
     ]) ++ (with pkgs.darwin; [
-      dyld Libsystem CF cctools ICU libiconv locale libxml2-nopython.out
+      dyld Libsystem CF cctools ICU libiconv locale
     ]);
 
     overrides = lib.composeExtensions persistent (self: super: {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

On Darwin, stdenv was building LLVM twice, with the only difference being that one used a stage 3 libxml2 and the other used one from stage 4. Unless I'm missing something (which is quite possible!), there's no reason to do this, and we can save a bunch of build time by just using the one LLVM.

I tested this by building stdenv and using it to build GNU hello, and also checked to make sure bootstrap-tools didn't end up in stdenv's closure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
