### PR TITLE
 python.pkgs.google-pasta: 0.1.8 -> 0.2.0

### DIFF
--- a/pkgs/development/python-modules/google-pasta/default.nix
+++ b/pkgs/development/python-modules/google-pasta/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "google-pasta";
-  version = "0.1.8";
+  version = "0.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "713813a9f7d6589e5defdaf21e80e4392eb124662f8bd829acd51a4f8735c0cb";
+    sha256 = "0vm1r1jlaiagj0l9yf7j6zn9w3733dr2169911c0svgrr3gwiwn9";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/google-pasta/default.nix
+++ b/pkgs/development/python-modules/google-pasta/default.nix
@@ -20,6 +20,8 @@ buildPythonPackage rec {
   meta = {
     description = "An AST-based Python refactoring library";
     homepage    = "https://github.com/google/pasta";
+    # Usually the tag message contains a one-line summary of the changes.
+    changelog   = "https://github.com/google/pasta/releases/tag/v${version}";
     license     = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ timokau ];
   };


### PR DESCRIPTION
###### Motivation for this change

Version bump for python 3.8 compatibility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
