### PR TITLE
openorienteering-mapper: 0.9.2 -> 0.9.3

### DIFF
--- a/pkgs/applications/gis/openorienteering-mapper/default.nix
+++ b/pkgs/applications/gis/openorienteering-mapper/default.nix
@@ -1,31 +1,61 @@
-{ stdenv, fetchFromGitHub, gdal, cmake, ninja, proj, clipper, zlib, qtbase, qttools
-, qtlocation, qtsensors, doxygen, cups, wrapQtAppsHook, qtimageformats
+{ stdenv
+, mkDerivation
+, fetchFromGitHub
+, gdal
+, cmake
+, ninja
+, proj
+, clipper
+, zlib
+, qttools
+, qtlocation
+, qtsensors
+, qttranslations
+, doxygen
+, cups
+, qtimageformats
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "OpenOrienteering-Mapper";
-  version = "0.9.2";
+  version = "0.9.3";
 
-  buildInputs = [ gdal qtbase qttools qtlocation qtimageformats
-                  qtsensors clipper zlib proj doxygen cups];
+  buildInputs = [
+    gdal
+    qtlocation
+    qtimageformats
+    qtsensors
+    clipper
+    zlib
+    proj
+    cups
+  ];
 
-  nativeBuildInputs = [ cmake wrapQtAppsHook ninja ];
+  nativeBuildInputs = [ cmake doxygen ninja qttools ];
 
   src = fetchFromGitHub {
     owner = "OpenOrienteering";
     repo = "mapper";
     rev = "v${version}";
-    sha256 = "1787f2agjzcyizk2m60icb44yv9dlwv6irw3k53fqfmwkhkd2h5p";
+    sha256 = "05bliglpc8170px6k9lfrp9ylpnb2zf47gnjns9b2bif8dv8zq0l";
   };
 
-  cmakeFlags =
-    [
+  patches = [
+    # See https://github.com/NixOS/nixpkgs/issues/86054
+    ./fix-qttranslations-path.diff
+  ];
+
+  postPatch = ''
+    substituteInPlace src/util/translation_util.cpp \
+      --subst-var-by qttranslations ${qttranslations}
+  '';
+
+  cmakeFlags = [
     # Building the manual and bundling licenses fails
+    # See https://github.com/NixOS/nixpkgs/issues/85306
     "-DLICENSING_PROVIDER:BOOL=OFF"
     "-DMapper_MANUAL_QTHELP:BOOL=OFF"
-    ] ++
-    (stdenv.lib.optionals stdenv.isDarwin
-    [
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
     # Usually enabled on Darwin
     "-DCMAKE_FIND_FRAMEWORK=never"
     # FindGDAL is broken and always finds /Library/Framework unless this is
@@ -38,16 +68,17 @@ stdenv.mkDerivation rec {
     "-DMapper_PACKAGE_QT=0"
     "-DMapper_PACKAGE_ASSISTANT=0"
     "-DMapper_PACKAGE_GDAL=0"
-    ]);
+  ];
 
-  postInstall =
-    stdenv.lib.optionalString stdenv.isDarwin ''
+  postInstall = with stdenv; lib.optionalString isDarwin ''
+    mkdir -p $out/Applications
+    mv $out/Mapper.app $out/Applications
     # Fixes "This application failed to start because it could not find or load the Qt
     # platform plugin "cocoa"."
-    wrapQtApp $out/Mapper.app/Contents/MacOS/Mapper
+    wrapQtApp $out/Applications/Mapper.app/Contents/MacOS/Mapper
     mkdir -p $out/bin
-    ln -s $out/Mapper.app/Contents/MacOS/Mapper $out/bin/mapper
-    '';
+    ln -s $out/Applications/Mapper.app/Contents/MacOS/Mapper $out/bin/mapper
+  '';
 
   meta = with stdenv.lib; {
     description = ''

--- a/pkgs/applications/gis/openorienteering-mapper/fix-qttranslations-path.diff
+++ b/pkgs/applications/gis/openorienteering-mapper/fix-qttranslations-path.diff
@@ -1,0 +1,13 @@
+diff --git i/src/util/translation_util.cpp w/src/util/translation_util.cpp
+index da03d216..c1f12751 100644
+--- i/src/util/translation_util.cpp
++++ w/src/util/translation_util.cpp
+@@ -103,7 +103,7 @@ TranslationUtil::TranslationUtil(const QString& code, QString translation_file)
+ 	}
+ 	
+ 	QString translation_name = QLatin1String("qt_") + language.code;
+-	if (!qt_translator.load(translation_name, QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
++	if (!qt_translator.load(translation_name, QLatin1String("@qttranslations@/translations")))
+ 		load(qt_translator, translation_name);
+ 	
+ 	load(app_translator, translation_file);


### PR DESCRIPTION
###### Motivation for this change
* [0.9.3 changelog](https://github.com/OpenOrienteering/mapper/releases/tag/v0.9.3)
* fix qt wrapping (https://github.com/NixOS/nixpkgs/issues/65399)
* fix qt translations path (https://github.com/NixOS/nixpkgs/issues/86054)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @mpickering