### PR TITLE
tree-wide: use systemctl of running system

### DIFF
--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -94,7 +94,7 @@ in
         after = [ "suspend.target" "hibernate.target" "hybrid-sleep.target" ];
         script =
           ''
-            ${config.systemd.package}/bin/systemctl try-restart post-resume.target
+            /run/current-system/systemd/bin/systemctl try-restart post-resume.target
             ${cfg.resumeCommands}
             ${cfg.powerUpCommands}
           '';

--- a/nixos/modules/config/resolvconf.nix
+++ b/nixos/modules/config/resolvconf.nix
@@ -21,7 +21,7 @@ let
     '' + optionalString config.services.nscd.enable ''
       # Invalidate the nscd cache whenever resolv.conf is
       # regenerated.
-      libc_restart='${pkgs.systemd}/bin/systemctl try-restart --no-block nscd.service 2> /dev/null'
+      libc_restart='/run/current-system/systemd/bin/systemctl try-restart --no-block nscd.service 2> /dev/null'
     '' + optionalString (length resolvconfOptions > 0) ''
       # Options as described in resolv.conf(5)
       resolv_conf_options='${concatStringsSep " " resolvconfOptions}'

--- a/nixos/modules/services/misc/docker-registry.nix
+++ b/nixos/modules/services/misc/docker-registry.nix
@@ -138,7 +138,7 @@ in {
 
       script = ''
         ${pkgs.docker-distribution}/bin/registry garbage-collect ${configFile}
-        ${pkgs.systemd}/bin/systemctl restart docker-registry.service
+        /run/current-system/systemd/bin/systemctl restart docker-registry.service
       '';
 
       startAt = optional cfg.enableGarbageCollect cfg.garbageCollectDates;

--- a/nixos/modules/services/misc/freeswitch.nix
+++ b/nixos/modules/services/misc/freeswitch.nix
@@ -78,7 +78,7 @@ in {
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ configDirectory ];
       serviceConfig = {
-        ExecStart = "${pkgs.systemd}/bin/systemctl try-reload-or-restart freeswitch.service";
+        ExecStart = "/run/current-system/systemd/bin/systemctl try-reload-or-restart freeswitch.service";
         RemainAfterExit = true;
         Type = "oneshot";
       };

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -81,7 +81,7 @@ let
           # anything ever again ("couldn't resolve ..., giving up on
           # it"), so we silently lose time synchronisation. This also
           # applies to openntpd.
-          ${config.systemd.package}/bin/systemctl try-reload-or-restart ntpd.service openntpd.service chronyd.service || true
+          /run/current-system/systemd/bin/systemctl try-reload-or-restart ntpd.service openntpd.service chronyd.service || true
       fi
 
       ${cfg.runHook}
@@ -217,7 +217,7 @@ in
     powerManagement.resumeCommands = mkIf config.systemd.services.dhcpcd.enable
       ''
         # Tell dhcpcd to rebind its interfaces if it's running.
-        ${config.systemd.package}/bin/systemctl reload dhcpcd.service
+        /run/current-system/systemd/bin/systemctl reload dhcpcd.service
       '';
 
   };

--- a/nixos/modules/services/networking/nsd.nix
+++ b/nixos/modules/services/networking/nsd.nix
@@ -252,7 +252,7 @@ let
           Use imports or pkgs.lib.readFile if you don't want this data in your config file.
         '';
       };
-      
+
       dnssec = mkEnableOption "DNSSEC";
 
       dnssecPolicy = {
@@ -970,7 +970,7 @@ in
       script = signZones;
 
       postStop = ''
-        ${pkgs.systemd}/bin/systemctl kill -s SIGHUP nsd.service
+        /run/current-system/systemd/bin/systemctl kill -s SIGHUP nsd.service
       '';
     };
 

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -253,12 +253,12 @@ in {
     };
 
     powerManagement.resumeCommands = ''
-      ${config.systemd.package}/bin/systemctl try-restart wpa_supplicant
+      /run/current-system/systemd/bin/systemctl try-restart wpa_supplicant
     '';
 
     # Restart wpa_supplicant when a wlan device appears or disappears.
     services.udev.extraRules = ''
