### PR TITLE
Add ibus-engines.rime

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6759,6 +6759,12 @@
     githubId = 8641;
     name = "Pierre Carrier";
   };
+  pengmeiyu = {
+    email = "pengmyu@gmail.com";
+    github = "pmeiyu";
+    githubId = 8529551;
+    name = "Peng Mei Yu";
+  };
   penguwin = {
     email = "penguwin@penguwin.eu";
     github = "penguwin";

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-rime/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-rime/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchFromGitHub, cmake, pkg-config, gdk-pixbuf, glib, ibus, libnotify
+, librime, brise }:
+
+stdenv.mkDerivation rec {
+  pname = "ibus-rime";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "rime";
+    repo = "ibus-rime";
+    rev = version;
+    sha256 = "0zbajz7i18vrqwdyclzywvsjg6qzaih64jhi3pkxp7mbw8jc5vhy";
+  };
+
+  buildInputs = [ gdk-pixbuf glib ibus libnotify librime brise ];
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+  dontUseCmakeConfigure = true;
+
+  prePatch = ''
+    substituteInPlace Makefile \
+       --replace 'cmake' 'cmake -DRIME_DATA_DIR=${brise}/share/rime-data'
+
+    substituteInPlace rime_config.h \
+       --replace '/usr' $out
+
+    substituteInPlace rime_config.h \
+       --replace 'IBUS_RIME_SHARED_DATA_DIR IBUS_RIME_INSTALL_PREFIX' \
+                 'IBUS_RIME_SHARED_DATA_DIR "${brise}"'
+
+    substituteInPlace rime.xml \
+       --replace '/usr' $out
+  '';
+
+  meta = with stdenv.lib; {
+    isIbusEngine = true;
+    description = "Rime input method engine for IBus";
+    homepage = "https://rime.im/";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ pengmeiyu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3035,6 +3035,8 @@ in
       protobuf = pkgs.protobuf3_8.overrideDerivation (oldAttrs: { stdenv = clangStdenv; });
     };
 
+    rime = callPackage ../tools/inputmethods/ibus-engines/ibus-rime { };
+
     table = callPackage ../tools/inputmethods/ibus-engines/ibus-table { };
 
     table-chinese = callPackage ../tools/inputmethods/ibus-engines/ibus-table-chinese {


### PR DESCRIPTION

###### Motivation for this change

This pull request adds ibus-engines.rime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
