### PR TITLE
.editorconfig: fix invalid value for diffs/patches

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,9 +13,9 @@ charset = utf-8
 
 # Ignore diffs/patches
 [*.{diff,patch}]
-end_of_line = ignore
-insert_final_newline = ignore
-trim_trailing_whitespace = ignore
+end_of_line = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
 
 # see https://nixos.org/nixpkgs/manual/#chap-conventions
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/87919

Despite being a fairly common pattern in `.editorconfig` files and being accepted by some editors/linters, it seems `ignore` is not a valid value.

`unset` is what is listed in the specification.

https://editorconfig-specification.readthedocs.io/en/latest/#supported-pairs

cc @Mic92