### PR TITLE
aflplusplus: 2.64c -> 2.65c

### DIFF
--- a/pkgs/tools/security/aflplusplus/default.nix
+++ b/pkgs/tools/security/aflplusplus/default.nix
@@ -1,5 +1,5 @@
 { stdenv, stdenvNoCC, fetchFromGitHub, callPackage, makeWrapper
-, clang_9, llvm_9, gcc, which, libcgroup, python, perl, gmp
+, clang, llvm, gcc, which, libcgroup, python, perl, gmp
 , file, wine ? null, fetchpatch
 }:
 
@@ -29,16 +29,16 @@ let
 
     # Note: libcgroup isn't needed for building, just for the afl-cgroup
     # script.
-    nativeBuildInputs = [ makeWrapper which clang_9 gcc ];
-    buildInputs = [ llvm_9 python gmp ]
+    nativeBuildInputs = [ makeWrapper which clang gcc ];
+    buildInputs = [ llvm python gmp ]
       ++ stdenv.lib.optional (wine != null) python.pkgs.wrapPython;
 
 
     postPatch = ''
       # Replace the CLANG_BIN variables with the correct path
       substituteInPlace llvm_mode/afl-clang-fast.c \
-        --replace "CLANGPP_BIN" '"${clang_9}/bin/clang++"' \
-        --replace "CLANG_BIN" '"${clang_9}/bin/clang"' \
+        --replace "CLANGPP_BIN" '"${clang}/bin/clang++"' \
+        --replace "CLANG_BIN" '"${clang}/bin/clang"' \
         --replace 'getenv("AFL_PATH")' "(getenv(\"AFL_PATH\") ? getenv(\"AFL_PATH\") : \"$out/lib/afl\")"
 
       # Replace "gcc" and friends with full paths in afl-gcc

--- a/pkgs/tools/security/aflplusplus/default.nix
+++ b/pkgs/tools/security/aflplusplus/default.nix
@@ -1,6 +1,6 @@
 { stdenv, stdenvNoCC, fetchFromGitHub, callPackage, makeWrapper
 , clang_9, llvm_9, gcc, which, libcgroup, python, perl, gmp
-, file, cmocka, wine ? null, fetchpatch
+, file, wine ? null, fetchpatch
 }:
 
 # wine fuzzing is only known to work for win32 binaries, and using a mixture of
@@ -105,7 +105,7 @@ let
         wrapPythonProgramsIn $out/bin ${python.pkgs.pefile}
     '';
 
-    installCheckInputs = [ perl file cmocka ];
+    installCheckInputs = [ perl file ];
     doInstallCheck = true;
     installCheckPhase = ''
       # replace references to tools in build directory with references to installed locations

--- a/pkgs/tools/security/aflplusplus/default.nix
+++ b/pkgs/tools/security/aflplusplus/default.nix
@@ -17,25 +17,15 @@ let
   libtokencap = callPackage ./libtokencap.nix { inherit aflplusplus; };
   aflplusplus = stdenvNoCC.mkDerivation rec {
     pname = "aflplusplus";
-    version = "2.64c";
+    version = "2.65c";
 
     src = fetchFromGitHub {
       owner = "AFLplusplus";
       repo = "AFLplusplus";
       rev = version;
-      sha256 = "0n618pk6nlmkcbv1qm05fny4mnhcprrw0ppmra1phvk1y22iildj";
+      sha256 = "1np2a3kypb2m8nyv6qnij18yzn41pl8619jzydci40br4vxial9l";
     };
     enableParallelBuilding = true;
-
-    # build of unsigaction32 broken in 2.64c:
-    # https://github.com/AFLplusplus/AFLplusplus/commit/079fdbf9bc5be1adba19e4bd08be965bd4dd79dc#commitcomment-38428357
-    # The applied patch fixes it.
-    patches = [
-      (fetchpatch {
-        url = "https://github.com/AFLplusplus/AFLplusplus/commit/5b9928f1a9d4b017ea04365ca8b522fde71236eb.patch";
-        sha256 = "1m4w9w4jaxb2mjkwvr6r4qa2j5cdzzpchjphpwd95861h0zvb6hh";
-      })
-    ];
 
     # Note: libcgroup isn't needed for building, just for the afl-cgroup
     # script.
@@ -123,7 +113,7 @@ let
         --replace '../libcompcov.so' '`$out/bin/get-afl-qemu-libcompcov-so`' \
         --replace '../libdislocator.so' '`$out/bin/get-libdislocator-so`' \
         --replace '../libtokencap.so' '`$out/bin/get-libtokencap-so`'
-      perl -pi -e 's|(?<!\.)(\.\./)([^\s\/]+?)(?<!\.c)(?<!\.s?o)(?=\s)|\$out/bin/\2|g' test/test.sh
+      perl -pi -e 's|(?<!\.)(?<!-I)(\.\./)([^\s\/]+?)(?<!\.c)(?<!\.s?o)(?=\s)|\$out/bin/\2|g' test/test.sh
       cd test && ./test.sh
     '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -588,7 +588,8 @@ in
   };
 
   aflplusplus = callPackage ../tools/security/aflplusplus {
-    stdenv = clangStdenv;
+    clang = clang_9;
+    llvm = llvm_9;
     python = python37;
     wine = null;
   };


### PR DESCRIPTION
###### Motivation for this change
New release. Fixes some annoying bugs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Mindavi 