### PR TITLE
python3Packages.cadquery: 2.0RC0 -> 2.0

### DIFF
--- a/pkgs/applications/graphics/cq-editor/default.nix
+++ b/pkgs/applications/graphics/cq-editor/default.nix
@@ -6,13 +6,13 @@
 
 mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "cq-editor";
-  version = "0.1RC1";
+  version = "0.1RC2";
 
   src = fetchFromGitHub {
     owner = "CadQuery";
     repo = "CQ-editor";
     rev = version;
-    sha256 = "0iwcpnj15s64k16948sakvkn1lb4mqwrhmbxk3r03bczs0z33zax";
+    sha256 = "0zima4pmn34s8b2axxwy6qd1f1r5ki34byq4x3rrd7n3g0hagxz5";
   };
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/development/python-modules/cadquery/default.nix
+++ b/pkgs/development/python-modules/cadquery/default.nix
@@ -2,6 +2,7 @@
   , buildPythonPackage
   , isPy3k
   , pythonOlder
+  , pythonAtLeast
   , fetchFromGitHub
   , pyparsing
   , opencascade
@@ -16,9 +17,12 @@
   , libGLU
   , libX11
   , six
+  , pytest
+  , makeFontsConf
+  , freefont_ttf
 }:
 
-let 
+let
   pythonocc-core-cadquery = stdenv.mkDerivation {
     pname = "pythonocc-core-cadquery";
     version = "0.18.2";
@@ -31,7 +35,7 @@ let
       sha256 = "07zmiiw74dyj4v0ar5vqkvk30wzcpjjzbi04nsdk5mnlzslmyi6c";
     };
 
-    nativeBuildInputs = [ 
+    nativeBuildInputs = [
       cmake
       swig
       ninja
@@ -63,27 +67,34 @@ let
 in
   buildPythonPackage rec {
     pname = "cadquery";
-    version = "2.0RC0";
-  
+    version = "2.0";
+
     src = fetchFromGitHub {
       owner = "CadQuery";
       repo = pname;
       rev = version;
-      sha256 = "1xgd00rih0gjcnlrf9s6r5a7ypjkzgf2xij2b6436i76h89wmir3";
+      sha256 = "1n63b6cjjrdwdfmwq0zx1xabjnhndk9mgfkm4w7z9ardcfpvg84l";
     };
-  
+
     buildInputs = [
       opencascade
     ];
-  
+
     propagatedBuildInputs = [
       pyparsing
       pythonocc-core-cadquery
     ];
-  
-    # Build errors on 2.7 and >=3.8 (officially only supports 3.6 and 3.7).
-    disabled = !(isPy3k && (pythonOlder "3.8"));
-  
+
+    FONTCONFIG_FILE = makeFontsConf {
+      fontDirectories = [ freefont_ttf ];
+    };
+
+    checkInputs = [
+      pytest
+    ];
+
+    disabled = pythonOlder "3.6" || pythonAtLeast "3.8";
+
     meta = with lib; {
       description = "Parametric scripting language for creating and traversing CAD models";
       homepage = "https://github.com/CadQuery/cadquery";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Move from release candidate to actual release for CadQuery and cq-editor.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
