### PR TITLE
Update Haskell package set to LTS 15.12 (plus other fixes) 

### DIFF
--- a/pkgs/data/misc/hackage/default.nix
+++ b/pkgs/data/misc/hackage/default.nix
@@ -1,6 +1,6 @@
 { fetchurl }:
 
 fetchurl {
-  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/a734b1438c8379ed3945412538ff4ec49823564c.tar.gz";
-  sha256 = "0y1y818n10fh0qq7cg67p9l293js78fyahk5f6s9w3c21xn9wn8r";
+  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/6515ef12bbcf8fbac87e12b4cb30b7eefa9ce9ce.tar.gz";
+  sha256 = "0plf0kk0wj1lbmks09afyqrl70z0miwxzfk3zh7y2qiw3g5l1v0x";
 }

--- a/pkgs/development/compilers/ghcjs-ng/default.nix
+++ b/pkgs/development/compilers/ghcjs-ng/default.nix
@@ -102,6 +102,7 @@ in stdenv.mkDerivation {
 
     inherit passthru;
 
-    meta.platforms = passthru.bootPkgs.ghc.meta.platforms;
+    meta.broken = true; # build does not succeed
+    meta.platforms = lib.platforms.none;  # passthru.bootPkgs.ghc.meta.platforms;
     meta.maintainers = [lib.maintainers.elvishjerricco];
   }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1502,13 +1502,13 @@ self: super: {
   });
 
   # stackage right now is not new enough for hlint-3.0
