### PR TITLE
arduino: 1.8.9 -> 1.8.12

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -1,22 +1,36 @@
-{ stdenv, lib, fetchFromGitHub, fetchurl, jdk, ant
-, libusb-compat-0_1, libusb1, unzip, zlib, ncurses, readline
-, withGui ? false, gtk2 ? null, withTeensyduino ? false
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchurl
+, jdk
+, ant
+, libusb-compat-0_1
+, libusb1
+, unzip
+, zlib
+, ncurses
+, readline
+, withGui ? false
+, gtk2 ? null
+, withTeensyduino ? false
   /* Packages needed for Teensyduino */
-, upx, fontconfig, xorg, gcc
-, atk, glib, pango, gdk-pixbuf, libpng12, expat, freetype
-, cairo, udev
+, upx
+, fontconfig
+, xorg
+, gcc
+, atk
+, glib
+, pango
+, gdk-pixbuf
+, libpng12
+, expat
+, freetype
+, cairo
+, udev
 }:
 
 assert withGui -> gtk2 != null;
 assert withTeensyduino -> withGui;
-
-# TODO: Teensyduino is disabled for i686-linux due to an indefinite hang in the
-# xdotool script; the cause of this hang is not yet known.
-# TODO: There is a fair chance that Teensyduino works with arm-linux, but it
-# has not yet been tested.
-if withTeensyduino && (stdenv.hostPlatform.system != "x86_64-linux") then throw
-  "Teensyduino is only supported on x86_64-linux at this time (patches welcome)."
-else
 let
   externalDownloads = import ./downloads.nix {
     inherit fetchurl;
@@ -25,12 +39,13 @@ let
   };
   # Some .so-files are later copied from .jar-s to $HOME, so patch them beforehand
   patchelfInJars =
-       lib.optional (stdenv.hostPlatform.system == "x86_64-linux") {jar = "share/arduino/lib/jssc-2.8.0-arduino3.jar"; file = "libs/linux/libjSSC-2.8_x86_64.so";}
-    ++ lib.optional (stdenv.hostPlatform.system == "i686-linux") {jar = "share/arduino/lib/jssc-2.8.0-arduino3.jar"; file = "libs/linux/libjSSC-2.8_x86.so";}
+    lib.optional (stdenv.hostPlatform.system == "aarch64-linux") { jar = "share/arduino/lib/jssc-2.8.0-arduino4.jar"; file = "libs/linux/libjSSC-2.8_aarch64.so"; }
+    ++ lib.optional (builtins.match "armv[67]l-linux" stdenv.hostPlatform.system != null) { jar = "share/arduino/lib/jssc-2.8.0-arduino4.jar"; file = "libs/linux/libjSSC-2.8_armhf.so"; }
+    ++ lib.optional (stdenv.hostPlatform.system == "x86_64-linux") { jar = "share/arduino/lib/jssc-2.8.0-arduino4.jar"; file = "libs/linux/libjSSC-2.8_x86_64.so"; }
+    ++ lib.optional (stdenv.hostPlatform.system == "i686-linux") { jar = "share/arduino/lib/jssc-2.8.0-arduino4.jar"; file = "libs/linux/libjSSC-2.8_x86.so"; }
   ;
   # abiVersion 6 is default, but we need 5 for `avrdude_bin` executable
   ncurses5 = ncurses.override { abiVersion = "5"; };
-
   teensy_libpath = stdenv.lib.makeLibraryPath [
     atk
     cairo
@@ -54,49 +69,61 @@ let
     zlib
   ];
   teensy_architecture =
