### PR TITLE
[20.03] samba: 4.11.5 -> 4.11.9

### DIFF
--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -20,11 +20,11 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "samba";
-  version = "4.11.5";
+  version = "4.11.9";
 
   src = fetchurl {
     url = "mirror://samba/pub/samba/stable/${pname}-${version}.tar.gz";
-    sha256 = "0gyr773dl0krcra6pvyp8i9adj3r16ihrrm2b71c0974cbzrkqpk";
+    sha256 = "1k4dxjspl0xgabdl3nb3wyz714l3df89dj04bf1siwzk9hsyz35d";
   };
 
   outputs = [ "out" "dev" "man" ];


### PR DESCRIPTION
This is not a [backport](https://github.com/NixOS/nixpkgs/pull/87181) from master since it has samba-4.12.

Release notes:

* https://www.samba.org/samba/history/samba-4.11.6.html
* https://www.samba.org/samba/history/samba-4.11.7.html
* https://www.samba.org/samba/history/samba-4.11.8.html
* https://www.samba.org/samba/history/samba-4.11.9.html

###### Motivation for this change

The 4.11.8 release fixes:

* https://nvd.nist.gov/vuln/detail/CVE-2020-10700
* https://nvd.nist.gov/vuln/detail/CVE-2020-10704

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
