### PR TITLE
python3.pkgs.ipykernel: skip test_unc_paths on darwin

### DIFF
--- a/pkgs/development/python-modules/ipykernel/default.nix
+++ b/pkgs/development/python-modules/ipykernel/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     "test_subprocess_error"
     "test_ipython_start_kernel_no_userns"
     
-    # see https://github.com/NixOS/nixpkgs/issues/87626
+    # https://github.com/ipython/ipykernel/issues/506
     "test_unc_paths"    
   ] ++ lib.optionals (pythonOlder "3.8") [
     # flaky test https://github.com/ipython/ipykernel/issues/485

--- a/pkgs/development/python-modules/ipykernel/default.nix
+++ b/pkgs/development/python-modules/ipykernel/default.nix
@@ -42,6 +42,9 @@ buildPythonPackage rec {
     "test_subprocess_print"
     "test_subprocess_error"
     "test_ipython_start_kernel_no_userns"
+    
+    # see https://github.com/NixOS/nixpkgs/issues/87626
+    "test_unc_paths"    
   ] ++ lib.optionals (pythonOlder "3.8") [
     # flaky test https://github.com/ipython/ipykernel/issues/485
     "test_shutdown"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix #87626

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
