### PR TITLE
[20.03] nixos/test-driver: Specify /bin/sh shell when running a bourne shell script as the user

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -367,7 +367,7 @@ class Machine:
             q = q.replace("'", "\\'")
             return self.execute(
                 (
-                    "su -l {} -c "
+                    "su -l {} --shell /bin/sh -c "
                     "$'XDG_RUNTIME_DIR=/run/user/`id -u` "
                     "systemctl --user {}'"
                 ).format(user, q)


### PR DESCRIPTION
###### Motivation for this change

Backport https://github.com/NixOS/nixpkgs/pull/87414 , which allows tests to run when a user has changed their login shell.

(cherry picked from commit 751a27020e733f064339eab208327b85c23e3c42)

Reason: Back-porting this straight-forward fix is the best way to
allow tests affected by this user-shell problem to run in 20.03.
There isn't a great override point to apply just this fix.  Copy/pasting
testing-python.nix just to specify a new test-driver.py isn't great --
it would cut off receiving any other fixes in the testing infrastructure
until 20.09.  A 20.03 system using testing-python.nix from the unstable
branch and then passing 20.03's pkgs in to avoid getting unstable's
pkgs is quite a bit of configuration to expect from clients and seems
fragile against future changes in the unstable branch that expect pkgs
to be mostly in-sync with the test driver.  Both of these not-great
options leave a bunch of "TODO: Remove after 20.09" junk in clients'
configs & make that upgrade harder.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
