### PR TITLE
exim: 4.92.3 -> 4.93

### DIFF
--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -7,11 +7,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "exim-4.92.3";
+  pname = "exim";
+  version = "4.93.0.4";
 
   src = fetchurl {
-    url = "https://ftp.exim.org/pub/exim/exim4/${name}.tar.xz";
-    sha256 = "1zfj4zblv5881qxpzkrg3f6a96pbcq270s9p6p1w85lfxjsknif4";
+    url = "https://ftp.exim.org/pub/exim/exim4/fixes/${pname}-${version}.tar.xz";
+    sha256 = "01g4sfycv13glnmfrapwhjbdw6z1z7w5bwjldxjmglwfw5p3czak";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -34,7 +35,7 @@ stdenv.mkDerivation rec {
       s:^\(FIXED_NEVER_USERS\)=root$:\1=0:
       s:^# \(WITH_CONTENT_SCAN\)=.*:\1=yes:
       s:^# \(AUTH_PLAINTEXT\)=.*:\1=yes:
-      s:^# \(SUPPORT_TLS\)=.*:\1=yes:
+      s:^# \(USE_OPENSSL\)=.*:\1=yes:
       s:^# \(USE_OPENSSL_PC=openssl\)$:\1:
       s:^# \(LOG_FILE_PATH=syslog\)$:\1:
       s:^# \(HAVE_IPV6=yes\)$:\1:


### PR DESCRIPTION
As per the [updating notes](https://git.exim.org/exim.git/blob_plain/885bb037cb791e057de2105bb3790c6135914c62:/src/README.UPDATING), DISABLE_TLS replaces SUPPORT_TLS.
The build system also wants you to choose between OpenSSL and GnuTLS.
Since we were using OpenSSL until now, I chose that.

###### Motivation for this change
Upstream release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I also checked that the 3 non-standard options (enableLDAP, enableMySQL and enablePAM) still compile, but I did not check if they work correctly.