-      lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") "linux64"
-      + lib.optionalString (stdenv.hostPlatform.system == "i686-linux") "linux32"
-      + lib.optionalString (stdenv.hostPlatform.system == "arm-linux") "linuxarm";
-
-  flavor = (if withTeensyduino then "teensyduino" else "arduino")
-             + stdenv.lib.optionalString (!withGui) "-core";
+    lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") "linux64"
+    + lib.optionalString (stdenv.hostPlatform.system == "i686-linux") "linux32"
+    + lib.optionalString (stdenv.hostPlatform.system == "aarch64-linux") "linuxaarch64"
+    + lib.optionalString (builtins.match "armv[67]l-linux" stdenv.hostPlatform.system != null) "linuxarm";
+  flavor = ( if withTeensyduino then "teensyduino" else "arduino")
+    + stdenv.lib.optionalString (!withGui) "-core";
 in
 stdenv.mkDerivation rec {
-  version = "1.8.9";
+  version = "1.8.12";
   name = "${flavor}-${version}";
 
   src = fetchFromGitHub {
     owner = "arduino";
     repo = "Arduino";
     rev = version;
-    sha256 = "0kblq0bqap2zzkflrj6rmdi8dvqxa28fcwwrc3lfmbz2893ni3w4";
+    sha256 = "0lxkyvsh55biz2q20ba4qabraind5cpxznl41zfq027vl22j6kd2";
   };
 
-  teensyduino_version = "147";
+  teensyduino_version = "151";
   teensyduino_src = fetchurl {
     url = "https://www.pjrc.com/teensy/td_${teensyduino_version}/TeensyduinoInstall.${teensy_architecture}";
     sha256 =
       lib.optionalString (teensy_architecture == "linux64")
-        "09ysanip5d2f5axzd81z2l74ayng60zqhjxmxs7xa5098fff46il"
+        "0q8mw9bm2vb5vwa98gwcs6ad164i98hc1qqh2qw029yhwm599pn0"
       + lib.optionalString (teensy_architecture == "linux32")
-        "1zw3cfv2p62dwg8838vh0gd1934b18cyx7c13azvwmrpj601l0xx"
+        "1rq6sx0048ab200jy0cz5vznwxi99avidngj42rjnh7kcfas5c4m"
+      + lib.optionalString (teensy_architecture == "linuxaarch64")
+        "09k78dycn1vcpcx37c1dak8bgjv8gs34l89n9r9s0c3rqmv3pg4x"
       + lib.optionalString (teensy_architecture == "linuxarm")
-        "12421z26ksx84aldw1pq0cakh8jhs33mwafgvfij0zfgn9x0i877";
-    };
+        "19j55bq36040rpdpfxcqimda76rkbx137q15bs8nvxj13wrbl4ip";
+  };
   # Used because teensyduino requires jars be a specific size
   arduino_dist_src = fetchurl {
     url = "http://downloads.arduino.cc/arduino-${version}-${teensy_architecture}.tar.xz";
     sha256 =
       lib.optionalString (teensy_architecture == "linux64")
-        "1lv4in9j0r8s0cis4zdvbk2637vlj12w69wdxgcxcrwvkcdahkpa"
+        "128f34kkxz7ab6ir5mqyr8d1mgxig8f9jygwxy44pdnq2rk6gmh9"
       + lib.optionalString (teensy_architecture == "linux32")
-        "0zla3a6gd9prclgrbbgsmhf8ds8zb221m65x21pvz0y1cwsdvjpm"
+        "11n85lwsn1w4ysfacyw08v85s3f3zvl8j8ac7rld19yxgjslvisi"
+      + lib.optionalString (teensy_architecture == "linuxaarch64")
+        "04v2nhyjhahml6nmz23bfb63c0an4a7zxgcgxqqq442i8vd304wa"
       + lib.optionalString (teensy_architecture == "linuxarm")
-        "1w5m49wfd68zazli0lf3w4zykab8n7mzp3wnbjqfpx2vip80bqnz";
+        "1k8yjivaydm6y16mplrjyblgx7l0wjzm3mjxh5saxrjq7drswmxx";
   };
 
 
