### PR TITLE
dpkg: 1.20.0 -> 1.20.5

### DIFF
--- a/pkgs/tools/package-management/dpkg/default.nix
+++ b/pkgs/tools/package-management/dpkg/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "dpkg";
-  version = "1.20.0";
+  version = "1.20.5";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/d/dpkg/dpkg_${version}.tar.xz";
-    sha256 = "0009dp4p3d2j5vd956achqczf8qizfixha8hw5hzn3h31qmwqcxn";
+    sha256 = "1pg0yd1q9l5cx7pr0853yds1n3mh5b28zkw79gjqjzcmjwqkzwpj";
   };
 
   configureFlags = [
@@ -69,6 +69,6 @@ stdenv.mkDerivation rec {
     homepage = "https://wiki.debian.org/Teams/Dpkg";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ siriobalmelli ];
   };
 }


### PR DESCRIPTION
This patch has also been submitted to
https://lists.debian.org/debian-dpkg/2020/05/threads.html
and is hopefully picked up upstream,
so it can be removed from here in future.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

###### Motivation for this change

dpkg build was failing on Darwin, starting with:

```
i18n.c:27:8: error: unknown type name 'locale_t'
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ / ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` ... some Debian package failures because of `/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation: file system sandbox blocked stat()` on macOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [N/A] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [N/A] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
