### PR TITLE
libaom: 1.0.0-errata1 -> 2.0.0

### DIFF
--- a/pkgs/development/libraries/libaom/default.nix
+++ b/pkgs/development/libraries/libaom/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1616xjhj6770ykn82ml741h8hx44v507iky3s9h7a5lnk9d4cxzy";
   };
 
+  patches = [ ./outputs.patch ];
+
   nativeBuildInputs = [
     yasm perl cmake pkgconfig python3
   ];
@@ -28,11 +30,15 @@ stdenv.mkDerivation rec {
   # https://aomedia.googlesource.com/aom/+/refs/heads/master/build/cmake/aom_config_defaults.cmake
 
   cmakeFlags = [
-    # For libaom these must be relative instead of absolute paths:
-    "-DCMAKE_INSTALL_BINDIR=bin"
-    "-DCMAKE_INSTALL_INCLUDEDIR=include"
-    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DENABLE_TESTS=OFF"
   ];
+
+  postFixup = ''
+    moveToOutput lib/libaom.a "$static"
+  '';
+
+  outputs = [ "out" "bin" "dev" "static" ];
 
   meta = with stdenv.lib; {
     description = "Alliance for Open Media AV1 codec library";

--- a/pkgs/development/libraries/libaom/default.nix
+++ b/pkgs/development/libraries/libaom/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "libaom";
-  version = "1.0.0-errata1";
+  version = "2.0.0";
 
   src = fetchgit {
     url = "https://aomedia.googlesource.com/aom";
     rev	= "v${version}";
-    sha256 = "090phh4jl9z6m2pwpfpwcjh6iyw0byngb2n112qxkg6a3gsaa62f";
+    sha256 = "1616xjhj6770ykn82ml741h8hx44v507iky3s9h7a5lnk9d4cxzy";
   };
 
   nativeBuildInputs = [
@@ -24,10 +24,26 @@ stdenv.mkDerivation rec {
     export PATH=$NIX_BUILD_TOP:$PATH
   '';
 
+  # Configuration options:
+  # https://aomedia.googlesource.com/aom/+/refs/heads/master/build/cmake/aom_config_defaults.cmake
+
+  cmakeFlags = [
+    # For libaom these must be relative instead of absolute paths:
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+  ];
+
   meta = with stdenv.lib; {
-    description = "AV1 Bitstream and Decoding Library";
+    description = "Alliance for Open Media AV1 codec library";
+    longDescription = ''
+      Libaom is the reference implementation of the AV1 codec from the Alliance
+      for Open Media. It contains an AV1 library as well as applications like
+      an encoder (aomenc) and a decoder (aomdec).
+    '';
     homepage    = "https://aomedia.org/av1-features/get-started/";
-    maintainers = with maintainers; [ kiloreux ];
+    changelog   = "https://aomedia.googlesource.com/aom/+/refs/tags/v${version}/CHANGELOG";
+    maintainers = with maintainers; [ primeos kiloreux ];
     platforms   = platforms.all;
     license = licenses.bsd2;
   };

--- a/pkgs/development/libraries/libaom/outputs.patch
+++ b/pkgs/development/libraries/libaom/outputs.patch
@@ -1,0 +1,45 @@
+--- a/build/cmake/aom_install.cmake
++++ b/build/cmake/aom_install.cmake
+@@ -45,2 +45,2 @@ macro(setup_aom_install_targets)
+-              -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
+-              -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
++              -DCMAKE_INSTALL_FULL_INCLUDEDIR=${CMAKE_INSTALL_FULL_INCLUDEDIR}
++              -DCMAKE_INSTALL_FULL_LIBDIR=${CMAKE_INSTALL_FULL_LIBDIR}
+@@ -82,14 +82,14 @@ macro(setup_aom_install_targets)
+     install(
+       FILES ${AOM_INSTALL_INCS}
+-      DESTINATION "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/aom")
++      DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/aom")
+     install(
+       FILES "${AOM_PKG_CONFIG_FILE}"
+-      DESTINATION "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++      DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
+     install(TARGETS ${AOM_INSTALL_LIBS} DESTINATION
+-                    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
++                    "${CMAKE_INSTALL_FULL_LIBDIR}")
+ 
+     if(ENABLE_EXAMPLES)
+       install(TARGETS ${AOM_INSTALL_BINS} DESTINATION
+-                      "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}")
++                      "${CMAKE_INSTALL_FULL_BINDIR}")
+     endif()
+   endif()
+--- a/build/cmake/pkg_config.cmake
++++ b/build/cmake/pkg_config.cmake
+@@ -14,2 +14,2 @@
+-                  "CMAKE_INSTALL_BINDIR" "CMAKE_INSTALL_INCLUDEDIR"
+-                  "CMAKE_INSTALL_LIBDIR" "CMAKE_PROJECT_NAME"
++                  "CMAKE_INSTALL_BINDIR" "CMAKE_INSTALL_FULL_INCLUDEDIR"
++                  "CMAKE_INSTALL_FULL_LIBDIR" "CMAKE_PROJECT_NAME"
+@@ -38,4 +38,4 @@ endif()
+-set(prefix "${CMAKE_INSTALL_PREFIX}")
+-set(bindir "${CMAKE_INSTALL_BINDIR}")
+-set(includedir "${CMAKE_INSTALL_INCLUDEDIR}")
+-set(libdir "${CMAKE_INSTALL_LIBDIR}")
++get_filename_component(prefix "${CMAKE_INSTALL_FULL_INCLUDEDIR}" DIRECTORY)
++get_filename_component(exec_prefix "${CMAKE_INSTALL_FULL_LIBDIR}" DIRECTORY)
++get_filename_component(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}" NAME)
++get_filename_component(libdir "${CMAKE_INSTALL_FULL_LIBDIR}" NAME)
+@@ -46 +46 @@ file(APPEND "${pkgconfig_file}" "prefix=${prefix}\n")
+-file(APPEND "${pkgconfig_file}" "exec_prefix=\${prefix}\n")
++file(APPEND "${pkgconfig_file}" "exec_prefix=${exec_prefix}\n")


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->
###### Testing

Tested using `ffmpeg-full` as well as `aomenc` and `aomdec` directly, LGTM.

###### Motivation for this change

There's finally a new release :)

> 2020-05-07 v2.0.0 "Applejack"
>   First official release of libaom.
>   This release includes new real-time mode and SVC support.
> 
>   - Upgrading:
>     AOM_SET_POSTPROC, AOM_CODEC_CAP_POSTPROC and AOM_CODEC_USE_POSTPROC are
>     removed.
> 
>     AOM_SET_DBG_* is removed.
> 
>     Multi-resolution encoding is removed.
> 
>     put_frame and put_slice callbacks are removed.
> 
>   - Enhancements:
>     Full-sweep document update for codec controls.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
