### PR TITLE
arrow-cpp: 0.16.0 -> 0.17.1

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -13,12 +13,12 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "arrow-cpp";
-  version = "0.17.0";
+  version = "0.17.1";
 
   src = fetchurl {
     url =
       "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
-    sha256 = "0vcfprf176jlmw6wsy6vyc49fiffyjk37rhl098sv2pqw71v8iic";
+    sha256 = "18lyvbibfdw3w77cy5whbq7c6mshn5fg2bhvgw7v226a7cs1rifb";
   };
 
   sourceRoot = "apache-arrow-${version}/cpp";

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -1,24 +1,24 @@
 { stdenv, lib, fetchurl, fetchFromGitHub, fetchpatch, fixDarwinDylibNames, autoconf, boost
 , brotli, cmake, flatbuffers, gflags, glog, gtest, lz4, perl
-, python, rapidjson, snappy, thrift, which, zlib, zstd
+, python3, rapidjson, snappy, thrift, which, zlib, zstd
 , enableShared ? true }:
 
 let
   parquet-testing = fetchFromGitHub {
     owner = "apache";
     repo = "parquet-testing";
-    rev = "46c9e977f58f6c5ef1b81f782f3746b3656e5a8c";
-    sha256 = "1z2s6zh58nf484s0yraw7b1aqgx66dn2wzp1bzv9ndq03msklwly";
+    rev = "bcd9ebcf9204a346df47204fe21b85c8d0498816";
+    sha256 = "0m16pqzbvxiaradq088q5ai6fwnz9srbap996397znwppvva479b";
   };
 
 in stdenv.mkDerivation rec {
   pname = "arrow-cpp";
-  version = "0.16.0";
+  version = "0.17.0";
 
   src = fetchurl {
     url =
       "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
-    sha256 = "1xdp1yni9i1cpml326s78qql1g832m800h7zjlqmk89983g94696";
+    sha256 = "0vcfprf176jlmw6wsy6vyc49fiffyjk37rhl098sv2pqw71v8iic";
   };
 
   sourceRoot = "apache-arrow-${version}/cpp";
@@ -28,19 +28,18 @@ in stdenv.mkDerivation rec {
     # ./cpp/cmake_modules/ThirdpartyToolchain.cmake
     # ./cpp/thirdparty/versions.txt
     url =
-      "https://github.com/jemalloc/jemalloc/releases/download/5.2.0/jemalloc-5.2.0.tar.bz2";
-    sha256 = "1d73a5c5qdrwck0fa5pxz0myizaf3s9alsvhiqwrjahdlr29zgkl";
+      "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2";
+    sha256 = "1xl7z0vwbn5iycg7amka9jd6hxd8nmfk7nahi4p9w2bnw9f0wcrl";
   };
 
   patches = [
     # patch to fix python-test
     ./darwin.patch
-    # Adjust CMake target names to make -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON work.
-    # Remove this when updating to the next version.
+
+    # fix musl build
     (fetchpatch {
-      name = "arrow-use-upstream-cmake-target-names.patch";
-      url = "https://github.com/apache/arrow/commit/396861b38d2f4e805db7c2ecd2c96fff0ca2678b.patch";
-      sha256 = "0ki7nx858374anvwyi4szz5hgnnzv4fghdd05c38bzry9rfljgb1";
+      url = "https://github.com/apache/arrow/commit/de4168786dfd8ab932f48801e0a7a6b8a370c19d.diff";
+      sha256 = "1nl4y1rwdl0gn67v7l05ibc4lwkn6x7fhwbmslmm08cqmwfjsx3y";
       stripLen = 1;
     })
   ] ++ lib.optionals (!enableShared) [
@@ -66,8 +65,9 @@ in stdenv.mkDerivation rec {
     thrift
     zlib
     zstd
-    python.pkgs.python
-    python.pkgs.numpy
+  ] ++ lib.optionals enableShared [
+    python3.pkgs.python
+    python3.pkgs.numpy
   ];
 
   preConfigure = ''
@@ -92,8 +92,6 @@ in stdenv.mkDerivation rec {
     # Parquet options:
     "-DARROW_PARQUET=ON"
     "-DPARQUET_BUILD_EXECUTABLES=ON"
-    "-DTHRIFT_COMPILER=${thrift}/bin/thrift"
-    "-DTHRIFT_VERSION=${thrift.version}"
   ] ++ lib.optionals (!enableShared) [
     "-DARROW_BUILD_SHARED=OFF"
     "-DARROW_BOOST_USE_SHARED=OFF"

--- a/pkgs/development/python-modules/awkward/default.nix
+++ b/pkgs/development/python-modules/awkward/default.nix
@@ -3,7 +3,6 @@
 , fetchPypi
 , numpy
 , pandas
-, pyarrow
 , pytestrunner
 , pytest
 , h5py
@@ -19,7 +18,7 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ pytestrunner ];
-  checkInputs = [ pandas pyarrow pytest h5py ];
+  checkInputs = [ pandas pytest h5py ];
   propagatedBuildInputs = [ numpy ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -1,28 +1,19 @@
-{ lib, fetchpatch, buildPythonPackage, python, isPy3k, arrow-cpp, cmake, cython, futures, hypothesis, numpy, pandas, pytestCheckHook, pytest-lazy-fixture, pkgconfig, setuptools_scm, six }:
+{ lib, buildPythonPackage, python, isPy3k, arrow-cpp, cmake, cython, futures, hypothesis, numpy, pandas, pytestCheckHook, pytest-lazy-fixture, pkgconfig, setuptools_scm, six }:
 
 let
-  _arrow-cpp = arrow-cpp.override { inherit python; };
+  _arrow-cpp = arrow-cpp.override { python3 = python; };
 in
 
 buildPythonPackage rec {
   pname = "pyarrow";
+  disabled = !isPy3k;
 
   inherit (_arrow-cpp) version src;
-
-  patches = [
-    # Remove when updating pkgs.arrow-cpp to 0.17
-    (fetchpatch {
-      name = "ARROW-8106-fix-conversion-test";
-      url = "https://github.com/apache/arrow/commit/af20bbff30adc560d7e57dd921345d00cc8b870c.patch";
-      sha256 = "0ihpw589vh35va31ajzy5zpx3bqd9gdn3342rghi03r245kch9zd";
-      stripLen = 1;
-    })
-  ];
 
   sourceRoot = "apache-arrow-${version}/python";
 
   nativeBuildInputs = [ cmake cython pkgconfig setuptools_scm ];
-  propagatedBuildInputs = [ numpy six ] ++ lib.optionals (!isPy3k) [ futures ];
+  propagatedBuildInputs = [ numpy six ];
   checkInputs = [ hypothesis pandas pytestCheckHook pytest-lazy-fixture ];
 
   PYARROW_BUILD_TYPE = "release";

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -166,7 +166,6 @@ in {
   });
   arrow-cpp = super.arrow-cpp.override {
     enableShared = false;
-    python = { pkgs = { python = null; numpy = null; }; };
   };
   boost = super.boost.override {
     enableStatic = true;


### PR DESCRIPTION
- Linux
  - [x] `arrow-cpp` builds
  - [x] `python3Packages.pyarrow` builds
  - [x] `python38Packages.pyarrow` builds
  - [ ] `pkgsi686Linux.arrow-cpp` builds
  - [x] `pkgsStatic.arrow-cpp` builds
- Darwin
  - [x] `arrow-cpp` builds
  - [x] `python3Packages.pyarrow` builds
  - [ ] ~~`python38Packages.pyarrow` builds~~ (`python38Packages.numexpr` broken)