### PR TITLE
fdkaac: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4603,6 +4603,16 @@
     githubId = 26020062;
     name = "lumi";
   };
+  lunik1 = {
+    email = "ch.nixpkgs@themaw.xyz";
+    github = "lunik1";
+    githubId = 13547699;
+    name = "Corin Hoad";
+    keys = [{
+      longkeyid = "rsa2048/0x6A37DF9483188492";
+      fingerprint = "BA3A 5886 AE6D 526E 20B4  57D6 6A37 DF94 8318 8492";
+    }];
+  };
   luz = {
     email = "luz666@daum.net";
     github = "Luz";

--- a/pkgs/applications/audio/fdkaac/default.nix
+++ b/pkgs/applications/audio/fdkaac/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, autoreconfHook, fetchFromGitHub, fdk_aac }:
+
+stdenv.mkDerivation rec {
+  pname = "fdkaac";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "nu774";
+    repo = pname;
+    rev = version;
+    sha256 = "16iwqmwagnb929byz8kj79pmmr0anbyv26drbavhppmxhk7rrpgh";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ fdk_aac ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Command line encoder frontend for libfdk-aac encder";
+    longDescription = ''
+      fdkaac reads linear PCM audio in either WAV, raw PCM, or CAF format,
+      and encodes it into either M4A / AAC file.
+    '';
+    homepage = "https://github.com/nu774/fdkaac";
+    license = licenses.zlib;
+    platforms = platforms.all;
+    maintainers = [ maintainers.lunik1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3453,6 +3453,8 @@ in
 
   fdk_aac = callPackage ../development/libraries/fdk-aac { };
 
+  fdk-aac-encoder = callPackage ../applications/audio/fdkaac { };
+
   feedgnuplot = callPackage ../tools/graphics/feedgnuplot { };
 
   fbv = callPackage ../tools/graphics/fbv { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adds cli for fdk aac encoding. Needed as a dependency in upcoming patch adding [m4b-tool](https://github.com/sandreas/m4b-tool) (edit: #87957).

Currently has a very similar name to [fdk_aac](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/fdk-aac/default.nix), aka libfdk-aac. Open to suggestions on alternative names for this package if needed - fdkaac-cli maybe?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
