### PR TITLE
expose gcov, gcc-ar, gcc-ranlib and others gcc tools in gcc-wrapper (fixes #86272)

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -217,6 +217,14 @@ stdenv.mkDerivation {
 
     + optionalString cc.langGo or false ''
       wrap ${targetPrefix}gccgo $wrapper $ccPath/${targetPrefix}gccgo
+    ''
+    + optionalString cc.isGNU or false ''
+      ln -s $ccPath/${targetPrefix}gcc-ar $out/bin/${targetPrefix}gcc-ar
+      ln -s $ccPath/${targetPrefix}gcc-nm $out/bin/${targetPrefix}gcc-nm
+      ln -s $ccPath/${targetPrefix}gcc-ranlib $out/bin/${targetPrefix}gcc-ranlib
+      ln -s $ccPath/${targetPrefix}gcov $out/bin/${targetPrefix}gcov
+      ln -s $ccPath/${targetPrefix}gcov-dump $out/bin/${targetPrefix}gcov-dump
+      ln -s $ccPath/${targetPrefix}gcov-tool $out/bin/${targetPrefix}gcov-tool
     '';
 
   strictDeps = true;


### PR DESCRIPTION
###### Motivation for this change

This commit fixes #86272. For full description, see the original bug report. It can be summarized as: previously NixOS didn't provide any gcc tools (like gcov, gcc-ar, gcc-ranlib and others).

###### Things done

I have tested this changes locally on a slightly outdated version (19.09) and now I cherry-picked them on top of master (there was a conflict). I haven't rebuilt master because compilation on my laptop takes days.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
