### PR TITLE
fontforge: CVE-2020-5395, CVE-2020-5496

### DIFF
--- a/pkgs/tools/misc/fontforge/default.nix
+++ b/pkgs/tools/misc/fontforge/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib
+{ stdenv, fetchurl, fetchpatch, lib
 , autoconf, automake, gnum4, libtool, perl, uthash, pkgconfig, gettext
 , python, freetype, zlib, glib, libungif, libpng, libjpeg, libtiff, libxml2, cairo, pango
 , readline, woff2, zeromq, libuninameslist
@@ -17,6 +17,14 @@ stdenv.mkDerivation rec {
     url = "https://github.com/${pname}/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
     sha256 = "0lh8yx01asbzxm6car5cfi64njh5p4lxc7iv8dldr5rwg357a86r";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2020-5395+CVE-2020-5496.patch";
+      url = "https://github.com/fontforge/fontforge/commit/048a91e2682c1a8936ae34dbc7bd70291ec05410.patch";
+      sha256 = "1vbhlpsh1qnwb16pndv10k9k5fvic0a41ifq0bcfk1mcxgyank75";
+    })
+  ];
 
   # use $SOURCE_DATE_EPOCH instead of non-deterministic timestamps
   postPatch = ''
@@ -67,7 +75,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A font editor";
-    homepage = "http://fontforge.github.io";
+    homepage = "https://fontforge.github.io";
     platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.bsd3;
     maintainers = [ stdenv.lib.maintainers.erictapen ];

--- a/pkgs/tools/misc/fontforge/default.nix
+++ b/pkgs/tools/misc/fontforge/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A font editor";
-    homepage = "https://fontforge.github.io";
+    homepage = "https://fontforge.org/";
     platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.bsd3;
     maintainers = [ stdenv.lib.maintainers.erictapen ];


### PR DESCRIPTION
###### Motivation for this change

Close https://github.com/NixOS/nixpkgs/issues/88291.

###### Things done

See the commit message for reasoning.

This needs to be backported to `nixos-20.03`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
