### PR TITLE
Deno: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3592,6 +3592,12 @@
     githubId = 51518420;
     name = "jitwit";
   };
+  jk = {
+    email = "hello+nixpkgs@j-k.io";
+    github = "06kellyjac";
+    githubId = 9866621;
+    name = "Jack";
+  };
   jlesquembre = {
     email = "jl@lafuente.me";
     github = "jlesquembre";

--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -1,0 +1,139 @@
+{ stdenv
+, fetchurl
+, fetchFromGitHub
+, rust
+, rustPlatform
+, python27
+, installShellFiles
+, Security
+, CoreServices
+}:
+let
+  pname = "deno";
+  version = "1.0.0";
+
+  denoSrc = fetchFromGitHub {
+    owner = "denoland";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0k8mqy1hf9hkp60jhd0x4z814y36g51083b3r7prc69ih2523hd1";
+
+    fetchSubmodules = true;
+  };
+  cargoSha256 = "1fjl07qqvl1f20qazcqxh32xmdfh80jni7i3jzvz6vgsfw1g5cmk";
+
+  rustyV8Lib = fetchlib "rusty_v8" "0.4.2" {
+    x86_64-linux = "1ac6kv3kv087df6kdgfd7kbh24187cg9z7xhbz6rw6jjv4ci2zbi";
+    aarch64-linux = "06iyjx4p4vp2i81wdy0vxai2k18pki972ff7k0scjqrgmnav1p8k";
+    x86_64-darwin = "02hwbpsqdzb9mvfndgykvv44f1jig3w3a26l0h26hs5shsrp47jv";
+  };
+
+  arch = rust.toRustTarget stdenv.hostPlatform;
+  fetchlib = name: version: sha256: fetchurl {
+    url = "https://github.com/denoland/${name}/releases/download/v${version}/librusty_v8_release_${arch}.a";
+    sha256 = sha256."${stdenv.hostPlatform.system}";
+    meta = { inherit version; };
+  };
+in
+rustPlatform.buildRustPackage rec {
+  inherit pname version cargoSha256;
+
+  src = denoSrc;
+
+  nativeBuildInputs = [
+    # chromium/V8 requires python 2.7, we're not building V8 from source
+    # but as a result rusty_v8's download script also uses python 2.7
+    # tracking issue: https://bugs.chromium.org/p/chromium/issues/detail?id=942720
+    python27
+
+    # Install completions post-install
+    installShellFiles
+  ];
+
+  buildInputs = with stdenv.lib; [ ]
+    ++ optionals stdenv.isDarwin [ Security CoreServices ];
+
+  # The rusty_v8 package will try to download a `librusty_v8.a` release at build time to our read-only filesystem
+  # To avoid this we pre-download the file and place it in the locations it will require it in advance
+  preBuild = ''
+    # Check the rusty_v8 lib downloaded matches the Cargo.lock file
+    rusty_v8_ver="$(grep 'name = "rusty_v8"' -A 1 Cargo.lock | grep "version =" | cut -d\" -f2)"
+    if [ "${rustyV8Lib.meta.version}" != "$rusty_v8_ver" ]; then
+      printf "%s\n" >&2 \
+        "version mismatch between 'rusty_v8' in Cargo.lock and downloaded library:" \
+        "  wanted: ${rustyV8Lib.meta.version}" \
+        "  got:    $rusty_v8_ver"
+      exit 1
+    fi;
+
+    _rusty_v8_setup() {
+      for v in "$@"; do
+        dir="target/$v/gn_out/obj"
+        mkdir -p "$dir" && cp "${rustyV8Lib}" "$dir/librusty_v8.a"
+      done
+    }
+
+    # Copy over the `librusty_v8.a` file inside target/XYZ/gn_out/obj, symlink not allowed
+    _rusty_v8_setup "debug" "release" "${arch}/release"
+  '';
+
+  # Set home to existing env var TMP dir so tests that write there work correctly
+  preCheck = ''
+    export HOME="$TMPDIR"
+  '';
+
+  checkFlags = [
+    # Strace not allowed on hydra
+    "--skip benchmark_test"
+
+    # Tests that try to write to `/build/source/target/debug`
+    "--skip _017_import_redirect"
+    "--skip https_import"
+    "--skip js_unit_tests"
+    "--skip lock_write_fetch"
+
+    # Cargo test runs a deno test on the std lib with sub-benchmarking-tests,
+    # The sub-sub-tests that are failing:
+    # forAwaitFetchDenolandX10, promiseAllFetchDenolandX10is
+    # Trying to access https://deno.land/ on build's limited network access
+    "--skip std_tests"
+
+    # Fails on aarch64 machines
+    # tracking issue: https://github.com/denoland/deno/issues/5324
+    "--skip run_v8_flags"
+
+    # Skip for multiple reasons:
+    # downloads x86_64 binary on aarch64 machines
+    # tracking issue: https://github.com/denoland/deno/pull/5402
+    # downloads a binary that needs ELF patching & tries to run imediately
+    # upgrade will likely never work with nix as it tries to replace itself
+    # code: https://github.com/denoland/deno/blob/v1.0.0/cli/upgrade.rs#L211
+    "--skip upgrade_in_tmpdir"
+    "--skip upgrade_with_version_in_tmpdir"
+  ];
+
+  # TODO: Move to enhanced installShellCompletion when merged: PR #83630
+  postInstall = ''
+    $out/bin/deno completions bash > deno.bash
+    $out/bin/deno completions fish > deno.fish
+    $out/bin/deno completions zsh  > _deno
+    installShellCompletion deno.{bash,fish} --zsh _deno
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://deno.land/";
+    description = "A secure runtime for JavaScript and TypeScript";
+    longDescription = ''
+      Deno aims to be a productive and secure scripting environment for the modern programmer.
+      Deno will always be distributed as a single executable.
+      Given a URL to a Deno program, it is runnable with nothing more than the ~15 megabyte zipped executable.
+      Deno explicitly takes on the role of both runtime and package manager.
+      It uses a standard browser-compatible protocol for loading modules: URLs.
+      Among other things, Deno is a great replacement for utility scripts that may have been historically written with
+      bash or python.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ jk ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2837,6 +2837,10 @@ in
 
   deer = callPackage ../shells/zsh/zsh-deer { };
 
+  deno = callPackage ../development/web/deno {
+    inherit (darwin.apple_sdk.frameworks) Security CoreServices;
+  };
+
   detox = callPackage ../tools/misc/detox { };
 
   devilspie2 = callPackage ../applications/misc/devilspie2 {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adding `deno` for it's `1.0.0` release

Resolves: #78461
Tracking issue for `1.0.0` release: https://github.com/denoland/deno/issues/2473
PR for `1.0.0` release: https://github.com/denoland/deno/pull/5273
Release post: <https://deno.land/v1>

~**Version is currently `1.0.0-rc3` as that's the latest release**. I will force-push once 1.0.0 is out (ETA 13th May)~

Any and all suggestions and criticisms welcome, most of my nix packaging experience is on my own machine so I'd like to know if I'm straying from best/good practices.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [x] macOS
   - [X] NixOS or other (aarch64 ARM)
    - Build passed, Build + Check ended SIGKILL 9 (Raspbian RPI4)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

**Concerns**

* ~Currently using built zip~ Now building from source, not rebuilding v8 though
  * ~Probably preferable to build from source releases but had issues with `rusty_v8`~ Solved
  * Building from source + also building v8 from source is probably not preferred as v8 takes ages to build (maybe have it as optional?)
* ~The release has a `.d.ts` definition~
  * ~I haven't done much actual work with `deno` yet so IDK if I should install this somewhere~
  * ~The [deno_install](https://github.com/denoland/deno_install) script doesn't seem to touch it so it should be fine~
  * Can just grab this from running `deno tags > lib.deno.d.ts`
* It has it's own upgrade command
  * Just hope people dont touch it?/Let it not work?
  * Add a patch to remove or hide it?
* No versioning like existing node (and other language/interpreter) releases
  * Not of particular concern now but something to think about for future versions

---

**Tests of `deno` after install:**

```sh
deno --version
deno 1.0.0
v8 8.4.300
typescript 3.9.2
```

**Examples from help**

```
deno run https://deno.land/std/examples/welcome.ts
Welcome to Deno

deno eval "console.log(30933 + 404)"
31337
```

**Watch fs**

`watch.ts`:
```ts
const watcher = Deno.watchFs("./");
for await (const event of watcher) {
  console.log(">>>> event", event);
  // { kind: "create", paths: [ "/foo.txt" ] }
}
```

`deno run --allow-read watch.ts`

**Deno Packages/Programs**

`deno install --unstable --allow-read --allow-run -f https://deno.land/x/denon/denon.ts`

`~/.deno/bin/denon log.ts`

`log.ts`:
```ts
console.log("hello, world!")
```
