### PR TITLE
zsh-prezto: 2019-03-18 -> 2020-05-02

### DIFF
--- a/pkgs/shells/zsh/zsh-prezto/default.nix
+++ b/pkgs/shells/zsh/zsh-prezto/default.nix
@@ -1,11 +1,13 @@
-{ stdenv, fetchgit }:
+{ stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation {
-  name = "zsh-prezto-2019-03-18";
-  src = fetchgit {
-    url = "https://github.com/sorin-ionescu/prezto";
-    rev = "1f4601e44c989b90dc7314b151891fa60a101251";
-    sha256 = "1dcd5r7pc4biiplm0lh7yca0h6hs0xpaq9dwaarmfsh9wrd68350";
+stdenv.mkDerivation rec {
+  pname = "zsh-prezto";
+  version = "2020-05-20";
+  src = fetchFromGitHub {
+    owner = "sorin-ionescu";
+    repo = "prezto";
+    rev = "793f239a5e38ef2c4b76a4955bb734520303e8c4";
+    sha256 = "0xhdl1g0rvlikq6qxh6cwp6wsrgmw4l1rmmq5xpc7wl6dyh35yri";
     fetchSubmodules = true;
   };
   buildPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update zsh-prezto to the latest version. Probably the highlight of this
update is https://github.com/sorin-ionescu/prezto/pull/1734.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).