### PR TITLE
[20.03] megasync 4.2.3.0 -> 4.3.0.9 (backport)

### DIFF
--- a/pkgs/applications/misc/megasync/default.nix
+++ b/pkgs/applications/misc/megasync/default.nix
@@ -5,13 +5,13 @@
 
 mkDerivation rec {
   pname = "megasync";
-  version = "4.2.5.0";
+  version = "4.3.0.8";
 
   src = fetchFromGitHub {
     owner = "meganz";
     repo = "MEGAsync";
     rev = "v${version}_Linux";
-    sha256 = "1zw7x8gpvzhnzyirs5ishjl5idzyyin4wdxa67d6gzfgvqi33n7w";
+    sha256 = "1rhxkc6j3039rcsi8cxy3n00g6w7acir82ymnksbpsnp4yxqv5r3";
     fetchSubmodules = true;
   };
 
@@ -40,13 +40,6 @@ mkDerivation rec {
     ./noinstall-distro-version.patch
     # megasync target is not part of the install rule thanks to a commented block
     ./install-megasync.patch
-
-    # Fix build errror also described upstream:
-    # https://github.com/meganz/MEGAsync/pull/313
-    (fetchpatch {
-      url = "https://github.com/meganz/MEGAsync/pull/313.patch";
-      sha256 = "1ld00cnh9afxibvkzkqi8gz59xlzidw2dy4yqngwwdqy76sfsn3w";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/applications/misc/megasync/default.nix
+++ b/pkgs/applications/misc/megasync/default.nix
@@ -1,28 +1,6 @@
-{ stdenv
-, autoconf
-, automake
-, c-ares
-, cryptopp
-, curl
-, doxygen
-, fetchFromGitHub
-, ffmpeg
-, libmediainfo
-, libraw
-, libsodium
-, libtool
-, libuv
-, libzen
-, lsb-release
-, mkDerivation
-, pkgconfig
-, qtbase
-, qttools
-, sqlite
-, swig
-, unzip
-, wget
-}:
+{ stdenv, autoconf, automake, c-ares, cryptopp, curl, doxygen, fetchFromGitHub
+, ffmpeg, libmediainfo, libraw, libsodium, libtool, libuv, libzen, lsb-release
+, mkDerivation, pkgconfig, qtbase, qttools, sqlite, swig, unzip, wget }:
 
 mkDerivation rec {
   pname = "megasync";
@@ -36,15 +14,8 @@ mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [
-    autoconf
-    automake
-    doxygen
-    lsb-release
-    pkgconfig
-    qttools
-    swig
-  ];
+  nativeBuildInputs =
+    [ autoconf automake doxygen lsb-release pkgconfig qttools swig ];
   buildInputs = [
     c-ares
     cryptopp
@@ -85,21 +56,21 @@ mkDerivation rec {
   '';
 
   configureFlags = [
-          "--disable-examples"
-          "--disable-java"
-          "--disable-php"
-          "--enable-chat"
-          "--with-cares"
-          "--with-cryptopp"
-          "--with-curl"
-          "--with-ffmpeg"
-          "--without-freeimage"  # unreferenced even when found
-          "--without-readline"
-          "--without-termcap"
-          "--with-sodium"
-          "--with-sqlite"
-          "--with-zlib"
-    ];
+    "--disable-examples"
+    "--disable-java"
+    "--disable-php"
+    "--enable-chat"
+    "--with-cares"
+    "--with-cryptopp"
+    "--with-curl"
+    "--with-ffmpeg"
+    "--without-freeimage" # unreferenced even when found
+    "--without-readline"
+    "--without-termcap"
+    "--with-sodium"
+    "--with-sqlite"
+    "--with-zlib"
+  ];
 
   postConfigure = ''
     cd ../..
@@ -114,10 +85,11 @@ mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Easy automated syncing between your computers and your MEGA Cloud Drive";
-    homepage    = https://mega.nz/;
-    license     = licenses.unfree;
-    platforms   = [ "i686-linux" "x86_64-linux" ];
+    description =
+      "Easy automated syncing between your computers and your MEGA Cloud Drive";
+    homepage = "https://mega.nz/";
+    license = licenses.unfree;
+    platforms = [ "i686-linux" "x86_64-linux" ];
     maintainers = [ maintainers.michojel ];
   };
 }

--- a/pkgs/applications/misc/megasync/default.nix
+++ b/pkgs/applications/misc/megasync/default.nix
@@ -1,16 +1,17 @@
 { stdenv, autoconf, automake, c-ares, cryptopp, curl, doxygen, fetchFromGitHub
-, ffmpeg, libmediainfo, libraw, libsodium, libtool, libuv, libzen, lsb-release
-, mkDerivation, pkgconfig, qtbase, qttools, sqlite, swig, unzip, wget }:
+, fetchpatch, ffmpeg, libmediainfo, libraw, libsodium, libtool, libuv, libzen
+, lsb-release, mkDerivation, pkgconfig, qtbase, qttools, sqlite, swig, unzip
+, wget }:
 
 mkDerivation rec {
   pname = "megasync";
-  version = "4.2.3.0";
+  version = "4.2.5.0";
 
   src = fetchFromGitHub {
     owner = "meganz";
     repo = "MEGAsync";
     rev = "v${version}_Linux";
-    sha256 = "0l4yfrxjb62vc9dnlzy8rjqi68ga1bys5x5rfzs40daw13yf1adv";
+    sha256 = "1zw7x8gpvzhnzyirs5ishjl5idzyyin4wdxa67d6gzfgvqi33n7w";
     fetchSubmodules = true;
   };
 
@@ -39,6 +40,13 @@ mkDerivation rec {
     ./noinstall-distro-version.patch
     # megasync target is not part of the install rule thanks to a commented block
     ./install-megasync.patch
+
+    # Fix build errror also described upstream:
+    # https://github.com/meganz/MEGAsync/pull/313
+    (fetchpatch {
+      url = "https://github.com/meganz/MEGAsync/pull/313.patch";
+      sha256 = "1ld00cnh9afxibvkzkqi8gz59xlzidw2dy4yqngwwdqy76sfsn3w";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Megasync does not currently build on 20.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
