### PR TITLE
vimUtils: customize accepts alternate {g}vimExecutable value

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -399,9 +399,11 @@ rec {
       wrapGui ? false,
       vimExecutableName ? name,
       gvimExecutableName ? (lib.concatStrings [ "g" name ]),
+      vimExecutable ? "vim",
+      gvimExecutable ? "gvim",
     }: vimWithRC {
-      vimExecutable = "${vim}/bin/vim";
-      gvimExecutable = "${vim}/bin/gvim";
+      vimExecutable = "${vim}/bin/${vimExecutable}";
+      gvimExecutable = "${vim}/bin/${gvimExecutable}";
       inherit name wrapManual wrapGui vimExecutableName gvimExecutableName;
       vimrcFile = vimrcFile vimrcConfig;
       vimManPages = buildEnv {


### PR DESCRIPTION
###### Motivation for this change

I use Nix on darwin and use MacVim. MacVim uses "mvim" as the shell executable to launch the GUI version. I want to wrap `pkgs.macvim` with `vimUtil.makeCustomizable` so I can customize the vimrc but this doesn't work because of the hardcoded "vim" and "gvim" executables.

I have to use `makeCustomizable` rather than call `vimWithRC` directly because `programs.vim` in home-manager uses `pkgs.vim_configurable` to set all the Vim settings. So I have to make an overlay that sets `pkgs.vim_configurable` to the customizable version of macvim. But this is a blocker! [See the vim module in home-manager here.](https://github.com/rycee/home-manager/blob/1ec45b11abdfbd92d608a6536d11e80bd648ec02/modules/programs/vim.nix#L138) Also, calling `vimWithRC` directly in general feels kinda weird, like I'm digging too far into the abstraction.

This introduces an argument to set the base name for these commands. I'm unsure what to name this so open to other requests.

This is my first PR so please let me know what else needs to be done. I followed the CONTRIBUTING.md guidelines as close as possible!

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
