### PR TITLE
alot: 0.9 → 0.9.1

### DIFF
--- a/pkgs/development/python-modules/alot/default.nix
+++ b/pkgs/development/python-modules/alot/default.nix
@@ -61,6 +61,6 @@ buildPythonPackage rec {
     description = "Terminal MUA using notmuch mail";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ geistesk ];
+    maintainers = with maintainers; [ aepsil0n ];
   };
 }

--- a/pkgs/development/python-modules/alot/default.nix
+++ b/pkgs/development/python-modules/alot/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "alot";
-  version = "0.9";
+  version = "0.9.1";
   outputs = [ "out" ] ++ lib.optional withManpage "man";
 
   disabled = !isPy3k;
@@ -16,17 +16,8 @@ buildPythonPackage rec {
     owner = "pazz";
     repo = "alot";
     rev = version;
-    sha256 = "sha256-WUwOJcq8JE7YO8sFeZwYikCRhpufO0pL6MKu54ZYsHI=";
+    sha256 = "0s94m17yph1gq9f2svipb3bbwbw1s4j3zf2xkg5h91006v8286r6";
   };
-
-  patches = [
-    # can't compose email if signature is set: https://github.com/pazz/alot/issues/1468
-    (fetchpatch {
-      name = "envelope-body.patch";
-      url = "https://github.com/pazz/alot/commit/28a4296c7f556c251d71d9502681980d46d9fa55.patch";
-      sha256 = "1iwvmjyz4mh1g08vr85ywhah2xarcqg8dazagygk19icgsn45w06";
-    })
-  ];
 
   nativeBuildInputs = lib.optional withManpage sphinx;
 


### PR DESCRIPTION
Dropped the patch, as it is included in the point release.

Switched the hash representation to regular base32.

###### Motivation for this change

New release came out. There are a few bug fixes in it including but not limited to the patch that was already in nixpkgs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).