### PR TITLE
nomachine-client: 6.9.2 -> 6.10.12

### DIFF
--- a/pkgs/tools/admin/nomachine-client/default.nix
+++ b/pkgs/tools/admin/nomachine-client/default.nix
@@ -1,29 +1,29 @@
 { stdenv, file, fetchurl, makeWrapper,
   autoPatchelfHook, jsoncpp, libpulseaudio }:
 let
-  versionMajor = "6.9";
-  versionMinor = "2";
+  versionMajor = "6.10";
+  versionMinor = "12";
   versionBuild_x86_64 = "1";
   versionBuild_i686 = "1";
 in
   stdenv.mkDerivation rec {
     pname = "nomachine-client";
     version = "${versionMajor}.${versionMinor}";
-  
+
     src =
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_x86_64}_x86_64.tar.gz";
-          sha256 = "1z2pcfkzicjma4lxrj4qx43xyml993v7qyjd7k8xy8hw85fwnzii";
+          sha256 = "17yb377ry7i7cmkb72xmhyqkfggv1ygqlz55ymvmrs7psbh7ql01";
         }
       else if stdenv.hostPlatform.system == "i686-linux" then
         fetchurl {
           url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_i686}_i686.tar.gz";
-          sha256 = "03421s0k91c02ga9k6bdvixw71brlgi13q82cinnfayg3fhb0rb6";
+          sha256 = "0k6dspmwdkm0zf0c2zqlqy0jya8qgsg90wwv9wa12fn4chp66gqg";
         }
       else
         throw "NoMachine client is not supported on ${stdenv.hostPlatform.system}";
-    
+
     postUnpack = ''
       mv $(find . -type f -name nxclient.tar.gz) .
       mv $(find . -type f -name nxplayer.tar.gz) .
@@ -32,7 +32,7 @@ in
       tar xf nxplayer.tar.gz
       rm $(find . -maxdepth 1 -type f)
     '';
-  
+
     nativeBuildInputs = [ file makeWrapper autoPatchelfHook ];
     buildInputs = [ jsoncpp libpulseaudio ];
 
@@ -50,7 +50,7 @@ in
           cp "$i"/* "$out/share/icons/hicolor/$(basename $i)/apps/"
         fi
       done
-  
+
       mkdir $out/share/applications
       cp share/applnk/player/xdg/*.desktop $out/share/applications/
       cp share/applnk/client/xdg-mime/*.desktop $out/share/applications/
@@ -62,7 +62,7 @@ in
         substituteInPlace "$i" --replace /usr/NX/bin $out/bin
       done
     '';
-  
+
     postFixup = ''
       makeWrapper $out/bin/nxplayer.bin $out/bin/nxplayer --set NX_SYSTEM $out/NX
       makeWrapper $out/bin/nxclient.bin $out/bin/nxclient --set NX_SYSTEM $out/NX
@@ -71,7 +71,7 @@ in
       # have a DT_NEEDED entry for it.
       patchelf --add-needed libpulse.so.0 $out/NX/lib/libnxcau.so
     '';
-  
+
     dontBuild = true;
     dontStrip = true;
 
@@ -87,4 +87,4 @@ in
       platforms = [ "x86_64-linux" "i686-linux" ];
     };
   }
-  
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrades nomachine-client 6.10.12
Notes: 6.9.2 seems to no longer even be available for download so its kind of important to merge this (maybe even backport later)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
