### PR TITLE
prometheus: Split options listenAddress and port

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -46,7 +46,7 @@ let
   cmdlineArgs = cfg.extraFlags ++ [
     "--storage.tsdb.path=${workingDir}/data/"
     "--config.file=${prometheusYml}"
-    "--web.listen-address=${cfg.listenAddress}"
+    "--web.listen-address=${cfg.listenAddress}:${builtins.toString cfg.port}"
     "--alertmanager.notification-queue-capacity=${toString cfg.alertmanagerNotificationQueueCapacity}"
     "--alertmanager.timeout=${toString cfg.alertmanagerTimeout}s"
   ] ++
@@ -489,9 +489,17 @@ in {
       '';
     };
 
+    port = mkOption {
+      type = types.int;
+      default = 9090;
+      description = ''
+        Port to listen on.
+      '';
+    };
+
     listenAddress = mkOption {
       type = types.str;
-      default = "0.0.0.0:9090";
+      default = "0.0.0.0";
       description = ''
         Address to listen on for the web interface, API, and telemetry.
       '';

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -490,7 +490,7 @@ in {
     };
 
     port = mkOption {
-      type = types.int;
+      type = types.port;
       default = 9090;
       description = ''
         Port to listen on.

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -627,6 +627,21 @@ in {
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      ( let
+          legacy = builtins.match "(.*):(.*)" cfg.listenAddress;
+        in {
+          assertion = legacy == null;
+          message = ''
+            Do not specify the port for Prometheus to listen on in the
+            listenAddress option; use the port option instead:
+              services.prometheus.listenAddress = ${builtins.elemAt legacy 0};
+              services.prometheus.port = ${builtins.elemAt legacy 1};
+          '';
+        }
+      )
+    ];
+
     users.groups.prometheus.gid = config.ids.gids.prometheus;
     users.users.prometheus = {
       description = "Prometheus daemon user";


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Accessing the configured port of a service is quite useful, for example when configuring virtual hosts for a service. The prometheus module did not expose the configured por separately, making it unnecessarily cumbersome to consume.


###### Things done
The option `listenAddress` currently has the format `host:port`. I've split this into two options `listenAddress` for the host, and `port` for the port, and updated the defaults.

This is a breaking change only if you were setting `listenAddress` to a non-standard value. If you were, you should now set `listenAddress` and `port` separately.

Perhaps there should be an assertion that `listenAddress` does not end in `:[0-9]+$` or similar, but I'm honestly not sure how to implement that.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
