### PR TITLE
ocamlPackages.curly: init at 2019-11-14

### DIFF
--- a/pkgs/development/ocaml-modules/curly/default.nix
+++ b/pkgs/development/ocaml-modules/curly/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildDunePackage, fetchFromGitHub, ocaml
+, result, alcotest, cohttp-lwt-unix, odoc, curl }:
+
+buildDunePackage rec {
+  pname = "curly";
+  version = "unstable-2019-11-14";
+
+  minimumOCamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner  = "rgrinberg";
+    repo   = pname;
+    rev    = "33a538c89ef8279d4591454a7f699a4183dde5d0";
+    sha256 = "10pxbvf5xrsajaxrccxh2lqhgp3yaf61z9w03rvb2mq44nc2dggz";
+  };
+
+  propagatedBuildInputs = [ result ];
+  checkInputs = [ alcotest cohttp-lwt-unix ];
+  # test dependencies are only available for >= 4.05
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
+
+  postPatch = ''
+    substituteInPlace src/curly.ml \
+      --replace "exe=\"curl\"" "exe=\"${curl}/bin/curl\""
+    '';
+}
+

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -189,6 +189,10 @@ let
 
     csv-lwt = callPackage ../development/ocaml-modules/csv/lwt.nix { };
 
+    curly = callPackage ../development/ocaml-modules/curly {
+      inherit (pkgs) curl;
+    };
+
     curses = callPackage ../development/ocaml-modules/curses { };
 
     custom_printf = callPackage ../development/ocaml-modules/custom_printf { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Dependency for [dune-release](https://github.com/ocamllabs/dune-release/) which I am working on packaging. Used a unstable version, since the last release's jbuilder setup seems broken by now and the old API isn't broken.

I decided to patch in a static path to `curl`, since `curly` assumes that it'll find `curl` in `PATH` by default, which is kind of hard to ensure for a library. The static path can still be overridden by the user of the library if they want to, however.

Another solution to the problem could be to not care about it in `curly`, but use `wrapProgram` for all user applications that use `curly` and add `curl` to `PATH` there. I think doing it in `curly` is nicer overall and should ensure that it works out of the box, but let me know what you think!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
