### PR TITLE
sensu-go: 5.18.1 -> 5.20.0

### DIFF
--- a/pkgs/servers/monitoring/sensu-go/default.nix
+++ b/pkgs/servers/monitoring/sensu-go/default.nix
@@ -4,8 +4,8 @@ let
   generic = { subPackages, pname, postInstall ? "" }:
     buildGoModule rec {
       inherit pname;
-      version = "5.18.1";
-      shortRev = "1f6d16b"; # for internal version info
+      version = "5.20.0";
+      shortRev = "3a1ac58"; # for internal version info
 
       goPackagePath = "github.com/sensu/sensu-go";
 
@@ -13,7 +13,7 @@ let
         owner = "sensu";
         repo = "sensu-go";
         rev = "v${version}";
-        sha256 = "1iwlkm7ac7brap45r6ly0blywgq6f28r1nws3yf0ybydv30brfj4";
+        sha256 = "0hnsgd6ryrl1y2prkavm7psqjnppkkfd891xkzbdfzblxsafs8cw";
       };
 
       inherit subPackages postInstall;


### PR DESCRIPTION
###### Motivation for this change

Package update

The modSha256 is unchanged. I verified that the `go.mod` did not change any dependency versions between the old and new package versions.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
