### PR TITLE
webbrowser: init at 29.0.0rc1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7654,6 +7654,12 @@
     githubId = 1141680;
     name = "Thane Gill";
   };
+  TheBrainScrambler = {
+    email = "the.pumpkin.man@disroot.org"; # This could change soon
+    github = "TheBrainScrambler";
+    githubId = 34945377;
+    name = "John Smith";
+  };
   thedavidmeister = {
     email = "thedavidmeister@gmail.com";
     github = "thedavidmeister";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7655,7 +7655,7 @@
     name = "Thane Gill";
   };
   TheBrainScrambler = {
-    email = "the.pumpkin.man@disroot.org"; # This could change soon
+    email = "esthromeris@riseup.net";
     github = "TheBrainScrambler";
     githubId = 34945377;
     name = "John Smith";

--- a/pkgs/applications/networking/browsers/webbrowser/default.nix
+++ b/pkgs/applications/networking/browsers/webbrowser/default.nix
@@ -1,0 +1,108 @@
+{ stdenv, lib, fetchgit, makeDesktopItem, pkgconfig, makeWrapper
+# Build
+, python2, autoconf213, yasm, perl, ccache
+, unzip, gnome2, gnum4
+
+# Runtime
+, xorg, zip, freetype, fontconfig, glibc, libffi
+, dbus, dbus-glib, gtk2, alsaLib, jack2, ffmpeg
+}:
+
+let
+
+  libPath = lib.makeLibraryPath [ ffmpeg ];
+
+in stdenv.mkDerivation rec {
+  pname = "webbrowser";
+  version = "29.0.0rc1";
+
+  src = fetchgit {
+    url = "https://git.nuegia.net/webbrowser.git";
+    rev = version;
+    sha256 = "1d82943mla6q3257081d946kgms91dg0n93va3zlzm9hbbqilzm6";
+    fetchSubmodules = true;
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "webbrowser";
+    exec = "webbrowser %U";
+    icon = "webbrowser";
+    desktopName = "Web Browser";
+    genericName = "Web Browser";
+    categories = "Network;WebBrowser;";
+    mimeType = lib.concatStringsSep ";" [
+      "text/html"
+      "text/xml"
+      "application/xhtml+xml"
+      "application/vnd.mozilla.xul+xml"
+      "x-scheme-handler/http"
+      "x-scheme-handler/https"
+    ];
+  };
+
+  nativeBuildInputs = [
+    gnum4 makeWrapper perl pkgconfig python2 ccache
+  ];
+
+  buildInputs = [
+    alsaLib dbus dbus-glib ffmpeg fontconfig freetype yasm zip jack2 gtk2
+    unzip gnome2.GConf xorg.libXt
+  ];
+
+  enableParallelBuilding = true;
+
+  configurePhase = ''
+    export MOZCONFIG=$PWD/.mozconfig
+    export MOZ_NOSPAM=1
+    export HOME=$PWD # Needed by ccache
+
+    cp $src/doc/mozconfig.example $MOZCONFIG
+    # Need to modify it
+    chmod 644 $MOZCONFIG
+
+    substituteInPlace $MOZCONFIG \
+      --replace "mk_add_options PYTHON=/usr/bin/python2" "mk_add_options PYTHON=${python2}/bin/python2" \
+      --replace "mk_add_options AUTOCONF=/usr/bin/autoconf-2.13" "mk_add_options AUTOCONF=${autoconf213}/bin/autoconf" \
+      --replace 'mk_add_options MOZ_OBJDIR=$HOME/build/wbobjects/' "" \
+      --replace "ac_add_options --x-libraries=/usr/lib64" "ac_add_options --x-libraries=${lib.makeLibraryPath [ xorg.libX11 ]}" \
+      --replace "_BUILD_64=1" "_BUILD_64=${lib.optionalString stdenv.hostPlatform.is64bit "1"}"
+
+    echo >> $MOZCONFIG '
+    #
+    # NixOS-specific adjustments
+    #
+
+    ac_add_options --prefix=$out
+
+    mk_add_options MOZ_MAKE_FLAGS="-j$NIX_BUILD_CORES"
+    '
+  '';
+
+  buildPhase = "$src/mach build";
+
+  installPhase = ''
+    $src/mach install
+
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/* $out/share/applications
+
+    for n in 16 32 48; do
+      size=$n"x"$n
+      mkdir -p $out/share/icons/hicolor/$size/apps
+      cp $src/webbrowser/branding/unofficial/default$n.png \
+         $out/share/icons/hicolor/$size/apps/webbrowser.png
+    done
+
+    # Needed to make videos work
+    wrapProgram $out/lib/webbrowser-${version}/webbrowser \
+      --prefix LD_LIBRARY_PATH : "${libPath}"
+  '';
+
+  meta = with lib; {
+    description = "Generic web browser without trackers compatible with XUL plugins using UXP rendering engine";
+    homepage    = "https://git.nuegia.net/webbrowser.git/";
+    license     = [ licenses.mpl20 licenses.gpl3 ];
+    maintainers = with maintainers; [ TheBrainScrambler ];
+    platforms   = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21250,6 +21250,8 @@ in
     stdenv = gcc7Stdenv;
   };
 
+  webbrowser = callPackage ../applications/networking/browsers/webbrowser {};
+
   pamix = callPackage ../applications/audio/pamix { };
 
   pamixer = callPackage ../applications/audio/pamixer { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Webrowser is, as its name suggests, a web browser. It is actually my first derivation, so mistakes could have been done. I made it as sort of training, but since it works I'm motivated to publish it here and to try to maintain it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Additionnal notes
Note that I am also not very used to git and Github.
This derivation was built using Github Actions, and ran on NixOS. The build can take a long time, on Github Action it was usually between 1h30 and 2h.
I removed the commit history, since I had 60 commit with many many useless ones to trigger Github Actions, and because I've heard that we should do that to clean the nixpkgs commit history.

Important : there is a withGTK3 option, but when I tested it the package was built using GTK2. I will maybe try to solve this issue, but it isn't a priority to me, so I'm already opening a PR.
EDIT : removed the withGTK3 option, as said above I will maybe implement it later.