### PR TITLE
go: stop setting GOPATH

### DIFF
--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -229,8 +229,6 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  setupHook = ./setup-hook.sh;
-
   disallowedReferences = [ goBootstrap ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/compilers/go/1.4.nix
+++ b/pkgs/development/compilers/go/1.4.nix
@@ -151,8 +151,6 @@ stdenv.mkDerivation rec {
     ./all.bash
   '';
 
-  setupHook = ./setup-hook.sh;
-
   meta = with stdenv.lib; {
     branch = "1.4";
     homepage = "http://golang.org/";

--- a/pkgs/development/compilers/go/setup-hook.sh
+++ b/pkgs/development/compilers/go/setup-hook.sh
@@ -1,5 +1,0 @@
-addToGoPath() {
-    addToSearchPath GOPATH $1/share/go
-}
-
-addEnvHooks "$targetOffset" addToGoPath


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The compiler does not need it anymore, has not needed it for many years
iirc. This just goes in and pollutes the environment overriding the users
GOPATH and causing grief.

Go even warns about it itself, without vs with this commit:

```sh
~> go env GOPATH
/home/manny/go
~> nix-shell -p go
~> go env GOPATH
warning: GOPATH set to GOROOT (/nix/store/gvw1mfpdrk7i82884yhxf9lf5j3c12zm-go-1.14.1/share/go) has no effect
/nix/store/gvw1mfpdrk7i82884yhxf9lf5j3c12zm-go-1.14.1/share/go
~> exit
~> nix-shell -I nixpkgs=cloned/NixOS/nixpkgs -p go
~> go env GOPATH
/home/manny/go
~> exit
```

https://discourse.nixos.org/t/what-do-you-do-with-gopath/7113

###### Things done

Removed setup-hook.sh which was only being used to add GOPATH to the env.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @cstrahan @orivej @Mic92 @rvolosatovs @kalbasit @Frostman 
