### PR TITLE
tamzen: init at 1.11.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8253,6 +8253,12 @@
     githubId = 6016963;
     name = "Patrick Winter";
   };
+  wishfort36 = {
+    email = "42300264+wishfort36@users.noreply.github.com";
+    github = "wishfort36";
+    githubId = 42300264;
+    name = "wishfort36";
+  };
   wizeman = {
     email = "rcorreia@wizy.org";
     github = "wizeman";

--- a/pkgs/data/fonts/tamzen/default.nix
+++ b/pkgs/data/fonts/tamzen/default.nix
@@ -1,0 +1,47 @@
+{ fetchFromGitHub, fontforge, mkfontscale, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "tamzen-font";
+  version = "1.11.4";
+
+  src = fetchFromGitHub {
+    owner = "sunaku";
+    repo = "tamzen-font";
+    rev = "Tamzen-${version}";
+    sha256 = "17kgmvg6q32mqhx9g44hjvzv0si0mnpprga4z7na930g2zdd8846";
+  };
+
+  nativeBuildInputs = [ fontforge mkfontscale ];
+
+  installPhase = ''
+    # convert pcf fonts to otb
+    for i in pcf/*.pcf; do
+      name=$(basename "$i" .pcf)
+      fontforge -lang=ff -c "Open(\"$i\"); Generate(\"$name.otb\")"
+    done
+
+    install -m 644 -D pcf/*.pcf -t "$out/share/fonts/misc"
+    install -m 644 -D psf/*.psf -t "$out/share/consolefonts"
+    install -m 644 -D *.otb     -t "$otb/share/fonts/misc"
+    mkfontdir "$out/share/fonts/misc"
+    mkfontdir "$otb/share/fonts/misc"
+  '';
+
+  outputs = [ "out" "otb" ];
+
+  meta = with stdenv.lib; {
+    description = "Bitmapped programming font based on Tamsyn";
+    longDescription = ''
+    Tamzen is a monospace bitmap font. It is programatically forked
+    from Tamsyn version 1.11, which backports glyphs from older
+    versions while deleting deliberately empty glyphs to allow
+    secondary/fallback fonts to provide real glyphs at those codepoints.
+    Tamzen also has fonts that additionally provide the Powerline
+    symbols.
+    '';
+    homepage = "https://github.com/sunaku/tamzen-font";
+    license = licenses.free;
+    maintainers = with maintainers; [ wishfort36 ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18276,6 +18276,8 @@ in
 
   tamsyn = callPackage ../data/fonts/tamsyn { inherit (buildPackages.xorg) mkfontscale; };
 
+  tamzen = callPackage ../data/fonts/tamzen { inherit (buildPackages.xorg) mkfontscale; };
+
   tango-icon-theme = callPackage ../data/icons/tango-icon-theme {
     gtk = res.gtk2;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Tamsyn is a cool font, but it doesn't have a powerline version.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
