### PR TITLE
write_stylus: updated broken icon hash

### DIFF
--- a/pkgs/applications/graphics/write_stylus/default.nix
+++ b/pkgs/applications/graphics/write_stylus/default.nix
@@ -4,7 +4,7 @@ let
   # license: Free for commercial use
   desktopIcon = fetchurl {
     url = "https://www.iconfinder.com/icons/50835/download/png/256";
-    sha256 = "0abdya42yf9alxbsmc2nf8jwld50zfria6z3d4ncvp1zw2a9jhb8";
+    sha256 = "1wpcrqgjhql587midg8n159w8pcln8rkd0vh99w615687rx9y0sb";
   };
 in
 mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change
Hash was broken.

###### Things done

Changed hash accordingly

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
