### PR TITLE
stdenv: always pass --build, --host to configure

### DIFF
--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -62,15 +62,13 @@ stdenv.mkDerivation rec {
   makeFlags= [
     "CC=${stdenv.cc.targetPrefix}cc"
     "STRIP="  # Disable install stripping as it breaks cross-compiling. We strip binaries anyway in fixupPhase.
+    "STRIP_OPTS="
     "prefix=${placeholder "out"}"
     "sysconfdir=${placeholder "out"}/etc"
     "systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
     # contrib modules require these
     "moduledir=${placeholder "out"}/lib/modules"
     "mandir=${placeholder "out"}/share/man"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-    # Can be unconditional, doing it like this to prevent a mass rebuild.
-    "STRIP_OPTS="
   ];
 
   extraContribModules = [

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -146,6 +146,10 @@ stdenv.mkDerivation {
   qtQmlPrefix = "lib/qt-${qtCompatVersion}/qml";
   qtDocPrefix = "share/doc/qt-${qtCompatVersion}";
 
+  # qmake is built during configure and it doesn't accept platforms flags
+  # 'ERROR: Unknown command line option '--build=x86_64-unknown-linux-gnu'.''
+  configurePlatforms = [ ];
+
   setOutputFlags = false;
   preConfigure = ''
     export LD_LIBRARY_PATH="$PWD/lib:$PWD/plugins/platforms''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -53,6 +53,11 @@ stdenv.mkDerivation rec {
     sha256 = "0fpz63dfac1i6wwf5wp3v1vs3r5yzh05g95m5vidx56h0g4dcp44";
   };
 
+  postPatch = ''
+    substituteInPlace ./configure \
+      --replace 'CC="''${HOST}-''${CC}"' 'CC="''${CC}"'
+  '';
+
   preBuild = ''
     cp -r ${arm64} libr/asm/arch/arm/v35arm64/arch-arm64
     chmod -R +w libr/asm/arch/arm/v35arm64/arch-arm64

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -118,11 +118,7 @@ makeOverlayable (overrideAttrs:
 , mesonFlags ? []
 , # Target is not included by default because most programs don't care.
   # Including it then would cause needless mass rebuilds.
-  #
-  # TODO(@Ericson2314): Make [ "build" "host" ] always the default.
-  configurePlatforms ? lib.optionals
-    (stdenv.hostPlatform != stdenv.buildPlatform)
-    [ "build" "host" ]
+  configurePlatforms ? [ "build" "host" ]
 
 # TODO(@Ericson2314): Make unconditional / resolve #33599
 # Check phase

--- a/pkgs/tools/text/discount/default.nix
+++ b/pkgs/tools/text/discount/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-S6OVKYulhvEPRqNXBsvZ7m2W4cbdnrpZKPAo3SfD+9s=";
   };
 
+  strictDeps = true;
+
+  # uses a custom configure script
+  # Bad option --build=x86_64-unknown-linux-gnu.
+  configurePlatforms = [ ];
   patches = [ ./fix-configure-path.patch ];
   configureScript = "./configure.sh";
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

See #21471 for why this is a good idea. The consensus there seemed to be "go for it," so here's me going for it. This is too big to reasonably test on my laptop, but I imagine this will break some stuff, so it might want to be its own hydra job? I'm not sure how one makes that happen. @edolstra, maybe?

This PR sets configurePlatforms to always default to `[ "build" "host" ]` in mkDerivation, which was probably the single biggest source of special-casing for cross compiling. However, many individual packages still have special cases; once the dust settles, we should clean those up as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
