### PR TITLE
[WIP] nixos/open-with: init

### DIFF
--- a/nixos/modules/programs/open-with/modifier.py
+++ b/nixos/modules/programs/open-with/modifier.py
@@ -1,0 +1,59 @@
+import sys;
+
+initialAssociationFileName = sys.argv[ 1 ]
+finalAssociationFileName   = sys.argv[ 2 ]
+
+iaf = open( initialAssociationFileName, 'r' ) ;
+initialAssociations = iaf.readlines()
+iaf.close();
+
+finalAssociations = []
+
+finalAssociations.append( initialAssociations[ 0 ] )
+
+customAssociationKeys = list( customAssociations.keys() )
+customAssociationKeys.sort()
+
+customAssociationIndex = 0;
+
+customMime = customAssociationKeys[ customAssociationIndex ] 
+# import pdb; pdb.set_trace()
+
+for i in range( 1, len( initialAssociations ) ):
+    initial = initialAssociations[ i ].split( "=" )
+    mimetype = initial[0]
+    association = initial[1]
+
+    while( customMime < mimetype ):
+
+        finalAssociations.append( 
+                customMime + "=" + customAssociations[ customMime ] + ";" 
+        )
+
+        customAssociationIndex += 1 
+        if customAssociationIndex == len( customAssociations ) : 
+            break
+        else:
+            customMime = customAssociationKeys[ customAssociationIndex ] 
+
+    if( customMime == mimetype ):
+        finalAssociations.append(
+                mimetype + "=" + customAssociations[ customMime ] + ";" + association 
+        )
+        customAssociationIndex += 1 
+        customMime = customAssociationKeys[ customAssociationIndex ] 
+    else:
+        finalAssociations.append( initialAssociations[ i ] )
+
+while customAssociationIndex < len( customAssociationKeys ):
+    customMime = customAssociationKeys[ customAssociationIndex ] 
+    finalAssociations.append( 
+            customMime + "=" + customAssociations[ customMime ] + ";" 
+    )
+    customAssociationIndex += 1 
+
+with open( finalAssociationFileName, 'w') as finalAssociationsFile:
+    for i in range( 0, len( finalAssociations ) ):
+        finalAssociationsFile.write( finalAssociations[ i ]  )
+
+

