### PR TITLE
WIP agda: Add libraries semi-automatically from package-index

### DIFF
--- a/pkgs/build-support/agda/package-index.nix
+++ b/pkgs/build-support/agda/package-index.nix
@@ -1,0 +1,29 @@
+# Downloads the Agda Package Index from https://github.com/agda/package-index and parses it into nix derivations
+{ pkgs }:
+with pkgs.lib;
+with builtins;
+let
+  package-index = fetchTarball {
+    url = "https://github.com/agda/package-index/archive/1bae82e018550dd5fdf46d9d98277f396ee59c1d.tar.gz";
+    sha256 = "08fcbh2ci442zs29bdg83s898svbr8bw0jr32kkp280943cb57h7";
+  };
+  makeAgdaPackage = name: { mkDerivation }: mkDerivation rec {
+    inherit name;
+    pname = name;
+
+    src =
+      let
+        basePath = "${package-index}/src/${name}";
+        revDir = head (attrNames (readDir "${package-index}/src/${name}/versions/")); # For now grab some ref at random
+      in fetchGit {
+      url = readFile "${basePath}/url";
+      rev = readFile "${basePath}/versions/${revDir}/sha1";
+    };
+  };
+  makeAgdaPackageAttr = name: {
+    inherit name;
+    value = makeAgdaPackage name;
+  };
+  thing = listToAttrs (map makeAgdaPackageAttr (attrNames (readDir "${package-index}/src")));
+in
+thing

--- a/pkgs/top-level/agda-packages.nix
+++ b/pkgs/top-level/agda-packages.nix
@@ -1,6 +1,7 @@
 { pkgs, lib, callPackage, newScope, Agda }:
 
 let
+  cubical = (import ../build-support/agda/package-index.nix { inherit pkgs; }).cubical;
   mkAgdaPackages = Agda: lib.makeScope newScope (mkAgdaPackages' Agda);
   mkAgdaPackages' = Agda: self: let
     callPackage = self.callPackage;
@@ -22,5 +23,7 @@ let
     agda-prelude = callPackage ../development/libraries/agda/agda-prelude { };
 
     agda-categories = callPackage ../development/libraries/agda/agda-categories { };
+
+    cubical = callPackage cubical {};
   };
 in mkAgdaPackages Agda


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

We don't want to keep a manual list of agda packages. This already exists in the form of https://github.com/agda/package-index/, and should be reused as far as automatically possible

This is work in progress. Further things to be done:

* [ ] Find a good way to select the best revisions for each library. Either we fix a rev here in nixpkgs, or there has to be an automatic way to get the newest recorded revision from `package-index`.
* [ ] Try to build all libraries and mark
* [ ] Metadata
  * [ ] Add myself (and @alexarice ?) as maintainers for each package
  * [ ] Descriptions and URL
* [ ] Overwrite mechanisms per library
  * [ ] Choose a different rev
  * [ ] add more maintainers
  * [ ] dependencies (those that cannot easily be parsed)
  * [ ] Custom files or build phases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@alexarice 