### PR TITLE
redis-dump: add redis-load

### DIFF
--- a/pkgs/development/tools/redis-dump/default.nix
+++ b/pkgs/development/tools/redis-dump/default.nix
@@ -3,7 +3,7 @@
 bundlerApp {
   pname = "redis-dump";
   gemdir = ./.;
-  exes = [ "redis-dump" ];
+  exes = [ "redis-dump" "redis-load" ];
 
   passthru.updateScript = bundlerUpdateScript "redis-dump";
 


### PR DESCRIPTION


###### Motivation for this change

Being able to restore from dumps created by redis-dump makes the tool way more useful.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
