### PR TITLE
python3Packages.qiskit: 0.18.2 -> 0.19.1

### DIFF
--- a/pkgs/development/python-modules/pylatexenc/default.nix
+++ b/pkgs/development/python-modules/pylatexenc/default.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "pylatexenc";
-  version = "2.2";
+  version = "2.4";
 
   src = fetchFromGitHub {
     owner = "phfaist";
     repo = "pylatexenc";
     rev = "v${version}";
-    sha256 = "0icwd7iipz3sv4jdh9iam7h4xslvdqg16rwsmczrna3mmjbwccdk";
+    sha256 = "0i4frypbv90mjir8bkp03cwkvwhgvc9p3fw6q2jz1dn7fw94v2rv";
   };
 
   pythonImportsCheck = [ "pylatexenc" ];

--- a/pkgs/development/python-modules/qiskit-aer/default.nix
+++ b/pkgs/development/python-modules/qiskit-aer/default.nix
@@ -2,6 +2,7 @@
 , pythonOlder
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , cvxpy
 , cython
@@ -18,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-aer";
-  version = "0.5.0";
+  version = "0.5.1";
 
   disabled = pythonOlder "3.5";
 
@@ -27,7 +28,7 @@ buildPythonPackage rec {
     repo = "qiskit-aer";
     rev = version;
     fetchSubmodules = true; # fetch muparserx and other required libraries
-    sha256 = "05lsirrdnnr5yqhwkgv08d9aib8xq4xpd6aq2pfqsi9qkii2fff1";
+    sha256 = "0pbi8ldz8f1zm7pf2n5229g6kccriq21f24q9cb7bd4j5gdky5sk";
   };
 
   nativeBuildInputs = [
@@ -47,7 +48,15 @@ buildPythonPackage rec {
     pybind11
   ];
 
-  prePatch = ''
+  patches = [
+    (fetchpatch{
+      name = "qiskit-aer-pr-727-fix-random-unitary-test.patch";
+      url = "https://github.com/Qiskit/qiskit-aer/commit/09afb3b6b0710042ab65d88e863363f2c843dcb0.patch";
+      sha256 = "0521b7i4fpc5brqs08w381g3c655f9cbn6my1740jnk7dv5lhsv9";
+    })
+  ];
+
+  postPatch = ''
     # remove dependency on PyPi cmake package, which isn't in Nixpkgs
     substituteInPlace setup.py --replace "'cmake!=3.17,!=3.17.0'" ""
   '';
@@ -81,7 +90,7 @@ buildPythonPackage rec {
     # Tests include a compiled "circuit" which is auto-built in $HOME
     export HOME=$(mktemp -d)
     # move tests b/c by default try to find (missing) cython-ized code in /build/source dir
-    cp -r test $HOME
+    cp -r $TMP/$sourceRoot/test $HOME
 
     # Add qiskit-aer compiled files to cython include search
     pushd $HOME

--- a/pkgs/development/python-modules/qiskit-aqua/default.nix
+++ b/pkgs/development/python-modules/qiskit-aqua/default.nix
@@ -2,6 +2,7 @@
 , pythonOlder
 , buildPythonPackage
 , fetchFromGitHub
+# , cplex
 , cvxopt
 , dlx
 , docplex
@@ -10,19 +11,20 @@
 , networkx
 , numpy
 , psutil
+, python
 , qiskit-ignis
 , qiskit-terra
 , quandl
 , scikitlearn
   # Check Inputs
-, parameterized
+, ddt
 , pytestCheckHook
 , qiskit-aer
 }:
 
 buildPythonPackage rec {
   pname = "qiskit-aqua";
-  version = "0.6.6";
+  version = "0.7.0";
 
   disabled = pythonOlder "3.5";
 
@@ -31,11 +33,12 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-aqua";
     rev = version;
-    sha256 = "080m5nsy3ia6bcdypq5d3ijb7762yl1l9llygmxsi6si449zl2cp";
+    sha256 = "0yykw6k1rb3f2ihcp0y9pb0695mcmy29nyqlj89qs4da0503vxvh";
   };
 
   # Optional packages: pyscf (see below NOTE) & pytorch. Can install via pip/nix if needed.
   propagatedBuildInputs = [
+    # cplex
     cvxopt
     docplex
     dlx # Python Dancing Links package
@@ -57,19 +60,33 @@ buildPythonPackage rec {
   # It can also be installed at runtime from the pip wheel.
   # We disable appropriate tests below to allow building without pyscf installed
 
+  # NOTE: we remove cplex b/c we can't build pythonPackages.cplex.
+  # cplex is only distributed in manylinux1 wheel (no source), and Nix python is not manylinux1 compatible
+
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "pyscf; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'win32')" ""
+      --replace "pyscf; sys_platform != 'win32'" "" \
+      --replace "cplex; python_version >= '3.6' and python_version < '3.8'" ""
 
     # Add ImportWarning when running qiskit.chemistry (pyscf is a chemistry package) that pyscf is not included
-    echo -e "\nimport warnings\ntry: import pyscf;\nexcept:\n    " \
+    echo -e "\nimport warnings\ntry: import pyscf;\nexcept ImportError:\n    " \
       "warnings.warn('pyscf is not supported on Nixpkgs so some qiskit features will fail." \
         "You must install it yourself via pip or add it to your environment from the Nix User Repository." \
         "See https://github.com/NixOS/nixpkgs/pull/83447 for details', ImportWarning)\n" \
       >> qiskit/chemistry/__init__.py
+
+    # Add ImportWarning when running qiskit.optimization that cplex (optimization package) is not included
+    echo -e "\nimport warnings\ntry: import cplex;\nexcept ImportError:\n    " \
+      "warnings.warn('cplex is not supported on Nixpkgs so some qiskit features will fail." \
+        "You must install it yourself via pip or add it to your environment from the Nix User Repository." \
+        "', ImportWarning)\n" \
+      >> qiskit/optimization/__init__.py
+
   '';
 
-  checkInputs = [ parameterized qiskit-aer pytestCheckHook ];
+  postInstall = "rm -rf $out/${python.sitePackages}/docs";  # Remove docs dir b/c it can cause conflicts.
+
+  checkInputs = [ ddt qiskit-aer pytestCheckHook ];
   dontUseSetuptoolsCheck = true;
   pythonImportsCheck = [
     "qiskit.aqua"
@@ -84,42 +101,35 @@ buildPythonPackage rec {
     "--ignore=test/chemistry/test_qeom_ee.py"
     "--ignore=test/chemistry/test_qeom_vqe.py"
     "--ignore=test/chemistry/test_vqe_uccsd_adapt.py"
-
-    # Following tend to be slow tests, all pass
-    "--ignore=test/aqua/test_vqc.py"
-    "--ignore=test/aqua/test_hhl.py"
-    "--ignore=test/aqua/test_qgan.py"
-    "--ignore=test/aqua/test_mcr.py"
-    "--ignore=test/aqua/test_mcu1.py"
-    "--ignore=test/aqua/test_vqe.py"
   ];
   disabledTests = [
     # Disabled due to missing pyscf
     "test_validate" # test/chemistry/test_inputparser.py
 
     # Disabling slow tests > 10 seconds
-    "test_clique_vqe"
-    "test_delta_3_qasm"
-    "test_evaluate_qasm_mode"
-    "test_evolve_1_suzuki"
-    "test_exact_cover_vqe"
-    "test_exchangedata"
-    "test_expected_value_0_statevector"
-    "test_expected_value_1_qasm"
-    "test_expected_value_2_statevector"
+    "TestVQE"
+    "TestVQC"
+    "TestQSVM"
     "test_graph_partition_vqe"
-    "test_lookup_rotation"
-    "test_mct_with_dirty_ancillae_15"
-    "test_mcrz_11"
+    "TestLookupRotation"
+    "_vqe"
+    "TestHHL"
+    "TestQGAN"
+    "test_evaluate_qasm_mode"
     "test_measurement_error_mitigation_auto_refresh"
-    "test_qgan_training"
-    "test_qsvm_multiclass"
-    "test_shor_factoring_0"
-    "test_vertex_cover_vqe"
-    "test_vqc_with_raw_feature_vector_on_wine"
-    "test_vqe_2_iqpe"
-    "test_vqe_qasm"
+    "test_exchangedata"
     "test_wikipedia"
+    "test_shor_factoring_1__15___qasm_simulator____3__5__"
+    "test_readme_sample"
+    "test_ecev"
+    "test_expected_value"
+    "test_qubo_gas_int_paper_example"
+    "test_shor_no_factors_1_5"
+    "test_shor_no_factors_2_7"
+    "test_evolve_2___suzuki___1__3_"
+    "test_delta_4"
+    "test_swaprz"
+    "test_deprecated_algo_result"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
+++ b/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-ibmq-provider";
-  version = "0.6.1";
+  version = "0.7.0";
 
   disabled = pythonOlder "3.6";
 
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "16c73m9gp1wcrygr6mnc0a9ps0i872bgc7v1zbqyh50kxbcrnpnz";
+    sha256 = "1n13jjx1cx5gswwk8rpxfjqyk97cwx1n2hwsabkcbi7fksw3c5jk";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/qiskit-ignis/default.nix
+++ b/pkgs/development/python-modules/qiskit-ignis/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , fetchpatch
+, python
 , numpy
 , qiskit-terra
 , scikitlearn
@@ -38,11 +39,12 @@ buildPythonPackage rec {
     scikitlearn
     scipy
   ];
+  postInstall = "rm -rf $out/${python.sitePackages}/docs";  # this dir can create conflicts
 
   # Tests
   pythonImportsCheck = [ "qiskit.ignis" ];
   dontUseSetuptoolsCheck = true;
-  preCheck = ''export HOME=$TMPDIR'';
+  preCheck = "export HOME=$TMPDIR";
   checkInputs = [
     ddt
     pytestCheckHook

--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -36,7 +36,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-terra";
-  version = "0.13.0";
+  version = "0.14.1";
 
   disabled = pythonOlder "3.5";
 
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "03fgqmyahgmkf5dbw19n9c1v8p4kmpk50wxhhc8435cclvs26x9j";
+    sha256 = "0pd7x2jrqy7q1s38ychqw9bayjn2rvi6rq7c2c0kd160rwj1l2sc";
   };
 
   nativeBuildInputs = [ cython ];
@@ -92,10 +92,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "qiskit"
     "qiskit.transpiler.passes.routing.cython.stochastic_swap.swap_trial"
-  ];
-
-  disabledTests = [
-    "test_jupyter_jobs_pbars" # needs IBMQ provider package (qiskit-ibmq-provider), circular dependency
   ];
 
   pytestFlagsArray = [

--- a/pkgs/development/python-modules/qiskit/default.nix
+++ b/pkgs/development/python-modules/qiskit/default.nix
@@ -15,7 +15,7 @@
 buildPythonPackage rec {
   pname = "qiskit";
   # NOTE: This version denotes a specific set of subpackages. See https://qiskit.org/documentation/release_notes.html#version-history
-  version = "0.18.2";
+  version = "0.19.1";
 
   disabled = pythonOlder "3.5";
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit";
     rev = version;
-    sha256 = "05pwpcps1ksqx6m6hwq90l8sbak64fsz76yv4q3jplfjf6597k6p";
+    sha256 = "0p1sahgf6qgbkvxb067mnyj6ya8nv7y57yyiiaadhjw242sjkjy5";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bumps metapackage and subcomponents according to https://qiskit.org/documentation/release_notes.html

Also fixes ``python3Packages.qiskit-aqua`` breakage on master. Tried to bisect to figure out what caused the breakage but couldn't diagnose. Closest I got was maybe ``pythonPackages.ipykernel``??

Closes #87432.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
