### PR TITLE
newsboat: fix on darwin

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsboat/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsboat/default.nix
@@ -16,6 +16,7 @@ rustPlatform.buildRustPackage rec {
 
   postPatch = ''
     substituteInPlace Makefile --replace "|| true" ""
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
     # Allow other ncurses versions on Darwin
     substituteInPlace config.sh \
       --replace "ncurses5.4" "ncurses"
@@ -25,13 +26,13 @@ rustPlatform.buildRustPackage rec {
     pkgconfig
     asciidoctor
     gettext
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [ makeWrapper libiconv ];
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ makeWrapper ncurses ];
 
   buildInputs = [ stfl sqlite curl libxml2 json_c ncurses ]
-    ++ stdenv.lib.optional stdenv.isDarwin Security;
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Security libiconv gettext ];
 
   postBuild = ''
-    make
+    make prefix="$out"
   '';
 
   # TODO: Check if that's still needed


### PR DESCRIPTION
###### Motivation for this change
Changelog:
1. Move libiconv from nativeBuildInputs to buildInputs, fixes:
```
./libxml/encoding.h:29:10: fatal error: 'iconv.h' file not found
#include <iconv.h>
         ^~~~~~~~~
1 error generated.
```
2. Add ncurses to nativeBuildInputs, fixes:
```
Checking for package ncurses using ncurses-config... not found

You need package ncurses in order to compile this program.
Please make sure it is installed.
./config.sh: line 87: curl-config: command not found
./config.sh: line 91: curl-config: command not found
```
3. Add gettext to buildInputs, fixes:
```
In file included from src/configcontainer.cpp:10:
./config.h:15:10: fatal error: 'libintl.h' file not found
#include <libintl.h>
         ^~~~~~~~~~~
1 error generated.
```
4. Fix prefix, otherwise newsboat searches for translations in /usr/local/share

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @dywedir @doronbehar 