### PR TITLE
ocamlPackages.labltk: init at 8.06.8 for OCaml 4.10

### DIFF
--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -7,13 +7,13 @@ then throw "labltk is not available for OCaml ${ocaml.version}"
 else
 
 let param =
-if OCamlVersionAtLeast "4.08" then rec {
-  version = "8.06.7";
-  src = fetchzip {
-    url = "https://github.com/garrigue/labltk/archive/${version}.tar.gz";
-    sha256 = "1cqnxjv2dvw9csiz4iqqyx6rck04jgylpglk8f69kgybf7k7xk2h";
-  };
-} else
+  let mkNewParam = { version, sha256 }: {
+    inherit version;
+    src = fetchzip {
+      url = "https://github.com/garrigue/labltk/archive/${version}.tar.gz";
+      inherit sha256;
+    };
+  }; in
   let mkOldParam = { version, key, sha256 }: {
     src = fetchurl {
       url = "https://forge.ocamlcore.org/frs/download.php/${key}/labltk-${version}.tar.gz";
@@ -21,7 +21,7 @@ if OCamlVersionAtLeast "4.08" then rec {
     };
     inherit version;
   }; in
- {
+ rec {
   "4.04" = mkOldParam {
     version = "8.06.2";
     key = "1628";
@@ -41,6 +41,16 @@ if OCamlVersionAtLeast "4.08" then rec {
     version = "8.06.5";
     key = "1764";
     sha256 = "0wgx65y1wkgf22ihpqmspqfp95fqbj3pldhp1p3b1mi8rmc37zwj";
+  };
+  _8_06_7 = mkNewParam {
+    version = "8.06.7";
+    sha256 = "1cqnxjv2dvw9csiz4iqqyx6rck04jgylpglk8f69kgybf7k7xk2h";
+  };
+  "4.08" = _8_06_7;
+  "4.09" = _8_06_7;
+  "4.10" = mkNewParam {
+    version = "8.06.8";
+    sha256 = "0lfjc7lscq81ibqb3fcybdzs2r1i2xl7rsgi7linq46a0pcpkinw";
   };
 }.${builtins.substring 0 4 ocaml.version};
 in


### PR DESCRIPTION
###### Motivation for this change

Fix build with OCaml 4.10

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
