### PR TITLE
Do not strip binary when darwin(OSX)

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -34,7 +34,15 @@ stdenv.mkDerivation rec {
     install -D op $out/bin/op
   '';
 
+  dontStrip = stdenv.isDarwin;
+
   nativeBuildInputs = stdenv.lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    $out/bin/op --version
+  '';
 
   meta = with stdenv.lib; {
     description  = "1Password command-line tool";


### PR DESCRIPTION
Stripping the binary on OSX causes op(1password) to fail immediately.
Setting dontStrip = true; fixes the issue.
Additionally, adding a very simple installCheck section for testing
purposes.

###### Motivation for this change
To fix the 1password-cli(op) on darwin(OSX)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
  Tried on both linux and OSX with `--option build-use-sandbox true`
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
