### PR TITLE
matrix-synapse: 1.12.4 -> 1.13.0, riot-{web,desktop}: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/riot/riot-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-desktop-package.json
@@ -1,15 +1,111 @@
 {
-  "name": "riot-web",
+  "name": "riot-desktop",
   "productName": "Riot",
   "main": "src/electron-main.js",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A feature-rich client for Matrix.org",
   "author": "New Vector Ltd.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vector-im/riot-desktop"
+  },
+  "license": "Apache-2.0",
+  "files": [],
+  "scripts": {
+    "mkdirs": "mkdirp packages deploys",
+    "fetch": "yarn run mkdirs && node scripts/fetch-package.js",
+    "start": "electron .",
+    "lint": "eslint src/ scripts/ hak/",
+    "build:native": "yarn run hak",
+    "build32": "electron-builder --ia32",
+    "build64": "electron-builder --x64",
+    "build": "electron-builder",
+    "docker:setup": "docker build -t riot-desktop-dockerbuild dockerbuild",
+    "docker:build:native": "scripts/in-docker.sh yarn run hak",
+    "docker:build": "scripts/in-docker.sh yarn run build",
+    "docker:install": "scripts/in-docker.sh yarn install",
+    "debrepo": "scripts/mkrepo.sh",
+    "clean": "rimraf webapp.asar dist packages deploys",
+    "hak": "node scripts/hak/index.js"
+  },
   "dependencies": {
     "auto-launch": "^5.0.1",
     "electron-store": "^2.0.0",
     "electron-window-state": "^4.1.0",
-    "minimist": "^1.2.0",
+    "minimist": "^1.2.3",
     "png-to-ico": "^1.0.2"
+  },
+  "devDependencies": {
+    "asar": "^2.0.1",
+    "electron-builder": "^22.3.2",
+    "electron-builder-squirrel-windows": "^22.3.2",
+    "electron-devtools-installer": "^2.2.4",
+    "electron-notarize": "^0.2.0",
+    "eslint": "^5.8.0",
+    "eslint-config-google": "^0.7.1",
+    "eslint-plugin-babel": "^4.1.2",
+    "find-npm-prefix": "^1.0.2",
+    "fs-extra": "^8.1.0",
+    "glob": "^7.1.6",
+    "matrix-js-sdk": "6.1.0",
+    "mkdirp": "^1.0.3",
+    "needle": "^2.3.2",
+    "node-pre-gyp": "^0.14.0",
+    "npm": "^6.13.7",
+    "rimraf": "^3.0.2",
+    "semver": "^7.1.3",
+    "tar": "^6.0.1"
+  },
+  "hakDependencies": {
+    "matrix-seshat": "^1.3.3"
+  },
+  "build": {
+    "appId": "im.riot.app",
+    "electronVersion": "8.0.3",
+    "files": [
+      "package.json",
+      {
+        "from": ".hak/hakModules",
+        "to": "node_modules"
+      },
+      "src/**"
+    ],
+    "extraResources": [
+      {
+        "from": "res/img",
+        "to": "img"
+      },
+      "webapp.asar"
+    ],
+    "linux": {
+      "target": "deb",
+      "category": "Network;InstantMessaging;Chat",
+      "maintainer": "support@riot.im",
+      "desktop": {
+        "StartupWMClass": "riot"
+      }
+    },
+    "mac": {
+      "category": "public.app-category.social-networking",
+      "darkModeSupport": true
+    },
+    "win": {
+      "target": {
+        "target": "squirrel"
+      },
+      "sign": "scripts/electron_winSign"
+    },
+    "directories": {
+      "output": "dist"
+    },
+    "afterSign": "scripts/electron_afterSign",
+    "protocols": [
+      {
+        "name": "riot",
+        "schemes": [
+          "riot"
+        ]
+      }
+    ]
   }
 }

