### PR TITLE
rhine, rhine-gloss: Remove broken marker

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8890,8 +8890,6 @@ broken-packages:
   - rfc-psql
   - rfc-redis
   - rfc-servant
-  - rhine
-  - rhine-gloss
   - rhythm-game-tutorial
   - ribbit
   - RichConditional


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I cloned fresh from `master` and tested like this:

```
$ echo "{ allowBroken = true; }" > ~/.config/nixpkgs/config.nix

$ nix repl .
Welcome to Nix version 2.3.4. Type :? for help.

Loading '.'...
Added 11883 variables.

nix-repl> :b haskellPackages.rhine
[2 built, 43 copied (132.5 MiB), 10.6 MiB DL]

this derivation produced the following outputs:
  doc -> /nix/store/2x5g9gk7396nz20fcglrca0cxrav5w97-rhine-0.6.0-doc
  out -> /nix/store/nq99lc10zm9wg0g50pmbhjzmikan66bn-rhine-0.6.0

nix-repl> :b haskellPackages.rhine-gloss
[2 built, 47 copied (1010.7 MiB), 142.0 MiB DL]

this derivation produced the following outputs:
  doc -> /nix/store/062pizv6mczkqb25fbcwgdf8a13h3flv-rhine-gloss-0.6.0.1-doc
  out -> /nix/store/aw6lcfcx06apx2jxq30ibs9vcgpaqqa1-rhine-gloss-0.6.0.1
``