### PR TITLE
Ubertooth package and module

### DIFF
--- a/nixos/modules/hardware/ubertooth.nix
+++ b/nixos/modules/hardware/ubertooth.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.ubertooth;
+
+  ubertoothPkg = pkgs.ubertooth.override {
+    udevGroup = cfg.group;
+  };
+in {
+  options.hardware.ubertooth = {
+    enable = mkEnableOption "Enable the Ubertooth software and its udev rules.";
+
+    group = mkOption {
+      type = types.str;
+      default = "ubertooth";
+      example = "wheel";
+      description = "Group for Ubertooth's udev rules.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ ubertoothPkg ];
+
+    services.udev.packages = [ ubertoothPkg ];
+    users.groups.${cfg.group} = {};
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -64,6 +64,7 @@
   ./hardware/steam-hardware.nix
   ./hardware/system-76.nix
   ./hardware/tuxedo-keyboard.nix
+  ./hardware/ubertooth.nix
   ./hardware/usb-wwan.nix
   ./hardware/onlykey.nix
   ./hardware/opentabletdriver.nix

--- a/pkgs/applications/radio/ubertooth/default.nix
+++ b/pkgs/applications/radio/ubertooth/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig, libbtbb, libpcap , libusb1, bluez }:
+{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig, libbtbb, libpcap , libusb1, bluez
+, udevGroup ? "ubertooth"
+}:
 
 stdenv.mkDerivation rec {
   pname = "ubertooth";
@@ -19,7 +21,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = lib.optionals stdenv.isLinux [
     "-DINSTALL_UDEV_RULES=TRUE"
     "-DUDEV_RULES_PATH=etc/udev/rules.d"
-    "-DUDEV_RULES_GROUP=ubertooth"
+    "-DUDEV_RULES_GROUP=${udevGroup}"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/radio/ubertooth/default.nix
+++ b/pkgs/applications/radio/ubertooth/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig, libbtbb, libpcap , libusb1, bluez }:
+
+stdenv.mkDerivation rec {
+  pname = "ubertooth";
+  version = "2018-12-R1";
+
+  src = fetchFromGitHub {
+    owner = "greatscottgadgets";
+    repo = pname;
+    rev = version;
+    sha256 = "1da5fsjwc5szclq6h5wznvgwikd1qqv8gbmv38h0fpc12lwn85c4";
+  };
+
+  sourceRoot = "source/host";
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ libbtbb libpcap libusb1 bluez ];
+
+  cmakeFlags = lib.optionals stdenv.isLinux [
+    "-DINSTALL_UDEV_RULES=TRUE"
+    "-DUDEV_RULES_PATH=etc/udev/rules.d"
+    "-DUDEV_RULES_GROUP=ubertooth"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Open source wireless development platform suitable for Bluetooth experimentation";
+    homepage = "https://github.com/greatscottgadgets/ubertooth";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ oxzi ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/radio/ubertooth/default.nix
+++ b/pkgs/applications/radio/ubertooth/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ubertooth";
-  version = "2018-12-R1";
+  version = "2020-12-R1";
 
   src = fetchFromGitHub {
     owner = "greatscottgadgets";
     repo = pname;
     rev = version;
-    sha256 = "1da5fsjwc5szclq6h5wznvgwikd1qqv8gbmv38h0fpc12lwn85c4";
+    sha256 = "11r5ag2l5xn4pr7ycicm30w9c3ldn9yiqj1sqnjc79csxl2vrcfw";
   };
 
   sourceRoot = "source/host";

--- a/pkgs/development/libraries/libbtbb/default.nix
+++ b/pkgs/development/libraries/libbtbb/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "libbtbb";
+  version = "2018-12-R1";
+
+  src = fetchFromGitHub {
+    owner = "greatscottgadgets";
+    repo = pname;
+    rev = version;
+    sha256 = "07g7yapnbfgm7by8i2ppvx8s66jzha61d1bvm064jb2yi1734ppr";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Bluetooth baseband decoding library";
+    homepage = "https://github.com/greatscottgadgets/libbtbb";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ oxzi ];
+  };
+}

--- a/pkgs/development/libraries/libbtbb/default.nix
+++ b/pkgs/development/libraries/libbtbb/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libbtbb";
-  version = "2018-12-R1";
+  version = "2020-12-R1";
 
   src = fetchFromGitHub {
     owner = "greatscottgadgets";
     repo = pname;
     rev = version;
-    sha256 = "07g7yapnbfgm7by8i2ppvx8s66jzha61d1bvm064jb2yi1734ppr";
+    sha256 = "1byv8174xam7siakr1p0523x97wkh0fmwmq341sd3g70qr2g767d";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8092,6 +8092,8 @@ in
 
   ubridge = callPackage ../tools/networking/ubridge { };
 
+  ubertooth = callPackage ../applications/radio/ubertooth { };
+
   ucl = callPackage ../development/libraries/ucl { };
 
   ucspi-tcp = callPackage ../tools/networking/ucspi-tcp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4036,6 +4036,8 @@ in
 
   libbladeRF = callPackage ../development/libraries/libbladeRF { };
 
+  libbtbb = callPackage ../development/libraries/libbtbb { };
+
   lp_solve = callPackage ../applications/science/math/lp_solve { };
 
   lprof = callPackage ../tools/graphics/lprof { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add the host driver for an [Ubertooth](https://github.com/greatscottgadgets/ubertooth) as a package and a module. Therefore, the required [`libbtbb`](https://github.com/greatscottgadgets/libbtbb) is added first.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
