### PR TITLE
ocamlPackages.jingoo: 1.2.18 → 1.3.4

### DIFF
--- a/pkgs/development/ocaml-modules/jingoo/default.nix
+++ b/pkgs/development/ocaml-modules/jingoo/default.nix
@@ -1,26 +1,26 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, pcre, uutf }:
+{ lib, buildDunePackage, fetchFromGitHub
+, menhir, ppx_deriving, re, uutf, uucp, ounit2 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "jingoo is not available for OCaml ${ocaml.version}"
-else
+buildDunePackage rec {
+  pname = "jingoo";
+  version = "1.3.4";
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-jingoo-${version}";
-  version = "1.2.18";
+  minimumOCamlVersion = "4.04";
 
   src = fetchFromGitHub {
     owner = "tategakibunko";
     repo = "jingoo";
     rev = "v${version}";
-    sha256 = "0gciiysrjy5r4yiisc41k4h0p530yawzqnr364xg8fdkk444fgkn";
+    sha256 = "0fsmm6wxa3axwbcgwdidik3drg754wyh2vxri2w12d662221m98s";
   };
 
-  buildInputs = [ ocaml findlib ];
-  propagatedBuildInputs = [ pcre uutf ];
+  buildInputs = [ menhir ];
+  propagatedBuildInputs = [ ppx_deriving re uutf uucp ];
+  checkInputs = [ ounit2 ];
+  doCheck = true;
 
-  createFindlibDestdir = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/tategakibunko/jingoo";
     description = "OCaml template engine almost compatible with jinja2";
     license = licenses.mit;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -393,9 +393,7 @@ let
 
     irmin-watcher = callPackage ../development/ocaml-modules/irmin-watcher { };
 
-    jingoo = callPackage ../development/ocaml-modules/jingoo {
-      pcre = ocaml_pcre;
-    };
+    jingoo = callPackage ../development/ocaml-modules/jingoo { };
 
     js_of_ocaml =
     if lib.versionOlder "4.02" ocaml.version


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update package, switch to dune build system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Also tested own project that depends on jingoo.