### PR TITLE
ocamlPackages.cairo2: disable tests for OCaml ≥ 4.10

### DIFF
--- a/pkgs/development/ocaml-modules/cairo2/default.nix
+++ b/pkgs/development/ocaml-modules/cairo2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, buildDunePackage
+{ stdenv, lib, fetchurl, buildDunePackage, ocaml
 , pkgconfig, cairo
 }:
 
@@ -14,7 +14,9 @@ buildDunePackage rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ cairo ];
 
-  doCheck = !stdenv.isDarwin;
+  doCheck = !(stdenv.isDarwin
+  # https://github.com/Chris00/ocaml-cairo/issues/19
+  || lib.versionAtLeast ocaml.version "4.10");
 
   meta = {
     homepage = "https://github.com/Chris00/ocaml-cairo";


### PR DESCRIPTION
###### Motivation for this change

Fix build with OCaml 4.10

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @wizeman who mentioned facing this build failure