### PR TITLE
xpra: fix #41106

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -42,6 +42,7 @@ in buildPythonApplication rec {
       src = ./fix-paths.patch;
       inherit (xorg) xkeyboardconfig;
     })
+    ./fix-41106.patch
   ];
 
   postPatch = ''

--- a/pkgs/tools/X11/xpra/fix-41106.patch
+++ b/pkgs/tools/X11/xpra/fix-41106.patch
@@ -1,0 +1,15 @@
+diff --git a/xpra/server/server_util.py b/xpra/server/server_util.py
+index 2ff2c0c..513201a 100644
+--- a/xpra/server/server_util.py
++++ b/xpra/server/server_util.py
+@@ -17,6 +17,10 @@ if PYTHON3:
+         return b"'" + s.replace(b"'", b"'\\''") + b"'"
+     
+     def xpra_runner_shell_script(xpra_file, starting_dir, socket_dir):
++        # Nixpkgs contortion:
++        # xpra_file points to a shell wrapper, not to the python script.
++        dirname, basename = os.path.split(xpra_file)
++        xpra_file = os.path.join(dirname, "."+basename+"-wrapped")
+         script = []
+         script.append(b"#!/bin/sh\n")
+         for var, value in os.environb.items():


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix #41106

###### Things done
A Python SyntaxError is raised when Xpra attempts to explicitly invoke python on the generated wrapper. To prevent that, we make it bypass the wrapper. The environment variables should still be correct because Xpra makes an effort to preserve the environment.


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
