### PR TITLE
keepass: 2.40 -> 2.45

### DIFF
--- a/pkgs/applications/misc/keepass/default.nix
+++ b/pkgs/applications/misc/keepass/default.nix
@@ -1,13 +1,13 @@
 { stdenv, lib, fetchurl, buildDotnetPackage, substituteAll, makeWrapper, makeDesktopItem,
-  unzip, icoutils, gtk2, xorg, xdotool, xsel, plugins ? [] }:
+  unzip, icoutils, gtk2, xorg, xdotool, xsel, coreutils, unixtools, glib, plugins ? [] }:
 
 with builtins; buildDotnetPackage rec {
   baseName = "keepass";
-  version = "2.40";
+  version = "2.45";
 
   src = fetchurl {
     url = "mirror://sourceforge/keepass/KeePass-${version}-Source.zip";
-    sha256 = "1gldl74wz2lvsci6rn71d6q1zmnhr52z6fjib9nsragsazq5byz9";
+    sha256 = "07wyp3k2kiprr47mc4vxb7vmh7g5kshcqw0gq3qr87gi78c9i66m";
   };
 
   sourceRoot = ".";
@@ -20,6 +20,9 @@ with builtins; buildDotnetPackage rec {
       xsel = "${xsel}/bin/xsel";
       xprop = "${xorg.xprop}/bin/xprop";
       xdotool = "${xdotool}/bin/xdotool";
+      uname = "${coreutils}/bin/uname";
+      whereis = "${unixtools.whereis}/bin/whereis";
+      gsettings = "${glib}/bin/gsettings";
     })
   ];
 

--- a/pkgs/applications/misc/keepass/fix-paths.patch
+++ b/pkgs/applications/misc/keepass/fix-paths.patch
@@ -1,8 +1,23 @@
+From 830d0db80f2fce09e12c117f8338b8e4b05866ff Mon Sep 17 00:00:00 2001
+From: Pascal Winkelmann <pascal@wnklmnn.de>
+Date: Tue, 19 May 2020 10:28:31 +0200
+Subject: [PATCH] fixpaths
+
+---
+ KeePass/Native/NativeMethods.Unix.cs  |  2 +-
+ KeePass/UI/UISystemFonts.cs           |  2 +-
+ KeePass/Util/AppLocator.cs            |  2 +-
+ KeePass/Util/ClipboardUtil.Unix.cs    | 14 +++++++-------
+ KeePassLib/Native/ClipboardU.cs       |  2 +-
+ KeePassLib/Native/NativeLib.cs        |  2 +-
+ KeePassLib/Utility/MonoWorkarounds.cs |  4 ++--
+ 7 files changed, 14 insertions(+), 14 deletions(-)
+
 diff --git a/KeePass/Native/NativeMethods.Unix.cs b/KeePass/Native/NativeMethods.Unix.cs
-index 7495a1c..4ef4727 100644
+index 4c47258..79cfdb2 100644
 --- a/KeePass/Native/NativeMethods.Unix.cs
 +++ b/KeePass/Native/NativeMethods.Unix.cs
-@@ -128,7 +128,7 @@ namespace KeePass.Native
+@@ -130,7 +130,7 @@ namespace KeePass.Native
  			try
  			{
  				Application.DoEvents(); // E.g. for clipboard updates
@@ -11,10 +26,54 @@ index 7495a1c..4ef4727 100644
  				Application.DoEvents(); // E.g. for clipboard updates
  				return (strOutput ?? string.Empty);
  			}
