### PR TITLE
openssl: split the (mostly empty) runtime dependencies of static builds into a separate output

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -50,9 +50,21 @@ let
       substituteInPlace crypto/async/arch/async_posix.h \
         --replace '!defined(__ANDROID__) && !defined(__OpenBSD__)' \
                   '!defined(__ANDROID__) && !defined(__OpenBSD__) && 0'
+    '' + optionalString static
+    # On static builds, the ENGINESDIR will be empty, but its path will be
+    # compiled into the library. In order to minimize the runtime dependencies
+    # of packages that statically link openssl, we move it into the OPENSSLDIR,
+    # which will be separated into the 'etc' output.
+    ''
+      substituteInPlace Configurations/unix-Makefile.tmpl \
+        --replace 'ENGINESDIR=$(libdir)/engines-{- $sover_dirname -}' \
+                  'ENGINESDIR=$(OPENSSLDIR)/engines-{- $sover_dirname -}'
     '';
 
-    outputs = [ "bin" "dev" "out" "man" ] ++ optional withDocs "doc";
+    outputs = [ "bin" "dev" "out" "man" ]
+      ++ optional withDocs "doc"
+      # Separate output for the runtime dependencies of the static build.
+      ++ optional static "etc";
     setOutputFlags = false;
     separateDebugInfo =
       !stdenv.hostPlatform.isDarwin &&
@@ -101,7 +113,17 @@ let
     configureFlags = [
       "shared" # "shared" builds both shared and static libraries
       "--libdir=lib"
-      "--openssldir=etc/ssl"
+      (if !static then
+         "--openssldir=etc/ssl"
+       else
+         # Separate the OPENSSLDIR into its own output, as its path will be
+         # compiled into 'libcrypto.a'. This makes it a runtime dependency of
+         # any package that statically links openssl, so we want to keep that
+         # output minimal. We need to prepend '/.' to the path in order to make
+         # it appear absolute before variable expansion, the 'prefix' would be
+         # prepended to it otherwise.
+         "--openssldir=/.$(etc)/etc/ssl"
+      )
     ] ++ lib.optionals withCryptodev [
       "-DHAVE_CRYPTODEV"
       "-DUSE_CRYPTODEV_DIGESTS"
@@ -131,6 +153,9 @@ let
       if [ -n "$(echo $out/lib/*.so $out/lib/*.dylib $out/lib/*.dll)" ]; then
           rm "$out/lib/"*.a
       fi
+
+      # 'etc' is a separate output on static builds only.
+      etc=$out
     '' + lib.optionalString (!stdenv.hostPlatform.isWindows)
       # Fix bin/c_rehash's perl interpreter line
       #
@@ -152,14 +177,15 @@ let
       mv $out/include $dev/
 
       # remove dependency on Perl at runtime
-      rm -r $out/etc/ssl/misc
+      rm -r $etc/etc/ssl/misc
 
-      rmdir $out/etc/ssl/{certs,private}
+      rmdir $etc/etc/ssl/{certs,private}
     '';
 
     postFixup = lib.optionalString (!stdenv.hostPlatform.isWindows) ''
-      # Check to make sure the main output doesn't depend on perl
-      if grep -r '${buildPackages.perl}' $out; then
+      # Check to make sure the main output and the static runtime dependencies
+      # don't depend on perl
+      if grep -r '${buildPackages.perl}' $out $etc; then
         echo "Found an erroneous dependency on perl ^^^" >&2
         exit 1
       fi


### PR DESCRIPTION
###### Motivation for this change

This closure size of all packages that statically link `openssl` is unnecessarily large, as they get a runtime dependency on the static openssl build.

This is because the paths to several mostly empty directories and files in `--openssldir` and `ENGINESDIR` that are being baked  into the `libcrypto.a` file: 

```bash
$ strings /nix/store/qlw2d1jwjijm1g70f0p4cbwqf9ccmw78-openssl-1.1.1d/lib/libcrypto.a | grep /nix/store
/nix/store/qlw2d1jwjijm1g70f0p4cbwqf9ccmw78-openssl-1.1.1d/etc/ssl/ct_log_list.cnf
OPENSSLDIR: "/nix/store/qlw2d1jwjijm1g70f0p4cbwqf9ccmw78-openssl-1.1.1d/etc/ssl"
ENGINESDIR: "/nix/store/qlw2d1jwjijm1g70f0p4cbwqf9ccmw78-openssl-1.1.1d/lib/engines-1.1"
/nix/store/qlw2d1jwjijm1g70f0p4cbwqf9ccmw78-openssl-1.1.1d/lib/engines-1.1
/nix/store/qlw2d1jwjijm1g70f0p4cbwqf9ccmw78-openssl-1.1.1d/etc/ssl/private
/nix/store/qlw2d1jwjijm1g70f0p4cbwqf9ccmw78-openssl-1.1.1d/etc/ssl
/nix/store/qlw2d1jwjijm1g70f0p4cbwqf9ccmw78-openssl-1.1.1d/etc/ssl/certs
```

This is an attempt to reduce the runtime dependencies of packages that statically link openssl by:

* Moving the '--openssldir' to a separate output.

This is relatively simple and clean, but unfortunately not enough, as the ENGINESDIR, which is also being baked into the static library and it cannot be configured (hardcoded to be under `libdir` by openssl). So we also need to:

* Patch the ENGINESDIR to be in the separate output instead of `libdir` on static builds.

This is a bit messy, but I could't figure out a cleaner solution so far... The substitution is only done on static builds, as the dynamic `*.so` files in ENGINESDIR contain references to `$out` and cannot be moved to a separate output.

I would be very grateful for any hints on how to improve this PR!

In my use case, this reduces the closure size of e.g. https://github.com/PostgREST/postgrest by over 60%, from 13mb compressed to about 5mb.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date (added comments)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).