### PR TITLE
grimshot: init at 2020-05-08

### DIFF
--- a/pkgs/tools/graphics/grimshot/default.nix
+++ b/pkgs/tools/graphics/grimshot/default.nix
@@ -1,0 +1,64 @@
+{ stdenv
+, fetchurl
+, coreutils
+, makeWrapper
+, sway-unwrapped
+, wl-clipboard
+, libnotify
+, slurp
+, grim
+, jq
+}:
+
+stdenv.mkDerivation rec {
+  pname = "grimshot";
+  version = "2020-05-08";
+  rev = "b1d08db5f5112ab562f89564825e3e791b0682c4";
+
+  # master has new fixes and features, and a man page
+  # after sway-1.5 these may be switched to sway-unwrapped.src
+  bsrc = fetchurl {
+    url = "https://raw.githubusercontent.com/swaywm/sway/${rev}/contrib/grimshot";
+    sha256 = "1awzmzkib8a7q5s78xyh8za03lplqfpbasqp3lidqqmjqs882jq9";
+  };
+
+  msrc = fetchurl {
+    url = "https://raw.githubusercontent.com/swaywm/sway/${rev}/contrib/grimshot.1";
+    sha256 = "191xxjfhf61gkxl3b0f694h0nrwd7vfnyp5afk8snhhr6q7ia4jz";
+  };
+
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  phases = [ "installPhase" "fixupPhase" "checkPhase" ];
+
+  installPhase = ''
+    install -D ${msrc} $out/share/man/man1/grimshot.1
+
+    install -Dm 0755 ${bsrc} $out/bin/grimshot
+    wrapProgram $out/bin/grimshot --set PATH \
+      "${stdenv.lib.makeBinPath [
+        sway-unwrapped
+        wl-clipboard
+        coreutils
+        libnotify
+        slurp
+        grim
+        jq
+        ] }"
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    $out/bin/grimshot check
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A helper for screenshots within sway";
+    homepage = "https://github.com/swaywm/sway/tree/master/contrib";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.evils ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1896,6 +1896,8 @@ in
 
   grim = callPackage ../tools/graphics/grim { };
 
+  grimshot = callPackage ../tools/graphics/grimshot { };
+
   gringo = callPackage ../tools/misc/gringo { };
 
   grobi = callPackage ../tools/X11/grobi { };


### PR DESCRIPTION
###### Motivation for this change
screenshot tool for sway from sway
this seems like a better solution than copying over snippets to my sway config


Though a different solution was suggested and implemented there, this closes #88577

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `101551232`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Stuff

ping @primeos since i only saw #76787 now
it seems like the dependencies of the other `contrib/` stuff are somewhat different
perhaps this could be added as `sway.contrib.grimshot` with a link to it in all-packages.nix?

having a separate description for this should improve discoverability