### PR TITLE
neovim: expose the neovim-unwrapped manpage

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -73,6 +73,10 @@ let
         --cmd \"${if withRuby then "let g:ruby_host_prog='$out/bin/nvim-ruby'" else "let g:loaded_ruby_provider=1"}\" " \
         --suffix PATH : ${binPath} \
         ${optionalString withRuby '' --set GEM_HOME ${rubyEnv}/${rubyEnv.ruby.gemPath}'' }
+
+        # expose the manpage from neovim-unwrapped
+        mkdir -p $out/share/man/man1
+        ln -s ${neovim}/share/man/man1/nvim.1.gz $out/share/man/man1/nvim.1.gz
       ''
       + optionalString (!stdenv.isDarwin) ''
         # copy icon and patch the original neovim.desktop file
@@ -81,10 +85,6 @@ let
         substitute ${neovim}/share/applications/nvim.desktop $out/share/applications/nvim.desktop \
           --replace 'TryExec=nvim' "TryExec=$out/bin/nvim" \
           --replace 'Name=Neovim' 'Name=WrappedNeovim'
-
-        # expose the manpage from neovim-unwrapped
-        mkdir -p $out/share/man/man1
-        ln -s ${neovim}/share/man/man1/nvim.1.gz $out/share/man/man1/nvim.1.gz
       ''
       + optionalString withPython ''
         makeWrapper ${pythonEnv}/bin/python $out/bin/nvim-python --unset PYTHONPATH

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -81,6 +81,10 @@ let
         substitute ${neovim}/share/applications/nvim.desktop $out/share/applications/nvim.desktop \
           --replace 'TryExec=nvim' "TryExec=$out/bin/nvim" \
           --replace 'Name=Neovim' 'Name=WrappedNeovim'
+
+        # expose the manpage from neovim-unwrapped
+        mkdir -p $out/share/man/man1
+        ln -s ${neovim}/share/man/man1/nvim.1.gz $out/share/man/man1/nvim.1.gz
       ''
       + optionalString withPython ''
         makeWrapper ${pythonEnv}/bin/python $out/bin/nvim-python --unset PYTHONPATH


### PR DESCRIPTION
###### Motivation for this change

Install the neovim manpage along with the neovim package. Before, the manpage was only installed with neovim-unwrapped.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Fedora, Void)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) (`Difference of +624`)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
