### PR TITLE
pre-commit: 1.21.0 -> 2.4.0 

### DIFF
--- a/pkgs/development/python-modules/pre-commit/default.nix
+++ b/pkgs/development/python-modules/pre-commit/default.nix
@@ -6,6 +6,7 @@
 , identify
 , importlib-metadata
 , importlib-resources
+, isPy27
 , nodeenv
 , python
 , six
@@ -15,16 +16,18 @@
 
 buildPythonPackage rec {
   pname = "pre-commit";
-  version = "1.21.0";
+  version = "2.4.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit version;
     pname = "pre_commit";
-    sha256 = "0l5qg1cw4a0670m96s0ryy5mqz5aslfrrnwpriqgmrnsgdixhj4g";
+    sha256 = "1l0lcl3l2544m2k8jlmblfsjn0p2hdxrzzwy646xpvp0rcs2wgkh";
   };
 
   patches = [
     ./hook-tmpl-use-the-hardcoded-path-to-pre-commit.patch
+    ./languages-use-the-hardcoded-path-to-python-binaries.patch
   ];
 
   propagatedBuildInputs = [
@@ -36,9 +39,8 @@ buildPythonPackage rec {
     six
     toml
     virtualenv
-    importlib-metadata
-  ] ++ lib.optional (pythonOlder "3.7") importlib-resources
-    ++ lib.optional (pythonOlder "3.2") futures;
+  ] ++ lib.optional (pythonOlder "3.8") importlib-metadata
+    ++ lib.optional (pythonOlder "3.7") importlib-resources;
 
   # slow and impure
   doCheck = false;
@@ -46,6 +48,10 @@ buildPythonPackage rec {
   preFixup = ''
     substituteInPlace $out/${python.sitePackages}/pre_commit/resources/hook-tmpl \
       --subst-var-by pre-commit $out
+    substituteInPlace $out/${python.sitePackages}/pre_commit/languages/python.py \
+      --subst-var-by virtualenv ${virtualenv}
+    substituteInPlace $out/${python.sitePackages}/pre_commit/languages/node.py \
+      --subst-var-by nodeenv ${nodeenv}
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pre-commit/hook-tmpl-use-the-hardcoded-path-to-pre-commit.patch
+++ b/pkgs/development/python-modules/pre-commit/hook-tmpl-use-the-hardcoded-path-to-pre-commit.patch
@@ -1,25 +1,15 @@
-From d9e6999e32112602ec276634cb004eda3ca64ec3 Mon Sep 17 00:00:00 2001
-From: "Wael M. Nasreddine" <wael.nasreddine@gmail.com>
-Date: Mon, 13 Jan 2020 11:04:58 -0800
-Subject: [PATCH] hook-tmpl: use the hardcoded path to pre-commit, if found
-
----
- pre_commit/resources/hook-tmpl | 2 ++
- 1 file changed, 2 insertions(+)
-
 diff --git a/pre_commit/resources/hook-tmpl b/pre_commit/resources/hook-tmpl
-index 213d16e..3a99211 100755
+index 299144e..6d12543 100755
 --- a/pre_commit/resources/hook-tmpl
 +++ b/pre_commit/resources/hook-tmpl
-@@ -107,6 +107,8 @@ def _exe() -> Tuple[str, ...]:
-             except OSError:
-                 pass
- 
-+    if os.path.isfile('@pre-commit@/bin/pre-commit') and os.access('@pre-commit@/bin/pre-commit', os.X_OK):
-+        return ('@pre-commit@/bin/pre-commit', 'run')
-     if distutils.spawn.find_executable('pre-commit'):
-         return ('pre-commit', 'run')
- 
--- 
-2.23.1
+@@ -25,8 +25,8 @@ ARGS.append('--')
+ ARGS.extend(sys.argv[1:])
 
+ DNE = '`pre-commit` not found.  Did you forget to activate your virtualenv?'
+-if os.access(INSTALL_PYTHON, os.X_OK):
+-    CMD = [INSTALL_PYTHON, '-mpre_commit']
++if os.access('@pre-commit@/bin/pre-commit', os.X_OK):
++    CMD = ['@pre-commit@/bin/pre-commit']
+ elif which('pre-commit'):
+     CMD = ['pre-commit']
+ else:

--- a/pkgs/development/python-modules/pre-commit/languages-use-the-hardcoded-path-to-python-binaries.patch
+++ b/pkgs/development/python-modules/pre-commit/languages-use-the-hardcoded-path-to-python-binaries.patch
@@ -1,0 +1,26 @@
+diff --git a/pre_commit/languages/node.py b/pre_commit/languages/node.py
+index 26f4919..4885ec1 100644
+--- a/pre_commit/languages/node.py
++++ b/pre_commit/languages/node.py
+@@ -82,7 +82,7 @@ def install_environment(
+         envdir = fr'\\?\{os.path.normpath(envdir)}'
+     with clean_path_on_failure(envdir):
+         cmd = [
+-            sys.executable, '-mnodeenv', '--prebuilt', '--clean-src', envdir,
++            '@nodeenv@/bin/nodeenv', '--prebuilt', '--clean-src', envdir,
+         ]
+         if version != C.DEFAULT:
+             cmd.extend(['-n', version])
+diff --git a/pre_commit/languages/python.py b/pre_commit/languages/python.py
+index e17376e..0c1d2ab 100644
+--- a/pre_commit/languages/python.py
++++ b/pre_commit/languages/python.py
+@@ -204,7 +204,7 @@ def install_environment(
+ ) -> None:
+     envdir = prefix.path(helpers.environment_dir(ENVIRONMENT_DIR, version))
+     python = norm_version(version)
+-    venv_cmd = (sys.executable, '-mvirtualenv', envdir, '-p', python)
++    venv_cmd = ('@virtualenv@/bin/virtualenv', envdir, '-p', python)
+     install_cmd = ('python', '-mpip', 'install', '.', *additional_dependencies)
+
+     with clean_path_on_failure(envdir):


### PR DESCRIPTION
###### Motivation for this change

pre-commit can't install environment for python based hooks because it use module version call: `python -mvirtualenv`

###### Things done

Created a patch that replace `python -mvirtualenv` with `${virtualenv}/bin/virtualenv`, used existing hook-tmpl patch as a guidance. 


###### Problem reproduction

Create .pre-commit-config.yaml

```yaml
repos:
  -   repo: https://gitlab.com/pycqa/flake8
      rev: 3.8.1
      hooks:
      -   id: flake8
```

Run `pre-commit`

```
[INFO] Initializing environment for https://gitlab.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/nix/store/2dcsn57cgaxs92ha5swihrab0g3l2h6g-python3-3.7.7/bin/python3.7', '-mvirtualenv', '/home/u/.cache/pre-commit/repoxx7im869/py_env-python3.7', '-p', '/nix/store/2dcsn57cgaxs92ha5swihrab0g3l2h6g-python3-3.7.7/bin/python3.7')
return code: 1
expected return code: 0
stdout: (none)
stderr:
    /nix/store/2dcsn57cgaxs92ha5swihrab0g3l2h6g-python3-3.7.7/bin/python3.7: No module named virtualenv

Check the log at /home/u/.cache/pre-commit/pre-commit.log
```