### PR TITLE
rounded-mgenplus: replace p7zip with libarchive

### DIFF
--- a/pkgs/data/fonts/rounded-mgenplus/default.nix
+++ b/pkgs/data/fonts/rounded-mgenplus/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchzip, p7zip }:
+{ lib, fetchzip, libarchive }:
 
 let
   pname = "rounded-mgenplus";
@@ -8,7 +8,7 @@ in fetchzip rec {
 
   url = "https://osdn.jp/downloads/users/8/8598/${name}.7z";
   postFetch = ''
-    ${p7zip}/bin/7z x $downloadedFile
+    ${libarchive}/bin/bsdtar xf $downloadedFile
     install -m 444 -D -t $out/share/fonts/${pname} ${pname}-*.ttf
   '';
   sha256 = "0vwdknagdrl5dqwpb1x5lxkbfgvbx8dpg7cb6yamgz71831l05v1";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

#86417

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] ~~Tested execution of all binary files (usually in `./result/bin/`)~~
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
