### PR TITLE
freerdp: 2.1.0 -> 2.1.1

### DIFF
--- a/pkgs/applications/networking/remote/freerdp/default.nix
+++ b/pkgs/applications/networking/remote/freerdp/default.nix
@@ -17,13 +17,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "freerdp";
-  version = "2.1.0";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "FreeRDP";
     repo = "FreeRDP";
     rev = version;
-    sha256 = "0905374k4x647052sr27m2hgjcavbxdl0xd8n02vm5xa6whz239j";
+    sha256 = "1avfsx837rjfk50qv3xjccx2309phn04rq6imadqvqpfnyx4ma66";
   };
 
   postPatch = ''


### PR DESCRIPTION
- [x] Built on nixos
- [x] Tested xfreerdp, wlfreerdp and freerdp-shadow-cli