### PR TITLE
fbmenugen: init at 2020-05-20

### DIFF
--- a/pkgs/applications/misc/fbmenugen/0001-Fix-paths.patch
+++ b/pkgs/applications/misc/fbmenugen/0001-Fix-paths.patch
@@ -1,0 +1,69 @@
+From 76c25147328d71960c70bbdd5a9396aac4a362a2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jos=C3=A9=20Romildo=20Malaquias?= <malaquias@gmail.com>
+Date: Wed, 20 May 2020 14:19:07 -0300
+Subject: [PATCH] Fix paths
+
+---
+ fbmenugen | 14 ++++++--------
+ 1 file changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/fbmenugen b/fbmenugen
+index 46a18dc..0c8eb08 100755
+--- a/fbmenugen
++++ b/fbmenugen
+@@ -214,9 +214,7 @@ my %CONFIG = (
+ 
+ #<<<
+         desktop_files_paths => [
+-            '/usr/share/applications',
+-            '/usr/local/share/applications',
+-            '/usr/share/applications/kde4',
++            '/run/current-system/sw/share/applications',
+             "$home_dir/.local/share/applications",
+         ],
+ #>>>
+@@ -232,7 +230,7 @@ my %CONFIG = (
+     force_icon_size  => 0,
+     generic_fallback => 0,
+     locale_support   => 1,
+-    use_gtk3         => 0,
++    use_gtk3         => 1,
+ 
+     VERSION => $version,
+              );
+@@ -252,7 +250,7 @@ if (not -e $config_file) {
+ }
+ 
+ if (not -e $schema_file) {
+-    if (-e (my $etc_schema_file = "/etc/xdg/$pkgname/schema.pl")) {
++    if (-e (my $etc_schema_file = "@fbmenugen@/etc/xdg/$pkgname/schema.pl")) {
+         require File::Copy;
+         File::Copy::copy($etc_schema_file, $schema_file)
+           or warn "$0: can't copy file `$etc_schema_file' to `$schema_file': $!\n";
+@@ -570,7 +568,7 @@ EXIT
+         $generated_menu .= begin_category(@{$schema->{fluxbox}}) . <<"FOOTER";
+ [config] (Configure)
+ [submenu] (System Styles) {Choose a style...}
+-  [stylesdir] (/usr/share/fluxbox/styles)
++  [stylesdir] (@fluxbox@/share/fluxbox/styles)
+ [end]
+ [submenu] (User Styles) {Choose a style...}
+   [stylesdir] (~/.fluxbox/styles)
+@@ -580,12 +578,12 @@ EXIT
+   [exec] (Screenshot - JPG) {import screenshot.jpg && display -resize 50% screenshot.jpg}
+   [exec] (Screenshot - PNG) {import screenshot.png && display -resize 50% screenshot.png}
+   [exec] (Run) {fbrun}
+-  [exec] (Regen Menu) {fluxbox-generate_menu}
++  [exec] (Regen Menu) {@fluxbox@/bin/fluxbox-generate_menu}
+ [end]
+ [commanddialog] (Fluxbox Command)
+   [reconfig] (Reload config)
+   [restart] (Restart)
+-  [exec] (About) {(fluxbox -v; fluxbox -info | sed 1d) | xmessage -file - -center}
++  [exec] (About) {(@fluxbox@/bin/fluxbox -v; @fluxbox@/bin/fluxbox -info | @gnused@/bin/sed 1d) | @xmessage@/bin/xmessage -file - -center}
+   [separator]
+   [exit] (Exit)
+ [end]
+-- 
+2.26.2
+

--- a/pkgs/applications/misc/fbmenugen/default.nix
+++ b/pkgs/applications/misc/fbmenugen/default.nix
@@ -1,0 +1,75 @@
+{ stdenv
+, fetchFromGitHub
+, fluxbox
+, gnused
+, makeWrapper
+, perlPackages
+, substituteAll
+, xorg
+, wrapGAppsHook
+}:
+
+perlPackages.buildPerlPackage rec {
+  pname = "fbmenugen";
+  version = "2020-05-20";
+
+  src = fetchFromGitHub {
+    owner = "trizen";
+    repo = pname;
+    rev = "ed9a680546edbb5b05086971b6a9f42a37cb485f";
+    sha256 = "1fikdl08a0s8d6k1ls1pzmw2rcwkfbbczsjfx6lr12ngd2bz222h";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./0001-Fix-paths.patch;
+      xmessage = xorg.xmessage;
+      inherit fluxbox gnused;
+    })
+  ];
+
+  outputs = [ "out" ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    fluxbox
+    gnused
+    perlPackages.DataDump
+    perlPackages.FileDesktopEntry
+    perlPackages.Gtk3
+    perlPackages.LinuxDesktopFiles
+    perlPackages.perl
+    xorg.xmessage
+  ];
+
+  dontConfigure = true;
+
+  dontBuild = true;
+
+  postPatch = ''
+    substituteInPlace fbmenugen --subst-var-by fbmenugen $out
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D -t $out/bin ${pname}
+    install -D -t $out/etc/xdg/${pname} schema.pl
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/${pname}" --prefix PERL5LIB : "$PERL5LIB"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/trizen/fbmenugen";
+    description = "Simple menu generator for the Fluxbox Window Manager";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19342,6 +19342,8 @@ in
 
   fasttext = callPackage ../applications/science/machine-learning/fasttext { };
 
+  fbmenugen = callPackage ../applications/misc/fbmenugen { };
+
   fbpanel = callPackage ../applications/window-managers/fbpanel { };
 
   fbreader = callPackage ../applications/misc/fbreader {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [fbmenugen](https://trizenx.blogspot.com/2012/02/fbmenugen.html), a Fluxbox menu generator (with support for icons).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).