### PR TITLE
todoman: Make it not reference glibLocale which is ~210Mb in closure size

### DIFF
--- a/pkgs/applications/office/todoman/default.nix
+++ b/pkgs/applications/office/todoman/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, python3, glibcLocales, installShellFiles, jq }:
+{ stdenv
+, python3
+, glibcLocales
+, installShellFiles
+, jq
+}:
 
 let
   inherit (python3.pkgs) buildPythonApplication fetchPypi;
@@ -12,22 +17,46 @@ buildPythonApplication rec {
     sha256 = "16brw2zhm5vamffin6qjb0lxjlj3ba40vaficl851nw2xh2mrdhy";
   };
 
-    LOCALE_ARCHIVE = stdenv.lib.optionalString stdenv.isLinux
-      "${glibcLocales}/lib/locale/locale-archive";
-    LANG = "en_US.UTF-8";
-    LC_TYPE = "en_US.UTF-8";
+  LOCALE_ARCHIVE = stdenv.lib.optionalString stdenv.isLinux
+    "${glibcLocales}/lib/locale/locale-archive";
+  LANG = "en_US.UTF-8";
+  LC_TYPE = "en_US.UTF-8";
 
-  nativeBuildInputs = [ installShellFiles ];
-  buildInputs = [ glibcLocales ];
-  propagatedBuildInputs = with python3.pkgs;
-    [ atomicwrites click click-log click-repl configobj humanize icalendar parsedatetime
-      python-dateutil pyxdg tabulate urwid ];
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+  buildInputs = [
+    glibcLocales
+  ];
+  propagatedBuildInputs = with python3.pkgs; [
+    atomicwrites
+    click
+    click-log
+    click-repl
+    configobj
+    humanize
+    icalendar
+    parsedatetime
+    python-dateutil
+    pyxdg
+    tabulate
+    urwid
+  ];
 
-  checkInputs = with python3.pkgs;
-    [ flake8 flake8-import-order freezegun hypothesis pytest pytestrunner pytestcov ];
+  checkInputs = with python3.pkgs; [
+    flake8
+    flake8-import-order
+    freezegun
+    hypothesis
+    pytest
+    pytestrunner
+    pytestcov
+  ];
 
-  makeWrapperArgs = [ "--set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive"
-                      "--set CHARSET en_us.UTF-8" ];
+  makeWrapperArgs = [
+    "--set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive"
+    "--set CHARSET en_us.UTF-8"
+  ];
 
   postInstall = ''
     installShellCompletion --bash contrib/completion/bash/_todo

--- a/pkgs/applications/office/todoman/default.nix
+++ b/pkgs/applications/office/todoman/default.nix
@@ -17,16 +17,8 @@ buildPythonApplication rec {
     sha256 = "16brw2zhm5vamffin6qjb0lxjlj3ba40vaficl851nw2xh2mrdhy";
   };
 
-  LOCALE_ARCHIVE = stdenv.lib.optionalString stdenv.isLinux
-    "${glibcLocales}/lib/locale/locale-archive";
-  LANG = "en_US.UTF-8";
-  LC_TYPE = "en_US.UTF-8";
-
   nativeBuildInputs = [
     installShellFiles
-  ];
-  buildInputs = [
-    glibcLocales
   ];
   propagatedBuildInputs = with python3.pkgs; [
     atomicwrites
@@ -51,12 +43,10 @@ buildPythonApplication rec {
     pytest
     pytestrunner
     pytestcov
+    glibcLocales
   ];
 
-  makeWrapperArgs = [
-    "--set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive"
-    "--set CHARSET en_us.UTF-8"
-  ];
+  LC_ALL = "en_US.UTF-8";
 
   postInstall = ''
     installShellCompletion --bash contrib/completion/bash/_todo


### PR DESCRIPTION
###### Motivation for this change

`todoman` references `glibLocales` which is ~210Mb in size. This PR removes this reference. I have no idea why the original maintainer has reached the conclusion it is needed. I tested it thoroughly and everything seems ok without the wrapping which I removed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
