### PR TITLE
etcd: 3.3.21 -> 3.3.22, 3.4.8 -> 3.4.9 

### DIFF
--- a/pkgs/servers/etcd/3.4.nix
+++ b/pkgs/servers/etcd/3.4.nix
@@ -2,15 +2,18 @@
 
 buildGoModule rec {
   pname = "etcd";
-  version = "3.4.8";
+  version = "3.4.9";
 
-  vendorSha256 = null;
+  #vendorSha256 = null; revert to `null` for > 3.4.9
+
+  vendorSha256 = "1fhrycl8m8ddb7mwasbyfiwrl4d9lfdk7zd3mxb7ahkipdp2c94z";
+  deleteVendor = true;
 
   src = fetchFromGitHub {
     owner = "etcd-io";
     repo = "etcd";
     rev = "v${version}";
-    sha256 = "0kx36kq6a7i3cja3wp9mwbnar752pz8c0n2fcvwyzi6l6ph6alx7";
+    sha256 = "16l4wmnm7mkhpb2vzf6xnhhyx6lj8xx3z6x1bfs05idajnrw824p";
   };
 
   buildPhase = ''

--- a/pkgs/servers/etcd/default.nix
+++ b/pkgs/servers/etcd/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "etcd";
-  version = "3.3.21";
+  version = "3.3.22";
 
   goPackagePath = "github.com/coreos/etcd";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "etcd-io";
     repo = "etcd";
     rev = "v${version}";
-    sha256 = "1xrhkynach3c7wsfac6zlpi5n1hy3y75vyimvw2zl7ryhm00413s";
+    sha256 = "1rd390qfx9k20j9gh1wp1g9ygc571f2kv1dg2wvqij3kwydhymcj";
   };
 
   buildPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.3.md#v3322-2020-05-20
https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.4.md#v349-2020-05-20

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
