### PR TITLE
python3Packages.azure*: bump, azure-cli: 2.40 -> 2.5.1

### DIFF
--- a/pkgs/development/python-modules/azure-mgmt-batch/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-batch/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure-mgmt-batch";
-  version = "7.0.0";
+  version = "8.0.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "18dwgbwk1kc0pdqa85hbsm9312l50rf8ymb60fia1c9rni9bdi8n";
+    sha256 = "228ea058361763a5a31273df7d813b9134d0ecff4567c533eb7e1afaf772fbc7";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-core/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-core/default.nix
@@ -7,13 +7,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.0.0";
+  version = "1.1.0";
   pname = "azure-mgmt-core";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "0pm565v05480f672l0n8z2sg6zk6iqyi91n0dhscibhdl54sy3si";
+    sha256 = "049dfb0bcc7961d0d988fee493d1ec4f4480e109e4661e360bad054cc297d43c";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-cosmosdb/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-cosmosdb/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure-mgmt-cosmosdb";
-  version = "0.13.0";
+  version = "0.14.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "e83d21462f9d5b02e90f5590c4247ab73e0ff85fc4ac1fba32be119a15b10c98";
+    sha256 = "692544dd2fa6276a7a4b4e094e2a5e0915d29b7829e266c6ade2b17a5fdcc2a9";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-eventhub/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-eventhub/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure-mgmt-eventhub";
-  version = "3.0.0";
+  version = "3.1.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "05c6isg13dslds94kv28v6navxj4bp4c5lsd9df0g3ndsxvpdrxp";
+    sha256 = "c823a0ed879230a3ec9f15c32c9788610af1db56e6aeae6b2725476ddbe0d138";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-iothub/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-iothub/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure-mgmt-iothub";
-  version = "0.11.0";
+  version = "0.12.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "f6fbb87d9bf29ce325543c9a3a125fbe45f4797f3a7f260c6c21ca60dc3f0885";
+    sha256 = "da20ee2b9b9a2c2f89be9037c3ee5421152e7f6d718eafbf50a91dbf0a07ffa0";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-network/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-network/default.nix
@@ -7,13 +7,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "10.1.0";
+  version = "10.2.0";
   pname = "azure-mgmt-network";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "e5ac0ee14b71ab57035c45bef15d3698b0b6026ecafb8320a7c704eb3f6fba3a";
+    sha256 = "d50c74cdc1c9be6861ddef9adffd3b05afc5a5092baf0209eea30f4439cba2d9";
   };
 
   postInstall = if isPy3k then "" else ''

--- a/pkgs/development/python-modules/azure-mgmt-storage/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-storage/default.nix
@@ -7,13 +7,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "9.0.0";
+  version = "10.0.0";
   pname = "azure-mgmt-storage";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "198r51av2rd1mr3q9j8jibhd14w0v8k59ipc3czsm4g1n44adgkl";
+    sha256 = "d1edead1ad36e957c9f9b605f547ad1ff7152f8f785fa03d3c7891bb428a68ef";
   };
 
   propagatedBuildInputs = [ azure-mgmt-common ];

--- a/pkgs/development/python-modules/azure-multiapi-storage/default.nix
+++ b/pkgs/development/python-modules/azure-multiapi-storage/default.nix
@@ -1,20 +1,28 @@
 { lib, python, buildPythonPackage, fetchPypi, isPy27
 , azure-common
+, azure-core
 , msrest
 , msrestazure
+, requests
 }:
 
 buildPythonPackage rec {
-  version = "0.2.4";
+  version = "0.3.2";
   pname = "azure-multiapi-storage";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0zqapc4dx6qd9bcim5fjykk3n1j84p85nwqyb876nb7qmqx9spig";
+    sha256 = "c403a47e40e4a80d9c42c854993f5c07f12c2a75bd9a85ba8225985493a9b792";
   };
 
-  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+  propagatedBuildInputs = [
+    azure-common
+    azure-core
+    msrest
+    msrestazure
+    requests
+  ];
 
   # fix namespace
   pythonNamespaces = [ "azure.multiapi" ];

--- a/pkgs/development/python-modules/azure-servicefabric/default.nix
+++ b/pkgs/development/python-modules/azure-servicefabric/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure-servicefabric";
-  version = "7.0.0.0";
+  version = "7.1.0.45";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "27712658fed7f5db6965d1035bbc0f3b16964fc88d6f3ad3e86cf4fae2b01bb9";
+    sha256 = "8dd0eb419ca62f2436c31982f6d236868f15f65bb062c4e5a98e50b16298dcda";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/tools/admin/azure-cli/default.nix
+++ b/pkgs/tools/admin/azure-cli/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, python, fetchFromGitHub, installShellFiles }:
 
 let
