### PR TITLE
xwallpaper: init at 0.6.5

### DIFF
--- a/pkgs/tools/X11/xwallpaper/default.nix
+++ b/pkgs/tools/X11/xwallpaper/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, pkg-config, autoreconfHook, pixman, xcbutil, xcbutilimage
+, libseccomp, libjpeg, libpng, libXpm }:
+
+stdenv.mkDerivation rec {
+  pname = "xwallpaper";
+  version = "0.6.5";
+
+  src = fetchFromGitHub {
+    owner = "stoeckmann";
+    repo = "xwallpaper";
+    rev = "v${version}";
+    sha256 = "121ai4dc0v65qk12gn9w62ixly8hc8a5qrygkbb82vy8ck4jqxj7";
+  };
+
+  preConfigure = "./autogen.sh";
+
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+  buildInputs = [ pixman xcbutilimage xcbutil libseccomp libjpeg libpng libXpm ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/stoeckmann/xwallpaper";
+    description = "Utility for setting wallpapers in X";
+    license = licenses.isc;
+    maintainers = with maintainers; [ ivar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7456,6 +7456,8 @@ in
 
   xcruiser = callPackage ../applications/misc/xcruiser { };
 
+  xwallpaper = callPackage ../tools/X11/xwallpaper { };
+
   xxkb = callPackage ../applications/misc/xxkb { };
 
   ugarit = callPackage ../tools/backup/ugarit {


### PR DESCRIPTION
###### Motivation for this change
Adds [xwallpaper](https://github.com/stoeckmann/xwallpaper), a minimalist wallpaper changing tool for X.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
