### PR TITLE
gdk-pixbuf: move xlib into separate package

### DIFF
--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -16,7 +16,6 @@
 , libtiff
 , libjpeg
 , libpng
-, libX11
 , gnome3
 , gobject-introspection
 , doCheck ? false
@@ -65,11 +64,6 @@ stdenv.mkDerivation rec {
     fixDarwinDylibNames
   ];
 
-  # !!! We might want to factor out the gdk-pixbuf-xlib subpackage.
-  buildInputs = [
-    libX11
-  ];
-
   propagatedBuildInputs = [
     glib
     libtiff
@@ -79,7 +73,7 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Ddocs=true"
-    "-Dx11=true"
+    "-Dx11=false" # use gdk-pixbuf-xlib
     "-Dgir=${if gobject-introspection != null then "true" else "false"}"
     "-Dgio_sniffing=false"
   ];

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -1,23 +1,44 @@
-{ stdenv, fetchurl, nixosTests, fixDarwinDylibNames, meson, ninja, pkgconfig, gettext, python3, libxml2, libxslt, docbook_xsl
-, docbook_xml_dtd_43, gtk-doc, glib, libtiff, libjpeg, libpng, libX11, gnome3
-, gobject-introspection, doCheck ? false, makeWrapper
+{ stdenv
+, fetchurl
+, nixosTests
+, fixDarwinDylibNames
+, meson
+, ninja
+, pkg-config
+, gettext
+, python3
+, libxml2
+, libxslt
+, docbook-xsl-nons
+, docbook_xml_dtd_43
+, gtk-doc
+, glib
+, libtiff
+, libjpeg
+, libpng
+, libX11
+, gnome3
+, gobject-introspection
+, doCheck ? false
+, makeWrapper
 , fetchpatch
 }:
 
-let
+stdenv.mkDerivation rec {
   pname = "gdk-pixbuf";
   version = "2.40.0";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+
+  outputs = [ "out" "dev" "man" "devdoc" "installedTests" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1rnlx9yfw970maxi2x6niaxmih5la11q1ilr7gzshz2kk585k0hm";
   };
 
   patches = [
     # Move installed tests to a separate output
     ./installed-tests-path.patch
+
     # Temporary until the fix is released.
     (fetchpatch {
       name = "tests-circular-table.patch";
@@ -26,20 +47,35 @@ in stdenv.mkDerivation rec {
     })
   ];
 
-  outputs = [ "out" "dev" "man" "devdoc" "installedTests" ];
-
-  setupHook = ./setup-hook.sh;
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gettext
+    python3
+    libxml2
+    libxslt
+    docbook-xsl-nons
+    docbook_xml_dtd_43
+    gtk-doc
+    gobject-introspection
+    makeWrapper
+    glib
+  ] ++ stdenv.lib.optional stdenv.isDarwin [
+    fixDarwinDylibNames
+  ];
 
   # !!! We might want to factor out the gdk-pixbuf-xlib subpackage.
-  buildInputs = [ libX11 ];
+  buildInputs = [
+    libX11
+  ];
 
-  nativeBuildInputs = [
-    meson ninja pkgconfig gettext python3 libxml2 libxslt docbook_xsl docbook_xml_dtd_43
-    gtk-doc gobject-introspection makeWrapper glib
-  ]
-    ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
-
-  propagatedBuildInputs = [ glib libtiff libjpeg libpng ];
+  propagatedBuildInputs = [
+    glib
+    libtiff
+    libjpeg
+    libpng
+  ];
 
   mesonFlags = [
     "-Ddocs=true"
@@ -87,6 +123,8 @@ in stdenv.mkDerivation rec {
   # The tests take an excessive amount of time (> 1.5 hours) and memory (> 6 GB).
   inherit doCheck;
 
+  setupHook = ./setup-hook.sh;
+
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = pname;
@@ -102,8 +140,8 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A library for image loading and manipulation";
-    homepage = "http://library.gnome.org/devel/gdk-pixbuf/";
-    maintainers = [ maintainers.eelco ];
+    homepage = "https://gitlab.gnome.org/GNOME/gdk-pixbuf";
+    maintainers = [ maintainers.eelco ] ++ teams.gnome.members;
     license = licenses.lgpl21;
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/gdk-pixbuf/xlib.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/xlib.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, docbook-xsl-nons
+, docbook_xml_dtd_43
+, gtk-doc
+, gdk-pixbuf
+, libX11
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gdk-pixbuf-xlib";
+  version = "2019-10-19-unstable";
+
+  outputs = [ "out" "dev" "devdoc" ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "Archive";
+    repo = "gdk-pixbuf-xlib";
+    rev = "dc22ea36f69755007c66877284596df270532cc1";
+    sha256 = "XhBQ4wano+MtGaqF6JNKoWgYQN6eBW+b8ZCGEBGt8IM=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    docbook-xsl-nons
+    docbook_xml_dtd_43
+    gtk-doc
+  ];
+
+  buildInputs = [
+    libX11
+  ];
+
+  propagatedBuildInputs = [
+    gdk-pixbuf
+  ];
+
+  mesonFlags = [
+    "-Dgtk_doc=true"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Deprecated API for integrating GdkPixbuf with Xlib data types";
+    homepage = "https://gitlab.gnome.org/Archive/gdk-pixbuf-xlib";
+    maintainers = teams.gnome.members;
+    license = licenses.lgpl21Plus;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12089,6 +12089,8 @@ in
 
   gdk-pixbuf = callPackage ../development/libraries/gdk-pixbuf { };
 
+  gdk-pixbuf-xlib = callPackage ../development/libraries/gdk-pixbuf/xlib.nix { };
+
   gnome-sharp = callPackage ../development/libraries/gnome-sharp { };
 
   gnome-menus = callPackage ../development/libraries/gnome-menus { };


### PR DESCRIPTION
###### Motivation for this change
gdk-pixbuf-xlib library is deprecated and will be removed:

https://mail.gnome.org/archives/desktop-devel-list/2019-November/msg00009.html

https://github.com/NixOS/nixpkgs/issues/74272

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
