### PR TITLE
gnucash: Add libdbiDrivers env var to wrapper

### DIFF
--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation rec {
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share/gsettings-schemas/${pname}-${version}" \
       --prefix XDG_DATA_DIRS : "${hicolor-icon-theme}/share" \
       --prefix PERL5LIB ":" "$PERL5LIB" \
+      --set GNC_DBD_DIR ${libdbiDrivers}/lib/dbd \
       --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib dconf}/lib/gio/modules"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

The GNU Cash package clearly *wants* to be able to use the libdbi
backends, since it pulls them in as dependencies.  However, you can only
open xml formatted GNU cash files.

The CMake scripts hard-code the DBD path to be basically
<PATH_OF_LIBDBI>/dbd.  However GNU Cash does check the environment
variable GNC_DBD_DIR, so I set that environment variable in the wrapper
script.

With this change, you should be able to e.g. "Save As" in the sqlite
format.

Fixes #57445

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after) *not sure why, but it increased the closure size by 17MB*
- [X] Ensured that relevant documentation is up to date  *No doc changes needed*
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
