### PR TITLE
terminal_tarot: init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -764,6 +764,12 @@
     githubId = 2093941;
     name = "Alexander Tsamutali";
   };
+  aswan89 = {
+    email = "andrew@swanso.net";
+    github = "aswan89";
+    githubId = 8301892;
+    name = "Andrew Swanson";
+  };
   asymmetric = {
     email = "lorenzo@mailbox.org";
     github = "asymmetric";

--- a/pkgs/tools/misc/terminal_tarot/default.nix
+++ b/pkgs/tools/misc/terminal_tarot/default.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "terminal_tarot";
+  version = "v0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "aswan89";
+    repo = pname;
+    rev = version;
+    sha256 = "0s1ahv7904z7z9r062pfgx3dn9z31l4xxq1vpizib969mvvnfg13";
+  };
+
+  cargoSha256 = "1djdm8b4q4s17kvn6392qy1zgm4jz14jzijsc4z6xrrn4mhpayvc";
+
+  meta = with stdenv.lib; {
+    description = "Toy application for making tarot readings at the terminal, Written in Rust";
+    homepage = "https://github.com/aswan89/terminal_tarot";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ maintainers.aswan89 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3371,6 +3371,8 @@ in
 
   teamocil = callPackage ../tools/misc/teamocil { };
 
+  terminal_tarot = callPackage ../tools/misc/terminal_tarot { };
+
   the-way = callPackage ../development/tools/the-way {
     inherit (darwin.apple_sdk.frameworks) AppKit Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adding a new toy application to the repository.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
