### PR TITLE
treewide: split name into pname/version for unstable packages

### DIFF
--- a/pkgs/applications/editors/gobby/default.nix
+++ b/pkgs/applications/editors/gobby/default.nix
@@ -5,7 +5,8 @@
 let
   libinf = libinfinity.override { gtkWidgets = true; inherit avahiSupport; };
 in stdenv.mkDerivation {
-  name = "gobby-unstable-2018-04-03";
+  pname = "gobby-unstable";
+  version = "2018-04-03";
   src = fetchFromGitHub {
     owner = "gobby";
     repo = "gobby";

--- a/pkgs/applications/graphics/meh/default.nix
+++ b/pkgs/applications/graphics/meh/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, libX11, libXext, libjpeg, libpng, giflib }:
 
 stdenv.mkDerivation {
-  name = "meh-unstable-2015-04-11";
+  pname = "meh-unstable";
+  version = "2015-04-11";
 
   src = fetchFromGitHub {
     owner = "jhawthorn";

--- a/pkgs/applications/graphics/photoflow/default.nix
+++ b/pkgs/applications/graphics/photoflow/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, gettext, glib, libxml2, pkgconfig, swig, automake, gobject-introspection, cmake, ninja, libtiff, libjpeg, fftw, exiv2, lensfun, gtkmm2, libraw, lcms2, libexif, vips, expat, pcre, pugixml }:
 
 stdenv.mkDerivation {
-  name = "photoflow-unstable-2018-08-28";
+  pname = "photoflow-unstable";
+  version = "2018-08-28";
 
   src = fetchFromGitHub {
     owner = "aferrero2707";

--- a/pkgs/applications/misc/colort/default.nix
+++ b/pkgs/applications/misc/colort/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  name = "colort-unstable-2017-03-12";
+  pname = "colort-unstable";
+  version = "2017-03-12";
 
   src = fetchFromGitHub {
     owner = "neeasade";

--- a/pkgs/applications/misc/mpvc/default.nix
+++ b/pkgs/applications/misc/mpvc/default.nix
@@ -1,7 +1,8 @@
 { stdenv, socat, fetchFromGitHub, makeWrapper }:
 
 stdenv.mkDerivation {
-  name = "mpvc-unstable-2017-03-18";
+  pname = "mpvc-unstable";
+  version = "2017-03-18";
 
   src = fetchFromGitHub {
     owner = "wildefyr";

--- a/pkgs/applications/misc/openbrf/default.nix
+++ b/pkgs/applications/misc/openbrf/default.nix
@@ -2,7 +2,8 @@
 
 
 mkDerivation {
-  name = "openbrf-unstable-2016-01-09";
+  pname = "openbrf-unstable";
+  version = "2016-01-09";
 
   src = fetchFromGitHub {
     owner = "cfcohen";

--- a/pkgs/applications/misc/speedread/default.nix
+++ b/pkgs/applications/misc/speedread/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, perl }:
 
 stdenv.mkDerivation rec {
-  name = "speedread-unstable-2016-09-21";
+  pname = "speedread-unstable";
+  version = "2016-09-21";
 
   src = fetchFromGitHub {
     owner  = "pasky";

--- a/pkgs/applications/misc/xrq/default.nix
+++ b/pkgs/applications/misc/xrq/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, libX11}:
 
 stdenv.mkDerivation {
-  name = "xrq-unstable-2016-01-15";
+  pname = "xrq-unstable";
+  version = "2016-01-15";
 
   src = fetchFromGitHub {
 	  owner = "arianon";

--- a/pkgs/applications/networking/irc/qweechat/default.nix
+++ b/pkgs/applications/networking/irc/qweechat/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchFromGitHub, python27Packages }:
 
 python27Packages.buildPythonApplication rec {
+  pname = "qweechat-unstable";
   version = "2016-07-29";
-  name = "qweechat-unstable-${version}";
   namePrefix = "";
 
- src = fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "weechat";
     repo = "qweechat";
     rev = "f5e54d01691adb3abef47e051a6412186c33313c";

--- a/pkgs/applications/radio/kalibrate-hackrf/default.nix
+++ b/pkgs/applications/radio/kalibrate-hackrf/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, fftw, hackrf, libusb1 }:
 
 stdenv.mkDerivation {
-  name = "kalibrate-hackrf-unstable-20160827";
+  pname = "kalibrate-hackrf-unstable";
+  version = "20160827";
 
   # There are no tags/releases, so use the latest commit from git master.
   # Currently, the latest commit is from 2016-07-03.

--- a/pkgs/applications/science/biology/EZminc/default.nix
+++ b/pkgs/applications/science/biology/EZminc/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, libminc, bicpl, itk4, fftwFloat, gsl }:
 
 stdenv.mkDerivation rec {
-  pname = "EZminc";
-  name  = "${pname}-unstable-2019-03-12";
+  pname = "EZminc-unstable";
+  version = "2019-03-12";
 
   src = fetchFromGitHub {
     owner  = "BIC-MNI";
-    repo   = pname;
+    repo   = "EZminc";
     rev    = "5e3333ee356f914d34d66d33ea8df809c7f7fa51";
     sha256 = "0wy8cppf5xpgfqvgb3mqs1cjh81n6qzkk6zxv29wvng8nar9wsy4";
   };
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/BIC-MNI/${pname}";
+    homepage = "https://github.com/BIC-MNI/EZminc";
     description = "Collection of Perl and shell scripts for processing MINC files";
     maintainers = with maintainers; [ bcdarwin ];
     platforms = platforms.unix;

--- a/pkgs/applications/science/logic/aspino/default.nix
+++ b/pkgs/applications/science/logic/aspino/default.nix
@@ -8,7 +8,8 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "aspino-unstable-2017-03-09";
+  pname = "aspino-unstable";
+  version = "2017-03-09";
 
   src = fetchFromGitHub {
     owner = "alviano";

--- a/pkgs/applications/science/misc/openmvs/default.nix
+++ b/pkgs/applications/science/misc/openmvs/default.nix
@@ -3,7 +3,8 @@
 , gmp, mpfr, glog, gflags, libjpeg_turbo }:
 
 stdenv.mkDerivation {
-  name = "openmvs-unstable-2018-05-26";
+  pname = "openmvs-unstable";
+  version = "2018-05-26";
 
   src = fetchFromGitHub {
     owner = "cdcseacave";

--- a/pkgs/applications/window-managers/bspwm/unstable.nix
+++ b/pkgs/applications/window-managers/bspwm/unstable.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, libxcb, libXinerama, xcbutil, xcbutilkeysyms, xcbutilwm }:
 
 stdenv.mkDerivation {
-  name = "bspwm-unstable-2016-09-30";
+  pname = "bspwm-unstable";
+  version = "2016-09-30";
 
 
   src = fetchFromGitHub {

--- a/pkgs/applications/window-managers/i3/lock-fancy.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy.nix
@@ -3,12 +3,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  rev = "7accfb2aa2f918d1a3ab975b860df1693d20a81a";
-  name = "i3lock-fancy-unstable-2018-11-25_rev${builtins.substring 0 7 rev}";
+  pname = "i3lock-fancy-unstable";
+  version = "2018-11-25";
   src = fetchFromGitHub {
     owner = "meskarune";
     repo = "i3lock-fancy";
-    inherit rev;
+    rev = "7accfb2aa2f918d1a3ab975b860df1693d20a81a";
     sha256 = "00lqsvz1knb8iqy8lnkn3sf4c2c4nzb0smky63qf48m8za5aw9b1";
   };
   patchPhase = ''

--- a/pkgs/applications/window-managers/lemonbar/xft.nix
+++ b/pkgs/applications/window-managers/lemonbar/xft.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, perl, libxcb, libXft }:
 
 stdenv.mkDerivation {
-  name = "lemonbar-xft-unstable-2016-02-17";
+  pname = "lemonbar-xft-unstable";
+  version = "2016-02-17";
 
   src = fetchFromGitHub {
     owner  = "krypt-n";

--- a/pkgs/data/misc/brise/default.nix
+++ b/pkgs/data/misc/brise/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, librime }:
 
 stdenv.mkDerivation {
-  name = "brise-unstable-2017-09-16";
+  pname = "brise-unstable";
+  version = "2017-09-16";
 
   src = fetchFromGitHub {
     owner = "rime";

--- a/pkgs/development/coq-modules/fiat/HEAD.nix
+++ b/pkgs/development/coq-modules/fiat/HEAD.nix
@@ -1,8 +1,7 @@
 {stdenv, fetchgit, coq, python27}:
 
 stdenv.mkDerivation rec {
-
-  name = "coq-fiat-${coq.coq-version}-unstable-${version}";
+  pname = "coq-fiat-unstable";
   version = "2016-10-24";
 
   src = fetchgit {

--- a/pkgs/development/libraries/bootil/default.nix
+++ b/pkgs/development/libraries/bootil/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, fetchpatch, premake4 }:
 
 stdenv.mkDerivation {
-  name = "bootil-unstable-2015-12-17";
+  pname = "bootil-unstable";
+  version = "2015-12-17";
 
   meta = {
     description = "Garry Newman's personal utility library";

--- a/pkgs/development/libraries/tremor/default.nix
+++ b/pkgs/development/libraries/tremor/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchgit, autoreconfHook, pkgconfig, libogg }:
 
 stdenv.mkDerivation {
-  name = "tremor-unstable-2018-03-16";
+  pname = "tremor-unstable";
+  version = "2018-03-16";
 
   src = fetchgit {
     url = "https://git.xiph.org/tremor.git";

--- a/pkgs/development/misc/rpiboot/unstable.nix
+++ b/pkgs/development/misc/rpiboot/unstable.nix
@@ -1,10 +1,8 @@
 { stdenv, fetchFromGitHub, libusb1 }:
 
-let
+stdenv.mkDerivation {
+  pname = "rpiboot-unstable";
   version = "2018-03-27";
-  name = "rpiboot-unstable-${version}";
-in stdenv.mkDerivation {
-  inherit name;
 
   src = fetchFromGitHub {
     owner = "raspberrypi";

--- a/pkgs/development/tools/analysis/pev/default.nix
+++ b/pkgs/development/tools/analysis/pev/default.nix
@@ -1,6 +1,7 @@
 { stdenv, openssl, fetchFromGitHub }:
 stdenv.mkDerivation {
-  name = "pev-unstable-2018-07-22";
+  pname = "pev-unstable";
+  version = "2018-07-22";
   buildInputs = [ openssl ];
   src = fetchFromGitHub {
     owner = "merces";

--- a/pkgs/development/tools/kexpand/default.nix
+++ b/pkgs/development/tools/kexpand/default.nix
@@ -1,7 +1,8 @@
 { buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage {
-  name = "kexpand-unstable-2017-05-12";
+  pname = "kexpand-unstable";
+  version = "2017-05-12";
 
   goPackagePath = "github.com/kopeio/kexpand";
 

--- a/pkgs/development/tools/manul/default.nix
+++ b/pkgs/development/tools/manul/default.nix
@@ -1,7 +1,8 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage {
-  name = "manul-unstable-2016-09-30";
+  pname = "manul-unstable";
+  version = "2016-09-30";
 
   goPackagePath = "github.com/kovetskiy/manul";
   excludedPackages = "tests";

--- a/pkgs/games/gmad/default.nix
+++ b/pkgs/games/gmad/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, premake4, bootil }:
 
 stdenv.mkDerivation rec {
-  name = "gmad-unstable-2015-04-16";
+  pname = "gmad-unstable";
+  version = "2015-04-16";
 
   meta = {
     description = "Garry's Mod Addon Creator and Extractor";

--- a/pkgs/os-specific/linux/firmware/rtl8192su-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/rtl8192su-firmware/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub }:
 with stdenv.lib;
 stdenv.mkDerivation {
-  name = "rtl8192su-unstable-2016-10-05";
+  pname = "rtl8192su-unstable";
+  version = "2016-10-05";
 
   src = fetchFromGitHub {
     owner = "chunkeey";

--- a/pkgs/shells/zsh/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/zsh/lambda-mod-zsh-theme/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, zsh }:
 
 stdenv.mkDerivation {
-  name = "lambda-mod-zsh-theme-unstable-2019-04-17";
+  pname = "lambda-mod-zsh-theme-unstable";
+  version = "2019-04-17";
 
   src = fetchFromGitHub {
     owner = "halfo";

--- a/pkgs/tools/audio/picotts/default.nix
+++ b/pkgs/tools/audio/picotts/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libtool, popt }:
 
 stdenv.mkDerivation {
-  name = "picotts-unstable-2018-10-19";
+  pname = "picotts-unstable";
+  version = "2018-10-19";
   src = fetchFromGitHub {
     repo = "picotts";
     owner = "naggety";

--- a/pkgs/tools/inputmethods/skk/skktools/default.nix
+++ b/pkgs/tools/inputmethods/skk/skktools/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     sha256 = "11v1i5gkxvfsipigc1w1m16ijzh85drpl694kg6ih4jfam1q4vdh";
   };
   # # See "12.2. Package naming"
-  # name = "skktools-unstable-${version}";
+  # pname = "skktools-unstable";
   # version = "2017-03-05";
   # src = fetchFromGitHub {
   #   owner = "skk-dev";

--- a/pkgs/tools/misc/fasd/default.nix
+++ b/pkgs/tools/misc/fasd/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub } :
 
 stdenv.mkDerivation rec {
-  pname = "fasd";
-  name = "${pname}-unstable-2016-08-11";
+  pname = "fasd-unstable";
+  version = "2016-08-11";
 
   src = fetchFromGitHub {
     owner = "clvv";
-    repo = pname;
+    repo = "fasd";
     rev = "90b531a5daaa545c74c7d98974b54cbdb92659fc";
     sha256 = "0i22qmhq3indpvwbxz7c472rdyp8grag55x7iyjz8gmyn8gxjc11";
   };
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "https://github.com/clvv/${pname}";
+    homepage = "https://github.com/clvv/fasd";
     description = "Quick command-line access to files and directories for POSIX shells";
     license = stdenv.lib.licenses.mit;
 

--- a/pkgs/tools/misc/git-fire/default.nix
+++ b/pkgs/tools/misc/git-fire/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  name = "git-fire-unstable-2017-08-27";
+  pname = "git-fire-unstable";
+  version = "2017-08-27";
 
   src = fetchFromGitHub {
     owner = "qw3rtman";

--- a/pkgs/tools/misc/loop/default.nix
+++ b/pkgs/tools/misc/loop/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage {
-  name = "loop-unstable-2018-12-04";
+  pname = "loop-unstable";
+  version = "2018-12-04";
 
   src = fetchFromGitHub {
     owner = "Miserlou";

--- a/pkgs/tools/misc/xdxf2slob/default.nix
+++ b/pkgs/tools/misc/xdxf2slob/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, python3Packages }:
 
 python3Packages.buildPythonApplication {
-  name = "xdxf2slob-unstable-2015-06-30";
+  pname = "xdxf2slob-unstable";
+  version = "2015-06-30";
 
   src = fetchFromGitHub {
     owner = "itkach";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

A little step forwards to untangle the unstable versioning mess.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
