### PR TITLE
asciidoctor: fix dangling ascidoctor-safe symlink

### DIFF
--- a/pkgs/tools/typesetting/asciidoctor/default.nix
+++ b/pkgs/tools/typesetting/asciidoctor/default.nix
@@ -12,7 +12,6 @@ let
     exes = [
       "asciidoctor"
       "asciidoctor-pdf"
-      "asciidoctor-safe"
       "asciidoctor-epub3"
     ];
 


### PR DESCRIPTION
as such a binary does not appear to be in the gem

###### Motivation for this change
i'm getting a warning about this seemingly every time i do anything with `nix-env`

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
<details>
<summary> nix-review pr 87646 </summary>

```
1 package marked as broken and skipped:
far2l

2 packages blacklisted:
tests.nixos-functions.nixos-test tests.nixos-functions.nixosTest-test

2 packages failed to build:
almanah rabbitvcs

118 packages built:
Sylk adapta-gtk-theme appimage-run asciidoctor atom atom-beta awesome bat-extras.batgrep btrbk calls cantata chrome-gnome-shell cinnamon.cinnamon-control-center clementine clementineUnfree deepin.dde-file-manager deepin.startdde deja-dup deltachat-electron dropbox-cli elementary-planner empathy esh evolution-data-server feedreader folks gfbgraph gnome-multi-writer gnome-online-accounts gnome-photos gnome-recipes gvfs gnome3.bijiben gnome3.cheese gnome3.evolution gnome3.file-roller gnome3.geary gnome3.gnome-applets gnome3.gnome-books gnome3.gnome-boxes gnome3.gnome-calendar gnome3.gnome-contacts gnome3.gnome-control-center gnome3.gnome-disk-utility gnome3.gnome-documents gnome3.gnome-flashback gnome3.gnome-initial-setup gnome3.gnome-maps gnome3.gnome-music gnome3.gnome-online-miners gnome3.gnome-panel gnome3.gnome-session gnome3.gnome-shell gnome3.gnome-software gnome3.gnome-terminal gnome3.gnome-todo gnome3.gnome-tweaks gnome3.gnome-user-share grilo-plugins gnome3.gvfs libgdata libzapojit gnome3.nautilus gnome3.nautilus-python gnome3.pomodoro shotwell gnome3.totem tracker-miners gnomeExtensions.gsconnect hal-flash irccloud jitsi-meet-electron joplin-desktop ledger-live-desktop libblockdev libndctl marktext mate.mate-utils minetime newsboat notable pantheon.elementary-calendar pantheon.elementary-greeter pantheon.elementary-session-settings pantheon.extra-elementary-contracts pantheon.wingpanel-indicator-datetime pantheon.wingpanel-with-indicators pmdk psensor rapid-photo-downloader ripcord ripgrep ripgrep-all runwayml soulseekqt spaceFM ssb-patchwork standardnotes station styx tusk udiskie udisks unityhub usermount vifm-full weechat weechat-unwrapped wootility wsjtx xfce.gigolo xfce.gvfs xfce.thunar xfce.thunar-archive-plugin xfce.thunar-dropbox-plugin xfce.xfdesktop xmonad_log_applet zulip
```
`almanah` fails without this commit
`rabbitvcs` is marked as broken

</details>

- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - used to be `337247856` is now `337247576`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
