### PR TITLE
amarok: add last.fm support, bump version

### DIFF
--- a/pkgs/applications/audio/amarok/default.nix
+++ b/pkgs/applications/audio/amarok/default.nix
@@ -3,21 +3,21 @@
 , qca-qt5, qjson, qtquickcontrols2, qtscript, qtwebengine
 , karchive, kcmutils, kconfig, kdnssd, kguiaddons, kinit, kirigami2, knewstuff, knotifyconfig, ktexteditor, kwindowsystem
 , fftw, phonon, plasma-framework, threadweaver
-, curl, ffmpeg_3, gdk-pixbuf, libaio, libmtp, loudmouth, lzo, lz4, mysql57, pcre, snappy, taglib, taglib_extras
+, curl, ffmpeg_3, gdk-pixbuf, libaio, liblastfm, libmtp, loudmouth, lzo, lz4, mysql57, pcre, snappy, taglib, taglib_extras
 }:
 
 mkDerivation rec {
-  pname = "amarok";
-  version = "2.9.0-20190824";
+  pname = "amarok-unstable";
+  version = "2020-06-12";
 
   src = fetchgit {
     # master has the Qt5 version as of April 2018 but a formal release has not
     # yet been made so change this back to the proper upstream when such a
     # release is out
-    url    = "git://anongit.kde.org/amarok.git";
+    url    = "https://invent.kde.org/multimedia/amarok.git";
     # url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    rev    = "457fbda25a85a102bfda92aa7137e7ef5e4c8b00";
-    sha256 = "1ig2mg8pqany6m2zplkrvldcv4ibxwsypnyv5igm7nz7ax82cd5j";
+    rev    = "fece39b0e81db310b6a6e08f93d83b0d498cd02b";
+    sha256 = "12casnq6w5yp2jlvnr466pjpkn0vriry8jzfq2qkjl564y0vhy9x";
   };
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
@@ -26,7 +26,7 @@ mkDerivation rec {
     qca-qt5 qjson qtquickcontrols2 qtscript qtwebengine
     karchive kcmutils kconfig kdnssd kguiaddons kinit kirigami2 knewstuff knotifyconfig ktexteditor kwindowsystem
     phonon plasma-framework threadweaver
-    curl fftw ffmpeg_3 gdk-pixbuf libaio libmtp loudmouth lz4 lzo mysql57.server mysql57.server.static
+    curl fftw ffmpeg_3 gdk-pixbuf libaio liblastfm libmtp loudmouth lz4 lzo mysql57.server mysql57.server.static
     pcre snappy taglib taglib_extras
   ];
 

--- a/pkgs/development/libraries/liblastfm/default.nix
+++ b/pkgs/development/libraries/liblastfm/default.nix
@@ -1,27 +1,24 @@
-{ stdenv, fetchurl, pkgconfig, which, cmake
+{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, which, cmake
 , fftwSinglePrec, libsamplerate, qtbase
 , darwin }:
 
-let version = "1.1.0"; in
-
 stdenv.mkDerivation rec {
-  pname = "liblastfm";
-  inherit version;
+  pname = "liblastfm-unstable";
+  version = "2019-08-23";
 
-  # Upstream does not package git tags as tarballs. Get tarball from github.
-  src = fetchurl {
-    url = "https://github.com/lastfm/liblastfm/tarball/${version}";
-    name = "${pname}-${version}.tar.gz";
-    sha256 = "1j34xc30vg7sfszm2jx9mlz9hy7p1l929fka9wnfcpbib8gfi43x";
+  src = fetchFromGitHub {
+    owner = "lastfm";
+    repo = "liblastfm";
+    rev = "2ce2bfe1879227af8ffafddb82b218faff813db9";
+    sha256 = "1crih9xxf3rb109aqw12bjqv47z28lvlk2dpvyym5shf82nz6yd0";
   };
 
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace 'find_package(Qt5Core QUIET)' \
-                'find_package(Qt5 REQUIRED COMPONENTS Core Network Sql Test Xml)'
-  '';
+  patches = [(fetchpatch {
+    url = "https://github.com/lastfm/liblastfm/commit/9c5d072b55f2863310e40291677e6397e9cbc3c2.patch";
+    name = "0001-Remove-deprecated-staging-server-and-fix-test-for-QT5-at-Ubuntu-19.10.patch";
+    sha256 = "04r14prydxshjgfws3pjajjmp2msszhjjs1mjh8s66yg29vq620l";
+  })];
 
-  prefixKey = "--prefix ";
   nativeBuildInputs = [ pkgconfig which cmake ];
   buildInputs = [ fftwSinglePrec libsamplerate qtbase ]
     ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.SystemConfiguration;
@@ -31,7 +28,7 @@ stdenv.mkDerivation rec {
     repositories.git = "git://github.com/lastfm/liblastfm.git";
     description = "Official LastFM library";
     platforms = platforms.unix;
-    maintainers =  [ maintainers.phreedom ];
+    maintainers = [ maintainers.phreedom ];
     license = licenses.gpl3;
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -252,6 +252,7 @@ mapAliases ({
   libjpeg_drop = libjpeg_original; # added 2020-06-05
   libjson_rpc_cpp = libjson-rpc-cpp; # added 2017-02-28
   liblapackWithoutAtlas = lapack-reference; # added 2018-11-05
+  liblastfm = libsForQt5.liblastfm; # added 2020-06-14
   liblrdf = lrdf; # added 2018-04-25
   libqrencode = qrencode;  # added 2019-01-01
   librdf = lrdf; # added 2020-03-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13074,8 +13074,6 @@ in
 
   liblastfmSF = callPackage ../development/libraries/liblastfmSF { };
 
-  liblastfm = libsForQt5.callPackage ../development/libraries/liblastfm { };
-
   liblcf = callPackage ../development/libraries/liblcf { };
 
   liblqr1 = callPackage ../development/libraries/liblqr-1 { };
@@ -14348,6 +14346,8 @@ in
     libkeyfinder = callPackage ../development/libraries/libkeyfinder { };
 
     libktorrent = callPackage ../development/libraries/libktorrent { };
+
+    liblastfm = callPackage ../development/libraries/liblastfm { };
 
     libopenshot = callPackage ../applications/video/openshot-qt/libopenshot.nix { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This PR bumps amarok to the most recent commit in master and adds liblastfm as a dependency to make use of the last.fm integration that has been re-enabled in upstream master (it was disabled for a while due to breakage on Qt5).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
