### PR TITLE
find-libs: extract from stage-1 and turn into its own package

### DIFF
--- a/pkgs/development/tools/misc/find-libs/default.nix
+++ b/pkgs/development/tools/misc/find-libs/default.nix
@@ -1,0 +1,52 @@
+# A utility for enumerating the shared-library dependencies of a program
+{ writeShellScriptBin, patchelf }:
+
+writeShellScriptBin "find-libs" ''
+  set -euo pipefail
+
+  declare -A seen
+  declare -a left
+
+  patchelf="${patchelf}/bin/patchelf"
+
+  function add_needed {
+    rpath="$($patchelf --print-rpath $1)"
+    dir="$(dirname $1)"
+    for lib in $($patchelf --print-needed $1); do
+      left+=("$lib" "$rpath" "$dir")
+    done
+  }
+
+  add_needed $1
+
+  while [ ''${#left[@]} -ne 0 ]; do
+    next=''${left[0]}
+    rpath=''${left[1]}
+    ORIGIN=''${left[2]}
+    left=("''${left[@]:3}")
+    if [ -z ''${seen[$next]+x} ]; then
+      seen[$next]=1
+
+      # Ignore the dynamic linker which for some reason appears as a DT_NEEDED of glibc but isn't in glibc's RPATH.
+      case "$next" in
+        ld*.so.?) continue;;
+      esac
+
+      IFS=: read -ra paths <<< $rpath
+      res=
+      for path in "''${paths[@]}"; do
+        path=$(eval "echo $path")
+        if [ -f "$path/$next" ]; then
+            res="$path/$next"
+            echo "$res"
+            add_needed "$res"
+            break
+        fi
+      done
+      if [ -z "$res" ]; then
+        echo "Couldn't satisfy dependency $next" >&2
+        exit 1
+      fi
+    fi
+  done
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -290,6 +290,8 @@ in
 
   fetchMavenArtifact = callPackage ../build-support/fetchmavenartifact { };
 
+  find-libs = callPackage ../development/tools/misc/find-libs { };
+
   prefer-remote-fetch = import ../build-support/prefer-remote-fetch;
 
   global-platform-pro = callPackage ../development/tools/global-platform-pro/default.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [N/A] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Remaining work

This PR is in a draft state primarily because **I have not yet tested that NixOS's stage-1 bootloader still works**.  Although this is a fairly simple extraction of code from one place to another, it is critical that this be fully tested before it is merged.

- [ ] Test that NixOS stage-1 bootloader still works identically to before
- [ ] Add package metadata for `find-libs`
- [ ] Decide whether `find-libs` is the correct name for this