### PR TITLE
go-neb: Init at unstable-2020-04-09

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4741,6 +4741,12 @@
     githubId = 3507;
     name = "Michael Fellinger";
   };
+  maralorn = {
+    email = "malte.brandy@maralorn.de";
+    github = "maralorn";
+    githubId = 1651325;
+    name = "Malte Brandy";
+  };
   marcweber = {
     email = "marco-oweber@gmx.de";
     github = "marcweber";

--- a/pkgs/applications/networking/instant-messengers/go-neb/default.nix
+++ b/pkgs/applications/networking/instant-messengers/go-neb/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule {
+  pname = "go-neb";
+  version = "unstable-2020-04-09";
+  src = fetchFromGitHub {
+    owner = "matrix-org";
+    repo = "go-neb";
+    rev = "1e297c50ad2938e511a3c86f4b190fd3fc3559d6";
+    sha256 = "1azwy4s4kmypps1fjbz76flpi1b7sjzjj4qwx94cry0hn3qfnrc6";
+  };
+
+  subPackages = [ "." ];
+
+  patches = [ ./go-mod.patch ];
+
+  vendorSha256 = "1k3980yf6zl00dkd1djwhm2f9nnffzrsbs3kq3alpw2gm0aln739";
+
+  meta = with lib; {
+    description = "Extensible matrix bot written in Go";
+    homepage = "https://github.com/matrix-org/go-neb";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa maralorn ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/go-neb/go-mod.patch
+++ b/pkgs/applications/networking/instant-messengers/go-neb/go-mod.patch
@@ -1,0 +1,50 @@
+diff --git a/go.mod b/go.mod
+index 8ed4e68..83526e7 100644
+--- a/go.mod
++++ b/go.mod
+@@ -4,24 +4,15 @@ go 1.14
+ 
+ require (
+ 	github.com/PuerkitoBio/goquery v1.5.1 // indirect
+-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+-	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 // indirect
+ 	github.com/andygrunwald/go-jira v1.11.0
+ 	github.com/beorn7/perks v1.0.1 // indirect
+-	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+ 	github.com/dghubble/oauth1 v0.6.0
+ 	github.com/die-net/lrucache v0.0.0-20190707192454-883874fe3947
+-	github.com/go-kit/kit v0.9.0 // indirect
+-	github.com/go-logfmt/logfmt v0.4.0 // indirect
+-	github.com/go-stack/stack v1.8.0 // indirect
+-	github.com/gogo/protobuf v1.1.1 // indirect
+ 	github.com/golang/protobuf v1.3.2 // indirect
+ 	github.com/google/go-cmp v0.4.0 // indirect
+ 	github.com/google/go-github v2.0.1-0.20160719063544-b5e5babef39c+incompatible
+ 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
+ 	github.com/jaytaylor/html2text v0.0.0-20200220170450-61d9dc4d7195
+-	github.com/json-iterator/go v1.1.9 // indirect
+-	github.com/julienschmidt/httprouter v1.2.0 // indirect
+ 	github.com/kr/pretty v0.1.0 // indirect
+ 	github.com/lib/pq v1.3.0
+ 	github.com/matrix-org/dugong v0.0.0-20180820122854-51a565b5666b
+@@ -32,9 +23,6 @@ require (
+ 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+ 	github.com/mmcdole/gofeed v1.0.0-beta2
+ 	github.com/mmcdole/goxpp v0.0.0-20181012175147-0068e33feabf // indirect
+-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+-	github.com/modern-go/reflect2 v1.0.1 // indirect
+-	github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 // indirect
+ 	github.com/olekukonko/tablewriter v0.0.4 // indirect
+ 	github.com/pkg/errors v0.8.1 // indirect
+ 	github.com/prometheus/client_golang v0.8.1-0.20160916180340-5636dc67ae77
+@@ -47,10 +35,7 @@ require (
+ 	github.com/stretchr/testify v1.4.0 // indirect
+ 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
+ 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+ 	golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 // indirect
+-	golang.org/x/tools v0.0.0-20200311090712-aafaee8bce8c // indirect
+-	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
+ 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+ 	gopkg.in/yaml.v2 v2.2.8
+ )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1852,6 +1852,8 @@ in
 
   go-dependency-manager = callPackage ../development/tools/gdm { };
 
+  go-neb = callPackage ../applications/networking/instant-messengers/go-neb { };
+
   geckodriver = callPackage ../development/tools/geckodriver { };
 
   geekbench = callPackage ../tools/misc/geekbench { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds a package for the go-neb matrix bot.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
