### PR TITLE
maintainers/scripts/update.nix: various fixes and clean-ups

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,6 +55,13 @@
 # NixOS integration test driver
 /nixos/lib/test-driver  @tfc
 
+# Updaters
+## update.nix
+/maintainers/scripts/update.nix   @jtojnar
+/maintainers/scripts/update.py    @jtojnar
+## common-updater-scripts
+/pkgs/common-updater/scripts/update-source-version    @jtojnar
+
 # Python-related code and docs
 /maintainers/scripts/update-python-libraries	@FRidh
 /pkgs/top-level/python-packages.nix     @FRidh @jonringer

--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -32,8 +32,8 @@ let
           (name: pkg:
             let
               result = builtins.tryEval (
-                if lib.isDerivation pkg && cond name pkg
-                  then [(return name pkg)]
+                if lib.isDerivation pkg
+                  then lib.optional (cond name pkg) (return name pkg)
                 else if pkg.recurseForDerivations or false || pkg.recurseForRelease or false
                   then packagesWith cond return pkg
                 else []


### PR DESCRIPTION
###### Motivation for this change

The `packagesWith` function expected an attrSet but `packagesWithUpdateScript` could be passing it a derivation or a list when the attribute path supplied by user through the `--argstr path` argument pointed to one. It only worked because derivations are also attrSets and contain their outputs as attributes, and did not work for lists at all.

Additionally, the improper handling would cause the `src` attribute to be built in some rare cases (`mkYarnPackage` seems to trigger this).

Rewriting the `packagesWith` function to be inductive with a derivation as a base case and attrSets and lists as inductive steps is much cleaner and also fixes the unnecessary build.

#### How to test this

Apply the following patch:

```patch
--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -27,6 +27,25 @@ lib.makeScope pkgs.newScope (self: with self; {
 
 #### Core (http://ftp.acc.umu.se/pub/GNOME/core/)
 
+  updateableBadSrc = pkgs.mkYarnPackage {
+    name = "test";
+    src = pkgs.fetchgit {
+      url = "https://example.com";
+      rev = "test";
+      sha256 = "0000000000000000000000000000000000000000000000000000000000000000";
+    };
+  };
+
+  updateableList = [
+    adwaita-icon-theme
+  ];
+
+  updateableAttrs = {
+    inherit adwaita-icon-theme;
+  };
+
+  nonUpdateable = 4;
+
   adwaita-icon-theme = callPackage ./core/adwaita-icon-theme { };
 
   baobab = callPackage ./core/baobab { };
```

and run:

```ShellSession
nix-shell maintainers/scripts/update.nix --argstr path gnome3.updateableBadSrc
nix-shell maintainers/scripts/update.nix --argstr path gnome3.updateableList
nix-shell maintainers/scripts/update.nix --argstr path gnome3.updateableAttrs
nix-shell maintainers/scripts/update.nix --argstr path gnome3.nonUpdateable
```

None of these should fail or try to download their sources.
