### PR TITLE
onnx: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/development/python-modules/onnx/default.nix
+++ b/pkgs/development/python-modules/onnx/default.nix
@@ -18,28 +18,17 @@
 
 buildPythonPackage rec {
   pname = "onnx";
-  version = "1.6.0";
+  version = "1.7.0";
 
   # Due to Protobuf packaging issues this build of Onnx with Python 2 gives
-  # errors on import
+  # errors on import.
+  # Also support for Python 2 will be deprecated from Onnx v1.8.
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0ig33jl3591041lyylxp52yi20rfrcqx3i030hd6al8iabzc721v";
+    sha256 = "0j6rgfbhsw3a8id8pyg18y93k68lbjbj1kq6qia36h69f6pvlyjy";
   };
-
-  # Remove the unqualified requirement for the typing package for running the
-  # tests. typing is already required for the installation, where it is
-  # correctly qualified so as to only be required for sufficiently old Python
-  # versions.
-  # This patch should be in the next release (>1.6).
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/onnx/onnx/commit/c963586d0f8dd5740777b2fd06f04ec60816de9f.patch";
-      sha256 = "1hl26cw5zckc91gmh0bdah87jyprccxiw0f4i5h1gwkq28hm6wbj";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -61,13 +50,17 @@ buildPythonPackage rec {
     patchShebangs tools/protoc-gen-mypy.py
   '';
 
+  preBuild = ''
+    export MAX_JOBS=$NIX_BUILD_CORES
+  '';
+
   # The executables are just utility scripts that aren't too important
   postInstall = ''
     rm -r $out/bin
   '';
 
-  # The setup.py does all the configuration (running CMake)
-  dontConfigure = true;
+  # The setup.py does all the configuration
+  dontUseCmakeConfigure = true;
 
   meta = {
     homepage    = "http://onnx.ai";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

Update to most recently released version. Also respect $NIX_BUILD_CORES now that the upstream build has a way to do so.

---

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
 - *No reverse dependencies*
- [x] Tested execution of all binary files (usually in `./result/bin/`)
 - *No executables of interest*
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/fxi0ajklnlqqsk2sbjbf8w6ai6vmrw0z-python3.7-onnx-1.6.0          336450424
/nix/store/wls15nm3zgrw19pkw71asz2cp8gxla05-python3.7-onnx-1.7.0          340229832
```
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
