### PR TITLE
gnupg22: reproducible build

### DIFF
--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -53,6 +53,10 @@ stdenv.mkDerivation rec {
     "--with-npth-prefix=${npth}"
   ] ++ optional guiSupport "--with-pinentry-pgm=${pinentry}/${pinentryBinaryPath}";
 
+  preBuild = ''
+    echo $SOURCE_DATE_EPOCH > doc/defsincdate
+  '';
+
   postInstall = if enableMinimal
   then ''
     rm -r $out/{libexec,sbin,share}

--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -53,8 +53,10 @@ stdenv.mkDerivation rec {
     "--with-npth-prefix=${npth}"
   ] ++ optional guiSupport "--with-pinentry-pgm=${pinentry}/${pinentryBinaryPath}";
 
+  # ensure doc/defsincdate is more recent than anything we touched until now, especially in postPatch
+  # otherwise these modification times might leak into the generated documentation
   preBuild = ''
-    echo $SOURCE_DATE_EPOCH > doc/defsincdate
+    touch doc/defsincdate
   '';
 
   postInstall = if enableMinimal


### PR DESCRIPTION
GnuPG has a very peculiar way of fixing the date for the documentation.
It relies on a timestamp in the file `doc/defsincdate`, which is by default
generated by looking at the timestamp of the latest git commit.
If building from a tarball, this file is empty and `mkdefsinc` will fall
back to the timestamp of the newest source file, which is `doc/defsincdate`.
Thus, the build date ends up in the documentation.

Creating and populating `doc/defsincdate` with the the value of
`SOURCE_DATE_EPOCH` provided by NixPkgs' stdEnv fixes this.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

GnuPG build was not fully reproducible according to [r13y.com](https://r13y.com/diff/140a9642a0b950574206f6c5514036b9b82303add34553c60ceb16fa1c3561a3-f5f8344c2c1e5ba661ca4f371408b81329ca8db64814904b606b5890003bc94b.html)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
