### PR TITLE
nixos/bind: allow zone declaration in nix expression

### DIFF
--- a/nixos/tests/bind.nix
+++ b/nixos/tests/bind.nix
@@ -4,19 +4,52 @@ import ./make-test-python.nix {
   machine = { pkgs, lib, ... }: {
     services.bind.enable = true;
     services.bind.extraOptions = "empty-zones-enable no;";
-    services.bind.zones = lib.singleton {
-      name = ".";
-      master = true;
-      file = pkgs.writeText "root.zone" ''
-        $TTL 3600
-        . IN SOA ns.example.org. admin.example.org. ( 1 3h 1h 1w 1d )
-        . IN NS ns.example.org.
+    services.bind.zones = {
+      "." = {
+        master = true;
+        file = pkgs.writeText "root.zone" ''
+          $TTL 3600
+          . IN SOA ns.example.org. admin.example.org. ( 1 3h 1h 1w 1d )
+          . IN NS ns.example.org.
 
-        ns.example.org. IN A    192.168.0.1
-        ns.example.org. IN AAAA abcd::1
+          ns.example.org. IN A    192.168.0.1
+          ns.example.org. IN AAAA abcd::1
 
-        1.0.168.192.in-addr.arpa IN PTR ns.example.org.
-      '';
+          1.0.168.192.in-addr.arpa IN PTR ns.example.org.
+        '';
+      };
+      # "fail-with-assert" = {};
+      "minimal" = {
+        name = "minimal";
+        file = {
+          records = [
+            { name = "ns"; value = "192.168.1.1"; }
+          ];
+        };
+      };
+      "common" = {
+        file = {
+          serial = 12;
+          records = [
+            { name = "ns"; value = "192.168.1.1"; }
+            { name = "webserver"; value = "192.168.1.1"; }
+          ];
+        };
+      };
+      "maxconf" = {
+        file = {
+          serial = 1;
+          refresh = "3H";
+          retry = "1H";
+          expire = "1W";
+          minimum_ttl = "1D";
+          name_primary = "ns1";
+          records = [
+            { name = "ns1"; value = "192.168.1.1"; }
+            { name = "ns"; value = "192.168.1.1"; type = "A"; ttl = "3H"; }
+          ];
+        };
+      };
     };
   };
 
@@ -24,5 +57,16 @@ import ./make-test-python.nix {
     machine.wait_for_unit("bind.service")
     machine.wait_for_open_port(53)
     machine.succeed("host 192.168.0.1 127.0.0.1")
+
+    machine.succeed("host ns.example.org 127.0.0.1")
+    machine.fail("host notfound.example.org 127.0.0.1")
+
+    machine.succeed("host ns.common 127.0.0.1")
+    machine.succeed("host webserver.common 127.0.0.1")
+    machine.fail("host notfound.common 127.0.0.1")
+
+    machine.succeed("host ns.maxconf 127.0.0.1")
+
+    machine.succeed("host webserver.common 127.0.0.1")
   '';
 }

--- a/nixos/tests/bind.nix
+++ b/nixos/tests/bind.nix
@@ -23,6 +23,6 @@ import ./make-test-python.nix {
   testScript = ''
     machine.wait_for_unit("bind.service")
     machine.wait_for_open_port(53)
-    machine.succeed("host 192.168.0.1 127.0.0.1 | grep -qF ns.example.org")
+    machine.succeed("host 192.168.0.1 127.0.0.1")
   '';
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This PR will allow the declaration of zone-files with a nix expression.

Minimal example:
``` nix
        {
          name = "minimal";
          file = {
            records = [
              { name = "ns"; value = "192.168.1.1"; }
            ];
          };
        }
```



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
