### PR TITLE
minecraft-server: add update script

### DIFF
--- a/pkgs/games/minecraft-server/default.nix
+++ b/pkgs/games/minecraft-server/default.nix
@@ -4,9 +4,9 @@ stdenv.mkDerivation {
   version = "1.15.2";
 
   src = fetchurl {
-    url =
-      "https://launcher.mojang.com/v1/objects/bb2b6b1aefcd70dfd1892149ac3a215f6c636b07/server.jar";
-    sha256 = "12kynrpxgcdg8x12wcvwkxka0fxgm5siqg8qq0nnmv0443f8dkw0";
+    url = "https://launcher.mojang.com/v1/objects/bb2b6b1aefcd70dfd1892149ac3a215f6c636b07/server.jar";
+    # sha1 because that comes from mojang via api
+    sha1 = "bb2b6b1aefcd70dfd1892149ac3a215f6c636b07";
   };
 
   preferLocalBuild = true;
@@ -24,6 +24,8 @@ stdenv.mkDerivation {
   '';
 
   phases = "installPhase";
+
+  passthru.updateScript = ./update.sh;
 
   meta = with stdenv.lib; {
     description = "Minecraft Server";

--- a/pkgs/games/minecraft-server/update.sh
+++ b/pkgs/games/minecraft-server/update.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+
+# get current release version
+versions=$(curl -s 'https://launchermeta.mojang.com/mc/game/version_manifest.json')
+version=$(echo $versions | jq .latest.release)
+url=$(echo $versions | jq -r ".versions[] | select(.id == $version) | .url")
+
+# get current server.jar
+versions=$(curl -s $url | jq .downloads.server)
+sha1=$(echo $versions | jq .sha1)
+url=$(echo $versions | jq .url)
+
+echo $version: $url:$sha1
+
+# change default.nix
+sed -i "s/version = \"[0-9.]*\";/version = ${version};/g" default.nix
+sed -i "s+url = \"[a-zA-Z0-9/:.]*/server.jar\";+url = $url;+g" default.nix
+sed -i "s/sha1 = \"[a-zA-Z0-9]*\";/sha1 = ${sha1};/g" default.nix

--- a/pkgs/games/minecraft-server/update.sh
+++ b/pkgs/games/minecraft-server/update.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p curl jq common-updater-scripts
 
+BASEDIR="$(dirname "$0")"
+
 # get current release version
 versions=$(curl -s 'https://launchermeta.mojang.com/mc/game/version_manifest.json')
 version=$(echo $versions | jq .latest.release)
@@ -14,6 +16,6 @@ url=$(echo $versions | jq .url)
 echo $version: $url:$sha1
 
 # change default.nix
-sed -i "s/version = \"[0-9.]*\";/version = ${version};/g" default.nix
-sed -i "s+url = \"[a-zA-Z0-9/:.]*/server.jar\";+url = $url;+g" default.nix
-sed -i "s/sha1 = \"[a-zA-Z0-9]*\";/sha1 = ${sha1};/g" default.nix
+sed -i "s/version = \"[0-9.]*\";/version = ${version};/g" "$BASEDIR/default.nix"
+sed -i "s+url = \"[a-zA-Z0-9/:.]*/server.jar\";+url = $url;+g" "$BASEDIR/default.nix"
+sed -i "s/sha1 = \"[a-zA-Z0-9]*\";/sha1 = ${sha1};/g" "$BASEDIR/default.nix"


### PR DESCRIPTION
###### Motivation for this change
Automatic updates for the Minecraft server package

###### Things done
create an update.sh script

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
