### PR TITLE
pkg-config, pkgconf: Misc fixes

### DIFF
--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -86,22 +86,20 @@ stdenv.mkDerivation {
   ];
 
   postFixup =
+    ##
+    ## User env support
+    ##
+
+    # Propagate the underling unwrapped pkg-config so that if you
+    # install the wrapper, you get anything else it might provide.
     ''
-
-      ##
-      ## User env support
-      ##
-
-      # Propagate the underling unwrapped pkg-config so that if you
-      # install the wrapper, you get anything else it might provide.
       printWords ${pkg-config} > $out/nix-support/propagated-user-env-packages
     ''
 
+    ##
+    ## Man page and doc support
+    ##
     + optionalString propagateDoc (''
-      ##
-      ## Man page and doc support
-      ##
-
       ln -s ${pkg-config.man} $man
     '' + optionalString (pkg-config ? doc) ''
       ln -s ${pkg-config.doc} $doc
@@ -110,12 +108,11 @@ stdenv.mkDerivation {
     + ''
       substituteAll ${./add-flags.sh} $out/nix-support/add-flags.sh
       substituteAll ${../wrapper-common/utils.bash} $out/nix-support/utils.bash
-
-      ##
-      ## Extra custom steps
-      ##
     ''
 
+    ##
+    ## Extra custom steps
+    ##
     + extraBuildCommands;
 
   meta =

--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   inherit targetPrefix suffixSalt;
 
-  outputs = [ "out" ] ++ optionals propagateDoc [ "man" ];
+  outputs = [ "out" ] ++ optionals propagateDoc ([ "man" ] ++ optional (pkg-config ? doc) "doc");
 
   passthru = {
     inherit pkg-config;
@@ -87,13 +87,15 @@ stdenv.mkDerivation {
       printWords ${pkg-config} > $out/nix-support/propagated-user-env-packages
     ''
 
-    + optionalString propagateDoc ''
+    + optionalString propagateDoc (''
       ##
-      ## Man page and info support
+      ## Man page and doc support
       ##
 
       ln -s ${pkg-config.man} $man
-    ''
+    '' + optionalString (pkg-config ? doc) ''
+      ln -s ${pkg-config.doc} $doc
+    '')
 
     + ''
       substituteAll ${./add-flags.sh} $out/nix-support/add-flags.sh

--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -4,6 +4,7 @@
 { stdenvNoCC
 , buildPackages
 , pkg-config
+, baseBinName ? "pkg-config"
 , propagateDoc ? pkg-config != null && pkg-config ? man
 , extraPackages ? [], extraBuildCommands ? ""
 }:
@@ -34,7 +35,7 @@ stdenv.mkDerivation {
 
   shell = getBin stdenvNoCC.shell + stdenvNoCC.shell.shellPath or "";
 
-  inherit targetPrefix suffixSalt;
+  inherit targetPrefix suffixSalt baseBinName;
 
   outputs = [ "out" ] ++ optionals propagateDoc ([ "man" ] ++ optional (pkg-config ? doc) "doc");
 
@@ -63,7 +64,7 @@ stdenv.mkDerivation {
 
       echo $pkg-config > $out/nix-support/orig-pkg-config
 
-      wrap ${targetPrefix}pkg-config ${./pkg-config-wrapper.sh} "${getBin pkg-config}/bin/pkg-config"
+      wrap ${targetPrefix}${baseBinName} ${./pkg-config-wrapper.sh} "${getBin pkg-config}/bin/${baseBinName}"
     ''
     # symlink in share for autoconf to find macros
 

--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -64,6 +64,15 @@ stdenv.mkDerivation {
       echo $pkg-config > $out/nix-support/orig-pkg-config
 
       wrap ${targetPrefix}pkg-config ${./pkg-config-wrapper.sh} "${getBin pkg-config}/bin/pkg-config"
+    ''
+    # symlink in share for autoconf to find macros
+
+    # TODO(@Ericson2314): in the future just make the unwrapped pkg-config a
+    # propagated dep once we can rely on downstream deps comming first in
+    # search paths. (https://github.com/NixOS/nixpkgs/pull/31414 took a crack
+    # at this.)
+    + ''
+      ln -s ${pkg-config}/share $out/share
     '';
 
   strictDeps = true;

--- a/pkgs/build-support/pkg-config-wrapper/setup-hook.sh
+++ b/pkgs/build-support/pkg-config-wrapper/setup-hook.sh
@@ -23,7 +23,7 @@ getTargetRoleWrapper
 
 addEnvHooks "$targetOffset" pkgConfigWrapper_addPkgConfigPath
 
-export PKG_CONFIG${role_post}=@targetPrefix@pkg-config
+export PKG_CONFIG${role_post}=@targetPrefix@@baseBinName@
 
 # No local scope in sourced file
 unset -v role_post

--- a/pkgs/development/tools/misc/pkg-config/default.nix
+++ b/pkgs/development/tools/misc/pkg-config/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   # Process Requires.private properly, see
-  # http://bugs.freedesktop.org/show_bug.cgi?id=4738.
+  # http://bugs.freedesktop.org/show_bug.cgi?id=4738, migrated to
+  # https://gitlab.freedesktop.org/pkg-config/pkg-config/issues/28
   patches = optional (!vanilla) ./requires-private.patch
     ++ optional stdenv.isCygwin ./2.36.3-not-win32.patch;
 

--- a/pkgs/development/tools/misc/pkg-config/default.nix
+++ b/pkgs/development/tools/misc/pkg-config/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.isCygwin ./2.36.3-not-win32.patch;
 
   # These three tests fail due to a (desired) behavior change from our ./requires-private.patch
-  postPatch = ''
+  postPatch = if vanilla then null else ''
     rm -f check/check-requires-private check/check-gtk check/missing
   '';
 

--- a/pkgs/development/tools/misc/pkg-config/default.nix
+++ b/pkgs/development/tools/misc/pkg-config/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "14fmwzki1rlz8bs2p810lk6jqdxsk966d8drgsjmi54cd00rrikg";
   };
 
+  outputs = [ "out" "man" "doc" ];
+
   # Process Requires.private properly, see
   # http://bugs.freedesktop.org/show_bug.cgi?id=4738, migrated to
   # https://gitlab.freedesktop.org/pkg-config/pkg-config/issues/28

--- a/pkgs/development/tools/misc/pkgconf/default.nix
+++ b/pkgs/development/tools/misc/pkgconf/default.nix
@@ -1,13 +1,40 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, removeReferencesTo }:
 
 stdenv.mkDerivation rec {
   pname = "pkgconf";
   version = "1.6.3";
 
+  nativeBuildInputs = [ removeReferencesTo ];
+
+  outputs = [ "out" "lib" "dev" "man" "doc" ];
+
+  enableParallelBuilding = true;
+
   src = fetchurl {
     url = "https://distfiles.dereferenced.org/${pname}/${pname}-${version}.tar.xz";
     sha256 = "04525vv0y849vvc2pi60g5wd9fjp1wbhra2lniifi82y1ldv7w31";
   };
+
+  # Debian has outputs like these too:
+  # https://packages.debian.org/source/buster/pkgconf, so take it this
+  # reference removing is safe.
+  postFixup = ''
+    remove-references-to \
+      -t "${placeholder "dev"}" \
+      "${placeholder "lib"}"/lib/* \
+      "${placeholder "out"}"/bin/*
+    remove-references-to \
+      -t "${placeholder "out"}" \
+      "${placeholder "lib"}"/lib/*
+  ''
+  # Move back share/aclocal. Yes, this normally goes in the dev output for good
+  # reason, but in this case the dev output is for the `libpkgconf` library,
+  # while the aclocal stuff is for the tool. The tool is already for use during
+  # development, so there is no reason to have separate "dev-bin" and "dev-lib"
+  # outputs or someting.
+  + ''
+    mv ${placeholder "dev"}/share ${placeholder "out"}
+  '';
 
   meta = with stdenv.lib; {
     description = "Package compiler and linker metadata toolkit";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10739,7 +10739,11 @@ in
 
   pmccabe = callPackage ../development/tools/misc/pmccabe { };
 
-  pkgconf = callPackage ../development/tools/misc/pkgconf {};
+  pkgconf-unwrapped = callPackage ../development/tools/misc/pkgconf {};
+  pkgconf = callPackage ../build-support/pkg-config-wrapper {
+    pkg-config = pkgconf-unwrapped;
+    baseBinName = "pkgconf";
+  };
 
   pkg-config-unwrapped = callPackage ../development/tools/misc/pkg-config { };
   pkg-config = callPackage ../build-support/pkg-config-wrapper {


### PR DESCRIPTION
###### Motivation for this change

See each commit for details. Most importantly this fixes builds using pkg-config-provided macros, like `libarchive`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
