### PR TITLE
kubernetes: 1.17.3 -> 1.17.5

### DIFF
--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -15,13 +15,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "kubernetes";
-  version = "1.17.3";
+  version = "1.17.5";
 
   src = fetchFromGitHub {
     owner = "kubernetes";
     repo = "kubernetes";
     rev = "v${version}";
-    sha256 = "0caqczz8hrwqb8j94158hz6919i7c9v1v0zknh9m2zbbng4b1awi";
+    sha256 = "0jnfk0p5w5xcj6i0q8xs1yzz8vvrcffymw63w033bjcdmr4sa269";
   };
 
   buildInputs = [ removeReferencesTo makeWrapper which go rsync go-bindata ];


### PR DESCRIPTION

###### Motivation for this change
Bump kubernetes.

Tests pass locally:
```
$ nix-build -I nixpkgs=. ./nixos/release.nix -A tests.kubernetes.rbac.multinode -A tests.kubernetes.rbac.singlenode -A tests.kubernetes.dns.singlenode -A tests.kubernetes.dns.multinode

/nix/store/xsf1l7227b2f62y17xzrg98lg03g9waa-vm-test-run-kubernetes-rbac-multinode
/nix/store/xjhm33s53b4fmz36p8lq1yi0fngm59wc-vm-test-run-kubernetes-rbac-singlenode
/nix/store/65jjnc445m31ji50v3mhfdlf81v6bdcm-vm-test-run-kubernetes-dns-singlenode
/nix/store/sd98cx1crijr57la8kgqfjz1ffkkzbv4-vm-test-run-kubernetes-dns-multinode
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
