### PR TITLE
dex2jar: init at 2.0

### DIFF
--- a/pkgs/development/tools/java/dex2jar/default.nix
+++ b/pkgs/development/tools/java/dex2jar/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchurl
+, jre
+, makeWrapper
+, unzip
+}:
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "dex2jar";
+  version  = "2.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${name}.zip";
+    sha256 = "1g3mrbyl8sdw1nhp17z23qbfzqpa0w2yxrywgphvd04jdr6yn1vr";
+  };
+
+  nativeBuildInputs = [ makeWrapper unzip ];
+
+  postPatch = ''
+    rm *.bat
+    chmod +x *.sh
+  '';
+
+  installPhase = ''
+    f=$out/lib/dex2jar/
+
+    mkdir -p $f $out/bin
+
+    mv * $f
+    for i in $f/*.sh; do
+      n=$(basename ''${i%.sh})
+      makeWrapper $i $out/bin/$n --prefix PATH : ${lib.makeBinPath [ jre ] }
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://sourceforge.net/projects/dex2jar/;
+    description = "Tools to work with android .dex and java .class files";
+    maintainers = with maintainers; [ makefu ];
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15513,6 +15513,8 @@ in
 
   dex-oidc = callPackage ../servers/dex { };
 
+  dex2jar = callPackage ../development/tools/java/dex2jar { };
+
   doh-proxy = callPackage ../servers/dns/doh-proxy {
     python3Packages = python36Packages;
   };


### PR DESCRIPTION
###### Motivation for this change

Add dex2jar from my local NUR to nixpkgs. dex2jar is a tool requested in #81418

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
