### PR TITLE
libressl: add 3.1.3, default to it, remove 2.9

### DIFF
--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -69,7 +69,7 @@ in {
   };
 
   libressl_3_1 = generic {
-    version = "3.1.2";
-    sha256 = "14nqg34yc9bm64hz96hhlvm00gwn2acjs0hcwhs9l50plrz2z2pq";
+    version = "3.1.3";
+    sha256 = "184znscbkww65aavy2p4v4xncalp1ni19c2w5yvfq4pnmhb06sy7";
   };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -79,4 +79,9 @@ in {
     version = "3.0.2";
     sha256 = "13ir2lpxz8y1m151k7lrx306498nzfhwlvgkgv97v5cvywmifyyz";
   };
+
+  libressl_3_1 = generic {
+    version = "3.1.1";
+    sha256 = "006vnr14499fdsvyy0ddpvcn13habymfxxvmqk2aybispdgcximx";
+  };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -63,18 +63,6 @@ let
   };
 
 in {
-
-  libressl_2_9 = generic {
-    version = "2.9.2";
-    sha256 = "1m6mz515dcbrbnyz8hrpdfjzdmj1c15vbgnqxdxb89g3z9kq3iy4";
-    patches = stdenv.lib.optional stdenv.hostPlatform.isMusl [
-      (fetchpatch {
-        url = "https://github.com/libressl-portable/portable/pull/529/commits/a747aacc23607c993cc481378782b2c7dd5bc53b.patch";
-        sha256 = "0wbrcscdkjpk4mhh7f3saghi4smia4lhf7fl6la3ahhgx1krn5zm";
-      })
-    ];
-  };
-
   libressl_3_0 = generic {
     version = "3.0.2";
     sha256 = "13ir2lpxz8y1m151k7lrx306498nzfhwlvgkgv97v5cvywmifyyz";

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -69,7 +69,7 @@ in {
   };
 
   libressl_3_1 = generic {
-    version = "3.1.1";
-    sha256 = "006vnr14499fdsvyy0ddpvcn13habymfxxvmqk2aybispdgcximx";
+    version = "3.1.2";
+    sha256 = "14nqg34yc9bm64hz96hhlvm00gwn2acjs0hcwhs9l50plrz2z2pq";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14002,7 +14002,9 @@ in
     libressl_3_0
     libressl_3_1;
 
-  libressl = libressl_3_0;
+  # Please keep this pointed to the latest version. See also
+  # https://discourse.nixos.org/t/nixpkgs-policy-regarding-libraries-available-in-multiple-versions/7026/2
+  libressl = libressl_3_1;
 
   boringssl = callPackage ../development/libraries/boringssl { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26254,6 +26254,9 @@ in
   wasmer = callPackage ../development/interpreters/wasmer { };
 
   wasm-pack = callPackage ../development/tools/wasm-pack {
+    # Wasm-pack depends on a version of rust-openssl which is incompatible with
+    # LibreSSL 3.1, so we explicitly opt for the older version.
+    libressl = libressl_3_0;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13999,7 +13999,6 @@ in
   openvdb = callPackage ../development/libraries/openvdb {};
 
   inherit (callPackages ../development/libraries/libressl { })
-    libressl_2_9
     libressl_3_0
     libressl_3_1;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14000,7 +14000,8 @@ in
 
   inherit (callPackages ../development/libraries/libressl { })
     libressl_2_9
-    libressl_3_0;
+    libressl_3_0
+    libressl_3_1;
 
   libressl = libressl_3_0;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

* [LibreSSL 3.1.1 has been released upstream](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.1.1-relnotes.txt).
* LibreSSL 2.9, which was part of [OpenBSD 6.5](https://www.openbsd.org/65.html), is no longer supported, because OpenBSD 6.5 is now more than one year old.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I also tested compiling Nginx against this LibreSSL, which succeeded.