### PR TITLE
nauty: 26r12 -> 27r1

### DIFF
--- a/pkgs/applications/science/math/nauty/default.nix
+++ b/pkgs/applications/science/math/nauty/default.nix
@@ -4,10 +4,10 @@
 }:
 stdenv.mkDerivation rec {
   pname = "nauty";
-  version = "26r12";
+  version = "27r1";
   src = fetchurl {
     url = "http://pallini.di.uniroma1.it/nauty${version}.tar.gz";
-    sha256 = "1p4mxf8q5wm47nxyskxbqwa5p1vvkycv1zgswvnk9nsn6vff0al6";
+    sha256 = "1nym0p2djws8ylkpr0kgpxfa6fxdlh46cmvz0gn5vd02jzgs0aww";
   };
   outputs = [ "out" "dev" ];
   configureFlags = {

--- a/pkgs/applications/science/math/nauty/default.nix
+++ b/pkgs/applications/science/math/nauty/default.nix
@@ -37,6 +37,10 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ raskin timokau ];
     platforms = platforms.unix;
+    # I'm not sure if the filename will remain the same for future changelog or
+    # if it will track changes to minor releases. Lets see. Better than nothing
+    # in any case.
+    changelog = "http://pallini.di.uniroma1.it/changes24-27.txt";
     homepage = "http://pallini.di.uniroma1.it/";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Version bump. Changes: http://pallini.di.uniroma1.it/changes24-27.txt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
