### PR TITLE
cortextool: init at version 0.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2248,6 +2248,12 @@
     githubId = 411447;
     name = "Leo Gaspard";
   };
+  ekpdt = {
+    email = "nix@pdtpartners.com";
+    github = "ekpdt";
+    githubId = 64796365;
+    name = "Elan Kugelmass";
+  };
   elasticdog = {
     email = "aaron@elasticdog.com";
     github = "elasticdog";

--- a/pkgs/servers/monitoring/cortex/cortextool.nix
+++ b/pkgs/servers/monitoring/cortex/cortextool.nix
@@ -5,9 +5,9 @@ buildGoModule rec {
   version = "0.1.4";
 
   src = fetchFromGitHub {
-    rev = "v${version}";
     owner = "grafana";
     repo = "cortextool";
+    rev = "v${version}";
     sha256 = "0p3g418bg6agk6manibazlb2rplv8253z5gka5nb37jvccz6k38v";
   };
 

--- a/pkgs/servers/monitoring/cortex/cortextool.nix
+++ b/pkgs/servers/monitoring/cortex/cortextool.nix
@@ -1,0 +1,34 @@
+{ lib, buildGoModule, fetchFromGitHub, go }:
+
+buildGoModule rec {
+  pname = "cortextool";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "grafana";
+    repo = "cortextool";
+    sha256 = "0p3g418bg6agk6manibazlb2rplv8253z5gka5nb37jvccz6k38v";
+  };
+
+  modSha256 = "0wpmn6clmsb5ird9h8wx6njg6xgpmw80zx4dbpmifsgirldi5yjd";
+
+  buildFlagsArray =''
+    -ldflags=
+        -X main.Version=${version}
+        -X main.Revision=unknown
+        -X main.Branch=unknown
+        -X main.BuildUser=nix@nixpkgs
+        -X main.BuildDate=unknown
+        -X main.GoVersion=${lib.getVersion go}
+    '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "A powerful command line tool for interacting with cortex";
+    homepage = "https://github.com/grafana/cortextool";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ekpdt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15488,6 +15488,8 @@ in
 
   couchpotato = callPackage ../servers/couchpotato {};
 
+  cortextool = callPackage ../servers/monitoring/cortex/cortextool.nix {};
+
   dex-oidc = callPackage ../servers/dex { };
 
   doh-proxy = callPackage ../servers/dns/doh-proxy {


### PR DESCRIPTION
###### Motivation for this change

Add `cortextool`, a CLI for interacting with [Cortex](http://cortexmetrics.io/) instances.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
