### PR TITLE
 palp: 2.1 -> 2.11 

### DIFF
--- a/pkgs/applications/science/math/palp/default.nix
+++ b/pkgs/applications/science/math/palp/default.nix
@@ -9,16 +9,15 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "palp";
-  version = "2.1";
+  version = "2.11";
 
   src = fetchurl {
     url = "http://hep.itp.tuwien.ac.at/~kreuzer/CY/palp/palp-${version}.tar.gz";
-    sha256 = "1s7s2lc5f0ig1yy7ygsh3sddm3sbq4mxwybqsj8lp9wjdxs7qfrs";
+    sha256 = "09l4ysrdkqs91igg1faah75ay6ii684634ggvcxbkjsck65378l4";
   };
 
   hardeningDisable = [
     "format"
-    "strictoverflow" # causes runtime failure (tested in checkPhase)
   ];
 
   patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''

--- a/pkgs/applications/science/math/palp/default.nix
+++ b/pkgs/applications/science/math/palp/default.nix
@@ -78,6 +78,9 @@ stdenv.mkDerivation rec {
       facet enumeration compares well with existing packages.
     '';
     homepage = "http://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html";
+    # Not really a changelog, but a one-line summary of each update that should
+    # be reviewed on update.
+    changelog = "http://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html";
     # Just a link on the website pointing to gpl -- now gplv3. When the last
     # version was released that pointed to gplv2 however, so thats probably
     # the right license.


### PR DESCRIPTION
###### Motivation for this change

Version bump, gcc 10 compatibility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
