### PR TITLE
firefox{,-beta}-bin bump

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "76.0b8";
+  version = "77.0b4";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ach/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ach/firefox-77.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "f4b15745610d97f3919b644ed47b515eadfeb654eb81c5a890a2d225f1223f2f554612a5df14c4514f0f835b25f44649a923d09fdd199db4b052384075df89ad";
+      sha512 = "06501efb2db804a1fa584149ef80de6584e634d60bdfa71f37882158ea1e3285e9880e8af269a4fb57cbbb7a326263d5ff64b9eb53a492b6ce493708cf12c576";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/af/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/af/firefox-77.0b4.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "a39343493647a46579ea6f37e5da14ed59ab5ef91a4e47b9b7f43cd3f469110b9544ef660b214b7a5f3df6373a9f6bf9b55656586a96a7f2991b4fb9a66abe42";
+      sha512 = "680bf3d96248e60f7541c0a416100f58c8dfe31cd5ead72e872045f200455bfc6ae9555f35ca6d0c1374f8f02c464c411e61539561b99a46f7ad72cf721c01b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/an/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/an/firefox-77.0b4.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "ff0655c7fb043f01c8c4cbde006a7835a6f0271133a9dd07b90b3e0bf369233f9dc0ed0caf38421ea9b1870f1daaa598508865a239f5f2391eccfa6c0341c94e";
+      sha512 = "86347dff7723f72429a818ede7099f6f31d91edc200d0e6f22cc4deff1c6c03559d4e87d301cfa77469307bacc2a682949faee34095302f1119089d2165c0a02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ar/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ar/firefox-77.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "b89d38b6a44ebe00806cf7b16a29264c324d6afecf4d83e20ae4b35c502b13ee04a052a879d1c68e084e99ebd9850a9b597b6d4ea19350e0005c8d006d5cfbc3";
+      sha512 = "29eaa6e1e728e16781caa5e3dedea52d8899a26c35429ad9bab265454bb49b70e6fe2e8e86063e554fa4889f49c5cb4390ca82986b851dd5b4f7eb2088b916cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ast/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ast/firefox-77.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "34a6db5926e8bc90e47e8ed8c413e3c47fe35d119aa3c2315c01b0ea38a04a8acb44551e689b798dc030902b9d3dba3f62971b2d927ed4cdc0f965657a189af6";
+      sha512 = "aec9c22e84708d95f40e36dd566f89868b05b3fa2ece5213d700b488878813e33649fcb4057cec73a58c7786ec8cce0b5a41daaadeb0f37449427790c52742e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/az/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/az/firefox-77.0b4.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "3a1bd479e251ad695dd397d019b3f492915f8051984ba399fd93035455070eb9a2b05bc43d87506e671ff80c4b2e4f17808f37e959d94dcb6a3067f8761f617f";
+      sha512 = "bc1358243ed92aca408afb972d25186083b1f1b75f1edde65fd5da47ef47a5e299503cae2e0c6310a781dc4a6e6d86bfbe9d96b7cc7ff35eda0e8bf81be881aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/be/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/be/firefox-77.0b4.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "0c53c0abf67079d254b5da7c3d7edee506678bc3be55d24b61865e18f8e81b9e26f8ec98d08e7e8aacfb47a231460cafa52e065a4d216cadfaae70ae0a9202f5";
+      sha512 = "f4990f8c30cb85fec211a886a12de2fe14fcfc064b849a06bbca21931c2ea497507124a2cdf97d816fa79ff973e1c18587054d54d0d32fe944575d8ed317e08f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/bg/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/bg/firefox-77.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "b608676213c5ce9cae42d18af0f6a836586d990d58042ac8bdd0112590f3aed30abd4272d4581a0cbb633043b4f0cadca7a90ac40777e5fdb7afe807fff1c2ac";
+      sha512 = "2212e3f5774a5426e6a747b3adafbbaf75dabaa4bca91914510235a8692d09c3d4df20bcc5c34e26d72152bc5e631ea7c19ea62a39e6c737f5555e167b59c3cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/bn/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/bn/firefox-77.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha512 = "44fc7a158689424b3c781812e46b38efefae4f49098bce533c1abfcf9cae78a6be2369fe21f6be12c96fd85afab875b8a6f77af399348f82a1cce3ad4b0279f0";
+      sha512 = "53095fba9a330240e712812157b89465edd81f1bbfdbd2d2e803c11963e226d0ac685a53591157e42a29bbfd7d431ccf01e3db32314d646c282527d026c19509";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/br/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/br/firefox-77.0b4.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "f9f3bc634fe7c21e1cf9800f8875979e9f77764f71861926b67e9addd604e88b22f90cf31da5dc93b3ebb2dfac8c04ad423b9b21416732c9000e9747ab588a11";
+      sha512 = "a973961b8366744688aca45455e787650cab21993a6ef9c65801b4d7042aaef3e4ca9b49d5176f4521e838efb948602eb174d926e34a806166e1581658edcd3a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/bs/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/bs/firefox-77.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "3558b3eb7da562ba50f1273ae461f753a95d42eca3714eb1e044bbca3e63de16ce1f040f5b34709c8a0e86fc59ac6c9d65f1dccf3a0fdc30e96c0f7490867d7d";
+      sha512 = "91138267b5c633b27bc8dd0af087580c9d28f9474a08cd8c38a65d7e1039fbba37c22d449b34b1117f7fc7e28a06c3be3e0c3df633316f66544668e9c40c9d44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ca-valencia/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ca-valencia/firefox-77.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha512 = "b79f0e814ce7df9de0f2a488a3a798ce9a33c840c7a39efc6a749a07e568ba881bd2e42b4a49fbe7ccee0ddbb3e7768382181ce16379a6b24551ad555685a792";
+      sha512 = "c02f934c9d1a66ad52d9f20c18321a7c96938aaafb38dc488e87397a780c884db69d69d62132c48e21dae1cba23d570ead070055700265a03f0e0212bec2d486";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ca/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ca/firefox-77.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "69a6c978b4c896091f6118b55783988fc505c819d74cd455ec6274d54fb6994a012f41d09d9b574be90bc10e47b8d186b8021421d86d05db6945ecda1e51d127";
+      sha512 = "0eeea98a64d3956c8759c7968d15f49996b7515a1706c655c0f857c0b95babde55ca5310d44157f17829270d80e2706e4e3ee0ee5f30ee18c0fbefa4ec91dd62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/cak/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/cak/firefox-77.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "8253f68114e9bb035edb0d718439f0d28f04e6afa7ea33d1001a1457723c4cbcd17362c0b517a23ca78a53ad2dfc847be396e28beb3a302f2380a6dad5eedee5";
+      sha512 = "0955f01d77ace505cd79b7e6a6c657f5b23dd88597b86a1091feccde18b0501510afa6ef54ae04c99567ce957a3fabbbe602e75a13d014aa72f4df29a62e8959";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/cs/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/cs/firefox-77.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "1413cbd3345770ce7597ef139242b72fcc9b7c53bca4b7cbfa707f00bc3d2778305f617047ba24fa22f808c0168524166a6fe7cc7db6ea0c5cd30b609e80d404";
+      sha512 = "749f5209a2166b2b2447b2bc8bc4da69e7fcbca4cd562bad3126e65aa0d03870a335a878a851aa2ddbeeafbbcc7654a9a8aeb429be56364563a8a9ef38c227ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/cy/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/cy/firefox-77.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "1628a73872c268d4aa8ac78bffe6ab49341735c6abd5c8f805c86129ca0fcf5d03251e962fcd4c9ecdda6af125b8d4f9d095e42b2ff5c185267cd41f3090acd0";
+      sha512 = "c04fecb70c28b3c3ef73a7a1a77094b8ea493efcd97e4f38880e1c14ad26d841bd74e0d60800f8155659b2a5aa9f13272ebfc43d4e0cd59882080beec80e9b45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/da/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/da/firefox-77.0b4.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "f51f300911731acd439068bcbbab712ce4920345b481b8db80b3f6ca1c1cf18fd201a9e639abc78db97933d4872c7241324591a9c045bc1c6d71898e2a2fca93";
+      sha512 = "ff0a8cc4f26ffde9cf707a709dfea929201f4a20667829e3f02938cf169d2de083f2507a8c58bcc0cf43d04c392d3c258cb7641f4df5df58fc239684f1f96f31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/de/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/de/firefox-77.0b4.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "196ce93a18112d7e0df8a8c1e444d503d3b0a2d11e70907963197760c2127c4f827ae9a0eb79fa7745190c92be10c7828a42414d33ec9ccea1f0b7194ffcc325";
+      sha512 = "1260f8dd00c6d6209c1d76c4ef0c8010b8b87b5e351cf7e21b5aa8f703c6f36df61c11dce2a05fae0bcd6f4517c61dbbe8c95ca52869d7d58db1f1c9ea100864";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/dsb/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/dsb/firefox-77.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "da6f0afd218345ffa1bc0b037ca20c9aa6b18597471d35d5cc8f4fcbd4f39f91e2839fe35f186577ed4445d34e76d4c8175f2df24f7bc0795f606cc6ab47db7f";
+      sha512 = "0a76df6f025f5c9fe6553299911da89da883298b9f6b2984a9f88a9e59169fe0e22052d12588af7f2fcbb249c7f71a299c07d0d05ac05fe82cc40d336bec1794";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/el/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/el/firefox-77.0b4.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "4ea4754aa0b337e94f3fec5b108c703ac80827d514e64e3e6c890e050107249367c4167b58f21177c3071c11301c37de08703136f03edc0aa901a22e2126b279";
+      sha512 = "ada58d8a5b11f27428616f2c0c2ef281256833e9842434197fd87e2a07fef415b69298996d049faf5f2f03f25cd61488f36cab11ff50627a7c6429dc394c0b33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/en-CA/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/en-CA/firefox-77.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "f6f59d13148c7e5510a03e93644b38a788911ed904e088be48cd1bde071ac372b4b047f988714ed44d1f64ca6a32502564f01780be80f6c49373119ff7021454";
+      sha512 = "cb2393594a5c6a0bf7d238892ef4b635b33510de83bf2f0221760d9ed0ff8171646568e1131058a3e1819c0b860e3ed576e78424f92a04c79b0a4536dd40d0a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/en-GB/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/en-GB/firefox-77.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "fa42017d8111e96c4d81ce515577e1307e187493866c04f3687746647904f2f89a3f0df822ffdc2004bb0fa06aeba102e29b660e250737b2264b5015010ab869";
+      sha512 = "0a77ccb55113e27966d2289cfaca422f89667f1edca47e5d1c697726af9f1d4b979a489264ad3b493f4274be78f9ea2eda7f33aa3eb20c6677f25bd3a25e2dfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/en-US/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/en-US/firefox-77.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "5f47dbf433ab20c2db027542eb0a3dcff7fb0b526ec93908f182e1dadde112da327f84edbaf44ccb26d36c120a414d64ebb9b10a77501644d9f1c9c3d34b7346";
+      sha512 = "0ecbfe52d212737d18a8217fa0176b461e8cbc33c5960951de95e7b5597ea6043b6fce03bb3f39782363bb72f977424349c8c2acbfa3efe6fc3b752cad104f24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/eo/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/eo/firefox-77.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "3cd5e9e99b73694aeded24d9acc7c594bcc582eafca5867a7123c5067e34f7e96781164fd7db2b53366bd0d0d66fc495931cad42b1e3d56726c8e5f82c8aea4b";
+      sha512 = "5ab7ef5bf01fd35048e38aa352721d4374c1ad31495235cdec422463e32e42284aaab9f34c7fa7d458b7e1e00ea12885fdf5ee300ad57d0e4630e0cb38289390";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/es-AR/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/es-AR/firefox-77.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "ae43f7147a3ce843488623c4558d9088690fe6ecf7153ff30da09051e9e9fe90df28bf6529a469b8d799554c8ee3ef92006e73a2cb9e68a5b71ab392a977e849";
+      sha512 = "cce7e9843d0dd45405f2782c5a863fb4968d9fe88e17843d711bd79457dd4eceba0184834a914fe9a3a96bb584db9642b283da80286cc0abb476f7202186e40b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/es-CL/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/es-CL/firefox-77.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "6ccde441b5c44514da5bf7cb9aa959f818d5c499fa8d33487102cb1a1cb98a501b1575ecc28f8288cbc4b69dc70bc76f365e9b52d4329b685f25a1ba9d1ff063";
+      sha512 = "1edefd23dfe2bc9a1e6747434ccc4f877f9618dc1ceaeccb04ce2954b56e42274dd84dc253bb11fb3994fc92d4e0811c96f97a72f236ffce6f87ed96176536c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/es-ES/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/es-ES/firefox-77.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "3800ba267d51d9046999c931b5bd9a743d2a3481486a7ee713f76c003c863b8579d44ca53ea56f5b32c8022ffd9ee0184b7c734e5671b412f60d04653ca2c8fb";
+      sha512 = "e006afce3b0dc0203f17ae8e5cd49d8d1357cb32739818c5193e4a78bc2b90739cee52b920b7a06a891729528a32b32f64299df3194b350fd0548f8df37fb99f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/es-MX/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/es-MX/firefox-77.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "600a1aa9a0b97fe66947107ee9018740e2f7c07bd3ac51b03c0c6d52728d72f93062c9dfebb97042c9a23a85631c88502feaa6a8cee395953ef23c2addf6a99f";
+      sha512 = "0cb5f8f0cd83bffc998763d9c22c7b8d1ff59127d05383aabfd9a55f06ab9aa94da9ebb384f2fd8621e57057504faea6850464752080a1db016a1aa58732b550";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/et/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/et/firefox-77.0b4.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "498f59dc3a6faf067c8c3d23eb5754dc8cf0478b50379359122b7a8e6ead6d7c6c39856cb34f3510f7fe1a11af3e0533a3805821ba49cb7cbf1d40b1caf36b3f";
+      sha512 = "c873b291933fb6508c14fdc59934a25abd150d095ebcfafe7002cb7ea4f4820030ae9291d99edcb6cd270842c894f9958bd4ec3280fb85677828d5c924f2ecc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/eu/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/eu/firefox-77.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "a5d58868468f9ccf22afe78734121e1f81961efc9c7add2a065ec9b9d5d68d8fe96b5f563a85b960ea7ff94c70e1c3aa3a9f0f1bb23cd175df549375c1479072";
+      sha512 = "6a824d37571f7cd44998c9c7516bbdbec4a1b1c2e2f46739daff297ba5e0053d9e80bd9260ce9375ca8df55ff263b90ab3ac39723fbad293b80e510e7c9bac6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/fa/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/fa/firefox-77.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "02a5d946542aff81bea82ec73fe30919fe4a1d1acbd18ef194a7c8879d9b70e319abaee2e4d8b3a2671cecd28fffaa37a182f7dfa06884f83d765b8701c60a9c";
+      sha512 = "3985159a097fdefeb06cdbe4e4fc2a82aff62709aae3597cf1ef9c852995ff3dd4e3e8d9d5722731cd8a1eed20289b96f7f0d55242abd7a8bab2a0273f661de4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ff/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ff/firefox-77.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "4ab405c47fbdb83eace54b0db61c734941d5ae6c5735d50dc6800271dc59cd82de9df9e1e98f238c4726ff9319c31a8879b2f0330792289db5e4b01cd3caf3da";
+      sha512 = "5df460f642323b553e374db01f21e5dfb580d1193a158d147698d6bb1e66ef718291d61ffe39751850d8d68057df035b72e936b22e2ba1fb44b2d561ae7a87fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/fi/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/fi/firefox-77.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "82f95d6462097fb2975285326ef6b35a572b4c25bf07517f3ad680a978aea95f5cd4ab946275dd74cd6aa98566d1a4288761c985c39e1cb3d9e963b892a37544";
+      sha512 = "4b294d9f2325083ed63367cf42c23d7e1b96b6b2d68bf1d16b50ca9cff8acdde75ea47a2262d3469ff001a393a3d45171e2505f86c71090a69b1d114872282f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/fr/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/fr/firefox-77.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "a6df8eea8918292c18b281f5118a0373bc69aabc585d3a711ff77355a1aa95f5049d31df3bdb72087931dfc347050f4ccd791a9729f7bd3d95cab20c78da8a59";
+      sha512 = "67bf7732ce940cfe39734886a9729043786765f137ef03f2d03f932a0358011255ced10806440fa09e512ca9c57ce89ac180f5da6ef18b32d1f8a35ee422bbde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/fy-NL/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/fy-NL/firefox-77.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "d5cbb68867369a82d84ade5a847d8574ff687c0cada8714c8a072291aa02eef748dc109b42f1b246980f1ca14060b799098885bff2d7e4c55e7ff644ccc01e9f";
+      sha512 = "dc2027781d3203c952d0aed96ba97d8b8305fdf29ddf15a6229693b2e90ef09cfb4ba183bef8332c6010b9649d036b563052ae1b6f59ea78d4502a9e2d757309";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ga-IE/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ga-IE/firefox-77.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "8d9a299c49949609f162f9bba7db369fe7c34f2b29d3075c607afd3c3bdb5ffa0ae0d9bb9d5ff5a5f0cd28556eeea5265b8f9809a2db36ae11209b9cbcb5b8c6";
+      sha512 = "3e06a3965d345816c5f395d7739cfd9f64dab4a9310114bc39413aa77dd63c8cea66a542b7e30bb940932d09850a9c139cd9e67e64142e5af38fcd0d0b53ddac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/gd/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/gd/firefox-77.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "4431eeb86c0e3920bd08db00c10185941bc7fb3f5b055b8ba114e63bdfd7b64ccb8cdffcb754453557bec011d08d87e08b6a2ce022c77fe32add49269f3ac6d6";
+      sha512 = "618dd36f73ac7307c64fade12262d90c27d6798f57ce85396f4965eeb7ee0f14fd1797c66d1676936db91b0c7b7f23cfd5385d265cf967e5adbd401b3b0f1ad0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/gl/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/gl/firefox-77.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "0963628808ab6f6ce65f70e09c12ca38c524992c82446a2654eb42917ee2d32dc1dae94b15578ac5209e12e0fc4cbd2f56265ae8c259336415d4a56b560be96e";
+      sha512 = "3764b131d9d8e74b06ad6aad008d23e192132e7196d52297f78dc3bc753f49f483102efed0f88329a26617748a4e810fac5fdcd00e09a440ebef051f1f62d300";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/gn/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/gn/firefox-77.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "1b19d9ca238eb05709007ddf00ff40596b49ec771839f6b1ac21162796101701fb523c0b8ff18dc6d3428eca3ed2ac0fd3bf17c5ea91efac998ebe4b8ece6c9c";
+      sha512 = "e426f157656b2d7cfd261ee54a77c12cac0b000563dcf1873947e0f797d042d34453e8d962bf4d4525df47bbab485df353e386f7bcd9a206af7d1e22b7ceb495";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/gu-IN/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/gu-IN/firefox-77.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "c0d2fa00166926927e1985ce112a035980ad24771d4ede83143c4bb9012006c811aed2612fb1f2c4b1bfc852a7c7799309f4b579aaf86fc5b11ab216239911b5";
+      sha512 = "b52b2e9816fb71488b40888188c3be8a715dba749cfa22c601484a1203bd233c2d5db0ca767c54d6992322acace76ccc4c2c189dffc9f44687eb07f3b694a274";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/he/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/he/firefox-77.0b4.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "b2a5440b57ef85a3e3ee607e9e497e6b70e3652c7f258a2c7e98e18b5a95c8d34de908d64e464be9ad224aac7869efde785e38462fad3c284649bb9c524574b9";
+      sha512 = "08a8ea92dab9fc5e392c4b388c7484f88e2d3c8c84414414ea0d2a5936772a8ee5a3cf8a12955e0d5645f6fd439b732f62ecf1aa60b52435a3f6917e168c64ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/hi-IN/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/hi-IN/firefox-77.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "2ffeeb8d559097e9d67f7603c34585d8b4d1571a23ef5a9d04c47407b03c4db2d4633637e8352ad96989facbacf6796aa48eb94ad81b70b0be3f0955b8a0e32a";
+      sha512 = "421ca2e7bc9ae568551358581b26b74d935947f5ae318a00f51e3f07a34f7ab571d268dfa9cd45e6580be97b9056266d077108a97c9edfb9f096f5e29996b071";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/hr/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/hr/firefox-77.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "91ef9459edcf44b88e9bb6c5bdf1a1d5689c99e5a44f14f4700d0821e0274e9f8c3f79388c7a97e0aa235b8ffe1099ac80a523b4d62420eba5163a608d48aae6";
+      sha512 = "3ce3d169a103c36153e817096f129215be0dbfe3f66e63bdaaf6bdb44fe7ee3d1b3a590c9aa99bd497f2dc151d224950e42fcc42533cd30496d97e8fb9bf6c43";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/hsb/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/hsb/firefox-77.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "8173f8c47566f7aa486266b8c0e83eadc11c484f597334aa48eebd3ed353f5910eef527bde508e98f082240d01804006ca4771aa7992290b254601d2eec6a206";
+      sha512 = "a6c6b0c5e70ce101ddc90f7405b9fc6e47ea6515fafa3821b9437f6ec51cf6766964a9b917ff97cff91a19bba037c8537f8095b5da8f5cc474e749e2747c57aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/hu/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/hu/firefox-77.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "7ceb26c11204ce6b1e6c3596d9dc3e6146422cc3eb0d1ef9c06251430e32f2353ee42b4363204852d6374cc845f8b84997958d2e66af3e770aad679d0ad3e66b";
+      sha512 = "c63252d147f96cb9be6e20f9b29a82099a7dfcea61d58deb410d26d1372279e300d77dc55327bbde09a01d742256c627347e0dea558babcdf5decf2c388eb738";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/hy-AM/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/hy-AM/firefox-77.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "cbc66db54c574aca15f8e2726ff68910d19a67cbbed9e2b63518976e3f614b4f5f6928bb7cdfd5c357d7152ef04ffe1a311656125ff5cb62e471ae59213b79e9";
+      sha512 = "07557abf8c286cb1446f29c8439b7fb8ef3ee90aef8914e78095a0461531f8247c4cd8c087a750478ec9ac72747aebff98d9011efdf06a4982267cbce86d8bc4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ia/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ia/firefox-77.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "19325c8a1aa3067fa8df803b93f124427519020903ace8cf12585711634f8d546662166f11b3944880dca5eb79ae87a9e2d0e4e273d95543a4641e9cf4324ebd";
+      sha512 = "1195a441c0d20e0cef92a4790ac921b4289332f6cf2bd33efd317aabfad274c39adf27072cb0c6d2296011769abebeb4bd314a96f4e730e090dd53670c05dce1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/id/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/id/firefox-77.0b4.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "b74338470d7eb1aecfc75ead675e2408df33fd4841ab4953cadadfb9a7f6169f8a10c4896d4d48fe86113d3f1ff312c4298976ef8b997c26d6406f8598b19a5e";
+      sha512 = "88d86c3f5944e524699e9ed0f90889e27f3de3b7b42a08449994f53fafc5256ae4f04cab4a913eb11073e6cfc7fd27f169d7ae7209bba2a447d0f7acd8c39d36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/is/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/is/firefox-77.0b4.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "cb3cae07b27f0d485f9eb70805671ae50325491d622dacace2a39606efd7a72e46220e4981ff012f115183641b8e00271ab06c5ab2e8bcf3baeda040546c8b12";
+      sha512 = "e242e39278cb0ea24bd0253161674a966fc0b05590edf2072f3393e8acc8a03988ea49ecc2654c6c15a1cdecbf5994ed61c577c56fbaa5197b982d2573bad1de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/it/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/it/firefox-77.0b4.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "83b7175ff91bad6733db2cd095172ef943867aa2dd911c6ec857dbeaad8cf4cd906278f3b8fd488e8905cd5d5574f727066ae73e92948d22804dabe16b4a11cf";
+      sha512 = "015966437f2327be31a1bb1d9a7e70adc186c5b20d3efc7321e45c45d7b421fd12749b82e07ba2b6c0608bf5a29ba6c079727fcdc79caeccb11947e35147cc4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ja/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ja/firefox-77.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "b97a3c637b1632b6a6285af946eb0a2c178d8fd901cb3a9b0fa5b62d14e3bc314acedd504153ae111557b78a2edbb056bd4a255f5971e1ebad3e335879dec40b";
+      sha512 = "2db6a8aa0313c913faca760f60a50b4f4a641033f50f6a3fd7bbab7be5359fe8b06fb1708d2e6600706622f5f7eae478bf32965e7c88cd33bd7baa0db1a74a24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ka/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ka/firefox-77.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "2f5ae830c52bcdef8fb47880c6941d5aaf4830139b77c59c8e188e82036d315f57732633ea785c54a950d086ea02423e97ea2ac01105b5d2990821c7a15036be";
+      sha512 = "d232b0fe777f7f1df334fd6affdf9679eee5e0e17ce34d7a81cef279f736301c1885a4acb90f41d6c01d0de1a4027b45287b43f3e1e74375f600249930f0b492";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/kab/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/kab/firefox-77.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "4be9c49a6b6203f2f3b3aa3b5ee2c3246d77409da5a7b7cde2c14a3fa592eba87715199447df96688e95d9905d6f1eadaf867ffe1d01be9a12feb03255848c84";
+      sha512 = "01b81e8cc4eb59d6df9a884582786b04ed364463701e737ad200d9dde99356439f1aa2908d93a1f095d2dc35222fa4d3201779a35f34142123e3de59a6eaf863";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/kk/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/kk/firefox-77.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "d15c5f6fbbe9b16510e94d1cf49f36fb758a97af5e75069f38b33aab8be007812d88babdb8aa365fe3e4c17a822be234111885a2d71ff335bd7ec6703e81434b";
+      sha512 = "4b7d645a68ba27b8dea59cb3f49498ea9acf089623cc0c20d4c22102643026386afbc84628ce09e18864531998c966d6c13c14645cb8d413329574b54f91cdb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/km/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/km/firefox-77.0b4.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "351facfee64d07ffedd0e5509e8b796d0432c7b44ad29d109c50668adb8fb13f408026166a49f37a92f99bdbf7e032929a22088d4bc42c14169449234841dc90";
+      sha512 = "662df518d6bf4ae80c6bdd67bd2aa0b61add0901e4caaff7672146a1648d416fb5a570f1f6b5d2bd384611826ba77b04c8fd6ff382e1569d022f49fa34a8ca0e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/kn/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/kn/firefox-77.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "dab3f1437cea072c466c9407fdf647f368838bbb7c30177642bc1247a8002874f832d0661e8a3aa32df8c0017f8c664caf6125b6989a113cd08f9c874753dfa2";
+      sha512 = "9f40f187391af6f78aaaff84367f69782b8d3507aa2d0f2d01740fe9e3c94358863abf35329d08da5c809153bbb5189cffe6b7bc6b297bea8add9d2ec812726d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ko/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ko/firefox-77.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "b62dde501b06b4d825d9ffa8008b45a40bbfc93123df07136128f22c7f6e1f1cc42a0ea7e97c1a962a7b1a1a23bccd5eb66785a246781769b22bb43b8ef451e3";
+      sha512 = "0e1863fc046a7b5dbf3b99a650906a47a940a364b819e165a10ff43142c1bffb289372cb5108bc648ab4712178dcefe54ecc2432097935df77db676ce7c7e982";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/lij/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/lij/firefox-77.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "9fe6488ed61c360ec1ba0d784409938159637c96abff94ebe18f198a8c0a72b052b5b0e6b5946339cdc5b5b3288c8e76811704366a4e9f9c498a9041955f7df8";
+      sha512 = "ad094d9845a1e5400499636d6d6ef54dcab87a3caa117582f9d043d9b9f7f3695d1e9a2a7ec8e0b67a4b20cba4e6b0a1ebad6af59bc8167c8b6ebe8682e3208b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/lt/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/lt/firefox-77.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "804c3639ec0275d844f9ea37b1ccf5f259c50301cd5ee719b6be07a5097218937b5337a25d375c0d534d59143af3fdb338809fd9490a898d226e9cbddf39b6c8";
+      sha512 = "b21deb61f4e2eda40b656c54f9f36993597eebf2215667523930a1c42133bc59d9190038f462d79cbe1ca89329bd5e3c64083f0db0fb126ed957861df2851115";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/lv/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/lv/firefox-77.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "14b263e7abfdad1ce738d58bc30f054f80099a7513ae443d32aa8dcde6b12f2daac56aefe9d3cbc2db9f9cab573a5ef2b046b8e8df9d5417cffea44d109d1403";
+      sha512 = "edbc41c2f1125fb667fa135e34bac37a43170720ee8c3d6f1d244563985184eec53ec0c9f901880d5512a1d2eb82a67d6d180ca45f969476d0332243c61a5949";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/mk/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/mk/firefox-77.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "068eae194df8e756a668b8e372a0790ab8fdcbd5c54b823c82106230a9cba32b5b6e530de7a981273c67af25e5d329da2c543c8a5c96c91f010d19b6ecb25bb9";
+      sha512 = "f37c2233805c431c4407fe9140096c3cfb99ef9a3faf6be7424db7e365c236096dfe07399a683e9de1d3569ca8e5ce531f55abcdf2c024a5e96857e17be37e41";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/mr/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/mr/firefox-77.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "6775e61398e028c2a6dcf9171ffb3d8fd4746653beb58e8c012f3256685e545abf4a62d53d67aaed3a2f04f216dedbb14a09920f24c2b6bc288fd29caa1ce2f9";
+      sha512 = "8e1d2b63da95558afe35d81b4ea87443050f013f7516bbcb89fea2917679a40c103700a3f40f457315cf090bc3547d7cd0decd6fae54687c3b8658ea31f649c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ms/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ms/firefox-77.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "b66a91988d816963731c823f16d001b89ce14928caa129ef90dfd1f01e3c54cea2ddcf0e5f7fe34ffe23b265c0a64715c3877fe0c5c8365f80b859d3e06e84ea";
+      sha512 = "249720875f00ff8b7256f004253fc63a13b6b3811b57fbc9babfc43dfe221da428cfce83d0ea6a225a4ebcb0c95300eca256ace6211291feed8d23b415545bc3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/my/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/my/firefox-77.0b4.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "29796ba9076ab6c46f16fc06119a267861b34652322397e77872a7570e8375e3efe88c3c08731cc8909d817d3eb71e269f7d245e691b8ba4778bb653a766914b";
+      sha512 = "dc55bd0a38113698c60f72724f1537a8c4d2c7744b80881e33d386f1a8ba78969d3b59751bff2006d976f049ed27393e5cb3c70708ccc8b9f0da2edda03f05fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/nb-NO/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/nb-NO/firefox-77.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "d7fe426dcbd53043a94d143a038fd901875630627e98547997be62b3319d5f2c2172ccf9315886d97d30c4a041a099e0ad8a229e840a0f4061faa9d6d3c64361";
+      sha512 = "def2dc3cc593e613732d605cd76e85fca1c82ed7dc2a89ffb20c375c641f2ce2700e611f0425f60b3b4fe2678978da2f45fcc919ddfc3a8bfe2bdc22c8536171";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ne-NP/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ne-NP/firefox-77.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "093ee3c1d513adaff69bf84f5b9236c245c4580ae25f7caa642be239a591ad9242b329f15e2dde0969d12223cb6ab8decfc657ca440e344a87e42dd880450adb";
+      sha512 = "6a8667b5abe55cfb22afabd5e84be837d0d22a0164910d50d9481b7309952b019005282fe0bf181dea90226e967c6e0fbc9e5de93d964197f7f0d908a964547c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/nl/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/nl/firefox-77.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "e912de72ee10ac764cccf1243c0c1f8fcf159d6ade88c7ff575a5f7a5175efe8086d8b4ad4c9a72cd65d59186665d0e11abc4399b0692428bb8c93d025de2f9f";
+      sha512 = "37e2421cf9511565a2d90ad1d276eafeb6d35a255421ad7e7d62419df4f06aa29a4713cfcc77cb958de83864056e3668b99741aa2c3a1dcfd14bc9f7a039382f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/nn-NO/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/nn-NO/firefox-77.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "52c57e140593211af5abdf729d4dd45be242539aaad4688ab081d311804d56afe05ac6ae3e21c439a560f5213e49abd1ae0e5650f091215948ca514ad3eb7e20";
+      sha512 = "6c44923c13ade0f7118a553d5ace720fe73d829237aba2426529c07f53230368e535e696f07e6b2daa72119a81849ed80499c8ab97b20c7def2dfb0e65187ff8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/oc/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/oc/firefox-77.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "d249ab86026370ce7f417ddb7d7cc0a4fc58563a1c12388a4e1628938e3af8a1428f2e43cf7ace0c9e455e4b4999942221fc3d96723bd927c50f7e45c7bc1a1d";
+      sha512 = "f3dbcfb729eba2774ff879749b8ddbb1eb40bb653c86a92b476f5e836893fe1022158f56748e83b7dca75cd3ae53b2abdedb44af14efc497ada6b0f2c75dd9da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/pa-IN/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/pa-IN/firefox-77.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "7d5d1861559627f9a77160106dd5c527d09656be5586791c2bf2a61292b1cb1150c545ff1f39a6744453af58bd44777b9668993a10e654ed4c8edddddec12467";
+      sha512 = "d285e9091102b94acd9d102e9ae431ef344a4dd69bb3cf9505e372fbdbdd99abf783b60f91ec5a13edd1b8e459fad3bddde67b9b39488285e84d99f8019bceed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/pl/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/pl/firefox-77.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "24a419ca7b8c82112bac80aa9d956f3198cb324991492f9f66bcf0d64fcbe5618a2e654849dcb5794399dad32de91bf48bd3bba70003e02b9bf28634b8d4b267";
+      sha512 = "decf8bc70559276ecb0b8a61d6c1c8bc1ec2a20a30ada0b899af1eea893a95f5377eea5b14480819e52d54a07f59350a517bcc93d745cb1a4c0909a954483b9d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/pt-BR/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/pt-BR/firefox-77.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "cf33be7018dfffc891e4cac9950ead0274957b9a44e27bd7924abd62f93e69b575dbaab1a663ebf829a05283f957dae0a7442abe76e8e1a8a6e35e12be6e2821";
+      sha512 = "124cc1a369c8a6d762ad9b2792ad2384a8db6a83ed81c48fb041eaa3a73dac6ae594e6245b3f0ac596049f563109e4ccc3f3594d207ab71e8a3a9b5e3d5c5085";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/pt-PT/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/pt-PT/firefox-77.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "c368498ffa8eb48801634fa6b50a74a563a28d4fcd23e4634eea52fb6ecf2872e4cd91aef5799afd8dcbf6020c7f694dd3eeff1197c3cfdac63bd72acfa7d7cd";
+      sha512 = "85f98cb16d1db84aedc3715c1bd97c5aa17ae72abffcf5636ccc1dd0480fe7bc06a21d0c8908688b6076ae65bb697db2d6d223beaf529ff6f6d800e9f4ff1c0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/rm/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/rm/firefox-77.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "d2064ab0dba1c122a599954efb01e4a68f189a1ce1d5059d60373e8c4b89c860d6b6a68c1e58afebe65107c3f8c5c5f87e771cad61efe7449e86f8ce25bacc5a";
+      sha512 = "208f45aba393e2b7f68a87f610ae09ed222793ef6c0bfa787ca514eb84c89d744fb6da96fccb363ffba9322bfb824f51ceff29ad8ca9c0217ece56f5fc2366d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ro/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ro/firefox-77.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "64d566ac3acb823cc062dddaa33e1ae321edd3a4e54b02e317a04595bbc145ee4cd06f3f84b20d1853ad6d0eb4cb7b13bb10bfc8383799264342a409e2254dd3";
+      sha512 = "7a24300a8c5b372bd753e8bf15421d10b373c5db326cbb17c89dc74461d47ce3b37c482efd220cb776279577e9b22a6857fffa2ea8c5bb29f08ee9b6815feba9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ru/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ru/firefox-77.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "2240c612c9d746774fba47019068391d6e08fc4933b082670269cab1416ce538b2bf9b948aac994e81a31a52b91a11df6968b847ce0e843615a75b8841443c23";
+      sha512 = "0dbed83785474c8901512c54e958a2faddace6f096604902e292b6a8831649c6adb9e561a7753dd8f95c61859ec3684ee8a2b178962df75cb41df42168269566";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/si/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/si/firefox-77.0b4.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "f579d1d21cb45d91394b9a08e1b960a43ddadd7040e417c20e66e1dd4d3f7ea3a8963ab8334e49cb22ad6eb2ef81ba98eae1298acab3abfa512fffb6024da622";
+      sha512 = "004b6c1f3e8a5f53695220535c72a937f6f9fc0a2ec70fe3b9d24966c8e64d629d9ac6582bf067b20549318b23361ebef86c020eddbb3fb4bcf0e82bdb86e478";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/sk/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/sk/firefox-77.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "6d2436ef789404b6d7247ca222cda81ccf518b91bb854d7f53b6c2c1c68b96cf5785bf6b768e49a0b0a4db02fc899c72969ac0c1441ad6bfb8ddb944e2388d8d";
+      sha512 = "3cc900ed882a48f786e13e7af151739363803f6116108784ea471ad086c8c4677b43014ac0c77d09b2f2636a76edc9193eabcab8426eae4ce800b2f644425b4a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/sl/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/sl/firefox-77.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "4ed452c03a08506498ec2663b6fab477b2aa52c9505085b493d799b19e5215ac72a90ab642ab2ba3520c609909b93a5b176d5f13c79066598492e7babd94ecaa";
+      sha512 = "8291aa174f048e0b713db73e7d2a6eeac91c9bc18988961891e24026e1aceaa605b605423ad4340d66dc70c42883ea5bf888cf3ad7e64c5224ea61016d870047";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/son/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/son/firefox-77.0b4.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "d3c77c8a85dbb280f75068ca49891de95fc081b4074cfbd569c773fcfd4d0b017e2b734a6531dabc41dfb3e3f7accb51d47e7cfcff2bae6f230fed8d69db2073";
+      sha512 = "7d55d2d1541768374a19a49eedecb51917bedcec5b2d9f12a9e24337248f5630c51f8d77ff4b5af9340695ab6e37c632d1cbbcf97aa92e1eeb6eede14913bd77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/sq/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/sq/firefox-77.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "94aa56c2d731533105c9e1c7d20862ca9cfd5729fd474b2ca784e2528f798915e9dc177e5966e2b5bb77d6eebc7962e6564f1494ecc284a91175565d25451cdf";
+      sha512 = "72f9aad9ad47a3f8f2a16f21a2dc32b94c5308f48c7c1683129a312dbfdf72a8750502ce24f8c5ea09c56b0b9521e474ea17dc924dfbc84b22385cda087106e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/sr/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/sr/firefox-77.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "3785e6ba189c2ec41f56282ca8925c8eb14d68157c5c035e90fab09f27941e67c9286298c07c31ab0792488f2cba86bce166adf76259d10cc3007f5047847392";
+      sha512 = "ee623ab6ea3abb8ce02b1cd056c8e1f1439d5cbcb1d7262e552b121eea242ee72df7de43ab706126b14631927654ed3aac6520f10b7eabcc0b99545c6df645c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/sv-SE/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/sv-SE/firefox-77.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "a98ea8c31d5e6ecf3d3c4b0def2d2921aacd901d095ab53aed1da202937022c073834fcb1d3ced826c294c18660d2e4888473b2f8f9e91083bbfd0e040fa6ae5";
+      sha512 = "2dfa3d94008506e69adfabd450629f1e1d9d05db5370de86c95cd80416b979d8e05c5b3a69ba3f06d0eb5e95212c427002887ee538f463789d6e3f9da771a55a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ta/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ta/firefox-77.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "5c64882b2fe34cbff29ebe7668ba96526abfe29cc599881331e048da2655ec735f8425d98f64475073e86508626b464364e3a7212b44ac297e6a50c7fdb5b4f9";
+      sha512 = "3b92b01950b66d1a570de445a19a7751e1f2d2cb98796498269d5e5e2410e4e65fdbb0b35e7f9171418a8edf94cf69852e3294564c2bebbbec66e4dcae57802b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/te/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/te/firefox-77.0b4.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "1506161ae00a4fa203cce5b31779a38f0e7df94021123cbd57197cff807a4a6ab2ee9907240b70b55e6795574b4074a83bd692d2b4ae208438a12357d6a898d5";
+      sha512 = "3f16762eb93ce7c389952da184691aa296c7cadce046d000f6b5a70ba51c1bb74cdd58807b8b0d83d54798b7852a83200de4fd8be684dd93deb45d44572075c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/th/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/th/firefox-77.0b4.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "97950bd4c56df1defdcc7f6f1693dd6fd0065805d63145aca80242e2d5a83186585dc1a165e7fe9a0dde52a8f60fa6b32ee097fe0febdbac5937a410e654b20a";
+      sha512 = "cadd45ada47c5dfd7e587cac67e496b5417752f4699153240a2c811e14d6e42682c381a9161d9f27da394150d2d9d34d7d0418d693dd54174603f0b53869664b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/tl/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/tl/firefox-77.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha512 = "994980dc3ad618140b0b422db46cf19cdaeb99c4d3202c426c415494812b5cac525b43c4b290fcb58ea66ab9330680c4add11e8ed92a5e36b7daeab19c96b4bf";
+      sha512 = "316748d8e4b15671b9c6d85d36ea41f6ee03d4a0a3b572b06f945daed72198169174cb37d03d7dc7de15e295afeed110ad9bf427b9d66011fbef9a090c54cd3e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/tr/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/tr/firefox-77.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "65558235961baf87812242607d8b77f6e843bc5828e79002d55dce462bb2d40a00ccc97a9e83de56777d1e0ca35991a2c577ce40217964c481930a4081955289";
+      sha512 = "8f8fd43eba863f0cf011e5a3d9052f7bd39144b3b8b62b421f80244386b76a57f6d0b941c44201fd6b96b4b7d3234ac7e78b6a91652281050d22bdf16b180316";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/trs/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/trs/firefox-77.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha512 = "cbc3c626919406af47ea8a00e01fc8146838042a8b7a04fde88f39e8b21bb3ec8c15b9ed2b327f5df1bae621427c8c2917837a29c95f27b1bade9d82e4eb93ef";
+      sha512 = "1fe9adea8f6bc61a2552c48e89e874a7f115cf6a61d7540c8b7c6637c194646350aa52dd767e8a7d55c4b9fa1e32fff07268d29d58ea6ad73fdd5c73f22b213c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/uk/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/uk/firefox-77.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "70ac4bcb16191992de317cc6dbe2f3e8d6ccd0b7bee0568d7a2272429bf164610621f53d6d3817ab6b3c7643d63db243273f6e99dfc5c5133dab4645f9824174";
+      sha512 = "fc4b69551fe65d5854be6c6f34be8394179f37953f9c07feb6a07618f59be7f7e16e30a8ee6f1da8dba993964855604d6bb35f9f410b76d6b07d154a09fc7d62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/ur/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/ur/firefox-77.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "e66011a9db9ff2512dd3b2a338440ecf268141200754b0dc09c484d1504534b109aeb83364181b3bee7b534ea078c879ebca1860af63c388689517397055f670";
+      sha512 = "ff2aa29f719ed7aeb75652bbe91dc8cf05acc56508566bb7d9b503be2bdf500cfa24757fc43e3de1d71747cbe84396a67a782242dac5728708dc04c741caed2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/uz/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/uz/firefox-77.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "e09d595c56d8fb54592a046a6e4f9868a1bcb2bb638cbecbb87f94000127d0f3acedca67ea7f8db15445cd2142052873bf73ddf4df2fcea16373c614d6501728";
+      sha512 = "ef41379120cd7401b7911f4f91797c66f36241786b43b45c192ae480f2f6164965303e8a0dce513ef8d81fd5c2dd6be20ff74700a93fdda8c6f4690c37db0aa3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/vi/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/vi/firefox-77.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "04d5647b360d52ddb714c25443b55558b3d54fdb31a385513832fba336e7db28a8dc27653ceef32e72a4dac7cb771e82178b6161b55917c07da839e80523a8bf";
+      sha512 = "e9dc2f3a99968a0211174289d8976ca65f90f69b300f4b8ea91f878767de29016718567c95c64196b14bc60d257b9ef7e1bff7d23a19b0d8a1440bb37766e977";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/xh/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/xh/firefox-77.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "bc564788b8fa57981b7963b584a445d69e4c198ae83d8d6ae1a5e4402796492bc2cf92d0119a9db067f75577240b0e9d6afb2f38fa94e3e101ce6481b8406fe2";
+      sha512 = "6c256e1814011858d637ea0f41384ce221cd7c84da9651f759260ac6edb3d2fcb9b18753b958ea6c9555ec182b78dfe34552ecd8529a908892eb63254ca98da6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/zh-CN/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/zh-CN/firefox-77.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "38fc3b4eef5cc6ffe867665d82dae4156ea2676749a9dd0b15bfbd9e01798829570bba75e0023ffdcf9b104ebe85911586eaba95868ab0773b22e121fc75679e";
+      sha512 = "4777aa8cc5c41e2500d59661ce0a222ff38030e58871a52d69ffd8c7b46f260c84513dd1f07d0f90ed422a2192b1c8ed9b1b2f8f4d2977bd7186c5917cbc2183";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-x86_64/zh-TW/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-x86_64/zh-TW/firefox-77.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "73477a782280c18dd42d7d62e26cfc5674201d3904d155c2ac712251ef8b65f422b522804104d7374865cd7e8286a8ea9291cbf7da37d412a1cdf8d24d18a3ae";
+      sha512 = "28b866dbe6302769c199dd146d193f00a314c55bc0573abac89e21f478041f4b14c564717d11e9fd75b461772d1c4858db1c57318d0096a5b67ed165f966cb21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ach/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ach/firefox-77.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "a35694c831c424eda7b6e5069c1b03d1e6b2fba051b3a29a7e8ebbded9b3b12fc1fbd39131d86f1c0d28a728a9ef2b7c8f903f6ba792d522c5e96490cf68563f";
+      sha512 = "2801bc2be545dc6373f1068b3f9756842479c56c91312874b6e8f71decf8fd9fb9fb7c57b29c155f19f1ea041d4a9157c633d37555e6a0a7274f46b404acc931";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/af/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/af/firefox-77.0b4.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "9fdc8e1e39d2fb69d3afb64f676fa85fd674b45eb86d4d4735df403bca27eb499be9e7a6f5f9e67cd3e588352adb29ee805b403f35a859c3226507684a69ecc2";
+      sha512 = "a0ab87641a8893f63600920978534ce9ab727ff74dd1001912aa8df3d2cf35745598b37224364175a340208a6cf7aebef22ad81aa3c4c955f1cd9aeb9a69fed2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/an/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/an/firefox-77.0b4.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "1da6aa658841d59069bf57960f9c5888e879056777e4c227037c1745648417356bd87bf062de6afe41058a290998e7e080ea7fec895cbc86619d0466ab0bf64a";
+      sha512 = "9147ebd11097dd5ff9fe3a07c5142f037ddb175b1eea745177fa9a94d18eaed02487a359560ca7728093636470eca4e9a8eb6a2c0573b58641e9f0a689f3a25e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ar/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ar/firefox-77.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "8cfc1c08b728727053277a60c19e289f0d0407e01cb2da5632cbbfe5ab48f751298f4f83930dfd5907d4be8973a4aeec3f3a719dae16827f48f0eb0d4151cd03";
+      sha512 = "bf3b6ef34c0e485a8fb228aef1c400a020f10fbf9222b1b446e7c72575a8b3c916c6c3294d1df63aef236c9ca87c927bc9c1cddaf8a2cbd6a0727d8fc0eb6148";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ast/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ast/firefox-77.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "96c7451450e0d6e133a6576b098b37dfab5059240a6107fb95be17a82e9600ffc4003b60918f4ccd8907d8aef814d55a79a61107504f41fe086fe3d6c83232b1";
+      sha512 = "48f667dcad6190147b1ccb0d82458077bb66ce6e9da9fac1a8a8732754736185f01ad114585f7e566c6bfce48cc9d5c2a3bc3f94e4dce5896ff51fdd52d0a637";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/az/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/az/firefox-77.0b4.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "0211b3ff84eb9e7e9f6a0c81a141273009a2afc7ff237bdad751bcd68a24b60c9e9c896a836068d3373f0a0e6469fc77ce8f502197cdf9701ba033ab63eb5e03";
+      sha512 = "246b072eede0c9c997e85c1ea4e1e33bdfbfa58de4022e37a5b7e911ae25c6d152f3c6cb5869b2e45d0966ce4c2cb7efe09b05bf099a51dbde1cf9a03b97f3d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/be/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/be/firefox-77.0b4.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "e268741abb735b0425d42fb21a1a70b7035f915122c64e45418f2e61a3fb5f9c123b53e93979c96e7a183b8511cfeea4c3c6e3af87756622f4f8d049657a7a4f";
+      sha512 = "91fc39407f1a6b4dbf0c25bae760286a3c8000b978b490d169241e8fed72071234d8481411c4db826b99854b4243539635cbe603d662fc24db1511d30a04fe27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/bg/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/bg/firefox-77.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "3de7753956fcee2d2697f2c8a3cde18719621ae4c728b190d43b7e936c39543d6d6dae3ca593698931fb17b0270a19840377ec9392d1eb8bc591dcc7fc915404";
+      sha512 = "7e126b23c398c83d638dcc185685a3df7e060f3819cc1e604661cf5cef24dece7e2d79479020b05a5addba0d1149cb6b522a184deea8c5e86d588b57d8316d03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/bn/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/bn/firefox-77.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha512 = "ff9b2217e043c7cbba98f9993c729d23dea838e6f120c6adcbb4d03ff127484111ac2be2426de2134dc914aa765550ae62a464822ed31b24231fdfb50d295610";
+      sha512 = "d67b62076cabfcd1d379f04d0c49e88a6a3038abfa0f994aa6f909384cd54986a0767d9c5c1176f378a7ebf2b51595bacaf76bb0aa412ced5fc820474b4886f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/br/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/br/firefox-77.0b4.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "805d85cad7af9264c1e8e3534b6c6248573ae445410616a8d74402cda2273b68dfeae4d47240e0247fb29b56bcf6f2d627f4a872afa8eda3d8156f14bf8851af";
+      sha512 = "2fdf55938798a8e29ce8866852ec7d752f5427c2c7b0b815d9f922d7b7949da6cb871b0627133a0189aadebac7f53a8b0952e6370d1d7171d3291ffa914c176f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/bs/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/bs/firefox-77.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "40f56cc3fa11d85b7e9e8d770ac5bec91ba5b8203e11a0cf898ef6bc94d58ddc73d6919e5c56a2e79a846393f28922233211784e693f3da63ae9315f3befc80d";
+      sha512 = "301fc3f78776a4429e2174e21b29224624b01745af7746ad618bef71016db125c7cd11e9bf865bce4b0a9fcccb9124efe4e25593bb9a3563faa7d3c63da5f632";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ca-valencia/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ca-valencia/firefox-77.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha512 = "00dafbfb3095d7b76d1bf08bdbe5e99cfd207b39ae2a787eacb39ca412f1b2ea7c4fade4c99715f44cdd774823c4929d0efb65b40757f1b86faec738d4f11493";
+      sha512 = "63b9405888d2cc6e2280672b44130347749c65202607cc9bcd3b8ddba72b01e766b5c60d0ab4c47593c2bceab611f515adbeaa3df6e69bc20f478e89a3d66d6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ca/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ca/firefox-77.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "24c21262e498e8840cba3f8411d8f46108f736f10bba2a0c37ad9fab6e0bc773f38ac086334d3d572e19223309e9d106035d3458e05c9b7b8db237b7bb1e1984";
+      sha512 = "bfe80bbcf41a896819ab41997c5af7200bde510190b8c0bee9a7a08b27be71f94e9eaa344886220c8358159306d5fae555c859214d882b65b4c9b864758f14bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/cak/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/cak/firefox-77.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "fa849173b8af4d6be6a499734042763d2ac532e213cb863a611e66e405acb5df7a51649bb1f9509ec637e15c055fdaac63e380128290623b6d3818e528a9c532";
+      sha512 = "53b8da7aae4032ea7ea694ac7ca7883601bdafcedcc88d9c74147e23ec0df11493fdf6e7ecac4f5d0bb97e6704541d7974d541c7e82e19188f4f03b396af72f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/cs/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/cs/firefox-77.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "5b718c2dc82230343e35b8d45725e9f7c331cdf5716d973d671b7465e06d50e92e0a353c73c7c31c33cec1115b9332e2457f17f6e5fcf8f033bcf7e222802267";
+      sha512 = "824fc08c27bebb1b4fb3da394158b98c84b4dd786e9955b7f10e9925fd0afcbf59892f7368bdf9f37a2b125c638d4a98dd24285878029e8b971fcc5190cdf409";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/cy/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/cy/firefox-77.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "7b037bdbe658d26c2ea75b8da80b4040b9a0c4cefc00784bb94512481de435463605c565eda38f0e958725adea11f09a9ec5a37d9513c16118214d0486db9031";
+      sha512 = "d691e6233288cca82d74aa303b5afef4a4a1084734e82403495d118ecb92a70eea5411debd63cd841a84ef0483d764973e1d79735c35e08c2ff1ff708f43d5f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/da/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/da/firefox-77.0b4.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "9752b73c59784ea54a95b0bbf63123ebbbfdfb7d2742e3418a872982c0d8198fc0450b3c33f4fc569fcd43a633cead3ea1893057b6d7e8c6ab78632fad3555cd";
+      sha512 = "e92ffc2acbff2f2a82b988563003fa36e3d27fb4981434cfbbbf9864ac61d27809f1051d7e3f9f0661c9a67eaff4e002ace1fe3c7f949989df2da12fe9d693e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/de/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/de/firefox-77.0b4.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "067ad7a8a5a4c6120c1f1be2f9b4066f1ef830e3cb49ba850478d18693c8e4ab12d54a07036d23ddf3e138837320728f1fd6bbfffed760b530d8ab6addba6b20";
+      sha512 = "6ac6d4a80c49d83b671241819d3d6aa75dbaaa484951085de09e1da26967a8034ba58b4fd895c500b5cfd90db4890ba1a7661601c3c8f81e1523a335f9105454";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/dsb/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/dsb/firefox-77.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "9f4b6f73a3966a7aa60c168c16d88382dcfb278f934f3fa485e691a6b6af43a14f49395a3f8177b4ca9802275706b2cf701aba2310262149b0bb42cf6d096c25";
+      sha512 = "4fdcfac64c85014354f5a2e220be9ba5b17257c244e05fab849628967f4233174fcf096f8f463d43bb29806a08668d37cdeb6db4b4bc46f44ad5ae15454f5164";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/el/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/el/firefox-77.0b4.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "43a0710f463542a1389e98b5993d1d1b35f443f0a0ccabca65ec5505d19c28311d91cdddee4f9c102b6f4a25a87e4c2c6ad7be89252f60a724c7af935e30f675";
+      sha512 = "c4d58a0d44be00fa45ef7c34ab3b1239db0fd1bd37313cf945924d8f27c155701335d9f4a859db149547675cc9061358148842d6b2c7bad2958655fbeac9bff1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/en-CA/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/en-CA/firefox-77.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "6717d9c590e5f06d3b02f643ad4eb27f48499ca759c41144aa5e0351e478bacc54163378faedd731042ce56ff5e8f55b2c6b6bde7768d3576b70a0abaf4c91bf";
+      sha512 = "53e213c87217b192758b578758593362ecfd9af1a30260bb064a633e9ca81a434abe75fd06e08795bb64307c94c7b2d552b56584ef3fd45a32b9a2c4febaf98b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/en-GB/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/en-GB/firefox-77.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "320a50b2461d617962093c1d7eea94517c56a93d6857a4d4efc4183e76f24dc9320619f9c3143c9dda017ec5e8e3d71c730a27d532bd7141c750598edbcb0121";
+      sha512 = "aeb2ead8691ef7d42a4446f22afbf3447050c7c7358765290799a6d6a7773ccf0997fcaf7d7c5f9a95f13a8a5d236be415d01c789dd1f5ba759956450bd00b6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/en-US/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/en-US/firefox-77.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "ea7f210807e2306d3578c39d1d58ce12525c47cb9dff3198dc9153683f8e49229e19dfd9fcfd3d76e109cda4f92392e4f9f1fac2cffbd59e6430105ebfc705f5";
+      sha512 = "17bfd9d30cd4a41dfe22701a7f77afb3ef70e04f92469e6f148d741d770d14a09252ae1b6c602ec7fd84f1abe00a0725f1bcd2657ec31ef753e66ea99b40ce2f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/eo/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/eo/firefox-77.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "bd1dbf20cbd4aadef8bafa74f308f097b5dce955ba7f2299cddcb1cc9cc9d8805e399684cbca1af750535ba0ddc939757f4d38331035e4a708ffe1c252da9c82";
+      sha512 = "3e864397b539cbf28ba91e12487ff4864e121f22df0d4ddfd63621a257bb5c172cee36c3c39aef3ce1656069a014a678236c8f5e7ca69254d9fb6ecd23001a32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/es-AR/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/es-AR/firefox-77.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "1e7a48ba49c4f96ff0d16efa3798e4254b7f38f0da8f51e62a4bb71c13e3f066a64c2c6d778da18b5db83da52684dc39067f6c765987d95921df2b3118de2c6e";
+      sha512 = "2519f6ced62b4c3d1d58921b895aeb19cd256123d6098d4cc1423ac523e2808513b45f8ff544212deaaf74a91e4b0335e928c24a60f71bc7a28687cd76dad03f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/es-CL/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/es-CL/firefox-77.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "9c7e6456459a4e2b6c7aba254afb145ca3c8efa4023f7e023c3cf326b0e0afd88149888265856e9f28179b686e1a458d453acace73f635a5fc8c90419e6fa043";
+      sha512 = "521173884ef61702b9720ea43e7cc6198ceabc3467f006a5740d1907d8c7053bcd17616f76151f21de598ee7be101fe5a9098ec471e50d66bb7c9133336a64ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/es-ES/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/es-ES/firefox-77.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "95e2d89e0f94f9ac95489f8a084d0857aa5339c8257fc1bbe7c7ecba31694963831917461537cb12199fda05372e1304e6820683802efc0b4ec02324194ec2de";
+      sha512 = "900368ccd729444e96054fa3fac46ab76dd019aa6d1c40af9971ce0bd4415939d1f09036653041648c7c63e99c6d996b4d76ad3fdc7c2fb3513f7038596e206d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/es-MX/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/es-MX/firefox-77.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "5fc41cbecc716fb024df2d13e9fffb2b656e18f47adcb496d3f8f3d61580f97fe801435240576f1403805151c7183c208425e83a2ac56373051f0e82031115ba";
+      sha512 = "ca6061a3beeb9cfa72d525f941d8668b3808d8740dba9eede1b8bb95db2b3eba0a9c53637f0bc627fe793af8a973587117ca246a0f523d7520915f59be24f152";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/et/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/et/firefox-77.0b4.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "16c5eb3e9739e100dbce0eb93f209fecb11b5b024ed62f18a47b00927452d8823b77a14fac1788d9c4bca9062e85e724a78c39630694b0d692b3867e4f62f7fa";
+      sha512 = "e63398db02df61b9676860a3785830c675699c2316d2ca5deb6ecd59c3c9013a93db6c99e7b1a742d3b5e047ce8050a40a8af5da5e4fb80e13273acb6d778fa2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/eu/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/eu/firefox-77.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "0352971bb2d43782052f20341f8fff0f6e919ced7909e6a860648e9772101e5f79bfdf0f912647d3593a0f6dc9dbe84fc193519c3b24ddcd13742f01ec59d1af";
+      sha512 = "c72806b00760512ce8c688d32e84c5620eb823591fd9d125bb852c49a9c0fd92ae2ae548c69c048091c6c34b8287777b79bbc9f9e08685daaa013e2982bbbe6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/fa/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/fa/firefox-77.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "4856a0b482dd0676cdb5d46de7bcd96a4c9aa61bd976f3b46205019493b8933c78d7b253c41f4c2178e2f79b000dea8a9cf13e1fc7a31a5242432e1c9205d445";
+      sha512 = "64646dd1a33a82cfff9f6764580f6db1dd7b584a64bff54cdd2774443a7e03d6af06e177c10d6f766aef720105d895eecba7274edf08bd81107151c0ff44d763";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ff/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ff/firefox-77.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "e85757478feafe009085ff55492913944d5d8490426f93cfca481cbd97842bc3c6dbf709e17c372b5b51b14fea3b057415120b6fe145de928a108c7464de9af4";
+      sha512 = "f9e02aced47dc24b3503266dfc95b6eb91f2337da2d7acd4468a9e7df49513ce849c42fe32568368c991cd57e4c61a8a9f467883578f549e10387ef7e2f501b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/fi/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/fi/firefox-77.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "f479d48fd6176baf30b0d648120669ba47ae2ec5d681ac6b610d6f0b0a617a0f259db863966625376b63a6b871d56049adc500ce8e8e0e27da3520a953bf1736";
+      sha512 = "fc5c46cf2b521417c7e81814f60bd23b1e94facb98a5891b3e5ae00a53ef5d82908656ff71b585876caae5f40c1ca961fb252fd62d55f12393dbbf8cfca1c081";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/fr/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/fr/firefox-77.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "4caa574275e5c0756ae787e73398f73a2702b36d4d3f49d3a3dfad8cda8393cef24ec0375d65d0cee4f41be8fc94b5419a3b613dda287d884f8e7b6317e3fe13";
+      sha512 = "31fd922ffd091a070aa77c3ec81d5eeba622b4e45c3e4e10c01cb72138b4f9d9a60d0fab9d175380eb020b331b7d5c6f0d00c222dbb9a600f4a4fa63cb1a37f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/fy-NL/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/fy-NL/firefox-77.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "28d31bc60979c84d874f444555e6157b906b9d34399cb87608099e67127dc7480d6789b855c38615b075f5b07f8a6b222f04dd99e5690ae36d56490953135149";
+      sha512 = "932da4575a2959ffb97e48741b032c9b3c5a2265fd8ccec549993f80f25481afd0fa57f76a61588c8673d7b618599fe65aa30663438c0638b08a3f54e0726da9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ga-IE/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ga-IE/firefox-77.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "b83c50b728bb1e4febc53ceb3a4fb8a6589751b5ef77ef81f03941ff33d3e289c8986b501d95afeb56feb8f94be7d9a7b38e5330ca359543948d762e71402f75";
+      sha512 = "858b351e65d520d036b4577cbfd7718e19e282d20f01e27914504d3f857316df14e166e3c966531b51783f7b1a7691e956681214d507272a8eeb3abf2ba3807a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/gd/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/gd/firefox-77.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "e1b2535e07364a29cedf36047b99dffeec8937b775a247b605532376b3a43a8c0037e2cc9a6a461a9b68e00eb67ac1d337bd40ee7110ce9890cf862dde3cfb60";
+      sha512 = "a13c142bbb1f26fd0f7c4089b2b10b107f436fb8a62fb78c6b701f5899387be1fc2e97ee7150ed8c43be8079f49d2fbb2ec730bd4e3e5021b0babd95a30f7910";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/gl/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/gl/firefox-77.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "776e2fb5cd75a8f5dd1e6340af21356141a24be87eeb6968ca926cb3d3aec1b48adde0881a7e4413a83fdf45f5caa3e829c0ca1754cf7176eebf2b9e3ccbb02f";
+      sha512 = "3f5e382e2e136926b6035ed5ed0fdde3f0d92bedb1536c96e687f961d39be12faaba47dad6d1287382aba98bd6d416869956b0d1ce8b45ab2236e3b1daca5d45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/gn/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/gn/firefox-77.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "bd3bb0d416557c94a57c8b364ad08ddcc1885bf55a2435f5a2f74f5af1607a828795fc68027a470cc95bf46d553d84eed1c0af3de1ae9d72546587b486a1bafa";
+      sha512 = "8f0e6752735b5f4dd53db277d2e808099fa27557ecc931f27964e6cf1b35491f23fa50cd08993ae6fe31a1c9bb9250ed177a1737daa68531d2eea74fba05b73e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/gu-IN/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/gu-IN/firefox-77.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "b789f7adc37302354f797988e052957fd95f270dce838352636a367e03475ea92a740ab5ed49c9561eb5e90b106e38a767d6d3b4e8f1b3f07db7dada400b6aa6";
+      sha512 = "9bab8e9f9b48ff5a7c493ba400bf3730cc1de32fbe3c2a34221bfc0b13f3f0f42004ca15be07d9a057945c16dde3f7c03dda4f5e046a1fc7e381872acc63e0f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/he/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/he/firefox-77.0b4.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "afbb11407ee19f4d3846673c451848ebd4efaf5795d1f864871c57f7e5d36d26e38c7107e326c5843109f89a315cbc38f25df1622f97d6c355f824d06986341b";
+      sha512 = "c64dc4ddbcd3ca74fb67a70f8b5f48d3cba38ede284b34a742a1fc801e54e33dd3b7f14a1abc8a312581b90b73bc695bdab5ff94355327392fa85e47b06c80c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/hi-IN/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/hi-IN/firefox-77.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "03c32d07601cf4b98d02495baf97b70a38a8e82abc8685ed507f0c9abb907468b1e8b8403b2272c9c06ea8b0cb020bb330f70f8abe5b5fe0c757fed710c912ce";
+      sha512 = "5528ab5d5d23672b298493e68f82dae81aa677ba84b06fd28f3f8de6d4c4189736b2c8fcd9c7806e116c5d90c47a06fce79783ecbc6cadf5ea3fe06bf804222a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/hr/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/hr/firefox-77.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "47c923096c22e509063298e9229f3b74df60142aec4296d7008b5e49c69ee9542915e639b52ef8aa65a7ab9f118d1d23117874a3b717b37930d8a988386b6ae7";
+      sha512 = "78c7da4d779b751776e4a2cbc42b6fc4557c677748002b06086be9e4272a2bc4c1ce5d5c005de6c7df1c55e0bdfc46dedd0d96034bc748f0af0ecde392b4cf70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/hsb/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/hsb/firefox-77.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "2e2b3c390ad20fef9860c4e3516a32a66b091e1f60a0dc71916172de3a667cdeab3d712f8f2a5baef8857da3d9211fb7bea808b975cf3cce1920e8ef2d73614d";
+      sha512 = "42ce0a1388e7a28e67fa54ffa755a165731a72b78b382da3c4104977f98c801568c7589990aa627755745bbaefbc039dd533549553964184079b9d88685e5f61";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/hu/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/hu/firefox-77.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "4c5e5fc5e859751cfdbe1eea6217b92dcd3bf2a30b4967965d0242de72deb6d497823b0d17c170be1e7113a15f9d607a6890a5283c47c254ef2c94022397b977";
+      sha512 = "c286e5c921b278c202523a1d38dfd22705e9ee6bbdd1fb972e27fec8013441dd871734deb55ad04922d008884a087a4dcbe7861e8b97bfb72338ce76c93bdcf4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/hy-AM/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/hy-AM/firefox-77.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "6953bf0ef7dfb0b703d4aa1ab9c26b85fc049c12a04d669121e9e98005ae870d92df9ce16bd567aa1586d02162ee94fd01800d4d291f5a0c1b6e0cfdafd89c8f";
+      sha512 = "d1be37810bf2d315c03faea66f1fdb1e76fb0eb105f9ff10f7cd4679a7d28781ff91eab5b1c9d0d48d636a3a4a4422a081a5b68e5a8103a3c8db1b3b46c37538";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ia/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ia/firefox-77.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "e7bb763c2049dfb8081384059313e977ca44eb3d147caa2fbba755e288e45d6ee5e47b6aef1267e23d4e8c6a625f9dbdda7b938a9183a7012b3d943b857645af";
+      sha512 = "d0fd3130c9811f5331f37eae375eb69f445e49444dfaa7220418b86152fb3859457edb45cb2aff22a8cfba77f54829211a74b1bd70ab1108bf7f1f5778706d78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/id/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/id/firefox-77.0b4.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "a4139cd488a85cd70e595bcbd3f8fce96fdebcce2c61c04c06b70ea0f2a99348ab69590f1ccabbf803798952fd436a30bf6c103beb3006ecbd14f70d6c3ecf93";
+      sha512 = "bd1443709d086d6e7f6f9b55b98df724ef910e0cb34d164208edbc465b09ec351eb16c42397e711842780cbc1d4aaf088de4d208cc49365d161f4c934c1aa230";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/is/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/is/firefox-77.0b4.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "e485e4b6f5a8ae5fda9be8ebcdfa102bad2c55ccee6d9dfbaf2778f92c68e68133a26a599998e134314186b296df68fc0dba7c849a109f699d3198a2c5a31001";
+      sha512 = "21fd7baae6e43ebe2ad1391861d4ab746361c0b7b37717cebe7b1eb2522b09fe266088013ff00e63c1362cbe24805841742dd2574255449e82e4ab2643b92174";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/it/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/it/firefox-77.0b4.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "032e3e3b854a0be7ace835d71dfa864c0c84004c87ff09314615e633d64011f8676118ea73797b725bcb1c1e079fe632e16c15eeedf78602201c7ed371222e2f";
+      sha512 = "fae32b59220a1bc302b61b5b7a7aa5f53a2cdd836c2c1680bbea9840f98ecb955adefa4115a5b45532d894f93ccd0d85d777fe747eb386add211e0a21b9ca4c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ja/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ja/firefox-77.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "dbdf163abdde2bfc22f5574d2be4e3daea52c7cca394a9b0f1f1b8af19c65593383a112a2fc7dc55e224ea6f5d63537f03be8d2cf02fd3d3566963bd0d51d204";
+      sha512 = "c42cd94705bd7b4c12250b56f9f6cc11e772d6ca0a12b41f2c9aec27405b069778a07ee1311ba38c509ce98c645d630c6fb2e7815b9cb7a097e7f35e5a760783";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ka/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ka/firefox-77.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "2cd1446890227f1ba4d7f50ef778731b350f694646b6cf33e1407325784b071db4bc2fe43eeefef2ed98ffc5353538d42df48ff8e546f4495a366d5acbc2aace";
+      sha512 = "eec9327f4c4addd1e0b2de53e5b41008b4ce1b9eae82b3c7f0219ee0045197a2d5af2fce07cd0988e65024bfa983d13f755f0284b26a7ca3cf821ca3ca7e67d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/kab/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/kab/firefox-77.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "87c131e32ad46194175e8ca8061cc1399813b2259c9c3e83e612c74bac27c9364cbbc63860c283eeb8416e3b108297ced4a1d9755c0a273c9143cc6b468f5cbc";
+      sha512 = "33d095b1cad9d9f76ce7659f706404867bdb2e809477bff07781e6724288c9adf1e687f89885ca3810f1c4c7b0fbe415ee5ebd991594bfaef9675a49b8ea579f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/kk/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/kk/firefox-77.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "6977a2478623dd8963121a1cb3da0a8669d1cf17357ed85475f61384a9e1ffc2c1b4286b3d7150386031786e365c33c188cded495036012a63dcf2db44e19d50";
+      sha512 = "b34568bd6db6647533dc610bbca224d7d121cf472402cec93b676968b6f3463dec57911129b18350af0572c83ab81c6bbe500c3a2ef57f7de522dfb568fba125";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/km/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/km/firefox-77.0b4.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "4893ae9bb4695b227a6906db91c1df7997c866953ae3960a334856f9a1c99e05937518ecea2e59c5bdf12a4ccd3e644ce328e99294dae53d7a9d9a9f5e2e483a";
+      sha512 = "324f4bd2640f8ad4e9ec33c8119870bcd4b886c8c6a70f850a41d2726707f3da477c859ff8aeedbacba282013a7d79afafa0bd082277a560d51fe43bf17fdc51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/kn/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/kn/firefox-77.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "eb78a32ea736f139fe1c5cf0a1ae59df33272c6078e643a571968d0a5e4f3801c280aade938a5a714a7695700dbd2db84116f6e5ccbb7362d394ee929a2d9efe";
+      sha512 = "9c72ed016cc5b07ec59edbbe5868726fc2c975d3a21697e1c50de164daf0c300573053d9faeffce07e1d6e9698e0a6746317c0126b74ef1dff8e4baf35028df5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ko/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ko/firefox-77.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "3bc572b109fe9c5b14cb94d7705ab7fa972a99e914eabddfbef4901e5be9f058ee6412c59b2173fa0620166612c982ed6bccb1f4fd684189845a5446c93364ff";
+      sha512 = "facc9f4802d2ef77511d674fe7fc78f99f4d510fdebf171f6f9ca1c525f4907a941a687958f9d4664316cd189b2604a15f31fce3132dd18108de4ccb2ab975eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/lij/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/lij/firefox-77.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "9364ab431f931727157b0722ed021736bb8a2771a01fd8e12e616c02d7ff8a2ad23add11ea720b1d462e727df51c985b5fcad908307af04ffb57af5d25674c24";
+      sha512 = "09259232515230ddbc9885c82d6fc4121c30f4bb3c7263dd7023eef8075276f9690d668aa377232ac4b30e04fcc52ac098f0db48faec66a277ea3edb709c3403";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/lt/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/lt/firefox-77.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "c2ebacf0d93c38d51d16cda493aa1152f8a682aa41b7f6626422596f21038ae16d3419873dd253f60f59971486568f3a71420df4d2c503a79aef80ec413adbc8";
+      sha512 = "78d892d0154f7241b86ceeb2502dece53fe6b49b78c7023b94f9d409ba242296dd2dcdf98134427a376690ae0b32e0af99be7b133ec1e279208e126a88dcf255";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/lv/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/lv/firefox-77.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "a1e0962bd4a10f1c1336650e97ce79fccfba6e752e2929156f60ae10a9b3a9e74b9e2cb8c265d7b1c242b2a34ec52f2368d07777bf7c687dbdd7914daae55c6c";
+      sha512 = "1bb7bd1ccf80935ba86231ee80996a10414dcefa8811bc278dc68bf7bde10eda00ee7cee04ae1fe669ea2e87a68d2f8d85f317d0d26844d20e4bc748cba7880f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/mk/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/mk/firefox-77.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "e6b4cc5658ffdcc1a52979845abda4870917f8d036588daf1c1db93645696c85cbddc8a8dfcdb6f6166c43276ff52069c3c4289db38e9e98e7592b0d83fe3d08";
+      sha512 = "82c284435208397983dfe2ad600e8d1e4b8d2d5026985b3204612c5f0cc77b817332d4044199adfcbb624c907130fa184b6e3746d29e938201973b5a8098d1f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/mr/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/mr/firefox-77.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "9d4cad2c1b192b199ac9a7c0ba233c0096546de7be31a21c4ee5789c82fa8fbaa5b9c5a37ac4001ef9bd774b62f57d33aa5760fbb0ee6ce60000f256e91f7054";
+      sha512 = "89e82c197e5bc3b9263d61590d7e7605282ea81d40746c052ad35afea10ca38ee414ca211d3b08e89d1c258e14c0f36e24ccba459adad4fdaac5bb9f8e3c740a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ms/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ms/firefox-77.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "56d8a03ac84fab825c387ce84a45efd656abae43f9ea965ee45a09b417bb2634ed1f7fde0874294cb09ff3e3789782df7db19b6fce4598073a81854a91a6f800";
+      sha512 = "01e3fa5d6bac393185251c9f14e63d03841743d3693e2de8dd76b128dd793e916f88af13bc9f7fd88b6fc317b6508b57d2626646b8eefbcc779a9f8d7900ea8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/my/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/my/firefox-77.0b4.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "a9768618490611f5073438986de4265bbc7bf3a2613f4314b78533430d1f830f83b7929c74d431d8bfaa2ee9d5ef64b189695ac838c52c5ee6dadde88d3a3606";
+      sha512 = "b4624f7821d81daef7e6f236debbcab193a85a467991768ef2fccfdafd43a3fbab8212c2337d6e0a5392cf679810d4d5357da40e09c15ae7d222efe3460142ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/nb-NO/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/nb-NO/firefox-77.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "4a413a17a3796f4ba4b0b783c4226419f7fb800ce4965288129cae2f1f087a11226376764afe51e09c57a23a85df762bbe833d167a13b6c93c22fa378f0ae47d";
+      sha512 = "33b660a8b3f87667c1aad968721ca49ad2025849a9fa5c04439f9c25a450b963f948f4410c9dedffacc1ef8c64f60c48924976b0afb1931e1cd1a8f3d78e76f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ne-NP/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ne-NP/firefox-77.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "899e26c0ab61e7dcd4ba97b4df082b13fd93d07c22e849a02dcbd887f870df0a6de4b05517b200a4917fda6f7cc83d7ff603d8e0bbd96a39ff016adacb669c32";
+      sha512 = "d0208a7e827bee00010b32155f0624acaa9c17401c43db957baf6081ee1e08445b03638601edcae60ac4dd0c3377386aff867b21b7fb5b59dddefc107ff704e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/nl/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/nl/firefox-77.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "59b6885bce4c6cb95288e1338d6df199e8710313bd569dcbfa2cd2029b02bdfee9e28d4aa11f561765ef9e51d982a999d689935e18fbdd0d60d8ec25cf4544e3";
+      sha512 = "44dd7691347c9d42eb7cd65df64bbb59a46d73307ab9cbe14d015ff8551fa01b06d3182d96d1f9aa7375eb78156e5e82a747786c5870876732793c22b5aee261";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/nn-NO/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/nn-NO/firefox-77.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "40e62963d39f0b23498a438c3ad184d0367cdceff9a2674e565153c70bc450992d11145e5f651bbb53f389d5a74eb3d7413968c608b7d7650e9d553ee26d5cb7";
+      sha512 = "fa1113a403d98e34362ab77b4039db05e12a3dc72dd00c4df6be596d0a5179f9092d7a559ec6f774a39d02fe86a41252e5fa9f804c48b9bbe8bbfce54e73294d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/oc/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/oc/firefox-77.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "3ea480ff19ffafa1812069ef7dd1ff1852b10abf2ec4cc094912173937b82c744f29f1480de2e95dc65ee1062a766f0ec33d234e3e3d714f49972458a09705f7";
+      sha512 = "2c549202784f7f7b19e1defec6a57a94772426b20b59426f988b9d00294073cb2324236958b78fc8bc57b2ca9fe480b3dbfdb19916f917105504d2b282e7eeab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/pa-IN/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/pa-IN/firefox-77.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "8a13731a6072abb0c34241f206898fb59d91dc26eb3f4c0627d2aee2e6a53fba8b3735d8f5f2b36dddca9609ff4c1d9c5d441c350e9164aecc2ce9a69b1f0c5e";
+      sha512 = "c7ec40c7614c12ccb2671330f77d02fc013744a33247f42a72669c9b943bef61aece93d184c42076e29f440984551b6f92806ded3a4b35550030a1578b04c89a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/pl/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/pl/firefox-77.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "853bd27d468111e512907ca3226f399ba0be48c3332836342ff15b4a8bc4e3253e31fe91a31f462863f9a6559273ad6693f1bf65a1763178aa3488185779da91";
+      sha512 = "723605773c6f40c67f0ac5940abe893d6e0ef913ccb704446adff60a58fd2f056a0ab4bedadea0ff71bb573ed6bc81f5d0bf37ccbfacaba5544602efd25e6f13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/pt-BR/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/pt-BR/firefox-77.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "d70bde7178c6ce76eedbd8a8e33617ddc7e7271aff41afae4d190e5f28bddec2094c1450c3782ae7dfe8ea7a6b844d50602e27294454946ab5c65a44b3553f9b";
+      sha512 = "11da5799a43f17a7d135366dd15c73e2ce23e3d22c12ebd7bb8a7279c548f0fef584fff9ac94506a5461edd637a3e01200d0ca25348f9b726d5be77fd9e0d565";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/pt-PT/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/pt-PT/firefox-77.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "6e8e2f7519e88809dd38d694f5a293379af1529afe7fdfd6f19e09e240bfd184291720ac48db382308c8d79c38c955916c57bf88d85ec2d220de7bd872954f43";
+      sha512 = "10b87591ba30357b06ab842598e8a5a65f4abef67b714212f6edde4d3d50f04022b3c0766bb3149e9edec72911b39e1ca575077e79ec5148994174990f4bcf8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/rm/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/rm/firefox-77.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "928018a321f1c0b86d13c092a5390652fe5d13bc63ee19274b6d3a107e2c5157fc969683e59055a13798c5982c75e02ae0e5cb40f5c94203a052c7898d1ad607";
+      sha512 = "25c4923e8e3fd7c25424afe7a1c34f854906b59498369e162ee66d889762ba3334f66d383742b5d69561ed2b571564ad5bca7c112e8ba3c7166e108720051a85";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ro/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ro/firefox-77.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "b2fe56c56cb25471fd7cd40d9fbdaad10d25438b94fdffbbd81ab93a7340befd1678d904a3629a28c8db6fa10d969243c27b003817ef3c9b38030d6f43f39f9c";
+      sha512 = "e33aa49a37a1980aba3cbfcd31b38c67714c6dda08eb86e4d13384f9b759cb0da7d45879a7bc0465d6d0f3f997f1f37ca8cd3a7076a0862b16de8c444a31378a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ru/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ru/firefox-77.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "bb4745d61f87f6e7acae842be9068a7f7b9d9da3c44d2d32a45c4d4a0dcd127e4c98bf5c7cc9ce03c9dd1782e4d9d03f8c1c82a6008a2b9b93b5ce380020d98c";
+      sha512 = "0518539bb611d752b3ff0e6ba6e0bd9c57ecf848c7e35b02711816174b3404cc140e847e4aca1e3aa151ef207bc53d6757bd634164822b513fa90976e7cce4a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/si/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/si/firefox-77.0b4.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "efa44e8a4e69d10feb35385ee01b171d08c46feffea0d74ea8ee9b7cf21a839b2cc43ff138752c50ad43db1923b264495b63a0d46b5b2e579c3ba61b6bdf3acb";
+      sha512 = "0d0ea136da8984d822f8a9f6432f3dd7adeb7689e4e65cbc1cbcac2c10230b642a958b2bb632c00891b8e6ce467fbd313472e7b37b7673de82463354275f50ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/sk/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/sk/firefox-77.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "3f9e63ad4c1e8a4f6bfac97925e189c9b3888c2e952c1801e4fcf935a246a294f9b088eaad6c18bf7dd93c136579529605bad6bcd95fa7b68c89a0fb087a44f8";
+      sha512 = "5544b8791df862cea1e0fec1b39b659c395fdbd1d21c72f4226b4cd6a99bc4dbba6799b9d37a3a8cc91229a54b2b91517f8fb38dca770d1c69ac2471e03eb0ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/sl/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/sl/firefox-77.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "79d4a1aed3c9afab1c1847ed4365ab7e99d0982fdaf09d6d9652b9f95ce3c32b123b2389a1a9d6486e6141953d25c06fac0a06156bff8c2eff6e295c8f79c28e";
+      sha512 = "e8e81467f132dc07286a8dddcdfb38a7fdf03abdb098a2145a8273287bef06264904e0c379a0fb90f6c77365716c0890fd44663a1004d77d2b0372fa888d183c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/son/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/son/firefox-77.0b4.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "5faec58c78ab2acb1fb5f3aa3aabdb9d5ad9df6168215f818967bc2b3575aeee1428ee8354aabfb36b37ed66137f8ca6b2ce9ce5fee0075562c618fc3cfba9e8";
+      sha512 = "28041383cc3e0e6a207bcc1d774e7743abfcdddd37cb5cde13fa6a0bb8820489252a939f28105888d03e0d5fce7b6f9dd9e325208f1c890ef6eeb7aa2c41eb69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/sq/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/sq/firefox-77.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "32c67a6ace809219fbd51775c421fa6a68e29bef9e908678b43b53e1bffc85d8bf773e2a5b9a00861b0a437d56ee3ad5ff1cd1e84504a48816cf74a69240b851";
+      sha512 = "e24531c349c1b6ba966c965358750d6ee7c34450bbb2253e210fc65067b66b62fa84855efab7dbb483ad5b4e691a40e4e6fcc2711309714014d1b022e45a9820";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/sr/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/sr/firefox-77.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "ea3aff47c7e428a445aea0ebd7fa98e8de3a41dad208cea39adcad84327d2181b862ecd977e9c7a6aa8fb21cc99ada9698be67c86c5a931b1b41edafb744450b";
+      sha512 = "471b6ffc71db1d0d689a9779e82852350cff950660d6de181451d01c9c70022546940ba1c89b7a2df84de654930872154e1032f280efe450559355e4b0919f94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/sv-SE/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/sv-SE/firefox-77.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "dcef09b5dee93167dbe6bc87d1fbb6f0e472db6471b99815d38532f6d223ac7a12183b323b5e979fa7943e4db1fc25b48760caf4540afa111f9dfd0958568767";
+      sha512 = "42aacefe7c0e43b4eeb2b688c9bd7ba714a215042e99326f64bd929b8a7659eac96a80568988d8e1096b66ec9180c1dc5036a241c313ae6528fb64264c41bde8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ta/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ta/firefox-77.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "598e3169673ad39832fea1afe0c141070795d54636846b18fd7ccb4a9e66575f779789553550552f9a9786ebe691afb10b81f0d0ba127242827e2d11f941c115";
+      sha512 = "75a42286cf7da96ee67a5f65cb276f9103af5d67b534344993d89ceaff69f01f0a67c222377f2bef8b4333f7d78ea322594df6dc0e3604f0ee60573de37fa225";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/te/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/te/firefox-77.0b4.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "a1501c3fe46adc0d29ea098aba2800c71f6eb14b33e44a367e33f5f9c705357cad8445e0980cc758102eb7c01c18a79f3007cfbd8d1b9c1ae9766e0e793ec3b3";
+      sha512 = "a71710c76dd83ad892abe76c878a16a5bea42425c09ba7665b1b5d9c84782908c2998581ac9aeaa1043a88dd4659b08d51c30ab58887fe431e4772669eda7eaa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/th/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/th/firefox-77.0b4.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "1bf0876237e5c8eea321970f86c3878770a3c54c7cbacf67bfb75904fd270ce88252d9844450086e00758cb2b1a0e1db40394246cb9ef8a7018c76bba03e3850";
+      sha512 = "6b33cd364c2c2b33ffafff23d4ef9460211ec942ecfba1785ff194325d0ffe29b68a3eb25196c18414eb576e0971aaef2cc65d8aa07d0cd8719d1236814aae8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/tl/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/tl/firefox-77.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha512 = "5a0f3514e196803d7d6062cac1ec75342ffb49155624a0035eb49ddcaf829dfeaf37f7e26997b31cb85b9e43ee21fca9f7129ab6bf4a065fdade9bdb06573628";
+      sha512 = "0e39277c79e9e059ce428e414d5893d119fe53dc398664fd574923ec3899edd28f70c7e52cf8468e812fabcad181f61be47e42e8586cf30b331061650277f65f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/tr/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/tr/firefox-77.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "8b81e0479b60cad9b97f2108745445f584986fef5521c9ab88bb6ecd48dbc9a989b906122fad29c755dfbff859719c1c9da34452383dbf027d69288a32ea7af4";
+      sha512 = "230c193ca5f7f0cca0f886df73eca4ea2bcbb3c9120b2198477397fe3c798c96bea29078ccd7f6d75176e0a9cf8bfe0d917c0365b3f8f366a61be2a45dc1fa71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/trs/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/trs/firefox-77.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha512 = "9b3d99608d163d860d0b123eddd794a2d3b44866e6b92bfc0f06c05fbdb59ebd1ade970850e5b1974332424886edfde04861abd1d47868e60970826846fc5b31";
+      sha512 = "f45d5c450b5ce0c4a5cdea19adf6a26e2840847725d6d2f46d5f4ecfda15944895f983ebbc14b28fb43f3fcb8a6d9ee951eacb790cf225ab12a6ba005b8037af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/uk/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/uk/firefox-77.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "f056c542bd5b83bdfc7b2a8d7234d40b64e88063208ee4b0b1b7b27017ede66b8acbbaa9d835a6d2667a321d6b965002bb87b68e5aae0eeae27aba8dfc87164a";
+      sha512 = "4f293f2152e0a47eb67c09f0f024211e0a1d2692d8c7d6a9a340bf028c68434aa79fc5a2919e865b0e74978fe8c70b0dcc6310d787a404e00d180814b0474234";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/ur/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/ur/firefox-77.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "a36a8c25ebe88fcf086fd476619a657b1ff26364133d05b32bdc13cca81b61009c4f1afb760bae961942ed1396b178c2eb3cda9add8c6b502353a2ce8c486cd0";
+      sha512 = "cd1519f49cb2442f2f48bcb15efd509bb1a127e77d389b9f1d00bd1084d4812a1e0e6de375461a8e16d0365485e8308d070adbd144e8337b8354ee0d8a72e835";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/uz/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/uz/firefox-77.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "d07515f921caedca18f7661fad83ac772369a2f7f99d65fb827a0236818fd8eff211dbab90aa9525a6318374b1a2f84d8099667d1957f21c30e9dca35f97a111";
+      sha512 = "6e627ef6d57baaef48d164f72f7987cf91be59d85ca84c9971a658508b7898adf096a0a67fcd106d8113537a4f35bbda9119fa4ee298863c46d96caec29d0322";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/vi/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/vi/firefox-77.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "de51d63ce79c249496222658ebbf53fa656916a753e6305d36047a99879b25e17a4ea4ebce1ccd07141cb507a7501362d0bb556aae97d115686d0d38db7742ab";
+      sha512 = "08696825bdb6b7ac02ba5cc3d0cc3ae4dc6189d35d8d90b1378e5522b7eba52cd20a47a9951676eb853b3a04840389f7835776e72bda47d716d480b64cc91c12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/xh/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/xh/firefox-77.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "b01037ce68d8147dc79aeb0d540fe22a06d89ba5cf804951d16af3a896f592a00be7519b184de2f3aca7531d3026f78283b9f6b409c24031faf4859e92bfd1bd";
+      sha512 = "4f3410b435e6e9116b1401c333c211fb6932a4db9111251cbde6acfe8da9d371878581b232c34af27f9a5d063cb374448c8dfd300ec5d9001e6bc4da227c7579";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/zh-CN/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/zh-CN/firefox-77.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "0e6088a9b32ec76410fc45fc1433c514b1deb9fdab7f5249bd7ab3e1db9e0e5ad4294bffbfabf2f665bcfbedf8234ab64192ee50b34259e4133d7d035f6f4ff6";
+      sha512 = "b44cb34fa3569f5ef30c476707aa4b30f11c2a5f083550fa5149b25b63bfa27aab9dc0a9b146b1f3d620037c1aa08fdd8d54e3c45865fab57924e8fd3ad4adc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0b8/linux-i686/zh-TW/firefox-76.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/77.0b4/linux-i686/zh-TW/firefox-77.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "82042857b33d2dd642c8d6404bb864c79c2ffd91d2f8b342f39d9389e63ca59738b0083f192b607a391cf2fadac056760fd07c2b76a74172118eb44ed5724a1b";
+      sha512 = "34f3de148a077bd3b4bda61926664745042cea245ab4a8bfa0dbef498c717567513137da082ba2f46545c3b536a95312ffe0bc77f8ec8b89294300a4b0d47b9a";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "76.0";
+  version = "76.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ach/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ach/firefox-76.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "d1bd187497c76c624e010ec50a43e68bd91cdfded37f85e02047acdb53027c79c8071632f1a31f35f0a2b52eacf94c905984f2edb7b83e0a74fb0a0565eb18a5";
+      sha512 = "56634c533fae4ffc35b4b7625ab1063f7f72221919b976cc37c0016368ae6b9e06bb641dbb332a116d2b4f499203f705f0be573a0df0e54a8ce2347a1aa21df5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/af/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/af/firefox-76.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "bd9e45046cb566cd3fc94eec9d5587b0270417d68091da1b29eca40645b2aff4f081c2a5b0292a0e06da410a64fd1f617543bf0702852a6fe424680fdf3ec39a";
+      sha512 = "884dc1f26c8e7b4b210b3a7ce4dab32d7f1280edf4224b0528fff9b1dbf843d1bae0938ccc1d3d7e996a51beb1b351dbe1bf2b1aa7b6a159ee89b74b71ce54c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/an/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/an/firefox-76.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "d5df04a513a349291d629941e519617cdcdee1c004ec8bcc3c02bf02ad310dad2dc33878268d8a4a6b115b3b02bd558159a8eaddda48e83aca29f2a377225396";
+      sha512 = "83d4935513f44e6c9960255c51a38ebb6b0810b56a850bf98e91cef028877d48e8dfe99359c034e7e7986e361e8c03dc438e85140b2efa9d9e905595a127375a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ar/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ar/firefox-76.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "753550131ee986f7a770f95959a26b24b17e0a6a5f2e12ec1b7d42b31886e32b9c93a559b7824cd5348f34f1fe26901f5198fca57ab2c9f412ce032882cf7b5b";
+      sha512 = "74fcfffad50d6cf2d95a244137797da4fe4d29b1fa3e6e9a76b25e72a41305382af3bab7325b6776b1c64abec2e8adda5ec06d173ee9036815ba64074ae81f8d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ast/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ast/firefox-76.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "8561ba0236a9524672c7ebacde935d4c3761fe2c5fc0125951d28f53c3d27388d48c108a6fa71064cbfa54cca57a72f6fb49b3b8314d28b875e250b218be4d55";
+      sha512 = "ec659bfa409ff8145c1012081be7d5fda94a5f225f561bab915ca7e763e24815e73b80258b91fba2eabfd8bd30a2d16f20a1662429e97f9b9443e5838297535d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/az/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/az/firefox-76.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "53b7a939d02ccc0a809079070afd4db528a4cb617a4fbfaa58cca573450be764e3894caf3a40477903151f8116460dc574749f0edf9bfae6981616772b649703";
+      sha512 = "a6b1628f2cf6a8e9d30e339638fd65c0d74f0b20d18e709eaa5ef938665451f0af994d8c997cef78fc23a8f9939d51789bc0db264c108fbaa8728a0c6db32e89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/be/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/be/firefox-76.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "36658c05c6b7b1f64ffe14ded709dbc08f0236f99f9457964c15a36a4ebf8d73bf482ac2f8518927b2d66fc9a1ba19289db1855a6dbc7b9502c2a3c0137bd7ab";
+      sha512 = "6979ead7f905acacce6da9609feea1ea862685693c253d1264a005e92826c4c1cb252a490599e2c6d599d05a36efcd380f36db46e8e6c9b0e923981a329140e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/bg/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/bg/firefox-76.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "890066ff182d6ce79cf0adf307a92a26ced29f633cbaaacd02eb5c1c3f0e2bc2de336a7b22fbb530ec85561d26dc44f93f2ce1f58843e1d87322badbdc92e8fc";
+      sha512 = "70ed0f728106e318846f4fdf7ddbdee1770c3fb35389fcd4b939b76711e085e83dedd7c6c9843ca8b62dc5206e3286d836cdf59e2f4ccde170fd9758ca8ddb58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/bn/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/bn/firefox-76.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha512 = "c6f9bda8a95351d79ecfe1e138ace440aecee6c1dc5ad2d7c6d249e5277b75b27797cdcbfa1b8d3ec2a899974f555b8b20f7c38f03a7979ca917ab050feb6cfa";
+      sha512 = "2a9575e2d741fabcb0653b6c716333a2bd34ea756651bd9d6189887f7530009118742ec1ce0776b77339296a0fe18612fa1a896738da5a0a7c55854f60a83108";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/br/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/br/firefox-76.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "b15b1cd34dc4799836d67ce4ed8b166b54e21076313a2f726c7b872aeabbcc40a35c7f859cf78e0f17825fcad38b6d4dfaadf5d27ef89ebea8da0ce427492311";
+      sha512 = "d6b00e92f56f847635b7a210f0b291d8210cfbbd430f3a4d41f696394ee7d0b0ad59e0b00b2544245ea2c40be7eb44787f3a74b84f9313894aa87698be0bdbd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/bs/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/bs/firefox-76.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "fee05346fed30422b79af7c0626a7763f404f8a3a2617bddd17b95434060bd1c47b47409a0147c130b51d08d98de2232abe8fc7ade9bc58cc1eeccaf0987aee7";
+      sha512 = "e8df2cc942ff74f3b4178cfed6ab6ca6ddf687dc1657a766d111a5e8d1433a259d3f679c8ac03945e96fc1fd343921c319bc4a0f334abbe33da76b3b71158832";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ca-valencia/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ca-valencia/firefox-76.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha512 = "beb5d44cabc7a80a0ceb4573e4e6fc2b554c6cc0ae38c9a5699d0d87d5f36aee892c4bee8ca1d103001b3305ef814f9a96a8fd63dc5b495363443f9abb4edc91";
+      sha512 = "dfdb981b46611b182182acb6b140dd362bdc502f9561252e58c24d14986445e9e267f947c3f09c92741c5a498dea69f1d8892eb62fde4a7226bd5d3cfe310bc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ca/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ca/firefox-76.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "1b8cc942602134a48e0d16a3244e97edafa133c74651ed4545f5e3eb515ad1881276cd2adc204e5c9cfd677dacec79030311483469174415199b9eb679729442";
+      sha512 = "767e1764ee62242d4202dbf5d40e751c6aaa9986216581e20e74cda42341c74cd9e3826c6ff52b68a4e735d52a0f92110414d8ead300bab5ba78543dd12ec3eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/cak/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/cak/firefox-76.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "2738e924257a81bb1ff956a6717e6ef4769e96f5940bb0fad58030e3d2ce65e84ecb2807e6e04ca820eeba61bd386c85716112535cc28d2bd3c9e7a364c734b2";
+      sha512 = "ef71d626cb8651f6febe0e89e16f4738c08cce3aae4c5ba4470762ffd71cf4df263c87730e11aac877779c78325099267b77c6454256a581fd99d5b96d3b832e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/cs/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/cs/firefox-76.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "3d58acd8bafbd11307ca58894992fcf8325a5679585d5c5e09e397b941019a8a8f7bc9b63997bcad2722e8cbba88715b789683b0428632e4ec4b728a36b54099";
+      sha512 = "5bebaff5f0526a8d3c4be391955310151c74414da25e2ca50982227f66c119d69f157db46b8a93e9f6fc1923d64137ce0b7d592f932ee0dee74c791b572be4c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/cy/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/cy/firefox-76.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "aa7aa1b06c1a28e30b532d41b4cf3bbae26c42a24a63afb1999f421577afac4e4591b465b3e659ed5c9278b2c5d2c4c449a84fcfa69b451804d2a0470524ab04";
+      sha512 = "760b8d9cd21e9882360d37499258514d61f188377ce426d9d385f0bd59a16e72287c2c05801c5ee2faac2648938725ef332f4b0c8134df640413890eb0afaf19";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/da/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/da/firefox-76.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "48160d3a437dee94c1070e2742c6bde4a36811e8d2eae87d7c8450476b30b912bc9cbef8a5f7d917ad4be771eeede9d7fa9315e27b154f50049ce80f4911024d";
+      sha512 = "67c8d9b13962a7ccdb4ceb8eb17842c339c45badb406b92450a0c953a7b68ca4d9ecd09d86f970b2a978e4f78aa308527d6f071a81db7e1e4bb4bcc8eb40a60b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/de/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/de/firefox-76.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "fc4d0ddd9649dd555b4abd4d90f9d6cff8fe7e702bcf5d2931565c469842f51ee215286f68802304868848f043e54c8224358c8f4060435a4674401d19bd6989";
+      sha512 = "e168bd8f2ea34c9060420164b6c3659e1b14cf9dcc3681061226f27c53aaddcd5349ca4ab5c42b2cfb41be270c5fee3d809261475a0d4a005dd8ead3407329c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/dsb/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/dsb/firefox-76.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "3cab1a498db5900b055a8bc6398e4dc9770657c41ba9bb6bf0f196566e9c535db99f02e5c51750e7c7185f2f0b1a26e84da51403775c33ef34915b43e3a8b27c";
+      sha512 = "36e0fc0db94dcb2e15c185f3266b5848f86ad8aeeb51adcd26b3c91a4ad3adfc795186494f80ac22cd489d6839419d12c33dd08ba67a75d66e25fb6df47879dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/el/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/el/firefox-76.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "d099758283e38566a4d9db744590f42b5fd28de8e985c2f240096e158995da00711e97d6feb3979bac40a2ad57cf7876da37c4ba69f3467930415d87a2d10c50";
+      sha512 = "a749c3ed35adc855dfc9f2e797095c961b750125aa28ae2c40c4235e9d7658d3c4d21b9d0bc5ad17361044edc1345888bdaf37894f8041c76b0e12304cd72220";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/en-CA/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/en-CA/firefox-76.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "442e60f0d132d96c58364e0d5f70e43ade8e6508f5d0a76b3d7e5c61bed0bffa5f9bc2096c89879dcb1681bc394699e39d3c31f2d02fa790dd8e38f1b406154c";
+      sha512 = "9022b1129785404bd62e10fe9fb1cd94bedf866979ba89c8bf4872dd2c298c38a62dc86d6b08552798606a334656d24d5b279e466075fe47a29549ebdded74ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/en-GB/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/en-GB/firefox-76.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "8c0d31a9123d8d8baf94f73505233786f7fd2ce721f8792f4cc1db337a1659badf08393a22159dcb9d8256e43f24661c3975e6a1f801e30d21bc54083f4da041";
+      sha512 = "dcb755d718adebf322362a819f42fe7bb3a53c9fe6cbb5c9f01328caceb9b0fef6bac14910279e1f376d25cf5854554ceb1215cbb8effedff7f8c45c608453c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/en-US/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/en-US/firefox-76.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "993e5410a946f802a47d8167c83e767fa9973754cfc1365e4cc2698a25524dc27c83f3b202990744dd654d68226c601ad9608ecc49d2c3952e50967e20ece34a";
+      sha512 = "045fa38e72c51852656ea2a1e61956ad1fda524b1ce1530c49638c75fdac2d558d823cdfca25ab7348a4e366c20a8769e073d89e9c5e308e404f2481f611bebf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/eo/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/eo/firefox-76.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "c2021ecd345cc45fd26ccd8a75ee66cd1eeb506a8e0f6b9811b4149b6bb15121edcdc9a0825703db52beea61f7249f45d23fa3822a9f47701adbc2e86c7ccaa3";
+      sha512 = "5e2f2dbba65b6bdaff7c60b08b19c9a467c1772e433ba48768ebe647d4275742189c43cc44443086b51a32a7eb903fc30fb33b26fcce22377c5e819a77740c67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/es-AR/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/es-AR/firefox-76.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "c397cdeebd4527189b898db2640c1a5b8b5bd4fc1664ef384662136232b5dc21f7033686d2624ec421542d1140f46cc95c8364d47e1c89a8653d541fab52e28c";
+      sha512 = "7be5982cb0d96deceb4fc81915c3ec854c654ea37b4cd6389c0eb3bfc82f6ec8bd5f42711b02c9317299ff08cf7077642b3fc8a63f65d7b48f0fb8911365fb9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/es-CL/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/es-CL/firefox-76.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "86940cd36df65d0515634c7abe6c7c81157a8bd3576acd9844784041c2239d25aa455da2fc33ba9b8cac0e5a840546dda0cc04765589dab0608ebe9b3cd53967";
+      sha512 = "a5147b6f317c2ab3ce83a3541c5131e7f6923c7b7e62f8c25a45a726f497e5c51b7f89f75e9d6475feebcda111092fc0bcfc85a4697f3c85a16201ce23ac6298";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/es-ES/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/es-ES/firefox-76.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "9a1404626e2b9716567e0c1b0a7d681acfc47bd488fcc585172fb40c4d18dc1bdd4356244c74d042ad085e0300aff73ff7619d651658655bdf7d668f64e72a3a";
+      sha512 = "92af33ef72b7a6f412332dfa4f3ff2c6005a7c98a160124bd5ddb9cddfc5d6b8b718aec72031838c5302f9ffcad19ea9388aedd6635a9ba496ea22fd295db374";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/es-MX/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/es-MX/firefox-76.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "870b2b135ffe3ece3ef4d16abc74d469421742bb32fe8b0add3a39dbd580aa07e251df4137f3a2950d6992cefcf0eaff162959ad5eeeb7e493c016769ad2751d";
+      sha512 = "24936c84e34d8a713959a213018319581304ef5a167744fa58dde8179c6728d057f7aaccf1272c58e372ca520a74dc2ebd89ce549b0036d195f651cb65e8e9ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/et/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/et/firefox-76.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "d20a3c1cb0649406d9cfcc22bffb4dacdee124b68c210ff25b1316be76a1ec26b7b9f21ee8d208cb7a6f1f733ae71b70af3fe084b92640cce03989f4d45cc375";
+      sha512 = "0218ce322fe210279dac2e6639815fd64c0df6262e150b6b785373c66e2143d33f702c72fbc3d789d0ed1eca93ff28503c725be7529a67166e36311f5e05aba3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/eu/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/eu/firefox-76.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "fcc4a18ab042f31153e1f5a4d090c920e687687ae8be4259394a771c839e8af167efdf9b0a3cd8ae80f15e70300d24ca894ec1381bd91738b7a5c1160dcf8eac";
+      sha512 = "64c9898bf140c56f34e1de44d087b808763f7ca65e966778041ed088e859331e97ad8a49083bc7b3f0582a44b149a7a797cc1b836dc1ea3772583e06a0fcea4a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/fa/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/fa/firefox-76.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "7ce0bce00836d4497a440f3c66421cbab38f5b856a8b0e3dea13b88c167b689a061be7261d9daed1ddebd23f21eb806fbe72c7cf08a2f49c31ea1486287404b7";
+      sha512 = "e21c262bfec83f0922f01782634ddbf0d2c3d9025db22374d461b1e53a5ff66e3d32977beea69c9ec3bdd2077b170942557527954735ff23bc614f43c5f51afe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ff/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ff/firefox-76.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "41c0639955bb82c8042e0cd9e76c6c6b30c5baf8f94206f1932e8a56cbc21a2de53fc9b31b6dec656822e215d11259a7b2dc158e58d1edce48dbe41f2cda4098";
+      sha512 = "8516977a70de07dde2e81fe1dd00efc71a13642d41e467851d6091588e7c5b0458c705c7c408a6cb44ccd9bc39d3a42bd0c6e8b90737f3e6092992286bd471a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/fi/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/fi/firefox-76.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "540f26080c0b85b71e40bb0eb5acd92d8b71cd9ad8dbe72121225afc2b9821519ed6a2d2bc58cc77b445c3fa42ac6e39647c1da8c8a8935617995dcb0376b9d8";
+      sha512 = "f21c5dcd31678f1e7a71056691fef705e3447556888b9b8158f00622c6ffd7ed303348f55eaa86e389f983138deb70715d7ab85adc5a6c92faba5ef0ba5595e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/fr/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/fr/firefox-76.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "ccf845aec06d7274acc7a850702e2dbfe69db8198a44537f7f0eef6b65bdf0cb71682b2a443f0e6a5e8ff310922bd29c39229813cd12ba54f70c0fa3418ff23a";
+      sha512 = "74ed0326dff879c3a3524a3e2af6d53bdb6b4a994a70afb27393e999298f52b8d820c6b00addcce9689a20792fd2f3adf3aac27960f24b22232e3d67a6d34df0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/fy-NL/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/fy-NL/firefox-76.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "5eca2e853a3458f5adf0a960cc7ec4f21db344e67e7e419ca19d34b807809bd0c954ae4011b5ee73b02d9ef88686ac57f2a0d1d3af43e6a4def2031b698cd656";
+      sha512 = "60c762ca3b4ef5a18f71307b8afd9286b2c45ac2691a695b202e7247ebc1aad5cd654e431d1bd84eab070d6c0e8a263b0060343fb2fdafae37068a966e5c16e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ga-IE/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ga-IE/firefox-76.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "4ceee43db5cbd6ef5b18442cba0c7c74998129280e14b20ad41de041b3053b518fe77767a7aed9c62fa2467b2d6ac36a680e276d79edbc959313b260950f7c8a";
+      sha512 = "5fe8d6a1b6ff62d3018cd3c552c80f5d3d0220a9eb64a6db5a0757a8a721f431eafc0bb03877e3a61df3cec0b876e52fb4e5e526973cd9e109ab87ff67931540";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/gd/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/gd/firefox-76.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "9a5115acf49a15e10a530041029081eff7bd7a6877dac1331391d5321533083162be0dbc5dcede2bb708d8a54d47af3773c89e498d8c7d99c28f7229747c0721";
+      sha512 = "dc67d892625f1175e665f704b3cf5430320d0ccfa54f2f101e382d3303f225a0b7c0837f7a2c4fcf518d51f728aa79d3667a931419215509c1e5c2a4d42d9388";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/gl/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/gl/firefox-76.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "435de08a8d536491b645d630e81bd9190b61e0073c3b170977a995f9599b0ebd0fe4a18279f0ef40ca242e854fd43ea36dab41a86a73c515a691b621f8b74ae2";
+      sha512 = "aadf93cb89f6183f2d43a94597fc22fed59e2c72fd9cca20c124f881de41caab0daebf18cae4e54611b971dd7273b24ef4d35c334bfd2ebbcb45b76b386e9e19";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/gn/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/gn/firefox-76.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "e4e4d05239306cbc0f91cf6d1eb890af45c40fff8ac53fa47c6dde6dbaa583d31b6e5e51bfac91d2fddba9f89e51125235b11f766ebc39ec5e55da65e1ba732d";
+      sha512 = "dd9e85e723d1c0d5e19730b042625403756c76fa009df884700961046b1a49378a9ebc6f8d7856151a53199e04998a4a2baf956c7219d9474feb085160a8cb5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/gu-IN/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/gu-IN/firefox-76.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "727b7db843fc1722cb5d837e02388170d06f8c6ef42aba22dde9e237808e5404820c8b14dd43ec5cf2ddfcdf4883bd678d5c9aeb2845e428c096382d8a805afa";
+      sha512 = "2d69e765ec90fa646617fbd93315c4f8237ff314a8cac195076d8a3c748cb7198a4d307533742f9754178ba4a212b0d3dcc6d95343fcc613867565dbc77c557d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/he/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/he/firefox-76.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "c151a281f8aaaf82a0021c20af2d12332674b27f2e5ac9c0ffea070c5c350f96de978a1662b5886f1d3b1d514061747f247ae3ebbd965e3ce940a2494c164243";
+      sha512 = "a42cfdbbbd3d56110f70561436664a259e63babef0e506fcbc8833d341966e11a9bbdbcf195d4a08e1230d175ecf7797846de1bbb1bbabf0c323ea55338c0bdd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/hi-IN/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/hi-IN/firefox-76.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "5048f072162e3b2cbfbcc24885aec83599a7c47bad212fbae741fa15b903014a9e29b362f1492b42341498398b009e5d929de0801a22b4333093f9057c47b42c";
+      sha512 = "a3625a9cc915b40ec3c3f7b3945b13f775a2b955699c6446aeba6f59b8995d3d2b6c3b3ccaedfa9511e8f8398a9996376ffa1ab9f2267310eb84dcd7a788ff68";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/hr/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/hr/firefox-76.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "ebd9c280598ebec64a230f6711d4d7839feb005d790c0660fe789e129a1acba78e170686eff21e0bad558dc7e9b0dc98a9139b7fff2426d9050ec0b3ed3e815b";
+      sha512 = "873db033d9a0e3585ed7a2d3b45c8d60cc351adda4cc941d92e3dfa0715fd6f711524b438bd6087c5dae1b4f24db8e24260f7bbe237199c28a158f82f971188a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/hsb/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/hsb/firefox-76.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "197ea2000df14ad17191e2e7eaf54bf7bd1df21fbd25c0e18b200d2c43686c4e256be329f57254422a8e156917ea3bf312a38e332b72596b5b93b97f61319be2";
+      sha512 = "2085d1649e6c346fc86bbe1a317cd63ad56dd2307735c401bf2a4a496277dd3cb37e0971708756efa044a1117ba39eab1701c2b2792cbdf8c1737ef6b604a8b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/hu/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/hu/firefox-76.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "ce3b86d39f27f1a5f2287cb88bb45be0b70ca8adf7e814e3fd5191fd41ab7e33c427d8ee0d4f5c7c5b279e2079e318239aa3485771bd2f211c9f1ae2e654fc5f";
+      sha512 = "55241670e93ab07cb9137a99ef81a73dae4e8409bd65920c491d2b0b8a672615f217d761528d977532f08e06a3873ab498a7e601395c0815edcf38e1c6628040";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/hy-AM/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/hy-AM/firefox-76.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "022053cf588d2f7aebb564342068d4bf3763dde50f3bbcf433dd2d7e5d90ecb134f9302b44f5bdcc84f56e74c7c965555e931ac7b6d85ce58dafe838026a91b6";
+      sha512 = "8e70d83f4222a2d41e98ac06b627a5c7bc6a5aad4decf2806c5305d1c93a3410b4e650e28575c39ba6c76bb0c115960c4b2f659802132c19c35bcb2b1903e466";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ia/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ia/firefox-76.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "bd57679165653b1557569d20eaa3ca83011e5704b76e3f29730e91d2c7a5fb553ab3563a1f26d38100ff8330d7efbbd133e959c4ae5c534da2e0888dac12ca5d";
+      sha512 = "ec1e2fde5db9737811a6cb5a45dd9aaf12b86520fc033d83f853c4ebbb46c05bdd2547ded0f699330af9994441268a06d9680cd2757708de1ab70ad149287155";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/id/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/id/firefox-76.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "72a391de2d665db794e5624f341245a85a85c45d8d2f3c71bcf526b273bbf1a06cdfca5e9d45ec05627570ee496e0899fd7756066f6f40a86df088c4e5025ac2";
+      sha512 = "7fb924ea881990a25937b0f02a3d518d20d7262c633edbf0cbb5d17810e9ad92f8a6008c0014a6f3b22c66c6569ec9e12aa0e521c9b46374f7e9c4d7265a2f03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/is/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/is/firefox-76.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "8707e9ea8665b0f2f773c98b7c457c00c99528676afaebd56570fea1460b11ac016ca257f10397e447581a3a8966db671bf33634255c015104c8435c067fbce3";
+      sha512 = "7948b2b40a2ad1a4501743fb80c3bf4cb4719ee447ec63cf6931472eb69c250e8e1b7ba4fcbdc47aca28bab73c8e52ae8460c9778f8f868cf21106780dfe38b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/it/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/it/firefox-76.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "10d74b74ca47e406919ac9589937ecadc55b637678f895d6bb3700aa072c261416591378845fcc2f032755da08a4e996c726fa1694b18883feb9fb90a36ab71e";
+      sha512 = "665c469114ba92f70f2a4394e588002cdc02ad206ac2d47d0340c085662aa59c738b2750de113f6b22855813d828f69ad5cf0aa144e0b3c872501fb915a792cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ja/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ja/firefox-76.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "9d7d45b0e1ef893145bce37a137e648b6292febbb08e66a0f0e8b6e9765e19ed3e864483c3892d327f3c75a4f73592a5cb2957ff6c17b20d19bf18179df5b083";
+      sha512 = "bc14bf87d7973fad95905252e9d459126deeaf026483e9bcd2626d7d7b13ee23f79f9f5dc87905de7cb3932573506f9ccc0cce34df2d4eb0f33dbcf84ad45187";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ka/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ka/firefox-76.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "22730ebd0eec5fe1c9f993c8964c81b31d2bce1b1b7ba901c3a7911d9544659e459fdd19024bb551169d17c9430e15a92c039969379da28a49db2f0b04d799c4";
+      sha512 = "0766ffb8d13b0d3ca4b129a3ea9568d3a46c8f7059815e3a0bc3f91a1447ddd0e95e3b604b4d8d818459ec05e4fd782278aabcd27109423f52f05f8439ef6bba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/kab/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/kab/firefox-76.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "e7455deffe566f95239e6b1b6eb5a4b20d849ff9f0fa26518d993581b5e76975e41a5bdb54f69be7ff182437ceca868779b67c6a6c118155569dd8792793979e";
+      sha512 = "94ad4a730371b473ac55e61b1a6f9203cdc72cf804421589ddda719411485d36e484667551a281d3f8e96e73b4896ce37bca5dd191421c1c3443ed71828bdad0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/kk/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/kk/firefox-76.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "56e36532e5babf3682edf5f278b971897cbd4854b0864dde5aedffa6a7828048557dee5992f9eabdfdb67c2054abc0dc2e5d0df8ec5882b07d8b266183177e06";
+      sha512 = "0b41b29deda91317257b324f208dfdab665ddd1c39d0f928d5265b7ba99fdd620d2dadcf0ad9fad4367e2f4c9e723c2eb5cacda4b555730bf9ed0d5f182a135c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/km/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/km/firefox-76.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "6d1ef5fb7b555d667bc1ced25b7ef49f8832b9c077b113db79ff8509d845d693af33bcccf4039805fc0c69293139a22f24ea3294706097ebde859cd0f9aae8bb";
+      sha512 = "7346493f892ff6db5e92908ff89e69a60afce76c6d0b5f90ac058e75e31252f57a6628e09f8b327788415aa795e8055acbc0b8708a604692a37ba98e4ca2eac6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/kn/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/kn/firefox-76.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "04626f922214d666f1da224b2ba52960f1697ff76a0b40f92718c536eb07de6b319700566a9c3d702e50b137d54b7a75af474bdf56d39bf80165b8430b636944";
+      sha512 = "c96dc074e028cff9ac7f6536c106b3912ac48132294046ce1e50a502b2c2380e76c2cc2c7645b5fdf9217ea5918c85c7e37be8c65d549f88170045913f2d5ba1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ko/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ko/firefox-76.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "e83f42c7c24b5a0536510ee736114d8e8ab6c6393ce63ca9e2f9d0e0216831b192781d0617e9793c6a8b687429275eafa6f84a8839900858412abff751256a4f";
+      sha512 = "790b1665e0d7a00c89ec96130d90867a92b17ddfbe68b67fbb7fc040f8bd224f0718cb5d6aef09d51edfe1a1745810e5d7479eeed5c10e31c6eb990086ff9a9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/lij/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/lij/firefox-76.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "524261eaf2fd311f92d85df46459bba17b06ca4e1a61a14453c9edbf37c31b1de2d781d466812c250353546bbde2044c79626840297c76a3986fc6ef869db863";
+      sha512 = "86c859bfdd4f93e1e827c81cf1e095370071a69c00bc6a93f2d7177db0636642f10438d556276a8bb4e9009e4b101298a1b1ebb1ee9076d58fafe4c444e3f929";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/lt/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/lt/firefox-76.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "f9c0665c4f4fa6f4a8f0fcc02b92c88d0c9eefcc7b018dd54c605c6b0f024282e25645ddf14cb2bc82827f7c4c8191a83c38d4d749af45db07bb81df99ec6d44";
+      sha512 = "b1458b5662d66cff5da2bbf66f59dc4b8155d04f1a054db591b1ec79af7217274140a7719cd541ac4a5aa01ff0bb10a2659b208ecefef24d3776bad1ceded962";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/lv/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/lv/firefox-76.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "b89f91a5223a2431ea272115b18fba29491d60ab5e0a69af4a1152644596b477876a7c8109ba08c5210b782ad11ddd2b65c775a4fe8cba1126b21cf31e31d1e9";
+      sha512 = "35ac1bd8b780018aceec6090398491529c32597f8b8f3fe539c27dbc2dadd6d69d3dbeed3b8eaa0086692abd3d3ed17492804e835e1ad9670f3e21efba1fe4c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/mk/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/mk/firefox-76.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "f10771c9b2f8634259b7252488e4fd3f9b249b33ab59ce9a02c77d0c4cdc5c567222a91271d4cf3949decd86602613e9fcf9e5e8a403f91255ad8a69bf2351dc";
+      sha512 = "f41f55515c96da4b5fe139da8536622d20bf5a662fa8f32d8d024f56331568a36ea1b364ce32c97622b898990123b8ad49d05849bfff1a6909b377302b4cfbcc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/mr/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/mr/firefox-76.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "49bf1846a330c4d43d554f048bc1c5061c1059d62c57ffa224d19b3b4b2fdc806be73e6bea8409763be182b37ab6a1243652c62f5f3e48a36c3443f509a06c56";
+      sha512 = "d129d52ac519b5ee06c2bcfb649da60a67d59ffab231337eb01c68dc4f925d810044428ff0a77cc1fa1979fc7eb3a058c1e2881171c36c705767d11c1cfc2765";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ms/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ms/firefox-76.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "018622ef6cec81de014191bf94f88aa1a7ce732324f70a1524e3866e5500ee93dc6ac48dff4603b2f86b909301ebd2440ab87bf976cf041f6f8ecc4bc7da25fc";
+      sha512 = "d3745179f2ef00250559fb695bd65e6d31ae2e64d47b171fa8ee2305987d2a1b84ee24b7557cc37b656872c1d85992d41a5bb5e22d51c476e85a04792260cb21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/my/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/my/firefox-76.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "24685648158e9da5e74bba611884c3d260e7bad4eb3b6b2e70cf57f15d505b87a7886868e88bfaf440f03f37f7da04fb6fcaa5947ac6ecb62a987b24e0be5759";
+      sha512 = "c75b0b0690493ee624c439c8ce87a1d0d295f7b77dd85b234dadfb538169f3b8af9297dd36e3418042b8106b83e4973d4d7f7f446fbe0b977210b66f09159a9d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/nb-NO/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/nb-NO/firefox-76.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "4fd040d08c704cbcade0a290020d591fc265bcbf63467f93c58603a3f96af06cb3b38d03aae5a32b4b78fe2c4f89ef81112a69bf539fa052b721f549423b42d9";
+      sha512 = "35fd435df3d7200899095cd35bc3d0972ed4665de35abf5b98ed6165027c536a7704750a4c4731427e980dcbef815ccca826d54adbf40db8f1afa0601d4f7166";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ne-NP/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ne-NP/firefox-76.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "0708208411de209aad6a692dc1b867011d589f2fe1e60dbb5c8448f96735d811aca6a444f7a3ae2d93a2953965b57a728e3af1b2a31ff8c86d1941a21ac2147a";
+      sha512 = "ba2e2e25fda2803dad8e846ad39aa92a226dc5eb773a653bc1e4e4f6a28ebbf0b78eb5c724196a81c493d2e42a1f6dc50b25cdb2f3cc8e593d8044110f6d197f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/nl/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/nl/firefox-76.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "2c6df617fe9e4c3ba1940aa86e313fa4a5e64db98f4df9abdcef2a5e7832e8586e939646e435c9725e5b97ec80da0f987b620a78faaf445c374a46cdda862f23";
+      sha512 = "6a39fe56548c38733d49923f70203336ca8e313f21645c356e8625b9c14f7dc4fb29cd77cfd575b501cbc7d135edbe49229affbe9d32cfd81176ac4f3fccffd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/nn-NO/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/nn-NO/firefox-76.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "5f02a673edacd9e9e9171c7324b3b45974bc5374fc5a05835a450b6aad1219dc76ee50dd4084243523fc3e10e7b65a51f33e33009f4393f790a9a8430442d87f";
+      sha512 = "ffb58f99ed7e496d855cbdb53ca9eb5cf6a560f16b8ceced6cd2bcbef66579c3525e866668dbc296e29561d2b90e46d90f7bedcb58656432c0bf2cee00bb73c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/oc/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/oc/firefox-76.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "cf24d386d8ad5a927e86929d053eebaf03be667bee4a4d0a85a76b6030e85f254b8e9b14091cb17ce3082890affa2c75ae2c1c0da8e007fed5189c9c2fb3b95a";
+      sha512 = "590794d6d7e6cc5e707ce2a4bbd8173bf2605297f274587ccc0d59c48f107a6821a0066c542c8c7ec86cea09b49daa65078fe66e9f3190a2bbcd367e0096891f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/pa-IN/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/pa-IN/firefox-76.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "1a8f07e70425bc65552fa82a16eb4009e036de60a6b84aacf7a4d47c2763b00b116f61fb87aa2a5dc28d2e09a82dc3621470b5589b3fba449e2eadf2996686aa";
+      sha512 = "5acc11130eaf9244879f560eb531fa5fcfb757f424979d18225129e8b8daed399068ea6ac2a95a39ca2a1bbec0f2be4e2fffc5464725115aa2837f883ea70d1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/pl/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/pl/firefox-76.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "ba8dcd5ad68f8506d4c637be831365fe230209ef58640da8bfec20cde9447daab678229e0a82931c022aa0c6fecdd0e405e92a4bfd51d7627235b689aa78c555";
+      sha512 = "16dec1306e4fd7a670f70084cfc3bd4bd08d7af8af754e43effc9d5a627bd423133d9b01e6b58d512a7a828aa142e2aabbadf5316c263cbdab899007bf75e245";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/pt-BR/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/pt-BR/firefox-76.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "fa1f67341221a907f24ce2953fd75a0003c04540a7673173fdc333081c82c24e68c0fcaa85e10264435a9540e356e94f0b4d5b38d892821bd307530ee10f9b7a";
+      sha512 = "12b24ad0de2fa9efda7d05af29374e2bfc669c7cb9bbe8af6955d62c2aa3488f713b3b6826da1812e251e23c364b096b25a43227f8f638f8dbb3d9324f3daeba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/pt-PT/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/pt-PT/firefox-76.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "c282b71b30ee4f2f67d98551eaeb1700d2867e8ae1f19dad417f8774b8a91db63ecc14c37712910b7476e837c4c23f4871a20d2afe37f61ba4ba0ca4b1684569";
+      sha512 = "8dcd5a176462e660a1f8c8022dfbeacc316261aafc29d39811509d19fa45bc3e8c139ab8d2a5e4f1c4c55afa40fc74d9e84694f93d75f6151d5ddba0bdbcf9f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/rm/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/rm/firefox-76.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "70cd918ccbeade126f36dee76600f7c6e78ec3291a12e6d60f684dbf5fba322bb7ab847cda9f101af5b48d9b0374573e8f6295dd8683ff3acf9a89512117d054";
+      sha512 = "bca05914220b3730a5dc725b429a74d74394957a8bebb7603a66664088bcfe6e637b1b9c021065294aa98fe682b198c11ee61a1bdd89246defb5887ff912f0f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ro/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ro/firefox-76.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "acf9a4914255bdde374ecdd77b39190c945621c51ab13b2d9e1e8b1655df593c6c7e174113d89e8b1afd223e6a0f63560ef4d991706d5f23db35a939ddf793da";
+      sha512 = "123865c906b0554cec7ac7ea80f62b9749ab9c6c6f33c4ee48872d975923fb2456a40201a83884b17bb093b91aae51d71e923adc3490004d19e2cb85711462c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ru/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ru/firefox-76.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "9457048e428958b55ae221471cfb2874ca16ea9c1e34a33d538b9964e6ed77711283207106814f6d18ab73f8c690e6c20b2c84d361242b228cc92c7ddb675a27";
+      sha512 = "328c5945ce5e6cf051717934227b8d198707d4dbe407100538d047190525e2e0c632fd7db6bef540a810cb8fe42315688851c839021760fa344608909419d71d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/si/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/si/firefox-76.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "897b488d3ba0592b902f2cdc4eeb2f454b9b6f67fb5e4c583f5f49fb062483ce1d30e64f6273894c698406f8be7dd8a2af02a67e8d9bf47f8d30a572fb18e7c9";
+      sha512 = "bd779f158817b8c181068fb2ebc4d4bfdd9d21cec5f15b1e7e2270e068023bd80fdfd3237af26af20cc274b85335a96174506455ce8dca18181c1719eece6bc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/sk/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/sk/firefox-76.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "2847545533829f45c22b85368c5fe262e2a43cef0e5d480a540ca47f0dacc8003b8e155b11098944c7012b03feb8ddca216649f645c46da0975183f42580e285";
+      sha512 = "b9034db11b9a0f1378e262b250a87d6d2dda4b019ff29c03e7b673e447928e60608f98b19ad93c21cc7d1ea668942699772d7b100e2d478222016f3537bb9883";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/sl/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/sl/firefox-76.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "9b0223b409774a62216c97e522696700dd95b65e1755d889d58137602fe4302d8f5280464636d94c97cfdde8c56e49492005e487730b591d19bc947271754e1e";
+      sha512 = "0cb29fc0664231bfb777b70c0747c406dd6c75651b8b032ca1a862f3b10bf09e2ba33025132418a17bbe67a354ae62aaa6a4483ea8714e199bc91dfc4f7e4daf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/son/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/son/firefox-76.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "097ff1df64b7ef62eee3a29672447c42c46dc23741ebe87365c4d41159052ba3560f7a10956dbae6b67daaf80607600d2241dd997573b8ef8c54fa94f064e629";
+      sha512 = "259f9870d3beddd86823c8d5fed94f6d34c6159a65ec214a0e9a95b9b93d739b6a31f103644c547ad92515f1f8fa6f7c73eb9620f9a4f671dd3ffc1819d0148a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/sq/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/sq/firefox-76.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "8a76a933f261708504fb637a93bf4d600514558f08832ceae8db23a404e5d911ef23803436e5513a4b7e4cb85f536e64c5ed801457ad2e1f9c559dfd1f8be807";
+      sha512 = "3da70cbeb1a5c76596cd720676e6a9b85815605f0c66c5608694a28a66c13acc1a28b1c966bac7ae78b4050e8ee5424272e5cef84ab37a50edc0d0de9525945a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/sr/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/sr/firefox-76.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "bf7d631608e91989a8cb63cc07b8e253cc2c764e9f712eb113c7b735bbe2da04ddcc91d43fc418eb208a75f4027256cfb10d15c21e82b7e3eea096ce6fce9a5a";
+      sha512 = "a7bc90d6104ca104ae182a088d8d6020f9dda952987b4ecc21168786e6e91ecd960d51c81009541fb3064b60189f475bea548717fbc1f0a5bc97201d0a2c6fad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/sv-SE/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/sv-SE/firefox-76.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "cfec4b5942c193b37e881569de1d40907d44b7ffdd6a08fdc3dc44ad27151427de0e368a08e4888d9248e07fda8de54f1b7d1eb3e106f0cb41c7fa1a8e4acb10";
+      sha512 = "9529ca870515e1cf0f5f87eecd18228dd016fe885eaae768ecf5ba84cb10d1dd4e9c484a8d425543ef73c6836ea2ce7485da30c4e49cc3d14d94b891eed1fd2f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ta/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ta/firefox-76.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "8f487289fff43075239d79d1d4b8b0e9e7a645a8dca26eff58ec32e534a870b5b67232ea6d43dc58b1b4bae9be8af65793f185e4b5747d9c374fe7802b92c9b4";
+      sha512 = "e273942d6059315ba93b74e28564cb25b2c8559f2557cfa4aaec16f60260f542062eeba85db473b0071ecfe087657587d016fc371822936777c7c2f31c7d65c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/te/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/te/firefox-76.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "a3ed83d4c34fe6d24c2d33c490d6d2de6fe56382bb87807f530bef967c25bfb9a00a1958ca13f2936357e3f1d75b029dd2bb89a13171574bc022f7da8b4f49f6";
+      sha512 = "a697763b3877bea268bd8271717e7ee278cc4487902fdcdc63b7931d41cd3ebfa86858370de8e11fa566a08716d1b1cd499ed325e11799e48cf62c0f732aa341";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/th/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/th/firefox-76.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "54c9f36ff4f00f1bfa3f947930988ce6985bf4e2682613a8368ab60d07abd02d3171cd2457987b2bcdd7d0929003580af9e4683b7e0f529b1ff3661004aafff7";
+      sha512 = "9bfed69a815a3c100b1741238d9c8d0c6242dfa84a560973ddf567adf87f675364d2558af335fd1948f248853e73585f5ef1094072d6d2366200f96c0df1c2b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/tl/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/tl/firefox-76.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha512 = "6dd5f5908e9ca66b7ab9e132dd6db3c5c2ea2e28eb9de211ceb6d2736746fcd50408cd327f098ffe1beb57199af6b60827bc11614c4c781d109ff315ccf9d7c8";
+      sha512 = "ce59a7ea3986122900d87fbb7c38d44cc442e53085d490eed70f355b2465c5b5a63aaee7cb5a6b5ad16ac69ddb2ba5d3c61f17b637f2df378c5078d63a5bc7ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/tr/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/tr/firefox-76.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "0222ab139a87a195fcc4489a2d2b1024e95b4b76d4ffd8c63408ab3f4c9ea0e4be019a57e31ef3eee3216fb0217c01cd92cbab9ea33b2d7f0a4660326dd0b8ce";
+      sha512 = "23dc6fc7d3d95a9bdb3ce3e8d486f803cf7b16edec8aba8921a057021b2e1c4275b1bee6bb4d0d279c7b13f16220096ec8a96438da3c21383eaffc2f0a86e703";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/trs/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/trs/firefox-76.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha512 = "a50634af2bb7d9cdd8ae8fd268b2bd5f24bbe68e7bfcb810e51921a56db7f831e84e73f93001a12f83a269a27df956df03e70aaf6231925b08399bc54aa71de7";
+      sha512 = "4ec8104615a025318f601400091c2844c6eed3c3aeba5da695d5b1883ba39e95b61d19d3702cfacf4d415ec9ab03b5e59e5957af17e59f7631d8d5e32fb6a036";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/uk/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/uk/firefox-76.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "9e32876027449c3b145cf7088b5b9bf7d941d3086f6d1da1dd13f3f06138b1c7c375dd7561d9342dd7a1aad1adae6da3a2f354927be1318eb79703753dbb0d00";
+      sha512 = "faff8183ea5d63604fdf79c47614f6b7226d30f9cc11d73b317a1db7d46e53a68138804e8038e91d469d07d5b944d133a7f67832fca2153ea2cfe403afcf93a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/ur/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/ur/firefox-76.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "f4331e2c47373a612083697f4a693d7c05edda3f08518642617aa274e735f7a64ac49f28a0c1681addfe488107367377757b12dedae49a14a4752ca726d0fe02";
+      sha512 = "c64f456e79d5966b915756469e80e81bb58b006cc58555d39a35f31e6586431c587f1376346c82c0b90a1eb9526e0f2eecd8ff591a45a9c3a51b25f4ecac44be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/uz/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/uz/firefox-76.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "ba7a39e9f8537bb5fff9253d01b3fb2a0c815c3d93fda024d1da6dffcaf313e7c75068c302887355b0e1b498157917be5f290fe81a2c30f8303c33ae2f23d9fe";
+      sha512 = "c174a2188519b5a7c56917a957572835163a02f381f495cd583f416e9d44ce0afa0cadcad7b51a14ecd7542f47d9e4034202b4a51c960878dd071d7a21883dbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/vi/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/vi/firefox-76.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "4382a78302dac11f2ec626627c65c528d756364b8332c0124cbfd45ce9ae226d4b42eddf723e306a1b1e0b7bb3fe70c9efd3019f91993ac2e140492900fc0ab0";
+      sha512 = "3965d727fc625874028f187e87266256c48f5f0378db3b92494bdaafa79ca88b5ec2e1a7cce70cbade49778045a66780767c6382c16a6d9f508118152ade3772";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/xh/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/xh/firefox-76.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "b23a1f3b7fa906fd6dc25638d8cafdf3adfe63346fdcdcf878b9f0f98c8803631fa608fd75086aa7808fa0d4730ea7a89998e2d695b2d1f140a178f14294d318";
+      sha512 = "08b89d8d8030acd752b8107425250c4ae88d69f8d30c0e773cde166e8ba9bbcc26c41caf6a8a6d7dc504f32ae8371836f693029300b196591f3c85eedc249de7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/zh-CN/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/zh-CN/firefox-76.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "b73405a8872f079f5f69cbd9fd69aa60e614a0e22f1f933be9a8a9e7312fca362549f57af17629548694e92679c763786978fb572faf4f9f6cb72d64b2661d60";
+      sha512 = "232a5fb73c492bfd23c826d75e4b545c386fcd2a6ffe2f306b54e712767bdfefbac6925739d2958cbc6a9b71d32a94047485e0e0f73636a878ae35cb6efe63d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-x86_64/zh-TW/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-x86_64/zh-TW/firefox-76.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "0069f82c583d88e9630fcb70c481969ada68a7ce919c4f5ab12ee442ca77f69d15179a46e5f2e7850a6686bcd6cd896f2e03163ddaa7e88affe6d62856d1fde6";
+      sha512 = "d7f70a991a0e2b8046b476799c9e0b56003fbe1e6663ff0fcbf2925a2f3d6855fb559a942a7c5d1be1afb9538090574b092088555d4ffaab7eacf280aea60bce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ach/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ach/firefox-76.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "1e81c77813d8f489ca2d2d75dcf74ef1085ddb367df885c2d25cc7051d759f26685da89860f67920a49ae4331762be74fbd2293bc2a6e0549187ed8fde643d4c";
+      sha512 = "6e829f5cdae51c26f9dc7c886c78334abc21cb47ae82c250aaafa017ad28fe7d5607b1ca6c24e4c974e6d2cbc2e6017d51fe4a4c81de13d0175ed892ef3990e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/af/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/af/firefox-76.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "a753254f0e302af7aea86499c1b03cec34a83691eff48231840a20c0afff1c595fab893d804b83aa0964eb5e570185102a701d31c668764d58c4715b3d0feeea";
+      sha512 = "2cbd472b2a09af3aa7f22eb2db955400e1de647ff8d77e1b8ce0761c714673e42b3b2d34cff0297074cfeccc8a5fd4dbd3ceb424a962a37b70315bd6f033aae2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/an/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/an/firefox-76.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "e1fa38d89cdc7d7c9a01f8de5ee19316b1ddbdce1f4f868e8ce1bbbf22e68b8f741246a5ba4f2a4e67c959b9575c73acd7b88e918e3be5fa285dc5ed42e9af61";
+      sha512 = "77d2a32762898686114f364830791e9c381c6e93e58e92e8ff64f70ff2bf7c76ab00422c5c0d4f8c4a91796f7c7dee5ab69427f60f0af5cd1cebd7f83e96f081";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ar/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ar/firefox-76.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "10270f9783b09b09fd7f43b8f3c4196d332644820796b097ca219819e81bd5fe23ffcd4df988d3f2f3d59fd005e38feece57b7dedb84a78aac6af7965e73421c";
+      sha512 = "afaa31f6b919b986c29aaed3a4c89492644f53285675717a6a4b93ce3f559cdc3b234e7f7d9b0a1526cfb45c5e5bfb45d194746abc562fa196a7d5b2a748106e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ast/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ast/firefox-76.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "1df6b8b479fe391bd128cd9b175ddc233b19b61b3f538ee75ba7728a4b59e4cf1ec09bd9576f82df66e89048b62ebd9cd2206038a0387492cf7b1994c36d84b2";
+      sha512 = "ecf2620ee5d42559fee3102c81d9009db6fa0b0aa07ba7b0f84d9bc853566b0d03df113d770eda0de2c08e58d802a7836fab642455488be9029df05a60d6c01c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/az/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/az/firefox-76.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "81305694cb1601b45d09aedb7bf6c0ecdda500c95209abaa00feb2cd2aaa1f5d86f5bb18933f00cbb5a6b676710db4e96495b17141cc62dea06c26483d90976f";
+      sha512 = "073c1d5355e252b3cca418e7648819a80f33a3dd59309ba0cec083ad409ffff3e37f587a7261782e138bb04ed169e04b2947b3427849991969dc528e84c49e90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/be/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/be/firefox-76.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "13e5c72791ccc0ee12844d8a9ffdb5ac60a2a9d79bb3f25818f4f1b3b606137b5eb3c8911f81d654028cef48a00d9cf10841465c7fe0304000357c62d964ec44";
+      sha512 = "acb385d0b1718260224e1cae0c169dd080581911bc9ab31586c96bf21dd0e6634c38bab0c1bdd21c5afa09ed30861325271506ced08c8011654e2daec21b636a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/bg/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/bg/firefox-76.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "06a1ba2fc944a15375029ff12ed9f566ccf6a795ea8e63743be8084c7e11004d72693c65b8a330cf945a530fde5298c69c83a0f549edca8fa50d85a904ee744f";
+      sha512 = "ffb829fc28467fdca0d0802a3bddd4fcf38b10b008fcfd73392b8a5ab79658cfa1ddb2e03a6ebd626f516e3420c1becf7a534fbf1075e939cf7df0382f614e31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/bn/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/bn/firefox-76.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha512 = "4b4c8871d5da372ddd15ac410ecfae08385a74b68e142b64e4e463d58b1e60583025f3855375b5adffb8a218839f86cf538a96dd285dabde96f8695af2ed1a4d";
+      sha512 = "6202a53eb7dbeb733f9d2c453dc5421f775ef518ddc837146f22f644a3a2a602670955ec2f26a81ef2fe371a979336f2ad501bfcdfd619e2dcaeedfd38c1b5ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/br/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/br/firefox-76.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "e33d927f88d4e0a67b28f27ed32696cadba6241fd3bb48800e68248173bcd7085adfd3dd3700c8d4ddf5be3df93403e20e9c0d57db9ff5d6a141ed58b74c26b8";
+      sha512 = "2f49caf10eeb3e2929c1f92d64fde47c9a3834f5fd003a29b3950400376670d14e0dd1bb03356311bef7d6370e4456b22e176361a6740454a9b42f4f7b54dc0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/bs/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/bs/firefox-76.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "680587ff748248a665751f004b02d0b0d4e28f90f672141961d47cff6239823431b863e8ba702cad8f43fa70b295ad69b47954d2abe2fcec423e68f704fddc6c";
+      sha512 = "411876e7426c2a40ee2b5cb8b0619b0ac9c85ba94df0e9e25cbf080e11902daa9e7c1a390aff5089c3b2957e376c491583879159f8f515dbab4fe86a34cf2eae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ca-valencia/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ca-valencia/firefox-76.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha512 = "3f740ce2af373a3154372796edc4e85f8bf87b83cf4895328dcdb357aa4214e7711cdacbed596c4d7a1ce1ccc16bfba32fdf2d38749f3144faf747d05e76e208";
+      sha512 = "85651231dbc578e83e4377f0c63f99afeede2e8a7950284636f4e9e021defa41bb850b9b51c505923aec3d8325eac49e6bb4065696443859f99594e338e161cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ca/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ca/firefox-76.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "ea9b71eee4f6e967753acf4e9f0a4014eeadadc6d1bcc5fad11a5975b778f92cade729338636d86a783ca08b0363942d7d9b7e4ad65fc3186760189ead9bf0ae";
+      sha512 = "ce3d0107709afb573f8b759a9f381105fb2dc7a2904b5d9a0fe67a32ed5a8635168a78e9eacd9889a2a7e30bf00178837a66b983328e2cbf054feafd5ccebd12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/cak/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/cak/firefox-76.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "bab4ceb14749b67877a99b96f47aa7a9d6d65281e78fc416d3bc3e5296ba2133d7548ccfd4ab32637c976d178fc911f55b6acc60dc6658b4193e1c6146bb641d";
+      sha512 = "09795a54fd582133ba924823300b8445b9d0a2d542bc639bf7cfa82eb33d4ea164d7c2c6dcaffecb7b8de8890b3582900998cc4148566b5d7928f083860ef1d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/cs/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/cs/firefox-76.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "e33adfe91886dc66f09cce26dc33ea26cdf432915674541a8fbde09cb41d2b14c0ebb3c41683cb1c29908dd652c83c92bacea3b8cab9bb3e8d9d6010a19f9646";
+      sha512 = "0b5d62e7e31c13c525266bcf9b541c2247712a177e8e15beeaccc617816c227cc841baa31520cadfc242bc1b3e37e5192f0b8771182e68f340a0a4a83ee47bfc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/cy/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/cy/firefox-76.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "1c5b5d518914fb69b6a978fbb8530589c0aa117da1f2f7398696fe29c6177f0ee932f88bfabeab049bdc80d6e457835a492853ee9095b10f12b68172004a2b73";
+      sha512 = "25d6bbb6a07cf562d44d8eec6abd66f52a5bde079f1e47366159c17c7503586dcf9cd4ec6cb84995c28167595d41181c352c7510fc299d98eeae1681f5ad3ef8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/da/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/da/firefox-76.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "90d385bf3faaea5ec6884c4042a72e6a23c68f1454309bc933670d0fed7a5aac2210ab4c6b23755d883fed385ae0f11639a932c2540687b219aa009067a3ab89";
+      sha512 = "39738fcec60811bf64784017dd18004ad4857c1e1edfa65b1aaa7290e5d0b40d1d5dea6392914eb7cc53db1f949b216b79e9ca4766928debd3544362542ccf18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/de/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/de/firefox-76.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "7fbc20a9cef66a6760fa314f2d074d2c597b420fee45fbc8c61a85f963130564e18d47a97833299283faf5c959d12f70e4f99089dabcbc3d83f3bfbefaec0f63";
+      sha512 = "5975c91bb029e0d1d4bcdb18338e21c899723e1f5baab59c6549add82b0392d0a308861908a36017905f7279834dfa175945ceb778dc2ef33943fe57dcbe17d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/dsb/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/dsb/firefox-76.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "2dc3dde5159c64b61a4599a0ee2aaf3e4d9e71d7a3913e086c0c187cca48e8bbaebf7d4253dab7a3cb4fbce55a1119e3f4c30026671b92b70059b8b3256e72db";
+      sha512 = "b093e322829d736b9bab6c4396fc2c9ce7a3024a9a30ef8b229809802823ad7e69d61b3185a1d477c9c2f7a0c4b453c14b72c5f7c2163d83b76a784f77ee6803";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/el/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/el/firefox-76.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "73bfdcc5482d5793c0c5673738ae08cb6a2187e61d8ee057ef89f4ceb801bfeec48b8c0a9f48bdd996bca8ae4a232afc61c6539a1c22c7bf96d06180364cecc6";
+      sha512 = "ef4f2711851de7306041f9950fec310bdad6560e5b91f643338c2c341a30e1210e88257dc20ab922405c4d26bbddfb9fa455b14c871cde82f3471ab971c10f3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/en-CA/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/en-CA/firefox-76.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "baf1441e6f6ce7a31ce5ff12b600b61068bdbb9beebfe74f6c9b97ed2533ec734bc34b702caa9e9c59bb4563bfdd64c2612151793067cef3ffa1fb0ada312e28";
+      sha512 = "5cf19ac0f2bb2d798cb439e3c357cecc7dcd7068904cfb112e97d9674e56259b8251f8cfae8bbe84cd2ddde83c92d04d0dcb4fafcae6554ea2c4a0571f2d45b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/en-GB/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/en-GB/firefox-76.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "60b276043c2ec3456b6b06acd2edf6f3df5149824d20c33974f3ac77fa0ef81a03f99f337add0209bb88b390fbf4dec08a30da207ad72ef91c9a89cd36e4452d";
+      sha512 = "e1dc8b6f64e2d605941879feb3a8260d542fa5a03e8ee3b72523444fe42c0c7d1871726b0e33d1aac4a7393160c8db66373dc4074c0e6d5af4d51a445627bd64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/en-US/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/en-US/firefox-76.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "26eae1d8a6f9e988695d59d418749fde988e48514d7c183039ee998b400f480dae16e9d5a590ff4364954e57a4008e7104cece212fa81fe73666d2bf3f0c0020";
+      sha512 = "aecc89ed562adcd72b9a20a52a36d0522555599429fe1c00dde42f50c7f179b37508647bf2bcf9eeaa8cea67c2c4dc3c90fb95f218c13bfefcabf4d329adf3c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/eo/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/eo/firefox-76.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "55aee2c68a1cb6b7e374f2622c8aa30a8f26e14ea0f0119d97bbe6e807c15c7df94ec74c0f31ef071ea7b112c3bd8ee501c7d7b33ab5eae9a8126b2fc9673047";
+      sha512 = "dbe8f63b77c1c44668375feb48fab035e97f7e7baa820c8de04de441b3d83fc85fee5d0a6c18047505542d5c985b1e6e459034c3c1b08037a06e6156cca4e0f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/es-AR/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/es-AR/firefox-76.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "dbd5aa229d0123a26290330df078967bff4d0484bcdcc3eb499a7cdc82176b49a2362a0ab08e2b55286141b25c8cd4970308cf48a1143a5af788eced5b84b83b";
+      sha512 = "b9e16029e62b83cc1d9ccf71b52e29d5b07a08ce55c0407603d73f0e331e8e60d524ced3cb4e2964a73e37d7a74931ce86db75197dfaa89f956db493ebf2def4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/es-CL/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/es-CL/firefox-76.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "5082bef600a311f560daa09b31945961766a0ec63ebf9f38a0f0e76560fca2a99594c1f26fd0b57a2dca0c94d1991a91501ee3e931740e59010c93d46d3e8a67";
+      sha512 = "1868daaaa19622040839f5196c386d580f8d7d39d0f807d26a93139315dc51f868d4fd44df987520eff95c4aee5574dd7ecb76738795f1b9cc9afd6172069880";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/es-ES/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/es-ES/firefox-76.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "87ef420353069862cd539aa8e53f93f50330e0c68bfa4a56913e9245bd4a972bcd271a7c159218f9ffb78c9d9be3046206f20fad4faae3d76e4e9687530ea6b8";
+      sha512 = "e65ca485b5da86aeb3f5cf7d5d2161f970d5e035cffed8d6a3b68d54ce694811fc821186557aa84bd76ce1300b000ccc84b84c8b6bf2d3eae996289c302552c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/es-MX/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/es-MX/firefox-76.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "d02362e93a290f34063fdfa7af8fea71a6cb92b964b872bfac8f5b5665dc6ce9cde7a38a445de1074fa8673cc2c0243af69e2663542c5c2fb8e53f2c41518cbd";
+      sha512 = "6fc9dcb18b5feb923c0a4af65ca5538eb7eb1f0945bbb31353d9785f3f128591b865fa3cbdaa015b74ec6b50417feba6e9065934012b223e081113dce7fd1173";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/et/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/et/firefox-76.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "0064c56cf6cfc38a5eff201f16df5c9037da8089655df5c88a348ffbeaf933941d5ce99b3618293d2154774b483298b4c28616c6e175fe0f6c9124ce00bb16f9";
+      sha512 = "9d8fda204a5dad16d02ffebbe81e787bd5dd7d8849a1d9cdc623b6a1dea251c1c496f39ecee6d6244e871275df396386dd0fae5c95d9b3d283b519abbaef80bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/eu/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/eu/firefox-76.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "bf5cd434f45bd057de94bdc219f25e4da878a0be58c4a864a22961ac5677d0a679204a069220cdfb353d319d493e10d3423888999de6701e33227b1dde16e43b";
+      sha512 = "5c45f044e7286faa58016ec396ef1e891dde449c931b251d0696f63205f71c4cbc7f47ac0866b5dfbed819648cb6ecc0da9a78744cac2e9c003d1ed375299ec7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/fa/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/fa/firefox-76.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "402f980bbffd145e9f6f832ad4bff8c6dbb0db9a77a303ffe16c44b449668e621c2edf75e41686cc69684069efa10b7853d57ed5ee928298bad5ed27c253eed0";
+      sha512 = "b7c62bf1a93e85f3bca2e1f73f36ce2dea5334389b501301fc1c9058d893681013b15252faa7f2f0e53659551a76f40f0c6406a656372fa9d8bbb5b1a5b04b88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ff/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ff/firefox-76.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "baae62b09a0a7fef88f64b43b854dc8c4ff583765338c4dd1e00db9c7717adfb3d8817c776cfc88f88ae6865d490a08bf4d0c97824ae3280835769ca04fd8c71";
+      sha512 = "037dad6fefd4a1e6f38a68461dd9449559d32170a9bbba61a83d8d6044d8d3f985efff592855acef474788fb8bccb7f663ce4ec326d11043d868ffaa90e33b16";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/fi/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/fi/firefox-76.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "161da9aa8cd66a9f691b218f5d11cdae19fbfb04f44a77e266731afdb7202af98f165e33107af15ee6ced477b0ae07d78f91f57d14fec0e9a6de24847cc73976";
+      sha512 = "0d0566e3510a28295f4dcff27eb3927af28f24b466faa561d4bfb542754533ca5ecab7ce1e2323d249de19db6588d93bdfe705518c307fc2ba55d35b56a0c6a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/fr/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/fr/firefox-76.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "150677eb9c0aafb0486dce2c846e0997f6eb1ccfb022a9ec2914628fa2affc32801fc34f0397fdade3cbe3afd1897ead515bc240043dd1cc7b879d92566a47c5";
+      sha512 = "b4002603609a7a9add95a6e9c0af394363a0e97cf1981795631e31a356626360896da953fbd491d1e45b9d56ddd0d08f56819079514fcc2903e92fb6efff582f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/fy-NL/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/fy-NL/firefox-76.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "b03e12ebeed5af0150715176e32a7da3ce20a57d227f3ef6da369f6fa27059cb23a8af0b4e165027598894c572d02e4d58e8fdb9a48b86d3bdc35385a249287f";
+      sha512 = "2c93e3a3c83f935e9febdad3e82b34c3fd064ffcf79409be23fb91375763512ecbc7a207109c5dd7d9564938f8f32b228037035476da4d2d91e1826571f21d8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ga-IE/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ga-IE/firefox-76.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "7122e4f914f5e8d42393a86e61baeecbcdf6fff646ddb38cbb2d7324a0be90d60bf609824f2dcc696c107f856a867e0ac9717fc098b1db3571bf60fb6d3b8a28";
+      sha512 = "a3571884efe2477253ad2a32c39bf119163228cafc58ae18069842b50f61918d2e0d62cb98ac8414e56b7af92e3e3eb70a8d8c2f7ef3ef38db481ad07d80452a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/gd/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/gd/firefox-76.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "f35b295657bbceb293cf1bb88a140d629f0b1fc654cf3f1ebcb5d9de84f40b17a9a7bc8973dc6699c4c6609e5cfbb858df52c0153ed4dcde6eff2e25c38f7ad0";
+      sha512 = "01c1371463039088cbf8af88bb5b3bcb874f53ddd37290d50a2b3626c1c269e6e4153372bbd14091b5a196dec88728df7b64ef854207d8a5c4badc4f80a51320";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/gl/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/gl/firefox-76.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "4a4a37fdce02108118cca5fddc2f2ebfeddb8a4fad97ef0584fb85748e09d43abe79b0d3f7b5250deeaec8ec0b2e698771100dca486831fdde09f41d8d77b093";
+      sha512 = "ca5556e3e26f6cefe89053b7461f6193493e4557e119d20fcf53662e9f8892842f009e09b4c6fd2be731ad67ca5c883cb9da2225ec225e233112f65c428d8b6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/gn/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/gn/firefox-76.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "6c4969572ce922eca81344f1b05747d3935f88486082bdc64c814825af2cfdf27eac7f8f0c25edfd4d249b9f469ada0b062abd0aff02b9849c7055e40bec5b67";
+      sha512 = "d1111ac6a8ed98a6bdfc62581937daf6b74215504c5064d9d7ee993ef60690f75a2d1aa939640a664cf6dc25a596da1766eeb35521b6a2482716d135f5b835e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/gu-IN/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/gu-IN/firefox-76.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "a5d1daf151be8d23dde730945343bfd507ba29314ab8acb71e4d5e71b534eadc573eb4eec1bcae0ab0bd72735cd891b72d8d931b634680881bf65f63a4a7abab";
+      sha512 = "e18722d7c09e8f1fd9ba07a3d18d36af5b4238d3071a5a7712dd03684bfdb536c2ab0d9a31f163db78e287dab0a4d1f08d44c9fa4f5275cf6c1f4f288ffb6e10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/he/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/he/firefox-76.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "87b6c4a1dfdb49bc9430d9740612d24ec9f61d74bd379caebef6d19fb3492cfd1a4c8112126ab509af1f35e3f6e10062a786a0e5397b424e057e9d13c924fd7d";
+      sha512 = "1a9bd79fad0cf2aa03ecc56c5b76397de897968587d6bc783d74fc342cf9562465b539be0e1759360af0d92f97bbf5432f324a70aabb4e63bde17c12ba0dcd81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/hi-IN/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/hi-IN/firefox-76.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "e2b96ab462227f70f4208b52b144d852e657edd3fc9885ba6b4217461a414a6aac6dedc206b4fc82d269c768662ce94ccc6cb3e0f096250d074b3d91ffa98c9e";
+      sha512 = "3ea77ddc6b43e67af9143240a49c57b5b34a9077142ba35ed6018e5854c8d365f94e56795afe57f151eb987adb2d912f3b5e03cd46cf305924105a38f82c21e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/hr/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/hr/firefox-76.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "1fcaff37d60936b68a6f2e368c414c69718e114bcdcf8f71114f5e3dfea1eb2fbfc8b5e237406576daae74f8c4371d8a824d2542dcdd36221c931a86c9ea7175";
+      sha512 = "5e16a2dd1137042de83fbdb303efa22cbc8c27d2d18b18b84228221d9681efa278b7812e29447c7dada13c0e1338a4b2ede8acd53c6355c63682cc3c8833e55f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/hsb/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/hsb/firefox-76.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "5146346331ed881f0f85f42bb43f4b4884cdeb659b392db28f7a534c685a579405fa482ad14c6c4e20422e8e22b07f2fc35ead1f3756539dcee797fb0df8c1dd";
+      sha512 = "22f2ad0f51f0e216c123f603b27ece79e57d0da7e49f45e1190d229df4ce327a4ad11ad5603443d5d9e53164426effdbbb1c5e59dd73af17d4c285a518d03137";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/hu/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/hu/firefox-76.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "eb043d50e735f1b99eab7cedef601aa302dce2b0270f08a9e93c1b1fa9b85da87305aa94e8db638e81dd8f6d9bed96b6c22f87928026cb042964bbb51420fff2";
+      sha512 = "e0c35f707d507b0a0325cc8c9649d2258dc6c84e5f3229fc4c69f4a91265f3bec6272a3ca0b6f9a5dc61e3c2f1341f66894182a0a3d3446eec0fb8c00fb3b096";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/hy-AM/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/hy-AM/firefox-76.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "eb0553646d6b53a41bff160379845b0a21c28815ea523ab0de21230ce6c519b7ee07c9d97ce26f2078f3c66448dcd1c09e978bb1f748e548d1b5c2e0fe4e7f7a";
+      sha512 = "273d77d38e940b785b2f6907dd394800fcb1c200ecffab410cdfba0a245c3700dad87a7ba60b7a3b9b6870d66d90dfaac9ff44ae7fbb92084054a5ac082c52ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ia/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ia/firefox-76.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "b43efaa2e45de94e9be8b8b9bea50966b0fa089dff9e25671577c724f45d0dba502044c2da7de32cf1431a38aaa92c2e5856659fb7f1ee557e38616beb4a9c96";
+      sha512 = "c7b3ca8df79cccba39c2ef32a82730c7c40388d8efd271b1c1f3253f8ef0ca659b86cfe8b7692d6162453482719da4a053ec198270841a6e50e0524b9785235e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/id/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/id/firefox-76.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "5fd68752ab6309af0bbc6d523e2e251c8378ac0a6c2ba0627b37ddf7dbb1efc444901a254944f4384a6fc10ccd1909f6312c0fd7c9e700ba5f223ccdf76d30d5";
+      sha512 = "169f3ac386ca710aad40b111591bb49e146c3d0642baa6a365408b6a70031f7568d52afbd04db595f457a73380ff01c7bbc28f210b1e2dddd333e9259642c7f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/is/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/is/firefox-76.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "1c128e7fffc103347329cbd65037e798292d5b0e843f878ffc44d9d53c32f1d9a917acd694cb3662ba0089e79063421705f30d39e9736c88b9c439660147b949";
+      sha512 = "c566aed75c440f639db271b3324eca7001d2fce02c63ea010680cf22d640e7c5e138e50610a880f5a61ca794904cccdfa46e7cbd86a576840c9d030b506fb9f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/it/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/it/firefox-76.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "890812041bb3ab8cb0ddc6a54222fec9f4e342f9734f3c92f9d0452122cceff739eb46d92ebef5d2571509e4c7821704a64da1ec3dfe8150193a6dc5b4aa8477";
+      sha512 = "9af0cadf85f8cd7c5eb2c21372bf7c9ef1ed909ee33a92af251e5ef8a5309834b84ff286bb5fef1ea7d417d1187375595dcfd6bc0b381e24a36d4e2a1c01bd6e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ja/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ja/firefox-76.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "13703e62dd8d6728553524723828cf7bd8db672febeff63324c93e300a9ed6c2f3b1919d6f4bf8f1f74164df278a0c95ac98c348531581b717ab09e921490a91";
+      sha512 = "dcb4cac1f3d130d5facc96da908e0651b82c328fa0735104020d3e5dc96010654dc3c7b72a0b276d2dc759cc458a6e2141b27b2f70175ecee89516b77c4f111f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ka/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ka/firefox-76.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "929b2e3ca70c8d9ee11405b1366faf957cde5075dec5631a49ebc724d4912291b1f3826ee01e5c90e2d68c09b2664599ed73e4f597298ffb066ff8419a8056d8";
+      sha512 = "2d09f4d5ebca239e5f304d97b4c44ddff2e3410e9b0b39d6f85d4800cdd5b1ef70feb09e02d7ce11f053374559620ec83cac493a06fa95186bc7d320dc67bb49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/kab/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/kab/firefox-76.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "83900bd13db0731508e516bfafb5bb540a43f6b8ba9c9e2e9c0878d67e9cd8f9b6b496e5b77ccf314346ea3089f6d95c1902b9280741ac3325638e972794872a";
+      sha512 = "d91cb34519f014dfcd5283a61da760f8604fb73d0aad498bb25c805de434c4a6cb58f4a2acb2baa1933af55c5152ffbfb37d259f8b22d7d40dff050ba101f66e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/kk/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/kk/firefox-76.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "a62767e00ba2c0d522f503331c2b6eb4cc82d3abb4879711c2d9f611c8454f2cbfa5e76707e6ec6ce54df8d40f64da6ad8af2e15079ea75b3b8ec55e6273ef2f";
+      sha512 = "e8a5ed887f76b977b1f189cc2c8f5be1047ff002faf8d262e266c2f7d28b48a6ec7d364279a7fc4e19a5a4a91393678ab21a614fcc5db1c7d525b9f2f1bd90f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/km/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/km/firefox-76.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "03a47578e51da36b51bbaa98e36927a1a5b3f216ff6ed60c337d905f414902c7638cdd361b5d8f4c29960dc93b19343b18567c7b40106f0e7e95fa941c0dae88";
+      sha512 = "3c58036dc85654cc07f4581e62c266bd7dbcd4f8e63ae00fada4a53d608ed841764020fd73f966d712ed3d6f69e14976b1bbf5c906da833ff05144e4183a703e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/kn/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/kn/firefox-76.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "c4cb00f4383f73c65930ff3626342cb53695ca4aaa29ec5f80400ed4d18e4dc87dc44445069c62265112980ac7a061d0839f542a792aa5d294561b201445b677";
+      sha512 = "78724abffacb98b6d2392713f06905dba4c9bab8b760ce39d9c43db6664dcd3a4abf6eb16f72f9e2494b8917bf6bb813ab4ea4fe4ab20d0dca2f6ac53701245a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ko/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ko/firefox-76.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "72fc61f2429fbef846eec40e53f50bd95d3b6b728d78e2199408b052b0d85ea66fbd6d2a114cd046311f88b419eeb7447b062cc9c5824cbae572debe872656db";
+      sha512 = "761e0c96916991e882da081266dea395d73df994612845ee671a30e530166c315fea1f6468358b1dc9aa760c1b7de127215598d853a43fbafed0afd794719397";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/lij/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/lij/firefox-76.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "9192d46b8b16129243ee2f5af47cd0f8fdf9af3ac953ae6481452cdd1f4da9ad9b75aa9c1b96416cba47dc16ca867db3135da810f32df5a33bed233a3b68f447";
+      sha512 = "9035366ac3636db3f94844f5161e0b5ec77441d0cbf0ff7e72681a2968978e12b1640557eb8769d9efb6b41f67e8481b999a41c650c5bc12cfe2c8d5c76514c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/lt/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/lt/firefox-76.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "89a5c07f1c1b7b389bf7074feb6b7c29470bfb143b720503783c35cabb36fbd0e5c3fe31349e1004728f128db36148ad6dd07f389099fab17c8a6d078c37675d";
+      sha512 = "f466bb0ba23dd74e0a08d30b17cc0648c57b32c72e11a55f992e4face7e3cc6fb0232de5f9ff5b8373673d2ee84a88cd72a3cdabd6449bf3e706a7519a2259e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/lv/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/lv/firefox-76.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "1bc60805513cfd6ab6d563108fecb176766e77bf10203c942ada3878d062e6a75c54129505fa63f16aeb72f4a1c6b360f7e65e8f23433d20fe134692e53f4210";
+      sha512 = "abbb64e473aa521b9c9900fd2a930c685a1c438e1ff2cf26a3239eea77366e94894a28f4e92ea85304b2f09db035e258dcf79bf359fb9d1c87eeb0461e5766a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/mk/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/mk/firefox-76.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "811449cc14b5bc3185c56a8ea2b640a3fdfcb60b309ae9ccb5498196677e1431719897e3e239dec4ee964575187430c1a0a1b4fa48fbd29dc874a1edceb7fd00";
+      sha512 = "63600db5357dd3c9a729b42c26967f4691d78a3dde4e4e204043155ccbf76a5e4d69133fba17fba5691400f8742b25424093805c961d6e41b4e53ea1b4241f79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/mr/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/mr/firefox-76.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "940563e7a93a08372790ea3f0403c4facc900a6ec680c0e7d71fa10978fbe484c448f1e7bdc8096e26528a969178273223592daba724296f423b1293b79aa5fe";
+      sha512 = "53c5def1edb8160b0ba926b97b507b4e04ce074b9d26dfe12e300fbd98d758a1471adf50b09f127c7ccaa6914dd657548be2e7afd7007313bef55fcde43e2e59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ms/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ms/firefox-76.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "ab8d456745a815934736ae25cf597dd6eec2dc25320dfe99c6af804823ad71b482b19eae071be08763c82678e7c966bd86ab1bc285925945b6800ab725dbebe5";
+      sha512 = "6920e5926417e37b8596addcf10b1e56d8f8b880e7a220c48f13d4ac332e2fad6e3fa7f8295513699247cebc3fb7e4facd1178b9b35af5207da2c07c936ad6ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/my/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/my/firefox-76.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "a8b4532eda52b3543767a28fb9550b21324c72976b71fd2101665e0ca89c63c4b1d8272a9f425feacb3bef188b43edacf603ac87fa1a3dd19c374d22877ac02f";
+      sha512 = "b2eb25db0fff5e7611bad70a28b5cc31bb7887c1a9d7581dccf61ee61e43618a1cf57b8065d5f0c79ac4f3c62dc0c41a3a0a52db74031e8050b1bb99402b57df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/nb-NO/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/nb-NO/firefox-76.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "a68193718025329d73e07b7199fc6a11e4834cf3f0ca327efbc182d0b33bff342e8a3012ae180fec2167f842781ae9c6d63d29e312e2385ee06e4ef25c851fbe";
+      sha512 = "be51fca39f0c6012d7ec3ea7d444c07ba5b55c7fa8d04b458612c71f8c7907bff8edff03421b8299a928daf3dc849d90d57877395796e7b9671b9dd256a91c06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ne-NP/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ne-NP/firefox-76.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "5ba2c7da5741d45b376de87c9d3abd65de5a74885cac25ba0c7c8a81d681c0dd0fb870764208b62aecbc93122daea5cd7dba1fec41a1d97eda0dc674f16dd6cd";
+      sha512 = "c203a3c4d863ffee1b7fa69a317877eb25ccd25d9f4401ccfa881a43822f0bdcc8a32454942f3fe53b0a561b2297f67a7769cd053b2a716395b228e34a044323";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/nl/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/nl/firefox-76.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "941cbc8f65b1b307f998c853010bd373541aa8043f1fc97e261453f7d49ed7ad9880e0cd85fd1bdb5b4b038272e210d9eeb7a5a24f27f1212ffbfde494c87b04";
+      sha512 = "5afbcd18416b8678f8c211349e84c0de9bc1093f2df588e8f5d0ee12d830dda8324818a1ffea407368d089966aabb1d8066e1186e29b6adbf1f2ce1aadadb51c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/nn-NO/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/nn-NO/firefox-76.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "0c0dd5ce17626e96c3e88a9771272f60e93c7ad4f1f40710d8b70d4f40a58010933de89a2b381dac94831db786621a35ef6894f46f1b19026c0eb7ce0b172459";
+      sha512 = "f5362cd6b2a45a91f8bbe7b0e3d274e498043c0615e39b50ebf586cec8ef1f28e70cd900cedf87721d694315241d9c71466ad6c057f31e080539bffabc5ae318";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/oc/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/oc/firefox-76.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "169b6a1a48b2711ecdccdd6a685ee10b5f602d0300cac13b56feb331901be88edf6e8386ce6e4bfc108f419de305a5603445f5b7561b37358a75adb8e8d418e0";
+      sha512 = "ce3853a04e7dbf9ca13e974bfcc71dce76626c7ffd858cfb0cebecc3f5dc96e17cf5278b54d604072ec835ffeaee4172a9df5f45d5995c7bd79eafb5b9787f39";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/pa-IN/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/pa-IN/firefox-76.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "96dda02dda90aaa1de2bd31e04d87b37a179773d1f3f8094d33fcdfa6ffc78616f9d7539b4405911a6dfd31382cba91ce34ca6680c36e7aec22493d3bf6f15fa";
+      sha512 = "b3f426fe12e7a342695dd265a9c7d5fe1f3838e3fc2df3e6f82e2479e2890296d1844564e991f47ac2338e31e5e2195ff722485a4fead02fc8c21b3cc7e5162f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/pl/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/pl/firefox-76.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "326b8b65388b6e7d8215a665fd6acd9ad9fd5a03edfd6ee428dc53b217df7b108a351094530621c5b78f3cfaed90092c17e1d1c9656a37a10c108aa441ae0e47";
+      sha512 = "3162745af966b8a688d1edbc6bdd3d1bf7e64e5b4399093176d70e618d592299e0cbcef96925817f0f61252f557764adf8a4294691bea0d74d2fd8ade3b3089f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/pt-BR/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/pt-BR/firefox-76.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "70a56009e39e06b701de62c7df02d3d648e04ffe94d2718f2f2cc4ee24f19e832decf0371425ab9791ed5db6a5b56d5f221163d3bd67bcbf6cd48617114353c4";
+      sha512 = "d9f9faeed618c031fe00d33284c4585ccae31b436a202ebd8dcd41006fd24c30c051860e0352a0045edb15716b866ac65ff67321a2b277ecfebad7e278d4cd51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/pt-PT/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/pt-PT/firefox-76.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "33a770a0ea0c177c1d839056f4045e41e8e2102e840c99c48abd2cb49733d44af2753f040696e859eb724dfbb6dddc3357bf505620f74c0c29b92211d8ab9572";
+      sha512 = "b37daf5ab76b8d8c6786cfabd60c474898ae2e9dcf9fd338a7353b314080dca2db7e02c611ecf53f83d06b59d8a95f5c7d5459e0615ac9b7ddc3b140f14c0f45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/rm/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/rm/firefox-76.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "233af09f6a4ebb88aa678362c85244f1465d5da57e193b26d676543d0d1df9e673b25096da705178d1784cf3682fb6a1d12564525b77723eca0924bad7ecb0e4";
+      sha512 = "e2449914aef91a57b9109166e059405781c2aeb02a3255ed314d5344f801338740e82e9081cd0e820c746e43230d87787116de64733db1bd7ad310cd9eeb85a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ro/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ro/firefox-76.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "6be29acfa925e3524c83ccd6915523cb8a37143855361b46fbd71465002f8791426ea9985d34486db17edffcf53d6197b7115cc0dd38a2be16502d07d3b26cf9";
+      sha512 = "f4e6291053009975e5ee6ab19cb5154fbb36331a905df59336f7ffbdef2ceb410cb854712c956d9a726e08e934081b7f8d32fb5449ea4721e913ca2d5fd8bb98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ru/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ru/firefox-76.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "46b2a7b8370fc173101dd1e78ce12e363f80a852d55b2e6be9f5b31232888750e07937afa60bee2571e0b3b18ca2987ffbbad8c6065d4bb71064c34acc46c3a1";
+      sha512 = "d362b4307150c2df6711d7db7cc938ccc31a1f0d451ecf9d0b83756c9d0a22dade9f271773ef67055ae715e65699b26cfab1c94da091f30188f157fe6416ad75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/si/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/si/firefox-76.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "934144d99326a139d994518e5aa763cf32035a7d310fa94eba7b4a2b7cf40eaff732dc20100f7bba35dbf415b7a5fc22c5122ef40a65732566063d4517321ffb";
+      sha512 = "cdc76fe1c43532646a26aa9520c590a9ac90a648c6929780fba6eded5869125fed7c62d6c6dfb313c47ab3ee31103a69d16ac3a25edc93ec4452ee35e51f29ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/sk/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/sk/firefox-76.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "a892ced0d9c5dac7cda65cd67abc1232d5be3ba8ebc2c98181f504b68d43018fc392e0e5b4b12ed22f1ca1b6469be83f68b12e60fad28fd42eba18d9b8d4d7b0";
+      sha512 = "841da84330a6056a885b23dfee0d3b4b2230f5b67872be18e581183d432a5d0fd1dbbe58a66cf3808a8261552c042ee3d52d8122f1aacf4204ce216d897b1045";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/sl/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/sl/firefox-76.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "229175292f435f3cb1db7ba671933508ba7b4daba1aa5db0ed9f03fe8bb83778a0b951b0248a27b4e4a7beaa374f9bc4eef3b2762596b22bd45045efc3038be3";
+      sha512 = "3173365c0561a37033ce6a76429acf84e4a07c1efdae950c1c341773110b1d6e3fc5c756e4af4b24bceb9cd6bb13c8f6c447c320e9aed16974477714cb711f65";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/son/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/son/firefox-76.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "44d585391132de3c4df67bdec4a5062bf71af4ae32084e0602de93d75c279e8ee76a022aa19926eee03a31022b4d7eb9feab8e349c2a6547b85f8a42f5b122d1";
+      sha512 = "b2267023f22be5d94bb24a7550e7350e1923d5ad52805f4999ea1776dcb25a94d7aed6257d286a3cda3aa9e8d82c28a7308aca88e90aba217736b7eeef3d79bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/sq/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/sq/firefox-76.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "f0b04a81888f8cac58e311f9f4fe16111a414f541bd1a5b3dc2fda028cf85b3a701ae5b91d223a3d6542580c1bec5459dd4dfe90cac517d3f974c1084ed6be1f";
+      sha512 = "2c9c939216d5a4817e7053a49be3702bcdfdc47714f14ee01597f1e09c5258bf81b4c09cff540397c02d80977ff47cd7dad6d24b9cadbb6101ff246f689e361d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/sr/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/sr/firefox-76.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "c3fae910a582dbcb5b8609dbfce0d759d776667e34c737755968f1a531e83b58b098b8a88bd948ee820ab76328210631b7d85ff65a88be630f795522831a7014";
+      sha512 = "9cc967fc48024648d9e607aae962b7605fe18573c278f53d35eb4c797ab94cc4e60a82389a89592ce603c0cbfe2a9343e70a97e778fdd78a90efc828ff9ad577";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/sv-SE/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/sv-SE/firefox-76.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "fd5feca0a4a107b018329ab2fc1d7eab9c0e51d2660d8356cba4792cf73f1176fd19411580f98a469f47eb6bacb2c311134194ee612caa7ad8a5a0021b062420";
+      sha512 = "7ebc62423c697ef354672d6dce28bff23c180ca198d983b323c9f679b6225ec8007883b3cd0cdf933e9b35e5b958fbac39f8d63eb446c94057f3bf943aba4176";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ta/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ta/firefox-76.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "c54d20862ec7c09e4ceaca3afb120938beb7ec0bf1c38e651355fad1247c61e75acbd0fe6b96a17fc19136720ba55755a8bb04726c714c812a333c9e300b9463";
+      sha512 = "504e6be9fb078d657a1e56b48e5eb6deb37aee9c6b366e733d27942d1b2a764e54b1e3d493ab88db53ae11eea45c1b5c214e57840fdbfdbaaa827f0f74b00359";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/te/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/te/firefox-76.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "a594904a68ccd42f5e6c0a829100fb99e37732a29775273ac202fbb65785549bbdf638e8ddbcf6b7269161cafd229354b5b350be8e2f2360892bcf17ef777e07";
+      sha512 = "a10e91594032cf92e47f901e62f8492655349ccdb1e080420d7fd84da9b42102d2356d859b3f421c469ac4433ac86429b94488e0ac47c3e7390cb5ef8eb84485";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/th/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/th/firefox-76.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "45b5fca122f7900da176ff3d55dd70a1a2d594fd9119b75760dc094b7a254e21aa6455c8370650f1b17d69ec1e81749881635d176dc72a45eec8f632d3a2e0f2";
+      sha512 = "9edf7765ea8a28b9151a62110dbe5c89e774b2ea596972adaf32e78da8bf750612e6791768724d932e7ae12dcaa6602c3b08859bddd351f22e8b56cdcaae6947";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/tl/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/tl/firefox-76.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha512 = "06b3fd1f4cf030377854ea39bfe0818322123d53299a3f5d7308db32683f3992240099491422858c3104079b566958dfa60b58248c0c6adcd0153d584429fca2";
+      sha512 = "f10a5cba0bb42ccb3439a19b7b73be4fca73c7990cc4e4cd92e6ae24b7716bcf4c519cd06d01f2b1005e57a93d2275df441d6f23f0ca213e222240f2a8ab4c8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/tr/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/tr/firefox-76.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "2cb1d03ced3d88344e24bda60687e9a0c34aade38fd635a63ffea3f072188bf6f5ab76cc7c54188280932c225f1e5c9b7c6cea4d2ee0b1798335e84b7826c886";
+      sha512 = "21394859c37438a9d25e19d562ecf2fda0bca4d721808afbb568985a3f5df8ff78ff893ae6ae5875495a891bf1324bf17d0e95311a7b654698ea4448a117e71f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/trs/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/trs/firefox-76.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha512 = "6fa6eb60bef978b82e6805c3a083ee40418125416f139bfae2695c2a4b28e34081a984e8c8e092e449e28fae28d812ac2c76b808da83f79c2be4e7f5361f4536";
+      sha512 = "7e379c0788cef697e426c355fd760d7ac173aaf0b0e1a8c46ff3162a676ce8a174648c72463c124450a1d0e8c676db81693529d804d81d01da77eb416490a092";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/uk/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/uk/firefox-76.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "e412938a9ff5bca8b770a83a2f7b9a03f92fc155df9088f60d758aa41c47bb348e331e34c8b04b1b2b5c796ec34261aebedc697c058bc5457265ee7b87d2d773";
+      sha512 = "cc58383b41c72d629a47924f8854d0a47aae725c6b189a392bb64852df5fb399fd500162496790105aa589655ee90a929fba8fcaf829158efb2565ae10f4e2c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/ur/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/ur/firefox-76.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "8a4d50ceae88d1ccb354135fa10df40a2427bc0e704dca5b7ceafafbfcb3970eb57d4d6eb427330a2198894e67e2da2532adcdf5f900f5e8ed15727e1dc4fa84";
+      sha512 = "98596cd0e8c2c50ee9765f4f125876fc46fbbecc98daf9c9f85371fb4e257c4da7151d5b995b5bc99ce07f588ca2387cacfb99a288bf08712224c23fb48b2fff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/uz/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/uz/firefox-76.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "cb1be90d64caa7ac445cc7a6b3549350eaf8859e7a4e662e602eee4218de98944360bcd828b62bdcf18a5a602b153a1e4cfb0bdac92a802a8b071f349c88262a";
+      sha512 = "e69a2ea55400504ea5c85cd26b405ae0f2bad77af98e8ea84c437bbfd624d788a87f3c9929e048a93607e1578059efc226f73ede5b80edb2dcf7137421cf3949";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/vi/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/vi/firefox-76.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "69fc97339bd8fddedf12ac5f545c2f768cb071c4786f08c43fe61775e43b2dcf065d84d23ef9b9fb3f09c6df6364413f61fec0fa1cdeea2b4b769e3ef0bf124f";
+      sha512 = "a6da6ac2c9dbb0e41bc72560b272bbeb77f404574ac05a82c377adfc797f02214617a2f015e329257fb3cb3393024a389853ef8391d9e959e590d6963319f6f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/xh/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/xh/firefox-76.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "b8013f7c0e1cfad11ef950015444105b1e8512d778fe4b2a7567e0613a1191a7a929c5fdca9c15ab846da05f189fea1b0c137784ca1061b43f7ebada27376a06";
+      sha512 = "4636496e0db8a5bee8b8ba34294ec55e0c99e4c1645e85b295c31371d143e05591bde9d12ed267a1c4a5016bdff0325f2a0862e01c09cd5359f6f98963ab0833";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/zh-CN/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/zh-CN/firefox-76.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "154bfde5424cca1af2e624596755fe95a1504be0ce977162117e937b6ab6ec6b03b1cdb470ef62c710129d19a16c42fac334477f8638de6472b742ab2395b262";
+      sha512 = "a8dd56ee0553341b0527b9ee7faee46ec7446dca6299e509b825d8cb5e2fc07c066dea923a9fe4bd3fee0526e286b45f4584d4d18371e0ea192be42697854102";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0/linux-i686/zh-TW/firefox-76.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/76.0.1/linux-i686/zh-TW/firefox-76.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "6c3d36ba9e4682600c2a99d6837dfe76032d6d1618c0ddb8dab5633c2961d413959e9fe0a9c0fc7ef4bbbc41af469a92fab566d24458c43c1671cd3288dcaae8";
+      sha512 = "9b3b7d93da99cdf5ff2baccd999646f667487022118501fd68d973232ce14c5c981adf84df89e8474a1f253a616a2bf9980765a0b5c0691acb3dc9fb966660f4";
     }
     ];
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Noticed it was out of date. cc. @andir 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
