### PR TITLE
fitnesstrax: derivation bugfix

### DIFF
--- a/pkgs/applications/misc/fitnesstrax/default.nix
+++ b/pkgs/applications/misc/fitnesstrax/default.nix
@@ -19,6 +19,8 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     wrapGAppsHook
+    glib
+    gtk3
   ];
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Make sure glib and gtk3 are both in nativeBuildInputs

I don't know why this didn't break before, but glib and (or) gtk3 need
to be in nativeBuildInputs for glib-compile-schemas to be available. But
they also need to be in buildInputs to be available at link time.

I think worldofpeace mentioned this to me, but that it got lost in all
of the other fixes I needed to make when I first submitted the
derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
