### PR TITLE
ocamlPackages.mirage-crypto 0.6.2 → 0.7.0 and updated/new dependencies

### DIFF
--- a/pkgs/development/ocaml-modules/eqaf/default.nix
+++ b/pkgs/development/ocaml-modules/eqaf/default.nix
@@ -3,11 +3,11 @@
 buildDunePackage rec {
   minimumOCamlVersion = "4.03";
   pname = "eqaf";
-  version = "0.6";
+  version = "0.7";
 
   src = fetchurl {
     url = "https://github.com/mirage/eqaf/releases/download/v${version}/eqaf-v${version}.tbz";
-    sha256 = "068r231ia87mpqpaqzqb9sjfj6yaqrwvcls2p173aa4qg38xvsq9";
+    sha256 = "1q09pwhs121vpficl2af1yzs4y7dd9bc1lcxbqyfc4x4m6p6drhh";
   };
 
   propagatedBuildInputs = [ cstruct bigarray-compat ];

--- a/pkgs/development/ocaml-modules/functoria/default.nix
+++ b/pkgs/development/ocaml-modules/functoria/default.nix
@@ -4,13 +4,13 @@
 
 buildDunePackage rec {
   pname   = "functoria";
-  version = "3.0.3";
+  version = "3.1.0";
 
   minimumOCamlVersion = "4.04";
 
   src = fetchurl {
     url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "08wv2890gz7ci1fa2b3z4cvqf98nqb09f89y08kcmnsirlbbzlfh";
+    sha256 = "15jdqdj1vfi0x9gjydrrnbwzwbzw34w1iir032jrji820xlblky2";
   };
 
   propagatedBuildInputs = [ cmdliner rresult astring fmt ocamlgraph logs bos fpath ptime ];

--- a/pkgs/development/ocaml-modules/functoria/runtime.nix
+++ b/pkgs/development/ocaml-modules/functoria/runtime.nix
@@ -1,0 +1,17 @@
+{ lib, buildDunePackage, functoria, cmdliner, fmt, alcotest }:
+
+buildDunePackage {
+  pname = "functoria-runtime";
+
+  inherit (functoria) version src;
+
+  propagatedBuildInputs = [ cmdliner fmt ];
+  checkInputs = [ alcotest functoria];
+  doCheck = true;
+
+  meta = with lib; {
+    inherit (functoria.meta) homepage license;
+    description = "Runtime support library for functoria-generated code";
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/io-page/default.nix
+++ b/pkgs/development/ocaml-modules/io-page/default.nix
@@ -1,16 +1,19 @@
-{ stdenv, fetchzip, buildDunePackage, configurator, cstruct }:
+{ stdenv, fetchurl, buildDunePackage, configurator, cstruct, bigarray-compat, ounit }:
 
 buildDunePackage rec {
   pname = "io-page";
-  version = "2.0.1";
+  version = "2.3.0";
 
-  src = fetchzip {
-    url = "https://github.com/mirage/${pname}/archive/${version}.tar.gz";
-    sha256 = "1rw04dwrlx5hah5dkjf7d63iff82j9cifr8ifjis5pdwhgwcff8i";
+  minimumOCamlVersion = "4.02.3";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
+    sha256 = "1hx27pwf419hrhwaw9cphbnl8akz8yy73hqj49l15g2k7shah1cn";
   };
 
-  buildInputs = [ configurator ];
-  propagatedBuildInputs = [ cstruct ];
+  propagatedBuildInputs = [ cstruct bigarray-compat ];
+  checkInputs = [ ounit ];
+  doCheck = true;
 
   meta = {
     homepage = "https://github.com/mirage/io-page";

--- a/pkgs/development/ocaml-modules/io-page/unix.nix
+++ b/pkgs/development/ocaml-modules/io-page/unix.nix
@@ -1,0 +1,17 @@
+{ lib, buildDunePackage, io-page, cstruct, ounit }:
+
+buildDunePackage {
+  pname = "io-page-unix";
+
+  inherit (io-page) version src minimumOCamlVersion;
+
+  propagatedBuildInputs = [ cstruct io-page ];
+  checkInputs = [ ounit ];
+  doCheck = true;
+
+  meta = with lib; {
+    inherit (io-page.meta) homepage license;
+    description = "Support for efficient handling of I/O memory pages on Unix";
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -1,28 +1,23 @@
-{ lib, fetchurl, buildDunePackage, ounit, cstruct, ocplib-endian
-, cpuid, dune-configurator, cpuAcceleration ? false }:
+{ lib, fetchurl, buildDunePackage, ounit, cstruct, dune-configurator, pkg-config }:
 
 buildDunePackage rec {
-  minimumOCamlVersion = "4.07";
+  minimumOCamlVersion = "4.08";
 
   pname = "mirage-crypto";
-  version = "0.6.2";
+  version = "0.7.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-crypto/releases/download/v${version}/mirage-crypto-v${version}.tbz";
-    sha256 = "08xq49cxn66yi0gfajzi8czcxfx24rd191rvf7s10wfkz304sa72";
+    sha256 = "0k7kllv3bh192yj6p9dk2z81r56w7x2kyr46pxygb5gnhqqxcncf";
   };
 
   useDune2 = true;
 
-  preBuild = ''
-    MIRAGE_CRYPTO_ACCELERATE=${lib.boolToString cpuAcceleration}
-  '';
-
   doCheck = true;
   checkInputs = [ ounit ];
 
-  nativeBuildInputs = [ cpuid dune-configurator ];
-  propagatedBuildInputs = [ cstruct ocplib-endian ];
+  nativeBuildInputs = [ dune-configurator pkg-config ];
+  propagatedBuildInputs = [ cstruct ];
 
   meta = with lib; {
     homepage = "https://github.com/mirage/mirage-crypto";

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
@@ -1,14 +1,19 @@
-{ buildDunePackage, mirage-crypto, ounit, randomconv, cstruct }:
+{ buildDunePackage, mirage-crypto, ounit, randomconv, dune-configurator
+, cstruct, duration, logs, mtime, ocaml_lwt, mirage-runtime, mirage-time
+, mirage-clock, mirage-time-unix, mirage-clock-unix, mirage-unix }:
 
 buildDunePackage {
   pname = "mirage-crypto-rng";
 
-  inherit (mirage-crypto) version src nativeBuildInputs useDune2 minimumOCamlVersion;
+  inherit (mirage-crypto) version src useDune2 minimumOCamlVersion;
 
   doCheck = true;
   checkInputs = [ ounit randomconv ];
 
-  propagatedBuildInputs = [ cstruct mirage-crypto ];
+  nativeBuildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ cstruct mirage-crypto duration logs mtime ocaml_lwt
+                            mirage-runtime mirage-time mirage-clock mirage-time-unix
+                            mirage-clock-unix mirage-unix ];
 
   meta = mirage-crypto.meta // {
     description = "A cryptographically secure PRNG";

--- a/pkgs/development/ocaml-modules/mirage-unix/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-unix/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildDunePackage, fetchurl, ocaml_lwt, duration, mirage-runtime, io-page-unix }:
+
+buildDunePackage rec {
+  pname = "mirage-unix";
+  version = "4.0.0";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
+    sha256 = "0kyd83bkpjhn382b4mw3a4325xr8vms78znxqvifpcyfvfnlx7hj";
+  };
+
+  propagatedBuildInputs = [ ocaml_lwt duration mirage-runtime io-page-unix ];
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/mirage/mirage-unix";
+    description = "Unix core platform libraries for MirageOS";
+    license = licenses.isc;
+    maintainers = with maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/mirage/runtime.nix
+++ b/pkgs/development/ocaml-modules/mirage/runtime.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, fetchurl, ipaddr, functoria-runtime
+, fmt, logs, ocaml_lwt, alcotest }:
+
+buildDunePackage rec {
+  pname = "mirage-runtime";
+  version = "3.7.7";
+
+  minimumOCamlVersion = "4.06";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage/releases/download/v${version}/mirage-v${version}.tbz";
+    sha256 = "1ds5zfwb0g340kbdlsjayyw4n25nj7skdl1mwyvpzmkv4qcsmdiv";
+  };
+
+  propagatedBuildInputs = [ ipaddr functoria-runtime fmt logs ocaml_lwt ];
+  checkInputs = [ alcotest ];
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/mirage/mirage";
+    description = "The base MirageOS runtime library, part of every MirageOS unikernel";
+    license = licenses.isc;
+    maintainers = with maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -290,6 +290,8 @@ let
 
     functoria = callPackage ../development/ocaml-modules/functoria { };
 
+    functoria-runtime = callPackage ../development/ocaml-modules/functoria/runtime.nix { };
+
     functory = callPackage ../development/ocaml-modules/functory { };
 
     gen = callPackage ../development/ocaml-modules/gen { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -555,6 +555,8 @@ let
 
     mirage-time-unix = callPackage ../development/ocaml-modules/mirage-time/unix.nix { };
 
+    mirage-unix = callPackage ../development/ocaml-modules/mirage-unix { };
+
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
     mlgmpidl =  callPackage ../development/ocaml-modules/mlgmpidl { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -320,6 +320,8 @@ let
 
     io-page = callPackage ../development/ocaml-modules/io-page { };
 
+    io-page-unix = callPackage ../development/ocaml-modules/io-page/unix.nix { };
+
     ipaddr = callPackage ../development/ocaml-modules/ipaddr { };
 
     irmin_1 = callPackage ../development/ocaml-modules/irmin/1.4.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -547,6 +547,8 @@ let
 
     mirage-random = callPackage ../development/ocaml-modules/mirage-random { };
 
+    mirage-runtime = callPackage ../development/ocaml-modules/mirage/runtime.nix { };
+
     mirage-stack = callPackage ../development/ocaml-modules/mirage-stack { };
 
     mirage-time = callPackage ../development/ocaml-modules/mirage-time { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New mirage-crypto release.

###### Things done

* Removed `cpuAcceleration` argument of `mirage-crypto` (now acceleration support is checked at runtime and the compile time switch has been removed as it is obsolete now)
* Packaged new dependency `mirage-unix` and the new packages it requires:
  * `io-page-unix` (also updated `io-page`)
  * `mirage-runtime` (added in mirage-subfolder in case we want to package the other packages of that repository)
  * `functoria-runtime` (also updated `functoria`)
* Updated `eqaf`, since build fails with 0.6 (0.7 also introduces tests which require `crowbar`, I'll work on packaging `crowbar` in the near future)

Sorry for the big PR, unfortunately more or less required due to the big changes in the release.

cc @vbgl


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
