### PR TITLE
python3Packages.intake: 0.5.4 -> 0.5.5

### DIFF
--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -11,6 +11,7 @@
 , numpy
 , pandas
 , panel
+, pyarrow
 , python-snappy
 , requests
 , ruamel_yaml
@@ -22,16 +23,16 @@
 
 buildPythonPackage rec {
   pname = "intake";
-  version = "0.5.4";
+  version = "0.5.5";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "81c3bdadbb81ec10c923b89e118c229d977a584ccbe27466f8fde41c0c274c3f";
+    sha256 = "0ypgf0046hln27gjcy7gjh4diblgmivkf7kxbcy1mjvwka55bdmw";
   };
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pyarrow pytest ];
   propagatedBuildInputs = [
     appdirs
     dask


### PR DESCRIPTION
###### Motivation for this change
noticed it was failing in #87381

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
