### PR TITLE
systembus-notify: init at 1.0

### DIFF
--- a/pkgs/applications/misc/systembus-notify/default.nix
+++ b/pkgs/applications/misc/systembus-notify/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
     install -Dm755 systembus-notify -t $out/bin
-    install -Dm644 systembus-notify.desktop -t $out/share/applications
+    install -Dm644 systembus-notify.desktop -t $out/etc/xdg/autostart
     runHook postInstall
   '';
 

--- a/pkgs/applications/misc/systembus-notify/default.nix
+++ b/pkgs/applications/misc/systembus-notify/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, systemd }:
+
+stdenv.mkDerivation rec {
+  pname = "systembus-notify";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "rfjakob";
+    repo = "systembus-notify";
+    rev = "v${version}";
+    sha256 = "11zq84qfmbyl51d3r6294l2bjhlgwa9bx7d263g9fkqrwsg0si0y";
+  };
+
+  buildInputs = [ systemd ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 systembus-notify -t $out/bin
+    install -Dm644 systembus-notify.desktop -t $out/share/applications
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "System bus notification daemon";
+    homepage = "https://github.com/rfjakob/systembus-notify";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6879,6 +6879,8 @@ in
     libxml2 = libxml2Python;
    };
 
+  systembus-notify = callPackage ../applications/misc/systembus-notify { };
+
   stricat = callPackage ../tools/security/stricat { };
 
   staruml = callPackage ../tools/misc/staruml { inherit (gnome2) GConf; libgcrypt = libgcrypt_1_5; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add a new package `systembus-notify` which works with `earlyoom` for desktop notifications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - 35.7 MiB
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
