### PR TITLE
highlight: 3.56 -> 3.57

### DIFF
--- a/pkgs/tools/text/highlight/default.nix
+++ b/pkgs/tools/text/highlight/default.nix
@@ -5,13 +5,13 @@ with stdenv.lib;
 let
   self = stdenv.mkDerivation rec {
     pname = "highlight";
-    version = "3.56";
+    version = "3.57";
 
     src = fetchFromGitLab {
       owner = "saalen";
       repo = "highlight";
       rev = "v${version}";
-      sha256 = "1pilx58dg96zm0yx7i6k92vibwpvpj8ir39f2akrsyjgijnv3sx4";
+      sha256 = "1xrk7c7akjiwh3wh9bll0qh4g0kqvbzjz9ancpadnk0k7bqi0kxf";
     };
 
     enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
<https://gitlab.com/saalen/highlight/-/releases/v3.57>

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