--- a/nixos/modules/programs/open-with/open-with.nix
+++ b/nixos/modules/programs/open-with/open-with.nix
@@ -1,0 +1,215 @@
+{ config, lib, utils, pkgs, ... }:
+with lib;
+
+let
+  cfg = config.programs.defaults;
+# This module defines an option to set 
+# default programs and "Open with" associations.
+
+# Why? No proper association. Inkspace pdf, dir vscode
+# No proper order
+# Home directory two of the most popular program mimeopen and xdg-open use differn
+
+# [~/XDG/下载]
+# $mimeopen -a resume.pdf                                                                                                      
+# Please choose an application
+# 
+# 	1) Foxit Reader  (FoxitReader)
+# 	2) Inkscape  (inkscape)
+# 	3) Document Viewer  (org.gnome.Evince)
+# 	4) pqiv  (pqiv)
+# 	5) TeXworks  (texworks)
+# 	6) Zathura  (org.pwmt.zathura)
+# 
+# use application #^C
+# $xdg-open resume.pdf                                                                                                         
+# 
+# (zathura:9334): Gtk-WARNING **: 19:57:30.912: GModule (/nix/store/pbfflw3gldyxfqx3s1kddvh49anzqvbm-fcitx-with-plugins-4.2.9.6/lib/gtk-3.0/3.0.0/immodules/im-fcitx.so) initialization check failed: GLib version too old (micro mismatch)
+# 
+# (zathura:9334): Gtk-WARNING **: 19:57:30.912: Loading IM context type 'fcitx' failed
+
+	singleEntryType = types.either types.str types.package;
+
+
+  doesEndInDesktop = 
+	  filePath: 
+	  (
+		  ( 
+			  builtins.substring  
+				  ( 
+					  builtins.stringLength filePath  - 8
+				  ) 
+				  ( 
+					  builtins.stringLength filePath - 1
+				  ) 
+				  filePath  
+		  ) 
+		  == 
+			  ".desktop"
+	)
+  ;
+
+  singleToList = 
+	  val:  
+		  if ( builtins.typeOf val != "list" ) 
+		  then 
+			  [ val ] 
+		  else 
+			  val 
+  ;
+  
+	mapAttrValues = 
+		f: set: 
+			builtins.listToAttrs (
+				 map 
+					 (
+						 attr: 
+						 { 
+							 name = attr; 
+							 value = f set.${attr};
+						 }
+					 )
+					 ( builtins.attrNames set ) 
+			 )
+	;
+
+	getSingleDesktopFileFromPackage = pkg: 
+	(
+		builtins.elemAt
+			( 
+				builtins.filter 
+					doesEndInDesktop
+					( 
+						builtins.attrNames( 
+							builtins.readDir "${pkg}/share/applications"
+						)
+					) 
+			) 
+			0
+	)
+	;
+
+	desktopFileNameFromPath = path:
+		(
+			let 
+				nodes = builtins.split "/" path;
+			in
+				builtins.elemAt nodes ( ( builtins.length nodes ) - 1 )
+		)
+	;
+	
+	
+	# list of mixed type, string and package
+	packageFilter = launcherAttrOfList: 
+		builtins.filter
+			(
+				p: ( builtins.typeOf p ) != "string"
+			)
+			( 
+				builtins.concatLists
+				( 
+					builtins.attrValues launcherAttrOfList 
+				)
+			)
+	;
+
+	mixedListToDesktopFileList = mixedList:
+		builtins.map
+			(
+				entry: 
+				(
+					if( builtins.typeOf entry == "string" )
+					then
+						desktopFileNameFromPath entry
+					else
+						( getSingleDesktopFileFromPackage entry )
+				)
+			)
+			mixedList
+	;
+
+	defaultLaunchers = cfg.defaults;
+	defaultLaunchersAttrOfList = 
+		mapAttrValues 
+			singleToList
+			defaultLaunchers 
+	;
+
+	allDirectPackages = packageFilter defaultLaunchersAttrOfList;
+
+	allCustomAssociations = mapAttrValues
+		(
+			mixedList: 
+				builtins.concatStringsSep
+					";"
+					( mixedListToDesktopFileList mixedList )
+		)
+		defaultLaunchersAttrOfList 
+	;
+
+
+	mimeInfoCacheModifierScript  = 
+		let
+			scriptHeader = "customAssociations={}\n";
+
+			dictionaryPopulationCode =
+				builtins.concatStringsSep
+					";\n"
+					( 
+						builtins.map
+							(
+								key: ''customAssociations["${key}"]="${allCustomAssociations.${key}}"''
+							)
+							( builtins.attrNames allCustomAssociations ) 
+					)
+			;
+
+			logic = builtins.readFile( ./modifier.py );
+		in
+		( 
+			pkgs.writeScript
+				"mimeInfoCacheModifier"
+				(	
+					scriptHeader + 	dictionaryPopulationCode + "\n" + logic
+				)
+		)
+
+	;
+
+in
+{
+	options.programs.defaults = {
+		defaults =
+			mkOption {
+				default = {};
+				example = { 
+					"application/pdf" = [ pkgs.zathura "${pkgs.evince}/share/applications/org.gnome.Evince.desktop" ];
+					"inode/directory" = [ "${pkgs.spaceFM}/share/applications/spacefm.desktop" pkgs.ranger pkgs.vifm ];
+					"video/mp4" = pkgs.vifm;
+				} ;
+				description = ''
+					Set that defines default launcher programs. Attribute name is the mimetype, 
+					and attribute values 
+					A set where mimetypes are keys and an array of .desktop files, or packages
+					are the values which would be used to open that file by default. 
+				'';
+
+
+				type = types.attrsOf (
+					types.either 
+						singleEntryType
+						( types.listOf singleEntryType )
+				) ;
+			};
+	};
+
+	config = {
+		environment.systemPackages = 
+			allDirectPackages
+		;
+
+		environment.extraSetup = ''
+			${pkgs.python3}/bin/python ${mimeInfoCacheModifierScript} $out/share/applications/mimeinfo.cache $out/share/applications/mimeinfo.cache
+		'';
+	};
+}


### PR DESCRIPTION
###### Motivation for this change
Some discussion here- https://discourse.nixos.org/t/configure-how-xdg-open-opens-html-files/6419/22 

On my computer currently- these are the liens in `mimeinfo.cache`

```
application/pdf=inkscape.desktop;org.gnome.Evince.desktop;pqiv.desktop;texworks.desktop;
inode/directory=code.desktop;pcmanfm.desktop;ranger.desktop;spacefm-find.desktop;spacefm-folder-handler.desktop;spacefm.desktop;vifm.desktop;
video/mp4=pqiv.desktop;vlc.desktop;
```
meaning that pdf is (not) opened in Inkscape, directory is (at a leisurely pace) opened in Visual Studio Code and `mp4` (barely) opens in pqiv.

At this point one would refer to Arch wiki to figure out how to override these settings manually. However, two of the probably most popular programs around this- `xdg-open` and `mimeopen` do not concur on how to do so. It appears that they read different files. The obvious solution would be to link to another but that doesn't work because, in my recollection one of those files is such that it is deleted and recreated upon every edit. 

So it seems that the only sane solution is to override the global (computer-wide) defaults because everybody seems to respect that at least. 

This code adds an option `programs.defaults.defaults` to achieve that. 

**This is a work in progress and this doesn't actually work** but I think I've done the hard part of actual logic, what I haven't managed is the final part of were to read mimeinfo.cache from

###### Things done
**Not application because this doesn't work, I'm seeking help here** Will update.
