### PR TITLE
Add day night plasma wallpapers

### DIFF
--- a/nixos/modules/services/desktops/plasma-5/day-night-plasma-wallpapers.nix
+++ b/nixos/modules/services/desktops/plasma-5/day-night-plasma-wallpapers.nix
@@ -1,0 +1,60 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.day-night-plasma-wallpapers;
+in {
+
+  options.services.day-night-plasma-wallpapers = {
+    enable = mkEnableOption "Day-Night Plasma Wallpapers, a software to update your wallpaper according to the day light";
+
+    install = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to install a user service for Day-Night.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.day-night-plasma-wallpapers;
+      defaultText = "pkgs.day-night-plasma-wallpapers";
+      description = "Day-night-plasma-wallpapers derivation to use.";
+    };
+
+    path = mkOption {
+      type = types.listOf types.path;
+      default = [];
+      example = literalExample "[ pkgs.bash pkgs.day-night-plasma-wallpapers ]";
+      description = "List of derivations to put in path.";
+    };
+
+    onCalendar = mkOption {
+      type = types.str;
+      default = "=*-*-* 16:00:00"; # Run at 4 pm everyday (16h)
+      description = "When in the evening do you want your wallpaper to go to bed. Default is at 4 pm. See systemd.time(7) for more information about the format.";
+    };
+  };
+
+  config = mkIf (cfg.enable || cfg.install) {
+    systemd.user.services.day-night-plasma-wallpapers = {
+      description = "Day-night-plasma-wallpapers: a software to update your wallpaper according to the day light";
+      serviceConfig = {
+        Type      = "oneshot";
+        ExecStart = "${cfg.package}/bin/update-day-night-plasma-wallpapers.sh";
+      };
+      path = cfg.path;
+    };
+    environment.systemPackages = [ cfg.package ];
+    systemd.user.timers.day-night-plasma-wallpapers = {
+      description = "Day-night-plasma-wallpapers timer";
+      timerConfig = {
+        Unit = "day-night-plasma-wallpapers.service";
+        OnCalendar = cfg.onCalendar;
+        Persistent = "true";
+      };
+    };
+  };
+}

--- a/pkgs/applications/graphics/day-night-plasma-wallpapers/default.nix
+++ b/pkgs/applications/graphics/day-night-plasma-wallpapers/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qttools
+, coreutils
+}:
+stdenv.mkDerivation rec {
+
+  pname = "day-night-plasma-wallpapers";
+  version = "unstable";
+
+  src = fetchFromGitHub {
+    owner = "SCOTT-HAMILTON";
+    repo = "Day-night-plasma-wallpapers";
+    rev = "59311ffd7f5861a447cec53d17873150628a8815";
+    sha256 = "1km2qp6bx76vfwg3s1wk8phmrrx7cdzqp8h2i99rmw805ky32ch5";
+  };
+
+  buildInputs = [ qttools ];
+
+  installPhase = ''
+    install -Dm 555 update-day-night-plasma-wallpapers.sh $out/bin/update-day-night-plasma-wallpapers.sh
+    install -D macOS-Mojave-Light/macOS-Mojave-Day-wallpaper.jpg $out/usr/share/wallpapers/macOS-Mojave-Light/macOS-Mojave-Day-wallpaper.jpg
+    install -D macOS-Mojave-Night/macOS-Mojave-Night-wallpaper.jpg $out/usr/share/wallpapers/macOS-Mojave-Night/macOS-Mojave-Night-wallpaper.jpg
+  '';
+
+  meta = {
+    description = "KDE Plasma utility to automatically change to a night wallpaper when the sun is reaching sunset.";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/SCOTT-HAMILTON/Day-night-plasma-wallpapers";
+    maintainers = with lib.maintainers; [ shamilton ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
In the process of ricing my new kde DE, I wanted a dynamic wallpaper that changes into some night themes when sun wasn't lighting my keyboard anymore.

###### Things done
Started working on the service and the package. Those must be tested but I don't have any idea to how I oould test those without first having them in the repo, help on that part is required.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
