### PR TITLE
libreswan: 3.31 -> 3.32

### DIFF
--- a/pkgs/tools/networking/libreswan/default.nix
+++ b/pkgs/tools/networking/libreswan/default.nix
@@ -5,9 +5,6 @@
   }:
 
 let
-  optional = stdenv.lib.optional;
-  version = "3.31";
-  name = "libreswan-${version}";
   binPath = stdenv.lib.makeBinPath [
     bash iproute iptables procps coreutils gnused gawk nss.tools which python
   ];
@@ -16,13 +13,13 @@ in
 assert docs -> xmlto != null;
 assert stdenv.isLinux -> libselinux != null;
 
-stdenv.mkDerivation {
-  inherit name;
-  inherit version;
+stdenv.mkDerivation rec {
+  pname = "libreswan";
+  version = "3.32";
 
   src = fetchurl {
-    url = "https://download.libreswan.org/${name}.tar.gz";
-    sha256 = "1wxqsv11nqgfj5and5xzfgh6ayqvl47midcghd5ryynh60mp7naa";
+    url = "https://download.libreswan.org/${pname}-${version}.tar.gz";
+    sha256 = "0bj3g6qwd3ir3gk6hdl9npy3k44shf56vcgjahn30qpmx3z5fsr3";
   };
 
   # These flags were added to compile v3.18. Try to lift them when updating.
@@ -37,8 +34,8 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ makeWrapper pkgconfig ];
   buildInputs = [ bash iproute iptables systemd coreutils gnused gawk gmp unbound bison flex pam libevent
                   libcap_ng curl nspr nss python ldns ]
-                ++ optional docs xmlto
-                ++ optional stdenv.isLinux libselinux;
+                ++ stdenv.lib.optional docs xmlto
+                ++ stdenv.lib.optional stdenv.isLinux libselinux;
 
   prePatch = ''
     # Correct bash path


### PR DESCRIPTION
Changes: https://github.com/libreswan/libreswan/releases/tag/v3.32

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://nvd.nist.gov/vuln/detail/CVE-2020-1763

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