-  buildInputs = [ jdk ant libusb-compat-0_1 libusb1 unzip zlib ncurses5 readline
+  buildInputs = [
+    jdk
+    ant
+    libusb-compat-0_1
+    libusb1
+    unzip
+    zlib
+    ncurses5
+    readline
   ] ++ stdenv.lib.optionals withTeensyduino [ upx ];
   downloadSrcList = builtins.attrValues externalDownloads;
   downloadDstList = builtins.attrNames externalDownloads;
@@ -116,7 +143,8 @@ stdenv.mkDerivation rec {
 
     # Deliberately break build.xml's download statement in order to cause
     # an error if anything needed is missing from download.nix.
-    substituteInPlace build/build.xml --replace "get src" "get error"
+    substituteInPlace build/build.xml \
+      --replace 'ignoreerrors="true"' 'ignoreerrors="false"'
 
     cd ./arduino-core && ant
     cd ../build && ant
@@ -125,11 +153,11 @@ stdenv.mkDerivation rec {
 
   # This will be patched into `arduino` wrapper script
   # Java loads gtk dynamically, so we need to provide it using LD_LIBRARY_PATH
-  dynamicLibraryPath = lib.makeLibraryPath [gtk2];
-  javaPath = lib.makeBinPath [jdk];
+  dynamicLibraryPath = lib.makeLibraryPath [ gtk2 ];
+  javaPath = lib.makeBinPath [ jdk ];
 
   # Everything else will be patched into rpath
-  rpath = (lib.makeLibraryPath [zlib libusb-compat-0_1 libusb1 readline ncurses5 stdenv.cc.cc]);
+  rpath = (lib.makeLibraryPath [ zlib libusb-compat-0_1 libusb1 readline ncurses5 stdenv.cc.cc ]);
 
   installPhase = ''
     mkdir -p $out/share/arduino
@@ -192,19 +220,19 @@ stdenv.mkDerivation rec {
     done
 
     ${lib.concatMapStringsSep "\n"
-        ({jar, file}:
+      ({ jar, file }:
           ''
-              jar xvf $out/${jar} ${file}
-              patchelf --set-rpath $rpath ${file}
-              jar uvf $out/${jar} ${file}
-              rm -f ${file}
+            jar xvf $out/${jar} ${file}
+            patchelf --set-rpath $rpath ${file}
+            jar uvf $out/${jar} ${file}
+            rm -f ${file}
           ''
         )
-        patchelfInJars}
+      patchelfInJars}
 
     # avrdude_bin is linked against libtinfo.so.5
     mkdir $out/lib/
-    ln -s ${lib.makeLibraryPath [ncurses5]}/libtinfo.so.5 $out/lib/libtinfo.so.5
+    ln -s ${lib.makeLibraryPath [ ncurses5 ]}/libtinfo.so.5 $out/lib/libtinfo.so.5
 
     ${stdenv.lib.optionalString withTeensyduino ''
       # Patch the Teensy loader binary

--- a/pkgs/development/arduino/arduino-core/downloads.nix
+++ b/pkgs/development/arduino/arduino-core/downloads.nix
@@ -1,4 +1,7 @@
-{fetchurl, optionalAttrs, system}:
+{ fetchurl
+, optionalAttrs
+, system
+}:
 # This file preloads all the archives which Arduino's build/build.xml
 # would otherwise try to download itself. When updating this for a new
 # version of Arduino, check build.xml for version numbers and new
@@ -56,9 +59,9 @@
     url = "https://github.com/arduino-libraries/RobotIRremote/archive/2.0.0.zip";
     sha256 = "0j5smap74j8p3wc6k0h73b1skj4gkr7r25jbjh1j1cg052dxri86";
   };
-  "build/SpacebrewYun-1.0.1.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/SpacebrewYun/archive/1.0.1.zip";
-    sha256 = "1zs6ymlzw66bglrm0x6d3cvr52q85c8rlm525x0wags111xx3s90";
+  "build/SpacebrewYun-1.0.2.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/SpacebrewYun/archive/1.0.2.zip";
+    sha256 = "1d8smmsx12qhf2ldvmi93h48cvdyz4id5gd68cvf076wfyv6dks8";
   };
   "build/Temboo-1.2.1.zip" = fetchurl {
     url = "https://github.com/arduino-libraries/Temboo/archive/1.2.1.zip";
@@ -76,108 +79,135 @@
     url = "https://github.com/arduino-libraries/Keyboard/archive/1.0.2.zip";
     sha256 = "17yfj95r1i7fb87q4krmxmaq07b4x2xf8cjngrj5imj68wgjck53";
   };
-  "build/SD-1.2.3.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/SD/archive/1.2.3.zip";
-    sha256 = "0i5hb5hmrsrhfgxx8w7zzrfrkc751vs63vhxrj6qvwazhfcdpjw2";
+  "build/SD-1.2.4.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/SD/archive/1.2.4.zip";
+    sha256 = "123g9px9nqcrsx696wqwzjd5s4hr55nxgfz95b7ws3v007i1f3fz";
   };
-  "build/Servo-1.1.3.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/Servo/archive/1.1.3.zip";
-    sha256 = "1m019a75cdn1fg0cwlzbahmaqvg8sgzr6v1812rd7rjh8ismiah6";
+  "build/Servo-1.1.6.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Servo/archive/1.1.6.zip";
+    sha256 = "1z9k9lxzj5d3f8h9hy86f4k5wgfr2a9zcvjh76qmpvv6clcv3js3";
   };
   "build/LiquidCrystal-1.0.7.zip" = fetchurl {
     url = "https://github.com/arduino-libraries/LiquidCrystal/archive/1.0.7.zip";
     sha256 = "1wrxrqz3n4yrj9j1a2b7pdd7a1rlyi974ra7crv5amjng8817x9n";
   };
-  "build/Adafruit_Circuit_Playground-1.8.1.zip" = fetchurl {
-    url = "https://github.com/Adafruit/Adafruit_CircuitPlayground/archive/1.8.1.zip";
-    sha256 = "1fl24px4c42f6shpb3livwsxgpj866yy285274qrj4m1zl07f18q";
+  "build/Adafruit_Circuit_Playground-1.10.4.zip" = fetchurl {
+    url = "https://github.com/adafruit/Adafruit_CircuitPlayground/archive/1.10.4.zip";
+    sha256 = "194az5pxxzs0wg4ng7w0zqrdw93qdyv02y0q2yy57dr4kwfrm6nl";
   };
-  "build/libastylej-2.05.1-4.zip" = fetchurl {
-    url = "https://downloads.arduino.cc/libastylej-2.05.1-4.zip";
-    sha256 = "0q307b85xba7izjh344kqby3qahg3f5zy18gg52sjk1lbkl9i39s";
+  "build/libastylej-2.05.1-5.zip" = fetchurl {
+    url = "https://downloads.arduino.cc/libastylej-2.05.1-5.zip";
+    sha256 = "11mlprwvqfq3nvmz6hdf1fcg02a7xi2a9qhffa1d8a4w15s2iwny";
   };
-  "build/liblistSerials-1.4.2.zip" = fetchurl {
-    url = "https://downloads.arduino.cc/liblistSerials/liblistSerials-1.4.2.zip";
-    sha256 = "1p58b421k92rbgwfgbihy0d04mby7kfssghpmjb4gk9yix09za3m";
+  "build/liblistSerials-1.4.2-2.zip" = fetchurl {
+    url = "https://downloads.arduino.cc/liblistSerials/liblistSerials-1.4.2-2.zip";
+    sha256 = "0sqzwp1lfjy452z3d4ma5c4blwsj7za72ymxf7crpq9dh9qd8f53";
   };
-  "build/shared/WiFi101-Updater-ArduinoIDE-Plugin-0.10.6.zip" = fetchurl {
-    url = "https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/releases/download/v0.10.6/WiFi101-Updater-ArduinoIDE-Plugin-0.10.6.zip";
-    sha256 = "1k23xyr5dmr60y8hb9x24wrgd4mfgvrzky621p6fvawn5xbdq8a3";
+  "build/shared/WiFi101-Updater-ArduinoIDE-Plugin-0.10.10.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/releases/download/v0.10.10/WiFi101-Updater-ArduinoIDE-Plugin-0.10.10.zip";
+    sha256 = "0bs5qdglsfc2q5c48m6wdjpzhz4ya4askh1g8364dp6p7jmg6w0d";
+  };
+  "build/avr-1.8.2.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/cores/avr-1.8.2.tar.bz2";
+    sha256 = "06zl8fwphknd0qdx87fcr1003gid1yqsazaj674mm9widqfd84v2";
   };
 }
+
 // optionalAttrs (system == "x86_64-linux") {
-  "build/arduino-builder-linux64-1.4.4.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/arduino-builder-linux64-1.4.4.tar.bz2";
-    sha256 = "1m5b4rc9i235ra6isqdpjj9llddb5sldkhidb8c4i14mcqbdci1n";
+  "build/arduino-builder-linux64-1.5.2.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduino-builder-linux64-1.5.2.tar.bz2";
+    sha256 = "0wypr9a2cbv9r0ignsr13raw09i3vfc5zvkjxp2xwb7mv35y77z3";
   };
-  "build/linux/avr-gcc-5.4.0-atmel3.6.1-arduino2-x86_64-pc-linux-gnu.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-x86_64-pc-linux-gnu.tar.bz2";
-    sha256 = "11ciwv9sw900wxb2fwm4i4ml4a85ylng0f595v0mf0xifc6jnhh5";
+  "build/linux/avr-gcc-7.3.0-atmel3.6.1-arduino5-x86_64-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-x86_64-pc-linux-gnu.tar.bz2";
+    sha256 = "1yq6a811dabrkcgzfi3jsys41r19qsna46kglkjbcy0rza7yvzry";
   };
