### PR TITLE
infra-arcana: init at rev e50a5ff4

### DIFF
--- a/pkgs/games/infra-arcana/build.sh
+++ b/pkgs/games/infra-arcana/build.sh
@@ -1,0 +1,60 @@
+source $stdenv/setup
+PATH=${cmake}/bin:$PATH
+
+configurePhase() {
+	:
+}
+
+buildPhase() {
+	:
+}
+
+installPhase() {
+	:
+}
+
+checkPhase() {
+	:
+}
+
+fixupPhase() {
+	:
+}
+
+installCheckPhase() {
+	:
+}
+
+distPhase() {
+	:
+}
+
+genericBuild
+
+mkdir build
+cd build
+CXXFLAGS="-Wno-narrowing" SDL2DIR=$SDL2 SDL2_PATH=$SDL2DEV SDL2_LIBRARY_TEMP=${SDL2}/lib SDL2IMAGEDIR=$SDL2_image SDL2MIXERDIR=$SDL2_mixer cmake -DCMAKE_INSTALL_PREFIX=${out}/ia-bin -DCMAKE_BUILD_TYPE=Release -DSDL2_INCLUDE_DIR=${SDL2DEV}/include/SDL2 $src
+
+make -j${NIX_BUILD_CORES} ia
+
+cd ..
+
+mkdir ${out}
+
+mkdir ${out}/bin
+
+cp -r ./build ${out}/bin
+
+mv ${out}/bin/build ${out}/bin/ia-files
+
+BINDIR=${out}/bin
+
+# Based on 'infra-arcana.sh' script from https://aur.archlinux.org/packages/infra-arcana/
+cat << EOF > ${out}/bin/infra-arcana
+#!/usr/bin/env bash
+cd "${BINDIR}"/ia-files
+./ia
+
+EOF
+
+chmod +x ${out}/bin/infra-arcana

--- a/pkgs/games/infra-arcana/default.nix
+++ b/pkgs/games/infra-arcana/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitLab, cmake, SDL2, SDL2_image, SDL2_mixer }:
+
+stdenv.mkDerivation {
+	name = "infra-arcana";
+	builder = ./build.sh;
+	src = fetchFromGitLab {
+		owner = "martin-tornqvist";
+		repo = "ia";
+		rev = "e50a5ff4";
+		sha256 = "0fgz6y0fahy7nrwip6k6392msvq5z1zbbrsrzrqam324rcb7rsmb";
+	};
+	patches = [ ./sdl2find.patch ];
+	inherit cmake;
+	inherit SDL2;
+	SDL2DEV = SDL2.dev;
+	inherit SDL2_image;
+	inherit SDL2_mixer;
+	meta = with stdenv.lib; {
+		homepage = "https://sites.google.com/site/infraarcana/";
+		description = "A Roguelike inspired by the horror fiction of writer H.P. Lovecraft";
+		longDescription = ''Infra Arcana is a Roguelike set in the early 20th century. The goal is to explore the lair of a dreaded cult 		called The Church of Starry Wisdom. Buried deep beneath their hallowed grounds lies an artifact called The Shining Trapezohedron - a window to all secrets of the universe. Your ultimate goal is to unearth this artifact.
+
+			The theme and inspiration for this game comes mainly from the horror fiction writer H.P. Lovecraft. The game also draws flavor from various B-horror movies, as well as the first-person shooter PC game Blood.
+
+			Infra Arcana adheres to the virtues of the Roguelike genre - high replay value and challenging tactical gameplay.
+		'';
+		license = licenses.agpl3Plus;
+		platforms = platforms.linux;
+	};
+}

--- a/pkgs/games/infra-arcana/sdl2find.patch
+++ b/pkgs/games/infra-arcana/sdl2find.patch
@@ -1,0 +1,31 @@
+From 45ace6fa3b111278b2ca9c7bca5f22270747fd69 Mon Sep 17 00:00:00 2001
+From: "Patrick J. Henning" <path@fea.st>
+Date: Tue, 19 May 2020 02:27:11 -0700
+Subject: [PATCH] Only search manually specified SDL2_PATH (nix)
+
+---
+ cmake/FindSDL2.cmake | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/cmake/FindSDL2.cmake b/cmake/FindSDL2.cmake
+index 0badaa10..c472a55c 100644
+--- a/cmake/FindSDL2.cmake
++++ b/cmake/FindSDL2.cmake
+@@ -68,14 +68,6 @@
+ message("<FindSDL2.cmake>")
+ 
+ SET(SDL2_SEARCH_PATHS
+-	~/Library/Frameworks
+-	/Library/Frameworks
+-	/usr/local
+-	/usr
+-	/sw # Fink
+-	/opt/local # DarwinPorts
+-	/opt/csw # Blastwave
+-	/opt
+ 	${SDL2_PATH}
+ )
+ 
+-- 
+2.24.0
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23617,6 +23617,8 @@ in
 
   icbm3d = callPackage ../games/icbm3d { };
 
+  infra-arcana = callPackage ../games/infra-arcana { };
+
   ingen = callPackage ../applications/audio/ingen {
     inherit (pythonPackages) rdflib;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adding a package for the rougelike game Infra Arcana :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md). **CAVEAT**: I was not sure whether to add myself as a maintainer.
