### PR TITLE
nixos/logrotate: Add options for basic paths

### DIFF
--- a/nixos/modules/services/logging/logrotate.nix
+++ b/nixos/modules/services/logging/logrotate.nix
@@ -51,8 +51,7 @@ let
   '';
 
   configFile = pkgs.writeText "logrotate.conf" (
-    (concatStringsSep "\n" (map pathConfig cfg.paths)) +
-    cfg.extraConfig
+    (concatStringsSep "\n" ((map pathConfig cfg.paths) ++ [cfg.extraConfig]))
   );
 
 in

--- a/nixos/modules/services/logging/logrotate.nix
+++ b/nixos/modules/services/logging/logrotate.nix
@@ -12,12 +12,7 @@ in
 {
   options = {
     services.logrotate = {
-      enable = mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Enable the logrotate cron job
-        '';
+      enable = mkEnableOption "the logrotate systemd service";
       };
 
       config = mkOption {

--- a/nixos/modules/services/logging/logrotate.nix
+++ b/nixos/modules/services/logging/logrotate.nix
@@ -5,21 +5,86 @@ with lib;
 let
   cfg = config.services.logrotate;
 
-  configFile = pkgs.writeText "logrotate.conf"
-    cfg.config;
+  pathOptions = {
+    options = {
+      path = mkOption {
+        type = types.str;
+        description = "The path to log files to be rotated";
+      };
+      user = mkOption {
+        type = types.str;
+        description = "The user account to use for rotation";
+      };
+      group = mkOption {
+        type = types.str;
+        description = "The group to use for rotation";
+      };
+      frequency = mkOption {
+        type = types.enum [
+          "daily" "weekly" "monthly" "yearly"
+        ];
+        default = "daily";
+        description = "How often to rotate the logs";
+      };
+      keep = mkOption {
+        type = types.int;
+        default = 20;
+        description = "How many rotations to keep";
+      };
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Extra logrotate config options for this path";
+      };
+    };
+  };
+
+  pathConfig = options: ''
+    "${options.path}" {
+      su ${options.user} ${options.group}
+      ${options.frequency}
+      missingok
+      notifempty
+      rotate ${toString options.keep}
+      ${options.extraConfig}
+    }
+  '';
+
+  configFile = pkgs.writeText "logrotate.conf" (
+    (concatStringsSep "\n" (map pathConfig cfg.paths)) +
+    cfg.extraConfig
+  );
 
 in
 {
+  imports = [
+    (mkRenamedOptionModule [ "services" "logrotate" "config" ] [ "services" "logrotate" "extraConfig" ])
+  ];
+
   options = {
     services.logrotate = {
       enable = mkEnableOption "the logrotate systemd service";
+
+      paths = mkOption {
+        type = types.listOf (types.submodule pathOptions);
+        default = [];
+        description = "List of attribute sets with paths to rotate";
+        example = {
+          "/var/log/myapp/*.log" = {
+            user = "myuser";
+            group = "mygroup";
+            rotate = "weekly";
+            keep = 5;
+          };
+        };
       };
 
-      config = mkOption {
+      extraConfig = mkOption {
         default = "";
         type = types.lines;
         description = ''
-          The contents of the logrotate config file
+          Extra contents to add to the logrotate config file.
+          See https://linux.die.net/man/8/logrotate
         '';
       };
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add basic options for rotating paths.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
