### PR TITLE
oraclejdk8: 8u241 -> 8u251

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,10 +1,10 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "241";
-  sha256.i686-linux = "1niiwifby8zqvsh0ccdf3n21vlqfvvms223dc3kw2c2rksch3yg4";
-  sha256.x86_64-linux = "1jz8d6663jspxgw8yxxx5ca6jaa3g67dbbi5d83pdxjmg1kk57a1";
-  sha256.armv7l-linux = "1pjzyi1qd4nzfwvh0z5fpwga7j8mksiv5h8wzirv2ccdyy4wqw24";
-  sha256.aarch64-linux = "1zliv4a0ygrsdpq36b89yl7jf7kidmxqbnp1sk2661y471x02p9l";
+  patchVersion = "251";
+  sha256.i686-linux = "0c6d25c09459e435570204f1a22a1cb765ce5d62c5bced92c9a9546b7be337f2";
+  sha256.x86_64-linux = "777a8d689e863275a647ae52cb30fd90022a3af268f34fc5b9867ce32f1b374e";
+  sha256.armv7l-linux = "f1b0c979e1b61ec52ebd5e1d0b754d7681d8623b09ac90c69718a553ef9b0cd1";
+  sha256.aarch64-linux = "58baeaab7da97dd5a6b02ad2dcd77c14b3b6ba014029ee67dbc2bd5f0fa98d1b";
   jceName = "jce_policy-8.zip";
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Upstream update. ([Release notes](https://www.oracle.com/technetwork/java/javase/8u251-relnotes-5972664.html))

###### Things done
Manually downloaded the 4 archives from oracle and built on x86_64, i686, and aarch64. (using qemu userspace emulation) I haven't been able to build on armv7l but the hash is correct.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` **no diff detected**
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
