### PR TITLE
jgmenu: optionally install a xfce4 panel plugin

### DIFF
--- a/pkgs/applications/misc/jgmenu/default.nix
+++ b/pkgs/applications/misc/jgmenu/default.nix
@@ -37,10 +37,6 @@ stdenv.mkDerivation rec {
     python3Packages.python
   ];
 
-  makeFlags = [
-    "prefix=${placeholder "out"}"
-  ];
-
   postFixup = ''
     wrapPythonProgramsIn "$out/lib/jgmenu"
     for f in $out/bin/jgmenu{,_run}; do

--- a/pkgs/applications/misc/jgmenu/default.nix
+++ b/pkgs/applications/misc/jgmenu/default.nix
@@ -8,6 +8,9 @@
 , menu-cache
 , xorg
 , makeWrapper
+, enableXfcePanelApplet ? false
+, xfce
+, gtk3
 }:
 
 stdenv.mkDerivation rec {
@@ -35,6 +38,16 @@ stdenv.mkDerivation rec {
     xorg.libXinerama
     xorg.libXrandr
     python3Packages.python
+  ] ++ stdenv.lib.optionals enableXfcePanelApplet [
+    gtk3
+    xfce.libxfce4util
+    xfce.xfce4-panel
+  ];
+
+  configureFlags = [
+  ]
+  ++ stdenv.lib.optionals enableXfcePanelApplet [
+    "--with-xfce4-panel-applet"
   ];
 
   postFixup = ''

--- a/pkgs/applications/misc/jgmenu/default.nix
+++ b/pkgs/applications/misc/jgmenu/default.nix
@@ -1,4 +1,14 @@
-{ stdenv, fetchFromGitHub, pkgconfig, python3Packages, pango, librsvg, libxml2, menu-cache, xorg, makeWrapper }:
+{ stdenv
+, fetchFromGitHub
+, pkgconfig
+, python3Packages
+, pango
+, librsvg
+, libxml2
+, menu-cache
+, xorg
+, makeWrapper
+}:
 
 stdenv.mkDerivation rec {
   pname = "jgmenu";
@@ -27,7 +37,9 @@ stdenv.mkDerivation rec {
     python3Packages.python
   ];
 
-  makeFlags = [ "prefix=${placeholder "out"}" ];
+  makeFlags = [
+    "prefix=${placeholder "out"}"
+  ];
 
   postFixup = ''
     wrapPythonProgramsIn "$out/lib/jgmenu"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- jgmenu: format with nixpkgs-fmt

- jgmenu: no need to explicitly set prefix make flag
  - It is automatically passed to the configure script.

- jgmenu: optionally install a xfce4 panel plugin
  - It is a contrib feature.
  - Default to false.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).