### PR TITLE
nixos/zram: make zstd the default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -413,6 +413,11 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
      The default output of <literal>buildGoPackage</literal> is now <literal>$out</literal> instead of <literal>$bin</literal>.
    </para>
    </listitem>
+   <listitem>
+   <para>
+     Default algorithm for ZRAM swap was changed to <literal>zstd</literal>.
+   </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/config/zram.nix
+++ b/nixos/modules/config/zram.nix
@@ -91,7 +91,7 @@ in
       };
 
       algorithm = mkOption {
-        default = "lzo";
+        default = "zstd";
         example = "lz4";
         type = with types; either (enum [ "lzo" "lz4" "zstd" ]) str;
         description = ''


### PR DESCRIPTION
This was made the default in https://github.com/NixOS/nixpkgs/pull/52991 and reverted in https://github.com/NixOS/nixpkgs/pull/56856 because the default kernel at the time (4.14) didn't support `zstd`.

cc @danbst @worldofpeace 