### PR TITLE
pysnooper: 0.3.0 -> 0.4.1

### DIFF
--- a/pkgs/development/python-modules/pysnooper/default.nix
+++ b/pkgs/development/python-modules/pysnooper/default.nix
@@ -1,26 +1,24 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, python-toolbox
 , pytest
 , isPy27
 }:
 
 buildPythonPackage rec {
-  version = "0.3.0";
+  version = "0.4.1";
   pname = "pysnooper";
 
   src = fetchPypi {
     inherit version;
     pname = "PySnooper";
-    sha256 = "14vcxrzfmfhsmdck1cb56a6lbfga15qfhlkap9mh47fgspcq8xkx";
+    sha256 = "1xngly13x3ylwwcdml2ns8skpxip2myzavp3b9ff2dpqaalf0hdl";
   };
 
   # test dependency python-toolbox fails with py27
   doCheck = !isPy27;
 
   checkInputs = [
-    python-toolbox
     pytest
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Version bump + a small dependency removal

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
