### PR TITLE
erlangR23: init at 23.0.2

### DIFF
--- a/pkgs/development/interpreters/erlang/R23.nix
+++ b/pkgs/development/interpreters/erlang/R23.nix
@@ -1,0 +1,13 @@
+{ mkDerivation }:
+
+# How to obtain `sha256`:
+# nix-prefetch-url --unpack https://github.com/erlang/otp/archive/OTP-${version}.tar.gz
+mkDerivation {
+  version = "23.0.2";
+  sha256 = "19ly2m0rjay6071r75s9870cm3sph25zd1mvy67l5v4jg7mxdjzy";
+
+  prePatch = ''
+    substituteInPlace make/configure.in --replace '`sw_vers -productVersion`' "''${MACOSX_DEPLOYMENT_TARGET:-10.12}"
+    substituteInPlace erts/configure.in --replace '-Wl,-no_weak_imports' ""
+  '';
+}

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -3,6 +3,7 @@
 , openjdk ? null # javacSupport
 , unixODBC ? null # odbcSupport
 , libGL ? null, libGLU ? null, wxGTK ? null, wxmac ? null, xorg ? null # wxSupport
+, parallelBuild ? false
 , withSystemd ? stdenv.isLinux, systemd # systemd support in epmd
 }:
 
@@ -60,7 +61,7 @@ in stdenv.mkDerivation ({
   debugInfo = enableDebugInfo;
 
   # On some machines, parallel build reliably crashes on `GEN    asn1ct_eval_ext.erl` step
-  enableParallelBuilding = false;
+  enableParallelBuilding = parallelBuild;
 
   # Clang 4 (rightfully) thinks signed comparisons of pointers with NULL are nonsense
   prePatch = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9465,7 +9465,7 @@ in
   beam = callPackage ./beam-packages.nix { };
 
   inherit (beam.interpreters)
-    erlang erlangR18 erlangR19 erlangR20 erlangR21 erlangR22
+    erlang erlangR23 erlangR22 erlangR21 erlangR20 erlangR19 erlangR18
     erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
     elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6;
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -13,17 +13,57 @@ rec {
     erlang_odbc_javac = erlangR22_odbc_javac;
     erlang_nox = erlangR22_nox;
 
-    # These are standard Erlang versions, using the generic builder.
-    erlangR18 = lib.callErlang ../development/interpreters/erlang/R18.nix {
+    # Standard Erlang versions, using the generic builder.
+
+    # R23
+    erlangR23 = lib.callErlang ../development/interpreters/erlang/R23.nix {
       wxGTK = wxGTK30;
-      openssl = openssl_1_0_2;
+      # Can be enabled since the bug has been fixed in https://github.com/erlang/otp/pull/2508
+      parallelBuild = true;
     };
-    erlangR18_odbc = erlangR18.override { odbcSupport = true; };
-    erlangR18_javac = erlangR18.override { javacSupport = true; };
-    erlangR18_odbc_javac = erlangR18.override {
+    erlangR23_odbc = erlangR23.override { odbcSupport = true; };
+    erlangR23_javac = erlangR23.override { javacSupport = true; };
+    erlangR23_odbc_javac = erlangR23.override {
       javacSupport = true; odbcSupport = true;
     };
-    erlangR18_nox = erlangR18.override { wxSupport = false; };
+    erlangR23_nox = erlangR23.override { wxSupport = false; };
+
+    # R22
+    erlangR22 = lib.callErlang ../development/interpreters/erlang/R22.nix {
+      wxGTK = wxGTK30;
+      # Can be enabled since the bug has been fixed in https://github.com/erlang/otp/pull/2508
+      parallelBuild = true;
+    };
+    erlangR22_odbc = erlangR22.override { odbcSupport = true; };
+    erlangR22_javac = erlangR22.override { javacSupport = true; };
+    erlangR22_odbc_javac = erlangR22.override {
+      javacSupport = true; odbcSupport = true;
+    };
+    erlangR22_nox = erlangR22.override { wxSupport = false; };
+
+    # R21
+    erlangR21 = lib.callErlang ../development/interpreters/erlang/R21.nix {
+      wxGTK = wxGTK30;
+    };
+    erlangR21_odbc = erlangR21.override { odbcSupport = true; };
+    erlangR21_javac = erlangR21.override { javacSupport = true; };
+    erlangR21_odbc_javac = erlangR21.override {
+      javacSupport = true; odbcSupport = true;
+    };
+    erlangR21_nox = erlangR21.override { wxSupport = false; };
+
+    # R20
+    erlangR20 = lib.callErlang ../development/interpreters/erlang/R20.nix {
+      wxGTK = wxGTK30;
+    };
+    erlangR20_odbc = erlangR20.override { odbcSupport = true; };
+    erlangR20_javac = erlangR20.override { javacSupport = true; };
+    erlangR20_odbc_javac = erlangR20.override {
+      javacSupport = true; odbcSupport = true;
+    };
+    erlangR20_nox = erlangR20.override { wxSupport = false; };
+
+    # R19
     erlangR19 = lib.callErlang ../development/interpreters/erlang/R19.nix {
       wxGTK = wxGTK30;
       openssl = openssl_1_0_2;
@@ -34,33 +74,18 @@ rec {
       javacSupport = true; odbcSupport = true;
     };
     erlangR19_nox = erlangR19.override { wxSupport = false; };
-    erlangR20 = lib.callErlang ../development/interpreters/erlang/R20.nix {
+
+    # R18
+    erlangR18 = lib.callErlang ../development/interpreters/erlang/R18.nix {
       wxGTK = wxGTK30;
+      openssl = openssl_1_0_2;
     };
-    erlangR20_odbc = erlangR20.override { odbcSupport = true; };
-    erlangR20_javac = erlangR20.override { javacSupport = true; };
-    erlangR20_odbc_javac = erlangR20.override {
+    erlangR18_odbc = erlangR18.override { odbcSupport = true; };
+    erlangR18_javac = erlangR18.override { javacSupport = true; };
+    erlangR18_odbc_javac = erlangR18.override {
       javacSupport = true; odbcSupport = true;
     };
-    erlangR20_nox = erlangR20.override { wxSupport = false; };
-    erlangR21 = lib.callErlang ../development/interpreters/erlang/R21.nix {
-      wxGTK = wxGTK30;
-    };
-    erlangR21_odbc = erlangR21.override { odbcSupport = true; };
-    erlangR21_javac = erlangR21.override { javacSupport = true; };
-    erlangR21_odbc_javac = erlangR21.override {
-      javacSupport = true; odbcSupport = true;
-    };
-    erlangR21_nox = erlangR21.override { wxSupport = false; };
-    erlangR22 = lib.callErlang ../development/interpreters/erlang/R22.nix {
-      wxGTK = wxGTK30;
-    };
-    erlangR22_odbc = erlangR22.override { odbcSupport = true; };
-    erlangR22_javac = erlangR22.override { javacSupport = true; };
-    erlangR22_odbc_javac = erlangR22.override {
-      javacSupport = true; odbcSupport = true;
-    };
-    erlangR22_nox = erlangR22.override { wxSupport = false; };
+    erlangR18_nox = erlangR18.override { wxSupport = false; };
 
     # Basho fork, using custom builder.
     erlang_basho_R16B02 = lib.callErlang ../development/interpreters/erlang/R16B02-basho.nix {
@@ -85,10 +110,12 @@ rec {
   packages = {
     # Packages built with default Erlang version.
     erlang = packagesWith interpreters.erlang;
-    erlangR18 = packagesWith interpreters.erlangR18;
-    erlangR19 = packagesWith interpreters.erlangR19;
-    erlangR20 = packagesWith interpreters.erlangR20;
-    erlangR21 = packagesWith interpreters.erlangR21;
+
+    erlangR23 = packagesWith interpreters.erlangR23;
     erlangR22 = packagesWith interpreters.erlangR22;
+    erlangR21 = packagesWith interpreters.erlangR21;
+    erlangR20 = packagesWith interpreters.erlangR20;
+    erlangR19 = packagesWith interpreters.erlangR19;
+    erlangR18 = packagesWith interpreters.erlangR18;
   };
 }


### PR DESCRIPTION
Additionally changed default erlang 22.3 -> 23.0.3.
& reordered the available versions (in preparation to fade out some older ones later).

###### Motivation for this change

- [OTP 23 Release](https://github.com/erlang/otp/releases/tag/OTP-23.0)
- [OTP 23.0.2 Release](https://github.com/erlang/otp/releases/tag/OTP-23.0.2)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
