### PR TITLE
dfhack: 0.47.04-alpha0 -> 0.47.04-r1

### DIFF
--- a/pkgs/games/dwarf-fortress/dfhack/default.nix
+++ b/pkgs/games/dwarf-fortress/dfhack/default.nix
@@ -53,10 +53,10 @@ let
       prerelease = true;
     };
     "0.47.04" = {
-      dfHackRelease = "0.47.04-alpha0";
-      sha256 = "07056k6717mqim9skwjprqplj8jmmli6g4p2c72c8000jwnn2hjy";
-      xmlRev = "23500e4e9bd1885365d0a2ef1746c321c1dd50aa";
-      prerelease = true;
+      dfHackRelease = "0.47.04-r1";
+      sha256 = "10awv5nlifqrw42hiiz846f4q5x8xbxzj6l4s8qznhi1dbmdnjqm";
+      xmlRev = "2079b9fb69b8b4db48aa35ec54a96f5cca7cc8ef";
+      prerelease = false;
     };
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
