### PR TITLE
qboot: 20170330 -> 20200423

### DIFF
--- a/pkgs/applications/virtualization/qboot/default.nix
+++ b/pkgs/applications/virtualization/qboot/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, meson, ninja, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  name = "qboot-20170330";
+  name = "qboot-20200423";
 
   src = fetchFromGitHub {
     owner = "bonzini";
     repo = "qboot";
-    rev = "ac9488f26528394856b94bda0797f5bd9c69a26a";
-    sha256 = "0l83nbjndin1cbcimkqkiqr5df8d76cnhyk26rd3aygb2bf7cspy";
+    rev = "de50b5931c08f5fba7039ddccfb249a5b3b0b18d";
+    sha256 = "1d0h29zz535m0pq18k3aya93q7lqm2858mlcp8mlfkbq54n8c5d8";
   };
+
+  nativeBuildInputs = [ meson ninja ];
 
   installPhase = ''
     mkdir -p $out
-    cp bios.bin* $out/.
+    cp bios.bin bios.bin.elf $out/.
   '';
 
   hardeningDisable = [ "stackprotector" "pic" ];


### PR DESCRIPTION
##### Motivation for this change

qboot has no particular releases, just intermittent commits to master. The latest commit works well for me in qemu, on Intel and AMD hosts.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