-  "build/linux/avrdude-6.3.0-arduino14-x86_64-pc-linux-gnu.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-x86_64-pc-linux-gnu.tar.bz2";
-    sha256 = "1z4b6pvn1823h8mg0iph88igmcnrk2y7skr3z44dqlwk0pryi1kr";
+  "build/linux/avrdude-6.3.0-arduino17-x86_64-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-x86_64-pc-linux-gnu.tar.bz2";
+    sha256 = "0gfic26af9vlcpkw8v914psn05vmq1rsrlk1fi7vzapj1a9gpkdc";
   };
-  "build/linux/arduinoOTA-1.2.1-linux_amd64.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/arduinoOTA-1.2.1-linux_amd64.tar.bz2";
-    sha256 = "1ya834p2cqjj8k1ad3yxcnzd4bcgrlqsqsli9brq1138ac6k30jv";
-  };
-  "build/avr-1.6.23.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/cores/avr-1.6.23.tar.bz2";
-    sha256 = "1al449r8hcdck7f4y295g7q388qvbn6qhk2zqdvws9kg4mzqsq8q";
+  "build/linux/arduinoOTA-1.3.0-linux_amd64.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_amd64.tar.bz2";
+    sha256 = "1ylz4pfa9np0nn0w9igmmm3sr8hz3na04n7cv8ia3hzz84jfwida";
   };
 }
