### PR TITLE
[20.03] youtube-viewer: 3.3.0 -> 3.7.5

### DIFF
--- a/pkgs/development/perl-modules/WWW-YoutubeViewer/default.nix
+++ b/pkgs/development/perl-modules/WWW-YoutubeViewer/default.nix
@@ -2,13 +2,13 @@
 
 buildPerlPackage rec {
   pname = "WWW-YoutubeViewer";
-  version = "3.3.0";
+  version = "3.7.5";
 
   src = fetchFromGitHub {
     owner  = "trizen";
     repo   = "youtube-viewer";
     rev    = version;
-    sha256 = "15xyrwv08fw8jmpydwzks26ipxnzliwddgyjcfqiaj0p7lwlhmx1";
+    sha256 = "1caz56sxy554avz2vdv9gm7gyqcq0gyixzrh5v9ixmg6vxif5d4f";
   };
 
   nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin shortenPerlShebang;


### PR DESCRIPTION
(cherry picked from commit 52ad14bbee1c44688acdffc6a3ac595b80adca15)

###### Motivation for this change
backport #84723

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
