### PR TITLE
Swapspace: dynamically manage swapspace on NixOS

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -163,6 +163,13 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://github.com/Tookmund/Swapspace">Swapspace</link>,
+          dynamic swap management via swapfiles. Avaliable at
+          <link linkend="opt-services.swapspace.enable">services.swapspace</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://timetagger.app">timetagger</link>,
           an open source time-tracker with an intuitive user experience
           and powerful reporting.

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -49,6 +49,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [prosody-filer](https://github.com/ThomasLeister/prosody-filer), a server for handling XMPP HTTP Upload requests. Available at [services.prosody-filer](#opt-services.prosody-filer.enable).
 
+- [Swapspace](https://github.com/Tookmund/Swapspace), dynamic swap management via swapfiles. Avaliable at [services.swapspace](#opt-services.swapspace.enable).
+
 - [timetagger](https://timetagger.app), an open source time-tracker with an intuitive user experience and powerful reporting. [services.timetagger](options.html#opt-services.timetagger.enable).
 
 - [rstudio-server](https://www.rstudio.com/products/rstudio/#rstudio-server), a browser-based version of the RStudio IDE for the R programming language. Available as [services.rstudio-server](options.html#opt-services.rstudio-server.enable).
@@ -58,7 +60,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 ## Backward Incompatibilities {#sec-release-22.05-incompatibilities}
 
 - `pkgs.ghc` now refers to `pkgs.targetPackages.haskellPackages.ghc`.
-  This *only* makes a difference if you are cross-compiling and will
+  This _only_ makes a difference if you are cross-compiling and will
   ensure that `pkgs.ghc` always runs on the host platform and compiles
   for the target platform (similar to `pkgs.gcc` for example).
   `haskellPackages.ghc` still behaves as before, running on the build
@@ -158,7 +160,7 @@ In addition to numerous new and upgraded packages, this release has the followin
   to allow users to make changes to the `nixos-rebuild build-vm` configuration
   that do not apply to their normal system.
 
-  The `config.system.build.vm` attribute now always exists and  defaults to the
+  The `config.system.build.vm` attribute now always exists and defaults to the
   value from `vmVariant`. Configurations that import the `virtualisation/qemu-vm.nix`
   module themselves will override this value, such that `vmVariant` is not used.
 
@@ -207,8 +209,9 @@ In addition to numerous new and upgraded packages, this release has the followin
   Plugins are automatically repackaged using autoPatchelf.
 
 - The `zrepl` package has been updated from 0.4.0 to 0.5:
-    * The RPC protocol version was bumped; all zrepl daemons in a setup must be updated and restarted before replication can resume.
-    * A bug involving encrypt-on-receive has been fixed.  Read the [zrepl documentation](https://zrepl.github.io/configuration/sendrecvoptions.html#job-recv-options-placeholder) and check the output of `zfs get -r encryption,zrepl:placeholder PATH_TO_ROOTFS` on the receiver.
+
+  - The RPC protocol version was bumped; all zrepl daemons in a setup must be updated and restarted before replication can resume.
+  - A bug involving encrypt-on-receive has been fixed. Read the [zrepl documentation](https://zrepl.github.io/configuration/sendrecvoptions.html#job-recv-options-placeholder) and check the output of `zfs get -r encryption,zrepl:placeholder PATH_TO_ROOTFS` on the receiver.
 
 - Renamed option `services.openssh.challengeResponseAuthentication` to `services.openssh.kbdInteractiveAuthentication`.
   Reason is that the old name has been deprecated upstream.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -977,6 +977,7 @@
   ./services/system/nscd.nix
   ./services/system/saslauthd.nix
   ./services/system/self-deploy.nix
+  ./services/system/swapspace.nix
   ./services/system/uptimed.nix
   ./services/torrent/deluge.nix
   ./services/torrent/flexget.nix

--- a/nixos/modules/services/system/swapspace.nix
+++ b/nixos/modules/services/system/swapspace.nix
@@ -22,7 +22,7 @@ in {
         type = types.path;
         default = "/var/lib/swap";
         description = ''
-          Location of the swap files. This directory will be restrticted to root.
+          Location of the swap files. This directory will be restricted to root.
         '';
       };
 
@@ -66,16 +66,12 @@ in {
   ###### implementation
 
   config = mkIf cfg.enable {
+    systemd.tmpfiles.rules = [ "d '${cfg.path}' 0700 - - - - " ];
     systemd.services.swapspace = with pkgs; {
       description = "SwapSpace Daemon";
-      preStart = ''
-        mkdir -p "${cfg.path}"
-        chmod 700 "${cfg.path}"
-      '';
       serviceConfig = {
         Type = "simple";
-        ExecStart =
-          ''${pkgs.swapspace}/sbin/swapspace --swappath="${cfg.path}"''
+        ExecStart = ''${pkgs.swapspace}/bin/swapspace --swappath="${cfg.path}"''
           + optionalString (cfg.cooldown != null)
           " --cooldown=${toString cfg.cooldown}"
           + optionalString (cfg.minSwapSize != null)
@@ -85,7 +81,6 @@ in {
         Restart = "always";
         RestartSec = 30;
       };
-      after = [ "local-fs.target" "systemd-udev-settle.service" ];
       wantedBy = [ "multi-user.target" ];
     };
   };

--- a/nixos/modules/services/system/swapspace.nix
+++ b/nixos/modules/services/system/swapspace.nix
@@ -1,0 +1,92 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.swapspace;
+in {
+  ###### interface
+
+  options = {
+
+    services.swapspace = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to create swapfiles dynamically using the SwapSpace manager.
+          Files will be added and removed based on current memory usage.
+        '';
+      };
+
+      path = mkOption {
+        type = types.path;
+        default = "/var/lib/swap";
+        description = ''
+          Location of the swap files. This directory will be restrticted to root.
+        '';
+      };
+
+      cooldown = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = ''
+          Cooldown period between changes.
+          SwapSpace will wait at least this many seconds before an action,
+          like removing a swapfile after adding one.
+        '';
+      };
+
+      minSwapSize = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = ''
+          Minimum size of a swapfile.
+        '';
+      };
+
+      maxSwapSize = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = ''
+          Maximum size of a swapfile.
+        '';
+      };
+
+      extraArgs = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Any extra arguments to pass to SwapSpace.
+        '';
+        example = "-P -v -u 5";
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    systemd.services.swapspace = with pkgs; {
+      description = "SwapSpace Daemon";
+      preStart = ''
+        mkdir -p "${cfg.path}"
+        chmod 700 "${cfg.path}"
+      '';
+      serviceConfig = {
+        Type = "simple";
+        ExecStart =
+          ''${pkgs.swapspace}/sbin/swapspace --swappath="${cfg.path}"''
+          + optionalString (cfg.cooldown != null)
+          " --cooldown=${toString cfg.cooldown}"
+          + optionalString (cfg.minSwapSize != null)
+          " --min_swapsize=${toString cfg.minSwapSize}"
+          + optionalString (cfg.maxSwapSize != null)
+          " --max_swapsize=${toString cfg.maxSwapSize}" + " ${cfg.extraArgs}";
+        Restart = "always";
+        RestartSec = 30;
+      };
+      after = [ "local-fs.target" "systemd-udev-settle.service" ];
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+}

--- a/pkgs/os-specific/linux/swapspace/default.nix
+++ b/pkgs/os-specific/linux/swapspace/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchgit, autoconf, automake, utillinux, btrfs-progs }:
+
+stdenv.mkDerivation rec {
+  version = "1.16.1";
+  name = "swapspace-${version}";
+
+  src = fetchgit {
+    url = "https://github.com/Tookmund/Swapspace.git";
+    rev = "refs/tags/v${version}";
+    sha256 = "1hbxaq05zdfhw5c8lypnl1qvh7n9ng0nawlizs9g6l77z8sn0ji8";
+    fetchSubmodules = false;
+  };
+
+  # TODO patch runcommands to include path to mkswap, swapon/off, btrfs (optional)
+  patchPhase = ''
+    sed -e 's@"mkswap"@"${utillinux}/bin/mkswap"@' \
+      -e 's@"/sbin/swapon"@"${utillinux}/bin/swapon"@' \
+      -e 's@"/sbin/swapoff"@"${utillinux}/bin/swapoff"@' \
+      -e 's@"btrfs"@"${btrfs-progs}/bin/btrfs"@' \
+      -i src/support.c src/swaps.c
+  '';
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ autoconf automake ];
+
+  preConfigure = ''
+    autoreconf -i
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Tookmund/Swapspace/tree/v1.16.1";
+    description =
+      "Dynamically add and remove swapfiles based on memory pressure";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ wmertens ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/swapspace/default.nix
+++ b/pkgs/os-specific/linux/swapspace/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchgit, autoconf, automake, utillinux }:
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, utillinux }:
 
 stdenv.mkDerivation rec {
+  pname = "swapspace";
   version = "1.17";
-  name = "swapspace-${version}";
 
-  src = fetchgit {
-    url = "https://github.com/Tookmund/Swapspace.git";
-    rev = "refs/tags/v${version}";
+  src = fetchFromGitHub {
+    owner = "Tookmund";
+    repo = "Swapspace";
+    rev = "v${version}";
     sha256 = "06xvmyy1fp94h00k9nn929j00ca3w12fiz07wf9az6srxa8i4ndz";
-    fetchSubmodules = false;
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   patchPhase = ''
     sed -e 's@"mkswap"@"${utillinux}/bin/mkswap"@' \
@@ -18,21 +20,22 @@ stdenv.mkDerivation rec {
       -i src/support.c src/swaps.c
   '';
 
-  enableParallelBuilding = true;
-
-  buildInputs = [ autoconf automake ];
-
-  preConfigure = ''
-    autoreconf -i
+  postInstall = ''
+    mkdir $out/bin
+    mv $out/sbin/swapspace $out/bin/swapspace
+    # This should be an empty directory, fail if not
+    rmdir $out/sbin
+    rm -r $out/var
   '';
 
-  makeFlags = [ "PREFIX=$(out)" ];
+  enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with lib; {
     homepage = "https://github.com/Tookmund/Swapspace";
-    description =
-      "Dynamically add and remove swapfiles based on memory pressure";
-    license = licenses.gpl3;
+    description = "Dynamically add and remove swapfiles based on memory pressure";
+    license = licenses.gpl2;
     maintainers = with maintainers; [ wmertens ];
     platforms = platforms.linux;
   };

--- a/pkgs/os-specific/linux/swapspace/default.nix
+++ b/pkgs/os-specific/linux/swapspace/default.nix
@@ -1,22 +1,20 @@
-{ stdenv, fetchgit, autoconf, automake, utillinux, btrfs-progs }:
+{ stdenv, fetchgit, autoconf, automake, utillinux }:
 
 stdenv.mkDerivation rec {
-  version = "1.16.1";
+  version = "1.17";
   name = "swapspace-${version}";
 
   src = fetchgit {
     url = "https://github.com/Tookmund/Swapspace.git";
     rev = "refs/tags/v${version}";
-    sha256 = "1hbxaq05zdfhw5c8lypnl1qvh7n9ng0nawlizs9g6l77z8sn0ji8";
+    sha256 = "06xvmyy1fp94h00k9nn929j00ca3w12fiz07wf9az6srxa8i4ndz";
     fetchSubmodules = false;
   };
 
-  # TODO patch runcommands to include path to mkswap, swapon/off, btrfs (optional)
   patchPhase = ''
     sed -e 's@"mkswap"@"${utillinux}/bin/mkswap"@' \
       -e 's@"/sbin/swapon"@"${utillinux}/bin/swapon"@' \
       -e 's@"/sbin/swapoff"@"${utillinux}/bin/swapoff"@' \
-      -e 's@"btrfs"@"${btrfs-progs}/bin/btrfs"@' \
       -i src/support.c src/swaps.c
   '';
 
@@ -31,7 +29,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/Tookmund/Swapspace/tree/v1.16.1";
+    homepage = "https://github.com/Tookmund/Swapspace";
     description =
       "Dynamically add and remove swapfiles based on memory pressure";
     license = licenses.gpl3;


### PR DESCRIPTION
###### Motivation for this change

Using NixOS with dynamic swap size management, the way macOS does it.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
