### PR TITLE
validatePkgConfig: init

### DIFF
--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -2085,6 +2085,16 @@ postInstall = ''
     </varlistentry>
     <varlistentry>
      <term>
+      validatePkgConfig
+     </term>
+     <listitem>
+      <para>
+       The <literal>validatePkgConfig</literal> hook validates all pkg-config (<filename>.pc</filename>) files in a package. This helps catching some common errors in pkg-config files, such as undefined variables.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
       cmake
      </term>
      <listitem>

--- a/pkgs/build-support/setup-hooks/validate-pkg-config.sh
+++ b/pkgs/build-support/setup-hooks/validate-pkg-config.sh
@@ -1,0 +1,19 @@
+# This setup hook validates each pkgconfig file in each output.
+
+fixupOutputHooks+=(_validatePkgConfig)
+
+_validatePkgConfig() {
+    for pc in $(find "$prefix" -name '*.pc'); do
+        local bail=0
+
+        # Do not fail immediately. It's nice to see all errors when
+        # there are multiple pkgconfig files.
+        if ! pkg-config --validate "$pc"; then
+            bail=1
+        fi
+    done
+
+    if [ $bail -eq 1 ]; then
+        exit 1
+    fi
+}

--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -1,9 +1,9 @@
 { stdenvNoCC
 , fetchurl
-, pkgconfig
 , rpmextract
 , undmg
 , darwin
+, validatePkgConfig
 , enableStatic ? false
 }:
 
@@ -46,15 +46,11 @@ in stdenvNoCC.mkDerivation {
         sha256 = "0v86hrqg15mbc78m9qk8dbkaaq3mlwashgbf9n79kxpl1gilnah8";
       });
 
-  nativeBuildInputs = if stdenvNoCC.isDarwin
+  nativeBuildInputs = [ validatePkgConfig ] ++ (if stdenvNoCC.isDarwin
     then
       [ undmg darwin.cctools ]
     else
-      [ rpmextract ];
-
-  installCheckInputs = [ pkgconfig ];
-
-  doInstallCheck = true;
+      [ rpmextract ]);
 
   buildPhase = if stdenvNoCC.isDarwin then ''
     for f in Contents/Resources/pkg/*.tgz; do
@@ -150,11 +146,6 @@ in stdenvNoCC.mkDerivation {
     install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libmkl_intel_thread.dylib
     install_name_tool -change @rpath/libtbb.dylib $out/lib/libtbb.dylib $out/lib/libmkl_tbb_thread.dylib
     install_name_tool -change @rpath/libtbbmalloc.dylib $out/lib/libtbbmalloc.dylib $out/lib/libtbbmalloc_proxy.dylib
-  '';
-
-  # Validate pkgconfig files, since they break often on updates.
-  installCheckPhase = ''
-    pkg-config --validate $out/lib/pkgconfig/*.pc
   '';
 
   # Per license agreement, do not modify the binary

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -501,6 +501,10 @@ in
 
   iconConvTools = callPackage ../build-support/icon-conv-tools {};
 
+  validatePkgConfig = makeSetupHook
+    { name = "validate-pkg-config"; deps = [ findutils pkgconfig ]; }
+    ../build-support/setup-hooks/validate-pkg-config.sh;
+
   #package writers
   writers = callPackage ../build-support/writers {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This adds the `validatePkgConfig` hook, which can be used to validate
pkg-config files in the output(s). Currently, this will just run
`pkg-config --validate` on all `.pc` files, capturing errors such as
the issue that was fixed in #87789.
    
The hook could be extended in the future with more fine-grained
checks.

I have also added a commit which enables this hook for the MKL derivation as an example.

This is the first time I touched the hooks at all, so I hope I didn't do anything bad ;).

@bhipple 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
