### PR TITLE
virtualisation/hyperv-image: remove diskImage after vhdx is generated

### DIFF
--- a/nixos/modules/virtualisation/hyperv-image.nix
+++ b/nixos/modules/virtualisation/hyperv-image.nix
@@ -37,6 +37,7 @@ in {
       name = cfg.vmDerivationName;
       postVM = ''
         ${pkgs.vmTools.qemu}/bin/qemu-img convert -f raw -o subformat=dynamic -O vhdx $diskImage $out/${cfg.vmFileName}
+        rm $diskImage
       '';
       format = "raw";
       diskSize = cfg.baseImageSize;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
## Remove the baseImage after the VHDX is generated.
I simply copied the approach taken here https://github.com/NixOS/nixpkgs/blob/4a302d1b9aab8c767bdae26a1d5bcc5dbdcb796a/nixos/modules/virtualisation/azure-image.nix#L22-L25
This was discovered when implementing https://github.com/nix-community/nixos-generators/pull/53

___

This PR solves two issues:
- We remove the extraneous base image and leave only the VHDX
### These are quite large, even with a bare-bones configuration
```
dr-xr-xr-x root root   3.4 KB Wed Dec 31 19:00:01 1969  .
drwxrwxr-t root nixbld  16 MB Wed May 20 19:34:11 2020  ..
.r--r--r-- root root   1.4 GB Wed Dec 31 19:00:01 1969  nixos-20.09pre226148.0f5ce2fac0c-x86_64-linux.vhdx
.r--r--r-- root root     2 GB Wed Dec 31 19:00:01 1969  nixos.img
```

- The VHDX image is printed after nixos-generate completes
This prints something like `/nix/store/36v2px1ca3k2x9q90cr8xzk5bvaqij0v-nixos-hyperv-20.09pre-git-x86_64-linux/nixos-20.09pre-git-x86_64-linux.vhdx`
rather than  `/nix/store/bx4132wc00d8dg10krslzh27bjm93sf7-nixos-hyperv-20.09pre226148.0f5ce2fac0c-x86_64-linux/nixos.img`.

Previously, the base image we were converting would be printed upon image generation.
Now, we are properly given the VHDX file.

___

###### Things done

- Built a VHDX image based on my changes in https://github.com/nix-community/nixos-generators/pull/53
- Imported VHDX into Hyper-V and booted NixOS system

![image](https://user-images.githubusercontent.com/1847524/82508481-2c494e00-9ad3-11ea-8935-2412873e3473.png)