### PR TITLE
WIP: gobject-introspection: Support cross

### DIFF
--- a/pkgs/development/libraries/gobject-introspection/absolute-python-shebang.patch
+++ b/pkgs/development/libraries/gobject-introspection/absolute-python-shebang.patch
@@ -1,0 +1,17 @@
+diff --git a/py-tools/meson.build b/py-tools/meson.build
+index 2fff98d5..7784fffc 100644
+--- a/py-tools/meson.build
++++ b/py-tools/meson.build
+@@ -9,11 +9,7 @@ if with_doctool
+   tools += [['g-ir-doc-tool', 'docmain', 'doc_main']]
+ endif
+
+-if cc.get_id() == 'msvc'
+-  python_cmd = '/usr/bin/env ' + python.path()
+-else
+-  python_cmd = '/usr/bin/env python@0@'.format(python.language_version().split('.')[0])
+-endif
++python_cmd = @python_bin@
+
+ tool_output = []
+ foreach tool : tools

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchurl
+, fetchFromGitLab
 , glib
 , flex
 , bison
@@ -26,16 +27,19 @@
 
 stdenv.mkDerivation rec {
   pname = "gobject-introspection";
-  version = "1.64.1";
+  version = "1.65-pre${stdenv.lib.strings.substring 0 7 src.rev}";
 
   # outputs TODO: share/gobject-introspection-1.0/tests is needed during build
   # by pygobject3 (and maybe others), but it's only searched in $out
   outputs = [ "out" "dev" "devdoc" "man" ];
   outputBin = "dev";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "19vz7vp10h0zj3f491yk72dp89bix6rgkzxg4qcm4d6151ksxgl0";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "Ericson2314";
+    repo = "gobject-introspection";
+    rev = "d7a4fcb82957271f98b4492494a71cfaa8699c03";
+    sha256 = "0qnbld1k08c91zgvlasg38d7kidl7rr0drzd4dnyslj0vhssd5qz";
   };
 
   patches = [

--- a/pkgs/development/libraries/gobject-introspection/setup-hook.sh
+++ b/pkgs/development/libraries/gobject-introspection/setup-hook.sh
@@ -10,7 +10,7 @@ make_gobject_introspection_find_gir_files() {
     fi
 }
 
-addEnvHooks "$hostOffset" make_gobject_introspection_find_gir_files
+addEnvHooks "$targetOffset" make_gobject_introspection_find_gir_files
 
 giDiscoverSelf() {
     if [ -d "$prefix/lib/girepository-1.0" ]; then

--- a/pkgs/development/tools/misc/prelink/default.nix
+++ b/pkgs/development/tools/misc/prelink/default.nix
@@ -1,23 +1,37 @@
-{ stdenv, fetchurl, libelf }:
+{ stdenv, fetchgit, autoreconfHook
+, libelf, libiberty
+}:
 
-let
-  version = "20130503";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "prelink";
-  inherit version;
+  version = "2019-6-24-" + stdenv.lib.substring 0 7 src.rev;
 
-  buildInputs = [
-    libelf stdenv.cc.libc (stdenv.lib.getOutput "static" stdenv.cc.libc)
-  ];
-
-  src = fetchurl {
-    url = "https://people.redhat.com/jakub/prelink/prelink-${version}.tar.bz2";
-    sha256 = "1w20f6ilqrz8ca51qhrn1n13h7q1r34k09g33d6l2vwvbrhcffb3";
+  src = fetchgit {
+    url = "https://git.yoctoproject.org/git/prelink-cross";
+    branchName = "cross_prelink";
+    rev = "f9975537dbfd9ade0fc813bd5cf5fcbe41753a37";
+    sha256 = "15x1p6x9wndbjqaajhmg5nd4rcg805blixwm0l0jaiqbi9kfiprv";
   };
 
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    stdenv.cc.libc (stdenv.lib.getOutput "static" stdenv.cc.libc)
+    libelf libiberty
+  ];
+
+  # There are some failures to investigate
+  doCheck = false;
+
+  preCheck = ''
+    patchShebangs --build testsuite
+  '';
+
   meta = {
-    homepage = "https://people.redhat.com/jakub/prelink/";
+    homepage = "https://wiki.yoctoproject.org/wiki/Cross-Prelink";
+    #homepage = "https://people.redhat.com/jakub/prelink/";
     license = "GPL";
     description = "ELF prelinking utility to speed up dynamic linking";
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12047,9 +12047,20 @@ in
   gns3-gui = gns3Packages.guiStable;
   gns3-server = gns3Packages.serverStable;
 
-  gobject-introspection = callPackage ../development/libraries/gobject-introspection {
+  gobject-introspection-full-classic = callPackage ../development/libraries/gobject-introspection {
     nixStoreDir = config.nix.storeDir or builtins.storeDir;
     inherit (darwin) cctools;
+  };
+
+  gobject-introspection-py-tools = gobject-introspection-full-classic.override {
+    build_python_tools = true;
+    build_library_and_c_tools = false;
+  };
+
+  gobject-introspection = gobject-introspection-full-classic.override {
+    build_python_tools = false;
+    build_library_and_c_tools = true;
+    gi_cross_use_prebuilt_gi = true;
   };
 
   goocanvas = callPackage ../development/libraries/goocanvas { };


### PR DESCRIPTION
###### Motivation for this change

The idea is to build the python tools separate from the C bits, and the python tools are run natively (including C extension module, in particular), but the C bits are either the installed library, or tools that must be run with an emulator (during cross compilation) and in both cases are non-native.

I need to still need to wrap the two together for downstream consumption, and I am also debating exactly how I'd like to do that.

CC @jtojnar @samueldr

Upstream issue: https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/337
Upstream PR: https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/224

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
