### PR TITLE
godot: add mono support

### DIFF
--- a/pkgs/development/tools/godot/generate-mono-deps.sh
+++ b/pkgs/development/tools/godot/generate-mono-deps.sh
@@ -1,0 +1,56 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p coreutils dotnet-sdk nix jq
+# Script to generate the mono-deps.nix file.
+set -e
+
+# Check for dotnet2nix.
+if ! command -v dotnet2nix &> /dev/null; then
+  echo This script requires dotnet2nix
+  echo Please install it from https://github.com/baracoder/dotnet2nix
+  exit 1
+fi
+
+# Create a temporary directory to store sources/intermediate files.
+# It will be deleted when the script finishes or if it is interrupted or fails.
+TMPDIR=$(mktemp -d)
+trap "rm -r $TMPDIR" EXIT
+
+# Use nix-shell to fetch the package source an unpack it in a temporary directory.
+nix-shell -E 'with import <nixpkgs>{}; callPackage ./default.nix {}' --run "cd $TMPDIR && unpackPhase"
+cd $TMPDIR/source
+
+# Generate a nugets.json file for each solution.
+for solution in `find . -name "*.sln" -type f`; do
+  dotnet restore --use-lock-file $solution
+  dotnet2nix $(dirname $solution)
+  mv nugets.json $(basename $solution).nugets.json
+done
+
+# Merge nugets.json files.
+jq -c '.[]' *.nugets.json | jq -s | jq -M 'unique_by(.sha512)' > nugets.json
+
+# Write packages to mono-deps.nix file.
+cat <<EOF > mono-deps.nix
+{ fetchurl }:
+[
+EOF
+for package in `jq -r '.[] | @base64' nugets.json`; do
+  getval() {
+    echo "$package" | base64 --decode | jq -r $1
+  }
+
+  name=$(getval '.fileName')
+  url=$(getval '.url')
+  sha512=$(getval '.sha512')
+
+  cat <<-EOF >> mono-deps.nix
+    (fetchurl {
+      name = "$name";
+      url = "$url";
+      sha512 = "$sha512";
+    })
+  EOF
+done
+echo "]" >> mono-deps.nix
+
+cp mono-deps.nix $OLDPWD/mono-deps.nix

--- a/pkgs/development/tools/godot/headless.nix
+++ b/pkgs/development/tools/godot/headless.nix
@@ -1,5 +1,5 @@
-{ godot, stdenv }:
-godot.overrideAttrs (oldAttrs: rec {
+{ godot, stdenv, withMono ? false }:
+(godot.override { withMono = withMono; }).overrideAttrs (oldAttrs: rec {
   pname = "godot-headless";
   sconsFlags = "target=release_debug platform=server tools=yes";
   installPhase = ''

--- a/pkgs/development/tools/godot/mono-deps.nix
+++ b/pkgs/development/tools/godot/mono-deps.nix
@@ -1,0 +1,148 @@
+{ fetchurl }:
+[
+  (fetchurl {
+    name = "NETStandard.Library.2.0.3";
+    url = "https://api.nuget.org/v3-flatcontainer/netstandard.library/2.0.3/netstandard.library.2.0.3.nupkg";
+    sha512 = "00ydpk4jxlaal21h87nkx6fy3sj3xq35ihrifb5ybx797j1l65f9hxzv1hy0aad5x99cp854sk331nfvdvl0r49n2qraj61d7m0r3z7";
+  })
+  (fetchurl {
+    name = "System.Runtime.4.1.0";
+    url = "https://api.nuget.org/v3-flatcontainer/system.runtime/4.1.0/system.runtime.4.1.0.nupkg";
+    sha512 = "037gpcgdp3ms0q9jzx7qmb6cx3681wf8ml966i80azvg4yijvz33ja109yxyb8lh4fi4apnqnvgzlqnjqzkkqsggiq4cn28pdlfn1ab";
+  })
+  (fetchurl {
+    name = "Microsoft.NETCore.Platforms.1.1.0";
+    url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.0/microsoft.netcore.platforms.1.1.0.nupkg";
+    sha512 = "03d34iyv3gja0bgiz2dmzdkq0vgdrphyr95qinw89fnicm6bslbgkkg1025zfayn3cwdgmps1j7y62fn81qagaf2v3y4vsrfk195y3b";
+  })
+  (fetchurl {
+    name = "Microsoft.VisualStudio.Setup.Configuration.Interop.1.16.30";
+    url = "https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.setup.configuration.interop/1.16.30/microsoft.visualstudio.setup.configuration.interop.1.16.30.nupkg";
+    sha512 = "0dxcwj9xy6f7g24mk39m6358cja6ribs553xpyv0lvrj14x9qhpv0v911b6y78b0kx1ph6wy60j89qs7m32z2zgpd4qkp45jxcpq3v1";
+  })
+  (fetchurl {
+    name = "System.Numerics.Vectors.4.4.0";
+    url = "https://api.nuget.org/v3-flatcontainer/system.numerics.vectors/4.4.0/system.numerics.vectors.4.4.0.nupkg";
+    sha512 = "0gflx3qr4v966m89c838asfzzyhks8677bn05bwnp8xy5jv349jmpw8sdl22li7s7hvn50y3bpklc32l76sfychvkbbhiimkd86pm41";
+  })
+  (fetchurl {
+    name = "System.Collections.Immutable.1.5.0";
+    url = "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/1.5.0/system.collections.immutable.1.5.0.nupkg";
+    sha512 = "0j88hv5svlm67ddgi7wdqmppgckhi5f0mjhphclwza16sy7adm7r5fc6cky6ciqk78jmvzzi69xscshh9hz0xqcwnxl7107ax1cd5ag";
+  })
+  (fetchurl {
+    name = "System.Resources.ResourceManager.4.0.1";
+    url = "https://api.nuget.org/v3-flatcontainer/system.resources.resourcemanager/4.0.1/system.resources.resourcemanager.4.0.1.nupkg";
+    sha512 = "0jwb86f8zxn0m7hbwiwz1q6kqgi856p3b1hq9909zz4l6a5y5xplkr8wswqhzgiyn64n9y1j405xabiwbf9iyvq6al8zlwd4mp92rai";
+  })
+  (fetchurl {
+    name = "System.IO.4.1.0";
+    url = "https://api.nuget.org/v3-flatcontainer/system.io/4.1.0/system.io.4.1.0.nupkg";
+    sha512 = "0qq7dxjn06qg4qg1ipy09ijpm9ix8q0g4jgm5h05z2yw53z84cghqw9wyp074bg631i2yj0k6pqrrzf3k6fgwypsn43qpvi7lpl66z0";
+  })
+  (fetchurl {
+    name = "System.Runtime.Serialization.Primitives.4.1.1";
+    url = "https://api.nuget.org/v3-flatcontainer/system.runtime.serialization.primitives/4.1.1/system.runtime.serialization.primitives.4.1.1.nupkg";
+    sha512 = "10ba72kh51sfa9wk92jar3w7rlrqr0w7swyvf5bfs3d4i1r4ph0qk4qsq5xs12w4jrk649wrmaskghy1avc1glaqir1w3vcnap90sps";
+  })
+  (fetchurl {
+    name = "System.Runtime.CompilerServices.Unsafe.4.5.2";
+    url = "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.5.2/system.runtime.compilerservices.unsafe.4.5.2.nupkg";
+    sha512 = "1d6ingx7n3xmqrqrwwjf9iks2h2yz7kypm5varhqswkx2h0k1skv5a9wpyc7rfz3l2ywh0025ryq03sj2ljayvh2ljr9jic35divjc4";
+  })
+  (fetchurl {
+    name = "GodotTools.IdeMessaging.1.1.1";
+    url = "https://api.nuget.org/v3-flatcontainer/godottools.idemessaging/1.1.1/godottools.idemessaging.1.1.1.nupkg";
+    sha512 = "1hbcsi8vrh06hvmdw7vps4hb5qckappjlw6s51swcn9qsxk99kpbfwww29h50d1abnix6k9f3l4788vv9w9xwrik54wq8jjlqrzc3k6";
+  })
+  (fetchurl {
+    name = "System.Threading.Tasks.Dataflow.4.9.0";
+    url = "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.dataflow/4.9.0/system.threading.tasks.dataflow.4.9.0.nupkg";
+    sha512 = "1kwcxi00i2birzvpjcfr0x12i4qpskflbpk7hq3w7rgw3sk4m5cap9yngwblipd8xy3jgq37z42y8gj37y3qjwgz8im77qfrxwc0aig";
+  })
+  (fetchurl {
+    name = "EnvDTE.8.0.2";
+    url = "https://api.nuget.org/v3-flatcontainer/envdte/8.0.2/envdte.8.0.2.nupkg";
+    sha512 = "1nzxi2g7dlak1p1n5jf3fafc7mzvf4l8q2sffnihpi0pc1jsh312prmxrhjq8cmy781h0s07nicxpladd9fsvar0cbvmb81g2yqmji3";
+  })
+  (fetchurl {
+    name = "JetBrains.Annotations.2019.1.3";
+    url = "https://api.nuget.org/v3-flatcontainer/jetbrains.annotations/2019.1.3/jetbrains.annotations.2019.1.3.nupkg";
+    sha512 = "1v0gfwfzy398dqvimg1s26r3f6j79n5xzch1p830cn6dgwxwvbd6n8mnir5lc8a7s6vqqqbxzgm34gw0yg6hmjvsy7r9i69xlisjmdn";
+  })
+  (fetchurl {
+    name = "System.Threading.Tasks.4.0.11";
+    url = "https://api.nuget.org/v3-flatcontainer/system.threading.tasks/4.0.11/system.threading.tasks.4.0.11.nupkg";
+    sha512 = "1xzlp0vk0gbxqar90945yld50ibdjgznjwdh71nnq5higzix4ljigd1hscqsbzij01l50fimv02y3z1439bgmz9nrf8rj5llnbc8rpv";
+  })
+  (fetchurl {
+    name = "System.Reflection.Primitives.4.0.1";
+    url = "https://api.nuget.org/v3-flatcontainer/system.reflection.primitives/4.0.1/system.reflection.primitives.4.0.1.nupkg";
+    sha512 = "1z70c3psgzi5gidlw30x72ychbhsnc6nhnhmwxm7s0vsybldf6621kxs948pa7a8lp6r543dsnln31nwi74p1dh8xdgk2pnqmw6zb88";
+  })
+  (fetchurl {
+    name = "stdole.7.0.3302";
+    url = "https://api.nuget.org/v3-flatcontainer/stdole/7.0.3302/stdole.7.0.3302.nupkg";
+    sha512 = "294q90prn9k3cv2nz78frr9ndnp243i1bxdxnbw0z9vxig4lmrjavxybswz5di0n6r7ihcdmmraf5k1p620rl2fc6jfiyx7asic67qx";
+  })
+  (fetchurl {
+    name = "System.Text.Encoding.4.0.11";
+    url = "https://api.nuget.org/v3-flatcontainer/system.text.encoding/4.0.11/system.text.encoding.4.0.11.nupkg";
+    sha512 = "2d3wzhc6d9vy05v013xprgi4nyr2llwd67bpz9ply3lsvjcnwknvmgv7ljgap9lar8aa7wvfjfhha3zi0sxa3h4py532szk8d8k6x7r";
+  })
+  (fetchurl {
+    name = "Microsoft.NETFramework.ReferenceAssemblies.1.0.0";
+    url = "https://api.nuget.org/v3-flatcontainer/microsoft.netframework.referenceassemblies/1.0.0/microsoft.netframework.referenceassemblies.1.0.0.nupkg";
+    sha512 = "2gfxqd6hp8jrqg7bmlvq3p5n4yr2c6zsjn6glrkka25yrivv75w2k02pd3cr5jd57mslpjgc7fhwq32kpypsgyrhr8cc4rir2gqpwf8";
+  })
+  (fetchurl {
+    name = "Microsoft.NETFramework.ReferenceAssemblies.net472.1.0.0";
+    url = "https://api.nuget.org/v3-flatcontainer/microsoft.netframework.referenceassemblies.net472/1.0.0/microsoft.netframework.referenceassemblies.net472.1.0.0.nupkg";
+    sha512 = "2nfvjz3b40ad5h58mz82w2522rwk61r7h4j9wz52kxcql4f0qly33bqakjaipgmvnzr4nr61i09bb676sg5q3ipqpgfsvxhz0fww1na";
+  })
+  (fetchurl {
+    name = "Microsoft.Build.16.5.0";
+    url = "https://api.nuget.org/v3-flatcontainer/microsoft.build/16.5.0/microsoft.build.16.5.0.nupkg";
+    sha512 = "2wx7ri07n0alkvsnc90r9f3vinwi9m4z3q8haqk59npd8n3qh7acv78hr88k7s3hjvs1z870hwz1fd473zhlp8ja9xmnp5q8snsjkhk";
+  })
+  (fetchurl {
+    name = "Microsoft.Build.Framework.16.5.0";
+    url = "https://api.nuget.org/v3-flatcontainer/microsoft.build.framework/16.5.0/microsoft.build.framework.16.5.0.nupkg";
+    sha512 = "30b40hk6n2jjjvxhll7vbf816ihdnc737hdmkdlvbikjsq5szdgljh3jdr08m7vs6a8p7grx75r6vs8hzbg8gwmiyqii7w41d4v8l93";
+  })
+  (fetchurl {
+    name = "System.Buffers.4.4.0";
+    url = "https://api.nuget.org/v3-flatcontainer/system.buffers/4.4.0/system.buffers.4.4.0.nupkg";
+    sha512 = "31165ykp5vzssq6wca5g9c6lcr1mkdzyda662d49715fhxkv3c1xmsq623kk0991v67wdp58f2jha6zcxz56pgafvfmq7bqsxwrnb92";
+  })
+  (fetchurl {
+    name = "System.Reflection.4.1.0";
+    url = "https://api.nuget.org/v3-flatcontainer/system.reflection/4.1.0/system.reflection.4.1.0.nupkg";
+    sha512 = "31gfigzm88v860n75hwxcy2whww51f2w2s8s73fmi7csndsn3j9z7kvx9i86cvpa6mdznpm1psm062g5fd6xikh1j1l847vyvw3w537";
+  })
+  (fetchurl {
+    name = "System.Threading.Thread.4.0.0";
+    url = "https://api.nuget.org/v3-flatcontainer/system.threading.thread/4.0.0/system.threading.thread.4.0.0.nupkg";
+    sha512 = "329hr4vpwvby148skclc0844l57f04bkbpgsc18jnkflapd0k4zaa05ng02xbyj8wrg3v9r1v0vbna6h02rzdpybmwb05bnxa92krcy";
+  })
+  (fetchurl {
+    name = "Microsoft.NETCore.Targets.1.0.1";
+    url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.0.1/microsoft.netcore.targets.1.0.1.nupkg";
+    sha512 = "34vzlw2b9jvd5znlzla5bcs0317ng4sy0saplykws4i6kasa559yiwsjp2072a3cb9f83rlficpl9f8yqff77pycq86a62sjigygn3f";
+  })
+  (fetchurl {
+    name = "System.Memory.4.5.3";
+    url = "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.3/system.memory.4.5.3.nupkg";
+    sha512 = "3dy3120c5r4z6zbfiygnd4p2vyqsr4irw34j9s05qm2zlmzsj3siizj8xbkwjnxlx0gcqrzj0r1v39r5sgfij05mv5slxnca9df3z3h";
+  })
+  (fetchurl {
+    name = "System.Globalization.4.0.11";
+    url = "https://api.nuget.org/v3-flatcontainer/system.globalization/4.0.11/system.globalization.4.0.11.nupkg";
+    sha512 = "3k9bwr70kv8np22n5f7dblchvqbism9yjrnkvgggkxqf092yxf7acghsq3304p021agsw37v050xmv3713b18zd273rp0szgxk23g36";
+  })
+  (fetchurl {
+    name = "Newtonsoft.Json.12.0.3";
+    url = "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/newtonsoft.json.12.0.3.nupkg";
+    sha512 = "3skbix5pwilpagjs2mvm7z5g1hm0lymbcafc7p0pkm282y219k0xzsq2fyb036lq45myycj9lpsfdfl2szz4i3ck6z8pibr0igncd39";
+  })
+]

--- a/pkgs/development/tools/godot/server.nix
+++ b/pkgs/development/tools/godot/server.nix
@@ -1,5 +1,5 @@
-{ godot, stdenv }:
-godot.overrideAttrs (oldAttrs: rec {
+{ godot, stdenv, withMono ? false }:
+(godot.override { withMono = withMono; }).overrideAttrs (oldAttrs: rec {
   pname = "godot-server";
   sconsFlags = "target=release platform=server tools=no";
   installPhase = ''


### PR DESCRIPTION
Following the guide https://docs.godotengine.org/en/3.2/development/compiling/compiling_with_mono.html

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The Godot game engine supports scripting with the C# programming language. However, in order to so it must be compiled with mono support. This pull request adds such an option to the Nixpkgs derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).