### PR TITLE
.github/workflows: build NixOS/Nixpkgs manuals 

### DIFF
--- a/.github/workflows/manual-nixos.yml
+++ b/.github/workflows/manual-nixos.yml
@@ -1,0 +1,19 @@
+name: "Build NixOS manual"
+
+on:
+  pull_request_target:
+    paths:
+      - 'nixos/**'
+
+jobs:
+  nixos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v11
+      - uses: cachix/cachix-action@v6
+        with:
+          name: nixpkgs-ci
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+      - name: Building NixOS manual
+        run: nix-build nixos/release.nix -A manual.x86_64-linux

--- a/.github/workflows/manual-nixpkgs.yml
+++ b/.github/workflows/manual-nixpkgs.yml
@@ -1,0 +1,19 @@
+name: "Build Nixpkgs manual"
+
+on:
+  pull_request_target:
+    paths:
+      - 'doc/**'
+
+jobs:
+  nixpkgs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v11
+      - uses: cachix/cachix-action@v6
+        with:
+          name: nixpkgs-ci
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+      - name: Building Nixpkgs manual
+        run: nix-build pkgs/top-level/release.nix -A manual


### PR DESCRIPTION
Continued from https://github.com/NixOS/nixpkgs/pull/87853

cc @grahamc @Mic92 

Using `ofborg` is probably better but this might be useful for now?

This action will only start if something in `/doc` or `/nixos/doc` is modified so most contributors shouldn't see it.

Each job will skip the cachix action/building the manual unless its paths have changed. 

They could be split further into one action per path if we really wanted to save a couple of seconds.