### PR TITLE
apache-airflow: Export PYTHONPATH in wrapper for gunicorn processes

### DIFF
--- a/pkgs/development/python-modules/apache-airflow/default.nix
+++ b/pkgs/development/python-modules/apache-airflow/default.nix
@@ -167,6 +167,9 @@ buildPythonPackage rec {
       --replace "/bin/bash" "${stdenv.shell}"
   '';
 
+  # allow for gunicorn processes to have access to python packages
+  makeWrapperArgs = [ "--prefix PYTHONPATH : $PYTHONPATH" ];
+
   checkPhase = ''
    export HOME=$(mktemp -d)
    export AIRFLOW_HOME=$HOME


### PR DESCRIPTION
###### Motivation for this change
closes: #84512 #87612

```
$ ./result/bin/airflow webserver
[2020-05-11 13:12:13,168] {__init__.py:51} INFO - Using executor SequentialExecutor
  ____________       _____________
 ____    |__( )_________  __/__  /________      __
____  /| |_  /__  ___/_  /_ __  /_  __ \_ | /| / /
___  ___ |  / _  /   _  __/ _  / / /_/ /_ |/ |/ /
 _/_/  |_/_/  /_/    /_/    /_/  \____/____/|__/
[2020-05-11 13:12:13,524] {dagbag.py:90} INFO - Filling up the DagBag from /home/jon/airflow/dags
Running the Gunicorn Server with:
Workers: 4 sync
Host: 0.0.0.0:8080
Timeout: 120
Logfiles: - -
=================================================================
[2020-05-11 13:12:14 -0700] [21413] [INFO] Starting gunicorn 20.0.4
[2020-05-11 13:12:14 -0700] [21413] [INFO] Listening at: http://0.0.0.0:8080 (21413)
[2020-05-11 13:12:14 -0700] [21413] [INFO] Using worker: sync
[2020-05-11 13:12:14 -0700] [21416] [INFO] Booting worker with pid: 21416
[2020-05-11 13:12:14 -0700] [21417] [INFO] Booting worker with pid: 21417
[2020-05-11 13:12:14 -0700] [21418] [INFO] Booting worker with pid: 21418
[2020-05-11 13:12:14,432] {__init__.py:51} INFO - Using executor SequentialExecutor
[2020-05-11 13:12:14,440] {__init__.py:51} INFO - Using executor SequentialExecutor
[2020-05-11 13:12:14,464] {__init__.py:51} INFO - Using executor SequentialExecutor
[2020-05-11 13:12:14 -0700] [21419] [INFO] Booting worker with pid: 21419
[2020-05-11 13:12:14,553] {__init__.py:51} INFO - Using executor SequentialExecutor
[2020-05-11 13:12:14,654] {dagbag.py:90} INFO - Filling up the DagBag from /home/jon/airflow/dags
[2020-05-11 13:12:14,656] {dagbag.py:90} INFO - Filling up the DagBag from /home/jon/airflow/dags
[2020-05-11 13:12:14,688] {dagbag.py:90} INFO - Filling up the DagBag from /home/jon/airflow/dags
[2020-05-11 13:12:14,773] {dagbag.py:90} INFO - Filling up the DagBag from /home/jon/airflow/dags
[2020-05-11 13:12:45 -0700] [21413] [INFO] Handling signal: ttin
[2020-05-11 13:12:45 -0700] [21429] [INFO] Booting worker with pid: 21429
[2020-05-11 13:12:45,676] {__init__.py:51} INFO - Using executor SequentialExecutor
[2020-05-11 13:12:45,885] {dagbag.py:90} INFO - Filling up the DagBag from /home/jon/airflow/dags
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @GTrunSec @glittershark 