### PR TITLE
python3Packages.venvShellHook: add postVenvCreation

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -905,7 +905,8 @@ are used in `buildPythonPackage`.
 - `setuptoolsBuildHook` to build a wheel using `setuptools`.
 - `setuptoolsCheckHook` to run tests with `python setup.py test`.
 - `venvShellHook` to source a Python 3 `venv` at the `venvDir` location. A
-  `venv` is created if it does not yet exist.
+  `venv` is created if it does not yet exist. `postVenvCreation` can be used to
+  to run commands only after venv is first created.
 - `wheelUnpackHook` to move a wheel to the correct folder so it can be installed
   with the `pipInstallHook`.
 
@@ -1174,10 +1175,17 @@ in pkgs.mkShell rec {
     zlib
   ];
 
+  # Run this command, only after creating the virtual environment
+  postVenvCreation = ''
+    unset SOURCE_DATE_EPOCH
+    pip install -r requirements.txt
+  '';
+
   # Now we can execute any commands within the virtual environment.
   # This is optional and can be left out to run pip manually.
   postShellHook = ''
-    pip install -r requirements.txt
+    # allow pip to install wheels
+    unset SOURCE_DATE_EPOCH
   '';
 
 }

--- a/pkgs/development/interpreters/python/hooks/venv-shell-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/venv-shell-hook.sh
@@ -4,12 +4,14 @@ venvShellHook() {
 
     if [ -d "${venvDir}" ]; then
       echo "Skipping venv creation, '${venvDir}' already exists"
+      source "${venvDir}/bin/activate"
     else
       echo "Creating new venv environment in path: '${venvDir}'"
       @pythonInterpreter@ -m venv "${venvDir}"
-    fi
 
-    source "${venvDir}/bin/activate"
+      source "${venvDir}/bin/activate"
+      runHook postVenvCreation
+    fi
 
     runHook postShellHook
     echo "Finished executing venvShellHook"


### PR DESCRIPTION
###### Motivation for this change
defer some of the costs of doing:
```
pip install -r requirements.txt
```
to only when creating the venv environment.

I can alter the docs to include this if people feel like this should be added.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