-      ACTION=="add|remove", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", RUN+="${config.systemd.package}/bin/systemctl try-restart wpa_supplicant.service"
+      ACTION=="add|remove", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", RUN+="/run/current-system/systemd/bin/systemctl try-restart wpa_supplicant.service"
     '';
   };
 

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -756,9 +756,9 @@ in
       serviceConfig.Type = "oneshot";
       serviceConfig.TimeoutSec = 60;
       script = ''
-        if ${pkgs.systemd}/bin/systemctl -q is-active nginx.service ; then
+        if /run/current-system/systemd/bin/systemctl -q is-active nginx.service ; then
           ${execCommand} -t && \
-            ${pkgs.systemd}/bin/systemctl reload nginx.service
+            /run/current-system/systemd/bin/systemctl reload nginx.service
         fi
       '';
       serviceConfig.RemainAfterExit = true;
@@ -772,7 +772,7 @@ in
             webroot = vhostConfig.acmeRoot;
             extraDomains = genAttrs vhostConfig.serverAliases (alias: null);
             postRun = ''
-              systemctl reload nginx
+              /run/current-system/systemd/bin/systemctl reload nginx
             '';
           }; }) acmeEnabledVhosts;
       in

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -39,8 +39,8 @@ let
 
       ${optionalString cfg.startDbusSession ''
         if test -z "$DBUS_SESSION_BUS_ADDRESS"; then
-          ${config.systemd.package}/bin/systemctl --user start dbus.socket
-          export `${config.systemd.package}/bin/systemctl --user show-environment | grep '^DBUS_SESSION_BUS_ADDRESS'`
+          /run/current-system/systemd/bin/systemctl --user start dbus.socket
+          export `/run/current-system/systemd/bin/systemctl --user show-environment | grep '^DBUS_SESSION_BUS_ADDRESS'`
         fi
       ''}
 
@@ -60,7 +60,7 @@ let
       #
       # Also tell systemd about the dbus session bus address.
       # This is required by user units using the session bus.
-      ${config.systemd.package}/bin/systemctl --user import-environment DISPLAY XAUTHORITY DBUS_SESSION_BUS_ADDRESS
+      /run/current-system/systemd/bin/systemctl --user import-environment DISPLAY XAUTHORITY DBUS_SESSION_BUS_ADDRESS
 
       # Load X defaults. This should probably be safe on wayland too.
       ${xorg.xrdb}/bin/xrdb -merge ${xresourcesXft}
@@ -89,7 +89,7 @@ let
       fi
 
       # Start systemd user services for graphical sessions
-      ${config.systemd.package}/bin/systemctl --user start graphical-session.target
+      /run/current-system/systemd/bin/systemctl --user start graphical-session.target
 
       # Allow the user to setup a custom session type.
       if test -x ~/.xsession; then
@@ -394,7 +394,7 @@ in
 
           test -n "$waitPID" && wait "$waitPID"
 
-          ${config.systemd.package}/bin/systemctl --user stop graphical-session.target
+          /run/current-system/systemd/bin/systemctl --user stop graphical-session.target
 
           exit 0
         '';

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -30,8 +30,8 @@ let
 
   cfgFile = pkgs.writeText "sddm.conf" ''
     [General]
-    HaltCommand=${pkgs.systemd}/bin/systemctl poweroff
-    RebootCommand=${pkgs.systemd}/bin/systemctl reboot
+    HaltCommand=/run/current-system/systemd/bin/systemctl poweroff
+    RebootCommand=/run/current-system/systemd/bin/systemctl reboot
     ${optionalString cfg.autoNumlock ''
     Numlock=on
     ''}

