### PR TITLE
doctl: 1.40.0 -> 1.43.0, switch to buildGoModule

### DIFF
--- a/pkgs/development/tools/doctl/default.nix
+++ b/pkgs/development/tools/doctl/default.nix
@@ -1,19 +1,19 @@
-{ lib, buildGoPackage, fetchFromGitHub, installShellFiles }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "doctl";
-  version = "1.40.0";
+  version = "1.43.0";
 
-  goPackagePath = "github.com/digitalocean/doctl";
+  vendorSha256 = null;
 
   subPackages = [ "cmd/doctl" ];
 
-  buildFlagsArray = ''
+  buildFlagsArray = let t = "github.com/digitalocean/doctl"; in ''
     -ldflags=
-    -X ${goPackagePath}.Major=${lib.versions.major version}
-    -X ${goPackagePath}.Minor=${lib.versions.minor version}
-    -X ${goPackagePath}.Patch=${lib.versions.patch version}
-    -X ${goPackagePath}.Label=release
+    -X ${t}.Major=${lib.versions.major version}
+    -X ${t}.Minor=${lib.versions.minor version}
+    -X ${t}.Patch=${lib.versions.patch version}
+    -X ${t}.Label=release
   '';
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
https://github.com/digitalocean/doctl/releases/tag/v1.41.0
https://github.com/digitalocean/doctl/releases/tag/v1.42.0
https://github.com/digitalocean/doctl/releases/tag/v1.43.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
