### PR TITLE
OldSindhi / MarathiCursive Fonts update

### DIFF
--- a/pkgs/data/fonts/marathi-cursive/default.nix
+++ b/pkgs/data/fonts/marathi-cursive/default.nix
@@ -1,21 +1,19 @@
-{ lib, fetchzip, p7zip }:
+{ lib, fetchzip }:
 
 let
-  version = "1.2";
+  version = "2.0";
 in fetchzip rec {
   name = "marathi-cursive-${version}";
 
-  url = "https://github.com/MihailJP/MarathiCursive/releases/download/${version}/MarathiCursive-${version}.7z";
+  url = "https://github.com/MihailJP/MarathiCursive/releases/download/v${version}/MarathiCursive-${version}.tar.xz";
 
   postFetch = ''
-    ${p7zip}/bin/7z x $downloadedFile
-    cd MarathiCursive
-
+    tar -xJf $downloadedFile --strip-components=1
     install -m444 -Dt $out/share/fonts/marathi-cursive *.otf *.ttf
-    install -m444 -Dt $out/share/doc/${name}           README *.txt
+    install -m444 -Dt $out/share/doc/${name} README *.txt
   '';
 
-  sha256 = "0wq4w79x8r5w6ikm9amcmapf0jcdgifs9zf1pbnw3fk4ncz5s551";
+  sha256 = "17pj60ajnjghxhxka8a046mz6vfwr79wnby7xd6pg5hgncin2hgg";
 
   meta = with lib; {
     homepage = "https://github.com/MihailJP/MarathiCursive";

--- a/pkgs/data/fonts/oldsindhi/default.nix
+++ b/pkgs/data/fonts/oldsindhi/default.nix
@@ -1,26 +1,25 @@
-{ lib, fetchzip, p7zip }:
+{ lib, fetchzip }:
 
 let
-  version = "0.1";
+  version = "1.0";
 in fetchzip rec {
   name = "oldsindhi-${version}";
 
-  url = "https://github.com/MihailJP/oldsindhi/releases/download/0.1/OldSindhi-0.1.7z";
+  url = "https://github.com/MihailJP/oldsindhi/releases/download/v${version}/OldSindhi-${version}.tar.xz";
 
   postFetch = ''
-    ${p7zip}/bin/7z x $downloadedFile
-
-    install -m444 -Dt $out/share/fonts/truetype OldSindhi/*.ttf
-    install -m444 -Dt $out/share/doc/${name}    OldSindhi/README OldSindhi/*.txt
+    tar -xJf $downloadedFile --strip-components=1
+    install -m444 -Dt $out/share/fonts/truetype *.ttf
+    install -m444 -Dt $out/share/doc/${name} README *.txt
   '';
 
-  sha256 = "0d4l9cg2vmh2pvnqsla8mgcwvc7wjxzcabhlli6633h3ifj2yp7b";
+  sha256 = "03c483vbrwz2fpdfbys42fmik9788zxfmjmc4fgq4s2d0mraa0j1";
 
   meta = with lib; {
     homepage = "https://github.com/MihailJP/oldsindhi";
     description = "Free Sindhi Khudabadi font";
     maintainers = with maintainers; [ mathnerd314 ];
-    license = licenses.bsd2;
+    license = with licenses; [mit ofl];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fallout from #86417 / #87837. The newer versions of the fonts use tar.xz and so don't need any special handling.

Or they could just be dropped. The original motivation for packaging these was Unicode coverage but Noto has added similar fonts that work fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested fonts show up in https://en.wiktionary.org/wiki/Appendix:Unicode/Modi and https://en.wikipedia.org/wiki/Khudawadi_(Unicode_block) correctly
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
