### PR TITLE
zxing-cpp: init at latest commit from march-20-2019

### DIFF
--- a/pkgs/tools/graphics/zxing-cpp/default.nix
+++ b/pkgs/tools/graphics/zxing-cpp/default.nix
@@ -7,8 +7,8 @@
 }:
 stdenv.mkDerivation rec {
 
-  pname = "zxing-cpp";
-  version = "0.0";
+  pname = "zxing-cpp-unstable";
+  version = "2020-03-20";
 
   src = fetchFromGitHub {
     owner = "glassechidna";

--- a/pkgs/tools/graphics/zxing-cpp/default.nix
+++ b/pkgs/tools/graphics/zxing-cpp/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, opencv
+}:
+stdenv.mkDerivation rec {
+
+  pname = "zxing-cpp";
+  version = "0.0";
+
+  src = fetchFromGitHub {
+    owner = "glassechidna";
+    repo = "zxing-cpp";
+    # No release tag yet, defaulting to latest commit
+    rev = "e0e40ddec63f38405aca5c8c1ff60b85ec8b1f10";
+    sha256 = "03mbqf156047nqmq00qkwk9lvcmi9iknim2b2jv59h9qywjzypxq";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ opencv ];
+
+  meta = {
+    description = "Zebra Crossing barcode scanning library ported to c++";
+    license = lib.licenses.asl20;
+    homepage = "https://github.com/glassechidna/zxing-cpp";
+    maintainers = with lib.maintainers; [ shamilton ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
Zxing-cpp is a dependency of OTPGen which is packaged in this PR https://github.com/NixOS/nixpkgs/pull/87887

###### Things done
Packaged https://github.com/glassechidna/zxing-cpp from latest commit.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
