### PR TITLE
accountsservice: add patch for upstream issue #55

### DIFF
--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -54,6 +54,11 @@ stdenv.mkDerivation rec {
   '';
 
   patches = [
+    # https://gitlab.freedesktop.org/accountsservice/accountsservice/-/issues/55
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/58.patch";
+      sha256 = "1pnwq4ycnryb2kkgvnz44qzm71240ybqj6507wynlkdsw8180fdw";
+    })
     (substituteAll {
       src = ./fix-paths.patch;
       inherit shadow coreutils;


### PR DESCRIPTION
###### Motivation for this change

Add upstream patch for https://gitlab.freedesktop.org/accountsservice/accountsservice/-/issues/55, fixes #47475.

Asked for a possibility of a new upstream release at https://gitlab.freedesktop.org/accountsservice/accountsservice/-/issues/55#note_500692 so marking this PR as draft for now pending upstream's response.

###### Things done

Been running my system with the patch applied locally and can confirm it fixes the issue on my end.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
