### PR TITLE
jamulus: init at 3.5.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6904,6 +6904,12 @@
     githubId = 2343853;
     name = "Sean Zicari";
   };
+  seb314 = {
+    email = "sebastian@seb314.com";
+    github = "seb314";
+    githubId = 19472270;
+    name = "Sebastian";
+  };
   sellout = {
     email = "greg@technomadic.org";
     github = "sellout";

--- a/pkgs/applications/audio/jamulus/default.nix
+++ b/pkgs/applications/audio/jamulus/default.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, stdenv, fetchFromGitHub, fetchpatch, pkg-config, qtscript, qmake, libjack2
+}:
+
+mkDerivation rec {
+  pname = "jamulus";
+  version = "3.5.5";
+  src = fetchFromGitHub {
+    owner = "corrados";
+    repo = "jamulus";
+    rev = "r${stdenv.lib.replaceStrings [ "." ] [ "_" ] version}";
+    sha256 = "04h0nwlj71qbp7h4yn8djqchrf47jk8rab9zp9bh9pnkcyv60h27";
+  };
+
+  nativeBuildInputs = [ pkg-config qmake ];
+  buildInputs = [ qtscript libjack2 ];
+
+  qmakeFlags = [ "CONFIG+=noupcasename" ];
+
+  meta = {
+    description = "Enables musicians to perform real-time jam sessions over the internet";
+    longDescription = "You also need to enable JACK and should enable several real-time optimizations. See project website for details";
+    homepage = "https://github.com/corrados/jamulus/wiki";
+    license = stdenv.lib.licenses.gpl2; # linked in git repo, at least
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.seb314 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4216,6 +4216,8 @@ in
 
   iannix = libsForQt5.callPackage ../applications/audio/iannix { };
 
+  jamulus = libsForQt5.callPackage ../applications/audio/jamulus { };
+
   ibm-sw-tpm2 = callPackage ../tools/security/ibm-sw-tpm2 { };
 
   ibniz = callPackage ../tools/graphics/ibniz { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Jamulus did not seem to be packaged for nixos before and it would be great to use it on nixos!
My first nix package, I hope I didn't do anything stupid (works fine on my nixos laptop).
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
