### PR TITLE
lite: init at 1.03

### DIFF
--- a/pkgs/applications/editors/lite/default.nix
+++ b/pkgs/applications/editors/lite/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, SDL2 }:
+
+stdenv.mkDerivation rec {
+  pname = "lite";
+  version = "1.03";
+
+  src = fetchFromGitHub {
+    owner = "rxi";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1h8z4fav5ns9sm92axs3k9v6jgkqq0vg9mixza14949blr426mlj";
+  };
+
+  buildInputs = [ SDL2 ];
+
+  buildPhase = "${stdenv.shell} build.sh";
+  installPhase = "install -Dm 755 lite $out/bin/lite";
+
+  meta = with stdenv.lib; {
+    description = "A lightweight text editor written in Lua";
+    homepage = "https://github.com/rxi/lite";
+    license = licenses.mit;
+    maintainers = with maintainers; [ filalex77 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19710,6 +19710,8 @@ in
 
   linssid = libsForQt5.callPackage ../applications/networking/linssid { };
 
+  lite = callPackage ../applications/editors/lite { };
+
   lollypop = callPackage ../applications/audio/lollypop { };
 
   m32edit = callPackage ../applications/audio/midas/m32edit.nix {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/rxi/lite/releases/tag/v1.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