+diff --git a/KeePass/UI/UISystemFonts.cs b/KeePass/UI/UISystemFonts.cs
+index 08d6134..2bfa4a2 100644
+--- a/KeePass/UI/UISystemFonts.cs
++++ b/KeePass/UI/UISystemFonts.cs
+@@ -188,7 +188,7 @@ namespace KeePass.UI
+ 
+ 		private static void UbuntuLoadFonts()
+ 		{
+-			string strDef = NativeLib.RunConsoleApp("gsettings",
++			string strDef = NativeLib.RunConsoleApp("@gsettings@",
+ 				"get org.gnome.desktop.interface font-name");
+ 			if(strDef == null) return;
+ 
+diff --git a/KeePass/Util/AppLocator.cs b/KeePass/Util/AppLocator.cs
+index af02803..8a32c9d 100644
+--- a/KeePass/Util/AppLocator.cs
++++ b/KeePass/Util/AppLocator.cs
+@@ -429,7 +429,7 @@ namespace KeePass.Util
+ 			if(NativeLib.GetPlatformID() == PlatformID.MacOSX)
+ 				strArgPrefix = string.Empty; // FR 3535696
+ 
+-			string str = NativeLib.RunConsoleApp("whereis", strArgPrefix + strApp);
++			string str = NativeLib.RunConsoleApp("@whereis@", strArgPrefix + strApp);
+ 			if(str == null) return null;
+ 
+ 			str = str.Trim();
 diff --git a/KeePass/Util/ClipboardUtil.Unix.cs b/KeePass/Util/ClipboardUtil.Unix.cs
-index e93a22a..3fd9a2b 100644
+index ab49ee2..7f6c50f 100644
 --- a/KeePass/Util/ClipboardUtil.Unix.cs
 +++ b/KeePass/Util/ClipboardUtil.Unix.cs
+@@ -42,7 +42,7 @@ namespace KeePass.Util
+ 			// string strGtk = GtkGetString();
+ 			// if(strGtk != null) return strGtk;
+ 
+-			return (NativeLib.RunConsoleApp("pbpaste", "-pboard general") ??
++			return (NativeLib.RunConsoleApp("@pbpaste@", "-pboard general") ??
+ 				string.Empty);
+ 		}
+ 
+@@ -50,7 +50,7 @@ namespace KeePass.Util
+ 		{
+ 			// if(GtkSetString(str)) return;
+ 
+-			NativeLib.RunConsoleApp("pbcopy", "-pboard general", str);
++			NativeLib.RunConsoleApp("@pbcopy@", "-pboard general", str);
+ 		}
+ 
+ 		private static string GetStringU()
 @@ -62,7 +62,7 @@ namespace KeePass.Util
  			//	"-out -selection clipboard");
  			// if(str != null) return str;
@@ -51,20 +110,33 @@ index e93a22a..3fd9a2b 100644
  				return;
  			}
 diff --git a/KeePassLib/Native/ClipboardU.cs b/KeePassLib/Native/ClipboardU.cs
-index ddd8f57..150eb82 100644
+index 291c51d..3c76380 100644
 --- a/KeePassLib/Native/ClipboardU.cs
 +++ b/KeePassLib/Native/ClipboardU.cs
 @@ -27,7 +27,7 @@ namespace KeePassLib.Native
  {
  	internal static class ClipboardU
  	{
--		private const string XSel = "xsel";
-+		private const string XSel = "@xsel@";
+-		internal const string XSel = "xsel";
++		internal const string XSel = "@xsel@";
  		private const string XSelV = "--version";
  		private const string XSelR = "--output --clipboard";
  		private const string XSelC = "--clear --clipboard";
+diff --git a/KeePassLib/Native/NativeLib.cs b/KeePassLib/Native/NativeLib.cs
+index 2d227a3..243f4ee 100644
+--- a/KeePassLib/Native/NativeLib.cs
++++ b/KeePassLib/Native/NativeLib.cs
+@@ -145,7 +145,7 @@ namespace KeePassLib.Native
+ 			// Mono returns PlatformID.Unix on Mac OS X, workaround this
+ 			if(m_platID.Value == PlatformID.Unix)
+ 			{
+-				if((RunConsoleApp("uname", null) ?? string.Empty).Trim().Equals(
++				if((RunConsoleApp("@uname@", null) ?? string.Empty).Trim().Equals(
+ 					"Darwin", StrUtil.CaseIgnoreCmp))
+ 					m_platID = PlatformID.MacOSX;
+ 			}
 diff --git a/KeePassLib/Utility/MonoWorkarounds.cs b/KeePassLib/Utility/MonoWorkarounds.cs
-index 0da7019..f6a1022 100644
+index e20bb3a..4fd875b 100644
 --- a/KeePassLib/Utility/MonoWorkarounds.cs
 +++ b/KeePassLib/Utility/MonoWorkarounds.cs
 @@ -41,7 +41,7 @@ namespace KeePassLib.Utility
@@ -76,7 +148,7 @@ index 0da7019..f6a1022 100644
  
  		private static Dictionary<uint, bool> g_dForceReq = new Dictionary<uint, bool>();
  		private static Thread g_thFixClip = null;
-@@ -303,7 +303,7 @@ namespace KeePassLib.Utility
+@@ -335,7 +335,7 @@ namespace KeePassLib.Utility
  				// }
  				// else { Debug.Assert(false); }
  
@@ -85,3 +157,6 @@ index 0da7019..f6a1022 100644
  					"-id " + strHandle + " WM_CLASS") ?? string.Empty);
  
  				if(strWmClass.IndexOf("\"" + PwDefs.ResClass + "\"",
+-- 
+2.25.4
+

--- a/pkgs/applications/misc/keepass/keepass-plugins.patch
+++ b/pkgs/applications/misc/keepass/keepass-plugins.patch
@@ -1,13 +1,25 @@
+From 4cb0b18f5326a07927453897180289a4b254ac4f Mon Sep 17 00:00:00 2001
+From: Pascal Winkelmann <pascal@wnklmnn.de>
+Date: Tue, 19 May 2020 10:43:49 +0200
+Subject: [PATCH] loadplugin
+
+---
+ KeePass/Forms/MainForm.cs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/KeePass/Forms/MainForm.cs b/KeePass/Forms/MainForm.cs
-index 3d5fca0..4c3f3d4 100644
+index 347eaf5..b92e1e2 100644
 --- a/KeePass/Forms/MainForm.cs
 +++ b/KeePass/Forms/MainForm.cs
-@@ -406,7 +406,$OUTPUT_LC$ @@ namespace KeePass.Forms
- 			m_pluginManager.Initialize(m_pluginDefaultHost);
+@@ -440,7 +440,7 @@ namespace KeePass.Forms
+ 				ToolStripItemCollection tsicT = m_ctxTray.Items;
+ 				ToolStripItem tsiPrevT = m_ctxTrayOptions;
  
- 			m_pluginManager.UnloadAllPlugins();
--			if(AppPolicy.Current.Plugins) m_pluginManager.LoadAllPlugins();
+-				m_pluginManager.LoadAllPlugins();
 $DO_LOADS$+
  
- 			// Delete old files *after* loading plugins (when timestamps
- 			// of loaded plugins have been updated already)
+ 				m_pluginManager.AddMenuItems(PluginMenuType.Main, tsicM, tsiPrevM);
+ 				m_pluginManager.AddMenuItems(PluginMenuType.Group, tsicGM, tsiPrevGM);
+-- 
+2.25.4
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://keepass.info/news/n200507_2.45.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
