### PR TITLE
krop: move libsForQt5.poppler out of propagatedBuildInputs

### DIFF
--- a/pkgs/applications/graphics/krop/default.nix
+++ b/pkgs/applications/graphics/krop/default.nix
@@ -15,8 +15,10 @@ python3Packages.buildPythonApplication rec {
     pyqt5
     pypdf2
     poppler-qt5
-    libsForQt5.poppler
     ghostscript
+  ];
+  buildInputs = [
+    libsForQt5.poppler
   ];
 
   nativeBuildInputs = [ qt5.wrapQtAppsHook ];


### PR DESCRIPTION
#### Motivation for this change 

I noticed `qtbase.dev` is in my closure after garbage collection. The referrer was `krop` and it is because `${qtbase.dev}/bin/` was in the `PATH` of the wrapper. The solution is trivial - move `libsForQt5.poppler` out of `propagatedBuildInputs` and put it in `buildInputs`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
