### PR TITLE
Update skaffold to v1.9.1

### DIFF
--- a/pkgs/development/tools/skaffold/default.nix
+++ b/pkgs/development/tools/skaffold/default.nix
@@ -2,9 +2,9 @@
 
 buildGoPackage rec {
   pname = "skaffold";
-  version = "1.8.0";
+  version = "1.9.1";
   # rev is the ${version} commit, mainly for skaffold version command output
-  rev = "bd280192092e28067f0f52584c8bcb4f4dc480e4";
+  rev = "7bac6a150c9618465f5ad38cc0a5dbc4677c39ba";
 
   goPackagePath = "github.com/GoogleContainerTools/skaffold";
   subPackages = ["cmd/skaffold"];
@@ -20,7 +20,7 @@ buildGoPackage rec {
     owner = "GoogleContainerTools";
     repo = "skaffold";
     rev = "v${version}";
-    sha256 = "0s1j1lij56idl981nq7dnvkil1ki283nfhcfqyl5g00payihlm73";
+    sha256 = "0l0x89xv5brinafrvbz6hgs5kvmpl4ajcrsjdjh3myf7i0mvh3gm";
   };
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
There is a new schema available in the YAML in 1.9 so this is needed to work with some of the new features. I believe you can still use the old schema.

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md] (think so - first time)(https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
