### PR TITLE
wxGTK31: 3.1.2 -> 3.1.3

### DIFF
--- a/pkgs/applications/radio/cubicsdr/default.nix
+++ b/pkgs/applications/radio/cubicsdr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, fftw, hamlib, libpulseaudio, libGL, libX11, liquid-dsp,
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, fftw, hamlib, libpulseaudio, libGL, libX11, liquid-dsp,
   pkgconfig, soapysdr-with-plugins, wxGTK31-gtk3, enableDigitalLab ? false }:
 
 stdenv.mkDerivation rec {
@@ -11,6 +11,23 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1ihbn18bzdcdvwpa4hnb55ns38bj4b8xy53hkmra809f9qpbcjhn";
   };
+
+  # Allow cubicsdr 0.2.5 to build with wxGTK 3.1.3
+  # these come from cubicsdr's master branch, subsequent releases may include them
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/cjcliffe/CubicSDR/commit/65a160fa356ce9665dfe05c6bfc6754535e16743.patch";
+      sha256 = "0vbr5x9fnm09bws5crqcm6kkhr1bg5r0bc1pxnwwjyc6jpvqi6ad";
+    })
+    (fetchpatch {
+      url = "https://github.com/cjcliffe/CubicSDR/commit/f449a65457e35bf8260d0b16b8a47b6bc0ea2c7e.patch";
+      sha256 = "1zjvjmhm8ybi6i9pq7by3fj3mvx37dy7gj4gk23d79yrnl9mk25p";
+    })
+    (fetchpatch {
+      url = "https://github.com/cjcliffe/CubicSDR/commit/0540d08c2dea79b668b32b1a6d58f235d65ce9d2.patch";
+      sha256 = "07l7b82f779sbcj0jza0mg463ac1153bs9hn6ai388j7dm3lvasn";
+    })
+  ];
 
   nativeBuildInputs = [ cmake pkgconfig ];
 

--- a/pkgs/development/libraries/wxwidgets/3.1/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.1/default.nix
@@ -18,14 +18,14 @@ assert withWebKit -> webkitgtk != null;
 assert assertMsg (withGtk2 -> withWebKit == false) "wxGTK31: You cannot enable withWebKit when using withGtk2.";
 
 stdenv.mkDerivation rec {
-  version = "3.1.2";
+  version = "3.1.3";
   pname = "wxwidgets";
 
   src = fetchFromGitHub {
     owner = "wxWidgets";
     repo = "wxWidgets";
     rev = "v${version}";
-    sha256 = "0gfdhb7xq5vzasm7s1di39nchv42zsp0dmn4v6knzb7mgsb107wb";
+    sha256 = "022mby78q7n0bhd4mph04hz93c9qamnvzv3h1s26r839k28760f4";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
wxWidgets 3.1.3 has been out since 2019-10-28

###### Things done

<details> <summary> nixpkgs-review </summary>

```
1 package failed to build:
cubicsdr

9 packages built:
diff-pdf grandorgue kicad-unstable kicad-unstable-small prusa-slicer pwsafe treesheets wxGTK31 wxhexeditor
```
</details>

@lasandell `cubicsdr` fails with this update, though comments on their github issues seem to indicate that it should be able to use 3.1.3

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - was `179060768` is now `179614160`
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
