### PR TITLE
nixos/systemd-sandbox: A generic sandboxing module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -202,6 +202,7 @@
   ./security/sudo.nix
   ./security/doas.nix
   ./security/systemd-confinement.nix
+  ./security/systemd-sandbox.nix
   ./security/tpm2.nix
   ./services/admin/oxidized.nix
   ./services/admin/salt/master.nix

--- a/nixos/modules/security/systemd-sandbox.nix
+++ b/nixos/modules/security/systemd-sandbox.nix
@@ -1,0 +1,69 @@
+{ config, lib, ... }:
+with lib;
+{
+  options.systemd.services = with types; mkOption {
+    type = attrsOf (submodule ({ name, config, ... }: {
+      options.sandbox = mkOption {
+        description = ''
+          Level of systemd service sandboxing for this particular unit.
+          All systemd confinement options are overrridable by assigning
+          another value to allow service-specific access.
+
+          0 is no confinement at all.
+          1 is basic sandboxing, probably not breaking anything.
+          2 is the highest amount of sandboxing this module supports right now.
+        '';
+        default = 0;
+        type = enum [ 0 1 2 ];
+      };
+
+      # mkDefault is 1000
+      # assignment is 100
+      # A value of 900 ensures that service defaults are overwritten, while
+      # giving the administrator a chance to override by assigning.
+      config.serviceConfig = mkMerge [
+        (mkIf (config.sandbox >= 1) (mapAttrs (_: mkOverride 900) {
+          # Filesystem stuff
+          PrivateTmp = true; # Give an own directory under /tmp
+          PrivateDevices = true; # Deny access to most of /dev
+          ProtectKernelTunables = true; # Protect some parts of /sys
+          ProtectControlGroups = true; # Remount cgroups read-only
+          RestrictSUIDSGID = true; # Prevent creating SETUID/SETGID files
+
+          # Kernel stuff
+          ProtectKernelModules = true; # Prevent loading of kernel modules
+          SystemCallArchitectures = "native"; # Usually no need to disable this
+          PrivateMounts = true; # Give an own mount namespace
+
+          # User
+          User = warn "warning: ${name}.service is sandboxed but running as root." "root";
+
+          # Misc
+          LockPersonality = true; # Prevent change of the personality
+          ProtectHostname = true; # Give an own UTS namespace
+          RestrictRealtime = true; # Prevent switching to RT scheduling
+        }))
+        (mkIf (config.sandbox >= 2) (mapAttrs (_: mkOverride 900) {
+          # Filesystem stuff
+          ProtectSystem = "strict"; # Prevent writing to most of /
+          ProtectHome = true; # Prevent accessing /home and /root
+
+          # Capabilities
+          CapabilityBoundingSet = ""; # Allow no capabilities at all
+          NoNewPrivileges = true; # Disallow getting more capabilities (i.e. setcap files). This is also implied by other options.
+
+          # Networking
+          RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6"; # Disallow AF_PACKET, AF_NETLINK, ...
+          PrivateNetwork = true; # Only give a dummy loopback interface
+
+          # Misc
+          MemoryDenyWriteExecute = true; # Maybe disable this for interpreters like python
+          PrivateUsers = true; # If anything randomly breaks, it's mostly because of this
+          SystemCallFilter = "@system-service"; # Only allow the most basic syscalls. See `systemd-analyze syscall-filter`.
+        }))
+      ];
+    }));
+  };
+
+  meta.maintainers = with maintainers; [ das_j ajs124 ];
+}


### PR DESCRIPTION
This can be enabled using `systemd.services.<name>.sandbox` and supports
different levels of confinement, allowing for new new confinement
options to be added in the future.

We have been using a similar module for about half a year with extreme success, being able to sandbox stuff quickly and efficently.

cc @ajs124 As you ~~also wrote parts of the module iirc~~ wanted me to write the module back then
cc @Izorkin Maybe this can make  #85567 more generic
cc @flokli @Mic92 @Ma27 because you might care about this

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
