### PR TITLE
buildRustCrate: Replace hyphen with underscore in env variables

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -179,9 +179,9 @@ in ''
        export $env
      done
 
-     CRATENAME=$(echo ${crateName} | sed -e "s/\(.*\)-sys$/\U\1/")
+     CRATENAME=$(echo ${crateName} | sed -e "s/\(.*\)-sys$/\U\1/" -e "s/-/_/g")
      grep -P "^cargo:(?!(rustc-|warning=|rerun-if-changed=|rerun-if-env-changed))" target/build/${crateName}.opt \
-       | sed -e "s/cargo:\([^=]*\)=\(.*\)/export DEP_$(echo $CRATENAME)_\U\1\E=\2/" > target/env
+       | awk -F= "/^cargo:/ { sub(/^cargo:/, \"\", \$1); gsub(/-/, \"_\", \$1); print \"export \" toupper(\"DEP_$(echo $CRATENAME)_\" \$1) \"=\" \$2 }" > target/env
      set -e
   fi
   runHook postConfigure


### PR DESCRIPTION
This fixes a bug that prevents encoding_c from building.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I tried to use crate2nix to build [a Rust package that depends on mozjs](https://github.com/notriddle/mozjs-example). This depends on encoding_c, which passes this output from `build.rs`:

    cargo:include-dir=$PWD/includes

Which gets rewritten to this env file:

    export DEPS_encoding_c_INCLUDE-DIR=$PWD/includes

This is invalid; nix doesn't allow environment variables to contain hyphens. In any case, it also doesn't match up with how mozjs is trying to reference it [here](https://github.com/servo/mozjs/blob/bdccbdc656fbaf6691ca3a3bc880eed4c499c9f3/build.rs#L152). The mozjs build script expects it to be spelled `DEPS_ENCODING_C_INCLUDE_DIR`, with all of it in `SCREAMING_CASE`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
