### PR TITLE
xpra: fix #85694

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -41,6 +41,7 @@ in buildPythonApplication rec {
     (substituteAll {
       src = ./fix-paths.patch;
       inherit (xorg) xkeyboardconfig;
+      inherit libfakeXinerama;
     })
   ];
 

--- a/pkgs/tools/X11/xpra/fix-paths.patch
+++ b/pkgs/tools/X11/xpra/fix-paths.patch
@@ -29,3 +29,40 @@ index bd7023d..064c6b5 100644
 
  ###################################
  # Headers, python magic
+diff --git a/xpra/x11/fakeXinerama.py b/xpra/x11/fakeXinerama.py
+index c867258..617af7c 100755
+--- a/xpra/x11/fakeXinerama.py
++++ b/xpra/x11/fakeXinerama.py
+@@ -22,31 +22,7 @@ fakeXinerama_config_files = [
+            ]
+ 
+ def find_libfakeXinerama():
+-    libname = "fakeXinerama"
+-    try:
+-        from ctypes.util import find_library
+-        flibname = find_library("fakeXinerama")
+-        if flibname:
+-            libname = flibname
+-    except Exception:
+-        pass
+-    if POSIX:
+-        for lib_dir in os.environ.get("LD_LIBRARY_PATH", "/usr/lib").split(os.pathsep):
+-            lib_path = os.path.join(lib_dir, libname)
+-            if not os.path.exists(lib_dir):
+-                continue
+-            if os.path.exists(lib_path) and os.path.isfile(lib_path):
+-                return lib_path
+-    if LINUX:
+-        try:
+-            libpath = find_lib_ldconfig("fakeXinerama")
+-            if libpath:
+-                return libpath
+-        except Exception as e:
+-            log("find_libfakeXinerama()", exc_info=True)
+-            log.error("Error: cannot launch ldconfig -p to locate libfakeXinerama:")
+-            log.error(" %s", e)
+-    return find_lib(libname)
++    return "@libfakeXinerama@/lib/libfakeXinerama.so.1.0"
+ 
+ current_xinerama_config = None
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix #85694 

###### Things done
Hard-code the default libfakeXinerama location instead of relying on the automatic detection dance that upstream does.

I tried to make the dance succeed but couldn't do it. It would require at least bringing in binutils so ctypes.util can call ld and adding a SONAME to libfakeXinerama, but in fine it would still be quite fragile.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
