### PR TITLE
nixos/haproxy: add reloading support, use upstream service hardening

### DIFF
--- a/nixos/modules/services/networking/haproxy.nix
+++ b/nixos/modules/services/networking/haproxy.nix
@@ -56,6 +56,9 @@ with lib;
       message = "You must provide services.haproxy.config.";
     }];
 
+    # configuration file indirection is needed to support reloading
+    environment.etc."haproxy.cfg".source = haproxyCfg;
+
     systemd.services.haproxy = {
       description = "HAProxy";
       after = [ "network.target" ];
@@ -64,11 +67,32 @@ with lib;
         User = cfg.user;
         Group = cfg.group;
         Type = "notify";
-        # when running the config test, don't be quiet so we can see what goes wrong
-        ExecStartPre = "${pkgs.haproxy}/sbin/haproxy -c -f ${haproxyCfg}";
-        ExecStart = "${pkgs.haproxy}/sbin/haproxy -Ws -f ${haproxyCfg}";
-        Restart = "on-failure";
+        ExecStartPre = [
+          # when the master process receives USR2, it reloads itself using exec(argv[0]),
+          # so we create a symlink there and update it before reloading
+          "${pkgs.coreutils}/bin/ln -sf ${pkgs.haproxy}/sbin/haproxy /run/haproxy/haproxy"
+          # when running the config test, don't be quiet so we can see what goes wrong
+          "/run/haproxy/haproxy -c -f ${haproxyCfg}"
+        ];
+        ExecStart = "/run/haproxy/haproxy -Ws -f /etc/haproxy.cfg -p /run/haproxy/haproxy.pid";
+        # support reloading
+        ExecReload = [
+          "${pkgs.haproxy}/sbin/haproxy -c -f ${haproxyCfg}"
+          "${pkgs.coreutils}/bin/ln -sf ${pkgs.haproxy}/sbin/haproxy /run/haproxy/haproxy"
+          "${pkgs.coreutils}/bin/kill -USR2 $MAINPID"
+        ];
+        KillMode = "mixed";
+        SuccessExitStatus = "143";
+        Restart = "always";
         RuntimeDirectory = "haproxy";
+        # upstream hardening options
+        NoNewPrivileges = true;
+        ProtectHome = true;
+        ProtectSystem = "strict";
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        SystemCallFilter= "~@cpu-emulation @keyring @module @obsolete @raw-io @reboot @swap @sync";
         # needed in case we bind to port < 1024
         AmbientCapabilities = "CAP_NET_BIND_SERVICE";
       };

--- a/nixos/tests/haproxy.nix
+++ b/nixos/tests/haproxy.nix
@@ -43,5 +43,13 @@ import ./make-test-python.nix ({ pkgs, ...}: {
     assert "haproxy_process_pool_allocated_bytes" in machine.succeed(
         "curl -k http://localhost:80/metrics"
     )
+
+    with subtest("reload"):
+        machine.succeed("systemctl reload haproxy")
+        # wait some time to ensure the following request hits the reloaded haproxy
+        machine.sleep(5)
+        assert "We are all good!" in machine.succeed(
+            "curl -k http://localhost:80/index.txt"
+        )
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

The current systemd service for haproxy doesn't support reloading. Reloading is useful for haproxy as it allows changing the configuration or updating the SSL certificates without losing the reverse proxy state (open connections, backend status, etc), and without missing requests during the restart time. Additionally, upstream recommends several configuration changes to the systemd service, mostly related to hardening, that are not used in the current systemd service.

###### Things done

 - Update the systemd service using the [example provided by upstream](https://github.com/haproxy/haproxy/blob/master/contrib/systemd/haproxy.service.in)
   + Enable `reloadIfChanged` by default
   + Store PID file in `/run/haproxy/haproxy.pid`
   + Add `ExecReload` commands for seamless reloading
   + Consider `143` as a success exit code
   + Change `Restart` to `always`
   + Add hardening options (`NoNewPrivileges`,`Protect*` and `SystemCallFilter`)
 - Add new tests for the reload feature
   + Check that `systemctl reload haproxy` succeeds
   + Check that no HTTP requests are lost during reloading
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Possible improvements/changes

 - Changing back `Restart` to `on-failure`, to preserve existing semantics
 - Not enabling `reloadIfChanged` by default, to preserve existing semantics
 - The reload test may be a bit fragile currently, I can try to improve it if needed.
