### PR TITLE
dav1d: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/development/libraries/dav1d/default.nix
+++ b/pkgs/development/libraries/dav1d/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, fetchpatch
+{ stdenv, fetchFromGitLab
 , meson, ninja, nasm, pkgconfig
 , withTools ? false # "dav1d" binary
 , withExamples ? false, SDL2 # "dav1dplay" binary
@@ -9,22 +9,15 @@ assert useVulkan -> withExamples;
 
 stdenv.mkDerivation rec {
   pname = "dav1d";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitLab {
     domain = "code.videolan.org";
     owner = "videolan";
     repo = pname;
     rev = version;
-    sha256 = "1gr859xzbqrsp892v9zzzgrg8smnnzgc1jmb68qzl54a4g6jrxm0";
+    sha256 = "0zmn4ald518vgs3cc0ga227aimr38h16mkliq5j8mg6p9dn7nx1w";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://code.videolan.org/videolan/dav1d/-/commit/e04227c5f6729b460e0b8e5fb52eae2d5acd15ef.patch";
-      sha256 = "18mpvwviqx0x9k6av98vgpjqlzcjd89g8496zsbf57bw5dadij3l";
-    })
-  ];
 
   nativeBuildInputs = [ meson ninja nasm pkgconfig ];
   # TODO: doxygen (currently only HTML and not build by default).


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Tested `dav1d` and `dav1dplay` so far.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
