### PR TITLE
[20.03] xonotic: split glx, sdl, dedicated, data (#83461)

### DIFF
--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -1,73 +1,31 @@
-{ stdenv, fetchurl
+{ lib, stdenv, fetchurl, fetchzip, makeWrapper, runCommandNoCC, makeDesktopItem
+, xonotic-data
 , # required for both
   unzip, libjpeg, zlib, libvorbis, curl
 , # glx
   libX11, libGLU, libGL, libXpm, libXext, libXxf86vm, alsaLib
 , # sdl
   SDL2
+
+, withSDL ? true
+, withGLX ? false
+, withDedicated ? true
 }:
 
-stdenv.mkDerivation rec {
-  name = "xonotic-0.8.2";
-
-  src = fetchurl {
-    url = "https://dl.xonotic.org/${name}.zip";
-    sha256 = "1mcs6l4clvn7ibfq3q69k2p0z6ww75rxvnngamdq5ic6yhq74bx2";
-  };
-
-  buildInputs = [
-    # required for both
-    unzip libjpeg
-    # glx
-    libX11 libGLU libGL libXpm libXext libXxf86vm alsaLib
-    # sdl
-    SDL2
-    zlib libvorbis curl
-  ];
-
-  sourceRoot = "Xonotic/source/darkplaces";
-
-  # "debug", "release", "profile"
-  target = "release";
-
-  dontStrip = target != "release";
-
-  buildPhase = ''
-    DP_FS_BASEDIR="$out/share/xonotic"
-    make DP_FS_BASEDIR=$DP_FS_BASEDIR cl-${target}
-    make DP_FS_BASEDIR=$DP_FS_BASEDIR sdl-${target}
-    make DP_FS_BASEDIR=$DP_FS_BASEDIR sv-${target}
-  '';
-  enableParallelBuilding = true;
-
-  installPhase = ''
-    mkdir -p "$out/bin"
-    cp darkplaces-dedicated "$out/bin/xonotic-dedicated"
-    cp darkplaces-sdl "$out/bin/xonotic-sdl"
-    cp darkplaces-glx "$out/bin/xonotic-glx"
-    cd ../..
-    mkdir -p "$out/share/xonotic"
-    mv data "$out/share/xonotic"
-
-    # default to sdl
-    ln -s "$out/bin/xonotic-sdl" "$out/bin/xonotic"
-  '';
-
-  # Xonotic needs to find libcurl.so at runtime for map downloads
-  dontPatchELF = true;
-  postFixup = ''
-    patchelf --add-needed ${curl.out}/lib/libcurl.so $out/bin/xonotic-dedicated
-    patchelf \
-        --add-needed ${curl.out}/lib/libcurl.so \
-        --add-needed ${libvorbis}/lib/libvorbisfile.so \
-        --add-needed ${libvorbis}/lib/libvorbis.so \
-        $out/bin/xonotic-glx
-    patchelf \
-        --add-needed ${curl.out}/lib/libcurl.so \
-        --add-needed ${libvorbis}/lib/libvorbisfile.so \
-        --add-needed ${libvorbis}/lib/libvorbis.so \
-        $out/bin/xonotic-sdl
-  '';
+let
+  pname = "xonotic";
+  version = "0.8.2";
+  name = "${pname}-${version}";
+  variant =
+    if withSDL && withGLX then
+      ""
+    else if withSDL then
+      "-sdl"
+    else if withGLX then
+      "-glx"
+    else if withDedicated then
+      "-dedicated"
+    else "-what-even-am-i";
 
   meta = {
     description = "A free fast-paced first-person shooter";
@@ -79,10 +37,121 @@ stdenv.mkDerivation rec {
       Nexuiz project with years of development between them, and it
       aims to become the best possible open-source FPS of its kind.
     '';
-    homepage = http://www.xonotic.org;
+    homepage = "https://www.xonotic.org/";
     license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [ astsmtl zalakain ];
+    maintainers = with stdenv.lib.maintainers; [ astsmtl zalakain petabyteboy ];
     platforms = stdenv.lib.platforms.linux;
-    hydraPlatforms = [];
   };
+
+  desktopItem = makeDesktopItem {
+    name = "xonotic";
+    exec = "$out/bin/xonotic";
+    comment = meta.description;
+    desktopName = "Xonotic";
+    categories = "Game;";
+    icon = "xonotic";
+    startupNotify = "false";
+  };
+
+  xonotic-unwrapped = stdenv.mkDerivation rec {
+    pname = "xonotic${variant}-unwrapped";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://dl.xonotic.org/${name}-source.zip";
+      sha256 = "0axxw04fyz6jlfqd0kp7hdrqa0li31sx1pbipf2j5qp9wvqicsay";
+    };
+
+    buildInputs = [ unzip libjpeg zlib libvorbis curl ]
+      ++ lib.optional withGLX [ libX11.dev libGLU.dev libGL.dev libXpm.dev libXext.dev libXxf86vm.dev alsaLib.dev ]
+      ++ lib.optional withSDL [ SDL2.dev ];
+
+    sourceRoot = "Xonotic/source/darkplaces";
+
+    # "debug", "release", "profile"
+    target = "release";
+
+    dontStrip = target != "release";
+
+    buildPhase = lib.optionalString withDedicated ''
+      make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES sv-${target}
+    '' + lib.optionalString withGLX ''
+      make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES cl-${target}
+    '' + lib.optionalString withSDL ''
+      make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES sdl-${target}
+    '';
+
+    enableParallelBuilding = true;
+
+    installPhase = ''
+      install -Dm644 ../../misc/logos/icons_png/xonotic_128.png $out/share/pixmaps/xonotic.png
+    '' + lib.optionalString withDedicated ''
+      install -Dm755 darkplaces-dedicated "$out/bin/xonotic-dedicated"
+    '' + lib.optionalString withGLX ''
+      install -Dm755 darkplaces-glx "$out/bin/xonotic-glx"
+    '' + lib.optionalString withSDL ''
+      install -Dm755 darkplaces-sdl "$out/bin/xonotic-sdl"
+    '';
+
+    # Xonotic needs to find libcurl.so at runtime for map downloads
+    dontPatchELF = true;
+    postFixup = lib.optionalString withDedicated ''
+      patchelf --add-needed ${curl.out}/lib/libcurl.so $out/bin/xonotic-dedicated
+    '' + lib.optionalString withGLX ''
+      patchelf \
+          --add-needed ${curl.out}/lib/libcurl.so \
+          --add-needed ${libvorbis}/lib/libvorbisfile.so \
+          --add-needed ${libvorbis}/lib/libvorbis.so \
+          --add-needed ${libGL.out}/lib/libGL.so \
+          $out/bin/xonotic-glx
+    '' + lib.optionalString withSDL ''
+      patchelf \
+          --add-needed ${curl.out}/lib/libcurl.so \
+          --add-needed ${libvorbis}/lib/libvorbisfile.so \
+          --add-needed ${libvorbis}/lib/libvorbis.so \
+          $out/bin/xonotic-sdl
+    '';
+  };
+
+in rec {
+  xonotic-data = fetchzip {
+    name = "xonotic-data-${version}";
+    url = "https://dl.xonotic.org/${name}.zip";
+    sha256 = "1ygkh0v68y4sd1w5vpk8dgb65h5jm599hwszdfgjp3ax4d3ml81x";
+    extraPostFetch = ''
+      cd $out
+      rm -rf $(ls | grep -v "^data$")
+    '';
+    meta.hydraPlatforms = [];
+    passthru.version = version;
+  };
+
+  xonotic = runCommandNoCC "xonotic${variant}-${version}" {
+    inherit xonotic-unwrapped;
+    buildInputs = [ makeWrapper ];
+    passthru = {
+      inherit version;
+      meta = meta // {
+        hydraPlatforms = [];
+      };
+    };
+  } (''
+    mkdir -p $out/bin
+  '' + lib.optionalString withDedicated ''
+    ln -s ${xonotic-unwrapped}/bin/xonotic-dedicated $out/bin/
+  '' + lib.optionalString withGLX ''
+    ln -s ${xonotic-unwrapped}/bin/xonotic-glx $out/bin/xonotic-glx
+    ln -s $out/bin/xonotic-glx $out/bin/xonotic
+  '' + lib.optionalString withSDL ''
+    ln -s ${xonotic-unwrapped}/bin/xonotic-sdl $out/bin/xonotic-sdl
+    ln -sf $out/bin/xonotic-sdl $out/bin/xonotic
+  '' + lib.optionalString (withSDL || withGLX) ''
+    mkdir -p $out/share
+    ln -s ${xonotic-unwrapped}/share/pixmaps $out/share/pixmaps
+    ${desktopItem.buildCommand}
+  '' + ''
+    for binary in $out/bin/xonotic-*; do
+      wrapProgram $binary --add-flags "-basedir ${xonotic-data}"
+    done
+  '');
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23635,7 +23635,26 @@ in
 
   xmoto = callPackage ../games/xmoto { };
 
-  xonotic = callPackage ../games/xonotic { };
+
+  inherit (callPackage ../games/xonotic { })
+    xonotic-data
+    xonotic;
+
+  xonotic-glx = (callPackage ../games/xonotic {
+    withSDL = false;
+    withGLX = true;
+  }).xonotic;
+
+  xonotic-dedicated = (callPackage ../games/xonotic {
+    withSDL = false;
+    withDedicated = true;
+  }).xonotic;
+
+  xonotic-sdl = xonotic;
+  xonotic-sdl-unwrapped = xonotic-sdl.xonotic-unwrapped;
+  xonotic-glx-unwrapped = xonotic-glx.xonotic-unwrapped;
+  xonotic-dedicated-unwrapped = xonotic-dedicated.xonotic-unwrapped;
+
 
   xpilot-ng = callPackage ../games/xpilot { };
   bloodspilot-server = callPackage ../games/xpilot/bloodspilot-server.nix {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Cherry picked from `master`. Original PR: #83461. Original description below.

> This has many advantages:
> - Each variant can be installed without pulling in the dependencies of the
>   other variants, which makes it possible to build an SDL variant
>   without X11 dependencies
> - Hydra can now build binaries without downloading 1GB of data, so users
>   do not have to build them on their own machines
> - Users do not have to redownload 1GB of data after each dependency
>   update
> 
> Includes the following fixes:
> - Add dependency on libGL for GLX variant as it will fail in some
>   environments otherwise
> - Pass -j and -l to make to enable parallel building
> - Quote homepage URI and use https
> - Add a .desktop file and icons

(cherry picked from commit 90354cd12784d7b48b074ac011a08a1ac00d0309)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
