### PR TITLE
all-packages.nix: added otpgen callPackage in lexical order

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5738,6 +5738,8 @@ in
 
   otfcc = callPackage ../tools/misc/otfcc { };
 
+  otpgen = libsForQt5.callPackage ../tools/security/otpgen {};
+
   otpw = callPackage ../os-specific/linux/otpw { };
 
   overcommit = callPackage ../development/tools/overcommit { };


### PR DESCRIPTION
###### Motivation for this change
Still can't run `nix-env -i otpgen`.

###### Things done
Added otpgen callPackage to all-packages.nix

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
