### PR TITLE
[20.03] openconnect: patch CVE-2020-12105 & CVE-2020-12823

### DIFF
--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, openssl ? null, gnutls ? null, gmp, libxml2, stoken, zlib, fetchgit, darwin } :
+{ stdenv, fetchurl, fetchpatch, pkgconfig, openssl ? null, gnutls ? null, gmp, libxml2, stoken, zlib, fetchgit, darwin } :
 
 assert (openssl != null) == (gnutls == null);
 
@@ -18,6 +18,19 @@ in stdenv.mkDerivation rec {
     ];
     sha256 = "14i9q727c2zc9xhzp1a9hz3gzb5lwgsslbhircm84dnbs192jp1k";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2020-12105.patch";
+      url = "https://gitlab.com/openconnect/openconnect/-/merge_requests/96.patch";
+      sha256 = "19ra55jql2f2sim9kkgybrm4abz28iax92iwpijiipz5lk2jz0ai";
+    })
+    (fetchpatch {
+      name = "CVE-2020-12823.patch";
+      url = "https://gitlab.com/openconnect/openconnect/-/merge_requests/108.patch";
+      sha256 = "1ycw0b7wbj6byb151vlyywr0y3x0prsyxal5gdds5xcsdr5s9va3";
+    })
+  ];
 
   outputs = [ "out" "dev" ];
   


### PR DESCRIPTION
Backport of #88095. Is bumping the version OK as opposed to including the CVE patches?

----

Also update vpnc script.

Changes: http://www.infradead.org/openconnect/changelog.html

###### Motivation for this change

- https://nvd.nist.gov/vuln/detail/CVE-2019-16239
- https://nvd.nist.gov/vuln/detail/CVE-2020-12105
- https://nvd.nist.gov/vuln/detail/CVE-2020-12823

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).