### PR TITLE
ofono: fix incorrect plugin path check in patch

### DIFF
--- a/pkgs/tools/networking/ofono/0001-Search-connectors-in-OFONO_PLUGIN_PATH.patch
+++ b/pkgs/tools/networking/ofono/0001-Search-connectors-in-OFONO_PLUGIN_PATH.patch
@@ -98,7 +98,7 @@ index 924a45ec..f05055c3 100644
 +
 +	plugin_path = g_getenv ("OFONO_PLUGIN_PATH");
 +
-+	if (!plugin_path) {
++	if (plugin_path) {
 +		gchar **plugin_path_list;
 +		gsize i;
 +


### PR DESCRIPTION
Fixes #88178

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
From the discussion at #88178 :
The nixpkgs version of ofono is patched to read a OFONO_PLUGIN_PATH environment variable. It crashes when this variable is not set.
This also means that the services.ofono service does not work if services.ofono.plugins is empty.

The issue is that the plugin path check is inverted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