+
 // optionalAttrs (system == "i686-linux") {
-  "build/arduino-builder-linux32-1.4.4.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/arduino-builder-linux32-1.4.4.tar.bz2";
-    sha256 = "0q3i1ba7vh14616d9ligizcz89yadr0skazxbrcq3mvvjqzbifw8";
+  "build/arduino-builder-linux32-1.5.2.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduino-builder-linux32-1.5.2.tar.bz2";
+    sha256 = "1slzw8fzxkqsp2izjisjd1rxxbqkrq6n72jc4frk5z2gdm6zfa0l";
   };
-  "build/linux/avr-gcc-5.4.0-atmel3.6.1-arduino2-i686-pc-linux-gnu.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-i686-pc-linux-gnu.tar.bz2";
-    sha256 = "13skspybzq80ndsi93s7v15900lf26n5243mbib77andyc27xy2i";
+  "build/linux/avr-gcc-7.3.0-atmel3.6.1-arduino5-i686-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-i686-pc-linux-gnu.tar.bz2";
+    sha256 = "078f3rbpdrghk63mbaq73bd5p6znimp14b1wdf6nh2gdswwjgw9g";
   };
-  "build/linux/avrdude-6.3.0-arduino14-i686-pc-linux-gnu.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-i686-pc-linux-gnu.tar.bz2";
-    sha256 = "1jklpk1sgrmbh1r25ynps4qcs5dbg6hd54fzjx4hcdf68cw0w42g";
+  "build/linux/avrdude-6.3.0-arduino17-i686-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-i686-pc-linux-gnu.tar.bz2";
+    sha256 = "0py0jvpim0frmv0dnvzfj122ni5hg1qwshgya4a0wc5rgp0wd32w";
   };
