### PR TITLE
gambit: disable use of poll() on Darwin

### DIFF
--- a/pkgs/development/compilers/gambit/build.nix
+++ b/pkgs/development/compilers/gambit/build.nix
@@ -40,7 +40,6 @@ gccStdenv.mkDerivation rec {
     "--enable-gcc-opts"
     "--enable-shared"
     "--enable-absolute-shared-libs" # Yes, NixOS will want an absolute path, and fix it.
-    "--enable-poll"
     "--enable-openssl"
     "--enable-default-runtime-options=${gambit-params.defaultRuntimeOptions}"
     # "--enable-debug" # Nope: enables plenty of good stuff, but also the costly console.log
@@ -57,7 +56,9 @@ gccStdenv.mkDerivation rec {
     # "--enable-coverage"
     # "--enable-inline-jumps"
     # "--enable-char-size=1" # default is 4
-  ];
+  ] ++
+    # due not enable poll on darwin due to https://github.com/gambit/gambit/issues/498
+    lib.optional (!gccStdenv.isDarwin) "--enable-poll";
 
   configurePhase = ''
     export CC=${gcc}/bin/gcc \


### PR DESCRIPTION
Darwin has a bug which affects the use of poll() with a tty fd,
which affects gambit's REPL when at a console, causing 100% CPU
usage.

Gambit recommends this is disabled on Darwin.

###### Motivation for this change

Make things work better on Mac OS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).