### PR TITLE
[20.03] pythonPackages.fritzconnection: 0.8.4 -> 1.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7474,6 +7474,12 @@
     github = "valeriangalliat";
     name = "Valérian Galliat";
   };
+  valodim = {
+    email = "look@my.amazin.horse";
+    github = "valodim";
+    githubId = 27813;
+    name = "Vincent Breitmoser";
+  };
   vandenoever = {
     email = "jos@vandenoever.info";
     github = "vandenoever";

--- a/pkgs/development/python-modules/fritzconnection/default.nix
+++ b/pkgs/development/python-modules/fritzconnection/default.nix
@@ -1,26 +1,38 @@
-{ stdenv, buildPythonPackage, fetchPypi, lxml, requests, tkinter, isPy38 }:
+{ stdenv, buildPythonPackage, pythonOlder, fetchFromGitHub, pytest, requests }:
 
 buildPythonPackage rec {
   pname = "fritzconnection";
-  version = "0.8.4";
+  version = "1.2.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "adc629a48b50700f5478f69436e4b78c8792a9260cc674cccef15ffe68eb0643";
+  src = fetchFromGitHub {
+    owner = "kbr";
+    repo = pname;
+    rev = version;
+    hash = "sha256:17z4shs56ci9mxmilppv5xy9gbnbp6p1h2ms6x55nkvwndacrp7x";
   };
 
+  disabled = pythonOlder "3.5";
+
+  # Exclude test files from build, which cause ImportMismtachErrors and
+  # otherwise missing resources during tests. This patch can be dropped once
+  # https://github.com/kbr/fritzconnection/pull/39 is merged.
   prePatch = ''
-    substituteInPlace fritzconnection/test.py \
-      --replace "from fritzconnection import" "from .fritzconnection import"
+    substituteInPlace setup.py \
+      --replace 'find_packages()' 'find_packages(exclude=["*.tests"])'
   '';
 
-  propagatedBuildInputs = [ lxml requests tkinter ];
+  propagatedBuildInputs = [ requests ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    pytest
+  '';
 
   meta = with stdenv.lib; {
     description = "Python-Tool to communicate with the AVM FritzBox using the TR-064 protocol";
-    homepage = https://bitbucket.org/kbr/fritzconnection;
+    homepage = "https://bitbucket.org/kbr/fritzconnection";
     license = licenses.mit;
-    maintainers = with maintainers; [ dotlambda ];
-    broken = isPy38;
+    maintainers = with maintainers; [ dotlambda valodim ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Backport #83451 to 20.03. There were a couple of conflicts that were easily solved.

The compiled package seems to be working, I've run the code mentioned in the [official documentation](https://fritzconnection.readthedocs.io/en/1.2.1/):

```
$ python test.py
FRITZ!Box 7530 at http://192.168.178.1
FRITZ!OS: 7.14
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
