### PR TITLE
fakeXinerama: clean up minor issues

### DIFF
--- a/pkgs/tools/X11/xpra/libfakeXinerama.nix
+++ b/pkgs/tools/X11/xpra/libfakeXinerama.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation  rec {
   installPhase = ''
     mkdir -p $out/lib
     cp libfakeXinerama.so.1.0 $out/lib
+    ln -s libfakeXinerama.so.1.0 $out/lib/libXinerama.so.1.0
     ln -s libXinerama.so.1.0 $out/lib/libXinerama.so.1
     ln -s libXinerama.so.1 $out/lib/libXinerama.so
   '';

--- a/pkgs/tools/X11/xpra/libfakeXinerama.nix
+++ b/pkgs/tools/X11/xpra/libfakeXinerama.nix
@@ -11,8 +11,6 @@ stdenv.mkDerivation  rec {
 
   buildInputs = [ libX11 libXinerama ];
 
-  phases = [ "unpackPhase" "buildPhase" "installPhase" ];
-
   buildPhase = ''
     gcc -O2 -Wall fakeXinerama.c -fPIC -o libfakeXinerama.so.1.0 -shared
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Originally I was putting fire on a xpra bug, but now it seems that this isn't strictly necessary. Still, applying some hygiene on this package now could help maintainers in the future.

###### Things done
- Fix dangling symlinks
- don't set phases on derivation because that's discouraged

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

TODO: e-mail maintainer Thomas Strobel

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
