### PR TITLE
openconnect: 8.05 -> 8.10

### DIFF
--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -4,19 +4,19 @@ assert (openssl != null) == (gnutls == null);
 
 let vpnc = fetchgit {
   url = "git://git.infradead.org/users/dwmw2/vpnc-scripts.git";
-  rev = "c84fb8e5a523a647a01a1229a9104db934e19f00";
-  sha256 = "01xdclx0y3x66mpbdr77n4ilapwzjz475h32q88ml9gnq6phjxrs";
+  rev = "c0122e891f7e033f35f047dad963702199d5cb9e";
+  sha256 = "11b1ls012mb704jphqxjmqrfbbhkdjb64j2q4k8wb5jmja8jnd14";
 };
 
 in stdenv.mkDerivation rec {
   pname = "openconnect";
-  version = "8.05";
+  version = "8.10";
 
   src = fetchurl {
     urls = [
       "ftp://ftp.infradead.org/pub/openconnect/${pname}-${version}.tar.gz"
     ];
-    sha256 = "14i9q727c2zc9xhzp1a9hz3gzb5lwgsslbhircm84dnbs192jp1k";
+    sha256 = "1cdsx4nsrwawbsisfkldfc9i4qn60g03vxb13nzppr2br9p4rrih";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Also update vpnc script.

Changes: http://www.infradead.org/openconnect/changelog.html

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- https://nvd.nist.gov/vuln/detail/CVE-2019-16239
- https://nvd.nist.gov/vuln/detail/CVE-2020-12105
- https://nvd.nist.gov/vuln/detail/CVE-2020-12823

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
