### PR TITLE
python3Packages.dotnetcore2: 2.1.13 -> 2.1.14

### DIFF
--- a/pkgs/development/python-modules/dotnetcore2/default.nix
+++ b/pkgs/development/python-modules/dotnetcore2/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "dotnetcore2";
-  version = "2.1.13";
+  version = "2.1.14";
   format = "wheel";
   disabled = isPy27;
 
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     inherit pname version format;
     python = "py3";
     platform = "manylinux1_x86_64";
-    sha256 = "1fbg3pn7g0a6pg0gb5vaapcc3cdp6wfnliim57fn3cnzmx5d8p6i";
+    sha256 = "0dxp9a73ncjylc09bjwq81fgj5ysk1yi27l8ka5f98121k1kmn6q";
   };
 
   nativeBuildInputs = [ unzip ];
@@ -35,14 +35,18 @@ buildPythonPackage rec {
     )
   ];
 
-  # prevent exposing a broken dotnet executable
-  postInstall = ''
-    rm -r $out/${python.sitePackages}/${pname}/bin
+  # remove bin, which has a broken dotnetcore installation
+  installPhase = ''
+    rm -rf dotnetcore2/bin
+    mkdir -p $out/${python.sitePackages}/
+    cp -r dotnetcore2 $out/${python.sitePackages}/
   '';
 
   # no tests, ensure it's one useful function works
   checkPhase = ''
-    ${python.interpreter} -c 'from dotnetcore2 import runtime; print(runtime.get_runtime_path())'
+    rm -r dotnetcore2 # avoid importing local directory
+    export PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
+    ${python.interpreter} -c 'from dotnetcore2 import runtime; print(runtime.get_runtime_path()); runtime.ensure_dependencies()'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Was having some issues with it.

Tested it locally using a ML user scenario.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
