### PR TITLE
m4b-tool: init at 0.4.2 

### DIFF
--- a/pkgs/tools/audio/m4b-tool/default.nix
+++ b/pkgs/tools/audio/m4b-tool/default.nix
@@ -1,0 +1,47 @@
+{ fetchurl
+, makeWrapper
+, mp4v2
+, php
+, stdenv
+, # By default m4b-tool will try to use the lbfdk_aac encoder (which cannot
+  # be built by default with ffmpeg due to licensing) but will fall back to
+  # ffmpeg's own aac encoder and issue a warning about the resulting audio
+  # quality. To silence this warning override ffmpeg with fdk-enabled ffmpeg
+  # e.g. ffmpeg-full.override { fdkaacExtlib = true; nonfreeLicensing = true; }
+  ffmpeg
+, fdkAacSupport ? true
+, fdk-aac-encoder
+,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "m4b-tool";
+  version = "0.4.2";
+
+  src = fetchurl {
+    url = "https://github.com/sandreas/m4b-tool/releases/download/v.${version}/m4b-tool.phar";
+    sha256 = "36b40a4867883688605597133f2055bb95ec964ff51be7bd30a3d18b25511e94";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  dontUnpack = true;
+
+  propagatedBuildInputs = [ ffmpeg mp4v2 ]
+    ++ stdenv.lib.optional fdkAacSupport fdk-aac-encoder;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D $src $out/libexec/m4b-tool/m4b-tool.phar
+    makeWrapper ${php}/bin/php $out/bin/m4b-tool \
+    --add-flags "$out/libexec/m4b-tool/m4b-tool.phar" \
+    --set PATH "${fdk-aac-encoder}/bin/:$PATH"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A command line utility to merge, split and chapterize audiobook files such as mp3, ogg, flac, m4a or m4b";
+    license = licenses.mit;
+    homepage = "https://github.com/sandreas/m4b-tool";
+    maintainers = [ maintainers.lunik1 ] ++ teams.php.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5179,6 +5179,8 @@ in
 
   kzipmix = pkgsi686Linux.callPackage ../tools/compression/kzipmix { };
 
+  m4b-tool = callPackage ../tools/audio/m4b-tool { };
+
   ma1sd = callPackage ../servers/ma1sd { };
 
   mailcatcher = callPackage ../development/web/mailcatcher { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adds m4b-tool - cli for audiobook manipulation. Requires fdkaac added in #87952.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
