### PR TITLE
mpv: wrap LUA_CPATH and LUA_PATH environment variables

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -184,6 +184,8 @@ in stdenv.mkDerivation rec {
 
   # Ensure youtube-dl is available in $PATH for mpv
   wrapperFlags =
+    ''--prefix LUA_CPATH ';' "${luaEnv}/lib/lua/${lua.luaversion}/?.so" \'' +
+    ''--prefix LUA_PATH ';' "${luaEnv}/share/lua/${lua.luaversion}/?.lua" \'' +
     ''--prefix PATH : "${luaEnv}/bin" \''
   + optionalString youtubeSupport ''
       --prefix PATH : "${youtube-dl}/bin" \


### PR DESCRIPTION
###### Motivation for this change

mpv scripts were unable to import luasocket modules. Running `mpv /dev/null --script=/tmp/path_to_script.lua` with the following script:

```lua
-- test whether lua scripts can import luasocket modules
require("socket")
require("mime")
print("import successful")
```

failed with a `Lua error: /tmp/script.lua:2: module 'socket' not found:` error message.

###### Things done

Add `LUA_CPATH` `LUA_PATH` environment variables to the wrapped mpv binary.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
