### PR TITLE
nixos/qemu-vm: add option to use qboot

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -441,6 +441,18 @@ in
           '';
       };
 
+    virtualisation.bios =
+      mkOption {
+        default = null;
+        type = types.nullOr types.package;
+        description =
+          ''
+            An alternate BIOS (such as <package>qboot</package>) with which to start the VM.
+            Should containin a file named <literal>bios.bin</literal>.
+            If <literal>null</literal>, QEMU's builtin SeaBIOS will be used.
+          '';
+      };
+
   };
 
   config = {
@@ -520,6 +532,9 @@ in
       ])
       (mkIf cfg.useEFIBoot [
         "-pflash $TMPDIR/bios.bin"
+      ])
+      (mkIf (cfg.bios != null) [
+        "-bios ${cfg.bios}/bios.bin"
       ])
       (mkIf (!cfg.graphics) [
         "-nographic"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -273,6 +273,7 @@ in
   prosody = handleTest ./xmpp/prosody.nix {};
   prosodyMysql = handleTest ./xmpp/prosody-mysql.nix {};
   proxy = handleTest ./proxy.nix {};
+  qboot = handleTestOn ["x86_64-linux" "i686-linux"] ./qboot.nix {};
   quagga = handleTest ./quagga.nix {};
   quorum = handleTest ./quorum.nix {};
   rabbitmq = handleTest ./rabbitmq.nix {};

--- a/nixos/tests/qboot.nix
+++ b/nixos/tests/qboot.nix
@@ -1,0 +1,13 @@
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "qboot";
+
+  machine = { ... }: {
+    virtualisation.bios = pkgs.qboot;
+  };
+
+  testScript =
+    ''
+      start_all()
+      machine.wait_for_unit("multi-user.target")
+    '';
+})

--- a/pkgs/applications/virtualization/qboot/default.nix
+++ b/pkgs/applications/virtualization/qboot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, meson, ninja, fetchFromGitHub }:
+{ stdenv, meson, ninja, fetchFromGitHub, nixosTests }:
 
 stdenv.mkDerivation {
   name = "qboot-20200423";
@@ -18,6 +18,8 @@ stdenv.mkDerivation {
   '';
 
   hardeningDisable = [ "stackprotector" "pic" ];
+
+  passthru.tests = { qboot = nixosTests.qboot; };
 
   meta = {
     description = "A simple x86 firmware for booting Linux";


### PR DESCRIPTION
###### Motivation for this change

qboot is a minimal x86 bios for use under QEMU, replacing the default (SeaBIOS).

This provides a 700-800ms improvement to boot times when enabled, so long-term I'd love to turn it on by default (at least for nixos tests).

See the runtimes of a simple "wait for multi-user.target" test, with and without the option enabled:

###### Desktop, AMD 2600X
![Screenshot_20200522_153812](https://user-images.githubusercontent.com/691552/82629388-af89b180-9c43-11ea-9fd6-165ec8e2b609.png)

###### Laptop, Intel i5-8250U
![Screenshot_20200522_154122](https://user-images.githubusercontent.com/691552/82629390-b0bade80-9c43-11ea-9855-251274a7eee7.png)

Percentage-wise, this becomes much more significant after further changes I'm working on, especially the use of virtiofs instead of 9pfs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
