### PR TITLE
Add note for necessary step of setting password

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -442,7 +442,11 @@ Retype new UNIX password: ***</screen>
       <para>
        For unattended installations, it is possible to use
        <command>nixos-install --no-root-passwd</command> in order to disable
-       the password prompt entirely.
+       the password prompt entirely. Note that at least one user with valid
+       password is required; you can do this later with
+       <command>chpasswd --root /mnt</command> (unattended version for
+       <command>passwd</command>). Be aware of security implication of setting
+       password non-interactively.
       </para>
      </note>
     </para>


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/39915#issuecomment-439283302

###### Things done

I don’t think they applies since this is only documentation update.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
