### PR TITLE
doas: enable timestamp by default and set pamdir

### DIFF
--- a/pkgs/tools/security/doas/default.nix
+++ b/pkgs/tools/security/doas/default.nix
@@ -3,6 +3,8 @@
 , fetchFromGitHub
 , bison
 , pam
+
+, withTimestamp ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -18,6 +20,11 @@ stdenv.mkDerivation rec {
 
   # otherwise confuses ./configure
   dontDisableStatic = true;
+
+  configureFlags = [
+    (lib.optionalString withTimestamp "--with-timestamp") # to allow the "persist" setting
+    "--pamdir=${placeholder "out"}/etc/pam.d"
+  ];
 
   postPatch = ''
     sed -i '/\(chown\|chmod\)/d' bsd.prog.mk


### PR DESCRIPTION
* `--with-timestamp` enables the usage of the `persist` setting in
`doas.conf`. It is possible some people might not want this, so the flag
`withTimestamp` was added to control this.
* `--pamdir` copies the PAM files to `$out/etc/pam.d`. This may or may
not have a use in the future, but it removes a some errors from the
build (when it tries to copy these files to /etc/pam.d).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The `persist` setting from nixos/doas will not actually work because you must opt in to timestamps (its presence when this is disabled will be silently ignored).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
