### PR TITLE
earlyoom: patch absolute dbus path and make nixos module up to date

### DIFF
--- a/nixos/modules/services/system/earlyoom.nix
+++ b/nixos/modules/services/system/earlyoom.nix
@@ -67,9 +67,19 @@ in
       notificationsCommand = mkOption {
         type = types.nullOr types.str;
         default = null;
-        example = "sudo -u example_user DISPLAY=:0 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus notify-send";
         description = ''
-          Command used to send notifications.
+          This option is deprecated and ignored by earlyoom since 1.6.
+          Use <option>services.earlyoom.enableNotifications</option> instead.
+        '';
+      };
+
+      enableNotifications = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Send notifications about killed processes via the system d-bus.
+          To actually see the notifications in your GUI session, you need to have
+          <literal>systembus-notify</literal> running as your user.
 
           See <link xlink:href="https://github.com/rfjakob/earlyoom#notifications">README</link> for details.
         '';
@@ -87,9 +97,13 @@ in
         message = "Both options in conjunction do not make sense"; }
     ];
 
+    warnings = optional (ecfg.notificationsCommand != null)
+      "`services.earlyoom.notificationsCommand` is deprecated and ignored by earlyoom since 1.6.";
+
     systemd.services.earlyoom = {
       description = "Early OOM Daemon for Linux";
       wantedBy = [ "multi-user.target" ];
+      path = optional ecfg.enableNotifications pkgs.dbus;
       serviceConfig = {
         StandardOutput = "null";
         StandardError = "syslog";
@@ -100,8 +114,7 @@ in
           ${optionalString ecfg.useKernelOOMKiller "-k"} \
           ${optionalString ecfg.ignoreOOMScoreAdjust "-i"} \
           ${optionalString ecfg.enableDebugInfo "-d"} \
-          ${optionalString (ecfg.notificationsCommand != null)
-            "-N ${escapeShellArg ecfg.notificationsCommand}"}
+          ${optionalString ecfg.enableNotifications "-n"}
         '';
       };
     };

--- a/nixos/modules/services/system/earlyoom.nix
+++ b/nixos/modules/services/system/earlyoom.nix
@@ -118,5 +118,7 @@ in
         '';
       };
     };
+
+    environment.systemPackages = optional ecfg.enableNotifications pkgs.systembus-notify;
   };
 }

--- a/pkgs/os-specific/linux/earlyoom/default.nix
+++ b/pkgs/os-specific/linux/earlyoom/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = stdenv.lib.optionals withManpage [ pandoc installShellFiles ];
 
+  patches = [ ./fix-dbus-path.patch ];
+
   makeFlags = [ "VERSION=${version}" ];
 
   installPhase = ''

--- a/pkgs/os-specific/linux/earlyoom/fix-dbus-path.patch
+++ b/pkgs/os-specific/linux/earlyoom/fix-dbus-path.patch
@@ -1,0 +1,11 @@
+--- a/kill.c
++++ b/kill.c
+@@ -55,7 +55,7 @@ static void notify(const char* summary, const char* body)
+     }
+     // Complete command line looks like this:
+     // dbus-send --system / net.nuetzlich.SystemNotifications.Notify 'string:summary text' 'string:and body text'
+-    execl("/usr/bin/dbus-send", "dbus-send", "--system", "/", "net.nuetzlich.SystemNotifications.Notify",
++    execlp("dbus-send", "dbus-send", "--system", "/", "net.nuetzlich.SystemNotifications.Notify",
+         summary2, body2, NULL);
+     warn("notify: exec failed: %s\n", strerror(errno));
+     exit(1);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
`earlyoom` v1.6 replaces old notification logic with `dbus-send` / `systembus-notify`. (See [Changelog](https://github.com/rfjakob/earlyoom/tree/v1.6#changelog).)
But dbus path is not patched and options of nixos/earlyoom is not up to date.

Related: #88441

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - Not changed.
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
