### PR TITLE
ksmoothdock: init at 6.3 stable

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6986,6 +6986,12 @@
     githubId = 1588288;
     name = "Shahrukh Khan";
   };
+  shamilton = {
+    email = "sgn.hamilton@protonmail.com";
+    github = "SCOTT-HAMILTON";
+    githubId = 24496705;
+    name = "Scott Hamilton";
+  };
   shanemikel = {
     email = "shanepearlman@pm.me";
     github = "shanemikel";

--- a/pkgs/applications/misc/ksmoothdock/default.nix
+++ b/pkgs/applications/misc/ksmoothdock/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, extra-cmake-modules
+, kactivities
+, qtbase
+}:
+
+mkDerivation rec {
+  pname = "KSmoothDock";
+  version = "6.2";
+
+  src = fetchFromGitHub {
+    owner = "dangvd";
+    repo = "ksmoothdock";
+    rev = "v${version}";
+    sha256 = "182x47cymgnp5xisa0xx93hmd5wrfigy8zccrr23p4r9hp8xbnam";
+  };
+
+  patches = [
+    # Fixed hard coded installation path to use CMAKE_INSTALL_BINDIR and CMAKE_INSTALL_PREFIX instead
+    (fetchpatch {
+      url = "https://github.com/dangvd/ksmoothdock/commit/00799bef8a1c1fe61ef9274866267d9fe9194041.patch";
+      sha256 = "1nmb7gf1ggzicxz8k4fd67xhwjy404myqzjpgjym66wqxm0arni4";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+
+  buildInputs = [ kactivities qtbase ];
+
+  cmakeDir = "../src";
+
+  meta = with lib; {
+    description = "A cool desktop panel for KDE Plasma 5";
+    license = licenses.mit;
+    homepage = "https://dangvd.github.io/ksmoothdock/";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4575,6 +4575,8 @@ in
 
   peruse = libsForQt5.callPackage ../tools/misc/peruse { };
 
+  ksmoothdock = libsForQt5.callPackage ../applications/misc/ksmoothdock { };
+
   kst = libsForQt5.callPackage ../tools/graphics/kst { gsl = gsl_1; };
 
   kstars = libsForQt5.callPackage ../applications/science/astronomy/kstars { };


### PR DESCRIPTION
###### Motivation for this change
Needed a nice dock for my MacOS KDE theming exerience. For the momen latte dock seems too buggy.

###### Things done
Packaged ksmoothdock at v6.2 stable

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
