### PR TITLE
kodi: Fix build

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -179,8 +179,8 @@ in stdenv.mkDerivation {
       # libdvdcss libdvdnav libdvdread
     ]
     ++ lib.optional x11Support [
-      libX11 xorgproto libXt libXmu libXext libXdmcp
-      libXinerama libXrandr libXtst libXfixes
+      libX11 xorgproto libXt libXmu libXext.dev libXdmcp
+      libXinerama libXrandr.dev libXtst libXfixes
     ]
     ++ lib.optional  dbusSupport     dbus
     ++ lib.optional joystickSupport cwiid


### PR DESCRIPTION
###### Motivation for this change

Fixes the `kodi` build. See #86770.

From the looks of it, the build was unable to find the following headers: `<X11/extensions/Xrandr.h>` & `<X11/extensions/dpms.h>`

```
Could NOT find XRandR (missing: XRANDR_INCLUDE_DIR)
```

```
/build/source/xbmc/powermanagement/DPMSSupport.cpp:99:10: fatal error: X11/extensions/dpms.h: No such file or directory
   99 | #include <X11/extensions/dpms.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
```

I've fixed this by switching `libXext` to `libXext.dev` and `libXrandr` to `libXrandr.dev` in the `buildInputs`.

I have checked that `kodi` runs, but only the `kodi` derivation, not `kodi-gbm` or `kodi-wayland`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
