### PR TITLE
ocamlPackages.ppxfind: 1.3 → 1.4; ocamlPackages.ocaml-migrate-parsetree: 1.5.0 → 1.7.3

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/default.nix
@@ -2,13 +2,13 @@
 
 buildDunePackage rec {
    pname = "ocaml-migrate-parsetree";
-   version = "1.5.0";
+   version = "1.7.3";
 
    src = fetchFromGitHub {
      owner = "ocaml-ppx";
      repo = pname;
      rev = "v${version}";
-     sha256 = "0ms7nx7x16nkbm9rln3sycbzg6ad8swz8jw6bjndrill8bg3fipv";
+     sha256 = "0336vz0galjnsazbmkxjwdv1qvdqsx2rgrvp778xgq2fzasz45cx";
    };
 
    propagatedBuildInputs = [ ppx_derivers result ];

--- a/pkgs/development/ocaml-modules/ppxfind/default.nix
+++ b/pkgs/development/ocaml-modules/ppxfind/default.nix
@@ -2,13 +2,14 @@
 
 buildDunePackage (rec {
 	pname = "ppxfind";
-	version = "1.3";
+	version = "1.4";
 	src = fetchurl {
 		url = "https://github.com/diml/ppxfind/releases/download/${version}/ppxfind-${version}.tbz";
-		sha256 = "1r4jp0516378js62ss50a9s8ql2pm8lfdd3mnk214hp7s0kb17fl";
+		sha256 = "0wa9vcrc26kirc2cqqs6kmarbi8gqy3dgdfiv9y7nzsgy1liqacq";
 	};
 
 	minimumOCamlVersion = "4.03";
+	useDune2 = true;
 
 	buildInputs = [ ocaml-migrate-parsetree ];
 


### PR DESCRIPTION
###### Motivation for this change

#87711

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
