### PR TITLE
enlightenment.efl: 1.24.0 -> 1.24.1

### DIFF
--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -142,6 +142,7 @@ stdenv.mkDerivation rec {
     "-D ecore-imf-loaders-disabler=ibus,scim" # ibus is disalbed by default, scim is not availabe in nixpkgs
     "-D embedded-lz4=false"
     "-D fb=true"
+    "-D network-backend=connman"
     "-D sdl=true"
   ];
 

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -55,11 +55,11 @@
 
 stdenv.mkDerivation rec {
   pname = "efl";
-  version = "1.24.0";
+  version = "1.24.1";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "1yhck2g4rwlzgnzqa4wjxw3lf6k6rd730hz4bwzajdjy7i26xfdk";
+    sha256 = "1xsbz5kl74cgzyzwmjy3p50m0iigvi53lklkp92v49k4j99zpak7";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -129,13 +129,10 @@ stdenv.mkDerivation rec {
     xorg.libXfixes
     xorg.libXi
     xorg.libXinerama
-    xorg.libXp
     xorg.libXrandr
     xorg.libXrender
     xorg.libXtst
     xorg.libxcb
-    xorg.libxkbfile
-    xorg.xcbutilkeysyms
   ];
 
   dontDropIconThemeCache = true;

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -121,7 +121,6 @@ stdenv.mkDerivation rec {
     luajit
     openjpeg
     poppler
-    python3Packages.dbus-python
     utillinux
     xorg.libXScrnSaver
     xorg.libXcomposite

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -3,7 +3,6 @@
 , meson
 , ninja
 , pkgconfig
-, SDL
 , SDL2
 , alsaLib
 , avahi
@@ -71,7 +70,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    SDL
     avahi
     fontconfig
     freetype

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -147,7 +147,6 @@ stdenv.mkDerivation rec {
     "-D ecore-imf-loaders-disabler=ibus,scim" # ibus is disalbed by default, scim is not availabe in nixpkgs
     "-D embedded-lz4=false"
     "-D fb=true"
-    "-D opengl=full"
     "-D sdl=true"
   ];
 

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -5,7 +5,6 @@
 , pkgconfig
 , SDL2
 , alsaLib
-, avahi
 , bullet
 , check
 , curl
@@ -70,7 +69,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    avahi
     fontconfig
     freetype
     giflib

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -144,9 +144,8 @@ stdenv.mkDerivation rec {
     "--buildtype=release"
     "-D build-tests=false" # disable build tests, which are not working
     "-D drm=true"
-    "-D embedded-lz4=false"
     "-D ecore-imf-loaders-disabler=ibus,scim" # ibus is disalbed by default, scim is not availabe in nixpkgs
-    "-D evas-loaders-disabler=json"
+    "-D embedded-lz4=false"
     "-D fb=true"
     "-D opengl=full"
     "-D sdl=true"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [1.24.1](https://www.enlightenment.org/news/efl-1.24.1).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).