### PR TITLE
[19.09] chromium: Mark as insecure

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -65,7 +65,6 @@ in rec {
         (all "nixos.tests.containers-imperative")
         (all "nixos.tests.containers-ipv4")
         (all "nixos.tests.containers-ipv6")
-        "nixos.tests.chromium.x86_64-linux"
         (all "nixos.tests.firefox")
         (all "nixos.tests.firewall")
         (all "nixos.tests.fontconfig-default-fonts")

--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -86,5 +86,15 @@ mkChromiumDerivation (base: rec {
     # backported to 19.09. Therefore we'll only maintain M81 for NixOS 19.09
     # which will give us approx. one month of security updates / time for users
     # to transition to 20.03 (as per our policy).
+    knownVulnerabilities = [
+      # Since the release of M83 the previous version isn't secure anymore.
+      # nixos-unstable update: https://github.com/NixOS/nixpkgs/pull/88206
+      ''
+        This version of Chromium is no longer being updated. Consider switching
+        to the new stable NixOS channel or installing Chromium from a different
+        channel. A list of the missing security fixes can be found here:
+        https://chromereleases.googleblog.com/2020/05/stable-channel-update-for-desktop_19.html
+      ''
+    ];
   };
 })

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -137,5 +137,15 @@ in stdenv.mkDerivation {
     license = licenses.unfree;
     maintainers = [ maintainers.msteen ];
     platforms = [ "x86_64-linux" ];
+    knownVulnerabilities = [
+      # Since the release of M83 the previous version isn't secure anymore.
+      # nixos-unstable update: https://github.com/NixOS/nixpkgs/pull/88206
+      ''
+        This version of Google Chrome is no longer being updated. Consider switching
+        to the new stable NixOS channel or installing Google Chrome from a different
+        channel. A list of the missing security fixes can be found here:
+        https://chromereleases.googleblog.com/2020/05/stable-channel-update-for-desktop_19.html
+      ''
+    ];
   };
 }


### PR DESCRIPTION
Since M81 won't receive any updates anymore and there are known
vulnerabilities we should mark it as insecure so that users are aware of
the risks.
Updating Chromium to M83 is unfortunately too challenging for
19.09, but as of today we've already covered the one month period of
security updates for "oldstable" and both 20.03 and nixos-unstable
contain recent versions (i.e. users should either update to the current
stable release or install Chromium from a different channel).

nixos-unstable PR for M83: #88206

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
