### PR TITLE
libgcrypt: always pass build and host to configure

### DIFF
--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -30,6 +30,10 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-libgpg-error-prefix=${libgpgerror.dev}" ]
    ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "--disable-asm";
 
+  # Necessary to generate correct assembly when compiling for aarch32 on
+  # aarch64
+  configurePlatforms = [ "host" "build" ];
+
   # Make sure libraries are correct for .pc and .la files
   # Also make sure includes are fixed for callers who don't use libgpgcrypt-config
   postFixup = ''


### PR DESCRIPTION
###### Motivation for this change

When building for aarch32 on aarch64 with extraPlatforms, libgcrypt fails to build because it tries to guess the host platform from uname, which returns the wrong result in this case. We fix this by always telling libgcrypt what platform to build for.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
