### PR TITLE
services/calibre-server: Allow multiple libraries, add "user" and "group" options

### DIFF
--- a/nixos/modules/services/misc/calibre-server.nix
+++ b/nixos/modules/services/misc/calibre-server.nix
@@ -9,24 +9,42 @@ let
 in
 
 {
+  imports = [
+    (mkChangedOptionModule [ "services" "calibre-server" "libraryDir" ] [ "services" "calibre-server" "libraries" ]
+      (config:
+        let libraryDir = getAttrFromPath [ "services" "calibre-server" "libraryDir" ] config;
+        in [ libraryDir ]
+      )
+    )
+  ];
 
   ###### interface
 
   options = {
-
     services.calibre-server = {
 
       enable = mkEnableOption "calibre-server";
 
-      libraryDir = mkOption {
+      libraries = mkOption {
         description = ''
-          The directory where the Calibre library to serve is.
-          '';
-          type = types.path;
+          The directories of the libraries to serve. They must be readable for the user under which the server runs.
+        '';
+        type = types.listOf types.path;
+      };
+
+      user = mkOption {
+        description = "The user under which calibre-server runs.";
+        type = types.str;
+        default = "calibre-server";
+      };
+
+      group = mkOption {
+        description = "The group under which calibre-server runs.";
+        type = types.str;
+        default = "calibre-server";
       };
 
     };
-
   };
 
 
@@ -34,29 +52,34 @@ in
 
   config = mkIf cfg.enable {
 
-    systemd.services.calibre-server =
-      {
+    systemd.services.calibre-server = {
         description = "Calibre Server";
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
-          User = "calibre-server";
+          User = cfg.user;
           Restart = "always";
-          ExecStart = "${pkgs.calibre}/bin/calibre-server ${cfg.libraryDir}";
+          ExecStart = "${pkgs.calibre}/bin/calibre-server ${lib.concatStringsSep " " cfg.libraries}";
         };
 
       };
 
     environment.systemPackages = [ pkgs.calibre ];
 
-    users.users.calibre-server = {
+    users.users = optionalAttrs (cfg.user == "calibre-server") {
+      calibre-server = {
+        home = "/var/lib/calibre-server";
+        createHome = true;
         uid = config.ids.uids.calibre-server;
-        group = "calibre-server";
+        group = cfg.group;
       };
+    };
 
-    users.groups.calibre-server = {
+    users.groups = optionalAttrs (cfg.group == "calibre-server") {
+      calibre-server = {
         gid = config.ids.gids.calibre-server;
       };
+    };
 
   };
 


### PR DESCRIPTION
###### Motivation for this change
* Enabled more than one library directory. The option has been renamed from `libraryDir` to `libraries`. The motivation for this is simply that `calibre-server` supports it and I would like to have it.
* There are now options to set the user and group the server should run under. If the standard user `calibre-server` is used, a home directory is created for it at `/var/lib/calibre-server`. The motivation for this change is the fact that there is currently no documentation about the user the server will run under and how this interacts with the library directory, as well as the fact that other similar server modules support setting the user and group.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
