### PR TITLE
Xpra: 3.0.9 -> 4.0.2

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -30,11 +30,11 @@ let
 
 in buildPythonApplication rec {
   pname = "xpra";
-  version = "3.0.9";
+  version = "4.0.2";
 
   src = fetchurl {
     url = "https://xpra.org/src/${pname}-${version}.tar.xz";
-    sha256 = "04qskz1x1pvbdfirpxk58d3dfnf1n6dc69q2rdkak0avzl1nlzi7";
+    sha256 = "1cs39jzi59hkl421xmhi549ndmdfzkg0ap45f4nlsn9zr9zwmp3x";
   };
 
   patches = [
@@ -85,7 +85,6 @@ in buildPythonApplication rec {
     "--with-Xdummy"
     "--without-strict"
     "--with-gtk3"
-    "--without-gtk2"
     # Override these, setup.py checks for headers in /usr/* paths
     "--with-pam"
     "--with-vsock"

--- a/pkgs/tools/X11/xpra/fix-41106.patch
+++ b/pkgs/tools/X11/xpra/fix-41106.patch
@@ -1,15 +1,15 @@
 diff --git a/xpra/server/server_util.py b/xpra/server/server_util.py
-index 2ff2c0c..513201a 100644
+index dd7c7c1..066b9ff 100644
 --- a/xpra/server/server_util.py
 +++ b/xpra/server/server_util.py
-@@ -17,6 +17,10 @@ if PYTHON3:
-         return b"'" + s.replace(b"'", b"'\\''") + b"'"
-     
-     def xpra_runner_shell_script(xpra_file, starting_dir, socket_dir):
-+        # Nixpkgs contortion:
-+        # xpra_file points to a shell wrapper, not to the python script.
-+        dirname, basename = os.path.split(xpra_file)
-+        xpra_file = os.path.join(dirname, "."+basename+"-wrapped")
-         script = []
-         script.append(b"#!/bin/sh\n")
-         for var, value in os.environb.items():
+@@ -37,6 +37,10 @@ def sh_quotemeta(s):
+     return b"'" + s.replace(b"'", b"'\\''") + b"'"
+ 
+ def xpra_runner_shell_script(xpra_file, starting_dir, socket_dir):
++    # Nixpkgs contortion:
++    # xpra_file points to a shell wrapper, not to the python script.
++    dirname, basename = os.path.split(xpra_file)
++    xpra_file = os.path.join(dirname, "."+basename+"-wrapped")
+     script = []
+     script.append(b"#!/bin/sh\n")
+     for var, value in os.environb.items():

--- a/pkgs/tools/X11/xpra/fix-paths.patch
+++ b/pkgs/tools/X11/xpra/fix-paths.patch
@@ -1,13 +1,13 @@
-gdiff --git a/setup.py b/setup.py
-index 8d3df15..6156206 100755
+diff --git a/setup.py b/setup.py
+index f962330..b02b6dd 100755
 --- a/setup.py
 +++ b/setup.py
- -2322,11 +2322,7 @@ if v4l2_ENABLED:                                                                                                                                                       
-     videodev2_h = "/usr/include/linux/videodev2.h"                                                                                                                                           
-     constants_pxi = "xpra/codecs/v4l2/constants.pxi"                                                                                                                                         
-     if not os.path.exists(videodev2_h) or should_rebuild(videodev2_h, constants_pxi):                                                                                                        
--        ENABLE_DEVICE_CAPS = 0                                                                                                                                                               
--        if os.path.exists(videodev2_h):                                                                                                                                                      
+@@ -2224,11 +2224,7 @@ if v4l2_ENABLED:
+     videodev2_h = "/usr/include/linux/videodev2.h"
+     constants_pxi = "xpra/codecs/v4l2/constants.pxi"
+     if not os.path.exists(videodev2_h) or should_rebuild(videodev2_h, constants_pxi):
+-        ENABLE_DEVICE_CAPS = 0
+-        if os.path.exists(videodev2_h):
 -            with open(videodev2_h) as f:
 -                hdata = f.read()
 -            ENABLE_DEVICE_CAPS = int(hdata.find("device_caps")>=0)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bump xpra version to 4.x series.

cc: 
@lourkeur @offlinehacker 

###### Things done
I was having issues with KDE (#88035), which I reported upstream. I patched pyxdg which is now merged in nixpkgs. There is a workaround for pyxdg issues in 4.0.2, which isn't strictly needed anymore, but we should still do the version bump.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
