### PR TITLE
Allow mpv to use youtube-dl provided at runtime

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -186,7 +186,7 @@ in stdenv.mkDerivation rec {
   wrapperFlags =
     ''--prefix PATH : "${luaEnv}/bin" \''
   + optionalString youtubeSupport ''
-      --prefix PATH : "${youtube-dl}/bin" \
+      --suffix PATH : "${youtube-dl}/bin" \
   '' + optionalString vapoursynthSupport ''
       --prefix PYTHONPATH : "${vapoursynth}/lib/${python3.libPrefix}/site-packages:$PYTHONPATH"
   '';


### PR DESCRIPTION
This change the `mpv` wrapper to allow it to use a `youtube-dl` script provided in the user's `PATH`. This is necessary because `youtube-dl` is changing very frequently, and the version in `nixpkgs` does not always work.

###### Motivation for this change

The `youtube-dl` script is changing very frequently to adapt with the integrated sources, and is often broken in `nixpkgs`. Users may use their own version of the script (for example in `~/bin`), but `mpv` ill not use this script as the `youtube-dl` `PATH` is prepended instead of being appended.

###### Things done

Change the `mpv` wrapper to make it append (`--suffix`) the `youtube-dl` `PATH` instead of prepending it (`--prefix`).

I'm not sure if this is necessary for the LUA environment as well. Most packages I've seen in `nixpkgs` seem to prefer `--prefix` so I kept it for the LUA environment, but can change it to `--suffix` as well on request.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
