### PR TITLE
nixos/manual: document use of systemd to mount filesystems

### DIFF
--- a/nixos/doc/manual/configuration/file-systems.xml
+++ b/nixos/doc/manual/configuration/file-systems.xml
@@ -16,6 +16,12 @@
     fsType = "ext4";
   };
 </programlisting>
+  This will create the <filename>fstab</filename> entry and a
+  <command>systemd</command> unit file for the filesystem, as well as
+  automatically mount it, unless <literal>"noauto"</literal> is present in
+  <link linkend="opt-fileSystems._name__.options">options</link>.
+  <literal>"noauto"</literal> filesystems can be mounted explicitly using
+  <command>systemctl</command> e.g. <command>systemctl start data.mount</command>.
   Mount points are created automatically if they don’t already exist. For
   <option><link linkend="opt-fileSystems._name__.device">device</link></option>,
   it’s best to use the topology-independent device aliases in

--- a/nixos/doc/manual/configuration/file-systems.xml
+++ b/nixos/doc/manual/configuration/file-systems.xml
@@ -16,12 +16,17 @@
     fsType = "ext4";
   };
 </programlisting>
-  This will create the <filename>fstab</filename> entry and a
-  <command>systemd</command> unit file for the filesystem, as well as
-  automatically mount it, unless <literal>"noauto"</literal> is present in
-  <link linkend="opt-fileSystems._name__.options">options</link>.
+  This will create an entry in <filename>/etc/fstab</filename>, which will
+  generate a corresponding
+  <link xlink:href="https://www.freedesktop.org/software/systemd/man/systemd.mount.html">systemd.mount</link>
+  unit via
+  <link xlink:href="https://www.freedesktop.org/software/systemd/man/systemd-fstab-generator.html">systemd-fstab-generator</link>.
+  The filesystem will be mounted automatically unless
+  <literal>"noauto"</literal> is present in <link
+  linkend="opt-fileSystems._name__.options">options</link>.
   <literal>"noauto"</literal> filesystems can be mounted explicitly using
-  <command>systemctl</command> e.g. <command>systemctl start data.mount</command>.
+  <command>systemctl</command> e.g. <command>systemctl start
+  data.mount</command>.
   Mount points are created automatically if they don’t already exist. For
   <option><link linkend="opt-fileSystems._name__.device">device</link></option>,
   it’s best to use the topology-independent device aliases in


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes #87291.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @flokli