### PR TITLE
jdupes: build with additional hardening

### DIFF
--- a/pkgs/tools/misc/jdupes/default.nix
+++ b/pkgs/tools/misc/jdupes/default.nix
@@ -15,8 +15,11 @@ stdenv.mkDerivation rec {
     extraPostFetch = "rm -r $out/testdir";
   };
 
+  dontConfigure = true;
+
   makeFlags = [
     "PREFIX=${placeholder "out"}"
+    "HARDEN=1"
   ] ++ stdenv.lib.optionals stdenv.isLinux [
     "ENABLE_DEDUPE=1"
     "STATIC_DEDUPE_H=1"
@@ -27,7 +30,7 @@ stdenv.mkDerivation rec {
   doCheck = false; # broken Makefile, the above also removes tests
 
   postInstall = ''
-    install -Dm644 -t $out/share/doc/jdupes CHANGES LICENSE README.md
+    install -Dm444 -t $out/share/doc/jdupes CHANGES LICENSE README.md
   '';
 
   meta = with stdenv.lib; {
@@ -40,6 +43,5 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/jbruchon/jdupes";
     license = licenses.mit;
     maintainers = with maintainers; [ romildo ];
-    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

jdupes supports additional compilation hardening flags, so use those.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).