### PR TITLE
nixos/pixiecore: fix escaping of cmdline

### DIFF
--- a/nixos/modules/services/networking/pixiecore.nix
+++ b/nixos/modules/services/networking/pixiecore.nix
@@ -115,7 +115,7 @@ in
               if cfg.mode == "boot"
               then [ "boot" cfg.kernel ]
                    ++ optional (cfg.initrd != "") cfg.initrd
-                   ++ optional (cfg.cmdLine != "") "--cmdline=${lib.escapeShellArg cfg.cmdLine}"
+                   ++ optionals (cfg.cmdLine != "") [ "--cmdline" cfg.cmdLine ]
               else [ "api" cfg.apiServer ];
           in
             ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I wanted to boot qemu-machines using pixieboot but it failed.
turns out: the cmdline was escaped badly.

using the following configuration i can now boot a qemu-vm from network:
```nix
{ pkgs, lib, config, ... }:
{

  services.pixiecore = let
    nixos = import <nixpkgs/nixos> {
      configuration = { config, pkgs, lib, ... }: with lib; {
        imports = [
          <nixpkgs/nixos/modules/profiles/minimal.nix>
          <nixpkgs/nixos/modules/profiles/all-hardware.nix>
          <nixpkgs/nixos/modules/installer/netboot/netboot.nix>
        ];
      };
    };
    build = nixos.config.system.build;
  in {
    enable = true;
    debug = true;
    openFirewall = true;
    dhcpNoBind = true;
    kernel = "${build.kernel}/bzImage";
    initrd = "${toString build.netbootRamdisk}/initrd";
    cmdLine = "init=${build.toplevel}/init ${lib.concatStringsSep " " nixos.config.boot.kernelParams}";
  };

}
```
###### Things done
Fix double-escaping of cmdline.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

fyi @Mic92 