### PR TITLE
htmlbeautifier: init at 1.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7661,6 +7661,12 @@
     githubId = 25388474;
     name = "Matej Urbas";
   };
+  mveytsman = {
+    email = "maxim@ontoillogical.com";
+    github = "mveytsman";
+    githubId = 34720;
+    name = "Max Veytsman";
+  };
   mvnetbiz = {
     email = "mvnetbiz@gmail.com";
     github = "mvnetbiz";

--- a/pkgs/development/web/htmlbeautifier/Gemfile
+++ b/pkgs/development/web/htmlbeautifier/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org' do
+  gem 'htmlbeautifier'
+end

--- a/pkgs/development/web/htmlbeautifier/Gemfile.lock
+++ b/pkgs/development/web/htmlbeautifier/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    htmlbeautifier (1.3.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  htmlbeautifier!
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/development/web/htmlbeautifier/default.nix
+++ b/pkgs/development/web/htmlbeautifier/default.nix
@@ -1,0 +1,18 @@
+{ lib, bundlerApp, bundlerUpdateScript, ruby }:
+
+bundlerApp {
+  inherit ruby;
+  pname = "htmlbeautifier";
+  gemdir = ./.;
+  exes = [ "htmlbeautifier" ];
+
+  passthru.updateScript = bundlerUpdateScript "htmlbeautifier";
+
+  meta = with lib; {
+    description = "A normaliser/beautifier for HTML that also understands embedded Ruby, ideal for tidying up Rails templates";
+    homepage = "https://github.com/threedaymonk/htmlbeautifier";
+    license = licenses.mit;
+    platforms = ruby.meta.platforms;
+    maintainers =  with maintainers; [ mveytsman ];
+  };
+}

--- a/pkgs/development/web/htmlbeautifier/gemset.nix
+++ b/pkgs/development/web/htmlbeautifier/gemset.nix
@@ -1,0 +1,12 @@
+{
+  htmlbeautifier = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17015f37xrrkzvw1mdvxlyk6iam5p8h5d4my39rd96lnc1mvkw8s";
+      type = "gem";
+    };
+    version = "1.3.1";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14187,6 +14187,8 @@ with pkgs;
 
   ccloud-cli = callPackage ../development/tools/ccloud-cli { };
 
+  htmlbeautifier = callPackage ../development/web/htmlbeautifier { };
+
   htmlunit-driver = callPackage ../development/tools/selenium/htmlunit-driver { };
 
   hyenae = callPackage ../tools/networking/hyenae { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds [htmlbeautifier](https://github.com/threedaymonk/htmlbeautifier) an HTML formatter with Ruby/ERB support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
