### PR TITLE
add `enableSound` parameter to `dwarf-fortress` derivation

### DIFF
--- a/pkgs/games/dwarf-fortress/lazy-pack.nix
+++ b/pkgs/games/dwarf-fortress/lazy-pack.nix
@@ -16,6 +16,7 @@
 , enableTruetype ? true
 , enableFPS ? false
 , enableTextMode ? false
+, enableSound ? true
 }:
 
 with lib;
@@ -32,7 +33,7 @@ buildEnv {
   paths = [
     (dwarf-fortress.override {
       inherit enableDFHack enableTWBT enableSoundSense enableStoneSense theme
-              enableIntro enableTruetype enableFPS enableTextMode;
+              enableIntro enableTruetype enableFPS enableTextMode enableSound;
     })]
     ++ lib.optional enableDwarfTherapist dwarf-therapist
     ++ lib.optional enableLegendsBrowser legends-browser;

--- a/pkgs/games/dwarf-fortress/wrapper/default.nix
+++ b/pkgs/games/dwarf-fortress/wrapper/default.nix
@@ -12,6 +12,7 @@
 , enableTruetype ? true
 , enableFPS ? false
 , enableTextMode ? false
+, enableSound ? true
 }:
 
 let
@@ -67,7 +68,8 @@ let
     substituteInPlace $out/data/init/init.txt \
       --replace '[INTRO:YES]' '[INTRO:${unBool enableIntro}]' \
       --replace '[TRUETYPE:YES]' '[TRUETYPE:${unBool enableTruetype}]' \
-      --replace '[FPS:NO]' '[FPS:${unBool enableFPS}]'
+      --replace '[FPS:NO]' '[FPS:${unBool enableFPS}]' \
+      --replace '[SOUND:YES]' '[SOUND:${unBool enableSound}]'
   ''));
 
   env = buildEnv {


### PR DESCRIPTION
###### Motivation for this change

The init file for this derivation can include `[SOUND:NO]` or `[SOUND:YES]`. This adds a parameter to control it. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
