### PR TITLE
agda-pkg: init at 0.1.50

### DIFF
--- a/pkgs/development/python-modules/ponywhoosh/default.nix
+++ b/pkgs/development/python-modules/ponywhoosh/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, pony, whoosh }:
+
+buildPythonPackage rec {
+  pname = "ponywhoosh";
+  version = "1.7.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mggj9d265hra4z67qyla686qvl0cf79655cszi136gh9hqlibv9";
+  };
+
+  propagatedBuildInputs = [
+    pony
+    whoosh
+  ];
+
+  meta = with lib; {
+    homepage = "https://pythonhosted.org/ponywhoosh/";
+    description = "Make your database over PonyORM searchable";
+    license = licenses.mit;
+    maintainers = with maintainers; [ alexarice ];
+  };
+}

--- a/pkgs/development/tools/agda-pkg/default.nix
+++ b/pkgs/development/tools/agda-pkg/default.nix
@@ -1,0 +1,44 @@
+{ lib, python3Packages }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  pname = "agda-pkg";
+  version = "0.1.50";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wpw90kw3danw91m3jzfdn7zmclimmiz74f77mpij9b1w6wvhm11";
+  };
+
+  # Checks need internet access, so we just check the program executes
+  # At the moment the help page needs to write to $HOME, this can
+  # be removed if https://github.com/agda/agda-pkg/issues/40 is fixed
+  checkPhase = ''
+    HOME=$NIX_BUILD_TOP $out/bin/apkg --help > /dev/null
+  '';
+
+  propagatedBuildInputs = [
+    click
+    GitPython
+    pony
+    whoosh
+    natsort
+    click-log
+    requests
+    humanize
+    distlib
+    jinja2
+    pyyaml
+    ponywhoosh
+  ];
+
+  meta = with lib; {
+    homepage = "https://agda.github.io/agda-pkg/";
+    description = "Package manager for Agda";
+    license = licenses.mit;
+    maintainers = with maintainers; [ alexarice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -599,6 +599,8 @@ in
 
   afpfs-ng = callPackage ../tools/filesystems/afpfs-ng { };
 
+  agda-pkg = callPackage ../development/tools/agda-pkg { };
+
   agrep = callPackage ../tools/text/agrep { };
 
   aha = callPackage ../tools/text/aha { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5055,6 +5055,8 @@ in {
 
   polib = callPackage ../development/python-modules/polib {};
 
+  ponywhoosh = callPackage ../development/python-modules/ponywhoosh { };
+
   posix_ipc = callPackage ../development/python-modules/posix_ipc { };
 
   portend = callPackage ../development/python-modules/portend { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds `agda-pkg` program, which we are experimenting with in https://github.com/NixOS/nixpkgs/pull/87903 and may also be useful otherwise to people who do not want to use nix infrastructure for agda

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @turion 