--- a/pkgs/applications/networking/instant-messengers/riot/riot-desktop-yarndeps.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-desktop-yarndeps.nix
@@ -2,19 +2,315 @@
   offline_cache = linkFarm "offline" packages;
   packages = [
     {
-      name = "_types_node___node_9.6.45.tgz";
+      name = "7zip_bin___7zip_bin_4.0.2.tgz";
       path = fetchurl {
-        name = "_types_node___node_9.6.45.tgz";
-        url  = "https://registry.yarnpkg.com/@types/node/-/node-9.6.45.tgz";
-        sha1 = "a9e5cfd026a3abaaf17e3c0318a470da9f2f178e";
+        name = "7zip_bin___7zip_bin_4.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-4.0.2.tgz";
+        sha1 = "6abbdc22f33cab742053777a26db2e25ca527179";
       };
     }
     {
-      name = "ajv___ajv_6.10.0.tgz";
+      name = "7zip_bin___7zip_bin_5.0.3.tgz";
       path = fetchurl {
-        name = "ajv___ajv_6.10.0.tgz";
-        url  = "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz";
-        sha1 = "90d0d54439da587cd7e843bfb7045f50bd22bdf1";
+        name = "7zip_bin___7zip_bin_5.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-5.0.3.tgz";
+        sha1 = "bc5b5532ecafd923a61f2fb097e3b108c0106a3f";
+      };
+    }
+    {
+      name = "7zip___7zip_0.0.6.tgz";
+      path = fetchurl {
+        name = "7zip___7zip_0.0.6.tgz";
+        url  = "https://registry.yarnpkg.com/7zip/-/7zip-0.0.6.tgz";
+        sha1 = "9cafb171af82329490353b4816f03347aa150a30";
+      };
+    }
+    {
+      name = "_babel_code_frame___code_frame_7.5.5.tgz";
+      path = fetchurl {
+        name = "_babel_code_frame___code_frame_7.5.5.tgz";
+        url  = "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz";
+        sha1 = "bc0782f6d69f7b7d49531219699b988f669a8f9d";
+      };
+    }
+    {
+      name = "_babel_highlight___highlight_7.5.0.tgz";
+      path = fetchurl {
+        name = "_babel_highlight___highlight_7.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.5.0.tgz";
+        sha1 = "56d11312bd9248fa619591d02472be6e8cb32540";
+      };
+    }
+    {
+      name = "_babel_runtime___runtime_7.9.2.tgz";
+      path = fetchurl {
+        name = "_babel_runtime___runtime_7.9.2.tgz";
+        url  = "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz";
+        sha1 = "d90df0583a3a252f09aaa619665367bae518db06";
+      };
+    }
+    {
+      name = "_develar_schema_utils___schema_utils_2.1.0.tgz";
+      path = fetchurl {
+        name = "_develar_schema_utils___schema_utils_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/@develar/schema-utils/-/schema-utils-2.1.0.tgz";
+        sha1 = "eceb1695bfbed6f6bb84666d5d3abe5e1fd54e17";
+      };
+    }
+    {
+      name = "_iarna_cli___cli_1.2.0.tgz";
+      path = fetchurl {
+        name = "_iarna_cli___cli_1.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/@iarna/cli/-/cli-1.2.0.tgz";
+        sha1 = "0f7af5e851afe895104583c4ca07377a8094d641";
+      };
+    }
+    {
+      name = "_sindresorhus_is___is_0.14.0.tgz";
+      path = fetchurl {
+        name = "_sindresorhus_is___is_0.14.0.tgz";
+        url  = "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz";
+        sha1 = "9fb3a3cf3132328151f353de4632e01e52102bea";
+      };
+    }
+    {
+      name = "_szmarczak_http_timer___http_timer_1.1.2.tgz";
+      path = fetchurl {
+        name = "_szmarczak_http_timer___http_timer_1.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz";
+        sha1 = "b1665e2c461a2cd92f4c1bbf50d5454de0d4b421";
+      };
+    }
+    {
+      name = "_types_color_name___color_name_1.1.1.tgz";
+      path = fetchurl {
+        name = "_types_color_name___color_name_1.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz";
+        sha1 = "1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0";
+      };
+    }
+    {
+      name = "_types_debug___debug_4.1.5.tgz";
+      path = fetchurl {
+        name = "_types_debug___debug_4.1.5.tgz";
+        url  = "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz";
+        sha1 = "b14efa8852b7768d898906613c23f688713e02cd";
+      };
+    }
+    {
+      name = "_types_fs_extra___fs_extra_8.0.1.tgz";
+      path = fetchurl {
+        name = "_types_fs_extra___fs_extra_8.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.0.1.tgz";
+        sha1 = "a2378d6e7e8afea1564e44aafa2e207dadf77686";
+      };
+    }
+    {
+      name = "_types_node___node_13.7.1.tgz";
+      path = fetchurl {
+        name = "_types_node___node_13.7.1.tgz";
+        url  = "https://registry.yarnpkg.com/@types/node/-/node-13.7.1.tgz";
+        sha1 = "238eb34a66431b71d2aaddeaa7db166f25971a0d";
+      };
+    }
+    {
+      name = "_types_node___node_9.6.55.tgz";
+      path = fetchurl {
+        name = "_types_node___node_9.6.55.tgz";
+        url  = "https://registry.yarnpkg.com/@types/node/-/node-9.6.55.tgz";
+        sha1 = "7cc1358c9c18e71f6c020e410962971863232cf5";
+      };
+    }
+    {
+      name = "JSONStream___JSONStream_1.3.5.tgz";
+      path = fetchurl {
+        name = "JSONStream___JSONStream_1.3.5.tgz";
+        url  = "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz";
+        sha1 = "3208c1f08d3a4d99261ab64f92302bc15e111ca0";
+      };
+    }
+    {
+      name = "abbrev___abbrev_1.1.1.tgz";
+      path = fetchurl {
+        name = "abbrev___abbrev_1.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz";
+        sha1 = "f8f2c887ad10bf67f634f005b6987fed3179aac8";
+      };
+    }
+    {
+      name = "acorn_jsx___acorn_jsx_5.1.0.tgz";
+      path = fetchurl {
+        name = "acorn_jsx___acorn_jsx_5.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz";
+        sha1 = "294adb71b57398b0680015f0a38c563ee1db5384";
+      };
+    }
+    {
+      name = "acorn___acorn_6.4.0.tgz";
+      path = fetchurl {
+        name = "acorn___acorn_6.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/acorn/-/acorn-6.4.0.tgz";
+        sha1 = "b659d2ffbafa24baf5db1cdbb2c94a983ecd2784";
+      };
+    }
+    {
+      name = "agent_base___agent_base_4.3.0.tgz";
+      path = fetchurl {
+        name = "agent_base___agent_base_4.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz";
+        sha1 = "8165f01c436009bccad0b1d122f05ed770efc6ee";
+      };
+    }
+    {
+      name = "agent_base___agent_base_4.2.1.tgz";
+      path = fetchurl {
+        name = "agent_base___agent_base_4.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz";
+        sha1 = "d89e5999f797875674c07d87f260fc41e83e8ca9";
+      };
+    }
+    {
+      name = "agentkeepalive___agentkeepalive_3.5.2.tgz";
+      path = fetchurl {
+        name = "agentkeepalive___agentkeepalive_3.5.2.tgz";
+        url  = "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-3.5.2.tgz";
+        sha1 = "a113924dd3fa24a0bc3b78108c450c2abee00f67";
+      };
+    }
+    {
+      name = "ajv_keywords___ajv_keywords_3.4.1.tgz";
+      path = fetchurl {
+        name = "ajv_keywords___ajv_keywords_3.4.1.tgz";
+        url  = "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz";
+        sha1 = "ef916e271c64ac12171fd8384eaae6b2345854da";
+      };
+    }
+    {
+      name = "ajv___ajv_6.10.2.tgz";
+      path = fetchurl {
+        name = "ajv___ajv_6.10.2.tgz";
+        url  = "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz";
+        sha1 = "d3cea04d6b017b2894ad69040fec8b623eb4bd52";
+      };
+    }
+    {
+      name = "another_json___another_json_0.2.0.tgz";
+      path = fetchurl {
+        name = "another_json___another_json_0.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/another-json/-/another-json-0.2.0.tgz";
+        sha1 = "b5f4019c973b6dd5c6506a2d93469cb6d32aeedc";
+      };
+    }
+    {
+      name = "ansi_align___ansi_align_2.0.0.tgz";
+      path = fetchurl {
+        name = "ansi_align___ansi_align_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz";
+        sha1 = "c36aeccba563b89ceb556f3690f0b1d9e3547f7f";
+      };
+    }
+    {
+      name = "ansi_align___ansi_align_3.0.0.tgz";
+      path = fetchurl {
+        name = "ansi_align___ansi_align_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz";
+        sha1 = "b536b371cf687caaef236c18d3e21fe3797467cb";
+      };
+    }
+    {
+      name = "ansi_escapes___ansi_escapes_3.2.0.tgz";
+      path = fetchurl {
+        name = "ansi_escapes___ansi_escapes_3.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz";
+        sha1 = "8780b98ff9dbf5638152d1f1fe5c1d7b4442976b";
+      };
+    }
+    {
+      name = "ansi_regex___ansi_regex_2.1.1.tgz";
+      path = fetchurl {
+        name = "ansi_regex___ansi_regex_2.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz";
+        sha1 = "c3b33ab5ee360d86e0e628f0468ae7ef27d654df";
+      };
+    }
+    {
+      name = "ansi_regex___ansi_regex_3.0.0.tgz";
+      path = fetchurl {
+        name = "ansi_regex___ansi_regex_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz";
+        sha1 = "ed0317c322064f79466c02966bddb605ab37d998";
+      };
+    }
+    {
+      name = "ansi_regex___ansi_regex_4.1.0.tgz";
+      path = fetchurl {
+        name = "ansi_regex___ansi_regex_4.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz";
+        sha1 = "8b9f8f08cf1acb843756a839ca8c7e3168c51997";
+      };
+    }
+    {
+      name = "ansi_regex___ansi_regex_5.0.0.tgz";
+      path = fetchurl {
+        name = "ansi_regex___ansi_regex_5.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz";
+        sha1 = "388539f55179bf39339c81af30a654d69f87cb75";
+      };
+    }
+    {
+      name = "ansi_styles___ansi_styles_3.2.1.tgz";
+      path = fetchurl {
+        name = "ansi_styles___ansi_styles_3.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz";
+        sha1 = "41fbb20243e50b12be0f04b8dedbf07520ce841d";
+      };
+    }
+    {
+      name = "ansi_styles___ansi_styles_4.2.1.tgz";
+      path = fetchurl {
+        name = "ansi_styles___ansi_styles_4.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz";
+        sha1 = "90ae75c424d008d2624c5bf29ead3177ebfcf359";
+      };
+    }
+    {
+      name = "ansicolors___ansicolors_0.3.2.tgz";
+      path = fetchurl {
+        name = "ansicolors___ansicolors_0.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.3.2.tgz";
+        sha1 = "665597de86a9ffe3aa9bfbe6cae5c6ea426b4979";
+      };
+    }
+    {
+      name = "ansistyles___ansistyles_0.1.3.tgz";
+      path = fetchurl {
+        name = "ansistyles___ansistyles_0.1.3.tgz";
+        url  = "https://registry.yarnpkg.com/ansistyles/-/ansistyles-0.1.3.tgz";
+        sha1 = "5de60415bda071bb37127854c864f41b23254539";
+      };
+    }
+    {
+      name = "app_builder_bin___app_builder_bin_3.5.2.tgz";
+      path = fetchurl {
+        name = "app_builder_bin___app_builder_bin_3.5.2.tgz";
+        url  = "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-3.5.2.tgz";
+        sha1 = "fba56e6e9ef76fcd37816738c5f9a0b3992d7183";
+      };
+    }
+    {
+      name = "app_builder_lib___app_builder_lib_22.3.2.tgz";
+      path = fetchurl {
+        name = "app_builder_lib___app_builder_lib_22.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.3.2.tgz";
+        sha1 = "d43e0bdff91d484c0bd07d7248043dbb2665b8ac";
+      };
+    }
+    {
+      name = "app_builder_lib___app_builder_lib_22.3.3.tgz";
+      path = fetchurl {
+        name = "app_builder_lib___app_builder_lib_22.3.3.tgz";
+        url  = "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.3.3.tgz";
+        sha1 = "9a95a3c14f69fb6131834dd840fba561191c9998";
       };
     }
     {
@@ -23,6 +319,78 @@
         name = "applescript___applescript_1.0.0.tgz";
         url  = "https://registry.yarnpkg.com/applescript/-/applescript-1.0.0.tgz";
         sha1 = "bb87af568cad034a4e48c4bdaf6067a3a2701317";
+      };
+    }
+    {
+      name = "aproba___aproba_1.2.0.tgz";
+      path = fetchurl {
+        name = "aproba___aproba_1.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz";
+        sha1 = "6802e6264efd18c790a1b0d517f0f2627bf2c94a";
+      };
+    }
+    {
+      name = "aproba___aproba_2.0.0.tgz";
+      path = fetchurl {
+        name = "aproba___aproba_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz";
+        sha1 = "52520b8ae5b569215b354efc0caa3fe1e45a8adc";
+      };
+    }
+    {
+      name = "archiver_utils___archiver_utils_2.1.0.tgz";
+      path = fetchurl {
+        name = "archiver_utils___archiver_utils_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-2.1.0.tgz";
+        sha1 = "e8a460e94b693c3e3da182a098ca6285ba9249e2";
+      };
+    }
+    {
+      name = "archiver___archiver_3.1.1.tgz";
+      path = fetchurl {
+        name = "archiver___archiver_3.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/archiver/-/archiver-3.1.1.tgz";
+        sha1 = "9db7819d4daf60aec10fe86b16cb9258ced66ea0";
+      };
+    }
+    {
+      name = "archy___archy_1.0.0.tgz";
+      path = fetchurl {
+        name = "archy___archy_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz";
+        sha1 = "f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40";
+      };
+    }
+    {
+      name = "are_we_there_yet___are_we_there_yet_1.1.5.tgz";
+      path = fetchurl {
+        name = "are_we_there_yet___are_we_there_yet_1.1.5.tgz";
+        url  = "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz";
+        sha1 = "4b35c2944f062a8bfcda66410760350fe9ddfc21";
+      };
+    }
+    {
+      name = "argparse___argparse_1.0.10.tgz";
+      path = fetchurl {
+        name = "argparse___argparse_1.0.10.tgz";
+        url  = "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz";
+        sha1 = "bcd6791ea5ae09725e17e5ad988134cd40b3d911";
+      };
+    }
+    {
+      name = "asap___asap_2.0.6.tgz";
+      path = fetchurl {
+        name = "asap___asap_2.0.6.tgz";
+        url  = "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz";
+        sha1 = "e50347611d7e690943208bbdafebcbc2fb866d46";
+      };
+    }
+    {
+      name = "asar___asar_2.0.1.tgz";
+      path = fetchurl {
+        name = "asar___asar_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/asar/-/asar-2.0.1.tgz";
+        sha1 = "8518a1c62c238109c15a5f742213e83a09b9fd38";
       };
     }
     {
@@ -39,6 +407,30 @@
         name = "assert_plus___assert_plus_1.0.0.tgz";
         url  = "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz";
         sha1 = "f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525";
+      };
+    }
+    {
+      name = "astral_regex___astral_regex_1.0.0.tgz";
+      path = fetchurl {
+        name = "astral_regex___astral_regex_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz";
+        sha1 = "6c8c3fb827dd43ee3918f27b82782ab7658a6fd9";
+      };
+    }
+    {
+      name = "async_exit_hook___async_exit_hook_2.0.1.tgz";
+      path = fetchurl {
+        name = "async_exit_hook___async_exit_hook_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz";
+        sha1 = "8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3";
+      };
+    }
+    {
+      name = "async___async_2.6.3.tgz";
+      path = fetchurl {
+        name = "async___async_2.6.3.tgz";
+        url  = "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz";
+        sha1 = "d72625e2344a3656e3a3ad4fa749fa83299d82ff";
       };
     }
     {
@@ -66,11 +458,35 @@
       };
     }
     {
-      name = "aws4___aws4_1.8.0.tgz";
+      name = "aws4___aws4_1.9.0.tgz";
       path = fetchurl {
-        name = "aws4___aws4_1.8.0.tgz";
-        url  = "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz";
-        sha1 = "f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f";
+        name = "aws4___aws4_1.9.0.tgz";
+        url  = "https://registry.yarnpkg.com/aws4/-/aws4-1.9.0.tgz";
+        sha1 = "24390e6ad61386b0a747265754d2a17219de862c";
+      };
+    }
+    {
+      name = "balanced_match___balanced_match_1.0.0.tgz";
+      path = fetchurl {
+        name = "balanced_match___balanced_match_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz";
+        sha1 = "89b4d199ab2bee49de164ea02b89ce462d71b767";
+      };
+    }
+    {
+      name = "base_x___base_x_3.0.7.tgz";
+      path = fetchurl {
+        name = "base_x___base_x_3.0.7.tgz";
+        url  = "https://registry.yarnpkg.com/base-x/-/base-x-3.0.7.tgz";
+        sha1 = "1c5a7fafe8f66b4114063e8da102799d4e7c408f";
+      };
+    }
+    {
+      name = "base64_js___base64_js_1.3.1.tgz";
+      path = fetchurl {
+        name = "base64_js___base64_js_1.3.1.tgz";
+        url  = "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz";
+        sha1 = "58ece8cb75dd07e71ed08c736abc5fac4dbf8df1";
       };
     }
     {
@@ -90,11 +506,91 @@
       };
     }
     {
+      name = "bin_links___bin_links_1.1.7.tgz";
+      path = fetchurl {
+        name = "bin_links___bin_links_1.1.7.tgz";
+        url  = "https://registry.yarnpkg.com/bin-links/-/bin-links-1.1.7.tgz";
+        sha1 = "34b79ea9d0e575d7308afeff0c6b2fc24c793359";
+      };
+    }
+    {
+      name = "bl___bl_3.0.0.tgz";
+      path = fetchurl {
+        name = "bl___bl_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/bl/-/bl-3.0.0.tgz";
+        sha1 = "3611ec00579fd18561754360b21e9f784500ff88";
+      };
+    }
+    {
+      name = "bluebird_lst___bluebird_lst_1.0.9.tgz";
+      path = fetchurl {
+        name = "bluebird_lst___bluebird_lst_1.0.9.tgz";
+        url  = "https://registry.yarnpkg.com/bluebird-lst/-/bluebird-lst-1.0.9.tgz";
+        sha1 = "a64a0e4365658b9ab5fe875eb9dfb694189bb41c";
+      };
+    }
+    {
+      name = "bluebird___bluebird_3.7.2.tgz";
+      path = fetchurl {
+        name = "bluebird___bluebird_3.7.2.tgz";
+        url  = "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz";
+        sha1 = "9f229c15be272454ffa973ace0dbee79a1b0c36f";
+      };
+    }
+    {
       name = "bmp_js___bmp_js_0.0.3.tgz";
       path = fetchurl {
         name = "bmp_js___bmp_js_0.0.3.tgz";
         url  = "https://registry.yarnpkg.com/bmp-js/-/bmp-js-0.0.3.tgz";
         sha1 = "64113e9c7cf1202b376ed607bf30626ebe57b18a";
+      };
+    }
+    {
+      name = "boxen___boxen_1.3.0.tgz";
+      path = fetchurl {
+        name = "boxen___boxen_1.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz";
+        sha1 = "55c6c39a8ba58d9c61ad22cd877532deb665a20b";
+      };
+    }
+    {
+      name = "boxen___boxen_4.2.0.tgz";
+      path = fetchurl {
+        name = "boxen___boxen_4.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/boxen/-/boxen-4.2.0.tgz";
+        sha1 = "e411b62357d6d6d36587c8ac3d5d974daa070e64";
+      };
+    }
+    {
+      name = "brace_expansion___brace_expansion_1.1.11.tgz";
+      path = fetchurl {
+        name = "brace_expansion___brace_expansion_1.1.11.tgz";
+        url  = "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz";
+        sha1 = "3c7fcbf529d87226f3d2f52b966ff5271eb441dd";
+      };
+    }
+    {
+      name = "browser_request___browser_request_0.3.3.tgz";
+      path = fetchurl {
+        name = "browser_request___browser_request_0.3.3.tgz";
+        url  = "https://registry.yarnpkg.com/browser-request/-/browser-request-0.3.3.tgz";
+        sha1 = "9ece5b5aca89a29932242e18bf933def9876cc17";
+      };
+    }
+    {
+      name = "bs58___bs58_4.0.1.tgz";
+      path = fetchurl {
+        name = "bs58___bs58_4.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz";
+        sha1 = "be161e76c354f6f788ae4071f63f34e8c4f0a42a";
+      };
+    }
+    {
+      name = "buffer_crc32___buffer_crc32_0.2.13.tgz";
+      path = fetchurl {
+        name = "buffer_crc32___buffer_crc32_0.2.13.tgz";
+        url  = "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz";
+        sha1 = "0d333e3f00eac50aa1454abd30ef8c2a5d9a7242";
       };
     }
     {
@@ -106,6 +602,126 @@
       };
     }
     {
+      name = "buffer_from___buffer_from_1.1.1.tgz";
+      path = fetchurl {
+        name = "buffer_from___buffer_from_1.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz";
+        sha1 = "32713bc028f75c02fdb710d7c7bcec1f2c6070ef";
+      };
+    }
+    {
+      name = "buffer___buffer_5.4.3.tgz";
+      path = fetchurl {
+        name = "buffer___buffer_5.4.3.tgz";
+        url  = "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz";
+        sha1 = "3fbc9c69eb713d323e3fc1a895eee0710c072115";
+      };
+    }
+    {
+      name = "builder_util_runtime___builder_util_runtime_8.6.0.tgz";
+      path = fetchurl {
+        name = "builder_util_runtime___builder_util_runtime_8.6.0.tgz";
+        url  = "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.6.0.tgz";
+        sha1 = "b7007c30126da9a90e99932128d2922c8c178649";
+      };
+    }
+    {
+      name = "builder_util___builder_util_22.3.2.tgz";
+      path = fetchurl {
+        name = "builder_util___builder_util_22.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/builder-util/-/builder-util-22.3.2.tgz";
+        sha1 = "23c61aaf0f0006f994087b33a26e47cdaec7aa8d";
+      };
+    }
+    {
+      name = "builder_util___builder_util_22.3.3.tgz";
+      path = fetchurl {
+        name = "builder_util___builder_util_22.3.3.tgz";
+        url  = "https://registry.yarnpkg.com/builder-util/-/builder-util-22.3.3.tgz";
+        sha1 = "62f0527ceaa1a2e4a60596a9b38ad1ffe3e20ae6";
+      };
+    }
+    {
+      name = "builtins___builtins_1.0.3.tgz";
+      path = fetchurl {
+        name = "builtins___builtins_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz";
+        sha1 = "cb94faeb61c8696451db36534e1422f94f0aee88";
+      };
+    }
+    {
+      name = "byline___byline_5.0.0.tgz";
+      path = fetchurl {
+        name = "byline___byline_5.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz";
+        sha1 = "741c5216468eadc457b03410118ad77de8c1ddb1";
+      };
+    }
+    {
+      name = "byte_size___byte_size_5.0.1.tgz";
+      path = fetchurl {
+        name = "byte_size___byte_size_5.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/byte-size/-/byte-size-5.0.1.tgz";
+        sha1 = "4b651039a5ecd96767e71a3d7ed380e48bed4191";
+      };
+    }
+    {
+      name = "cacache___cacache_12.0.3.tgz";
+      path = fetchurl {
+        name = "cacache___cacache_12.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/cacache/-/cacache-12.0.3.tgz";
+        sha1 = "be99abba4e1bf5df461cd5a2c1071fc432573390";
+      };
+    }
+    {
+      name = "cacheable_request___cacheable_request_6.1.0.tgz";
+      path = fetchurl {
+        name = "cacheable_request___cacheable_request_6.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz";
+        sha1 = "20ffb8bd162ba4be11e9567d823db651052ca912";
+      };
+    }
+    {
+      name = "call_limit___call_limit_1.1.1.tgz";
+      path = fetchurl {
+        name = "call_limit___call_limit_1.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/call-limit/-/call-limit-1.1.1.tgz";
+        sha1 = "ef15f2670db3f1992557e2d965abc459e6e358d4";
+      };
+    }
+    {
+      name = "callsites___callsites_3.1.0.tgz";
+      path = fetchurl {
+        name = "callsites___callsites_3.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz";
+        sha1 = "b3630abd8943432f54b3f0519238e33cd7df2f73";
+      };
+    }
+    {
+      name = "camelcase___camelcase_4.1.0.tgz";
+      path = fetchurl {
+        name = "camelcase___camelcase_4.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz";
+        sha1 = "d545635be1e33c542649c69173e5de6acfae34dd";
+      };
+    }
+    {
+      name = "camelcase___camelcase_5.3.1.tgz";
+      path = fetchurl {
+        name = "camelcase___camelcase_5.3.1.tgz";
+        url  = "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz";
+        sha1 = "e3c9b31569e106811df242f715725a1f4c494320";
+      };
+    }
+    {
+      name = "capture_stack_trace___capture_stack_trace_1.0.1.tgz";
+      path = fetchurl {
+        name = "capture_stack_trace___capture_stack_trace_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz";
+        sha1 = "a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d";
+      };
+    }
+    {
       name = "caseless___caseless_0.12.0.tgz";
       path = fetchurl {
         name = "caseless___caseless_0.12.0.tgz";
@@ -114,11 +730,267 @@
       };
     }
     {
-      name = "combined_stream___combined_stream_1.0.7.tgz";
+      name = "chalk___chalk_2.4.2.tgz";
       path = fetchurl {
-        name = "combined_stream___combined_stream_1.0.7.tgz";
-        url  = "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz";
-        sha1 = "2d1d24317afb8abe95d6d2c0b07b57813539d828";
+        name = "chalk___chalk_2.4.2.tgz";
+        url  = "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz";
+        sha1 = "cd42541677a54333cf541a49108c1432b44c9424";
+      };
+    }
+    {
+      name = "chalk___chalk_3.0.0.tgz";
+      path = fetchurl {
+        name = "chalk___chalk_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz";
+        sha1 = "3f73c2bf526591f574cc492c51e2456349f844e4";
+      };
+    }
+    {
+      name = "chardet___chardet_0.7.0.tgz";
+      path = fetchurl {
+        name = "chardet___chardet_0.7.0.tgz";
+        url  = "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz";
+        sha1 = "90094849f0937f2eedc2425d0d28a9e5f0cbad9e";
+      };
+    }
+    {
+      name = "chownr___chownr_1.1.4.tgz";
+      path = fetchurl {
+        name = "chownr___chownr_1.1.4.tgz";
+        url  = "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz";
+        sha1 = "6fc9d7b42d32a583596337666e7d08084da2cc6b";
+      };
+    }
+    {
+      name = "chownr___chownr_1.1.3.tgz";
+      path = fetchurl {
+        name = "chownr___chownr_1.1.3.tgz";
+        url  = "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz";
+        sha1 = "42d837d5239688d55f303003a508230fa6727142";
+      };
+    }
+    {
+      name = "chromium_pickle_js___chromium_pickle_js_0.2.0.tgz";
+      path = fetchurl {
+        name = "chromium_pickle_js___chromium_pickle_js_0.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz";
+        sha1 = "04a106672c18b085ab774d983dfa3ea138f22205";
+      };
+    }
+    {
+      name = "ci_info___ci_info_1.6.0.tgz";
+      path = fetchurl {
+        name = "ci_info___ci_info_1.6.0.tgz";
+        url  = "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz";
+        sha1 = "2ca20dbb9ceb32d4524a683303313f0304b1e497";
+      };
+    }
+    {
+      name = "ci_info___ci_info_2.0.0.tgz";
+      path = fetchurl {
+        name = "ci_info___ci_info_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz";
+        sha1 = "67a9e964be31a51e15e5010d58e6f12834002f46";
+      };
+    }
+    {
+      name = "cidr_regex___cidr_regex_2.0.10.tgz";
+      path = fetchurl {
+        name = "cidr_regex___cidr_regex_2.0.10.tgz";
+        url  = "https://registry.yarnpkg.com/cidr-regex/-/cidr-regex-2.0.10.tgz";
+        sha1 = "af13878bd4ad704de77d6dc800799358b3afa70d";
+      };
+    }
+    {
+      name = "cli_boxes___cli_boxes_1.0.0.tgz";
+      path = fetchurl {
+        name = "cli_boxes___cli_boxes_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz";
+        sha1 = "4fa917c3e59c94a004cd61f8ee509da651687143";
+      };
+    }
+    {
+      name = "cli_boxes___cli_boxes_2.2.0.tgz";
+      path = fetchurl {
+        name = "cli_boxes___cli_boxes_2.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz";
+        sha1 = "538ecae8f9c6ca508e3c3c95b453fe93cb4c168d";
+      };
+    }
+    {
+      name = "cli_columns___cli_columns_3.1.2.tgz";
+      path = fetchurl {
+        name = "cli_columns___cli_columns_3.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/cli-columns/-/cli-columns-3.1.2.tgz";
+        sha1 = "6732d972979efc2ae444a1f08e08fa139c96a18e";
+      };
+    }
+    {
+      name = "cli_cursor___cli_cursor_2.1.0.tgz";
+      path = fetchurl {
+        name = "cli_cursor___cli_cursor_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz";
+        sha1 = "b35dac376479facc3e94747d41d0d0f5238ffcb5";
+      };
+    }
+    {
+      name = "cli_table3___cli_table3_0.5.1.tgz";
+      path = fetchurl {
+        name = "cli_table3___cli_table3_0.5.1.tgz";
+        url  = "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz";
+        sha1 = "0252372d94dfc40dbd8df06005f48f31f656f202";
+      };
+    }
+    {
+      name = "cli_width___cli_width_2.2.0.tgz";
+      path = fetchurl {
+        name = "cli_width___cli_width_2.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz";
+        sha1 = "ff19ede8a9a5e579324147b0c11f0fbcbabed639";
+      };
+    }
+    {
+      name = "cliui___cliui_3.2.0.tgz";
+      path = fetchurl {
+        name = "cliui___cliui_3.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz";
+        sha1 = "120601537a916d29940f934da3b48d585a39213d";
+      };
+    }
+    {
+      name = "cliui___cliui_4.1.0.tgz";
+      path = fetchurl {
+        name = "cliui___cliui_4.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz";
+        sha1 = "348422dbe82d800b3022eef4f6ac10bf2e4d1b49";
+      };
+    }
+    {
+      name = "cliui___cliui_6.0.0.tgz";
+      path = fetchurl {
+        name = "cliui___cliui_6.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz";
+        sha1 = "511d702c0c4e41ca156d7d0e96021f23e13225b1";
+      };
+    }
+    {
+      name = "clone_response___clone_response_1.0.2.tgz";
+      path = fetchurl {
+        name = "clone_response___clone_response_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz";
+        sha1 = "d1dc973920314df67fbeb94223b4ee350239e96b";
+      };
+    }
+    {
+      name = "clone___clone_1.0.4.tgz";
+      path = fetchurl {
+        name = "clone___clone_1.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz";
+        sha1 = "da309cc263df15994c688ca902179ca3c7cd7c7e";
+      };
+    }
+    {
+      name = "cmd_shim___cmd_shim_3.0.3.tgz";
+      path = fetchurl {
+        name = "cmd_shim___cmd_shim_3.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-3.0.3.tgz";
+        sha1 = "2c35238d3df37d98ecdd7d5f6b8dc6b21cadc7cb";
+      };
+    }
+    {
+      name = "code_point_at___code_point_at_1.1.0.tgz";
+      path = fetchurl {
+        name = "code_point_at___code_point_at_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz";
+        sha1 = "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77";
+      };
+    }
+    {
+      name = "color_convert___color_convert_1.9.3.tgz";
+      path = fetchurl {
+        name = "color_convert___color_convert_1.9.3.tgz";
+        url  = "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz";
+        sha1 = "bb71850690e1f136567de629d2d5471deda4c1e8";
+      };
+    }
+    {
+      name = "color_convert___color_convert_2.0.1.tgz";
+      path = fetchurl {
+        name = "color_convert___color_convert_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz";
+        sha1 = "72d3a68d598c9bdb3af2ad1e84f21d896abd4de3";
+      };
+    }
+    {
+      name = "color_name___color_name_1.1.3.tgz";
+      path = fetchurl {
+        name = "color_name___color_name_1.1.3.tgz";
+        url  = "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz";
+        sha1 = "a7d0558bd89c42f795dd42328f740831ca53bc25";
+      };
+    }
+    {
+      name = "color_name___color_name_1.1.4.tgz";
+      path = fetchurl {
+        name = "color_name___color_name_1.1.4.tgz";
+        url  = "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz";
+        sha1 = "c2a09a87acbde69543de6f63fa3995c826c536a2";
+      };
+    }
+    {
+      name = "colors___colors_1.4.0.tgz";
+      path = fetchurl {
+        name = "colors___colors_1.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz";
+        sha1 = "c50491479d4c1bdaed2c9ced32cf7c7dc2360f78";
+      };
+    }
+    {
+      name = "columnify___columnify_1.5.4.tgz";
+      path = fetchurl {
+        name = "columnify___columnify_1.5.4.tgz";
+        url  = "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz";
+        sha1 = "4737ddf1c7b69a8a7c340570782e947eec8e78bb";
+      };
+    }
+    {
+      name = "combined_stream___combined_stream_1.0.8.tgz";
+      path = fetchurl {
+        name = "combined_stream___combined_stream_1.0.8.tgz";
+        url  = "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz";
+        sha1 = "c3d45a8b34fd730631a110a8a2520682b31d5a7f";
+      };
+    }
+    {
+      name = "commander___commander_2.20.3.tgz";
+      path = fetchurl {
+        name = "commander___commander_2.20.3.tgz";
+        url  = "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz";
+        sha1 = "fd485e84c03eb4881c20722ba48035e8531aeb33";
+      };
+    }
+    {
+      name = "compress_commons___compress_commons_2.1.1.tgz";
+      path = fetchurl {
+        name = "compress_commons___compress_commons_2.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/compress-commons/-/compress-commons-2.1.1.tgz";
+        sha1 = "9410d9a534cf8435e3fbbb7c6ce48de2dc2f0610";
+      };
+    }
+    {
+      name = "concat_map___concat_map_0.0.1.tgz";
+      path = fetchurl {
+        name = "concat_map___concat_map_0.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz";
+        sha1 = "d8a96bd77fd68df7793a73036a3ba0d5405d477b";
+      };
+    }
+    {
+      name = "concat_stream___concat_stream_1.6.2.tgz";
+      path = fetchurl {
+        name = "concat_stream___concat_stream_1.6.2.tgz";
+        url  = "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz";
+        sha1 = "904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34";
       };
     }
     {
@@ -130,11 +1002,139 @@
       };
     }
     {
+      name = "config_chain___config_chain_1.1.12.tgz";
+      path = fetchurl {
+        name = "config_chain___config_chain_1.1.12.tgz";
+        url  = "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz";
+        sha1 = "0fde8d091200eb5e808caf25fe618c02f48e4efa";
+      };
+    }
+    {
+      name = "configstore___configstore_3.1.2.tgz";
+      path = fetchurl {
+        name = "configstore___configstore_3.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/configstore/-/configstore-3.1.2.tgz";
+        sha1 = "c6f25defaeef26df12dd33414b001fe81a543f8f";
+      };
+    }
+    {
+      name = "configstore___configstore_5.0.1.tgz";
+      path = fetchurl {
+        name = "configstore___configstore_5.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/configstore/-/configstore-5.0.1.tgz";
+        sha1 = "d365021b5df4b98cdd187d6a3b0e3f6a7cc5ed96";
+      };
+    }
+    {
+      name = "console_control_strings___console_control_strings_1.1.0.tgz";
+      path = fetchurl {
+        name = "console_control_strings___console_control_strings_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz";
+        sha1 = "3d7cf4464db6446ea644bf4b39507f9851008e8e";
+      };
+    }
+    {
+      name = "content_type___content_type_1.0.4.tgz";
+      path = fetchurl {
+        name = "content_type___content_type_1.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz";
+        sha1 = "e138cc75e040c727b1966fe5e5f8c9aee256fe3b";
+      };
+    }
+    {
+      name = "copy_concurrently___copy_concurrently_1.0.5.tgz";
+      path = fetchurl {
+        name = "copy_concurrently___copy_concurrently_1.0.5.tgz";
+        url  = "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz";
+        sha1 = "92297398cae34937fcafd6ec8139c18051f0b5e0";
+      };
+    }
+    {
       name = "core_util_is___core_util_is_1.0.2.tgz";
       path = fetchurl {
         name = "core_util_is___core_util_is_1.0.2.tgz";
         url  = "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz";
         sha1 = "b5fd54220aa2bc5ab57aab7140c940754503c1a7";
+      };
+    }
+    {
+      name = "crc32_stream___crc32_stream_3.0.1.tgz";
+      path = fetchurl {
+        name = "crc32_stream___crc32_stream_3.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-3.0.1.tgz";
+        sha1 = "cae6eeed003b0e44d739d279de5ae63b171b4e85";
+      };
+    }
+    {
+      name = "crc___crc_3.8.0.tgz";
+      path = fetchurl {
+        name = "crc___crc_3.8.0.tgz";
+        url  = "https://registry.yarnpkg.com/crc/-/crc-3.8.0.tgz";
+        sha1 = "ad60269c2c856f8c299e2c4cc0de4556914056c6";
+      };
+    }
+    {
+      name = "create_error_class___create_error_class_3.0.2.tgz";
+      path = fetchurl {
+        name = "create_error_class___create_error_class_3.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz";
+        sha1 = "06be7abef947a3f14a30fd610671d401bca8b7b6";
+      };
+    }
+    {
+      name = "cross_spawn___cross_spawn_5.1.0.tgz";
+      path = fetchurl {
+        name = "cross_spawn___cross_spawn_5.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz";
+        sha1 = "e8bd0efee58fcff6f8f94510a0a554bbfa235449";
+      };
+    }
+    {
+      name = "cross_spawn___cross_spawn_6.0.5.tgz";
+      path = fetchurl {
+        name = "cross_spawn___cross_spawn_6.0.5.tgz";
+        url  = "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz";
+        sha1 = "4a5ec7c64dfae22c3a14124dbacdee846d80cbc4";
+      };
+    }
+    {
+      name = "cross_unzip___cross_unzip_0.0.2.tgz";
+      path = fetchurl {
+        name = "cross_unzip___cross_unzip_0.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/cross-unzip/-/cross-unzip-0.0.2.tgz";
+        sha1 = "5183bc47a09559befcf98cc4657964999359372f";
+      };
+    }
+    {
+      name = "crypto_random_string___crypto_random_string_1.0.0.tgz";
+      path = fetchurl {
+        name = "crypto_random_string___crypto_random_string_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz";
+        sha1 = "a230f64f568310e1498009940790ec99545bca7e";
+      };
+    }
+    {
+      name = "crypto_random_string___crypto_random_string_2.0.0.tgz";
+      path = fetchurl {
+        name = "crypto_random_string___crypto_random_string_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz";
+        sha1 = "ef2a7a966ec11083388369baa02ebead229b30d5";
+      };
+    }
+    {
+      name = "cuint___cuint_0.2.2.tgz";
+      path = fetchurl {
+        name = "cuint___cuint_0.2.2.tgz";
+        url  = "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz";
+        sha1 = "408086d409550c2631155619e9fa7bcadc3b991b";
+      };
+    }
+    {
+      name = "cyclist___cyclist_1.0.1.tgz";
+      path = fetchurl {
+        name = "cyclist___cyclist_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz";
+        sha1 = "596e9698fd0c80e12038c2b82d6eb1b35b6224d9";
       };
     }
     {
@@ -146,11 +1146,99 @@
       };
     }
     {
-      name = "deep_equal___deep_equal_1.0.1.tgz";
+      name = "debug___debug_3.1.0.tgz";
       path = fetchurl {
-        name = "deep_equal___deep_equal_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz";
-        sha1 = "f5d260292b660e084eff4cdbc9f08ad3247448b5";
+        name = "debug___debug_3.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz";
+        sha1 = "5bb5a0672628b64149566ba16819e61518c67261";
+      };
+    }
+    {
+      name = "debug___debug_3.2.6.tgz";
+      path = fetchurl {
+        name = "debug___debug_3.2.6.tgz";
+        url  = "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz";
+        sha1 = "e83d17de16d8a7efb7717edbe5fb10135eee629b";
+      };
+    }
+    {
+      name = "debug___debug_4.1.1.tgz";
+      path = fetchurl {
+        name = "debug___debug_4.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz";
+        sha1 = "3b72260255109c6b589cee050f1d516139664791";
+      };
+    }
+    {
+      name = "debuglog___debuglog_1.0.1.tgz";
+      path = fetchurl {
+        name = "debuglog___debuglog_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz";
+        sha1 = "aa24ffb9ac3df9a2351837cfb2d279360cd78492";
+      };
+    }
+    {
+      name = "decamelize___decamelize_1.2.0.tgz";
+      path = fetchurl {
+        name = "decamelize___decamelize_1.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz";
+        sha1 = "f6534d15148269b20352e7bee26f501f9a191290";
+      };
+    }
+    {
+      name = "decode_uri_component___decode_uri_component_0.2.0.tgz";
+      path = fetchurl {
+        name = "decode_uri_component___decode_uri_component_0.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz";
+        sha1 = "eb3913333458775cb84cd1a1fae062106bb87545";
+      };
+    }
+    {
+      name = "decompress_response___decompress_response_3.3.0.tgz";
+      path = fetchurl {
+        name = "decompress_response___decompress_response_3.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz";
+        sha1 = "80a4dd323748384bfa248083622aedec982adff3";
+      };
+    }
+    {
+      name = "deep_equal___deep_equal_1.1.1.tgz";
+      path = fetchurl {
+        name = "deep_equal___deep_equal_1.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz";
+        sha1 = "b5c98c942ceffaf7cb051e24e1434a25a2e6076a";
+      };
+    }
+    {
+      name = "deep_extend___deep_extend_0.6.0.tgz";
+      path = fetchurl {
+        name = "deep_extend___deep_extend_0.6.0.tgz";
+        url  = "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz";
+        sha1 = "c4fa7c95404a17a9c3e8ca7e1537312b736330ac";
+      };
+    }
+    {
+      name = "deep_is___deep_is_0.1.3.tgz";
+      path = fetchurl {
+        name = "deep_is___deep_is_0.1.3.tgz";
+        url  = "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz";
+        sha1 = "b369d6fb5dbc13eecf524f91b070feedc357cf34";
+      };
+    }
+    {
+      name = "defaults___defaults_1.0.3.tgz";
+      path = fetchurl {
+        name = "defaults___defaults_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz";
+        sha1 = "c656051e9817d9ff08ed881477f3fe4019f3ef7d";
+      };
+    }
+    {
+      name = "defer_to_connect___defer_to_connect_1.1.1.tgz";
+      path = fetchurl {
+        name = "defer_to_connect___defer_to_connect_1.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.1.tgz";
+        sha1 = "88ae694b93f67b81815a2c8c769aef6574ac8f2f";
       };
     }
     {
@@ -170,6 +1258,62 @@
       };
     }
     {
+      name = "delegates___delegates_1.0.0.tgz";
+      path = fetchurl {
+        name = "delegates___delegates_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz";
+        sha1 = "84c6e159b81904fdca59a0ef44cd870d31250f9a";
+      };
+    }
+    {
+      name = "detect_indent___detect_indent_5.0.0.tgz";
+      path = fetchurl {
+        name = "detect_indent___detect_indent_5.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz";
+        sha1 = "3871cc0a6a002e8c3e5b3cf7f336264675f06b9d";
+      };
+    }
+    {
+      name = "detect_libc___detect_libc_1.0.3.tgz";
+      path = fetchurl {
+        name = "detect_libc___detect_libc_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz";
+        sha1 = "fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b";
+      };
+    }
+    {
+      name = "detect_newline___detect_newline_2.1.0.tgz";
+      path = fetchurl {
+        name = "detect_newline___detect_newline_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz";
+        sha1 = "f41f1c10be4b00e87b5f13da680759f2c5bfd3e2";
+      };
+    }
+    {
+      name = "dezalgo___dezalgo_1.0.3.tgz";
+      path = fetchurl {
+        name = "dezalgo___dezalgo_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz";
+        sha1 = "7f742de066fc748bc8db820569dddce49bf0d456";
+      };
+    }
+    {
+      name = "dmg_builder___dmg_builder_22.3.2.tgz";
+      path = fetchurl {
+        name = "dmg_builder___dmg_builder_22.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.3.2.tgz";
+        sha1 = "4c052f75d601e3358da1ff9d7d57738e1c01b157";
+      };
+    }
+    {
+      name = "doctrine___doctrine_3.0.0.tgz";
+      path = fetchurl {
+        name = "doctrine___doctrine_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz";
+        sha1 = "addebead72a6574db783639dc87a121773973961";
+      };
+    }
+    {
       name = "dom_walk___dom_walk_0.1.1.tgz";
       path = fetchurl {
         name = "dom_walk___dom_walk_0.1.1.tgz";
@@ -186,11 +1330,123 @@
       };
     }
     {
+      name = "dot_prop___dot_prop_5.2.0.tgz";
+      path = fetchurl {
+        name = "dot_prop___dot_prop_5.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.2.0.tgz";
+        sha1 = "c34ecc29556dc45f1f4c22697b6f4904e0cc4fcb";
+      };
+    }
+    {
+      name = "dotenv_expand___dotenv_expand_5.1.0.tgz";
+      path = fetchurl {
+        name = "dotenv_expand___dotenv_expand_5.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz";
+        sha1 = "3fbaf020bfd794884072ea26b1e9791d45a629f0";
+      };
+    }
+    {
+      name = "dotenv___dotenv_5.0.1.tgz";
+      path = fetchurl {
+        name = "dotenv___dotenv_5.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz";
+        sha1 = "a5317459bd3d79ab88cff6e44057a6a3fbb1fcef";
+      };
+    }
+    {
+      name = "dotenv___dotenv_8.2.0.tgz";
+      path = fetchurl {
+        name = "dotenv___dotenv_8.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz";
+        sha1 = "97e619259ada750eea3e4ea3e26bceea5424b16a";
+      };
+    }
+    {
+      name = "duplexer3___duplexer3_0.1.4.tgz";
+      path = fetchurl {
+        name = "duplexer3___duplexer3_0.1.4.tgz";
+        url  = "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz";
+        sha1 = "ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2";
+      };
+    }
+    {
+      name = "duplexify___duplexify_3.7.1.tgz";
+      path = fetchurl {
+        name = "duplexify___duplexify_3.7.1.tgz";
+        url  = "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz";
+        sha1 = "2a4df5317f6ccfd91f86d6fd25d8d8a103b88309";
+      };
+    }
+    {
       name = "ecc_jsbn___ecc_jsbn_0.1.2.tgz";
       path = fetchurl {
         name = "ecc_jsbn___ecc_jsbn_0.1.2.tgz";
         url  = "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz";
         sha1 = "3a83a904e54353287874c564b7549386849a98c9";
+      };
+    }
+    {
+      name = "editor___editor_1.0.0.tgz";
+      path = fetchurl {
+        name = "editor___editor_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz";
+        sha1 = "60c7f87bd62bcc6a894fa8ccd6afb7823a24f742";
+      };
+    }
+    {
+      name = "ejs___ejs_3.0.1.tgz";
+      path = fetchurl {
+        name = "ejs___ejs_3.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/ejs/-/ejs-3.0.1.tgz";
+        sha1 = "30c8f6ee9948502cc32e85c37a3f8b39b5a614a5";
+      };
+    }
+    {
+      name = "electron_builder_squirrel_windows___electron_builder_squirrel_windows_22.3.3.tgz";
+      path = fetchurl {
+        name = "electron_builder_squirrel_windows___electron_builder_squirrel_windows_22.3.3.tgz";
+        url  = "https://registry.yarnpkg.com/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-22.3.3.tgz";
+        sha1 = "0a417af35c83b067096bd3217b6b7bd75c6c48a9";
+      };
+    }
+    {
+      name = "electron_builder___electron_builder_22.3.2.tgz";
+      path = fetchurl {
+        name = "electron_builder___electron_builder_22.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.3.2.tgz";
+        sha1 = "902d150fc0670cb90213262e5e0aa3c4f299ffa4";
+      };
+    }
+    {
+      name = "electron_devtools_installer___electron_devtools_installer_2.2.4.tgz";
+      path = fetchurl {
+        name = "electron_devtools_installer___electron_devtools_installer_2.2.4.tgz";
+        url  = "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.4.tgz";
+        sha1 = "261a50337e37121d338b966f07922eb4939a8763";
+      };
+    }
+    {
+      name = "electron_notarize___electron_notarize_0.2.1.tgz";
+      path = fetchurl {
+        name = "electron_notarize___electron_notarize_0.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-0.2.1.tgz";
+        sha1 = "759e8006decae19134f82996ed910db26d9192cc";
+      };
+    }
+    {
+      name = "electron_publish___electron_publish_22.3.2.tgz";
+      path = fetchurl {
+        name = "electron_publish___electron_publish_22.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.3.2.tgz";
+        sha1 = "d2e60caf7a9643fe57e501c20acaf32c737b1c50";
+      };
+    }
+    {
+      name = "electron_publish___electron_publish_22.3.3.tgz";
+      path = fetchurl {
+        name = "electron_publish___electron_publish_22.3.3.tgz";
+        url  = "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.3.3.tgz";
+        sha1 = "7d1e757a20ce0558fdc42900b6e3d773fdae9d9e";
       };
     }
     {
@@ -210,6 +1466,38 @@
       };
     }
     {
+      name = "emoji_regex___emoji_regex_7.0.3.tgz";
+      path = fetchurl {
+        name = "emoji_regex___emoji_regex_7.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz";
+        sha1 = "933a04052860c85e83c122479c4748a8e4c72156";
+      };
+    }
+    {
+      name = "emoji_regex___emoji_regex_8.0.0.tgz";
+      path = fetchurl {
+        name = "emoji_regex___emoji_regex_8.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz";
+        sha1 = "e818fd69ce5ccfcb404594f842963bf53164cc37";
+      };
+    }
+    {
+      name = "encoding___encoding_0.1.12.tgz";
+      path = fetchurl {
+        name = "encoding___encoding_0.1.12.tgz";
+        url  = "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz";
+        sha1 = "538b66f3ee62cd1ab51ec323829d1f9480c74beb";
+      };
+    }
+    {
+      name = "end_of_stream___end_of_stream_1.4.4.tgz";
+      path = fetchurl {
+        name = "end_of_stream___end_of_stream_1.4.4.tgz";
+        url  = "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz";
+        sha1 = "5ae64a5f45057baf3626ec14da0ca5e4b2431eb0";
+      };
+    }
+    {
       name = "env_paths___env_paths_1.0.0.tgz";
       path = fetchurl {
         name = "env_paths___env_paths_1.0.0.tgz";
@@ -218,19 +1506,51 @@
       };
     }
     {
-      name = "es_abstract___es_abstract_1.13.0.tgz";
+      name = "env_paths___env_paths_2.2.0.tgz";
       path = fetchurl {
-        name = "es_abstract___es_abstract_1.13.0.tgz";
-        url  = "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz";
-        sha1 = "ac86145fdd5099d8dd49558ccba2eaf9b88e24e9";
+        name = "env_paths___env_paths_2.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz";
+        sha1 = "cdca557dc009152917d6166e2febe1f039685e43";
       };
     }
     {
-      name = "es_to_primitive___es_to_primitive_1.2.0.tgz";
+      name = "err_code___err_code_1.1.2.tgz";
       path = fetchurl {
-        name = "es_to_primitive___es_to_primitive_1.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz";
-        sha1 = "edf72478033456e8dda8ef09e00ad9650707f377";
+        name = "err_code___err_code_1.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz";
+        sha1 = "06e0116d3028f6aef4806849eb0ea6a748ae6960";
+      };
+    }
+    {
+      name = "errno___errno_0.1.7.tgz";
+      path = fetchurl {
+        name = "errno___errno_0.1.7.tgz";
+        url  = "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz";
+        sha1 = "4684d71779ad39af177e3f007996f7c67c852618";
+      };
+    }
+    {
+      name = "error_ex___error_ex_1.3.2.tgz";
+      path = fetchurl {
+        name = "error_ex___error_ex_1.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz";
+        sha1 = "b4ac40648107fdcdcfae242f428bea8a14d4f1bf";
+      };
+    }
+    {
+      name = "es_abstract___es_abstract_1.16.3.tgz";
+      path = fetchurl {
+        name = "es_abstract___es_abstract_1.16.3.tgz";
+        url  = "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.16.3.tgz";
+        sha1 = "52490d978f96ff9f89ec15b5cf244304a5bca161";
+      };
+    }
+    {
+      name = "es_to_primitive___es_to_primitive_1.2.1.tgz";
+      path = fetchurl {
+        name = "es_to_primitive___es_to_primitive_1.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz";
+        sha1 = "e55cd4c9cdc188bcefb03b366c736323fc5c898a";
       };
     }
     {
@@ -239,6 +1559,150 @@
         name = "es6_promise___es6_promise_3.3.1.tgz";
         url  = "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz";
         sha1 = "a08cdde84ccdbf34d027a1451bc91d4bcd28a613";
+      };
+    }
+    {
+      name = "es6_promise___es6_promise_4.2.8.tgz";
+      path = fetchurl {
+        name = "es6_promise___es6_promise_4.2.8.tgz";
+        url  = "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz";
+        sha1 = "4eb21594c972bc40553d276e510539143db53e0a";
+      };
+    }
+    {
+      name = "es6_promisify___es6_promisify_5.0.0.tgz";
+      path = fetchurl {
+        name = "es6_promisify___es6_promisify_5.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz";
+        sha1 = "5109d62f3e56ea967c4b63505aef08291c8a5203";
+      };
+    }
+    {
+      name = "escape_goat___escape_goat_2.1.1.tgz";
+      path = fetchurl {
+        name = "escape_goat___escape_goat_2.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz";
+        sha1 = "1b2dc77003676c457ec760b2dc68edb648188675";
+      };
+    }
+    {
+      name = "escape_string_regexp___escape_string_regexp_1.0.5.tgz";
+      path = fetchurl {
+        name = "escape_string_regexp___escape_string_regexp_1.0.5.tgz";
+        url  = "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
+        sha1 = "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4";
+      };
+    }
+    {
+      name = "eslint_config_google___eslint_config_google_0.7.1.tgz";
+      path = fetchurl {
+        name = "eslint_config_google___eslint_config_google_0.7.1.tgz";
+        url  = "https://registry.yarnpkg.com/eslint-config-google/-/eslint-config-google-0.7.1.tgz";
+        sha1 = "5598f8498e9e078420f34b80495b8d959f651fb2";
+      };
+    }
+    {
+      name = "eslint_plugin_babel___eslint_plugin_babel_4.1.2.tgz";
+      path = fetchurl {
+        name = "eslint_plugin_babel___eslint_plugin_babel_4.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.1.2.tgz";
+        sha1 = "79202a0e35757dd92780919b2336f1fa2fe53c1e";
+      };
+    }
+    {
+      name = "eslint_scope___eslint_scope_4.0.3.tgz";
+      path = fetchurl {
+        name = "eslint_scope___eslint_scope_4.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz";
+        sha1 = "ca03833310f6889a3264781aa82e63eb9cfe7848";
+      };
+    }
+    {
+      name = "eslint_utils___eslint_utils_1.4.3.tgz";
+      path = fetchurl {
+        name = "eslint_utils___eslint_utils_1.4.3.tgz";
+        url  = "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz";
+        sha1 = "74fec7c54d0776b6f67e0251040b5806564e981f";
+      };
+    }
+    {
+      name = "eslint_visitor_keys___eslint_visitor_keys_1.1.0.tgz";
+      path = fetchurl {
+        name = "eslint_visitor_keys___eslint_visitor_keys_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz";
+        sha1 = "e2a82cea84ff246ad6fb57f9bde5b46621459ec2";
+      };
+    }
+    {
+      name = "eslint___eslint_5.16.0.tgz";
+      path = fetchurl {
+        name = "eslint___eslint_5.16.0.tgz";
+        url  = "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz";
+        sha1 = "a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea";
+      };
+    }
+    {
+      name = "espree___espree_5.0.1.tgz";
+      path = fetchurl {
+        name = "espree___espree_5.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz";
+        sha1 = "5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a";
+      };
+    }
+    {
+      name = "esprima___esprima_4.0.1.tgz";
+      path = fetchurl {
+        name = "esprima___esprima_4.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz";
+        sha1 = "13b04cdb3e6c5d19df91ab6987a8695619b0aa71";
+      };
+    }
+    {
+      name = "esquery___esquery_1.0.1.tgz";
+      path = fetchurl {
+        name = "esquery___esquery_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz";
+        sha1 = "406c51658b1f5991a5f9b62b1dc25b00e3e5c708";
+      };
+    }
+    {
+      name = "esrecurse___esrecurse_4.2.1.tgz";
+      path = fetchurl {
+        name = "esrecurse___esrecurse_4.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz";
+        sha1 = "007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf";
+      };
+    }
+    {
+      name = "estraverse___estraverse_4.3.0.tgz";
+      path = fetchurl {
+        name = "estraverse___estraverse_4.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz";
+        sha1 = "398ad3f3c5a24948be7725e83d11a7de28cdbd1d";
+      };
+    }
+    {
+      name = "esutils___esutils_2.0.3.tgz";
+      path = fetchurl {
+        name = "esutils___esutils_2.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz";
+        sha1 = "74d2eb4de0b8da1293711910d50775b9b710ef64";
+      };
+    }
+    {
+      name = "execa___execa_0.7.0.tgz";
+      path = fetchurl {
+        name = "execa___execa_0.7.0.tgz";
+        url  = "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz";
+        sha1 = "944becd34cc41ee32a63a9faf27ad5a65fc59777";
+      };
+    }
+    {
+      name = "execa___execa_1.0.0.tgz";
+      path = fetchurl {
+        name = "execa___execa_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz";
+        sha1 = "c6236a5bb4df6d6f15e88e7f017798216749ddd8";
       };
     }
     {
@@ -255,6 +1719,14 @@
         name = "extend___extend_3.0.2.tgz";
         url  = "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz";
         sha1 = "f8b1136b4071fbd8eb140aff858b1019ec2915fa";
+      };
+    }
+    {
+      name = "external_editor___external_editor_3.1.0.tgz";
+      path = fetchurl {
+        name = "external_editor___external_editor_3.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz";
+        sha1 = "cb03f740befae03ea4d283caed2741a83f335495";
       };
     }
     {
@@ -290,11 +1762,51 @@
       };
     }
     {
+      name = "fast_levenshtein___fast_levenshtein_2.0.6.tgz";
+      path = fetchurl {
+        name = "fast_levenshtein___fast_levenshtein_2.0.6.tgz";
+        url  = "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz";
+        sha1 = "3d8a5c66883a16a30ca8643e851f19baa7797917";
+      };
+    }
+    {
+      name = "figgy_pudding___figgy_pudding_3.5.1.tgz";
+      path = fetchurl {
+        name = "figgy_pudding___figgy_pudding_3.5.1.tgz";
+        url  = "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz";
+        sha1 = "862470112901c727a0e495a80744bd5baa1d6790";
+      };
+    }
+    {
+      name = "figures___figures_2.0.0.tgz";
+      path = fetchurl {
+        name = "figures___figures_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz";
+        sha1 = "3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962";
+      };
+    }
+    {
+      name = "file_entry_cache___file_entry_cache_5.0.1.tgz";
+      path = fetchurl {
+        name = "file_entry_cache___file_entry_cache_5.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz";
+        sha1 = "ca0f6efa6dd3d561333fb14515065c2fafdf439c";
+      };
+    }
+    {
       name = "file_type___file_type_3.9.0.tgz";
       path = fetchurl {
         name = "file_type___file_type_3.9.0.tgz";
         url  = "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz";
         sha1 = "257a078384d1db8087bc449d107d52a52672b9e9";
+      };
+    }
+    {
+      name = "find_npm_prefix___find_npm_prefix_1.0.2.tgz";
+      path = fetchurl {
+        name = "find_npm_prefix___find_npm_prefix_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz";
+        sha1 = "8d8ce2c78b3b4b9e66c8acc6a37c231eb841cfdf";
       };
     }
     {
@@ -306,11 +1818,43 @@
       };
     }
     {
-      name = "for_each___for_each_0.3.3.tgz";
+      name = "find_up___find_up_3.0.0.tgz";
       path = fetchurl {
-        name = "for_each___for_each_0.3.3.tgz";
-        url  = "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz";
-        sha1 = "69b447e88a0a5d32c3e7084f3f1710034b21376e";
+        name = "find_up___find_up_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz";
+        sha1 = "49169f1d7993430646da61ecc5ae355c21c97b73";
+      };
+    }
+    {
+      name = "find_up___find_up_4.1.0.tgz";
+      path = fetchurl {
+        name = "find_up___find_up_4.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz";
+        sha1 = "97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19";
+      };
+    }
+    {
+      name = "flat_cache___flat_cache_2.0.1.tgz";
+      path = fetchurl {
+        name = "flat_cache___flat_cache_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz";
+        sha1 = "5d296d6f04bda44a4630a301413bdbc2ec085ec0";
+      };
+    }
+    {
+      name = "flatted___flatted_2.0.1.tgz";
+      path = fetchurl {
+        name = "flatted___flatted_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz";
+        sha1 = "69e57caa8f0eacbc281d2e2cb458d46fdb449e08";
+      };
+    }
+    {
+      name = "flush_write_stream___flush_write_stream_1.1.1.tgz";
+      path = fetchurl {
+        name = "flush_write_stream___flush_write_stream_1.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz";
+        sha1 = "8dd7d873a1babc207d94ead0c2e0e44276ebf2e8";
       };
     }
     {
@@ -330,11 +1874,155 @@
       };
     }
     {
+      name = "from2___from2_1.3.0.tgz";
+      path = fetchurl {
+        name = "from2___from2_1.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/from2/-/from2-1.3.0.tgz";
+        sha1 = "88413baaa5f9a597cfde9221d86986cd3c061dfd";
+      };
+    }
+    {
+      name = "from2___from2_2.3.0.tgz";
+      path = fetchurl {
+        name = "from2___from2_2.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz";
+        sha1 = "8bfb5502bde4a4d36cfdeea007fcca21d7e382af";
+      };
+    }
+    {
+      name = "fs_constants___fs_constants_1.0.0.tgz";
+      path = fetchurl {
+        name = "fs_constants___fs_constants_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz";
+        sha1 = "6be0de9be998ce16af8afc24497b9ee9b7ccd9ad";
+      };
+    }
+    {
+      name = "fs_extra___fs_extra_8.1.0.tgz";
+      path = fetchurl {
+        name = "fs_extra___fs_extra_8.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz";
+        sha1 = "49d43c45a88cd9677668cb7be1b46efdb8d2e1c0";
+      };
+    }
+    {
+      name = "fs_minipass___fs_minipass_1.2.7.tgz";
+      path = fetchurl {
+        name = "fs_minipass___fs_minipass_1.2.7.tgz";
+        url  = "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz";
+        sha1 = "ccff8570841e7fe4265693da88936c55aed7f7c7";
+      };
+    }
+    {
+      name = "fs_minipass___fs_minipass_2.0.0.tgz";
+      path = fetchurl {
+        name = "fs_minipass___fs_minipass_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.0.0.tgz";
+        sha1 = "a6415edab02fae4b9e9230bc87ee2e4472003cd1";
+      };
+    }
+    {
+      name = "fs_vacuum___fs_vacuum_1.2.10.tgz";
+      path = fetchurl {
+        name = "fs_vacuum___fs_vacuum_1.2.10.tgz";
+        url  = "https://registry.yarnpkg.com/fs-vacuum/-/fs-vacuum-1.2.10.tgz";
+        sha1 = "b7629bec07a4031a2548fdf99f5ecf1cc8b31e36";
+      };
+    }
+    {
+      name = "fs_write_stream_atomic___fs_write_stream_atomic_1.0.10.tgz";
+      path = fetchurl {
+        name = "fs_write_stream_atomic___fs_write_stream_atomic_1.0.10.tgz";
+        url  = "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz";
+        sha1 = "b47df53493ef911df75731e70a9ded0189db40c9";
+      };
+    }
+    {
+      name = "fs.realpath___fs.realpath_1.0.0.tgz";
+      path = fetchurl {
+        name = "fs.realpath___fs.realpath_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz";
+        sha1 = "1504ad2523158caa40db4a2787cb01411994ea4f";
+      };
+    }
+    {
       name = "function_bind___function_bind_1.1.1.tgz";
       path = fetchurl {
         name = "function_bind___function_bind_1.1.1.tgz";
         url  = "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz";
         sha1 = "a56899d3ea3c9bab874bb9773b7c5ede92f4895d";
+      };
+    }
+    {
+      name = "functional_red_black_tree___functional_red_black_tree_1.0.1.tgz";
+      path = fetchurl {
+        name = "functional_red_black_tree___functional_red_black_tree_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz";
+        sha1 = "1b0ab3bd553b2a0d6399d29c0e3ea0b252078327";
+      };
+    }
+    {
+      name = "gauge___gauge_2.7.4.tgz";
+      path = fetchurl {
+        name = "gauge___gauge_2.7.4.tgz";
+        url  = "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz";
+        sha1 = "2c03405c7538c39d7eb37b317022e325fb018bf7";
+      };
+    }
+    {
+      name = "genfun___genfun_5.0.0.tgz";
+      path = fetchurl {
+        name = "genfun___genfun_5.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz";
+        sha1 = "9dd9710a06900a5c4a5bf57aca5da4e52fe76537";
+      };
+    }
+    {
+      name = "gentle_fs___gentle_fs_2.3.0.tgz";
+      path = fetchurl {
+        name = "gentle_fs___gentle_fs_2.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/gentle-fs/-/gentle-fs-2.3.0.tgz";
+        sha1 = "13538db5029400f98684be4894e8a7d8f0d1ea7f";
+      };
+    }
+    {
+      name = "get_caller_file___get_caller_file_1.0.3.tgz";
+      path = fetchurl {
+        name = "get_caller_file___get_caller_file_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz";
+        sha1 = "f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a";
+      };
+    }
+    {
+      name = "get_caller_file___get_caller_file_2.0.5.tgz";
+      path = fetchurl {
+        name = "get_caller_file___get_caller_file_2.0.5.tgz";
+        url  = "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz";
+        sha1 = "4f94412a82db32f36e3b0b9741f8a97feb031f7e";
+      };
+    }
+    {
+      name = "get_stream___get_stream_3.0.0.tgz";
+      path = fetchurl {
+        name = "get_stream___get_stream_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz";
+        sha1 = "8e943d1358dc37555054ecbe2edb05aa174ede14";
+      };
+    }
+    {
+      name = "get_stream___get_stream_4.1.0.tgz";
+      path = fetchurl {
+        name = "get_stream___get_stream_4.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz";
+        sha1 = "c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5";
+      };
+    }
+    {
+      name = "get_stream___get_stream_5.1.0.tgz";
+      path = fetchurl {
+        name = "get_stream___get_stream_5.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz";
+        sha1 = "01203cdc92597f9b909067c3e656cc1f4d3c4dc9";
       };
     }
     {
@@ -346,6 +2034,30 @@
       };
     }
     {
+      name = "glob___glob_7.1.6.tgz";
+      path = fetchurl {
+        name = "glob___glob_7.1.6.tgz";
+        url  = "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz";
+        sha1 = "141f33b81a7c2492e125594307480c46679278a6";
+      };
+    }
+    {
+      name = "global_dirs___global_dirs_0.1.1.tgz";
+      path = fetchurl {
+        name = "global_dirs___global_dirs_0.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz";
+        sha1 = "b319c0dd4607f353f3be9cca4c72fc148c49f445";
+      };
+    }
+    {
+      name = "global_dirs___global_dirs_2.0.1.tgz";
+      path = fetchurl {
+        name = "global_dirs___global_dirs_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/global-dirs/-/global-dirs-2.0.1.tgz";
+        sha1 = "acdf3bb6685bcd55cb35e8a052266569e9469201";
+      };
+    }
+    {
       name = "global___global_4.3.2.tgz";
       path = fetchurl {
         name = "global___global_4.3.2.tgz";
@@ -354,11 +2066,35 @@
       };
     }
     {
-      name = "graceful_fs___graceful_fs_4.1.15.tgz";
+      name = "globals___globals_11.12.0.tgz";
       path = fetchurl {
-        name = "graceful_fs___graceful_fs_4.1.15.tgz";
-        url  = "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz";
-        sha1 = "ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00";
+        name = "globals___globals_11.12.0.tgz";
+        url  = "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz";
+        sha1 = "ab8795338868a0babd8525758018c2a7eb95c42e";
+      };
+    }
+    {
+      name = "got___got_6.7.1.tgz";
+      path = fetchurl {
+        name = "got___got_6.7.1.tgz";
+        url  = "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz";
+        sha1 = "240cd05785a9a18e561dc1b44b41c763ef1e8db0";
+      };
+    }
+    {
+      name = "got___got_9.6.0.tgz";
+      path = fetchurl {
+        name = "got___got_9.6.0.tgz";
+        url  = "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz";
+        sha1 = "edf45e7d67f99545705de1f7bbeeeb121765ed85";
+      };
+    }
+    {
+      name = "graceful_fs___graceful_fs_4.2.3.tgz";
+      path = fetchurl {
+        name = "graceful_fs___graceful_fs_4.2.3.tgz";
+        url  = "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz";
+        sha1 = "4a12ff1b60376ef09862c2093edd908328be8423";
       };
     }
     {
@@ -378,11 +2114,43 @@
       };
     }
     {
-      name = "has_symbols___has_symbols_1.0.0.tgz";
+      name = "has_flag___has_flag_3.0.0.tgz";
       path = fetchurl {
-        name = "has_symbols___has_symbols_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz";
-        sha1 = "ba1a8f1af2a0fc39650f5c850367704122063b44";
+        name = "has_flag___has_flag_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz";
+        sha1 = "b5d454dc2199ae225699f3467e5a07f3b955bafd";
+      };
+    }
+    {
+      name = "has_flag___has_flag_4.0.0.tgz";
+      path = fetchurl {
+        name = "has_flag___has_flag_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz";
+        sha1 = "944771fd9c81c81265c4d6941860da06bb59479b";
+      };
+    }
+    {
+      name = "has_symbols___has_symbols_1.0.1.tgz";
+      path = fetchurl {
+        name = "has_symbols___has_symbols_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz";
+        sha1 = "9f5214758a44196c406d9bd76cebf81ec2dd31e8";
+      };
+    }
+    {
+      name = "has_unicode___has_unicode_2.0.1.tgz";
+      path = fetchurl {
+        name = "has_unicode___has_unicode_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz";
+        sha1 = "e0e6fe6a28cf51138855e086d1691e771de2a8b9";
+      };
+    }
+    {
+      name = "has_yarn___has_yarn_2.1.0.tgz";
+      path = fetchurl {
+        name = "has_yarn___has_yarn_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/has-yarn/-/has-yarn-2.1.0.tgz";
+        sha1 = "137e11354a7b5bf11aa5cb649cf0c6f3ff2b2e77";
       };
     }
     {
@@ -394,11 +2162,139 @@
       };
     }
     {
+      name = "hosted_git_info___hosted_git_info_2.8.5.tgz";
+      path = fetchurl {
+        name = "hosted_git_info___hosted_git_info_2.8.5.tgz";
+        url  = "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz";
+        sha1 = "759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c";
+      };
+    }
+    {
+      name = "hosted_git_info___hosted_git_info_3.0.2.tgz";
+      path = fetchurl {
+        name = "hosted_git_info___hosted_git_info_3.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.2.tgz";
+        sha1 = "8b7e3bd114b59b51786f8bade0f39ddc80275a97";
+      };
+    }
+    {
+      name = "http_cache_semantics___http_cache_semantics_3.8.1.tgz";
+      path = fetchurl {
+        name = "http_cache_semantics___http_cache_semantics_3.8.1.tgz";
+        url  = "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz";
+        sha1 = "39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2";
+      };
+    }
+    {
+      name = "http_cache_semantics___http_cache_semantics_4.0.3.tgz";
+      path = fetchurl {
+        name = "http_cache_semantics___http_cache_semantics_4.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz";
+        sha1 = "495704773277eeef6e43f9ab2c2c7d259dda25c5";
+      };
+    }
+    {
+      name = "http_proxy_agent___http_proxy_agent_2.1.0.tgz";
+      path = fetchurl {
+        name = "http_proxy_agent___http_proxy_agent_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz";
+        sha1 = "e4821beef5b2142a2026bd73926fe537631c5405";
+      };
+    }
+    {
       name = "http_signature___http_signature_1.2.0.tgz";
       path = fetchurl {
         name = "http_signature___http_signature_1.2.0.tgz";
         url  = "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz";
         sha1 = "9aecd925114772f3d95b65a60abb8f7c18fbace1";
+      };
+    }
+    {
+      name = "https_proxy_agent___https_proxy_agent_2.2.4.tgz";
+      path = fetchurl {
+        name = "https_proxy_agent___https_proxy_agent_2.2.4.tgz";
+        url  = "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz";
+        sha1 = "4ee7a737abd92678a293d9b34a1af4d0d08c787b";
+      };
+    }
+    {
+      name = "humanize_ms___humanize_ms_1.2.1.tgz";
+      path = fetchurl {
+        name = "humanize_ms___humanize_ms_1.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz";
+        sha1 = "c46e3159a293f6b896da29316d8b6fe8bb79bbed";
+      };
+    }
+    {
+      name = "iconv_lite___iconv_lite_0.4.24.tgz";
+      path = fetchurl {
+        name = "iconv_lite___iconv_lite_0.4.24.tgz";
+        url  = "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz";
+        sha1 = "2022b4b25fbddc21d2f524974a474aafe733908b";
+      };
+    }
+    {
+      name = "iconv_lite___iconv_lite_0.5.1.tgz";
+      path = fetchurl {
+        name = "iconv_lite___iconv_lite_0.5.1.tgz";
+        url  = "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.5.1.tgz";
+        sha1 = "b2425d3c7b18f7219f2ca663d103bddb91718d64";
+      };
+    }
+    {
+      name = "ieee754___ieee754_1.1.13.tgz";
+      path = fetchurl {
+        name = "ieee754___ieee754_1.1.13.tgz";
+        url  = "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz";
+        sha1 = "ec168558e95aa181fd87d37f55c32bbcb6708b84";
+      };
+    }
+    {
+      name = "iferr___iferr_0.1.5.tgz";
+      path = fetchurl {
+        name = "iferr___iferr_0.1.5.tgz";
+        url  = "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz";
+        sha1 = "c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501";
+      };
+    }
+    {
+      name = "iferr___iferr_1.0.2.tgz";
+      path = fetchurl {
+        name = "iferr___iferr_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/iferr/-/iferr-1.0.2.tgz";
+        sha1 = "e9fde49a9da06dc4a4194c6c9ed6d08305037a6d";
+      };
+    }
+    {
+      name = "ignore_walk___ignore_walk_3.0.3.tgz";
+      path = fetchurl {
+        name = "ignore_walk___ignore_walk_3.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz";
+        sha1 = "017e2447184bfeade7c238e4aefdd1e8f95b1e37";
+      };
+    }
+    {
+      name = "ignore___ignore_4.0.6.tgz";
+      path = fetchurl {
+        name = "ignore___ignore_4.0.6.tgz";
+        url  = "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz";
+        sha1 = "750e3db5862087b4737ebac8207ffd1ef27b25fc";
+      };
+    }
+    {
+      name = "import_fresh___import_fresh_3.2.1.tgz";
+      path = fetchurl {
+        name = "import_fresh___import_fresh_3.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz";
+        sha1 = "633ff618506e793af5ac91bf48b72677e15cbe66";
+      };
+    }
+    {
+      name = "import_lazy___import_lazy_2.1.0.tgz";
+      path = fetchurl {
+        name = "import_lazy___import_lazy_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz";
+        sha1 = "05698e3d45c88e8d7e9d92cb0584e77f096f3e43";
       };
     }
     {
@@ -410,11 +2306,107 @@
       };
     }
     {
+      name = "infer_owner___infer_owner_1.0.4.tgz";
+      path = fetchurl {
+        name = "infer_owner___infer_owner_1.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz";
+        sha1 = "c4cefcaa8e51051c2a40ba2ce8a3d27295af9467";
+      };
+    }
+    {
+      name = "inflight___inflight_1.0.6.tgz";
+      path = fetchurl {
+        name = "inflight___inflight_1.0.6.tgz";
+        url  = "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz";
+        sha1 = "49bd6331d7d02d0c09bc910a1075ba8165b56df9";
+      };
+    }
+    {
+      name = "inherits___inherits_2.0.4.tgz";
+      path = fetchurl {
+        name = "inherits___inherits_2.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz";
+        sha1 = "0fa2c64f932917c3433a0ded55363aae37416b7c";
+      };
+    }
+    {
+      name = "ini___ini_1.3.5.tgz";
+      path = fetchurl {
+        name = "ini___ini_1.3.5.tgz";
+        url  = "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz";
+        sha1 = "eee25f56db1c9ec6085e0c22778083f596abf927";
+      };
+    }
+    {
+      name = "init_package_json___init_package_json_1.10.3.tgz";
+      path = fetchurl {
+        name = "init_package_json___init_package_json_1.10.3.tgz";
+        url  = "https://registry.yarnpkg.com/init-package-json/-/init-package-json-1.10.3.tgz";
+        sha1 = "45ffe2f610a8ca134f2bd1db5637b235070f6cbe";
+      };
+    }
+    {
+      name = "inquirer___inquirer_6.5.2.tgz";
+      path = fetchurl {
+        name = "inquirer___inquirer_6.5.2.tgz";
+        url  = "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz";
+        sha1 = "ad50942375d036d327ff528c08bd5fab089928ca";
+      };
+    }
+    {
+      name = "invert_kv___invert_kv_1.0.0.tgz";
+      path = fetchurl {
+        name = "invert_kv___invert_kv_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz";
+        sha1 = "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6";
+      };
+    }
+    {
+      name = "invert_kv___invert_kv_2.0.0.tgz";
+      path = fetchurl {
+        name = "invert_kv___invert_kv_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz";
+        sha1 = "7393f5afa59ec9ff5f67a27620d11c226e3eec02";
+      };
+    }
+    {
       name = "ip_regex___ip_regex_1.0.3.tgz";
       path = fetchurl {
         name = "ip_regex___ip_regex_1.0.3.tgz";
         url  = "https://registry.yarnpkg.com/ip-regex/-/ip-regex-1.0.3.tgz";
         sha1 = "dc589076f659f419c222039a33316f1c7387effd";
+      };
+    }
+    {
+      name = "ip_regex___ip_regex_2.1.0.tgz";
+      path = fetchurl {
+        name = "ip_regex___ip_regex_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz";
+        sha1 = "fa78bf5d2e6913c911ce9f819ee5146bb6d844e9";
+      };
+    }
+    {
+      name = "ip___ip_1.1.5.tgz";
+      path = fetchurl {
+        name = "ip___ip_1.1.5.tgz";
+        url  = "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz";
+        sha1 = "bdded70114290828c0a039e72ef25f5aaec4354a";
+      };
+    }
+    {
+      name = "is_arguments___is_arguments_1.0.4.tgz";
+      path = fetchurl {
+        name = "is_arguments___is_arguments_1.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz";
+        sha1 = "3faf966c7cba0ff437fb31f6250082fcf0448cf3";
+      };
+    }
+    {
+      name = "is_arrayish___is_arrayish_0.2.1.tgz";
+      path = fetchurl {
+        name = "is_arrayish___is_arrayish_0.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz";
+        sha1 = "77c99840527aa8ecb1a8ba697b80645a7a926a9d";
       };
     }
     {
@@ -426,11 +2418,59 @@
       };
     }
     {
+      name = "is_ci___is_ci_1.2.1.tgz";
+      path = fetchurl {
+        name = "is_ci___is_ci_1.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz";
+        sha1 = "e3779c8ee17fccf428488f6e281187f2e632841c";
+      };
+    }
+    {
+      name = "is_ci___is_ci_2.0.0.tgz";
+      path = fetchurl {
+        name = "is_ci___is_ci_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz";
+        sha1 = "6bc6334181810e04b5c22b3d589fdca55026404c";
+      };
+    }
+    {
+      name = "is_cidr___is_cidr_3.1.0.tgz";
+      path = fetchurl {
+        name = "is_cidr___is_cidr_3.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-cidr/-/is-cidr-3.1.0.tgz";
+        sha1 = "72e233d8e1c4cd1d3f11713fcce3eba7b0e3476f";
+      };
+    }
+    {
       name = "is_date_object___is_date_object_1.0.1.tgz";
       path = fetchurl {
         name = "is_date_object___is_date_object_1.0.1.tgz";
         url  = "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz";
         sha1 = "9aa20eb6aeebbff77fbd33e74ca01b33581d3a16";
+      };
+    }
+    {
+      name = "is_fullwidth_code_point___is_fullwidth_code_point_1.0.0.tgz";
+      path = fetchurl {
+        name = "is_fullwidth_code_point___is_fullwidth_code_point_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz";
+        sha1 = "ef9e31386f031a7f0d643af82fde50c457ef00cb";
+      };
+    }
+    {
+      name = "is_fullwidth_code_point___is_fullwidth_code_point_2.0.0.tgz";
+      path = fetchurl {
+        name = "is_fullwidth_code_point___is_fullwidth_code_point_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz";
+        sha1 = "a3b30a5c4f199183167aaab93beefae3ddfb654f";
+      };
+    }
+    {
+      name = "is_fullwidth_code_point___is_fullwidth_code_point_3.0.0.tgz";
+      path = fetchurl {
+        name = "is_fullwidth_code_point___is_fullwidth_code_point_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz";
+        sha1 = "f116f8064fe90b3f7844a38997c0b75051269f1d";
       };
     }
     {
@@ -442,11 +2482,83 @@
       };
     }
     {
+      name = "is_installed_globally___is_installed_globally_0.1.0.tgz";
+      path = fetchurl {
+        name = "is_installed_globally___is_installed_globally_0.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz";
+        sha1 = "0dfd98f5a9111716dd535dda6492f67bf3d25a80";
+      };
+    }
+    {
+      name = "is_installed_globally___is_installed_globally_0.3.1.tgz";
+      path = fetchurl {
+        name = "is_installed_globally___is_installed_globally_0.3.1.tgz";
+        url  = "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.3.1.tgz";
+        sha1 = "679afef819347a72584617fd19497f010b8ed35f";
+      };
+    }
+    {
+      name = "is_npm___is_npm_1.0.0.tgz";
+      path = fetchurl {
+        name = "is_npm___is_npm_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz";
+        sha1 = "f2fb63a65e4905b406c86072765a1a4dc793b9f4";
+      };
+    }
+    {
+      name = "is_npm___is_npm_4.0.0.tgz";
+      path = fetchurl {
+        name = "is_npm___is_npm_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-npm/-/is-npm-4.0.0.tgz";
+        sha1 = "c90dd8380696df87a7a6d823c20d0b12bbe3c84d";
+      };
+    }
+    {
       name = "is_obj___is_obj_1.0.1.tgz";
       path = fetchurl {
         name = "is_obj___is_obj_1.0.1.tgz";
         url  = "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz";
         sha1 = "3e4729ac1f5fde025cd7d83a896dab9f4f67db0f";
+      };
+    }
+    {
+      name = "is_obj___is_obj_2.0.0.tgz";
+      path = fetchurl {
+        name = "is_obj___is_obj_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz";
+        sha1 = "473fb05d973705e3fd9620545018ca8e22ef4982";
+      };
+    }
+    {
+      name = "is_path_inside___is_path_inside_1.0.1.tgz";
+      path = fetchurl {
+        name = "is_path_inside___is_path_inside_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz";
+        sha1 = "8ef5b7de50437a3fdca6b4e865ef7aa55cb48036";
+      };
+    }
+    {
+      name = "is_path_inside___is_path_inside_3.0.2.tgz";
+      path = fetchurl {
+        name = "is_path_inside___is_path_inside_3.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz";
+        sha1 = "f5220fc82a3e233757291dddc9c5877f2a1f3017";
+      };
+    }
+    {
+      name = "is_promise___is_promise_2.1.0.tgz";
+      path = fetchurl {
+        name = "is_promise___is_promise_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz";
+        sha1 = "79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa";
+      };
+    }
+    {
+      name = "is_redirect___is_redirect_1.0.0.tgz";
+      path = fetchurl {
+        name = "is_redirect___is_redirect_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz";
+        sha1 = "1d03dded53bd8db0f30c26e4f95d36fc7c87dc24";
       };
     }
     {
@@ -458,11 +2570,27 @@
       };
     }
     {
-      name = "is_symbol___is_symbol_1.0.2.tgz";
+      name = "is_retry_allowed___is_retry_allowed_1.2.0.tgz";
       path = fetchurl {
-        name = "is_symbol___is_symbol_1.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz";
-        sha1 = "a055f6ae57192caee329e7a860118b497a950f38";
+        name = "is_retry_allowed___is_retry_allowed_1.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz";
+        sha1 = "d778488bd0a4666a3be8a1482b9f2baafedea8b4";
+      };
+    }
+    {
+      name = "is_stream___is_stream_1.1.0.tgz";
+      path = fetchurl {
+        name = "is_stream___is_stream_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz";
+        sha1 = "12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44";
+      };
+    }
+    {
+      name = "is_symbol___is_symbol_1.0.3.tgz";
+      path = fetchurl {
+        name = "is_symbol___is_symbol_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz";
+        sha1 = "38e1014b9e6329be0de9d24a414fd7441ec61937";
       };
     }
     {
@@ -471,6 +2599,46 @@
         name = "is_typedarray___is_typedarray_1.0.0.tgz";
         url  = "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz";
         sha1 = "e479c80858df0c1b11ddda6940f96011fcda4a9a";
+      };
+    }
+    {
+      name = "is_yarn_global___is_yarn_global_0.3.0.tgz";
+      path = fetchurl {
+        name = "is_yarn_global___is_yarn_global_0.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz";
+        sha1 = "d502d3382590ea3004893746754c89139973e232";
+      };
+    }
+    {
+      name = "isarray___isarray_0.0.1.tgz";
+      path = fetchurl {
+        name = "isarray___isarray_0.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz";
+        sha1 = "8a18acfca9a8f4177e09abfc6038939b05d1eedf";
+      };
+    }
+    {
+      name = "isarray___isarray_1.0.0.tgz";
+      path = fetchurl {
+        name = "isarray___isarray_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz";
+        sha1 = "bb935d48582cba168c06834957a54a3e07124f11";
+      };
+    }
+    {
+      name = "isbinaryfile___isbinaryfile_4.0.4.tgz";
+      path = fetchurl {
+        name = "isbinaryfile___isbinaryfile_4.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.4.tgz";
+        sha1 = "6803f81a8944201c642b6e17da041e24deb78712";
+      };
+    }
+    {
+      name = "isexe___isexe_2.0.0.tgz";
+      path = fetchurl {
+        name = "isexe___isexe_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz";
+        sha1 = "e8fbf374dc556ff8947a10dcb0572d633f2cfa10";
       };
     }
     {
@@ -498,11 +2666,43 @@
       };
     }
     {
+      name = "js_tokens___js_tokens_4.0.0.tgz";
+      path = fetchurl {
+        name = "js_tokens___js_tokens_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz";
+        sha1 = "19203fb59991df98e3a287050d4647cdeaf32499";
+      };
+    }
+    {
+      name = "js_yaml___js_yaml_3.13.1.tgz";
+      path = fetchurl {
+        name = "js_yaml___js_yaml_3.13.1.tgz";
+        url  = "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz";
+        sha1 = "aff151b30bfdfa8e49e05da22e7415e9dfa37847";
+      };
+    }
+    {
       name = "jsbn___jsbn_0.1.1.tgz";
       path = fetchurl {
         name = "jsbn___jsbn_0.1.1.tgz";
         url  = "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz";
         sha1 = "a5e654c2e5a2deb5f201d96cefbca80c0ef2f513";
+      };
+    }
+    {
+      name = "json_buffer___json_buffer_3.0.0.tgz";
+      path = fetchurl {
+        name = "json_buffer___json_buffer_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz";
+        sha1 = "5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898";
+      };
+    }
+    {
+      name = "json_parse_better_errors___json_parse_better_errors_1.0.2.tgz";
+      path = fetchurl {
+        name = "json_parse_better_errors___json_parse_better_errors_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz";
+        sha1 = "bb867cfb3450e69107c131d1c514bab3dc8bcaa9";
       };
     }
     {
@@ -522,11 +2722,27 @@
       };
     }
     {
+      name = "json_stable_stringify_without_jsonify___json_stable_stringify_without_jsonify_1.0.1.tgz";
+      path = fetchurl {
+        name = "json_stable_stringify_without_jsonify___json_stable_stringify_without_jsonify_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz";
+        sha1 = "9db7b59496ad3f3cfef30a75142d2d930ad72651";
+      };
+    }
+    {
       name = "json_stringify_safe___json_stringify_safe_5.0.1.tgz";
       path = fetchurl {
         name = "json_stringify_safe___json_stringify_safe_5.0.1.tgz";
         url  = "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz";
         sha1 = "1296a2d58fd45f19a0f6ce01d65701e2c735b6eb";
+      };
+    }
+    {
+      name = "json5___json5_2.1.1.tgz";
+      path = fetchurl {
+        name = "json5___json5_2.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz";
+        sha1 = "81b6cb04e9ba496f1c7005d07b4368a2638f90b6";
       };
     }
     {
@@ -538,11 +2754,179 @@
       };
     }
     {
+      name = "jsonfile___jsonfile_4.0.0.tgz";
+      path = fetchurl {
+        name = "jsonfile___jsonfile_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz";
+        sha1 = "8771aae0799b64076b76640fca058f9c10e33ecb";
+      };
+    }
+    {
+      name = "jsonparse___jsonparse_1.3.1.tgz";
+      path = fetchurl {
+        name = "jsonparse___jsonparse_1.3.1.tgz";
+        url  = "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz";
+        sha1 = "3f4dae4a91fac315f71062f8521cc239f1366280";
+      };
+    }
+    {
       name = "jsprim___jsprim_1.4.1.tgz";
       path = fetchurl {
         name = "jsprim___jsprim_1.4.1.tgz";
         url  = "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz";
         sha1 = "313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2";
+      };
+    }
+    {
+      name = "keyv___keyv_3.1.0.tgz";
+      path = fetchurl {
+        name = "keyv___keyv_3.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz";
+        sha1 = "ecc228486f69991e49e9476485a5be1e8fc5c4d9";
+      };
+    }
+    {
+      name = "latest_version___latest_version_3.1.0.tgz";
+      path = fetchurl {
+        name = "latest_version___latest_version_3.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz";
+        sha1 = "a205383fea322b33b5ae3b18abee0dc2f356ee15";
+      };
+    }
+    {
+      name = "latest_version___latest_version_5.1.0.tgz";
+      path = fetchurl {
+        name = "latest_version___latest_version_5.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz";
+        sha1 = "119dfe908fe38d15dfa43ecd13fa12ec8832face";
+      };
+    }
+    {
+      name = "lazy_property___lazy_property_1.0.0.tgz";
+      path = fetchurl {
+        name = "lazy_property___lazy_property_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/lazy-property/-/lazy-property-1.0.0.tgz";
+        sha1 = "84ddc4b370679ba8bd4cdcfa4c06b43d57111147";
+      };
+    }
+    {
+      name = "lazy_val___lazy_val_1.0.4.tgz";
+      path = fetchurl {
+        name = "lazy_val___lazy_val_1.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.4.tgz";
+        sha1 = "882636a7245c2cfe6e0a4e3ba6c5d68a137e5c65";
+      };
+    }
+    {
+      name = "lazystream___lazystream_1.0.0.tgz";
+      path = fetchurl {
+        name = "lazystream___lazystream_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz";
+        sha1 = "f6995fe0f820392f61396be89462407bb77168e4";
+      };
+    }
+    {
+      name = "lcid___lcid_1.0.0.tgz";
+      path = fetchurl {
+        name = "lcid___lcid_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz";
+        sha1 = "308accafa0bc483a3867b4b6f2b9506251d1b835";
+      };
+    }
+    {
+      name = "lcid___lcid_2.0.0.tgz";
+      path = fetchurl {
+        name = "lcid___lcid_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz";
+        sha1 = "6ef5d2df60e52f82eb228a4c373e8d1f397253cf";
+      };
+    }
+    {
+      name = "levn___levn_0.3.0.tgz";
+      path = fetchurl {
+        name = "levn___levn_0.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz";
+        sha1 = "3b09924edf9f083c0490fdd4c0bc4421e04764ee";
+      };
+    }
+    {
+      name = "libcipm___libcipm_4.0.7.tgz";
+      path = fetchurl {
+        name = "libcipm___libcipm_4.0.7.tgz";
+        url  = "https://registry.yarnpkg.com/libcipm/-/libcipm-4.0.7.tgz";
+        sha1 = "76cd675c98bdaae64db88b782b01b804b6d02c8a";
+      };
+    }
+    {
+      name = "libnpm___libnpm_3.0.1.tgz";
+      path = fetchurl {
+        name = "libnpm___libnpm_3.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/libnpm/-/libnpm-3.0.1.tgz";
+        sha1 = "0be11b4c9dd4d1ffd7d95c786e92e55d65be77a2";
+      };
+    }
+    {
+      name = "libnpmaccess___libnpmaccess_3.0.2.tgz";
+      path = fetchurl {
+        name = "libnpmaccess___libnpmaccess_3.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-3.0.2.tgz";
+        sha1 = "8b2d72345ba3bef90d3b4f694edd5c0417f58923";
+      };
+    }
+    {
+      name = "libnpmconfig___libnpmconfig_1.2.1.tgz";
+      path = fetchurl {
+        name = "libnpmconfig___libnpmconfig_1.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/libnpmconfig/-/libnpmconfig-1.2.1.tgz";
+        sha1 = "c0c2f793a74e67d4825e5039e7a02a0044dfcbc0";
+      };
+    }
+    {
+      name = "libnpmhook___libnpmhook_5.0.3.tgz";
+      path = fetchurl {
+        name = "libnpmhook___libnpmhook_5.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/libnpmhook/-/libnpmhook-5.0.3.tgz";
+        sha1 = "4020c0f5edbf08ebe395325caa5ea01885b928f7";
+      };
+    }
+    {
+      name = "libnpmorg___libnpmorg_1.0.1.tgz";
+      path = fetchurl {
+        name = "libnpmorg___libnpmorg_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/libnpmorg/-/libnpmorg-1.0.1.tgz";
+        sha1 = "5d2503f6ceb57f33dbdcc718e6698fea6d5ad087";
+      };
+    }
+    {
+      name = "libnpmpublish___libnpmpublish_1.1.3.tgz";
+      path = fetchurl {
+        name = "libnpmpublish___libnpmpublish_1.1.3.tgz";
+        url  = "https://registry.yarnpkg.com/libnpmpublish/-/libnpmpublish-1.1.3.tgz";
+        sha1 = "e3782796722d79eef1a0a22944c117e0c4ca4280";
+      };
+    }
+    {
+      name = "libnpmsearch___libnpmsearch_2.0.2.tgz";
+      path = fetchurl {
+        name = "libnpmsearch___libnpmsearch_2.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/libnpmsearch/-/libnpmsearch-2.0.2.tgz";
+        sha1 = "9a4f059102d38e3dd44085bdbfe5095f2a5044cf";
+      };
+    }
+    {
+      name = "libnpmteam___libnpmteam_1.0.2.tgz";
+      path = fetchurl {
+        name = "libnpmteam___libnpmteam_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/libnpmteam/-/libnpmteam-1.0.2.tgz";
+        sha1 = "8b48bcbb6ce70dd8150c950fcbdbf3feb6eec820";
+      };
+    }
+    {
+      name = "libnpx___libnpx_10.2.2.tgz";
+      path = fetchurl {
+        name = "libnpx___libnpx_10.2.2.tgz";
+        url  = "https://registry.yarnpkg.com/libnpx/-/libnpx-10.2.2.tgz";
+        sha1 = "5a4171b9b92dd031463ef66a4af9f5cbd6b09572";
       };
     }
     {
@@ -554,11 +2938,187 @@
       };
     }
     {
+      name = "load_json_file___load_json_file_2.0.0.tgz";
+      path = fetchurl {
+        name = "load_json_file___load_json_file_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz";
+        sha1 = "7947e42149af80d696cbf797bcaabcfe1fe29ca8";
+      };
+    }
+    {
       name = "locate_path___locate_path_2.0.0.tgz";
       path = fetchurl {
         name = "locate_path___locate_path_2.0.0.tgz";
         url  = "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz";
         sha1 = "2b568b265eec944c6d9c0de9c3dbbbca0354cd8e";
+      };
+    }
+    {
+      name = "locate_path___locate_path_3.0.0.tgz";
+      path = fetchurl {
+        name = "locate_path___locate_path_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz";
+        sha1 = "dbec3b3ab759758071b58fe59fc41871af21400e";
+      };
+    }
+    {
+      name = "locate_path___locate_path_5.0.0.tgz";
+      path = fetchurl {
+        name = "locate_path___locate_path_5.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz";
+        sha1 = "1afba396afd676a6d42504d0a67a3a7eb9f62aa0";
+      };
+    }
+    {
+      name = "lock_verify___lock_verify_2.2.0.tgz";
+      path = fetchurl {
+        name = "lock_verify___lock_verify_2.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/lock-verify/-/lock-verify-2.2.0.tgz";
+        sha1 = "12432feb68bb647071c78c44bde16029a0f7d935";
+      };
+    }
+    {
+      name = "lockfile___lockfile_1.0.4.tgz";
+      path = fetchurl {
+        name = "lockfile___lockfile_1.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.4.tgz";
+        sha1 = "07f819d25ae48f87e538e6578b6964a4981a5609";
+      };
+    }
+    {
+      name = "lodash._baseuniq___lodash._baseuniq_4.6.0.tgz";
+      path = fetchurl {
+        name = "lodash._baseuniq___lodash._baseuniq_4.6.0.tgz";
+        url  = "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz";
+        sha1 = "0ebb44e456814af7905c6212fa2c9b2d51b841e8";
+      };
+    }
+    {
+      name = "lodash._createset___lodash._createset_4.0.3.tgz";
+      path = fetchurl {
+        name = "lodash._createset___lodash._createset_4.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz";
+        sha1 = "0f4659fbb09d75194fa9e2b88a6644d363c9fe26";
+      };
+    }
+    {
+      name = "lodash._root___lodash._root_3.0.1.tgz";
+      path = fetchurl {
+        name = "lodash._root___lodash._root_3.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz";
+        sha1 = "fba1c4524c19ee9a5f8136b4609f017cf4ded692";
+      };
+    }
+    {
+      name = "lodash.clonedeep___lodash.clonedeep_4.5.0.tgz";
+      path = fetchurl {
+        name = "lodash.clonedeep___lodash.clonedeep_4.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz";
+        sha1 = "e23f3f9c4f8fbdde872529c1071857a086e5ccef";
+      };
+    }
+    {
+      name = "lodash.defaults___lodash.defaults_4.2.0.tgz";
+      path = fetchurl {
+        name = "lodash.defaults___lodash.defaults_4.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz";
+        sha1 = "d09178716ffea4dde9e5fb7b37f6f0802274580c";
+      };
+    }
+    {
+      name = "lodash.difference___lodash.difference_4.5.0.tgz";
+      path = fetchurl {
+        name = "lodash.difference___lodash.difference_4.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz";
+        sha1 = "9ccb4e505d486b91651345772885a2df27fd017c";
+      };
+    }
+    {
+      name = "lodash.flatten___lodash.flatten_4.4.0.tgz";
+      path = fetchurl {
+        name = "lodash.flatten___lodash.flatten_4.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz";
+        sha1 = "f31c22225a9632d2bbf8e4addbef240aa765a61f";
+      };
+    }
+    {
+      name = "lodash.isplainobject___lodash.isplainobject_4.0.6.tgz";
+      path = fetchurl {
+        name = "lodash.isplainobject___lodash.isplainobject_4.0.6.tgz";
+        url  = "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz";
+        sha1 = "7c526a52d89b45c45cc690b88163be0497f550cb";
+      };
+    }
+    {
+      name = "lodash.union___lodash.union_4.6.0.tgz";
+      path = fetchurl {
+        name = "lodash.union___lodash.union_4.6.0.tgz";
+        url  = "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz";
+        sha1 = "48bb5088409f16f1821666641c44dd1aaae3cd88";
+      };
+    }
+    {
+      name = "lodash.uniq___lodash.uniq_4.5.0.tgz";
+      path = fetchurl {
+        name = "lodash.uniq___lodash.uniq_4.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz";
+        sha1 = "d0225373aeb652adc1bc82e4945339a842754773";
+      };
+    }
+    {
+      name = "lodash.without___lodash.without_4.4.0.tgz";
+      path = fetchurl {
+        name = "lodash.without___lodash.without_4.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz";
+        sha1 = "3cd4574a00b67bae373a94b748772640507b7aac";
+      };
+    }
+    {
+      name = "lodash___lodash_4.17.15.tgz";
+      path = fetchurl {
+        name = "lodash___lodash_4.17.15.tgz";
+        url  = "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz";
+        sha1 = "b447f6670a0455bbfeedd11392eff330ea097548";
+      };
+    }
+    {
+      name = "loglevel___loglevel_1.6.6.tgz";
+      path = fetchurl {
+        name = "loglevel___loglevel_1.6.6.tgz";
+        url  = "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.6.tgz";
+        sha1 = "0ee6300cc058db6b3551fa1c4bf73b83bb771312";
+      };
+    }
+    {
+      name = "lowercase_keys___lowercase_keys_1.0.1.tgz";
+      path = fetchurl {
+        name = "lowercase_keys___lowercase_keys_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz";
+        sha1 = "6f9e30b47084d971a7c820ff15a6c5167b74c26f";
+      };
+    }
+    {
+      name = "lowercase_keys___lowercase_keys_2.0.0.tgz";
+      path = fetchurl {
+        name = "lowercase_keys___lowercase_keys_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz";
+        sha1 = "2603e78b7b4b0006cbca2fbcc8a3202558ac9479";
+      };
+    }
+    {
+      name = "lru_cache___lru_cache_4.1.5.tgz";
+      path = fetchurl {
+        name = "lru_cache___lru_cache_4.1.5.tgz";
+        url  = "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz";
+        sha1 = "8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd";
+      };
+    }
+    {
+      name = "lru_cache___lru_cache_5.1.1.tgz";
+      path = fetchurl {
+        name = "lru_cache___lru_cache_5.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz";
+        sha1 = "1da27e6710271947695daf6848e847f01d84b920";
       };
     }
     {
@@ -570,19 +3130,75 @@
       };
     }
     {
-      name = "mime_db___mime_db_1.38.0.tgz";
+      name = "make_dir___make_dir_3.0.2.tgz";
       path = fetchurl {
-        name = "mime_db___mime_db_1.38.0.tgz";
-        url  = "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz";
-        sha1 = "1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad";
+        name = "make_dir___make_dir_3.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.2.tgz";
+        sha1 = "04a1acbf22221e1d6ef43559f43e05a90dbb4392";
       };
     }
     {
-      name = "mime_types___mime_types_2.1.22.tgz";
+      name = "make_fetch_happen___make_fetch_happen_5.0.2.tgz";
       path = fetchurl {
-        name = "mime_types___mime_types_2.1.22.tgz";
-        url  = "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.22.tgz";
-        sha1 = "fe6b355a190926ab7698c9a0556a11199b2199bd";
+        name = "make_fetch_happen___make_fetch_happen_5.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz";
+        sha1 = "aa8387104f2687edca01c8687ee45013d02d19bd";
+      };
+    }
+    {
+      name = "map_age_cleaner___map_age_cleaner_0.1.3.tgz";
+      path = fetchurl {
+        name = "map_age_cleaner___map_age_cleaner_0.1.3.tgz";
+        url  = "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz";
+        sha1 = "7d583a7306434c055fe474b0f45078e6e1b4b92a";
+      };
+    }
+    {
+      name = "matrix_js_sdk___matrix_js_sdk_6.1.0.tgz";
+      path = fetchurl {
+        name = "matrix_js_sdk___matrix_js_sdk_6.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/matrix-js-sdk/-/matrix-js-sdk-6.1.0.tgz";
+        sha1 = "c28ad67c113c4aa9c8bce409c7ba550170bdc2ee";
+      };
+    }
+    {
+      name = "meant___meant_1.0.1.tgz";
+      path = fetchurl {
+        name = "meant___meant_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/meant/-/meant-1.0.1.tgz";
+        sha1 = "66044fea2f23230ec806fb515efea29c44d2115d";
+      };
+    }
+    {
+      name = "mem___mem_1.1.0.tgz";
+      path = fetchurl {
+        name = "mem___mem_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz";
+        sha1 = "5edd52b485ca1d900fe64895505399a0dfa45f76";
+      };
+    }
+    {
+      name = "mem___mem_4.3.0.tgz";
+      path = fetchurl {
+        name = "mem___mem_4.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz";
+        sha1 = "461af497bc4ae09608cdb2e60eefb69bff744178";
+      };
+    }
+    {
+      name = "mime_db___mime_db_1.42.0.tgz";
+      path = fetchurl {
+        name = "mime_db___mime_db_1.42.0.tgz";
+        url  = "https://registry.yarnpkg.com/mime-db/-/mime-db-1.42.0.tgz";
+        sha1 = "3e252907b4c7adb906597b4b65636272cf9e7bac";
+      };
+    }
+    {
+      name = "mime_types___mime_types_2.1.25.tgz";
+      path = fetchurl {
+        name = "mime_types___mime_types_2.1.25.tgz";
+        url  = "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.25.tgz";
+        sha1 = "39772d46621f93e2a80a856c53b86a62156a6437";
       };
     }
     {
@@ -594,11 +3210,51 @@
       };
     }
     {
+      name = "mime___mime_2.4.4.tgz";
+      path = fetchurl {
+        name = "mime___mime_2.4.4.tgz";
+        url  = "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz";
+        sha1 = "bd7b91135fc6b01cde3e9bae33d659b63d8857e5";
+      };
+    }
+    {
+      name = "mimic_fn___mimic_fn_1.2.0.tgz";
+      path = fetchurl {
+        name = "mimic_fn___mimic_fn_1.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz";
+        sha1 = "820c86a39334640e99516928bd03fca88057d022";
+      };
+    }
+    {
+      name = "mimic_fn___mimic_fn_2.1.0.tgz";
+      path = fetchurl {
+        name = "mimic_fn___mimic_fn_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz";
+        sha1 = "7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b";
+      };
+    }
+    {
+      name = "mimic_response___mimic_response_1.0.1.tgz";
+      path = fetchurl {
+        name = "mimic_response___mimic_response_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz";
+        sha1 = "4923538878eef42063cb8a3e3b0798781487ab1b";
+      };
+    }
+    {
       name = "min_document___min_document_2.19.0.tgz";
       path = fetchurl {
         name = "min_document___min_document_2.19.0.tgz";
         url  = "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz";
         sha1 = "7bd282e3f5842ed295bb748cdd9f1ffa2c824685";
+      };
+    }
+    {
+      name = "minimatch___minimatch_3.0.4.tgz";
+      path = fetchurl {
+        name = "minimatch___minimatch_3.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz";
+        sha1 = "5166e286457f03306064be5497e8dbb0c3d32083";
       };
     }
     {
@@ -618,11 +3274,315 @@
       };
     }
     {
+      name = "minipass___minipass_2.9.0.tgz";
+      path = fetchurl {
+        name = "minipass___minipass_2.9.0.tgz";
+        url  = "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz";
+        sha1 = "e713762e7d3e32fed803115cf93e04bca9fcc9a6";
+      };
+    }
+    {
+      name = "minipass___minipass_3.1.1.tgz";
+      path = fetchurl {
+        name = "minipass___minipass_3.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/minipass/-/minipass-3.1.1.tgz";
+        sha1 = "7607ce778472a185ad6d89082aa2070f79cedcd5";
+      };
+    }
+    {
+      name = "minizlib___minizlib_1.3.3.tgz";
+      path = fetchurl {
+        name = "minizlib___minizlib_1.3.3.tgz";
+        url  = "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz";
+        sha1 = "2290de96818a34c29551c8a8d301216bd65a861d";
+      };
+    }
+    {
+      name = "minizlib___minizlib_2.1.0.tgz";
+      path = fetchurl {
+        name = "minizlib___minizlib_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.0.tgz";
+        sha1 = "fd52c645301ef09a63a2c209697c294c6ce02cf3";
+      };
+    }
+    {
+      name = "mississippi___mississippi_3.0.0.tgz";
+      path = fetchurl {
+        name = "mississippi___mississippi_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz";
+        sha1 = "ea0a3291f97e0b5e8776b363d5f0a12d94c67022";
+      };
+    }
+    {
       name = "mkdirp___mkdirp_0.5.1.tgz";
       path = fetchurl {
         name = "mkdirp___mkdirp_0.5.1.tgz";
         url  = "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz";
         sha1 = "30057438eac6cf7f8c4767f38648d6697d75c903";
+      };
+    }
+    {
+      name = "mkdirp___mkdirp_1.0.3.tgz";
+      path = fetchurl {
+        name = "mkdirp___mkdirp_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz";
+        sha1 = "4cf2e30ad45959dddea53ad97d518b6c8205e1ea";
+      };
+    }
+    {
+      name = "move_concurrently___move_concurrently_1.0.1.tgz";
+      path = fetchurl {
+        name = "move_concurrently___move_concurrently_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz";
+        sha1 = "be2c005fda32e0b29af1f05d7c4b33214c701f92";
+      };
+    }
+    {
+      name = "ms___ms_2.0.0.tgz";
+      path = fetchurl {
+        name = "ms___ms_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz";
+        sha1 = "5608aeadfc00be6c2901df5f9861788de0d597c8";
+      };
+    }
+    {
+      name = "ms___ms_2.1.2.tgz";
+      path = fetchurl {
+        name = "ms___ms_2.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz";
+        sha1 = "d09d1f357b443f493382a8eb3ccd183872ae6009";
+      };
+    }
+    {
+      name = "mute_stream___mute_stream_0.0.7.tgz";
+      path = fetchurl {
+        name = "mute_stream___mute_stream_0.0.7.tgz";
+        url  = "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz";
+        sha1 = "3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab";
+      };
+    }
+    {
+      name = "mute_stream___mute_stream_0.0.8.tgz";
+      path = fetchurl {
+        name = "mute_stream___mute_stream_0.0.8.tgz";
+        url  = "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz";
+        sha1 = "1630c42b2251ff81e2a283de96a5497ea92e5e0d";
+      };
+    }
+    {
+      name = "natural_compare___natural_compare_1.4.0.tgz";
+      path = fetchurl {
+        name = "natural_compare___natural_compare_1.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz";
+        sha1 = "4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7";
+      };
+    }
+    {
+      name = "needle___needle_2.3.2.tgz";
+      path = fetchurl {
+        name = "needle___needle_2.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/needle/-/needle-2.3.2.tgz";
+        sha1 = "3342dea100b7160960a450dc8c22160ac712a528";
+      };
+    }
+    {
+      name = "nice_try___nice_try_1.0.5.tgz";
+      path = fetchurl {
+        name = "nice_try___nice_try_1.0.5.tgz";
+        url  = "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz";
+        sha1 = "a3378a7696ce7d223e88fc9b764bd7ef1089e366";
+      };
+    }
+    {
+      name = "node_fetch_npm___node_fetch_npm_2.0.2.tgz";
+      path = fetchurl {
+        name = "node_fetch_npm___node_fetch_npm_2.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz";
+        sha1 = "7258c9046182dca345b4208eda918daf33697ff7";
+      };
+    }
+    {
+      name = "node_gyp___node_gyp_5.1.0.tgz";
+      path = fetchurl {
+        name = "node_gyp___node_gyp_5.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/node-gyp/-/node-gyp-5.1.0.tgz";
+        sha1 = "8e31260a7af4a2e2f994b0673d4e0b3866156332";
+      };
+    }
+    {
+      name = "node_pre_gyp___node_pre_gyp_0.14.0.tgz";
+      path = fetchurl {
+        name = "node_pre_gyp___node_pre_gyp_0.14.0.tgz";
+        url  = "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz";
+        sha1 = "9a0596533b877289bcad4e143982ca3d904ddc83";
+      };
+    }
+    {
+      name = "nopt___nopt_4.0.1.tgz";
+      path = fetchurl {
+        name = "nopt___nopt_4.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz";
+        sha1 = "d0d4685afd5415193c8c7505602d0d17cd64474d";
+      };
+    }
+    {
+      name = "normalize_package_data___normalize_package_data_2.5.0.tgz";
+      path = fetchurl {
+        name = "normalize_package_data___normalize_package_data_2.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz";
+        sha1 = "e66db1838b200c1dfc233225d12cb36520e234a8";
+      };
+    }
+    {
+      name = "normalize_path___normalize_path_3.0.0.tgz";
+      path = fetchurl {
+        name = "normalize_path___normalize_path_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz";
+        sha1 = "0dcd69ff23a1c9b11fd0978316644a0388216a65";
+      };
+    }
+    {
+      name = "normalize_url___normalize_url_4.5.0.tgz";
+      path = fetchurl {
+        name = "normalize_url___normalize_url_4.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz";
+        sha1 = "453354087e6ca96957bd8f5baf753f5982142129";
+      };
+    }
+    {
+      name = "npm_audit_report___npm_audit_report_1.3.2.tgz";
+      path = fetchurl {
+        name = "npm_audit_report___npm_audit_report_1.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/npm-audit-report/-/npm-audit-report-1.3.2.tgz";
+        sha1 = "303bc78cd9e4c226415076a4f7e528c89fc77018";
+      };
+    }
+    {
+      name = "npm_bundled___npm_bundled_1.1.1.tgz";
+      path = fetchurl {
+        name = "npm_bundled___npm_bundled_1.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz";
+        sha1 = "1edd570865a94cdb1bc8220775e29466c9fb234b";
+      };
+    }
+    {
+      name = "npm_cache_filename___npm_cache_filename_1.0.2.tgz";
+      path = fetchurl {
+        name = "npm_cache_filename___npm_cache_filename_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz";
+        sha1 = "ded306c5b0bfc870a9e9faf823bc5f283e05ae11";
+      };
+    }
+    {
+      name = "npm_install_checks___npm_install_checks_3.0.2.tgz";
+      path = fetchurl {
+        name = "npm_install_checks___npm_install_checks_3.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/npm-install-checks/-/npm-install-checks-3.0.2.tgz";
+        sha1 = "ab2e32ad27baa46720706908e5b14c1852de44d9";
+      };
+    }
+    {
+      name = "npm_lifecycle___npm_lifecycle_3.1.4.tgz";
+      path = fetchurl {
+        name = "npm_lifecycle___npm_lifecycle_3.1.4.tgz";
+        url  = "https://registry.yarnpkg.com/npm-lifecycle/-/npm-lifecycle-3.1.4.tgz";
+        sha1 = "de6975c7d8df65f5150db110b57cce498b0b604c";
+      };
+    }
+    {
+      name = "npm_logical_tree___npm_logical_tree_1.2.1.tgz";
+      path = fetchurl {
+        name = "npm_logical_tree___npm_logical_tree_1.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz";
+        sha1 = "44610141ca24664cad35d1e607176193fd8f5b88";
+      };
+    }
+    {
+      name = "npm_normalize_package_bin___npm_normalize_package_bin_1.0.1.tgz";
+      path = fetchurl {
+        name = "npm_normalize_package_bin___npm_normalize_package_bin_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz";
+        sha1 = "6e79a41f23fd235c0623218228da7d9c23b8f6e2";
+      };
+    }
+    {
+      name = "npm_package_arg___npm_package_arg_6.1.1.tgz";
+      path = fetchurl {
+        name = "npm_package_arg___npm_package_arg_6.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-6.1.1.tgz";
+        sha1 = "02168cb0a49a2b75bf988a28698de7b529df5cb7";
+      };
+    }
+    {
+      name = "npm_packlist___npm_packlist_1.4.8.tgz";
+      path = fetchurl {
+        name = "npm_packlist___npm_packlist_1.4.8.tgz";
+        url  = "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz";
+        sha1 = "56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e";
+      };
+    }
+    {
+      name = "npm_pick_manifest___npm_pick_manifest_3.0.2.tgz";
+      path = fetchurl {
+        name = "npm_pick_manifest___npm_pick_manifest_3.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz";
+        sha1 = "f4d9e5fd4be2153e5f4e5f9b7be8dc419a99abb7";
+      };
+    }
+    {
+      name = "npm_profile___npm_profile_4.0.2.tgz";
+      path = fetchurl {
+        name = "npm_profile___npm_profile_4.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/npm-profile/-/npm-profile-4.0.2.tgz";
+        sha1 = "8272a71c19634d0dce9c35a5daf8ee589cbb0f52";
+      };
+    }
+    {
+      name = "npm_registry_fetch___npm_registry_fetch_4.0.2.tgz";
+      path = fetchurl {
+        name = "npm_registry_fetch___npm_registry_fetch_4.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-4.0.2.tgz";
+        sha1 = "2b1434f93ccbe6b6385f8e45f45db93e16921d7a";
+      };
+    }
+    {
+      name = "npm_run_path___npm_run_path_2.0.2.tgz";
+      path = fetchurl {
+        name = "npm_run_path___npm_run_path_2.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz";
+        sha1 = "35a9232dfa35d7067b4cb2ddf2357b1871536c5f";
+      };
+    }
+    {
+      name = "npm_user_validate___npm_user_validate_1.0.0.tgz";
+      path = fetchurl {
+        name = "npm_user_validate___npm_user_validate_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/npm-user-validate/-/npm-user-validate-1.0.0.tgz";
+        sha1 = "8ceca0f5cea04d4e93519ef72d0557a75122e951";
+      };
+    }
+    {
+      name = "npm___npm_6.13.7.tgz";
+      path = fetchurl {
+        name = "npm___npm_6.13.7.tgz";
+        url  = "https://registry.yarnpkg.com/npm/-/npm-6.13.7.tgz";
+        sha1 = "9533a3ddc57f9792db8a8b303efabaf878047841";
+      };
+    }
+    {
+      name = "npmlog___npmlog_4.1.2.tgz";
+      path = fetchurl {
+        name = "npmlog___npmlog_4.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz";
+        sha1 = "08a7f2a8bf734604779a9efa4ad5cc717abb954b";
+      };
+    }
+    {
+      name = "number_is_nan___number_is_nan_1.0.1.tgz";
+      path = fetchurl {
+        name = "number_is_nan___number_is_nan_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz";
+        sha1 = "097b602b53422a522c1afb8790318336941a011d";
       };
     }
     {
@@ -634,11 +3594,147 @@
       };
     }
     {
-      name = "object_keys___object_keys_1.1.0.tgz";
+      name = "object_assign___object_assign_4.1.1.tgz";
       path = fetchurl {
-        name = "object_keys___object_keys_1.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz";
-        sha1 = "11bd22348dd2e096a045ab06f6c85bcc340fa032";
+        name = "object_assign___object_assign_4.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz";
+        sha1 = "2109adc7965887cfc05cbbd442cac8bfbb360863";
+      };
+    }
+    {
+      name = "object_inspect___object_inspect_1.7.0.tgz";
+      path = fetchurl {
+        name = "object_inspect___object_inspect_1.7.0.tgz";
+        url  = "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz";
+        sha1 = "f4f6bd181ad77f006b5ece60bd0b6f398ff74a67";
+      };
+    }
+    {
+      name = "object_is___object_is_1.0.1.tgz";
+      path = fetchurl {
+        name = "object_is___object_is_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz";
+        sha1 = "0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6";
+      };
+    }
+    {
+      name = "object_keys___object_keys_1.1.1.tgz";
+      path = fetchurl {
+        name = "object_keys___object_keys_1.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz";
+        sha1 = "1c47f272df277f3b1daf061677d9c82e2322c60e";
+      };
+    }
+    {
+      name = "object.getownpropertydescriptors___object.getownpropertydescriptors_2.0.3.tgz";
+      path = fetchurl {
+        name = "object.getownpropertydescriptors___object.getownpropertydescriptors_2.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz";
+        sha1 = "8758c846f5b407adab0f236e0986f14b051caa16";
+      };
+    }
+    {
+      name = "once___once_1.4.0.tgz";
+      path = fetchurl {
+        name = "once___once_1.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz";
+        sha1 = "583b1aa775961d4b113ac17d9c50baef9dd76bd1";
+      };
+    }
+    {
+      name = "onetime___onetime_2.0.1.tgz";
+      path = fetchurl {
+        name = "onetime___onetime_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz";
+        sha1 = "067428230fd67443b2794b22bba528b6867962d4";
+      };
+    }
+    {
+      name = "opener___opener_1.5.1.tgz";
+      path = fetchurl {
+        name = "opener___opener_1.5.1.tgz";
+        url  = "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz";
+        sha1 = "6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed";
+      };
+    }
+    {
+      name = "optionator___optionator_0.8.3.tgz";
+      path = fetchurl {
+        name = "optionator___optionator_0.8.3.tgz";
+        url  = "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz";
+        sha1 = "84fa1d036fe9d3c7e21d99884b601167ec8fb495";
+      };
+    }
+    {
+      name = "os_homedir___os_homedir_1.0.2.tgz";
+      path = fetchurl {
+        name = "os_homedir___os_homedir_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz";
+        sha1 = "ffbc4988336e0e833de0c168c7ef152121aa7fb3";
+      };
+    }
+    {
+      name = "os_locale___os_locale_2.1.0.tgz";
+      path = fetchurl {
+        name = "os_locale___os_locale_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz";
+        sha1 = "42bc2900a6b5b8bd17376c8e882b65afccf24bf2";
+      };
+    }
+    {
+      name = "os_locale___os_locale_3.1.0.tgz";
+      path = fetchurl {
+        name = "os_locale___os_locale_3.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz";
+        sha1 = "a802a6ee17f24c10483ab9935719cef4ed16bf1a";
+      };
+    }
+    {
+      name = "os_tmpdir___os_tmpdir_1.0.2.tgz";
+      path = fetchurl {
+        name = "os_tmpdir___os_tmpdir_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz";
+        sha1 = "bbe67406c79aa85c5cfec766fe5734555dfa1274";
+      };
+    }
+    {
+      name = "osenv___osenv_0.1.5.tgz";
+      path = fetchurl {
+        name = "osenv___osenv_0.1.5.tgz";
+        url  = "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz";
+        sha1 = "85cdfafaeb28e8677f416e287592b5f3f49ea410";
+      };
+    }
+    {
+      name = "p_cancelable___p_cancelable_1.1.0.tgz";
+      path = fetchurl {
+        name = "p_cancelable___p_cancelable_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz";
+        sha1 = "d078d15a3af409220c886f1d9a0ca2e441ab26cc";
+      };
+    }
+    {
+      name = "p_defer___p_defer_1.0.0.tgz";
+      path = fetchurl {
+        name = "p_defer___p_defer_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz";
+        sha1 = "9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c";
+      };
+    }
+    {
+      name = "p_finally___p_finally_1.0.0.tgz";
+      path = fetchurl {
+        name = "p_finally___p_finally_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz";
+        sha1 = "3fbcfb15b899a44123b34b6dcc18b724336a2cae";
+      };
+    }
+    {
+      name = "p_is_promise___p_is_promise_2.1.0.tgz";
+      path = fetchurl {
+        name = "p_is_promise___p_is_promise_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz";
+        sha1 = "918cebaea248a62cf7ffab8e3bca8c5f882fc42e";
       };
     }
     {
@@ -650,6 +3746,22 @@
       };
     }
     {
+      name = "p_limit___p_limit_2.2.1.tgz";
+      path = fetchurl {
+        name = "p_limit___p_limit_2.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz";
+        sha1 = "aa07a788cc3151c939b5131f63570f0dd2009537";
+      };
+    }
+    {
+      name = "p_limit___p_limit_2.2.2.tgz";
+      path = fetchurl {
+        name = "p_limit___p_limit_2.2.2.tgz";
+        url  = "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz";
+        sha1 = "61279b67721f5287aa1c13a9a7fbbc48c9291b1e";
+      };
+    }
+    {
       name = "p_locate___p_locate_2.0.0.tgz";
       path = fetchurl {
         name = "p_locate___p_locate_2.0.0.tgz";
@@ -658,11 +3770,75 @@
       };
     }
     {
+      name = "p_locate___p_locate_3.0.0.tgz";
+      path = fetchurl {
+        name = "p_locate___p_locate_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz";
+        sha1 = "322d69a05c0264b25997d9f40cd8a891ab0064a4";
+      };
+    }
+    {
+      name = "p_locate___p_locate_4.1.0.tgz";
+      path = fetchurl {
+        name = "p_locate___p_locate_4.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz";
+        sha1 = "a3428bb7088b3a60292f66919278b7c297ad4f07";
+      };
+    }
+    {
       name = "p_try___p_try_1.0.0.tgz";
       path = fetchurl {
         name = "p_try___p_try_1.0.0.tgz";
         url  = "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz";
         sha1 = "cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3";
+      };
+    }
+    {
+      name = "p_try___p_try_2.2.0.tgz";
+      path = fetchurl {
+        name = "p_try___p_try_2.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz";
+        sha1 = "cb2868540e313d61de58fafbe35ce9004d5540e6";
+      };
+    }
+    {
+      name = "package_json___package_json_4.0.1.tgz";
+      path = fetchurl {
+        name = "package_json___package_json_4.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz";
+        sha1 = "8869a0401253661c4c4ca3da6c2121ed555f5eed";
+      };
+    }
+    {
+      name = "package_json___package_json_6.5.0.tgz";
+      path = fetchurl {
+        name = "package_json___package_json_6.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/package-json/-/package-json-6.5.0.tgz";
+        sha1 = "6feedaca35e75725876d0b0e64974697fed145b0";
+      };
+    }
+    {
+      name = "pacote___pacote_9.5.12.tgz";
+      path = fetchurl {
+        name = "pacote___pacote_9.5.12.tgz";
+        url  = "https://registry.yarnpkg.com/pacote/-/pacote-9.5.12.tgz";
+        sha1 = "1e11dd7a8d736bcc36b375a9804d41bb0377bf66";
+      };
+    }
+    {
+      name = "parallel_transform___parallel_transform_1.2.0.tgz";
+      path = fetchurl {
+        name = "parallel_transform___parallel_transform_1.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.2.0.tgz";
+        sha1 = "9049ca37d6cb2182c3b1d2c720be94d14a5814fc";
+      };
+    }
+    {
+      name = "parent_module___parent_module_1.0.1.tgz";
+      path = fetchurl {
+        name = "parent_module___parent_module_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz";
+        sha1 = "691d2709e78c79fae3a156622452d00762caaaa2";
       };
     }
     {
@@ -690,11 +3866,19 @@
       };
     }
     {
-      name = "parse_headers___parse_headers_2.0.2.tgz";
+      name = "parse_headers___parse_headers_2.0.3.tgz";
       path = fetchurl {
-        name = "parse_headers___parse_headers_2.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.2.tgz";
-        sha1 = "9545e8a4c1ae5eaea7d24992bca890281ed26e34";
+        name = "parse_headers___parse_headers_2.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.3.tgz";
+        sha1 = "5e8e7512383d140ba02f0c7aa9f49b4399c92515";
+      };
+    }
+    {
+      name = "parse_json___parse_json_2.2.0.tgz";
+      path = fetchurl {
+        name = "parse_json___parse_json_2.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz";
+        sha1 = "f480f40434ef80741f8469099f8dea18f55a4dc9";
       };
     }
     {
@@ -706,11 +3890,51 @@
       };
     }
     {
+      name = "path_exists___path_exists_4.0.0.tgz";
+      path = fetchurl {
+        name = "path_exists___path_exists_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz";
+        sha1 = "513bdbe2d3b95d7762e8c1137efa195c6c61b5b3";
+      };
+    }
+    {
       name = "path_is_absolute___path_is_absolute_1.0.1.tgz";
       path = fetchurl {
         name = "path_is_absolute___path_is_absolute_1.0.1.tgz";
         url  = "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz";
         sha1 = "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f";
+      };
+    }
+    {
+      name = "path_is_inside___path_is_inside_1.0.2.tgz";
+      path = fetchurl {
+        name = "path_is_inside___path_is_inside_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz";
+        sha1 = "365417dede44430d1c11af61027facf074bdfc53";
+      };
+    }
+    {
+      name = "path_key___path_key_2.0.1.tgz";
+      path = fetchurl {
+        name = "path_key___path_key_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz";
+        sha1 = "411cadb574c5a140d3a4b1910d40d80cc9f40b40";
+      };
+    }
+    {
+      name = "path_parse___path_parse_1.0.6.tgz";
+      path = fetchurl {
+        name = "path_parse___path_parse_1.0.6.tgz";
+        url  = "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz";
+        sha1 = "d62dbb5679405d72c4737ec58600e9ddcf06d24c";
+      };
+    }
+    {
+      name = "path_type___path_type_2.0.0.tgz";
+      path = fetchurl {
+        name = "path_type___path_type_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz";
+        sha1 = "f012ccb8415b7096fc2daa1054c3d72389594c73";
       };
     }
     {
@@ -727,6 +3951,14 @@
         name = "phin___phin_2.9.3.tgz";
         url  = "https://registry.yarnpkg.com/phin/-/phin-2.9.3.tgz";
         sha1 = "f9b6ac10a035636fb65dfc576aaaa17b8743125c";
+      };
+    }
+    {
+      name = "pify___pify_2.3.0.tgz";
+      path = fetchurl {
+        name = "pify___pify_2.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz";
+        sha1 = "ed141a6ac043a849ea588498e7dca8b15330e90c";
       };
     }
     {
@@ -770,6 +4002,38 @@
       };
     }
     {
+      name = "prelude_ls___prelude_ls_1.1.2.tgz";
+      path = fetchurl {
+        name = "prelude_ls___prelude_ls_1.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz";
+        sha1 = "21932a549f5e52ffd9a827f570e04be62a97da54";
+      };
+    }
+    {
+      name = "prepend_http___prepend_http_1.0.4.tgz";
+      path = fetchurl {
+        name = "prepend_http___prepend_http_1.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz";
+        sha1 = "d4f4562b0ce3696e41ac52d0e002e57a635dc6dc";
+      };
+    }
+    {
+      name = "prepend_http___prepend_http_2.0.0.tgz";
+      path = fetchurl {
+        name = "prepend_http___prepend_http_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz";
+        sha1 = "e92434bfa5ea8c19f41cdfd401d741a3c819d897";
+      };
+    }
+    {
+      name = "process_nextick_args___process_nextick_args_2.0.1.tgz";
+      path = fetchurl {
+        name = "process_nextick_args___process_nextick_args_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz";
+        sha1 = "7820d9b16120cc55ca9ae7792680ae7dba6d7fe2";
+      };
+    }
+    {
       name = "process___process_0.5.2.tgz";
       path = fetchurl {
         name = "process___process_0.5.2.tgz";
@@ -778,11 +4042,99 @@
       };
     }
     {
-      name = "psl___psl_1.1.31.tgz";
+      name = "progress___progress_2.0.3.tgz";
       path = fetchurl {
-        name = "psl___psl_1.1.31.tgz";
-        url  = "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz";
-        sha1 = "e9aa86d0101b5b105cbe93ac6b784cd547276184";
+        name = "progress___progress_2.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz";
+        sha1 = "7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8";
+      };
+    }
+    {
+      name = "promise_inflight___promise_inflight_1.0.1.tgz";
+      path = fetchurl {
+        name = "promise_inflight___promise_inflight_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz";
+        sha1 = "98472870bf228132fcbdd868129bad12c3c029e3";
+      };
+    }
+    {
+      name = "promise_retry___promise_retry_1.1.1.tgz";
+      path = fetchurl {
+        name = "promise_retry___promise_retry_1.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/promise-retry/-/promise-retry-1.1.1.tgz";
+        sha1 = "6739e968e3051da20ce6497fb2b50f6911df3d6d";
+      };
+    }
+    {
+      name = "promzard___promzard_0.3.0.tgz";
+      path = fetchurl {
+        name = "promzard___promzard_0.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/promzard/-/promzard-0.3.0.tgz";
+        sha1 = "26a5d6ee8c7dee4cb12208305acfb93ba382a9ee";
+      };
+    }
+    {
+      name = "proto_list___proto_list_1.2.4.tgz";
+      path = fetchurl {
+        name = "proto_list___proto_list_1.2.4.tgz";
+        url  = "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz";
+        sha1 = "212d5bfe1318306a420f6402b8e26ff39647a849";
+      };
+    }
+    {
+      name = "protoduck___protoduck_5.0.1.tgz";
+      path = fetchurl {
+        name = "protoduck___protoduck_5.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/protoduck/-/protoduck-5.0.1.tgz";
+        sha1 = "03c3659ca18007b69a50fd82a7ebcc516261151f";
+      };
+    }
+    {
+      name = "prr___prr_1.0.1.tgz";
+      path = fetchurl {
+        name = "prr___prr_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz";
+        sha1 = "d3fc114ba06995a45ec6893f484ceb1d78f5f476";
+      };
+    }
+    {
+      name = "pseudomap___pseudomap_1.0.2.tgz";
+      path = fetchurl {
+        name = "pseudomap___pseudomap_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz";
+        sha1 = "f052a28da70e618917ef0a8ac34c1ae5a68286b3";
+      };
+    }
+    {
+      name = "psl___psl_1.6.0.tgz";
+      path = fetchurl {
+        name = "psl___psl_1.6.0.tgz";
+        url  = "https://registry.yarnpkg.com/psl/-/psl-1.6.0.tgz";
+        sha1 = "60557582ee23b6c43719d9890fb4170ecd91e110";
+      };
+    }
+    {
+      name = "pump___pump_2.0.1.tgz";
+      path = fetchurl {
+        name = "pump___pump_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz";
+        sha1 = "12399add6e4cf7526d973cbc8b5ce2e2908b3909";
+      };
+    }
+    {
+      name = "pump___pump_3.0.0.tgz";
+      path = fetchurl {
+        name = "pump___pump_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz";
+        sha1 = "b4a2116815bde2f4e1ea602354e8c75565107a64";
+      };
+    }
+    {
+      name = "pumpify___pumpify_1.5.1.tgz";
+      path = fetchurl {
+        name = "pumpify___pumpify_1.5.1.tgz";
+        url  = "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz";
+        sha1 = "36513be246ab27570b1a374a5ce278bfd74370ce";
       };
     }
     {
@@ -802,11 +4154,59 @@
       };
     }
     {
+      name = "pupa___pupa_2.0.1.tgz";
+      path = fetchurl {
+        name = "pupa___pupa_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/pupa/-/pupa-2.0.1.tgz";
+        sha1 = "dbdc9ff48ffbea4a26a069b6f9f7abb051008726";
+      };
+    }
+    {
+      name = "qrcode_terminal___qrcode_terminal_0.12.0.tgz";
+      path = fetchurl {
+        name = "qrcode_terminal___qrcode_terminal_0.12.0.tgz";
+        url  = "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz";
+        sha1 = "bb5b699ef7f9f0505092a3748be4464fe71b5819";
+      };
+    }
+    {
+      name = "qs___qs_6.9.1.tgz";
+      path = fetchurl {
+        name = "qs___qs_6.9.1.tgz";
+        url  = "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz";
+        sha1 = "20082c65cb78223635ab1a9eaca8875a29bf8ec9";
+      };
+    }
+    {
       name = "qs___qs_6.5.2.tgz";
       path = fetchurl {
         name = "qs___qs_6.5.2.tgz";
         url  = "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz";
         sha1 = "cb3ae806e8740444584ef154ce8ee98d403f3e36";
+      };
+    }
+    {
+      name = "query_string___query_string_6.10.1.tgz";
+      path = fetchurl {
+        name = "query_string___query_string_6.10.1.tgz";
+        url  = "https://registry.yarnpkg.com/query-string/-/query-string-6.10.1.tgz";
+        sha1 = "30b3505f6fca741d5ae541964d1b3ae9dc2a0de8";
+      };
+    }
+    {
+      name = "qw___qw_1.0.1.tgz";
+      path = fetchurl {
+        name = "qw___qw_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz";
+        sha1 = "efbfdc740f9ad054304426acb183412cc8b996d4";
+      };
+    }
+    {
+      name = "rc___rc_1.2.8.tgz";
+      path = fetchurl {
+        name = "rc___rc_1.2.8.tgz";
+        url  = "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz";
+        sha1 = "cd924bf5200a075b83c188cd6b9e211b7fc0d3ed";
       };
     }
     {
@@ -818,11 +4218,299 @@
       };
     }
     {
+      name = "read_cmd_shim___read_cmd_shim_1.0.5.tgz";
+      path = fetchurl {
+        name = "read_cmd_shim___read_cmd_shim_1.0.5.tgz";
+        url  = "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz";
+        sha1 = "87e43eba50098ba5a32d0ceb583ab8e43b961c16";
+      };
+    }
+    {
+      name = "read_config_file___read_config_file_5.0.1.tgz";
+      path = fetchurl {
+        name = "read_config_file___read_config_file_5.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/read-config-file/-/read-config-file-5.0.1.tgz";
+        sha1 = "ead3df0d9822cc96006ca16322eaa79dac8591c2";
+      };
+    }
+    {
+      name = "read_installed___read_installed_4.0.3.tgz";
+      path = fetchurl {
+        name = "read_installed___read_installed_4.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/read-installed/-/read-installed-4.0.3.tgz";
+        sha1 = "ff9b8b67f187d1e4c29b9feb31f6b223acd19067";
+      };
+    }
+    {
+      name = "read_package_json___read_package_json_2.1.1.tgz";
+      path = fetchurl {
+        name = "read_package_json___read_package_json_2.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/read-package-json/-/read-package-json-2.1.1.tgz";
+        sha1 = "16aa66c59e7d4dad6288f179dd9295fd59bb98f1";
+      };
+    }
+    {
+      name = "read_package_tree___read_package_tree_5.3.1.tgz";
+      path = fetchurl {
+        name = "read_package_tree___read_package_tree_5.3.1.tgz";
+        url  = "https://registry.yarnpkg.com/read-package-tree/-/read-package-tree-5.3.1.tgz";
+        sha1 = "a32cb64c7f31eb8a6f31ef06f9cedf74068fe636";
+      };
+    }
+    {
+      name = "read_pkg_up___read_pkg_up_2.0.0.tgz";
+      path = fetchurl {
+        name = "read_pkg_up___read_pkg_up_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz";
+        sha1 = "6b72a8048984e0c41e79510fd5e9fa99b3b549be";
+      };
+    }
+    {
+      name = "read_pkg___read_pkg_2.0.0.tgz";
+      path = fetchurl {
+        name = "read_pkg___read_pkg_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz";
+        sha1 = "8ef1c0623c6a6db0dc6713c4bfac46332b2368f8";
+      };
+    }
+    {
+      name = "read___read_1.0.7.tgz";
+      path = fetchurl {
+        name = "read___read_1.0.7.tgz";
+        url  = "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz";
+        sha1 = "b3da19bd052431a97671d44a42634adf710b40c4";
+      };
+    }
+    {
+      name = "readable_stream___readable_stream_2.3.7.tgz";
+      path = fetchurl {
+        name = "readable_stream___readable_stream_2.3.7.tgz";
+        url  = "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz";
+        sha1 = "1eca1cf711aef814c04f62252a36a62f6cb23b57";
+      };
+    }
+    {
+      name = "readable_stream___readable_stream_2.3.6.tgz";
+      path = fetchurl {
+        name = "readable_stream___readable_stream_2.3.6.tgz";
+        url  = "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz";
+        sha1 = "b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf";
+      };
+    }
+    {
+      name = "readable_stream___readable_stream_3.4.0.tgz";
+      path = fetchurl {
+        name = "readable_stream___readable_stream_3.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz";
+        sha1 = "a51c26754658e0a3c21dbf59163bd45ba6f447fc";
+      };
+    }
+    {
+      name = "readable_stream___readable_stream_1.1.14.tgz";
+      path = fetchurl {
+        name = "readable_stream___readable_stream_1.1.14.tgz";
+        url  = "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz";
+        sha1 = "7cf4c54ef648e3813084c636dd2079e166c081d9";
+      };
+    }
+    {
+      name = "readdir_scoped_modules___readdir_scoped_modules_1.1.0.tgz";
+      path = fetchurl {
+        name = "readdir_scoped_modules___readdir_scoped_modules_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz";
+        sha1 = "8d45407b4f870a0dcaebc0e28670d18e74514309";
+      };
+    }
+    {
+      name = "regenerator_runtime___regenerator_runtime_0.13.5.tgz";
+      path = fetchurl {
+        name = "regenerator_runtime___regenerator_runtime_0.13.5.tgz";
+        url  = "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz";
+        sha1 = "d878a1d094b4306d10b9096484b33ebd55e26697";
+      };
+    }
+    {
+      name = "regexp.prototype.flags___regexp.prototype.flags_1.2.0.tgz";
+      path = fetchurl {
+        name = "regexp.prototype.flags___regexp.prototype.flags_1.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz";
+        sha1 = "6b30724e306a27833eeb171b66ac8890ba37e41c";
+      };
+    }
+    {
+      name = "regexpp___regexpp_2.0.1.tgz";
+      path = fetchurl {
+        name = "regexpp___regexpp_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz";
+        sha1 = "8d19d31cf632482b589049f8281f93dbcba4d07f";
+      };
+    }
+    {
+      name = "registry_auth_token___registry_auth_token_3.4.0.tgz";
+      path = fetchurl {
+        name = "registry_auth_token___registry_auth_token_3.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.4.0.tgz";
+        sha1 = "d7446815433f5d5ed6431cd5dca21048f66b397e";
+      };
+    }
+    {
+      name = "registry_auth_token___registry_auth_token_4.0.0.tgz";
+      path = fetchurl {
+        name = "registry_auth_token___registry_auth_token_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.0.0.tgz";
+        sha1 = "30e55961eec77379da551ea5c4cf43cbf03522be";
+      };
+    }
+    {
+      name = "registry_url___registry_url_3.1.0.tgz";
+      path = fetchurl {
+        name = "registry_url___registry_url_3.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz";
+        sha1 = "3d4ef870f73dde1d77f0cf9a381432444e174942";
+      };
+    }
+    {
+      name = "registry_url___registry_url_5.1.0.tgz";
+      path = fetchurl {
+        name = "registry_url___registry_url_5.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/registry-url/-/registry-url-5.1.0.tgz";
+        sha1 = "e98334b50d5434b81136b44ec638d9c2009c5009";
+      };
+    }
+    {
       name = "request___request_2.88.0.tgz";
       path = fetchurl {
         name = "request___request_2.88.0.tgz";
         url  = "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz";
         sha1 = "9c2fca4f7d35b592efe57c7f0a55e81052124fef";
+      };
+    }
+    {
+      name = "require_directory___require_directory_2.1.1.tgz";
+      path = fetchurl {
+        name = "require_directory___require_directory_2.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz";
+        sha1 = "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42";
+      };
+    }
+    {
+      name = "require_main_filename___require_main_filename_1.0.1.tgz";
+      path = fetchurl {
+        name = "require_main_filename___require_main_filename_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz";
+        sha1 = "97f717b69d48784f5f526a6c5aa8ffdda055a4d1";
+      };
+    }
+    {
+      name = "require_main_filename___require_main_filename_2.0.0.tgz";
+      path = fetchurl {
+        name = "require_main_filename___require_main_filename_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz";
+        sha1 = "d0b329ecc7cc0f61649f62215be69af54aa8989b";
+      };
+    }
+    {
+      name = "resolve_from___resolve_from_4.0.0.tgz";
+      path = fetchurl {
+        name = "resolve_from___resolve_from_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz";
+        sha1 = "4abcd852ad32dd7baabfe9b40e00a36db5f392e6";
+      };
+    }
+    {
+      name = "resolve___resolve_1.13.1.tgz";
+      path = fetchurl {
+        name = "resolve___resolve_1.13.1.tgz";
+        url  = "https://registry.yarnpkg.com/resolve/-/resolve-1.13.1.tgz";
+        sha1 = "be0aa4c06acd53083505abb35f4d66932ab35d16";
+      };
+    }
+    {
+      name = "responselike___responselike_1.0.2.tgz";
+      path = fetchurl {
+        name = "responselike___responselike_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz";
+        sha1 = "918720ef3b631c5642be068f15ade5a46f4ba1e7";
+      };
+    }
+    {
+      name = "restore_cursor___restore_cursor_2.0.0.tgz";
+      path = fetchurl {
+        name = "restore_cursor___restore_cursor_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz";
+        sha1 = "9f7ee287f82fd326d4fd162923d62129eee0dfaf";
+      };
+    }
+    {
+      name = "retry___retry_0.10.1.tgz";
+      path = fetchurl {
+        name = "retry___retry_0.10.1.tgz";
+        url  = "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz";
+        sha1 = "e76388d217992c252750241d3d3956fed98d8ff4";
+      };
+    }
+    {
+      name = "retry___retry_0.12.0.tgz";
+      path = fetchurl {
+        name = "retry___retry_0.12.0.tgz";
+        url  = "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz";
+        sha1 = "1b42a6266a21f07421d1b0b54b7dc167b01c013b";
+      };
+    }
+    {
+      name = "rimraf___rimraf_2.6.3.tgz";
+      path = fetchurl {
+        name = "rimraf___rimraf_2.6.3.tgz";
+        url  = "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz";
+        sha1 = "b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab";
+      };
+    }
+    {
+      name = "rimraf___rimraf_2.7.1.tgz";
+      path = fetchurl {
+        name = "rimraf___rimraf_2.7.1.tgz";
+        url  = "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz";
+        sha1 = "35797f13a7fdadc566142c29d4f07ccad483e3ec";
+      };
+    }
+    {
+      name = "rimraf___rimraf_3.0.2.tgz";
+      path = fetchurl {
+        name = "rimraf___rimraf_3.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz";
+        sha1 = "f1a5402ba6220ad52cc1282bac1ae3aa49fd061a";
+      };
+    }
+    {
+      name = "run_async___run_async_2.3.0.tgz";
+      path = fetchurl {
+        name = "run_async___run_async_2.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz";
+        sha1 = "0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0";
+      };
+    }
+    {
+      name = "run_queue___run_queue_1.0.3.tgz";
+      path = fetchurl {
+        name = "run_queue___run_queue_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz";
+        sha1 = "e848396f057d223f24386924618e25694161ec47";
+      };
+    }
+    {
+      name = "rxjs___rxjs_6.5.3.tgz";
+      path = fetchurl {
+        name = "rxjs___rxjs_6.5.3.tgz";
+        url  = "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz";
+        sha1 = "510e26317f4db91a7eb1de77d9dd9ba0a4899a3a";
+      };
+    }
+    {
+      name = "safe_buffer___safe_buffer_5.2.0.tgz";
+      path = fetchurl {
+        name = "safe_buffer___safe_buffer_5.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz";
+        sha1 = "b74daec49b1148f88c64b68d49b1e815c1f2f519";
       };
     }
     {
@@ -842,11 +4530,91 @@
       };
     }
     {
+      name = "sanitize_filename___sanitize_filename_1.6.3.tgz";
+      path = fetchurl {
+        name = "sanitize_filename___sanitize_filename_1.6.3.tgz";
+        url  = "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.3.tgz";
+        sha1 = "755ebd752045931977e30b2025d340d7c9090378";
+      };
+    }
+    {
       name = "sax___sax_1.2.4.tgz";
       path = fetchurl {
         name = "sax___sax_1.2.4.tgz";
         url  = "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz";
         sha1 = "2816234e2378bddc4e5354fab5caa895df7100d9";
+      };
+    }
+    {
+      name = "semver_diff___semver_diff_2.1.0.tgz";
+      path = fetchurl {
+        name = "semver_diff___semver_diff_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz";
+        sha1 = "4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36";
+      };
+    }
+    {
+      name = "semver_diff___semver_diff_3.1.1.tgz";
+      path = fetchurl {
+        name = "semver_diff___semver_diff_3.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/semver-diff/-/semver-diff-3.1.1.tgz";
+        sha1 = "05f77ce59f325e00e2706afd67bb506ddb1ca32b";
+      };
+    }
+    {
+      name = "semver___semver_5.7.1.tgz";
+      path = fetchurl {
+        name = "semver___semver_5.7.1.tgz";
+        url  = "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz";
+        sha1 = "a954f931aeba508d307bbf069eff0c01c96116f7";
+      };
+    }
+    {
+      name = "semver___semver_6.3.0.tgz";
+      path = fetchurl {
+        name = "semver___semver_6.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz";
+        sha1 = "ee0a64c8af5e8ceea67687b133761e1becbd1d3d";
+      };
+    }
+    {
+      name = "semver___semver_7.1.3.tgz";
+      path = fetchurl {
+        name = "semver___semver_7.1.3.tgz";
+        url  = "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz";
+        sha1 = "e4345ce73071c53f336445cfc19efb1c311df2a6";
+      };
+    }
+    {
+      name = "set_blocking___set_blocking_2.0.0.tgz";
+      path = fetchurl {
+        name = "set_blocking___set_blocking_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz";
+        sha1 = "045f9782d011ae9a6803ddd382b24392b3d890f7";
+      };
+    }
+    {
+      name = "sha___sha_3.0.0.tgz";
+      path = fetchurl {
+        name = "sha___sha_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/sha/-/sha-3.0.0.tgz";
+        sha1 = "b2f2f90af690c16a3a839a6a6c680ea51fedd1ae";
+      };
+    }
+    {
+      name = "shebang_command___shebang_command_1.2.0.tgz";
+      path = fetchurl {
+        name = "shebang_command___shebang_command_1.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz";
+        sha1 = "44aac65b695b03398968c39f363fee5deafdf1ea";
+      };
+    }
+    {
+      name = "shebang_regex___shebang_regex_1.0.0.tgz";
+      path = fetchurl {
+        name = "shebang_regex___shebang_regex_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz";
+        sha1 = "da42f49740c0b42db2ca9728571cb190c98efea3";
       };
     }
     {
@@ -858,11 +4626,171 @@
       };
     }
     {
+      name = "slice_ansi___slice_ansi_2.1.0.tgz";
+      path = fetchurl {
+        name = "slice_ansi___slice_ansi_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz";
+        sha1 = "cacd7693461a637a5788d92a7dd4fba068e81636";
+      };
+    }
+    {
+      name = "slide___slide_1.1.6.tgz";
+      path = fetchurl {
+        name = "slide___slide_1.1.6.tgz";
+        url  = "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz";
+        sha1 = "56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707";
+      };
+    }
+    {
+      name = "smart_buffer___smart_buffer_4.1.0.tgz";
+      path = fetchurl {
+        name = "smart_buffer___smart_buffer_4.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz";
+        sha1 = "91605c25d91652f4661ea69ccf45f1b331ca21ba";
+      };
+    }
+    {
+      name = "socks_proxy_agent___socks_proxy_agent_4.0.2.tgz";
+      path = fetchurl {
+        name = "socks_proxy_agent___socks_proxy_agent_4.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz";
+        sha1 = "3c8991f3145b2799e70e11bd5fbc8b1963116386";
+      };
+    }
+    {
+      name = "socks___socks_2.3.3.tgz";
+      path = fetchurl {
+        name = "socks___socks_2.3.3.tgz";
+        url  = "https://registry.yarnpkg.com/socks/-/socks-2.3.3.tgz";
+        sha1 = "01129f0a5d534d2b897712ed8aceab7ee65d78e3";
+      };
+    }
+    {
+      name = "sorted_object___sorted_object_2.0.1.tgz";
+      path = fetchurl {
+        name = "sorted_object___sorted_object_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/sorted-object/-/sorted-object-2.0.1.tgz";
+        sha1 = "7d631f4bd3a798a24af1dffcfbfe83337a5df5fc";
+      };
+    }
+    {
+      name = "sorted_union_stream___sorted_union_stream_2.1.3.tgz";
+      path = fetchurl {
+        name = "sorted_union_stream___sorted_union_stream_2.1.3.tgz";
+        url  = "https://registry.yarnpkg.com/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz";
+        sha1 = "c7794c7e077880052ff71a8d4a2dbb4a9a638ac7";
+      };
+    }
+    {
+      name = "source_map_support___source_map_support_0.5.16.tgz";
+      path = fetchurl {
+        name = "source_map_support___source_map_support_0.5.16.tgz";
+        url  = "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz";
+        sha1 = "0ae069e7fe3ba7538c64c98515e35339eac5a042";
+      };
+    }
+    {
+      name = "source_map___source_map_0.6.1.tgz";
+      path = fetchurl {
+        name = "source_map___source_map_0.6.1.tgz";
+        url  = "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz";
+        sha1 = "74722af32e9614e9c287a8d0bbde48b5e2f1a263";
+      };
+    }
+    {
+      name = "spdx_correct___spdx_correct_3.1.0.tgz";
+      path = fetchurl {
+        name = "spdx_correct___spdx_correct_3.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz";
+        sha1 = "fb83e504445268f154b074e218c87c003cd31df4";
+      };
+    }
+    {
+      name = "spdx_exceptions___spdx_exceptions_2.2.0.tgz";
+      path = fetchurl {
+        name = "spdx_exceptions___spdx_exceptions_2.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz";
+        sha1 = "2ea450aee74f2a89bfb94519c07fcd6f41322977";
+      };
+    }
+    {
+      name = "spdx_expression_parse___spdx_expression_parse_3.0.0.tgz";
+      path = fetchurl {
+        name = "spdx_expression_parse___spdx_expression_parse_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz";
+        sha1 = "99e119b7a5da00e05491c9fa338b7904823b41d0";
+      };
+    }
+    {
+      name = "spdx_license_ids___spdx_license_ids_3.0.5.tgz";
+      path = fetchurl {
+        name = "spdx_license_ids___spdx_license_ids_3.0.5.tgz";
+        url  = "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz";
+        sha1 = "3694b5804567a458d3c8045842a6358632f62654";
+      };
+    }
+    {
+      name = "split_on_first___split_on_first_1.1.0.tgz";
+      path = fetchurl {
+        name = "split_on_first___split_on_first_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz";
+        sha1 = "f610afeee3b12bce1d0c30425e76398b78249a5f";
+      };
+    }
+    {
+      name = "sprintf_js___sprintf_js_1.0.3.tgz";
+      path = fetchurl {
+        name = "sprintf_js___sprintf_js_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz";
+        sha1 = "04e6926f662895354f3dd015203633b857297e2c";
+      };
+    }
+    {
       name = "sshpk___sshpk_1.16.1.tgz";
       path = fetchurl {
         name = "sshpk___sshpk_1.16.1.tgz";
         url  = "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz";
         sha1 = "fb661c0bef29b39db40769ee39fa70093d6f6877";
+      };
+    }
+    {
+      name = "ssri___ssri_6.0.1.tgz";
+      path = fetchurl {
+        name = "ssri___ssri_6.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz";
+        sha1 = "2a3c41b28dd45b62b63676ecb74001265ae9edd8";
+      };
+    }
+    {
+      name = "stat_mode___stat_mode_1.0.0.tgz";
+      path = fetchurl {
+        name = "stat_mode___stat_mode_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/stat-mode/-/stat-mode-1.0.0.tgz";
+        sha1 = "68b55cb61ea639ff57136f36b216a291800d1465";
+      };
+    }
+    {
+      name = "stream_each___stream_each_1.2.3.tgz";
+      path = fetchurl {
+        name = "stream_each___stream_each_1.2.3.tgz";
+        url  = "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz";
+        sha1 = "ebe27a0c389b04fbcc233642952e10731afa9bae";
+      };
+    }
+    {
+      name = "stream_iterate___stream_iterate_1.2.0.tgz";
+      path = fetchurl {
+        name = "stream_iterate___stream_iterate_1.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/stream-iterate/-/stream-iterate-1.2.0.tgz";
+        sha1 = "2bd7c77296c1702a46488b8ad41f79865eecd4e1";
+      };
+    }
+    {
+      name = "stream_shift___stream_shift_1.0.1.tgz";
+      path = fetchurl {
+        name = "stream_shift___stream_shift_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz";
+        sha1 = "d7088281559ab2778424279b0877da3c392d5a3d";
       };
     }
     {
@@ -882,11 +4810,259 @@
       };
     }
     {
-      name = "string.prototype.trim___string.prototype.trim_1.1.2.tgz";
+      name = "strict_uri_encode___strict_uri_encode_2.0.0.tgz";
       path = fetchurl {
-        name = "string.prototype.trim___string.prototype.trim_1.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz";
-        sha1 = "d04de2c89e137f4d7d206f086b5ed2fae6be8cea";
+        name = "strict_uri_encode___strict_uri_encode_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz";
+        sha1 = "b9c7330c7042862f6b142dc274bbcc5866ce3546";
+      };
+    }
+    {
+      name = "string_width___string_width_1.0.2.tgz";
+      path = fetchurl {
+        name = "string_width___string_width_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz";
+        sha1 = "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3";
+      };
+    }
+    {
+      name = "string_width___string_width_2.1.1.tgz";
+      path = fetchurl {
+        name = "string_width___string_width_2.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz";
+        sha1 = "ab93f27a8dc13d28cac815c462143a6d9012ae9e";
+      };
+    }
+    {
+      name = "string_width___string_width_3.1.0.tgz";
+      path = fetchurl {
+        name = "string_width___string_width_3.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz";
+        sha1 = "22767be21b62af1081574306f69ac51b62203961";
+      };
+    }
+    {
+      name = "string_width___string_width_4.2.0.tgz";
+      path = fetchurl {
+        name = "string_width___string_width_4.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz";
+        sha1 = "952182c46cc7b2c313d1596e623992bd163b72b5";
+      };
+    }
+    {
+      name = "string.prototype.trimleft___string.prototype.trimleft_2.1.0.tgz";
+      path = fetchurl {
+        name = "string.prototype.trimleft___string.prototype.trimleft_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz";
+        sha1 = "6cc47f0d7eb8d62b0f3701611715a3954591d634";
+      };
+    }
+    {
+      name = "string.prototype.trimright___string.prototype.trimright_2.1.0.tgz";
+      path = fetchurl {
+        name = "string.prototype.trimright___string.prototype.trimright_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz";
+        sha1 = "669d164be9df9b6f7559fa8e89945b168a5a6c58";
+      };
+    }
+    {
+      name = "string_decoder___string_decoder_1.3.0.tgz";
+      path = fetchurl {
+        name = "string_decoder___string_decoder_1.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz";
+        sha1 = "42f114594a46cf1a8e30b0a84f56c78c3edac21e";
+      };
+    }
+    {
+      name = "string_decoder___string_decoder_0.10.31.tgz";
+      path = fetchurl {
+        name = "string_decoder___string_decoder_0.10.31.tgz";
+        url  = "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz";
+        sha1 = "62e203bc41766c6c28c9fc84301dab1c5310fa94";
+      };
+    }
+    {
+      name = "string_decoder___string_decoder_1.1.1.tgz";
+      path = fetchurl {
+        name = "string_decoder___string_decoder_1.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz";
+        sha1 = "9cf1611ba62685d7030ae9e4ba34149c3af03fc8";
+      };
+    }
+    {
+      name = "stringify_package___stringify_package_1.0.1.tgz";
+      path = fetchurl {
+        name = "stringify_package___stringify_package_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz";
+        sha1 = "e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85";
+      };
+    }
+    {
+      name = "strip_ansi___strip_ansi_3.0.1.tgz";
+      path = fetchurl {
+        name = "strip_ansi___strip_ansi_3.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz";
+        sha1 = "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf";
+      };
+    }
+    {
+      name = "strip_ansi___strip_ansi_4.0.0.tgz";
+      path = fetchurl {
+        name = "strip_ansi___strip_ansi_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz";
+        sha1 = "a8479022eb1ac368a871389b635262c505ee368f";
+      };
+    }
+    {
+      name = "strip_ansi___strip_ansi_5.2.0.tgz";
+      path = fetchurl {
+        name = "strip_ansi___strip_ansi_5.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz";
+        sha1 = "8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae";
+      };
+    }
+    {
+      name = "strip_ansi___strip_ansi_6.0.0.tgz";
+      path = fetchurl {
+        name = "strip_ansi___strip_ansi_6.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz";
+        sha1 = "0b1571dd7669ccd4f3e06e14ef1eed26225ae532";
+      };
+    }
+    {
+      name = "strip_bom___strip_bom_3.0.0.tgz";
+      path = fetchurl {
+        name = "strip_bom___strip_bom_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz";
+        sha1 = "2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3";
+      };
+    }
+    {
+      name = "strip_eof___strip_eof_1.0.0.tgz";
+      path = fetchurl {
+        name = "strip_eof___strip_eof_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz";
+        sha1 = "bb43ff5598a6eb05d89b59fcd129c983313606bf";
+      };
+    }
+    {
+      name = "strip_json_comments___strip_json_comments_2.0.1.tgz";
+      path = fetchurl {
+        name = "strip_json_comments___strip_json_comments_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz";
+        sha1 = "3c531942e908c2697c0ec344858c286c7ca0a60a";
+      };
+    }
+    {
+      name = "supports_color___supports_color_5.5.0.tgz";
+      path = fetchurl {
+        name = "supports_color___supports_color_5.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz";
+        sha1 = "e2e69a44ac8772f78a1ec0b35b689df6530efc8f";
+      };
+    }
+    {
+      name = "supports_color___supports_color_7.1.0.tgz";
+      path = fetchurl {
+        name = "supports_color___supports_color_7.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz";
+        sha1 = "68e32591df73e25ad1c4b49108a2ec507962bfd1";
+      };
+    }
+    {
+      name = "table___table_5.4.6.tgz";
+      path = fetchurl {
+        name = "table___table_5.4.6.tgz";
+        url  = "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz";
+        sha1 = "1292d19500ce3f86053b05f0e8e7e4a3bb21079e";
+      };
+    }
+    {
+      name = "tar_stream___tar_stream_2.1.0.tgz";
+      path = fetchurl {
+        name = "tar_stream___tar_stream_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.0.tgz";
+        sha1 = "d1aaa3661f05b38b5acc9b7020efdca5179a2cc3";
+      };
+    }
+    {
+      name = "tar___tar_4.4.13.tgz";
+      path = fetchurl {
+        name = "tar___tar_4.4.13.tgz";
+        url  = "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz";
+        sha1 = "43b364bc52888d555298637b10d60790254ab525";
+      };
+    }
+    {
+      name = "tar___tar_6.0.1.tgz";
+      path = fetchurl {
+        name = "tar___tar_6.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/tar/-/tar-6.0.1.tgz";
+        sha1 = "7b3bd6c313cb6e0153770108f8d70ac298607efa";
+      };
+    }
+    {
+      name = "temp_file___temp_file_3.3.6.tgz";
+      path = fetchurl {
+        name = "temp_file___temp_file_3.3.6.tgz";
+        url  = "https://registry.yarnpkg.com/temp-file/-/temp-file-3.3.6.tgz";
+        sha1 = "bd7a1951338bf93b59380b498ec1804d5b76c449";
+      };
+    }
+    {
+      name = "term_size___term_size_1.2.0.tgz";
+      path = fetchurl {
+        name = "term_size___term_size_1.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz";
+        sha1 = "458b83887f288fc56d6fffbfad262e26638efa69";
+      };
+    }
+    {
+      name = "term_size___term_size_2.2.0.tgz";
+      path = fetchurl {
+        name = "term_size___term_size_2.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/term-size/-/term-size-2.2.0.tgz";
+        sha1 = "1f16adedfe9bdc18800e1776821734086fcc6753";
+      };
+    }
+    {
+      name = "text_table___text_table_0.2.0.tgz";
+      path = fetchurl {
+        name = "text_table___text_table_0.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz";
+        sha1 = "7f5ee823ae805207c00af2df4a84ec3fcfa570b4";
+      };
+    }
+    {
+      name = "through2___through2_2.0.5.tgz";
+      path = fetchurl {
+        name = "through2___through2_2.0.5.tgz";
+        url  = "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz";
+        sha1 = "01c1e39eb31d07cb7d03a96a70823260b23132cd";
+      };
+    }
+    {
+      name = "through___through_2.3.8.tgz";
+      path = fetchurl {
+        name = "through___through_2.3.8.tgz";
+        url  = "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz";
+        sha1 = "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5";
+      };
+    }
+    {
+      name = "timed_out___timed_out_4.0.1.tgz";
+      path = fetchurl {
+        name = "timed_out___timed_out_4.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz";
+        sha1 = "f32eacac5a175bea25d7fab565ab3ed8741ef56f";
+      };
+    }
+    {
+      name = "tiny_relative_date___tiny_relative_date_1.3.0.tgz";
+      path = fetchurl {
+        name = "tiny_relative_date___tiny_relative_date_1.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz";
+        sha1 = "fa08aad501ed730f31cc043181d995c39a935e07";
       };
     }
     {
@@ -898,11 +5074,59 @@
       };
     }
     {
+      name = "tmp_promise___tmp_promise_1.1.0.tgz";
+      path = fetchurl {
+        name = "tmp_promise___tmp_promise_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-1.1.0.tgz";
+        sha1 = "bb924d239029157b9bc1d506a6aa341f8b13e64c";
+      };
+    }
+    {
+      name = "tmp___tmp_0.1.0.tgz";
+      path = fetchurl {
+        name = "tmp___tmp_0.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz";
+        sha1 = "ee434a4e22543082e294ba6201dcc6eafefa2877";
+      };
+    }
+    {
+      name = "tmp___tmp_0.0.33.tgz";
+      path = fetchurl {
+        name = "tmp___tmp_0.0.33.tgz";
+        url  = "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz";
+        sha1 = "6d34335889768d21b2bcda0aa277ced3b1bfadf9";
+      };
+    }
+    {
+      name = "to_readable_stream___to_readable_stream_1.0.0.tgz";
+      path = fetchurl {
+        name = "to_readable_stream___to_readable_stream_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz";
+        sha1 = "ce0aa0c2f3df6adf852efb404a783e77c0475771";
+      };
+    }
+    {
       name = "tough_cookie___tough_cookie_2.4.3.tgz";
       path = fetchurl {
         name = "tough_cookie___tough_cookie_2.4.3.tgz";
         url  = "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz";
         sha1 = "53f36da3f47783b0925afa06ff9f3b165280f781";
+      };
+    }
+    {
+      name = "truncate_utf8_bytes___truncate_utf8_bytes_1.0.2.tgz";
+      path = fetchurl {
+        name = "truncate_utf8_bytes___truncate_utf8_bytes_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz";
+        sha1 = "405923909592d56f78a5818434b0b78489ca5f2b";
+      };
+    }
+    {
+      name = "tslib___tslib_1.10.0.tgz";
+      path = fetchurl {
+        name = "tslib___tslib_1.10.0.tgz";
+        url  = "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz";
+        sha1 = "c3c19f95973fb0a62973fb09d90d961ee43e5c8a";
       };
     }
     {
@@ -922,11 +5146,139 @@
       };
     }
     {
+      name = "type_check___type_check_0.3.2.tgz";
+      path = fetchurl {
+        name = "type_check___type_check_0.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz";
+        sha1 = "5884cab512cf1d355e3fb784f30804b2b520db72";
+      };
+    }
+    {
+      name = "type_fest___type_fest_0.8.1.tgz";
+      path = fetchurl {
+        name = "type_fest___type_fest_0.8.1.tgz";
+        url  = "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz";
+        sha1 = "09e249ebde851d3b1e48d27c105444667f17b83d";
+      };
+    }
+    {
+      name = "typedarray_to_buffer___typedarray_to_buffer_3.1.5.tgz";
+      path = fetchurl {
+        name = "typedarray_to_buffer___typedarray_to_buffer_3.1.5.tgz";
+        url  = "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz";
+        sha1 = "a97ee7a9ff42691b9f783ff1bc5112fe3fca9080";
+      };
+    }
+    {
+      name = "typedarray___typedarray_0.0.6.tgz";
+      path = fetchurl {
+        name = "typedarray___typedarray_0.0.6.tgz";
+        url  = "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz";
+        sha1 = "867ac74e3864187b1d3d47d996a78ec5c8830777";
+      };
+    }
+    {
+      name = "uid_number___uid_number_0.0.6.tgz";
+      path = fetchurl {
+        name = "uid_number___uid_number_0.0.6.tgz";
+        url  = "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz";
+        sha1 = "0ea10e8035e8eb5b8e4449f06da1c730663baa81";
+      };
+    }
+    {
+      name = "umask___umask_1.1.0.tgz";
+      path = fetchurl {
+        name = "umask___umask_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz";
+        sha1 = "f29cebf01df517912bb58ff9c4e50fde8e33320d";
+      };
+    }
+    {
+      name = "unhomoglyph___unhomoglyph_1.0.3.tgz";
+      path = fetchurl {
+        name = "unhomoglyph___unhomoglyph_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/unhomoglyph/-/unhomoglyph-1.0.3.tgz";
+        sha1 = "8d3551622b57754e10a831bf81442d7f15d1ddfd";
+      };
+    }
+    {
+      name = "unique_filename___unique_filename_1.1.1.tgz";
+      path = fetchurl {
+        name = "unique_filename___unique_filename_1.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz";
+        sha1 = "1d69769369ada0583103a1e6ae87681b56573230";
+      };
+    }
+    {
+      name = "unique_slug___unique_slug_2.0.2.tgz";
+      path = fetchurl {
+        name = "unique_slug___unique_slug_2.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.2.tgz";
+        sha1 = "baabce91083fc64e945b0f3ad613e264f7cd4e6c";
+      };
+    }
+    {
+      name = "unique_string___unique_string_1.0.0.tgz";
+      path = fetchurl {
+        name = "unique_string___unique_string_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz";
+        sha1 = "9e1057cca851abb93398f8b33ae187b99caec11a";
+      };
+    }
+    {
+      name = "unique_string___unique_string_2.0.0.tgz";
+      path = fetchurl {
+        name = "unique_string___unique_string_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz";
+        sha1 = "39c6451f81afb2749de2b233e3f7c5e8843bd89d";
+      };
+    }
+    {
+      name = "universalify___universalify_0.1.2.tgz";
+      path = fetchurl {
+        name = "universalify___universalify_0.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz";
+        sha1 = "b646f69be3942dabcecc9d6639c80dc105efaa66";
+      };
+    }
+    {
+      name = "unpipe___unpipe_1.0.0.tgz";
+      path = fetchurl {
+        name = "unpipe___unpipe_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz";
+        sha1 = "b2bf4ee8514aae6165b4817829d21b2ef49904ec";
+      };
+    }
+    {
       name = "untildify___untildify_3.0.3.tgz";
       path = fetchurl {
         name = "untildify___untildify_3.0.3.tgz";
         url  = "https://registry.yarnpkg.com/untildify/-/untildify-3.0.3.tgz";
         sha1 = "1e7b42b140bcfd922b22e70ca1265bfe3634c7c9";
+      };
+    }
+    {
+      name = "unzip_response___unzip_response_2.0.1.tgz";
+      path = fetchurl {
+        name = "unzip_response___unzip_response_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz";
+        sha1 = "d2f0f737d16b0615e72a6935ed04214572d56f97";
+      };
+    }
+    {
+      name = "update_notifier___update_notifier_2.5.0.tgz";
+      path = fetchurl {
+        name = "update_notifier___update_notifier_2.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz";
+        sha1 = "d0744593e13f161e406acb1d9408b72cad08aff6";
+      };
+    }
+    {
+      name = "update_notifier___update_notifier_4.1.0.tgz";
+      path = fetchurl {
+        name = "update_notifier___update_notifier_4.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/update-notifier/-/update-notifier-4.1.0.tgz";
+        sha1 = "4866b98c3bc5b5473c020b1250583628f9a328f3";
       };
     }
     {
@@ -938,6 +5290,22 @@
       };
     }
     {
+      name = "url_parse_lax___url_parse_lax_1.0.0.tgz";
+      path = fetchurl {
+        name = "url_parse_lax___url_parse_lax_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz";
+        sha1 = "7af8f303645e9bd79a272e7a14ac68bc0609da73";
+      };
+    }
+    {
+      name = "url_parse_lax___url_parse_lax_3.0.0.tgz";
+      path = fetchurl {
+        name = "url_parse_lax___url_parse_lax_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz";
+        sha1 = "16b5cafc07dbe3676c1b1999177823d6503acb0c";
+      };
+    }
+    {
       name = "url_regex___url_regex_3.2.0.tgz";
       path = fetchurl {
         name = "url_regex___url_regex_3.2.0.tgz";
@@ -946,11 +5314,75 @@
       };
     }
     {
-      name = "uuid___uuid_3.3.2.tgz";
+      name = "utf8_byte_length___utf8_byte_length_1.0.4.tgz";
       path = fetchurl {
-        name = "uuid___uuid_3.3.2.tgz";
-        url  = "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz";
-        sha1 = "1b4af4955eb3077c501c23872fc6513811587131";
+        name = "utf8_byte_length___utf8_byte_length_1.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz";
+        sha1 = "f45f150c4c66eee968186505ab93fcbb8ad6bf61";
+      };
+    }
+    {
+      name = "util_deprecate___util_deprecate_1.0.2.tgz";
+      path = fetchurl {
+        name = "util_deprecate___util_deprecate_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz";
+        sha1 = "450d4dc9fa70de732762fbd2d4a28981419a0ccf";
+      };
+    }
+    {
+      name = "util_extend___util_extend_1.0.3.tgz";
+      path = fetchurl {
+        name = "util_extend___util_extend_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/util-extend/-/util-extend-1.0.3.tgz";
+        sha1 = "a7c216d267545169637b3b6edc6ca9119e2ff93f";
+      };
+    }
+    {
+      name = "util_promisify___util_promisify_2.1.0.tgz";
+      path = fetchurl {
+        name = "util_promisify___util_promisify_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/util-promisify/-/util-promisify-2.1.0.tgz";
+        sha1 = "3c2236476c4d32c5ff3c47002add7c13b9a82a53";
+      };
+    }
+    {
+      name = "util.promisify___util.promisify_1.0.0.tgz";
+      path = fetchurl {
+        name = "util.promisify___util.promisify_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz";
+        sha1 = "440f7165a459c9a16dc145eb8e72f35687097030";
+      };
+    }
+    {
+      name = "uuid___uuid_3.3.3.tgz";
+      path = fetchurl {
+        name = "uuid___uuid_3.3.3.tgz";
+        url  = "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz";
+        sha1 = "4568f0216e78760ee1dbf3a4d2cf53e224112866";
+      };
+    }
+    {
+      name = "uuid___uuid_3.4.0.tgz";
+      path = fetchurl {
+        name = "uuid___uuid_3.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz";
+        sha1 = "b23e4358afa8a202fe7a100af1f5f883f02007ee";
+      };
+    }
+    {
+      name = "validate_npm_package_license___validate_npm_package_license_3.0.4.tgz";
+      path = fetchurl {
+        name = "validate_npm_package_license___validate_npm_package_license_3.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz";
+        sha1 = "fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a";
+      };
+    }
+    {
+      name = "validate_npm_package_name___validate_npm_package_name_3.0.0.tgz";
+      path = fetchurl {
+        name = "validate_npm_package_name___validate_npm_package_name_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz";
+        sha1 = "5fa912d81eb7d0c74afc140de7317f0ca7df437e";
       };
     }
     {
@@ -962,6 +5394,54 @@
       };
     }
     {
+      name = "wcwidth___wcwidth_1.0.1.tgz";
+      path = fetchurl {
+        name = "wcwidth___wcwidth_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz";
+        sha1 = "f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8";
+      };
+    }
+    {
+      name = "which_module___which_module_2.0.0.tgz";
+      path = fetchurl {
+        name = "which_module___which_module_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz";
+        sha1 = "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a";
+      };
+    }
+    {
+      name = "which___which_1.3.1.tgz";
+      path = fetchurl {
+        name = "which___which_1.3.1.tgz";
+        url  = "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz";
+        sha1 = "a45043d54f5805316da8d62f9f50918d3da70b0a";
+      };
+    }
+    {
+      name = "wide_align___wide_align_1.1.3.tgz";
+      path = fetchurl {
+        name = "wide_align___wide_align_1.1.3.tgz";
+        url  = "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz";
+        sha1 = "ae074e6bdc0c14a431e804e624549c633b000457";
+      };
+    }
+    {
+      name = "widest_line___widest_line_2.0.1.tgz";
+      path = fetchurl {
+        name = "widest_line___widest_line_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.1.tgz";
+        sha1 = "7438764730ec7ef4381ce4df82fb98a53142a3fc";
+      };
+    }
+    {
+      name = "widest_line___widest_line_3.1.0.tgz";
+      path = fetchurl {
+        name = "widest_line___widest_line_3.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/widest-line/-/widest-line-3.1.0.tgz";
+        sha1 = "8292333bbf66cb45ff0de1603b136b7ae1496eca";
+      };
+    }
+    {
       name = "winreg___winreg_1.2.4.tgz";
       path = fetchurl {
         name = "winreg___winreg_1.2.4.tgz";
@@ -970,11 +5450,83 @@
       };
     }
     {
-      name = "write_file_atomic___write_file_atomic_2.4.2.tgz";
+      name = "word_wrap___word_wrap_1.2.3.tgz";
       path = fetchurl {
-        name = "write_file_atomic___write_file_atomic_2.4.2.tgz";
-        url  = "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.2.tgz";
-        sha1 = "a7181706dfba17855d221140a9c06e15fcdd87b9";
+        name = "word_wrap___word_wrap_1.2.3.tgz";
+        url  = "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz";
+        sha1 = "610636f6b1f703891bd34771ccb17fb93b47079c";
+      };
+    }
+    {
+      name = "worker_farm___worker_farm_1.7.0.tgz";
+      path = fetchurl {
+        name = "worker_farm___worker_farm_1.7.0.tgz";
+        url  = "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.7.0.tgz";
+        sha1 = "26a94c5391bbca926152002f69b84a4bf772e5a8";
+      };
+    }
+    {
+      name = "wrap_ansi___wrap_ansi_2.1.0.tgz";
+      path = fetchurl {
+        name = "wrap_ansi___wrap_ansi_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz";
+        sha1 = "d8fc3d284dd05794fe84973caecdd1cf824fdd85";
+      };
+    }
+    {
+      name = "wrap_ansi___wrap_ansi_6.2.0.tgz";
+      path = fetchurl {
+        name = "wrap_ansi___wrap_ansi_6.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz";
+        sha1 = "e9393ba07102e6c91a3b221478f0257cd2856e53";
+      };
+    }
+    {
+      name = "wrappy___wrappy_1.0.2.tgz";
+      path = fetchurl {
+        name = "wrappy___wrappy_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz";
+        sha1 = "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f";
+      };
+    }
+    {
+      name = "write_file_atomic___write_file_atomic_2.4.3.tgz";
+      path = fetchurl {
+        name = "write_file_atomic___write_file_atomic_2.4.3.tgz";
+        url  = "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz";
+        sha1 = "1fd2e9ae1df3e75b8d8c367443c692d4ca81f481";
+      };
+    }
+    {
+      name = "write_file_atomic___write_file_atomic_3.0.1.tgz";
+      path = fetchurl {
+        name = "write_file_atomic___write_file_atomic_3.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.1.tgz";
+        sha1 = "558328352e673b5bb192cf86500d60b230667d4b";
+      };
+    }
+    {
+      name = "write___write_1.0.3.tgz";
+      path = fetchurl {
+        name = "write___write_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz";
+        sha1 = "0800e14523b923a387e415123c865616aae0f5c3";
+      };
+    }
+    {
+      name = "xdg_basedir___xdg_basedir_3.0.0.tgz";
+      path = fetchurl {
+        name = "xdg_basedir___xdg_basedir_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz";
+        sha1 = "496b2cc109eca8dbacfe2dc72b603c17c5870ad4";
+      };
+    }
+    {
+      name = "xdg_basedir___xdg_basedir_4.0.0.tgz";
+      path = fetchurl {
+        name = "xdg_basedir___xdg_basedir_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz";
+        sha1 = "4bc8d9984403696225ef83a1573cbbcb4e79db13";
       };
     }
     {
@@ -994,27 +5546,123 @@
       };
     }
     {
-      name = "xml2js___xml2js_0.4.19.tgz";
+      name = "xml2js___xml2js_0.4.22.tgz";
       path = fetchurl {
-        name = "xml2js___xml2js_0.4.19.tgz";
-        url  = "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz";
-        sha1 = "686c20f213209e94abf0d1bcf1efaa291c7827a7";
+        name = "xml2js___xml2js_0.4.22.tgz";
+        url  = "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.22.tgz";
+        sha1 = "4fa2d846ec803237de86f30aa9b5f70b6600de02";
       };
     }
     {
-      name = "xmlbuilder___xmlbuilder_9.0.7.tgz";
+      name = "xmlbuilder___xmlbuilder_11.0.1.tgz";
       path = fetchurl {
-        name = "xmlbuilder___xmlbuilder_9.0.7.tgz";
-        url  = "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz";
-        sha1 = "132ee63d2ec5565c557e20f4c22df9aca686b10d";
+        name = "xmlbuilder___xmlbuilder_11.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz";
+        sha1 = "be9bae1c8a046e76b31127726347d0ad7002beb3";
       };
     }
     {
-      name = "xtend___xtend_4.0.1.tgz";
+      name = "xtend___xtend_4.0.2.tgz";
       path = fetchurl {
-        name = "xtend___xtend_4.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz";
-        sha1 = "a5c6d532be656e23db820efb943a1f04998d63af";
+        name = "xtend___xtend_4.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz";
+        sha1 = "bb72779f5fa465186b1f438f674fa347fdb5db54";
+      };
+    }
+    {
+      name = "y18n___y18n_3.2.1.tgz";
+      path = fetchurl {
+        name = "y18n___y18n_3.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz";
+        sha1 = "6d15fba884c08679c0d77e88e7759e811e07fa41";
+      };
+    }
+    {
+      name = "y18n___y18n_4.0.0.tgz";
+      path = fetchurl {
+        name = "y18n___y18n_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz";
+        sha1 = "95ef94f85ecc81d007c264e190a120f0a3c8566b";
+      };
+    }
+    {
+      name = "yallist___yallist_2.1.2.tgz";
+      path = fetchurl {
+        name = "yallist___yallist_2.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz";
+        sha1 = "1c11f9218f076089a47dd512f93c6699a6a81d52";
+      };
+    }
+    {
+      name = "yallist___yallist_3.1.1.tgz";
+      path = fetchurl {
+        name = "yallist___yallist_3.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz";
+        sha1 = "dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd";
+      };
+    }
+    {
+      name = "yallist___yallist_4.0.0.tgz";
+      path = fetchurl {
+        name = "yallist___yallist_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz";
+        sha1 = "9bb92790d9c0effec63be73519e11a35019a3a72";
+      };
+    }
+    {
+      name = "yargs_parser___yargs_parser_16.1.0.tgz";
+      path = fetchurl {
+        name = "yargs_parser___yargs_parser_16.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz";
+        sha1 = "73747d53ae187e7b8dbe333f95714c76ea00ecf1";
+      };
+    }
+    {
+      name = "yargs_parser___yargs_parser_7.0.0.tgz";
+      path = fetchurl {
+        name = "yargs_parser___yargs_parser_7.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz";
+        sha1 = "8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9";
+      };
+    }
+    {
+      name = "yargs_parser___yargs_parser_9.0.2.tgz";
+      path = fetchurl {
+        name = "yargs_parser___yargs_parser_9.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz";
+        sha1 = "9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077";
+      };
+    }
+    {
+      name = "yargs___yargs_11.1.1.tgz";
+      path = fetchurl {
+        name = "yargs___yargs_11.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/yargs/-/yargs-11.1.1.tgz";
+        sha1 = "5052efe3446a4df5ed669c995886cc0f13702766";
+      };
+    }
+    {
+      name = "yargs___yargs_15.1.0.tgz";
+      path = fetchurl {
+        name = "yargs___yargs_15.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz";
+        sha1 = "e111381f5830e863a89550bd4b136bb6a5f37219";
+      };
+    }
+    {
+      name = "yargs___yargs_8.0.2.tgz";
+      path = fetchurl {
+        name = "yargs___yargs_8.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz";
+        sha1 = "6299a9055b1cefc969ff7e79c1d918dceb22c360";
+      };
+    }
+    {
+      name = "zip_stream___zip_stream_2.1.2.tgz";
+      path = fetchurl {
+        name = "zip_stream___zip_stream_2.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/zip-stream/-/zip-stream-2.1.2.tgz";
+        sha1 = "841efd23214b602ff49c497cba1a85d8b5fbc39c";
       };
     }
   ];

