### PR TITLE
pre-commit: use buildPythonPackage

### DIFF
--- a/pkgs/development/python-modules/pre-commit/default.nix
+++ b/pkgs/development/python-modules/pre-commit/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, buildPythonApplication, pythonOlder
+{ lib, fetchPypi, buildPythonPackage, pythonOlder
 , aspy-yaml
 , cached-property
 , cfgv
@@ -13,7 +13,7 @@
 , virtualenv
 }:
 
-buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "pre-commit";
   version = "1.21.0";
 


### PR DESCRIPTION
###### Motivation for this change

Allows to build a python env with pre_commit module:

```
python3.withPackages(p: [p.pre-commit])
```

pre-commit is already converted to an application in `git-and-tools/default.nix`:

```
pre-commit = pkgs.python3Packages.toPythonApplication pkgs.python3Packages.pre-commit;
```

So that it can still be installed as a standalone application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
