### PR TITLE
rpiboot-unstable: 2018-03-27 -> 2020-02-17

### DIFF
--- a/pkgs/development/misc/rpiboot/unstable.nix
+++ b/pkgs/development/misc/rpiboot/unstable.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, libusb1 }:
 
 let
-  version = "2018-03-27";
+  version = "2020-02-17";
   name = "rpiboot-unstable-${version}";
 in stdenv.mkDerivation {
   inherit name;
@@ -9,8 +9,8 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "usbboot";
-    rev = "fb86716935f2e820333b037a2ff93a338ad9b695";
-    sha256 = "163g7iw7kf6ra71adx6lf1xzf3kv20bppva15ljwn54jlah5mv98";
+    rev = "7ef900578a2c410062cfc93c439157aec0ef9f5c";
+    sha256 = "095fvdiijhi1wl650ssw2bqcxnhpvhldppx8fir5c8h6qjkh1f1i";
   };
 
   nativeBuildInputs = [ libusb1 ];
@@ -28,7 +28,7 @@ in stdenv.mkDerivation {
 
   meta = {
     homepage = "https://github.com/raspberrypi/usbboot";
-    description = "Utility to boot a Raspberry Pi CM/CM3/Zero over USB";
+    description = "Utility to boot a Raspberry Pi 4/CM/CM3/Zero over USB";
     maintainers = [ stdenv.lib.maintainers.cartr ];
     license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.unix;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Upstream added support for RPi 4, fixed a few bugs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