-  "build/linux/arduinoOTA-1.2.1-linux_386.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/arduinoOTA-1.2.1-linux_386.tar.bz2";
-    sha256 = "1m56ps58h0fs8rr4ifc45slmrdvalc63vhldy85isv28g15zdz9g";
+  "build/linux/arduinoOTA-1.3.0-linux_386.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_386.tar.bz2";
+    sha256 = "1cl79019ldsq0sc3fd4pm0vx2kqcklld7w03hdcj99y7zgb5jzry";
   };
 }
+
 // optionalAttrs (system == "x86_64-darwin") {
-  "build/arduino-builder-macosx-1.4.4.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/arduino-builder-macosx-1.4.4.tar.bz2";
-    sha256 = "1jp5kg32aiw062kcxlv660w38iaprifm8h3g2798izpwyfj0dmwg";
+  "build/arduino-builder-macosx-1.5.2-signed.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduino-builder-macosx-1.5.2-signed.tar.bz2";
+    sha256 = "1pa795vwly1z9h1bp5qzbx2c2pq4n6p7ab5ivhmd3q89z0ywyqgz";
   };
-  "build/macosx/avr-gcc-5.4.0-atmel3.6.1-arduino2-i386-apple-darwin11.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-i386-apple-darwin11.tar.bz2";
-    sha256 = "1y2972b08ac59xwjqkyjmi5lf2pmzw88a6sdgci3x9rvahvh3idb";
+  "build/macosx/avr-gcc-7.3.0-atmel3.6.1-arduino5-x86_64-apple-darwin14-signed.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-x86_64-apple-darwin14-signed.tar.bz2";
+    sha256 = "0lcnp525glnc2chcynnz2nllm4q6ar4n9nrjqd1jbj4m706zbv67";
   };
-  "build/macosx/avrdude-6.3.0-arduino14-i386-apple-darwin11.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-i386-apple-darwin11.tar.bz2";
-    sha256 = "0qsa3sb3f480fm2z75fq14cqddw5hq8w8q0c2a9cw8i7aa8kkl27";
+  "build/macosx/avrdude-6.3.0-arduino17-x86_64-apple-darwin12-signed.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-x86_64-apple-darwin12-signed.tar.bz2";
+    sha256 = "1m24dci8mjf70yrf033mp1834pbp870m8sns2jxs3iy2i4qviiki";
   };
-  "build/macosx/appbundler/appbundler-1.0ea-arduino4.jar.zip" = fetchurl {
-    url = "https://downloads.arduino.cc/appbundler-1.0ea-arduino4.jar.zip";
-    sha256 = "1vz0g98ancfqdf7yx5m3zrxmzb3fwp18zh5lkh2nyl5xlr9m368z";
+  "build/linux/arduinoOTA-1.3.0-darwin_amd64-signed.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduinoOTA-1.3.0-darwin_amd64-signed.tar.bz2";
+    sha256 = "12pwfnikq3z3ji5wgjhzx1mfyaha5cym7mr63r8kfl5a85fhk8nz";
+  };
+  "build/macosx/appbundler/appbundler-1.0ea-arduino5.jar.zip" = fetchurl {
+    url = "https://downloads.arduino.cc/appbundler-1.0ea-arduino5.jar.zip";
+    sha256 = "1ims951z7ajprqms7yd8ll83c79n7krhd9ljw30yn61f6jk46x82";
   };
 }
