### PR TITLE
ccls: Use latest llvmPackages

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10266,8 +10266,8 @@ in
 
 
   ccls = callPackage ../development/tools/misc/ccls {
-    llvmPackages = llvmPackages_8;
-    stdenv = llvmPackages_8.stdenv;
+    # From some reason the build fails for darwin if it uses llvm 10
+    llvmPackages = if stdenv.isDarwin then llvmPackages_latest else llvmPackages_9;
   };
 
   credstash = with python3Packages; toPythonApplication credstash;


### PR DESCRIPTION
##### Motivation for this change

In order to decrease overall closure size and to align with Nixpkgs' policy regarding the issue, packages which can work with the latest version of `libfoo` should use the latest version of it, even if `libfoo` points to `libfoo2` while there's also `libfoo3` available. This is influential on closure size in the following scenario:

- A user installs Program A which depends on `libfoo`.
- `libfoo` points to `libfoo2`.
- There's also a `libfoo_latest` which points to `libfoo3`.
- The user installs Program B which depends on `libfoo_latest` which is `libfoo3`.
- Program A can work with both `libfoo3` and `libfoo2`.

The result of this somewhat common pattern is that the user has both `libfoo2` and `libfoo_latest` in their store, but it's not necessary because Program A _can_ use `libfoo_latest` instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
