### PR TITLE
go_1_13: 1.13.8 -> 1.13.11, stop setting GOPATH

### DIFF
--- a/pkgs/development/compilers/go/1.13.nix
+++ b/pkgs/development/compilers/go/1.13.nix
@@ -30,11 +30,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.13.8";
+  version = "1.13.11";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "0d7cxffk72568h46srzswrxd0bsdip7amgkf499wzn6l6d3g0fxi";
+    sha256 = "0y86q2k00lh8c7wj3lha43g804iwr61nap8j3i907l2sway1mvc9";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.13.nix
+++ b/pkgs/development/compilers/go/1.13.nix
@@ -229,8 +229,6 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  setupHook = ./setup-hook.sh;
-
   disallowedReferences = [ goBootstrap ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
This hook is removed in a1e13f6140a568b73c1c36bb9ef79d7876ccaae3 on staging.

cc @Mic92 @zimbatm 
