### PR TITLE
Pulumi Update 1.12.0 > 2.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5400,6 +5400,12 @@
     githubId = 5139265;
     name = "James Wood";
   };
+  mudrii = {
+    email = "mudreac@gmail.com";
+    github = "mudrii";
+    githubId = 220262;
+    name = "Ion Mudreac";
+  };
   muflax = {
     email = "mail@muflax.com";
     github = "muflax";

--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,50 +1,58 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "1.12.0";
+  version = "2.2.1";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.12.0-linux-x64.tar.gz";
-        sha256 = "14j8f43h920k62h8bhywapphhfbj7whb9l6pjmyigld6x2jpr4mc";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.2.1-linux-x64.tar.gz";
+        sha256 = "0bvwkvsinnhlh1yhh5llffh89w07f412q6z03ypzl19p6fvik1k1";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v1.5.0-linux-amd64.tar.gz";
-        sha256 = "1vdd5ghlsxqrfd1nrdj7hsl745k8myhxmd3gh1fq6ksa3apnh1ca";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.1.1-linux-amd64.tar.gz";
+        sha256 = "0ggi1c4lg6pip6d4bh2cji25hcwv3ii870bjwd35ax668z0dc28d";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v2.8.0-linux-amd64.tar.gz";
-        sha256 = "1q34kv41dbmz45s1sg0rqdxp1qlfq0ii0hy9p95lkzd7qj19qrvv";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v3.5.1-linux-amd64.tar.gz";
+        sha256 = "1dz30pwf1aafgbnbwc2jpwx7x7cwc2fcvcdfg2nfxb8650vp4rl6";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.5.6-linux-amd64.tar.gz";
-        sha256 = "1g5zgkqnzjqfri61p8876czn0ab2n3mjqf1acdyn8kg5q52sd8ix";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.5.0-linux-amd64.tar.gz";
+        sha256 = "0bjchcdkaqrkxa0b9slyhyhwlnlvwyn9g3qis51ijf3iy3ndjlrm";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.24.0-linux-amd64.tar.gz";
-        sha256 = "1fwnad5p1v4bigcr2icgzmxdn1b3x0j8c361546pqzk67vskn9fg";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.2.0-linux-amd64.tar.gz";
+        sha256 = "1maiy1i43p0gl2w12hfk9zgfz418innzi7nkv68qlyxd4hi5v6mf";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.4.0-linux-amd64.tar.gz";
+        sha256 = "00dgqhmr8b3jn8hjmg7bczwf1wwic71m7m9qrjh1spw43sp31byz";
       }
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.12.0-darwin-x64.tar.gz";
-        sha256 = "1bg6vnxic8fzycgv8q7m1bf8pk2bxvcn0b6lwy7aa2f3kzw70q46";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.2.1-darwin-x64.tar.gz";
+        sha256 = "1fizddk1hxazn33xliankps3fv0casx4r8rvwkdzqx1piqq18xy4";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v1.5.0-darwin-amd64.tar.gz";
-        sha256 = "1skvfg8s8f81l4yfgm49jca38cx96khk3f9rpq4ywa3r3f450kni";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.1.1-darwin-amd64.tar.gz";
+        sha256 = "1mdchvibk989xq5zfjb7cdzgh9m769cvj2l5dfxmkava7zhmj2bj";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v2.8.0-darwin-amd64.tar.gz";
-        sha256 = "0f0gnbiv2gbam5n3ng9j5rbrml0jfv9k402vd4j9ryfkly4grpa9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v3.5.1-darwin-amd64.tar.gz";
+        sha256 = "1qcnzkv6dpz9g5sb1178sk738v2d27i85kgr43my85k5jagsy7ac";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.5.6-darwin-amd64.tar.gz";
-        sha256 = "1l610a0bvwrsbqv4s00ghbplwnk11q3c0n3py0l7w0a2mpl8izzd";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.5.0-darwin-amd64.tar.gz";
+        sha256 = "0xh6pqm074fvd73sasxip3n38m3gnq4298mf2iagj1531326pgbi";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.24.0-darwin-amd64.tar.gz";
-        sha256 = "17qq7w2wk0803y0if7dn3gnxxnfqnb4n2gcil3zgbc4yhqz4py0y";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.2.0-darwin-amd64.tar.gz";
+        sha256 = "0maca137agmig8njz0fd0yhxahdra7pqaw23mxfxa8m5j44p787a";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.4.0-darwin-amd64.tar.gz";
+        sha256 = "10jb21b1j68ircn4k0g97649pfqby9y2dn7ksxa1la1q0nkf7j9a";
       }
     ];
   };

--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -31,6 +31,7 @@ in stdenv.mkDerivation {
     maintainers = with maintainers; [
       peterromfeldhk
       jlesquembre
+      mudrii
     ];
   };
 }

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
-VERSION="1.12.0"
+VERSION="2.2.1"
 
 declare -A plugins
 plugins=(
-    ["aws"]="1.24.0"
-    ["gcp"]="2.8.0"
-    ["random"]="1.5.0"
-    ["kubernetes"]="1.5.6"
+    ["aws"]="2.4.0"
+    ["gcp"]="3.5.0"
+    ["azure"]="3.5.1"
+    ["random"]="2.1.1"
+    ["kubernetes"]="2.2.0"
 )
 
 function genMainSrc() {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update pulumi to new version 2.2.1
Add new core cloud plugin for pulumi Azure

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @peterromfeldhk @jlesquembre
