### PR TITLE
home-assistant: 0.109.6 → 0.110.1

### DIFF
--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -76,7 +76,7 @@ in {
         hass.succeed("test -f ${configDir}/ui-lovelace.yaml")
     with subtest("Check that Home Assistant's web interface and API can be reached"):
         hass.wait_for_open_port(8123)
-        hass.succeed("curl --fail http://localhost:8123/states")
+        hass.succeed("curl --fail http://localhost:8123/lovelace")
         assert "API running" in hass.succeed(
             "curl --fail -H 'x-ha-access: ${apiPassword}' http://localhost:8123/api/"
         )

--- a/pkgs/servers/home-assistant/0001-setup.py-relax-dependencies.patch
+++ b/pkgs/servers/home-assistant/0001-setup.py-relax-dependencies.patch
@@ -1,18 +1,14 @@
-From 55cb3ba4458bd43588e7921906d091d001130ab0 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
-Date: Thu, 9 Apr 2020 07:20:46 +0100
+From 9d730514540929dc95a7313bdb385bab95d9a28c Mon Sep 17 00:00:00 2001
+From: Martin Weinelt <hexa@darmstadt.ccc.de>
+Date: Wed, 20 May 2020 23:23:23 +0200
 Subject: [PATCH] setup.py: relax dependencies
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
 
-Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
 ---
- setup.py | 16 ++++++++--------
- 1 file changed, 8 insertions(+), 8 deletions(-)
+ setup.py | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/setup.py b/setup.py
-index 0c56e89b67..ba04546130 100755
+index 1473fd1f5f..149af58b3a 100755
 --- a/setup.py
 +++ b/setup.py
 @@ -32,24 +32,24 @@ PROJECT_URLS = {
@@ -23,25 +19,24 @@ index 0c56e89b67..ba04546130 100755
 +    "aiohttp>=3.6.1",
      "astral==1.10.1",
      "async_timeout==3.0.1",
--    "attrs==19.3.0",
-+    "attrs>=19.3.0",
+     "attrs==19.3.0",
      "bcrypt==3.1.7",
--    "certifi>=2020.4.5.1",
-+    "certifi>=2019.11.28",
+     "certifi>=2020.4.5.1",
      "ciso8601==2.1.3",
 -    "importlib-metadata==1.6.0",
 +    "importlib-metadata>=1.5.0",
      "jinja2>=2.11.1",
      "PyJWT==1.7.1",
      # PyJWT has loose dependency. We want the latest one.
--    "cryptography==2.9",
+-    "cryptography==2.9.2",
 +    "cryptography>=2.9",
      "pip>=8.0.3",
      "python-slugify==4.0.0",
-     "pytz>=2019.03",
+-    "pytz>=2020.1",
 -    "pyyaml==5.3.1",
 -    "requests==2.23.0",
 -    "ruamel.yaml==0.15.100",
++    "pytz>=2019.03",
 +    "pyyaml>=5.2",
 +    "requests>=2.22",
 +    "ruamel.yaml>=0.15.100",
@@ -49,5 +44,5 @@ index 0c56e89b67..ba04546130 100755
      "voluptuous-serialize==2.3.0",
  ]
 -- 
-2.26.1
+2.26.2
 

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.110.0";
+  version = "0.110.1";
   components = {
     "abode" = ps: with ps; [ ]; # missing inputs: abodepy
     "acer_projector" = ps: with ps; [ pyserial];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.109.6";
+  version = "0.110.0";
   components = {
     "abode" = ps: with ps; [ ]; # missing inputs: abodepy
     "acer_projector" = ps: with ps; [ pyserial];
@@ -10,6 +10,7 @@
     "adguard" = ps: with ps; [ ]; # missing inputs: adguardhome
     "ads" = ps: with ps; [ ]; # missing inputs: pyads
     "aftership" = ps: with ps; [ ]; # missing inputs: pyaftership
+    "agent_dvr" = ps: with ps; [ ]; # missing inputs: agent-py
     "air_quality" = ps: with ps; [ ];
     "airly" = ps: with ps; [ ]; # missing inputs: airly
     "airvisual" = ps: with ps; [ pyairvisual];
@@ -75,6 +76,7 @@
     "bitcoin" = ps: with ps; [ ]; # missing inputs: blockchain
     "bizkaibus" = ps: with ps; [ ]; # missing inputs: bizkaibus
     "blackbird" = ps: with ps; [ ]; # missing inputs: pyblackbird
+    "blebox" = ps: with ps; [ ]; # missing inputs: blebox_uniapi
     "blink" = ps: with ps; [ ]; # missing inputs: blinkpy
     "blinksticklight" = ps: with ps; [ BlinkStick];
     "blinkt" = ps: with ps; [ ]; # missing inputs: blinkt
@@ -94,6 +96,7 @@
     "brottsplatskartan" = ps: with ps; [ ]; # missing inputs: brottsplatskartan
     "browser" = ps: with ps; [ ];
     "brunt" = ps: with ps; [ ]; # missing inputs: brunt
+    "bsblan" = ps: with ps; [ ]; # missing inputs: bsblan
     "bt_home_hub_5" = ps: with ps; [ ]; # missing inputs: bthomehub5-devicelist
     "bt_smarthub" = ps: with ps; [ ]; # missing inputs: btsmarthub_devicelist
     "buienradar" = ps: with ps; [ ]; # missing inputs: buienradar
@@ -154,6 +157,7 @@
     "device_automation" = ps: with ps; [ aiohttp-cors];
     "device_sun_light_trigger" = ps: with ps; [ ];
     "device_tracker" = ps: with ps; [ ];
+    "devolo_home_control" = ps: with ps; [ ]; # missing inputs: devolo-home-control-api
     "dht" = ps: with ps; [ ]; # missing inputs: Adafruit-DHT
     "dialogflow" = ps: with ps; [ aiohttp-cors];
     "digital_ocean" = ps: with ps; [ digital-ocean];
@@ -243,6 +247,7 @@
     "fleetgo" = ps: with ps; [ ]; # missing inputs: ritassist
     "flexit" = ps: with ps; [ ]; # missing inputs: pyflexit pymodbus
     "flic" = ps: with ps; [ ]; # missing inputs: pyflic-homeassistant
+    "flick_electric" = ps: with ps; [ ]; # missing inputs: PyFlick
     "flock" = ps: with ps; [ ];
     "flume" = ps: with ps; [ ]; # missing inputs: pyflume
     "flunearyou" = ps: with ps; [ ]; # missing inputs: pyflunearyou
@@ -251,6 +256,7 @@
     "folder" = ps: with ps; [ ];
     "folder_watcher" = ps: with ps; [ watchdog];
     "foobot" = ps: with ps; [ ]; # missing inputs: foobot_async
+    "forked_daapd" = ps: with ps; [ ]; # missing inputs: pyforked-daapd pylibrespot-java
     "fortigate" = ps: with ps; [ ]; # missing inputs: pyfgt
     "fortios" = ps: with ps; [ ]; # missing inputs: fortiosapi
     "foscam" = ps: with ps; [ ]; # missing inputs: libpyfoscam
@@ -328,8 +334,9 @@
     "hitron_coda" = ps: with ps; [ ];
     "hive" = ps: with ps; [ ]; # missing inputs: pyhiveapi
     "hlk_sw16" = ps: with ps; [ ]; # missing inputs: hlk-sw16
+    "home_connect" = ps: with ps; [ aiohttp-cors]; # missing inputs: homeconnect
     "homeassistant" = ps: with ps; [ ];
-    "homekit" = ps: with ps; [ HAP-python pyqrcode aiohttp-cors]; # missing inputs: base36 fnvhash
+    "homekit" = ps: with ps; [ HAP-python pyqrcode aiohttp-cors ha-ffmpeg]; # missing inputs: PyTurboJPEG base36 fnvhash
     "homekit_controller" = ps: with ps; [ ]; # missing inputs: aiohomekit[IP]
     "homematic" = ps: with ps; [ pyhomematic];
     "homematicip_cloud" = ps: with ps; [ ]; # missing inputs: homematicip
@@ -379,7 +386,7 @@
     "irish_rail_transport" = ps: with ps; [ ]; # missing inputs: pyirishrail
     "islamic_prayer_times" = ps: with ps; [ ]; # missing inputs: prayer_times_calculator
     "iss" = ps: with ps; [ ]; # missing inputs: pyiss
-    "isy994" = ps: with ps; [ ]; # missing inputs: PyISY
+    "isy994" = ps: with ps; [ ]; # missing inputs: pyisy
     "itach" = ps: with ps; [ ]; # missing inputs: pyitachip2ir
     "itunes" = ps: with ps; [ ];
     "izone" = ps: with ps; [ ]; # missing inputs: python-izone
@@ -533,6 +540,7 @@
     "nuheat" = ps: with ps; [ ]; # missing inputs: nuheat
     "nuimo_controller" = ps: with ps; [ ]; # missing inputs: --only-binary=all nuimo
     "nuki" = ps: with ps; [ ]; # missing inputs: pynuki
+    "numato" = ps: with ps; [ ]; # missing inputs: numato-gpio
     "nut" = ps: with ps; [ ]; # missing inputs: pynut2
     "nws" = ps: with ps; [ ]; # missing inputs: pynws
     "nx584" = ps: with ps; [ ]; # missing inputs: pynx584
@@ -546,14 +554,14 @@
     "onboarding" = ps: with ps; [ aiohttp-cors];
     "onewire" = ps: with ps; [ ]; # missing inputs: pyownet
     "onkyo" = ps: with ps; [ onkyo-eiscp];
-    "onvif" = ps: with ps; [ ha-ffmpeg]; # missing inputs: onvif-zeep-async
+    "onvif" = ps: with ps; [ ha-ffmpeg]; # missing inputs: WSDiscovery onvif-zeep-async
     "openalpr_cloud" = ps: with ps; [ ];
     "openalpr_local" = ps: with ps; [ ];
     "opencv" = ps: with ps; [ numpy]; # missing inputs: opencv-python-headless
     "openerz" = ps: with ps; [ ]; # missing inputs: openerz-api
     "openevse" = ps: with ps; [ ]; # missing inputs: openevsewifi
     "openexchangerates" = ps: with ps; [ ];
-    "opengarage" = ps: with ps; [ ];
+    "opengarage" = ps: with ps; [ ]; # missing inputs: open-garage
     "openhardwaremonitor" = ps: with ps; [ ];
     "openhome" = ps: with ps; [ ]; # missing inputs: openhomedevice
     "opensensemap" = ps: with ps; [ ]; # missing inputs: opensensemap-api
@@ -569,6 +577,7 @@
     "osramlightify" = ps: with ps; [ ]; # missing inputs: lightify
     "otp" = ps: with ps; [ pyotp];
     "owntracks" = ps: with ps; [ pynacl aiohttp-cors];
+    "ozw" = ps: with ps; [ ]; # missing inputs: python-openzwave-mqtt
     "panasonic_bluray" = ps: with ps; [ ]; # missing inputs: panacotta
     "panasonic_viera" = ps: with ps; [ ]; # missing inputs: panasonic_viera
     "pandora" = ps: with ps; [ pexpect];
@@ -604,7 +613,7 @@
     "proxy" = ps: with ps; [ pillow];
     "ps4" = ps: with ps; [ ]; # missing inputs: pyps4-2ndscreen
     "ptvsd" = ps: with ps; [ ]; # missing inputs: ptvsd
-    "pulseaudio_loopback" = ps: with ps; [ ];
+    "pulseaudio_loopback" = ps: with ps; [ pulsectl];
     "push" = ps: with ps; [ aiohttp-cors];
     "pushbullet" = ps: with ps; [ pushbullet];
     "pushover" = ps: with ps; [ pushover-complete];
@@ -647,7 +656,7 @@
     "ripple" = ps: with ps; [ ]; # missing inputs: python-ripple-api
     "rmvtransport" = ps: with ps; [ ]; # missing inputs: PyRMVtransport
     "rocketchat" = ps: with ps; [ ]; # missing inputs: rocketchat-API
-    "roku" = ps: with ps; [ roku];
+    "roku" = ps: with ps; [ ]; # missing inputs: rokuecp
     "roomba" = ps: with ps; [ ]; # missing inputs: roombapy
     "route53" = ps: with ps; [ boto3]; # missing inputs: ipify
     "rova" = ps: with ps; [ ]; # missing inputs: rova
@@ -736,7 +745,7 @@
     "spotcrime" = ps: with ps; [ ]; # missing inputs: spotcrime
     "spotify" = ps: with ps; [ aiohttp-cors spotipy];
     "sql" = ps: with ps; [ sqlalchemy];
-    "squeezebox" = ps: with ps; [ ];
+    "squeezebox" = ps: with ps; [ ]; # missing inputs: pysqueezebox
     "ssdp" = ps: with ps; [ defusedxml netdisco];
     "starline" = ps: with ps; [ ]; # missing inputs: starline
     "starlingbank" = ps: with ps; [ ]; # missing inputs: starlingbank
@@ -836,6 +845,7 @@
     "unifi_direct" = ps: with ps; [ pexpect];
     "unifiled" = ps: with ps; [ ]; # missing inputs: unifiled
     "universal" = ps: with ps; [ ];
+    "upb" = ps: with ps; [ ]; # missing inputs: upb_lib
     "upc_connect" = ps: with ps; [ ]; # missing inputs: connect-box
     "upcloud" = ps: with ps; [ ]; # missing inputs: upcloud-api
     "updater" = ps: with ps; [ distro];
@@ -883,6 +893,7 @@
     "websocket_api" = ps: with ps; [ aiohttp-cors];
     "wemo" = ps: with ps; [ ]; # missing inputs: pywemo
     "whois" = ps: with ps; [ ]; # missing inputs: python-whois
+    "wiffi" = ps: with ps; [ ]; # missing inputs: wiffi
     "wink" = ps: with ps; [ aiohttp-cors]; # missing inputs: pubnubsub-handler python-wink
     "wirelesstag" = ps: with ps; [ ]; # missing inputs: wirelesstagpy
     "withings" = ps: with ps; [ aiohttp-cors]; # missing inputs: withings-api
@@ -919,8 +930,9 @@
     "zamg" = ps: with ps; [ ];
     "zengge" = ps: with ps; [ ]; # missing inputs: zengge
     "zeroconf" = ps: with ps; [ aiohttp-cors zeroconf];
+    "zerproc" = ps: with ps; [ ]; # missing inputs: pyzerproc
     "zestimate" = ps: with ps; [ xmltodict];
-    "zha" = ps: with ps; [ zha-quirks zigpy-deconz zigpy]; # missing inputs: bellows-homeassistant zigpy-cc zigpy-xbee-homeassistant zigpy-zigate
+    "zha" = ps: with ps; [ pyserial zha-quirks zigpy-deconz]; # missing inputs: bellows zigpy-cc zigpy-xbee zigpy-zigate zigpy
     "zhong_hong" = ps: with ps; [ ]; # missing inputs: zhong_hong_hvac
     "zigbee" = ps: with ps; [ ]; # missing inputs: xbee-helper
     "ziggo_mediabox_xl" = ps: with ps; [ ]; # missing inputs: ziggo-mediabox-xl

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -67,7 +67,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.109.6";
+  hassVersion = "0.110.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -84,9 +84,9 @@ in with py.pkgs; buildPythonApplication rec {
   # PyPI tarball is missing tests/ directory
   src = fetchFromGitHub {
     owner = "home-assistant";
-    repo = "home-assistant";
+    repo = "core";
     rev = version;
-    sha256 = "133l6n165yivnc9qmrahk423hmns0hn0dbnx4ys7yaw3x5hqwyns";
+    sha256 = "1z6dvq75nx8l9d9siifqf08qf4rx95shpk28g055nsv0g89wmxbs";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -67,7 +67,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.110.0";
+  hassVersion = "0.110.1";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -86,7 +86,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "1z6dvq75nx8l9d9siifqf08qf4rx95shpk28g055nsv0g89wmxbs";
+    sha256 = "1495kl997mvk9k11lk1ahv5w0yc0185qmxwa1h51j6d0zyqwz749";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20200519.0";
+  version = "20200519.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1kdwkn4586qqcp0l0v5z9j2awwgcw0hqi8wwv7h8xss97dh0ybdv";
+    sha256 = "149v56q5anzdfxf0dw1h39vdmcigx732a7abqjfb0xny5484iq8w";
   };
 
   # no Python tests implemented

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20200505.0";
+  version = "20200519.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0h19ddgnws5l49fwr4b0j99j4xkhpxkwdsmq71q36akd4s5lj0ll";
+    sha256 = "1kdwkn4586qqcp0l0v5z9j2awwgcw0hqi8wwv7h8xss97dh0ybdv";
   };
 
   # no Python tests implemented


### PR DESCRIPTION
###### Motivation for this change

New upstream release.

https://www.home-assistant.io/blog/2020/05/20/release-110/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@Mic92 