### PR TITLE
chrome-gnome-shell: Fix missing introspection data

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
@@ -6,6 +6,7 @@
 , python3
 , gnome3
 , wrapGAppsHook
+, gobject-introspection
 }:
 
 let
@@ -25,6 +26,7 @@ stdenv.mkDerivation rec {
     ninja
     jq
     wrapGAppsHook
+    gobject-introspection # for setup-hook
   ];
 
   buildInputs = [
@@ -32,6 +34,7 @@ stdenv.mkDerivation rec {
     python
     pygobject3
     requests
+    gobject-introspection # for Gio typelib
   ];
 
   cmakeFlags = [

--- a/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
@@ -1,29 +1,53 @@
-{stdenv, fetchurl, cmake, ninja, jq, python3, gnome3, wrapGAppsHook}:
+{ stdenv
+, fetchurl
+, cmake
+, ninja
+, jq
+, python3
+, gnome3
+, wrapGAppsHook
+}:
 
 let
-  version = "10.1";
-
   inherit (python3.pkgs) python pygobject3 requests;
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "chrome-gnome-shell";
-  inherit version;
+  version = "10.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/chrome-gnome-shell/${version}/${pname}-${version}.tar.xz";
     sha256 = "0f54xyamm383ypbh0ndkza0pif6ljddg2f947p265fkqj3p4zban";
   };
 
-  nativeBuildInputs = [ cmake ninja jq wrapGAppsHook ];
-  buildInputs = [ gnome3.gnome-shell python pygobject3 requests ];
+  nativeBuildInputs = [
+    cmake
+    ninja
+    jq
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gnome3.gnome-shell
+    python
+    pygobject3
+    requests
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_EXTENSION=OFF"
+  ];
+
+  wrapPrefixVariables = [
+    "PYTHONPATH"
+  ];
+
+  # cmake setup hook changes /etc/opt into /var/empty
+  dontFixCmake = true;
 
   preConfigure = ''
     substituteInPlace CMakeLists.txt --replace "/etc" "$out/etc"
   '';
-  # cmake setup hook changes /etc/opt into /var/empty
-  dontFixCmake = true;
-
-  cmakeFlags = [ "-DBUILD_EXTENSION=OFF" ];
-  wrapPrefixVariables = [ "PYTHONPATH" ];
 
   passthru = {
     updateScript = gnome3.updateScript {


### PR DESCRIPTION
###### Motivation for this change
It was crashing with:

    TypeError: gobject `__main__+ChromeGNOMEShell' doesn't support property `application_id'

– that is the constructor of parent class Gio.Application does not recognize the kwarg.

This is typically caused by missing pygobject overrides but I think ones for Gio are built-in into pygobject.

Even weirder, adding just `${gobject-introspection}/lib/girepository-1.0` seems to fix the issue so it might be missing the whole typelib.
But then why does not it fail when importing it?

    from gi.repository import GLib, Gio

For now, I am adding the Gio typelib which should been done from the start but more debugging should be done since weirdness like this can bring more bugs.

Fixes: https://github.com/NixOS/nixpkgs/issues/87740

cc @worldofpeace @glasserc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