--- a/pkgs/applications/networking/instant-messengers/riot/riot-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-desktop.nix
@@ -8,20 +8,18 @@
 
 let
   executableName = "riot-desktop";
-  version = "1.6.0";
-  riot-web-src = fetchFromGitHub {
+  version = "1.6.1";
+  src = fetchFromGitHub {
     owner = "vector-im";
-    repo = "riot-web";
+    repo = "riot-desktop";
     rev = "v${version}";
-    sha256 = "16zm6l4c7vkfdlxh6gdw531k5r4v3mb0h66q41h94dvmj79dz2bj";
+    sha256 = "05mhapcgr1802c27428m8wkmw8qis1akv4m7z3m0l89wgv4kh6za";
   };
   electron = electron_7;
 
 in mkYarnPackage rec {
   name = "riot-desktop-${version}";
-  inherit version;
-
-  src = "${riot-web-src}/electron_app";
+  inherit version src;
 
   packageJSON = ./riot-desktop-package.json;
   yarnNix = ./riot-desktop-yarndeps.nix;
@@ -32,8 +30,8 @@ in mkYarnPackage rec {
     # resources
     mkdir -p "$out/share/riot"
     ln -s '${riot-web}' "$out/share/riot/webapp"
-    cp -r './deps/riot-web' "$out/share/riot/electron"
-    cp -r './deps/riot-web/img' "$out/share/riot"
+    cp -r './deps/riot-desktop' "$out/share/riot/electron"
+    cp -r './deps/riot-desktop/res/img' "$out/share/riot"
     rm "$out/share/riot/electron/node_modules"
     cp -r './node_modules' "$out/share/riot/electron"
 
@@ -80,7 +78,7 @@ in mkYarnPackage rec {
     description = "A feature-rich client for Matrix.org";
     homepage = "https://about.riot.im/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ pacien worldofpeace ];
+    maintainers = with maintainers; [ pacien worldofpeace ma27 ];
     inherit (electron.meta) platforms;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
@@ -12,11 +12,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "riot-web";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchurl {
     url = "https://github.com/vector-im/riot-web/releases/download/v${version}/riot-v${version}.tar.gz";
-    sha256 = "1mm4xk69ya1k3gz6jjhc4njx7b3rp157jmrqsxr5i382zs035ff7";
+    sha256 = "0mqb9y38vnngwz38qgdn24mspmk6zh4v1j778ppban034ga0almv";
   };
 
   installPhase = ''

--- a/pkgs/applications/networking/instant-messengers/riot/update-riot-desktop.sh
+++ b/pkgs/applications/networking/instant-messengers/riot/update-riot-desktop.sh
@@ -9,9 +9,9 @@ if [ "$#" -ne 1 ] || [[ "$1" == -* ]]; then
 	exit 1
 fi
 
-RIOT_WEB_SRC="https://raw.githubusercontent.com/vector-im/riot-web/$1"
+RIOT_WEB_SRC="https://raw.githubusercontent.com/vector-im/riot-desktop/$1"
 
-wget "$RIOT_WEB_SRC/electron_app/package.json" -O riot-desktop-package.json
-wget "$RIOT_WEB_SRC/electron_app/yarn.lock" -O riot-desktop-yarndeps.lock
+wget "$RIOT_WEB_SRC/package.json" -O riot-desktop-package.json
+wget "$RIOT_WEB_SRC/yarn.lock" -O riot-desktop-yarndeps.lock
 yarn2nix --lockfile=riot-desktop-yarndeps.lock > riot-desktop-yarndeps.nix
 rm riot-desktop-yarndeps.lock

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -23,11 +23,11 @@ let
 
 in buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "1.12.4";
+  version = "1.13.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0psr17ai42ma9923g9bj3q9fd8kph9rx7jpxsxwbfzr2y6lwr306";
+    sha256 = "10s34h1qh9k88bxv0l0whvy7kirmx9kwgdxrz7sv3rv42cyr1989";
   };
 
   patches = [


### PR DESCRIPTION

###### Motivation for this change

Some Matrix-related updates:

* `matrix-synapse`: https://github.com/matrix-org/synapse/releases/tag/v1.13.0
* `riot-web`: https://github.com/vector-im/riot-web/releases/tag/v1.6.1
* `riot-desktop`: https://github.com/vector-im/riot-desktop/releases/tag/v1.6.1

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
