### PR TITLE
welle-io: fix, add qtgraphicaleffects to inputs

### DIFF
--- a/pkgs/applications/radio/welle-io/default.nix
+++ b/pkgs/applications/radio/welle-io/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib, fetchFromGitHub, cmake, pkgconfig
-, qtbase, qtcharts, qtmultimedia, qtquickcontrols, qtquickcontrols2
+, qtbase, qtcharts, qtmultimedia, qtquickcontrols, qtquickcontrols2, qtgraphicaleffects
 , faad2, rtl-sdr, soapysdr-with-plugins, libusb-compat-0_1, fftwSinglePrec, lame, mpg123 }:
 let
 
@@ -30,6 +30,7 @@ in mkDerivation {
     qtmultimedia
     qtquickcontrols
     qtquickcontrols2
+    qtgraphicaleffects
     rtl-sdr
     soapysdr-with-plugins
   ];


### PR DESCRIPTION
###### Motivation for this change
Welle-io refuses to start without the `qtgraphicaleffects` package.
Needs backport to 20.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
