### PR TITLE
backport: visidata is supported on darwin + add setuptools

### DIFF
--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -1,5 +1,16 @@
-{ buildPythonApplication, lib, fetchFromGitHub
-, dateutil, pyyaml, openpyxl, xlrd, h5py, fonttools, lxml, pandas, pyshp
+{ buildPythonApplication
+, lib
+, fetchFromGitHub
+, dateutil
+, pyyaml
+, openpyxl
+, xlrd
+, h5py
+, fonttools
+, lxml
+, pandas
+, pyshp
+, setuptools
 }:
 buildPythonApplication rec {
   pname = "visidata";
@@ -12,16 +23,26 @@ buildPythonApplication rec {
     sha256 = "19gs8i6chrrwibz706gib5sixx1cjgfzh7v011kp3izcrn524mc0";
   };
 
-  propagatedBuildInputs = [dateutil pyyaml openpyxl xlrd h5py fonttools
-    lxml pandas pyshp ];
+  propagatedBuildInputs = [
+    dateutil
+    pyyaml
+    openpyxl
+    xlrd
+    h5py
+    fonttools
+    lxml
+    pandas
+    pyshp
+    setuptools
+  ];
 
   doCheck = false;
 
   meta = {
     inherit version;
     description = "Interactive terminal multitool for tabular data";
-    license = lib.licenses.gpl3 ;
-    maintainers = [lib.maintainers.raskin];
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;
     homepage = "http://visidata.org/";
   };

--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -43,7 +43,7 @@ buildPythonApplication rec {
     description = "Interactive terminal multitool for tabular data";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.raskin ];
-    platforms = lib.platforms.linux;
+    platforms = with lib.platforms; linux ++ darwin;
     homepage = "http://visidata.org/";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Use visidata on darwin. This brings the 20.03 branch up to date with master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