--- a/nixos/modules/services/x11/xautolock.nix
+++ b/nixos/modules/services/x11/xautolock.nix
@@ -66,7 +66,7 @@ in
 
         killer = mkOption {
           default = null; # default according to `man xautolock` is none
-          example = "${pkgs.systemd}/bin/systemctl suspend";
+          example = "/run/current-system/systemd/bin/systemctl suspend";
           type = types.nullOr types.str;
 
           description = ''

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -327,7 +327,7 @@ let
                   # if `libvirtd.service` is not running, do not use `virsh` which would try activate it via 'libvirtd.socket' and thus start it out-of-order.
                   # `libvirtd.service` will set up bridge interfaces when it will start normally.
                   #
-                  if ${pkgs.systemd}/bin/systemctl --quiet is-active 'libvirtd.service'; then
+                  if /run/current-system/systemd/bin/systemctl --quiet is-active 'libvirtd.service'; then
                     for uri in qemu:///system lxc:///; do
                       for dom in $(${pkgs.libvirt}/bin/virsh -c $uri list --name); do
                         ${pkgs.libvirt}/bin/virsh -c $uri dumpxml "$dom" | \

--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -48,7 +48,7 @@ let
 
   provisionedHook = pkgs.writeScript "provisioned-hook" ''
     #!${pkgs.runtimeShell}
-    ${config.systemd.package}/bin/systemctl start provisioned.target
+    /run/current-system/systemd/bin/systemctl start provisioned.target
   '';
 
 in

--- a/pkgs/desktops/deepin/dde-control-center/default.nix
+++ b/pkgs/desktops/deepin/dde-control-center/default.nix
@@ -121,7 +121,7 @@ mkDerivation rec {
     substituteInPlace dde-control-center.desktop \
       --replace "dbus-send" "${dbus}/bin/dbus-send"
     substituteInPlace com.deepin.controlcenter.addomain.policy \
-      --replace "/bin/systemctl" "${systemd}/bin/systemctl"
+      --replace "/bin/systemctl" "/run/current-system/sw/bin/systemctl"
   '';
 
   dontWrapQtApps = true;

--- a/pkgs/os-specific/linux/displaylink/udev-installer.patch
+++ b/pkgs/os-specific/linux/displaylink/udev-installer.patch
@@ -5,13 +5,13 @@
  start_service()
  {
 -  systemctl start displaylink-driver
-+  @systemd@/bin/systemctl start --no-block dlm
++  /run/current-system/systemd/bin/systemctl start --no-block dlm
  }
  
  stop_service()
  {
 -  systemctl stop displaylink-driver
-+  @systemd@/bin/systemctl stop dlm
++  /run/current-system/systemd/bin/systemctl stop dlm
  }
  
  EOF

--- a/pkgs/tools/misc/autorandr/default.nix
+++ b/pkgs/tools/misc/autorandr/default.nix
@@ -34,7 +34,7 @@ in
           SYSTEMD_UNIT_DIR=/lib/systemd/system \
           UDEV_RULES_DIR=/etc/udev/rules.d
         substituteInPlace $out/etc/udev/rules.d/40-monitor-hotplug.rules \
-          --replace /bin/systemctl "${systemd}/bin/systemctl"
+          --replace /bin/systemctl "/run/current-system/systemd/bin/systemctl"
       '' else ''
         make install TARGETS='pmutils' DESTDIR=$out \
           PM_SLEEPHOOKS_DIR=/lib/pm-utils/sleep.d

--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -29,7 +29,7 @@ buildPythonApplication rec {
   postPatch = ''
     for file in $(find google_compute_engine -type f); do
       substituteInPlace "$file" \
-        --replace /bin/systemctl "/run/current-system/sw/bin/systemctl" \
+        --replace /bin/systemctl "/run/current-system/systemd/bin/systemctl" \
         --replace /bin/bash "${bashInteractive}/bin/bash" \
         --replace /sbin/hwclock "${utillinux}/bin/hwclock"
       # SELinux tool ???  /sbin/restorecon


### PR DESCRIPTION
In many different places in nixpkgs, when shelling out to `systemctl`, we referred to it as `${pkgs.systemd}/bin/systemctl` or `${config.systemd.package}/bin/systemctl`.

While this provides a `systemctl` binary, it's not necessarily one that's fully compatible with the one that's currently running. As the systemd of the running configuration is available at `/run/current-system/systemd`, we can refer to `systemctl` via `/run/current-system/systemd/bin/systemctl`.

This should also prevent some service restarts in the case of `systemd.package` being updated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
