### PR TITLE
ocamlPackages.dune_2: enable for OCaml < 4.07

### DIFF
--- a/pkgs/development/ocaml-modules/dune-private-libs/default.nix
+++ b/pkgs/development/ocaml-modules/dune-private-libs/default.nix
@@ -7,6 +7,8 @@ buildDunePackage rec {
 
   inherit (dune_2) src version;
 
+  minimumOCamlVersion = "4.07";
+
   dontAddPrefix = true;
 
   meta = with lib; {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -219,7 +219,12 @@ let
 
     dune = callPackage ../development/tools/ocaml/dune { };
 
-    dune_2 = callPackage ../development/tools/ocaml/dune/2.nix { };
+    dune_2 =
+      if lib.versionAtLeast ocaml.version "4.07"
+      then callPackage ../development/tools/ocaml/dune/2.nix { }
+      else if lib.versionAtLeast ocaml.version "4.02"
+      then pkgs.dune_2
+      else throw "dune_2 is not available for OCaml ${ocaml.version}";
 
     dune-build-info = callPackage ../development/ocaml-modules/dune-build-info { };
 


### PR DESCRIPTION
###### Motivation for this change

Have packages that use dune_2 and OCaml < 4.07.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
