### PR TITLE
nixos/podman: libpod.conf -> containers.conf

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -34,6 +34,25 @@ in
         '';
       };
 
+    containersConf = mkOption {
+      default = {};
+      description = "containers.conf configuration";
+      type = types.submodule {
+        options = {
+
+          extraConfig = mkOption {
+            type = types.lines;
+            default = "";
+            description = ''
+              Extra configuration that should be put in the containers.conf
+              configuration file
+            '';
+
+          };
+        };
+      };
+    };
+
     registries = {
       search = mkOption {
         type = types.listOf types.str;
@@ -92,6 +111,12 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+
+    environment.etc."containers/containers.conf".text = ''
+      [network]
+      cni_plugin_dirs = ["${pkgs.cni-plugins}/bin/"]
+
+    '' + cfg.containersConf.extraConfig;
 
     environment.etc."containers/registries.conf".source = toTOML "registries.conf" {
       registries = lib.mapAttrs (n: v: { registries = v; }) cfg.registries;

--- a/nixos/modules/virtualisation/podman.nix
+++ b/nixos/modules/virtualisation/podman.nix
@@ -28,6 +28,10 @@ let
 
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule [ "virtualisation" "podman" "libpod" ] [ "virtualisation" "containers" "containersConf" ])
+  ];
+
   meta = {
     maintainers = lib.teams.podman.members;
   };
@@ -67,25 +71,6 @@ in
       '';
     };
 
-    libpod = mkOption {
-      default = {};
-      description = "Libpod configuration";
-      type = types.submodule {
-        options = {
-
-          extraConfig = mkOption {
-            type = types.lines;
-            default = "";
-            description = ''
-              Extra configuration that should be put in the libpod.conf
-              configuration file
-            '';
-
-          };
-        };
-      };
-    };
-
     package = lib.mkOption {
       type = types.package;
       default = podmanPackage;
@@ -102,11 +87,6 @@ in
 
     environment.systemPackages = [ cfg.package ]
       ++ lib.optional cfg.dockerCompat dockerCompat;
-
-    environment.etc."containers/libpod.conf".text = ''
-      cni_plugin_dir = ["${pkgs.cni-plugins}/bin/"]
-
-    '' + cfg.libpod.extraConfig;
 
     environment.etc."cni/net.d/87-podman-bridge.conflist".source = copyFile "${pkgs.podman-unwrapped.src}/cni/87-podman-bridge.conflist";
 


### PR DESCRIPTION
> https://github.com/containers/libpod/releases/tag/v1.9.0
> Initial support for the new `containers.conf` configuration file has been added. `containers.conf` allows for much more detailed configuration of some Podman functionality

> https://github.com/containers/libpod/releases/tag/v1.9.2
> Packages managed by the core Podman team will no longer include a default `libpod.conf`, instead defaulting to `containers.conf`. The default libpod.conf will remain available in the Github repository until the release of Podman 2.0

https://github.com/containers/common/blob/master/docs/containers.conf.5.md

https://github.com/containers/common/blob/master/pkg/config/containers.conf

This file is also used by `buildah` so we might want to move it out of `virtualisation.podman`?

cc @NixOS/podman 