### PR TITLE
glpaper: init at unstable-2020-03-30

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1280,6 +1280,12 @@
     githubId = 64804;
     name = "Dennis Gosnell";
   };
+  ccellado = {
+    email = "annplague@gmail.com";
+    github = "ccellado";
+    githubId = 44584960;
+    name = "Denis Khalmatov";
+  };
   ceedubs = {
     email = "ceedubs@gmail.com";
     github = "ceedubs";

--- a/pkgs/development/tools/glpaper/default.nix
+++ b/pkgs/development/tools/glpaper/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchhg, meson, ninja, pkg-config, wlroots, wayland, wayland-protocols
+, libX11, libGL }:
+
+stdenv.mkDerivation {
+  name = "glpaper";
+  version = "unstable-2020-03-30";
+
+  src = fetchhg {
+    url = "https://hg.sr.ht/~scoopta/glpaper";
+    rev = "a95db77088dfb5636a87f3743fc9b5eca70c1ae2";
+    sha256 = "04y12910wvhy4aqx2sa63dy9l6nbs7b77yqpdhc96x2b3mgzgjfs";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [
+    wayland
+    libX11 # required by libglvnd
+    libGL
+  ];
+
+  meta = with stdenv.lib; {
+    description =
+      "Wallpaper program for wlroots based Wayland compositors such as sway that allows you to render glsl shaders as your wallpaper";
+    homepage = "https://hg.sr.ht/~scoopta/glpaper";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ccellado ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1856,6 +1856,8 @@ in
 
   gixy = callPackage ../tools/admin/gixy { };
 
+  glpaper = callPackage ../development/tools/glpaper { };
+  
   gllvm = callPackage ../development/tools/gllvm { };
 
   glide = callPackage ../development/tools/glide { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add new useful package to the Wayland stack.

###### Things done

Added glpaper package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
