### PR TITLE
bat: 0.15.0 -> 0.15.1

### DIFF
--- a/pkgs/tools/misc/bat/default.nix
+++ b/pkgs/tools/misc/bat/default.nix
@@ -4,17 +4,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname   = "bat";
-  version = "0.15.0";
+  version = "0.15.1";
 
   src = fetchFromGitHub {
     owner  = "sharkdp";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "07yng5bwhin7yqj1hihmxgi8w0n45nks05a8795zwsw92k373ib4";
+    sha256 = "10cs94ja1dmn0f24gqkcy8rf68b3b43k6qpbb5njbg0hcx3x6cyj";
     fetchSubmodules = true;
   };
 
-  cargoSha256 = "1xqbpij6lr0bqyi0cfwgp3d4hcjhibpdc4dfm9gb39mmbgradrzf";
+  cargoSha256 = "13cphi08bp6lg054acgliir8dx2jajll4m3c4xxy04skmx555zr8";
+
+  # Disable test that's broken on macOS.
+  # This should probably be removed on the next release.
+  # https://github.com/sharkdp/bat/issues/983
+  patches = [ ./macos.patch ];
 
   nativeBuildInputs = [ pkgconfig llvmPackages.libclang installShellFiles makeWrapper ];
 

--- a/pkgs/tools/misc/bat/macos.patch
+++ b/pkgs/tools/misc/bat/macos.patch
@@ -1,0 +1,13 @@
+diff --git a/src/assets.rs b/src/assets.rs
+index 4f8556f..222abc2 100644
+--- a/src/assets.rs
++++ b/src/assets.rs
+@@ -336,7 +336,7 @@ mod tests {
+         assert_eq!(test.syntax_for_file("Makefile"), "Makefile");
+     }
+ 
+-    #[cfg(unix)]
++    #[cfg(all(unix,not(target_os = "macos")))]
+     #[test]
+     fn syntax_detection_invalid_utf8() {
+         use std::os::unix::ffi::OsStrExt;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/sharkdp/bat/releases/tag/v0.15.1

One of the tests fails 100% in macOS due to the way the filesystem behaves, so I've patched it out. https://github.com/sharkdp/bat/issues/983 is the upstream issue to track this, so hopefully we can remove the patch in the next version.

Oddly, trying to build this with sandboxing failed on the cargo vendor stage where it couldn't update the index. I don't recall having this issue before, so I'm wondering if something changed on the nixpkgs side? Not directly related to `bat` though, and I assume it's specific to macOS sandboxing too or someone would have noticed this problem before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