-  ghc-lib-parser-ex_8_10_0_6 = super.ghc-lib-parser-ex_8_10_0_6.override {
+  ghc-lib-parser-ex_8_10_0_8 = super.ghc-lib-parser-ex_8_10_0_8.override {
     ghc-lib-parser = self.ghc-lib-parser_8_10_1_20200412;
   };
 
   hlint = super.hlint.override {
     ghc-lib-parser = self.ghc-lib-parser_8_10_1_20200412;
-    ghc-lib-parser-ex = self.ghc-lib-parser-ex_8_10_0_6;
+    ghc-lib-parser-ex = self.ghc-lib-parser-ex_8_10_0_8;
     extra = self.extra_1_7_1;
     filepattern = self.filepattern.override {
       extra = self.extra_1_7_1;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1515,4 +1515,8 @@ self: super: {
     };
   };
 
+  # hasn‘t bumped upper bounds
+  # upstream: https://github.com/obsidiansystems/which/pull/6
+  which = doJailbreak super.which;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -84,7 +84,7 @@ self: super: {
   zlib = doJailbreak super.zlib;
 
   # Use the latest version to fix the build.
-  dhall = self.dhall_1_31_1;
+  dhall = self.dhall_1_32_0;
   ghc-lib-parser-ex = self.ghc-lib-parser-ex_8_10_0_4;
   lens = self.lens_4_19_2;
   optics-core = self.optics-core_0_3;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2708,6 +2708,7 @@ broken-packages:
   - adaptive-containers
   - adaptive-tuple
   - adb
+  - addy
   - adhoc-network
   - adict
   - adobe-swatch-exchange
@@ -7432,6 +7433,7 @@ broken-packages:
   - miniforth
   - minilens
   - minilight
+  - minilight-lua
   - minimung
   - minions
   - minioperational
@@ -9282,6 +9284,13 @@ broken-packages:
   - ShortestPathProblems
   - show-prettyprint
   - showdown
+  - Shpadoinkle
+  - Shpadoinkle-backend-pardiff
+  - Shpadoinkle-backend-snabbdom
+  - Shpadoinkle-backend-static
+  - Shpadoinkle-html
+  - Shpadoinkle-router
+  - Shpadoinkle-widgets
   - shpider
   - shuffle
   - si-clock

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -72,7 +72,7 @@ default-package-overrides:
   # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
   # not yet available in Nixpkgs
   - gi-gdkx11 < 4
-  # LTS Haskell 15.11
+  # LTS Haskell 15.12
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
   - AC-Angle ==1.0
@@ -390,7 +390,7 @@ default-package-overrides:
   - cast ==0.1.0.2
   - category ==0.2.5.0
   - cayley-client ==0.4.12
-  - cborg ==0.2.2.1
+  - cborg ==0.2.3.0
   - cborg-json ==0.2.2.0
   - cereal ==0.5.8.1
   - cereal-conduit ==0.8.0
@@ -601,7 +601,7 @@ default-package-overrides:
   - diagrams-lib ==1.4.3
   - diagrams-postscript ==1.5
   - diagrams-rasterific ==1.4.2
-  - diagrams-solve ==0.1.1
+  - diagrams-solve ==0.1.2
   - diagrams-svg ==1.4.3
   - di-core ==1.0.4
   - dictionary-sharing ==0.1.0.0
@@ -893,7 +893,7 @@ default-package-overrides:
   - gravatar ==0.8.0
   - greskell ==1.0.1.0
   - greskell-core ==0.1.3.2
-  - greskell-websocket ==0.1.2.1
+  - greskell-websocket ==0.1.2.2
   - groom ==0.1.2.1
   - group-by-date ==0.1.0.3
   - groups ==0.4.1.0
@@ -1060,7 +1060,7 @@ default-package-overrides:
   - human-readable-duration ==0.2.1.4
   - HUnit ==1.6.0.0
   - HUnit-approx ==1.1.1.1
-  - hunit-dejafu ==2.0.0.1
+  - hunit-dejafu ==2.0.0.2
   - hvect ==0.4.0.0
   - hvega ==0.5.0.0
   - hw-balancedparens ==0.3.1.0
@@ -1081,7 +1081,7 @@ default-package-overrides:
   - hw-json ==1.3.2.0
   - hw-json-simd ==0.1.1.0
   - hw-json-simple-cursor ==0.1.1.0
-  - hw-json-standard-cursor ==0.2.2.0
+  - hw-json-standard-cursor ==0.2.3.1
   - hw-mquery ==0.2.1.0
   - hw-packed-vector ==0.2.1.0
   - hw-parser ==0.1.1.0
@@ -1111,7 +1111,7 @@ default-package-overrides:
   - if ==0.1.0.0
   - iff ==0.0.6
   - ihs ==0.1.0.3
-  - ilist ==0.4.0.0
+  - ilist ==0.4.0.1
   - imagesize-conduit ==1.1
   - Imlib ==0.1.2
   - immortal ==0.3
@@ -1157,7 +1157,7 @@ default-package-overrides:
   - iproute ==1.7.9
   - IPv6Addr ==1.1.3
   - ipynb ==0.1.0.1
-  - ipython-kernel ==0.10.1.0
+  - ipython-kernel ==0.10.2.0
   - irc ==0.6.1.0
   - irc-client ==1.1.1.1
   - irc-conduit ==0.3.0.4
@@ -1195,8 +1195,8 @@ default-package-overrides:
   - keycode ==0.2.2
   - keys ==3.12.3
   - kind-apply ==0.3.2.0
-  - kind-generics ==0.4.0.0
-  - kind-generics-th ==0.2.1.0
+  - kind-generics ==0.4.1.0
+  - kind-generics-th ==0.2.2.0
   - kmeans ==0.1.3
   - koofr-client ==1.0.0.3
   - kubernetes-webhook-haskell ==0.2.0.1
@@ -1265,7 +1265,7 @@ default-package-overrides:
   - load-env ==0.2.1.0
   - loch-th ==0.2.2
   - lockfree-queue ==0.2.3.1
-  - log-base ==0.8.0.0
+  - log-base ==0.8.0.1
   - log-domain ==0.13
   - logfloat ==0.13.3.3
   - logging-effect ==1.3.9
@@ -1712,7 +1712,7 @@ default-package-overrides:
   - read-env-var ==1.0.0.0
   - reanimate-svg ==0.9.8.0
   - rebase ==1.4.1
-  - record-dot-preprocessor ==0.2.3
+  - record-dot-preprocessor ==0.2.5
   - record-hasfield ==1.0
   - records-sop ==0.1.0.3
   - recursion-schemes ==5.1.3
@@ -1823,7 +1823,7 @@ default-package-overrides:
   - sequence-formats ==1.4.1
   - sequenceTools ==1.4.0.5
   - serf ==0.1.1.0
-  - serialise ==0.2.2.0
+  - serialise ==0.2.3.0
   - servant ==0.16.2
   - servant-auth ==0.3.2.0
   - servant-auth-server ==0.4.5.1
@@ -1867,7 +1867,7 @@ default-package-overrides:
   - shared-memory ==0.2.0.0
   - shell-conduit ==4.7.0
   - shell-escape ==0.2.0
-  - shellmet ==0.0.3.0
+  - shellmet ==0.0.3.1
   - shelltestrunner ==1.9
   - shell-utility ==0.0
   - shelly ==1.9.0
@@ -1898,8 +1898,8 @@ default-package-overrides:
   - sized ==0.4.0.0
   - skein ==1.0.9.4
   - skip-var ==0.1.1.0
-  - skylighting ==0.8.3.4
-  - skylighting-core ==0.8.3.4
+  - skylighting ==0.8.4
+  - skylighting-core ==0.8.4
   - slist ==0.1.1.0
   - small-bytearray-builder ==0.3.4.0
   - smallcheck ==1.1.5
@@ -1968,7 +1968,7 @@ default-package-overrides:
   - string-combinators ==0.6.0.5
   - string-conv ==0.1.2
   - string-conversions ==0.4.0.1
-  - string-interpolate ==0.2.0.3
+  - string-interpolate ==0.2.1.0
   - string-qq ==0.0.4
   - stringsearch ==0.3.6.6
   - string-transform ==1.1.1
@@ -2010,7 +2010,7 @@ default-package-overrides:
   - tardis ==0.4.1.0
   - tasty ==1.2.3
   - tasty-ant-xml ==1.1.6
-  - tasty-dejafu ==2.0.0.1
+  - tasty-dejafu ==2.0.0.3
   - tasty-discover ==4.2.1
   - tasty-expected-failure ==0.11.1.2
   - tasty-golden ==2.3.3.2
@@ -2130,14 +2130,14 @@ default-package-overrides:
   - triplesec ==0.2.2.1
   - trivial-constraint ==0.6.0.0
   - tsv2csv ==0.1.0.2
-  - ttc ==0.2.0.0
+  - ttc ==0.2.1.0
   - ttl-hashtables ==1.4.1.0
   - ttrie ==0.1.2.1
   - tuple ==0.3.0.2
   - tuples-homogenous-h98 ==0.1.1.0
   - tuple-sop ==0.3.1.0
   - tuple-th ==0.2.5
-  - turtle ==1.5.18
+  - turtle ==1.5.19
   - TypeCompose ==0.9.14
   - typed-process ==0.2.6.0
   - typed-uuid ==0.0.0.2
@@ -2211,7 +2211,7 @@ default-package-overrides:
   - uuid-types ==1.0.3
   - validation ==1.1
   - validity ==0.9.0.3
-  - validity-aeson ==0.2.0.3
+  - validity-aeson ==0.2.0.4
   - validity-bytestring ==0.4.1.1
   - validity-containers ==0.5.0.3
   - validity-path ==0.4.0.1
@@ -2234,7 +2234,7 @@ default-package-overrides:
   - vector-instances ==3.4
   - vector-mmap ==0.0.3
   - vector-rotcev ==0.1.0.0
-  - vector-sized ==1.4.0.0
+  - vector-sized ==1.4.1.0
   - vector-space ==0.16
   - vector-split ==1.0.0.2
   - vector-th-unbox ==0.2.1.7
@@ -2270,7 +2270,7 @@ default-package-overrides:
   - webex-teams-conduit ==0.2.0.0
   - webex-teams-pipes ==0.2.0.0
   - webrtc-vad ==0.1.0.3
-  - websockets ==0.12.7.0
+  - websockets ==0.12.7.1
   - websockets-snap ==0.10.3.1
   - weigh ==0.0.16
   - wide-word ==0.1.1.1
@@ -2330,7 +2330,7 @@ default-package-overrides:
   - xss-sanitize ==0.3.6
   - xturtle ==0.2.0.0
   - xxhash-ffi ==0.2.0.0
-  - yaml ==0.11.3.0
+  - yaml ==0.11.4.0
   - yesod ==1.6.0.1
   - yesod-auth ==1.6.10
   - yesod-auth-hashdb ==1.7.1.2

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2733,7 +2733,6 @@ broken-packages:
   - aeson-diff-generic
   - aeson-filthy
   - aeson-flowtyped
-  - aeson-gadt-th
   - aeson-injector
   - aeson-iproute
   - aeson-native
@@ -7801,7 +7800,6 @@ broken-packages:
   - neural
   - neural-network-blashs
   - neural-network-hmatrix
-  - neuron
   - newhope
   - newports
   - newsletter
@@ -8895,7 +8893,6 @@ broken-packages:
   - rhine
   - rhine-gloss
   - rhythm-game-tutorial
-  - rib
   - ribbit
   - RichConditional
   - ridley
@@ -10608,7 +10605,6 @@ broken-packages:
   - wheb-mongo
   - wheb-redis
   - wheb-strapped
-  - which
   - while-lang-parser
   - whim
   - whiskers

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -730,4 +730,24 @@ self: super: builtins.intersectAttrs super {
 
   # Tests access homeless-shelter.
   hie-bios = dontCheck super.hie-bios;
+
+  # Compiling the readme throws errors and has no purpose in nixpkgs
+  aeson-gadt-th =
+    disableCabalFlag (doJailbreak (super.aeson-gadt-th)) "build-readme";
+
+  neuron = overrideCabal (super.neuron) (drv: {
+    # neuron expects the neuron-search script to be in PATH at built-time.
+    buildTools = [ pkgs.makeWrapper ];
+    preConfigure = ''
+      mkdir -p $out/bin
+      cp src-bash/neuron-search $out/bin/neuron-search
+      chmod +x $out/bin/neuron-search
+      wrapProgram $out/bin/neuron-search --prefix 'PATH' ':' ${
+        with pkgs;
+        lib.makeBinPath [ fzf ripgrep gawk bat findutils envsubst ]
+      }
+      PATH=$PATH:$out/bin
+    '';
+  });
+
 }

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -383,7 +383,8 @@ stdenv.mkDerivation ({
 
     for d in $(grep '^dynamic-library-dirs:' "$packageConfDir"/* | cut -d' ' -f2- | tr ' ' '\n' | sort -u); do
       for lib in "$d/"*.{dylib,so}; do
-        ln -s "$lib" "$dynamicLinksDir"
+        # Allow overwriting because C libs can be pulled in multiple times.
+        ln -sf "$lib" "$dynamicLinksDir"
       done
     done
     # Edit the local package DB to reference the links directory.


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2020-05-15 [20:00 +02:00](http://www.thetimezoneconverter.com/?t=20:00&tz=Berlin). You can watch this live on Twitch at https://www.twitch.tv/peti343. In addition to the chat features offered by Twitch, there is also a voice conference at https://discord.gg/YTEa3XR that viewers can use to chat with me and with each other.

## TODO

- [x] Update `all-cabal-hashes` reference.