### PR TITLE
pythonPackages.stack-data: init at 0.0.7

### DIFF
--- a/pkgs/development/python-modules/littleutils/default.nix
+++ b/pkgs/development/python-modules/littleutils/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "littleutils";
+  version = "0.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0vwijrylppmk0nbddqvn527r9cg3zw8d6zk6r58hslry42jf7jp6";
+  };
+
+  # This tiny package has no unit tests at all
+  doCheck = false;
+  pythonImportsCheck = [ "littleutils" ];
+
+  meta = with lib; {
+    description = "Small collection of Python utility functions";
+    homepage = "https://github.com/alexmojaki/littleutils";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/stack-data/default.nix
+++ b/pkgs/development/python-modules/stack-data/default.nix
@@ -1,0 +1,54 @@
+{ asttokens
+, buildPythonPackage
+, executing
+, fetchFromGitHub
+, git
+, lib
+, littleutils
+, pure-eval
+, pygments
+, pytestCheckHook
+, setuptools_scm
+, toml
+, typeguard
+}:
+
+buildPythonPackage rec {
+  pname = "stack_data";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    owner = "alexmojaki";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "148lhxihak8jm5dvryhsiykmn3s4mrlba8ki4dy1nbd8jnz06a4w";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    git
+    setuptools_scm
+    toml
+  ];
+
+  propagatedBuildInputs = [
+    asttokens
+    executing
+    pure-eval
+  ];
+
+  checkInputs = [
+    littleutils
+    pygments
+    pytestCheckHook
+    typeguard
+  ];
+
+  meta = with lib; {
+    description = "Extract data from stack frames and tracebacks";
+    homepage = "https://github.com/alexmojaki/stack_data/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3510,6 +3510,8 @@ in {
 
   lirc = disabledIf isPy27 (toPythonModule (pkgs.lirc.override { python3 = python; }));
 
+  littleutils = callPackage ../development/python-modules/littleutils { };
+
   livelossplot = callPackage ../development/python-modules/livelossplot { };
 
   livereload = callPackage ../development/python-modules/livereload { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6905,6 +6905,8 @@ in {
 
   sslyze = callPackage ../development/python-modules/sslyze { };
 
+  stack-data = callPackage ../development/python-modules/stack-data { };
+
   starlette = callPackage ../development/python-modules/starlette { };
 
   staticjinja = callPackage ../development/python-modules/staticjinja { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add Python package stack-data and its dependencies.

IPython will soon need this dependency: https://github.com/ipython/ipython/blob/master/setup.py#L194 (permalink https://github.com/ipython/ipython/blob/a483781c6e480b18b6cdc78a9851c23cd528a890/setup.py#L194), so with this PR stack-data would be readily available in nixpkgs when IPython release will depend on stack-data. I needed to add this to nixpkgs already now because I was using master branch of IPython locally. So I thought I'd provide a PR for these upcoming dependencies.

I'll run nixpkgs-review soon.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
