### PR TITLE
libexif: 0.6.21 -> 0.6.22

### DIFF
--- a/pkgs/development/libraries/libexif/default.nix
+++ b/pkgs/development/libraries/libexif/default.nix
@@ -1,36 +1,15 @@
-{ stdenv, fetchurl, fetchpatch, gettext }:
+{ stdenv, fetchurl, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "libexif-0.6.21";
+  pname = "libexif";
+  version = "0.6.22";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/libexif/${name}.tar.bz2";
-    sha256 = "06nlsibr3ylfwp28w8f5466l6drgrnydgxrm4jmxzrmk5svaxk8n";
+  src = let
+    underscoreVersion = builtins.replaceStrings [ "." ] [ "_" ] version;
+  in fetchurl {
+    url = "https://github.com/${pname}/${pname}/releases/download/${pname}-${underscoreVersion}-release/${pname}-${version}.tar.xz";
+    sha256 = "0mhcad5zab7fsn120rd585h8ncwkq904nzzrq8vcd72hzk4g2j2h";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2017-7544.patch";
-      url = "https://github.com/libexif/libexif/commit/c39acd1692023b26290778a02a9232c873f9d71a.patch";
-      sha256 = "0xgx6ly2i4q05shb61mfx6njwf1yp347jkznm0ka4m85i41xm6sd";
-    })
-    (fetchpatch {
-      name = "CVE-2018-20030-1.patch";
-      url = "https://github.com/libexif/libexif/commit/5d28011c40ec86cf52cffad541093d37c263898a.patch";
-      sha256 = "1wv8s962wmbn2m2xypgirf12g6msrbplpsmd5bh86irfwhkcppj3";
-    })
-    (fetchpatch {
-      name = "CVE-2018-20030-2.patch";
-      url = "https://github.com/libexif/libexif/commit/6aa11df549114ebda520dde4cdaea2f9357b2c89.patch";
-      sha256 = "01aqvz63glwq6wg0wr7ykqqghb4abgq77ghvhizbzadg1k4h7drx";
-      excludes = [ "NEWS" ];
-    })
-    (fetchpatch {
-      name = "CVE-2019-9278.patch";
-      url = "https://github.com/libexif/libexif/commit/75aa73267fdb1e0ebfbc00369e7312bac43d0566.patch";
-      sha256 = "10ikg33mips5zq9as7l9xqnyzbg1wwr4sw17517nzf4hafjpasrj";
-    })
-  ];
 
   buildInputs = [ gettext ];
 


### PR DESCRIPTION
Changes: https://github.com/libexif/libexif/releases/tag/libexif-0_6_22-release

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- https://nvd.nist.gov/vuln/detail/CVE-2020-0093
- https://nvd.nist.gov/vuln/detail/CVE-2020-12767
- https://nvd.nist.gov/vuln/detail/CVE-2020-13112
- https://nvd.nist.gov/vuln/detail/CVE-2020-13113
- https://nvd.nist.gov/vuln/detail/CVE-2020-13114

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