-  version = "2.4.0";
+  version = "2.5.1";
   src = fetchFromGitHub {
     owner = "Azure";
     repo = "azure-cli";
     rev = "azure-cli-${version}";
-    sha256 = "1j0h75cxrxa5yrijr7jfip7q5qrddaaqapd90f0qp2r4k9qb0y41";
+    sha256 = "129v01da0whayqi9nvrfnlrq10mn5j096k43xl72214nk7iliwfy";
   };
 
   # put packages that needs to be overriden in the py package scope

--- a/pkgs/tools/admin/azure-cli/python-packages.nix
+++ b/pkgs/tools/admin/azure-cli/python-packages.nix
@@ -61,6 +61,8 @@ let
           humanfriendly
           jmespath
           knack
+          msal
+          msal-extensions
           msrest
           msrestazure
           paramiko
@@ -119,6 +121,9 @@ let
       azure-mgmt-apimanagement = overrideAzureMgmtPackage super.azure-mgmt-apimanagement "0.1.0" "zip"
         "06bqqkn5mx127x1z7ycm6rl8ajxlrmrm2kcdpgkbl4baii1x6iax";
 
+      azure-mgmt-batch = overrideAzureMgmtPackage super.azure-mgmt-batch "7.0.0" "zip"
+        "18dwgbwk1kc0pdqa85hbsm9312l50rf8ymb60fia1c9rni9bdi8n";
+
       azure-mgmt-policyinsights = overrideAzureMgmtPackage super.azure-mgmt-policyinsights "0.4.0" "zip"
         "1b69rz9wm0jvc54vx3b7h633x8gags51xwxrkp6myar40jggxw6g";
 
@@ -149,8 +154,11 @@ let
       azure-mgmt-containerservice = overrideAzureMgmtPackage super.azure-mgmt-containerservice "9.0.1" "zip"
         "11nqjpi9qypb0xvfy63l98q5m5jfv5iqx15mliksm96vkdkmji3y";
 
-      azure-mgmt-cosmosdb = overrideAzureMgmtPackage super.azure-mgmt-cosmosdb "0.12.0" "zip"
-        "07c0hr7nha9789x1wz0ndca0sr0zscq63m9vd8pm1c6y0ss4iyn5";
+      azure-mgmt-core = overrideAzureMgmtPackage super.azure-mgmt-core "1.0.0" "zip"
+        "0pm565v05480f672l0n8z2sg6zk6iqyi91n0dhscibhdl54sy3si";
+
+      azure-mgmt-cosmosdb = overrideAzureMgmtPackage super.azure-mgmt-cosmosdb "0.13.0" "zip"
+        "160cn4arl4dy6ax1zb64bzw0ygmpg8jc942m1zlh4nwx5x322gg8";
 
       azure-mgmt-deploymentmanager = overrideAzureMgmtPackage super.azure-mgmt-deploymentmanager "0.2.0" "zip"
         "0c6pyr36n9snx879vas5r6l25db6nlp2z96xn759mz4kg4i45qs6";
@@ -176,8 +184,8 @@ let
       azure-mgmt-dns = overrideAzureMgmtPackage super.azure-mgmt-dns "2.1.0" "zip"
         "1l55py4fzzwhxlmnwa41gpmqk9v2ncc79w7zq11sm9a5ynrv2c1p";
 
-      azure-mgmt-loganalytics = overrideAzureMgmtPackage super.azure-mgmt-loganalytics "0.2.0" "zip"
-        "11kx4ck58nhhn9zf5vq0rqh7lfh2yj758s6ainrqyqadxvq5ycf7";
+      azure-mgmt-loganalytics = overrideAzureMgmtPackage super.azure-mgmt-loganalytics "0.5.0" "zip"
+        "0k91zdlzx6nfly1v2i7qmzqrdiygdx8rmgar3iz8nwgafvvc9x0n";
 
       azure-mgmt-network = overrideAzureMgmtPackage super.azure-mgmt-network "10.1.0" "zip"
         "0fmsdwzyn167lwh87yyadq1bdc4q6rfz3gj5bh1mgavi9ghhxb75";
@@ -312,12 +320,22 @@ let
       });
 
       knack = super.knack.overridePythonAttrs(oldAttrs: rec {
-        version = "0.7.0rc3";
+        version = "0.7.0rc4";
 
         src = super.fetchPypi {
           inherit (oldAttrs) pname;
           inherit version;
-          sha256 = "1mazy5a3505wqa68fxq7h55m0vbmjygv2wbgmxmrrrgw3w84q5r7";
+          sha256 = "10v6qjpr7sbq5irq3kz24jiivpfm0f7jbj9iyx4dm8fgkrhgzlb6";
+        };
+      });
+
+      msal = super.msal.overridePythonAttrs(oldAttrs: rec {
+        version = "1.0.0";
+
+        src = super.fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          sha256 = "0h33wayvakggr684spdyhiqvrwraavcbk3phmcbavb3zqxd3zgpc";
         };
       });
 


### PR DESCRIPTION
###### Motivation for this change
It was out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
