### PR TITLE
jugglinglab: init at 1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8301,6 +8301,12 @@
     githubId = 54934;
     name = "Wout Mertens";
   };
+  wnklmnn = {
+    email = "pascal@wnklmnn.de";
+    github = "wnklmnn";
+    githubId = 9423014;
+    name = "Pascal Winkelmann";
+  };
   woffs = {
     email = "github@woffs.de";
     github = "woffs";

--- a/pkgs/tools/misc/jugglinglab/default.nix
+++ b/pkgs/tools/misc/jugglinglab/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchgit, jre, makeWrapper, ant, jdk }:
+stdenv.mkDerivation rec {
+  major= "1";
+  minor = "2";
+  version = "${major}.${minor}";
+  name = "jugglinglab";
+  src = fetchgit {
+    url = "https://github.com/jkboyce/jugglinglab";
+    rev = "v${major}.${minor}";
+    sha256 = "1p62kb9hfch7pi4way18c5mgky4xbxcrfgrw0hd25sd6cpr88z92";
+  };
+  buildInputs = [ jre ];
+  nativeBuildInputs = [ ant jdk makeWrapper ];
+  buildPhase = "ant";
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    mkdir -p "$out/lib"
+    cp bin/JugglingLab.jar $out/lib/
+
+    makeWrapper ${jre}/bin/java $out/bin/jugglinglab \
+      --add-flags "-jar $out/lib/JugglingLab.jar"
+  '';
+
+  meta = with stdenv.lib; {
+      description = "A program to visualize different juggling pattens";
+      license = licenses.gpl2;
+      maintainers = with maintainers; [ wnklmnn ];
+  };
+}

--- a/pkgs/tools/misc/jugglinglab/default.nix
+++ b/pkgs/tools/misc/jugglinglab/default.nix
@@ -1,13 +1,12 @@
-{ stdenv, fetchgit, jre, makeWrapper, ant, jdk }:
+{ stdenv, fetchFromGitHub, jre, makeWrapper, ant, jdk }:
 stdenv.mkDerivation rec {
-  major= "1";
-  minor = "2";
-  version = "${major}.${minor}";
+  version = "1.2.1";
   name = "jugglinglab";
-  src = fetchgit {
-    url = "https://github.com/jkboyce/jugglinglab";
-    rev = "v${major}.${minor}";
-    sha256 = "1p62kb9hfch7pi4way18c5mgky4xbxcrfgrw0hd25sd6cpr88z92";
+  src = fetchFromGitHub {
+    owner = "jkboyce";
+    repo = "jugglinglab";
+    rev = "1908012682d8c39a9b92248a20f285455104c510"; # v1.2.1 does not have a tag on Github
+    sha256 = "0dvcyjwynvapqbjchrln59vdskrm3w6kh0knxcn4bx61vcz3171z";
   };
   buildInputs = [ jre ];
   nativeBuildInputs = [ ant jdk makeWrapper ];
@@ -26,5 +25,6 @@ stdenv.mkDerivation rec {
       description = "A program to visualize different juggling pattens";
       license = licenses.gpl2;
       maintainers = with maintainers; [ wnklmnn ];
+      platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4468,6 +4468,8 @@ in
 
   jucipp = callPackage ../applications/editors/jucipp { };
 
+  jugglinglab = callPackage ../tools/misc/jugglinglab { };
+
   jupp = callPackage ../applications/editors/jupp { };
 
   jupyter = callPackage ../applications/editors/jupyter { };
@@ -7203,8 +7205,6 @@ in
   uif2iso = callPackage ../tools/cd-dvd/uif2iso { };
 
   umlet = callPackage ../tools/misc/umlet { };
-
-  jugglinglab = callPackage ../tools/misc/jugglinglab { };
 
   unetbootin = callPackage ../tools/cd-dvd/unetbootin { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7204,6 +7204,8 @@ in
 
   umlet = callPackage ../tools/misc/umlet { };
 
+  jugglinglab = callPackage ../tools/misc/jugglinglab { };
+
   unetbootin = callPackage ../tools/cd-dvd/unetbootin { };
 
   unfs3 = callPackage ../servers/unfs3 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds jugglinglab. A program to visualize different juggling patterns.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
