### PR TITLE
pythonPackage.bleak: init at 0.6.2

### DIFF
--- a/pkgs/development/python-modules/bleak/default.nix
+++ b/pkgs/development/python-modules/bleak/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, buildPythonPackage, isPy3k, fetchPypi, bluez, txdbus, pytest, pytestcov }:
+
+buildPythonPackage rec {
+  pname = "bleak";
+  version = "0.6.2";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kmq2z3dhq6dd20i5w71gshjrfvyw0pkpnld8iib9ai2rz6a8aj0";
+  };
+
+  postPatch = ''
+    # bleak checks BlueZ's version with a call to `bluetoothctl -v` twice
+    substituteInPlace bleak/__init__.py \
+      --replace \"bluetoothctl\" \"${bluez}/bin/bluetoothctl\"
+    substituteInPlace bleak/backends/bluezdbus/client.py \
+      --replace \"bluetoothctl\" \"${bluez}/bin/bluetoothctl\"
+  '';
+
+  propagatedBuildInputs = [ txdbus ];
+  checkInputs = [ pytest pytestcov ];
+
+  checkPhase = "AGENT_OS=linux py.test";
+
+  meta = with stdenv.lib; {
+    description = "Bluetooth Low Energy platform Agnostic Klient for Python";
+    homepage = "https://github.com/hbldh/bleak";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/development/python-modules/txdbus/default.nix
+++ b/pkgs/development/python-modules/txdbus/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, six, twisted }:
+
+buildPythonPackage rec {
+  pname = "txdbus";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0z41n1ikpdvk0nm8dbyh6g9bg781q4j6hg2b09b5k4wdqm17zxbg";
+  };
+
+  propagatedBuildInputs = [ six twisted ];
+  pythonImportsCheck = [ "txdbus" ];
+
+  meta = with stdenv.lib; {
+    description = "Native Python implementation of DBus for Twisted";
+    homepage = "https://github.com/cocagne/txdbus";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2095,6 +2095,8 @@ in {
 
   bleach = callPackage ../development/python-modules/bleach { };
 
+  bleak = callPackage ../development/python-modules/bleak { };
+
   blinker = callPackage ../development/python-modules/blinker { };
 
   blockdiag = callPackage ../development/python-modules/blockdiag { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5945,6 +5945,8 @@ in {
 
   txtorcon = callPackage ../development/python-modules/txtorcon { };
 
+  txdbus = callPackage ../development/python-modules/txdbus { };
+
   tzlocal = callPackage ../development/python-modules/tzlocal { };
 
   u-msgpack-python = callPackage ../development/python-modules/u-msgpack-python { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adds [`bleak`](https://github.com/hbldh/bleak) and its dependency [`txdbus`](https://github.com/cocagne/txdbus).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
