### PR TITLE
processing: 3.5.3 -> 3.5.4 | fix / refactor

### DIFF
--- a/pkgs/applications/graphics/processing/default.nix
+++ b/pkgs/applications/graphics/processing/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, lib, jdk, patchelf, makeWrapper, xlibs, zip, unzip, rsync
+{ stdenv, lib, jdk, patchelf, makeWrapper, xorg, zip, unzip, rsync, fetchzip
 , xdg_utils ? null, gsettings-desktop-schemas ? null }:
 let
   arch = "linux64";
-  libs = (with xlibs; [ libXext libX11 libXrender libXtst libXi libXxf86vm ]);
+  libs = (with xorg; [ libXext libX11 libXrender libXtst libXi libXxf86vm ]);
 in stdenv.mkDerivation rec {
   pname = "processing";
   version = "3.5.4";
 
-  src = fetchTarball {
+  src = fetchzip {
     url = "https://download.processing.org/${pname}-${version}-${arch}.tgz";
     sha256 = "0fqjsa1j05wriwpa7fzvv2rxhhsz6ixqzf52syxr4z74j3wkxk8k";
   };
@@ -95,7 +95,7 @@ in stdenv.mkDerivation rec {
           "--prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}"
         } \
         --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=lcd" \
-        --prefix LD_LIBRARY_PATH : "${xlibs.libXxf86vm}/lib"
+        --prefix LD_LIBRARY_PATH : "${xorg.libXxf86vm}/lib"
     done
   '' + (lib.optionalString (xdg_utils != null) ''
     # See: $out/processing/install.sh


### PR DESCRIPTION
The old expression downloaded `http://download.processing.org/reference.zip` with a fixed hash, and would break when new versions were released.

This expression remedies that by using a versioned tarball.

Further, it avoids compiling by applying our patch (to avoid the spurious "Not fond of this Java VM" warning message) directly to the compiled `.class` file.

###### Motivation for this change

The old `processing` expression was broken by a change to `http://download.processing.org/reference.zip`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
