### PR TITLE
copper: init at 4.4

### DIFF
--- a/pkgs/development/compilers/copper/default.nix
+++ b/pkgs/development/compilers/copper/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchurl
+, libffi
+}:
+stdenv.mkDerivation rec {
+  pname = "copper";
+  version = "4.4";
+  src = fetchurl {
+    url = "https://tibleiz.net/download/copper-${version}-src.tar.gz";
+    sha256 = "1nf0bw143rjhd019yms3k6k531rahl8anidwh6bif0gm7cngfwfw";
+  };
+  buildInputs = [
+    libffi
+  ];
+  postPatch = ''
+    substituteInPlace Makefile --replace "-s scripts/" "scripts/"
+    patchShebangs .
+  '';
+  buildPhase = ''
+    make BACKEND=elf64 boot-elf64
+    make BACKEND=elf64 COPPER=stage3/copper-elf64 copper-elf64
+  '';
+  installPhase = ''
+    make BACKEND=elf64 install prefix=$out
+  '';
+  meta = with stdenv.lib; {
+    description = "Simple imperative language, statically typed with type inference and genericity.";
+    homepage = "https://tibleiz.net/copper/";
+    license = licenses.bsd2;
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3984,7 +3984,7 @@ in
   gocryptfs = callPackage ../tools/filesystems/gocryptfs { };
 
   godot = callPackage ../development/tools/godot {};
-  
+
   godot-headless = callPackage ../development/tools/godot/headless.nix { };
 
   godot-server = callPackage ../development/tools/godot/server.nix { };
@@ -8469,6 +8469,8 @@ in
       echo "--gcc-toolchain=${gccForLibs}" >> $out/nix-support/cc-cflags
     '';
   };
+
+  copper = callPackage ../development/compilers/copper {};
 
   inherit (callPackages ../development/compilers/crystal {
     inherit (llvmPackages_10) stdenv clang llvm;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Copper is used to build code-browser: https://tibleiz.net/code-browser/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
