### PR TITLE
pkger: init at 0.16.0

### DIFF
--- a/pkgs/development/libraries/pkger/default.nix
+++ b/pkgs/development/libraries/pkger/default.nix
@@ -1,0 +1,26 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "pkger";
+  version = "0.16.0";
+
+  src = fetchFromGitHub {
+    owner = "markbates";
+    repo = "pkger";
+    rev = "v${version}";
+    sha256 = "0fpvrgww5h40l2js7raarx6gpysafvj75x26ljx4qz925x8nb6zn";
+  };
+
+  vendorSha256 = "1b9gpym6kb4hpdbrixphfh1qylmqr265jrmcd4vxb87ahvrsrvgp";
+
+  meta = with stdenv.lib; {
+    description = "Embed static files in Go binaries (replacement for gobuffalo/packr) ";
+    homepage = "https://github.com/markbates/pkger";
+    license = licenses.mit;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -302,6 +302,8 @@ in
 
   pet = callPackage ../development/tools/pet { };
 
+  pkger = callPackage ../development/libraries/pkger { };
+
   run = callPackage ../development/tools/run { };
 
   mod = callPackage ../development/tools/mod { };


### PR DESCRIPTION
###### Motivation for this change
https://blog.gobuffalo.io/introducing-pkger-static-file-embedding-in-go-1ce76dc79c65

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
