### PR TITLE
gotify: adapt update script to use vendor sha

### DIFF
--- a/pkgs/servers/gotify/default.nix
+++ b/pkgs/servers/gotify/default.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
     sha256 = import ./source-sha.nix;
   };
 
-  vendorSha256 = "1ha0zgz1n07sd3if6823fi83j7yajysjdzfbwqk9rpsi6zv3cfh3";
+  vendorSha256 = import ./vendor-sha.nix;
 
   postPatch = ''
     substituteInPlace app.go \

--- a/pkgs/servers/gotify/update.sh
+++ b/pkgs/servers/gotify/update.sh
@@ -11,9 +11,9 @@ echo got version $version
 echo \""${version#v}"\" > "$dirname/version.nix"
 printf '%s' $(nix-prefetch-git --quiet --rev ${version} https://github.com/gotify/server | jq .sha256) > $dirname/source-sha.nix
 tput setaf 1
-echo zeroing modSha256 in $dirname/mod-sha.nix
+echo zeroing vendorSha256 in $dirname/vendor-sha.nix
 tput sgr0
-printf '"%s"' "0000000000000000000000000000000000000000000000000000" > $dirname/mod-sha.nix
+printf '"%s"' "0000000000000000000000000000000000000000000000000000" > $dirname/vendor-sha.nix
 
 GOTIFY_WEB_SRC="https://raw.githubusercontent.com/gotify/server/$version"
 
@@ -28,13 +28,13 @@ echo removed yarn.lock
 
 echo running nix-build for ui
 nix-build -A gotify-server.ui
-echo running nix-build for gotify itself in order to get modSha256
+echo running nix-build for gotify itself in order to get vendorSha256
 set +e
-modSha256="$(nix-build -A gotify-server 2>&1 | grep "got:" | cut -d':' -f3)"
+vendorSha256="$(nix-build -A gotify-server 2>&1 | grep "got:" | cut -d':' -f3)"
 set -e
-printf '"%s"' "$modSha256" > $dirname/mod-sha.nix
+printf '"%s"' "$vendorSha256" > $dirname/vendor-sha.nix
 tput setaf 2
-echo got modSha256 of: $modSha256
+echo got vendorSha256 of: $vendorSha256
 tput sgr0
 echo running nix-build -A gotify-server which should build gotify-server normally
 nix-build -A gotify-server

--- a/pkgs/servers/gotify/vendor-sha.nix
+++ b/pkgs/servers/gotify/vendor-sha.nix
@@ -1,0 +1,1 @@
+"1ha0zgz1n07sd3if6823fi83j7yajysjdzfbwqk9rpsi6zv3cfh3"


### PR DESCRIPTION

###### Motivation for this change

Adapt update script and derivation to use vendor sha etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
