### PR TITLE
[backport] openafs_1_8: include 5.6 fixes 

### DIFF
--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -1,7 +1,9 @@
 { stdenv, fetchurl, which, autoconf, automake, flex, yacc
 , kernel, glibc, perl, libtool_2, kerberos, fetchpatch }:
 
-with (import ./srcs.nix { inherit fetchurl; });
+with (import ./srcs.nix {
+  inherit fetchurl;
+});
 
 let
   modDestDir = "$out/lib/modules/${kernel.modDirVersion}/extra/openafs";
@@ -15,6 +17,22 @@ in stdenv.mkDerivation {
     ++ kernel.moduleBuildDependencies;
 
   buildInputs = [ kerberos ];
+
+  patches = [
+    # openafs 5.6 patches, included in the next release
+    (fetchpatch {
+      url = "https://github.com/openafs/openafs/commit/34f1689b7288688550119638ee9959e453fde414.patch";
+      sha256 = "0rxjqzr8c5ajlk8wrhgjc1qp1934qiriqdi0qxsnk4gj5ibbk4d5";
+    })
+    (fetchpatch {
+      url = "https://github.com/openafs/openafs/commit/355ea43f0d1b7feae1b3af58bc33af12838db7c3.patch";
+      sha256 = "1f9xn8ql6vnxglpj3dvi30sj8vkncazjab2rc13hbw48nvsvcnhm";
+    })
+    (fetchpatch {
+      url = "https://github.com/openafs/openafs/commit/17d38e31e6f2e237a7fb4dfb46841060296310b6.patch";
+      sha256 = "14dydxfm0f5fvnj0kmvgm3bgh0ajhh04i3l7l0hr9cpmwl7vrlcg";
+    })
+  ];
 
   hardeningDisable = [ "pic" ];
 


### PR DESCRIPTION
(cherry picked from commit 5fb7ac3d1845c409a7502e73b137092a4c52d330)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
