### PR TITLE
SDL2: Add withStatic option

### DIFF
--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -15,6 +15,7 @@
 , libpulseaudio
 , AudioUnit, Cocoa, CoreAudio, CoreServices, ForceFeedback, OpenGL
 , audiofile, libiconv
+, withStatic ? false
 }:
 
 # NOTE: When editing this expression see if the same change applies to
@@ -30,7 +31,7 @@ stdenv.mkDerivation rec {
     url = "https://www.libsdl.org/release/${pname}-${version}.tar.gz";
     sha256 = "0qy8wbqvfkb5ps8kxgaaf2zzpkjqbsw712hlp74znbn0jpv6i4il";
   };
-
+  dontDisableStatic = withStatic;
   outputs = [ "out" "dev" ];
   outputBin = "dev"; # sdl-config
 


### PR DESCRIPTION
###### Motivation for this change

Build of the package `devilutionx` [fails](https://hydra.nixos.org/build/119255137).

The error message:

```
make[2]: *** No rule to make target '/nix/store/slyxpxxprgdq3x54nanqg7sd3wg1cks7-SDL2-2.0.12/lib/libSDL2main.a', needed by 'devilutionx'.  Stop.
```

From my limited understanding of the build process, this is due probably to [this commit](57908c1624f93fd5c77b5d6cd094ab6bca8577e8), which stopped moving `/libSDL2main.a` to `$dev` folder.

The same commit added a possibility of removing `*.la` files insteaf of `*.a` files. It can be done by setting `dontDisableStatic` flag, but curiously it is not possible to set this flag for SDL2. Or maybe I'm missing something...

This PR adds a new parameter to SDL2: `withStatic ? false`. It is used to set `dontDisableStatic = withStatic;`. By default, if not used, it won't change the current behaviour. Setting it to `true` for the build of `devolutionx` fixes the build on my machine.

`dontDisableStatic = withStatic;` exists in other packages, and inspired this solution.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Pinging @cpages, the maintainer, and @nh2, who committed 57908c1624f93fd5c77b5d6cd094ab6bca8577e8
