### PR TITLE
openbox: Use python3 instead of python2

### DIFF
--- a/pkgs/applications/window-managers/openbox/default.nix
+++ b/pkgs/applications/window-managers/openbox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, python2
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, python3
 , libxml2, libXinerama, libXcursor, libXau, libXrandr, libICE, libSM
 , imlib2, pango, libstartup_notification, makeWrapper }:
 
@@ -7,22 +7,24 @@ stdenv.mkDerivation rec {
   version = "3.6.1";
 
   nativeBuildInputs = [
+    autoreconfHook
     pkgconfig
     makeWrapper
-    python2.pkgs.wrapPython
+    python3.pkgs.wrapPython
   ];
 
   buildInputs = [
     libxml2
     libXinerama libXcursor libXau libXrandr libICE libSM
     libstartup_notification
+    python3
   ];
 
   propagatedBuildInputs = [
     pango imlib2
   ];
 
-  pythonPath = with python2.pkgs; [
+  pythonPath = with python3.pkgs; [
     pyxdg
   ];
 
@@ -35,6 +37,15 @@ stdenv.mkDerivation rec {
     url = "http://openbox.org/dist/tools/setlayout.c";
     sha256 = "1ci9lq4qqhl31yz1jwwjiawah0f7x0vx44ap8baw7r6rdi00pyiv";
   };
+
+  patches = [
+    # Use fetchurl to avoid "fetchpatch: ignores file renames" #32084
+    # This patch adds python3 support
+    (fetchurl {
+      url = "https://git.archlinux.org/svntogit/community.git/plain/openbox/trunk/py3.patch?id=90cb57ef53d952bb6ab4c33a184f815bbe1791c0";
+      sha256 = "1ks99awlkhd5ph9kz94s1r6m1bfvh42g4rmxd14dyg5b421p1ljc";
+    })
+  ];
 
   postBuild = "gcc -O2 -o setlayout $(pkg-config --cflags --libs x11) $setlayoutSrc";
 


### PR DESCRIPTION
###### Motivation for this change

Openbox contains a single python script that is trivially convertible to python3 (print statements to print functions). With an automatic conversion in the patch phase we can drop the python2 dependency.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
