### PR TITLE
mpvScripts.autoload: init

### DIFF
--- a/pkgs/applications/video/mpv/scripts/autoload.nix
+++ b/pkgs/applications/video/mpv/scripts/autoload.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, mpv-unwrapped, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "mpv-autoload";
+  version = mpv-unwrapped.version;
+  src = "${mpv-unwrapped.src.outPath}/TOOLS/lua/autoload.lua";
+  dontBuild = true;
+  dontUnpack = true;
+  installPhase = ''
+    install -Dm644 ${src} $out/share/mpv/scripts/autoload.lua
+  '';
+  passthru.scriptName = "autoload.lua";
+
+  meta = {
+    description = "This script automatically loads playlist entries before and after the the currently played file";
+    homepage = "https://github.com/mpv-player/mpv/blob/master/TOOLS/lua/autoload.lua";
+    maintainers = [ lib.maintainers.dawidsowa ];
+    license = lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20836,6 +20836,7 @@ in
   mpv-with-scripts = callPackage ../applications/video/mpv/wrapper.nix { };
 
   mpvScripts = recurseIntoAttrs {
+    autoload = callPackage ../applications/video/mpv/scripts/autoload.nix {};
     convert = callPackage ../applications/video/mpv/scripts/convert.nix {};
     mpris = callPackage ../applications/video/mpv/scripts/mpris.nix {};
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
