### PR TITLE
ledger2beancount: init at 2.1

### DIFF
--- a/pkgs/tools/text/ledger2beancount/default.nix
+++ b/pkgs/tools/text/ledger2beancount/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchFromGitHub, makeWrapper, perlPackages, beancount }:
+
+with stdenv.lib;
+
+let
+  perlDeps = with perlPackages; [
+    ConfigOnion DateCalc
+    FileBaseDir YAMLLibYAML
+    GetoptLongDescriptive DateTimeFormatStrptime
+    StringInterpolate
+  ];
+
+in stdenv.mkDerivation rec {
+  pname = "ledger2beancount";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "zacchiro";
+    repo = "ledger2beancount";
+    rev = "${version}";
+    sha256 = "0w88jb1x0w02jwwf6ipx3cxr89kzffrrdqws3556zrvvs01bh84j";
+  };
+
+  phases = [
+    "unpackPhase"
+    "installPhase"
+    "fixupPhase"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ perlPackages.perl beancount ] ++ perlDeps;
+
+  makeFlags = [ "prefix=$(out)" ];
+  installFlags = [ "INSTALL=install" ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r $src/bin $out/bin
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/ledger2beancount" \
+      --set PERL5LIB "${perlPackages.makeFullPerlPath perlDeps}"
+  '';
+
+  meta = {
+    description = "Ledger to Beancount text-based converter";
+    longDescription = ''
+      A script to automatically convert Ledger-based textual ledgers to Beancount ones.
+
+      Conversion is based on (concrete) syntax, so that information that is not meaningful for accounting reasons but still valuable (e.g., comments, formatting, etc.) can be preserved.
+    '';
+    homepage = "https://github.com/zacchiro/ledger2beancount";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ pablovsky ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21965,6 +21965,8 @@ in
 
   ledger-web = callPackage ../applications/office/ledger-web { };
 
+  ledger2beancount = callPackage ../tools/text/ledger2beancount { };
+
   lightburn = libsForQt5.callPackage ../applications/graphics/lightburn { };
 
   lighthouse = callPackage ../applications/misc/lighthouse { };


### PR DESCRIPTION
###### Motivation for this change
This PR adds a package for [ledger2beancount](https://github.com/zacchiro/ledger2beancount), a "
Ledger to Beancount text-based converter"

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
