### PR TITLE
freeimage: mark as broken on aarch64

### DIFF
--- a/pkgs/development/libraries/freeimage/default.nix
+++ b/pkgs/development/libraries/freeimage/default.nix
@@ -1,5 +1,8 @@
 { lib, stdenv, fetchurl, unzip, darwin }:
 
+# TODO: consider unvendoring various dependencies (libpng, libjpeg,
+# libwebp, zlib, ...)
+
 stdenv.mkDerivation {
   name = "freeimage-3.18.0";
 
@@ -50,5 +53,7 @@ stdenv.mkDerivation {
     license = "GPL";
     maintainers = with lib.maintainers; [viric];
     platforms = with lib.platforms; unix;
+    # see https://github.com/NixOS/nixpkgs/issues/77653
+    broken = stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Prevent ofborg/hydra from trying to build things that depend on freeimage until #77653 is fixed, and add a comment to consider unvendoring these dependencies since they'll probably cause a lot of issues like this in the future.

This came up while reviewing #86694.

cc @colemickens @viric

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).