### PR TITLE
mpd: enable tests + install docs + split outputs

### DIFF
--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -19,6 +19,10 @@
 # Tag support
 , libid3tag
 , nixosTests
+# For tests
+, gtest
+, fetchpatch # used to fetch an upstream patch fixing a failing test
+, zip
 }:
 
 let
@@ -112,9 +116,28 @@ let
         sha256 = "0jnhjhm1ilpcwb4f58b8pgyzjq3dlr0j2xyk0zck0afwkdxyj9cb";
       };
 
+      # Won't be needed when 0.21.24 will be out
+      patches = [
+        # Tests fail otherwise, see https://github.com/MusicPlayerDaemon/MPD/issues/844
+        (fetchpatch {
+          url = "https://github.com/MusicPlayerDaemon/MPD/commit/7aea2853612743e111ae5e947c8d467049e291a8.patch";
+          sha256 = "1bmxlsaiz3wlg1yyc4rkwsmgvc0pirv0s1vdxxsn91yssmh16c2g";
+          excludes = [
+            # The patch fails otherwise because it tries to update the NEWS
+            # file which doesn't have the title "ver 0.21.24" yet.
+            "NEWS"
+          ];
+        })
+      ];
+
       buildInputs = [
         glib
         boost
+        # According to the configurePhase of meson, gtest is considered a
+        # runtime dependency. Quoting:
+        #
+        #    Run-time dependency GTest found: YES 1.10.0
+        gtest
       ]
         ++ (lib.concatLists (lib.attrVals features_ featureDependencies))
         ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.AudioToolbox darwin.apple_sdk.frameworks.AudioUnit ];
@@ -125,11 +148,21 @@ let
         pkg-config
       ];
 
+      # Otherwise, the meson log says:
+      #
+      #    Program zip found: NO
+      checkInputs = [ zip ];
+
+      doCheck = true;
+
       enableParallelBuilding = true;
 
       mesonAutoFeatures = "disabled";
-      mesonFlags =
-        map (x: "-D${x}=enabled") features_
+
+      mesonFlags = [
+        "-Dtest=true"
+      ]
+        ++ map (x: "-D${x}=enabled") features_
         ++ map (x: "-D${x}=disabled") (lib.subtractLists features_ knownFeatures)
         ++ lib.optional (builtins.elem "zeroconf" features_)
           "-Dzeroconf=avahi"

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -19,6 +19,9 @@
 # Tag support
 , libid3tag
 , nixosTests
+# For documentation
+, doxygen
+, python3Packages # for sphinx-build
 # For tests
 , gtest
 , fetchpatch # used to fetch an upstream patch fixing a failing test
@@ -146,6 +149,8 @@ let
         meson
         ninja
         pkg-config
+        python3Packages.sphinx
+        doxygen
       ];
 
       # Otherwise, the meson log says:
@@ -159,7 +164,12 @@ let
 
       mesonAutoFeatures = "disabled";
 
+      outputs = [ "out" "doc" "man" ];
+
       mesonFlags = [
+        # Documentation is enabled unconditionally but it's not installed
+        # unconditionally thanks to the outputs being split
+        "-Ddocumentation=true"
         "-Dtest=true"
       ]
         ++ map (x: "-D${x}=enabled") features_

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, glib, systemd, boost, darwin
+{ stdenv, fetchFromGitHub, meson, ninja, pkg-config, glib, systemd, boost, darwin
 # Inputs
 , curl, libmms, libnfs, samba
 # Archive support
@@ -116,7 +116,7 @@ let
         ++ (lib.concatLists (lib.attrVals features_ featureDependencies))
         ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.AudioToolbox darwin.apple_sdk.frameworks.AudioUnit ];
 
-      nativeBuildInputs = [ meson ninja pkgconfig ];
+      nativeBuildInputs = [ meson ninja pkg-config ];
 
       enableParallelBuilding = true;
 

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -112,11 +112,18 @@ let
         sha256 = "0jnhjhm1ilpcwb4f58b8pgyzjq3dlr0j2xyk0zck0afwkdxyj9cb";
       };
 
-      buildInputs = [ glib boost ]
+      buildInputs = [
+        glib
+        boost
+      ]
         ++ (lib.concatLists (lib.attrVals features_ featureDependencies))
         ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.AudioToolbox darwin.apple_sdk.frameworks.AudioUnit ];
 
-      nativeBuildInputs = [ meson ninja pkg-config ];
+      nativeBuildInputs = [
+        meson
+        ninja
+        pkg-config
+      ];
 
       enableParallelBuilding = true;
 


### PR DESCRIPTION

###### Motivation for this change

I want to have the docs installed and they aren't installed if `mesonFlags` don't include `-Ddocumentation=true`.

Also, I noticed there are tests which I enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
