### PR TITLE
handbrake: allow building from checkout

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -108,13 +108,12 @@ _EOF
   enableParallelBuilding = true;
 
   configureFlags = [
-    "--harden" # enable buffer overflow protection
     "--disable-df-fetch"
     "--disable-df-verify"
     (if useGtk          then "--disable-gtk-update-checks" else "--disable-gtk")
     (if useFdk          then "--enable-fdk-aac"            else "")
     (if stdenv.isDarwin then "--disable-xcode"             else "")
-  ];
+  ] ++ lib.optional (stdenv.isx86_32 || stdenv.isx86_64) "--harden";
 
   # NOTE: 2018-12-27: Check NixOS HandBrake test if changing
   NIX_LDFLAGS = [

--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -7,7 +7,7 @@
 # be nice to add the native GUI (and/or the GTK GUI) as an option too, but that
 # requires invoking the Xcode build system, which is non-trivial for now.
 
-{ stdenv, lib, fetchurl,
+{ stdenv, lib, fetchFromGitHub,
   # Main build tools
   pkgconfig, autoconf, automake, libtool, m4, lzma, python3,
   numactl,
@@ -30,34 +30,61 @@
   # for now we disable GTK GUI support on Darwin. (It may be possible to remove
   # this restriction later.)
   useGtk ? !stdenv.isDarwin, wrapGAppsHook ? null,
-                             intltool ? null,
-                             glib ? null,
-                             gtk3 ? null,
-                             libappindicator-gtk3 ? null,
-                             libnotify ? null,
-                             gst_all_1 ? null,
-                             dbus-glib ? null,
-                             udev ? null,
-                             libgudev ? null,
-                             hicolor-icon-theme ? null,
+  intltool ? null,
+  glib ? null,
+  gtk3 ? null,
+  libappindicator-gtk3 ? null,
+  libnotify ? null,
+  gst_all_1 ? null,
+  dbus-glib ? null,
+  udev ? null,
+  libgudev ? null,
+  hicolor-icon-theme ? null,
   # FDK
   useFdk ? false, fdk_aac ? null
 }:
 
-assert stdenv.isDarwin -> AudioToolbox != null && Foundation != null
-  && libobjc != null && VideoToolbox != null;
+assert stdenv.isDarwin -> AudioToolbox != null
+       && Foundation != null
+       && libobjc != null
+       && VideoToolbox != null;
 
 stdenv.mkDerivation rec {
   pname = "handbrake";
   version = "1.3.2";
 
-  src = fetchurl {
-    #  2020-05-05: NOTE: Thou fetching from GitHub, still fetchurl required,
-    #  because this tarball has their "special" packaging and so
-    #  internal "special" version information
-    url = ''https://github.com/HandBrake/HandBrake/releases/download/${version}/HandBrake-${version}-source.tar.bz2'';
-    sha256 = "0w7jxjrccvxp7g15dv0spildg5apmqp4gwbcqmg58va2gylynvzc";
+  src = fetchFromGitHub {
+    owner = "HandBrake";
+    repo = "HandBrake";
+    rev = version;
+    sha256 = "04z3hcy7m5yvma849rlrsx2wdqmkilkl1qds9yrzr2ydpw697f85";
+    extraPostFetch = ''
+      echo "DATE=$(date +"%F %T %z" -r $out/NEWS.markdown)" > $out/version.txt
+    '';
   };
+
+  # we put as little as possible in src.extraPostFetch as it's much easier to
+  # add to it here without having to fiddle with src.sha256
+  # only DATE and HASH are absolutely necessary
+  postPatch = ''
+    cat >> version.txt <<_EOF
+HASH=${src.rev}
+SHORTHASH=${src.rev}
+TAG=${version}
+URL=${src.meta.homepage}
+_EOF
+
+    patchShebangs scripts
+
+    substituteInPlace libhb/module.defs \
+      --replace /usr/include/libxml2 ${libxml2.dev}/include/libxml2
+
+    # Force using nixpkgs dependencies
+    sed -i '/MODULES += contrib/d' make/include/main.defs
+    sed -e 's/^[[:space:]]*\(meson\|ninja\|nasm\)[[:space:]]*= ToolProbe.*$//g' \
+        -e '/    ## Additional library and tool checks/,/    ## MinGW specific library and tool checks/d' \
+        -i make/configure.py
+  '';
 
   nativeBuildInputs = [
     pkgconfig autoconf automake libtool m4 python3
@@ -73,25 +100,15 @@ stdenv.mkDerivation rec {
     gst_all_1.gstreamer gst_all_1.gst-plugins-base dbus-glib udev
     libgudev hicolor-icon-theme
   ] ++ lib.optional useFdk fdk_aac
-    ++ lib.optionals stdenv.isDarwin [ AudioToolbox Foundation libobjc VideoToolbox ]
+  ++ lib.optionals stdenv.isDarwin [ AudioToolbox Foundation libobjc VideoToolbox ]
   # NOTE: 2018-12-27: Handbrake supports nv-codec-headers for Linux only,
   # look at ./make/configure.py search "enable_nvenc"
-    ++ lib.optional stdenv.isLinux nv-codec-headers;
+  ++ lib.optional stdenv.isLinux nv-codec-headers;
 
-  preConfigure = ''
-    patchShebangs scripts
-
-    substituteInPlace libhb/module.defs \
-      --replace /usr/include/libxml2 ${libxml2.dev}/include/libxml2
-
-    # Force using nixpkgs dependencies
-    sed -i '/MODULES += contrib/d' make/include/main.defs
-    sed -e 's/^[[:space:]]*\(meson\|ninja\|nasm\)[[:space:]]*= ToolProbe.*$//g' \
-        -e '/    ## Additional library and tool checks/,/    ## MinGW specific library and tool checks/d' \
-        -i make/configure.py
-  '';
+  enableParallelBuilding = true;
 
   configureFlags = [
+    "--harden"
     "--disable-df-fetch"
     "--disable-df-verify"
     (if useGtk          then "--disable-gtk-update-checks" else "--disable-gtk")

--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -108,7 +108,7 @@ _EOF
   enableParallelBuilding = true;
 
   configureFlags = [
-    "--harden"
+    "--harden" # enable buffer overflow protection
     "--disable-df-fetch"
     "--disable-df-verify"
     (if useGtk          then "--disable-gtk-update-checks" else "--disable-gtk")
@@ -117,7 +117,7 @@ _EOF
   ];
 
   # NOTE: 2018-12-27: Check NixOS HandBrake test if changing
-  NIX_LDFLAGS = toString [
+  NIX_LDFLAGS = [
     "-lx265"
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Further to #86857, there is a bit of an anti-pattern with how the source is handled, that I would like to rectify:

1. Use fetchFromGitHub and construct version.txt so we can point $src at something else (a fork, a local checkout, etc) and still be able to build it.
2. Build in parallel to speed things up.
3. Do the patching in postPatch where it belongs as opposed to preConfigure
4. Build with additional hardening in case we try to process a wonky file

Cc: @Anton-Latukha @doronbehar

We really only need DATE and HASH in version.txt for things to work -
the rest are just to be make the "About" window look nicer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).