### PR TITLE
ocamlPackages: add crowbar, enable crowbar tests

### DIFF
--- a/pkgs/development/ocaml-modules/eqaf/default.nix
+++ b/pkgs/development/ocaml-modules/eqaf/default.nix
@@ -1,4 +1,5 @@
-{ lib, fetchurl, buildDunePackage, cstruct, bigarray-compat }:
+{ lib, fetchurl, buildDunePackage, cstruct, bigarray-compat
+, alcotest, crowbar, base64 }:
 
 buildDunePackage rec {
   minimumOCamlVersion = "4.03";
@@ -11,6 +12,8 @@ buildDunePackage rec {
   };
 
   propagatedBuildInputs = [ cstruct bigarray-compat ];
+  checkInputs = [ crowbar alcotest base64 ];
+  doCheck = true;
 
   meta = {
     description = "Constant time equal function to avoid timing attacks in OCaml";

--- a/pkgs/development/ocaml-modules/index/default.nix
+++ b/pkgs/development/ocaml-modules/index/default.nix
@@ -1,4 +1,5 @@
-{ lib, fetchurl, buildDunePackage, fmt, logs, mtime, stdlib-shims }:
+{ lib, fetchurl, buildDunePackage, fmt, logs, mtime, stdlib-shims
+, alcotest, crowbar, re }:
 
 buildDunePackage rec {
   pname = "index";
@@ -13,6 +14,9 @@ buildDunePackage rec {
 
   buildInputs = [ stdlib-shims ];
   propagatedBuildInputs = [ fmt logs mtime ];
+
+  doCheck = true;
+  checkInputs = [ crowbar alcotest re ];
 
   meta = {
     homepage = "https://github.com/mirage/index";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add crowbar, an afl based test framework, which some test suites in `ocamlPackages` depend on (`index` and `eqaf` as far as I know which have their test suites enabled in this PR).

One issue this PR currently has is that it probably doesn't make sense to run the crowbar tests on a compiler which does not support afl. We could detect afl and enable/disable the tests like this (although its not nice):
```nix
{
  doCheck = lib.hasInfix "afl" ocaml.name;
}
```

However, this has another issue: The affected packages have a normal test suite as well which doesn't require `crowbar`. Selectively activating and deactivating parts of the test suite could become rather cumbersome and I think it is not really that big of an issue since `crowbar` runs and compiles without any errors even when afl is not enabled.

Note that this PR also includes the eqaf update from #88467.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
