### PR TITLE
pythonPackages.ptvsd: init at 4.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4331,6 +4331,12 @@
     githubId = 1572058;
     name = "Leonardo Cecchi";
   };
+  leungbk = {
+    email = "leungbk@mailfence.com";
+    github = "leungbk";
+    githubId = 29217594;
+    name = "Brian Leung";
+  };
   leshainc = {
     email = "leshainc@fomalhaut.me";
     github = "LeshaInc";

--- a/pkgs/development/python-modules/ptvsd/default.nix
+++ b/pkgs/development/python-modules/ptvsd/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest }:
+
+buildPythonPackage rec {
+  pname = "ptvsd";
+  version = "4.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "3b05c06018fdbce5943c50fb0baac695b5c11326f9e21a5266c854306bda28ab";
+  };
+
+  # no tests in the wheel or the zip
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Microsoft/ptvsd/";
+    description = "An implementation of the Debug Adapter Protocol for Python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ leungbk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5022,6 +5022,8 @@ in {
 
   prox-tv = callPackage ../development/python-modules/prox-tv { };
 
+  ptvsd = callPackage ../development/python-modules/ptvsd { };
+
   pvlib = callPackage ../development/python-modules/pvlib { };
 
   pybase64 = callPackage ../development/python-modules/pybase64 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add `ptvsd`, a Python debugging tool compliant with the Debug Adapter Protocol.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
