### PR TITLE
terraria-server: 1.3.5.3 -> 1.4.0.3

### DIFF
--- a/pkgs/games/terraria-server/default.nix
+++ b/pkgs/games/terraria-server/default.nix
@@ -1,36 +1,30 @@
-{ stdenv, lib, file, fetchurl, unzip }:
+{ stdenv, lib, file, fetchurl, autoPatchelfHook, unzip }:
 
 stdenv.mkDerivation rec {
   pname = "terraria-server";
-  version = "1.3.5.3";
-  urlVersion = lib.replaceChars ["."] [""] version;
+  version = "1.4.0.3";
+  urlVersion = lib.replaceChars [ "." ] [ "" ] version;
 
   src = fetchurl {
-    url = "https://terraria.org/server/terraria-server-${urlVersion}.zip";
-    sha256 = "0l7j2n6ip4hxph7dfal7kzdm3dqnm1wba6zc94gafkh97wr35ck3";
+    url = "https://terraria.org/system/dedicated_servers/archives/000/000/037/original/terraria-server-${urlVersion}.zip";
+    sha256 = "1g9rd0a40gsljk8xp3bkvwy8ngywjzk8chf2x9l43s2kf40ib0p8";
   };
 
   buildInputs = [ file unzip ];
+  nativeBuildInputs = [ autoPatchelfHook ];
 
   installPhase = ''
     mkdir -p $out/bin
     cp -r Linux $out/
     chmod +x "$out/Linux/TerrariaServer.bin.x86_64"
     ln -s "$out/Linux/TerrariaServer.bin.x86_64" $out/bin/TerrariaServer
-    # Fix "/lib64/ld-linux-x86-64.so.2" like references in ELF executables.
-    find "$out" | while read filepath; do
-      if file "$filepath" | grep -q "ELF.*executable"; then
-        echo "setting interpreter $(cat "$NIX_CC"/nix-support/dynamic-linker) in $filepath"
-        patchelf --set-interpreter "$(cat "$NIX_CC"/nix-support/dynamic-linker)" "$filepath"
-        test $? -eq 0 || { echo "patchelf failed to process $filepath"; exit 1; }
-      fi
-    done
   '';
 
   meta = with lib; {
-    homepage = "http://terraria.org";
-    description = "Dedicated server for Terraria, a 2D action-adventure sandbox";
-    platforms = ["x86_64-linux"];
+    homepage = "https://terraria.org";
+    description =
+      "Dedicated server for Terraria, a 2D action-adventure sandbox";
+    platforms = [ "x86_64-linux" ];
     license = licenses.unfree;
   };
 }


### PR DESCRIPTION
Also use autoPatchelfHook and nixfmt it

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