-// optionalAttrs (system == "armv6l-linux") {
-  "build/arduino-builder-linuxarm-1.4.4.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/arduino-builder-linuxarm-1.4.4.tar.bz2";
-    sha256 = "03bhlhdkg1jx0d3lh9194xgaqsbank9njhlnwy8braa7pw4p58gn";
+
+// optionalAttrs (system == "aarch64-linux") {
+  "build/arduino-builder-linuxaarch64-1.5.2.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduino-builder-linuxaarch64-1.5.2.tar.bz2";
+    sha256 = "14k7h7anjizbs2h04phw784slpfbi6hch9skvhy5ll805dmr24ci";
   };
-  "build/linux/avr-gcc-5.4.0-atmel3.6.1-arduino2-armhf-pc-linux-gnu.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-armhf-pc-linux-gnu.tar.bz2";
-    sha256 = "17z9li387mx2acgad733h7l1jnnwv09ynw4nrwlqfahqqdfgjhb7";
+  "build/linux/avr-gcc-7.3.0-atmel3.6.1-arduino5-aarch64-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-aarch64-pc-linux-gnu.tar.bz2";
+    sha256 = "040cspc41iv59fb2g9fzc6w5523dvqa1bavxni7s8w731ccp176x";
   };
-  "build/linux/avrdude-6.3.0-arduino14-armhf-pc-linux-gnu.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-armhf-pc-linux-gnu.tar.bz2";
-    sha256 = "12amp8hqcj6gcdga7hfs22asgmgzafy8ny0rqhqs8n8d95sn586i";
+  "build/linux/avrdude-6.3.0-arduino17-aarch64-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-aarch64-pc-linux-gnu.tar.bz2";
+    sha256 = "1z59dx2j2j4675awjzag9fswhvkn3hlz4ds5d2b7pzmca7vliybc";
   };
-  "build/linux/arduinoOTA-1.2.1-linux_arm.tar.bz2" = fetchurl {
-    url = "https://downloads.arduino.cc/tools/arduinoOTA-1.2.1-linux_arm.tar.bz2";
-    sha256 = "1q79w1d0h2lp3jcg58qrlh3k5lak7dbsnawrzm0jj8c6spfb6m5d";
+  "build/linux/arduinoOTA-1.3.0-linux_aarch64.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_aarch64.tar.bz2";
+    sha256 = "04s1is2w8xhvc7lg0lmyk0yjsnar2l2gdc6ig7lkgb7zgkrxhpl3";
+  };
+}
+
+// optionalAttrs (builtins.match "armv[67]l-linux" system != null) {
+  "build/arduino-builder-linuxarm-1.5.2.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduino-builder-linuxarm-1.5.2.tar.bz2";
+    sha256 = "1vs2s5px07jb2sdv83qxkf9lxmsy8j4dm7bn3vpw5dcjqd3qdyww";
+  };
+  "build/linux/avr-gcc-7.3.0-atmel3.6.1-arduino5-arm-linux-gnueabihf.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-arm-linux-gnueabihf.tar.bz2";
+    sha256 = "0fcn0s0fdgbz3yma2gjv16s1idrzn6nhmypdw8awg0kb3i9xbb7l";
+  };
+  "build/linux/avrdude-6.3.0-arduino17-armhf-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-armhf-pc-linux-gnu.tar.bz2";
+    sha256 = "1lah9wvwvliajrrf5jw5blkjhk1sxivz26gj5s86zah3v32ni3ia";
+  };
+  "build/linux/arduinoOTA-1.3.0-linux_arm.tar.bz2" = fetchurl {
+    url = "https://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_arm.tar.bz2";
+    sha256 = "0mm6spjlg0lhkfx5c9q27b6agjywnc1nf3mbl15yysmm15s5i20q";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

+ version update
+ added aarch64-linux support
+ reformatted via nixpkgs-fmt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
