### PR TITLE
unicorn-emulator-git: init at unstable-2020-05-18

### DIFF
--- a/pkgs/development/libraries/unicorn-emu/git.nix
+++ b/pkgs/development/libraries/unicorn-emu/git.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, pkgconfig, python }:
+
+stdenv.mkDerivation rec {
+  pname = "unicorn-emulator-git";
+  version = "unstable-2020-05-18";
+
+  src = fetchFromGitHub {
+    owner = "unicorn-engine";
+    repo = "unicorn";
+    rev = "2c66acf4ee967e8397dd3d935ff14164fd4b2431";
+    sha256 = "1sjsrcw6jj3vjdlg5naydfpdcrzlzxxki3zsqx6slzn0pbfhpcdj";
+  };
+
+  configurePhase = '' patchShebangs make.sh '';
+  buildPhase = '' ./make.sh '' + stdenv.lib.optionalString stdenv.isDarwin "macos-universal-no";
+  installPhase = '' env PREFIX=$out ./make.sh install '';
+
+  nativeBuildInputs = [ pkgconfig python ];
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Lightweight multi-platform CPU emulator library";
+    homepage    = "http://www.unicorn-engine.org";
+    license     = stdenv.lib.licenses.gpl2;
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1388,6 +1388,7 @@ in
 
   capstone = callPackage ../development/libraries/capstone { };
   unicorn-emu = callPackage ../development/libraries/unicorn-emu { };
+  unicorn-emu-git = callPackage ../development/libraries/unicorn-emu/git.nix { };
 
   casync = callPackage ../applications/networking/sync/casync {
     sphinx = python3Packages.sphinx;


### PR DESCRIPTION
###### Motivation for this change
Required for #84117, as the latest release is quite old. The changes we need are already in master, however not in the latest release from 2017. Could also update to a [pre-release](https://github.com/unicorn-engine/unicorn/releases/tag/1.0.2-rc3), however i thought it'd be better to keep the base package at a stable release, and just have an unstable git package as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
