### PR TITLE
podman, etc packages: fix/update inputs/tags

### DIFF
--- a/pkgs/applications/virtualization/cri-o/default.nix
+++ b/pkgs/applications/virtualization/cri-o/default.nix
@@ -6,8 +6,6 @@
 , gpgme
 , installShellFiles
 , libapparmor
-, libassuan
-, libgpgerror
 , libseccomp
 , libselinux
 , lvm2
@@ -32,15 +30,15 @@ buildGoModule rec {
     btrfs-progs
     gpgme
     libapparmor
-    libassuan
-    libgpgerror
     libseccomp
     libselinux
     lvm2
   ] ++ stdenv.lib.optionals (glibc != null) [ glibc glibc.static ];
 
-  BUILDTAGS = "apparmor seccomp selinux containers_image_ostree_stub";
+  BUILDTAGS = "apparmor seccomp selinux containers_image_openpgp containers_image_ostree_stub";
   buildPhase = ''
+    patchShebangs .
+
     sed -i '/version.buildDate/d' Makefile
 
     make binaries docs BUILDTAGS="$BUILDTAGS"

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -6,7 +6,9 @@
 , gpgme
 , lvm2
 , btrfs-progs
+, libapparmor
 , libseccomp
+, libselinux
 , systemd
 , go-md2man
 , nixosTests
@@ -29,7 +31,15 @@ buildGoModule rec {
 
   nativeBuildInputs = [ pkg-config go-md2man installShellFiles ];
 
-  buildInputs = stdenv.lib.optionals stdenv.isLinux [ btrfs-progs libseccomp gpgme lvm2 systemd ];
+  buildInputs = stdenv.lib.optionals stdenv.isLinux [
+    btrfs-progs
+    gpgme
+    libapparmor
+    libseccomp
+    libselinux
+    lvm2
+    systemd
+  ];
 
   buildPhase = ''
     patchShebangs .

--- a/pkgs/applications/virtualization/runc/default.nix
+++ b/pkgs/applications/virtualization/runc/default.nix
@@ -8,6 +8,7 @@
 , libapparmor
 , apparmor-parser
 , libseccomp
+, libselinux
 }:
 
 buildGoPackage rec {
@@ -25,9 +26,11 @@ buildGoPackage rec {
   outputs = [ "out" "man" ];
 
   nativeBuildInputs = [ go-md2man installShellFiles pkg-config which ];
-  buildInputs = [ libseccomp libapparmor apparmor-parser ];
 
-  makeFlags = [ "BUILDTAGS+=seccomp" "BUILDTAGS+=apparmor" ];
+  buildInputs = [ libselinux libseccomp libapparmor apparmor-parser ];
+
+  # these will be the default in the next release
+  makeFlags = [ "BUILDTAGS+=seccomp" "BUILDTAGS+=apparmor" "BUILDTAGS+=selinux" ];
 
   buildPhase = ''
     cd go/src/${goPackagePath}

--- a/pkgs/development/tools/buildah/default.nix
+++ b/pkgs/development/tools/buildah/default.nix
@@ -4,9 +4,9 @@
 , installShellFiles
 , pkg-config
 , gpgme
-, libgpgerror
 , lvm2
 , btrfs-progs
+, libapparmor
 , libselinux
 , libseccomp
 }:
@@ -27,9 +27,18 @@ buildGoModule rec {
   vendorSha256 = null;
 
   nativeBuildInputs = [ installShellFiles pkg-config ];
-  buildInputs = [ gpgme libgpgerror lvm2 btrfs-progs libselinux libseccomp ];
+
+  buildInputs = [
+    btrfs-progs
+    gpgme
+    libapparmor
+    libseccomp
+    libselinux
+    lvm2
+  ];
 
   buildPhase = ''
+    patchShebangs .
     make GIT_COMMIT="unknown"
     make -C docs
   '';

--- a/pkgs/development/tools/skopeo/default.nix
+++ b/pkgs/development/tools/skopeo/default.nix
@@ -3,11 +3,9 @@
 , fetchFromGitHub
 , runCommand
 , gpgme
-, libgpgerror
 , lvm2
 , btrfs-progs
 , pkg-config
-, libselinux
 , go-md2man
 , installShellFiles
 , makeWrapper
@@ -41,8 +39,9 @@ buildGoModule {
   excludedPackages = [ "integration" ];
 
   nativeBuildInputs = [ pkg-config go-md2man installShellFiles makeWrapper ];
+
   buildInputs = [ gpgme ]
-  ++ stdenv.lib.optionals stdenv.isLinux [ libgpgerror lvm2 btrfs-progs libselinux ];
+  ++ stdenv.lib.optionals stdenv.isLinux [ lvm2 btrfs-progs ];
 
   buildFlagsArray = ''
     -ldflags=


### PR DESCRIPTION
~~Draft as I want to go over this again before it gets merged.~~

This adds/fixes/updates inputs and (inferred) build tags.

`libassuan` and `libgpgerror` are propagated by `gpgme`.

Add `libapparmor` and `libselinux` to most things.

Since `ostree` has been removed from `skopeo`, `libselinux` can be removed.
