### PR TITLE
sway-contrib: init with grimshot and inactive-windows-transparency

### DIFF
--- a/pkgs/applications/window-managers/sway/contrib.nix
+++ b/pkgs/applications/window-managers/sway/contrib.nix
@@ -1,0 +1,79 @@
+{ stdenv
+, fetchurl
+, coreutils
+, makeWrapper
+, sway-unwrapped
+, installShellFiles
+, wl-clipboard
+, libnotify
+, slurp
+, grim
+, jq
+}:
+
+{
+
+grimshot = stdenv.mkDerivation rec {
+  pname = "grimshot";
+  version = "2020-05-08";
+  rev = "b1d08db5f5112ab562f89564825e3e791b0682c4";
+
+  # master has new fixes and features, and a man page
+  # after sway-1.5 these may be switched to sway-unwrapped.src
+  bsrc = fetchurl {
+    url = "https://raw.githubusercontent.com/swaywm/sway/${rev}/contrib/grimshot";
+    sha256 = "1awzmzkib8a7q5s78xyh8za03lplqfpbasqp3lidqqmjqs882jq9";
+  };
+
+  msrc = fetchurl {
+    url = "https://raw.githubusercontent.com/swaywm/sway/${rev}/contrib/grimshot.1";
+    sha256 = "191xxjfhf61gkxl3b0f694h0nrwd7vfnyp5afk8snhhr6q7ia4jz";
+  };
+
+  dontBuild = true;
+  dontUnpack = true;
+  dontConfigure = true;
+
+  outputs = [ "out" "man" ];
+
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
+  installPhase = ''
+    installManPage ${msrc}
+
+    install -Dm 0755 ${bsrc} $out/bin/grimshot
+    wrapProgram $out/bin/grimshot --set PATH \
+      "${stdenv.lib.makeBinPath [
+        sway-unwrapped
+        wl-clipboard
+        coreutils
+        libnotify
+        slurp
+        grim
+        jq
+        ] }"
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    # check always returns 0
+    if [[ $($out/bin/grimshot check | grep "NOT FOUND") ]]; then false
+    else
+      echo "grimshot check passed"
+    fi
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A helper for screenshots within sway";
+    homepage = "https://github.com/swaywm/sway/tree/master/contrib";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [
+      sway-unwrapped.meta.maintainers
+      evils
+    ];
+  };
+};
+
+}

--- a/pkgs/applications/window-managers/sway/contrib.nix
+++ b/pkgs/applications/window-managers/sway/contrib.nix
@@ -1,4 +1,5 @@
 { stdenv
+
 , fetchurl
 , coreutils
 , makeWrapper
@@ -9,6 +10,8 @@
 , slurp
 , grim
 , jq
+
+, python3Packages
 }:
 
 {
@@ -73,6 +76,31 @@ grimshot = stdenv.mkDerivation rec {
       sway-unwrapped.meta.maintainers
       evils
     ];
+  };
+};
+
+
+inactive-windows-transparency = python3Packages.buildPythonApplication rec {
+  # long name is long
+  lname = "inactive-windows-transparency";
+  pname = "sway-${lname}";
+  version = sway-unwrapped.version;
+
+  src = sway-unwrapped.src;
+
+  format = "other";
+  dontBuild = true;
+  dontConfigure = true;
+
+  propagatedBuildInputs = [ python3Packages.i3ipc ];
+
+  installPhase = ''
+    install -Dm 0755 $src/contrib/${lname}.py $out/bin/${lname}.py
+  '';
+
+  meta = sway-unwrapped.meta // {
+    description = "It makes inactive sway windows transparent";
+    homepage    = "https://github.com/swaywm/sway/tree/${sway-unwrapped.version}/contrib";
   };
 };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20187,6 +20187,7 @@ in
   swaybg = callPackage ../applications/window-managers/sway/bg.nix { };
   swayidle = callPackage ../applications/window-managers/sway/idle.nix { };
   swaylock = callPackage ../applications/window-managers/sway/lock.nix { };
+  sway-contrib = recurseIntoAttrs (callPackages ../applications/window-managers/sway/contrib.nix { });
 
   swaylock-fancy = callPackage ../applications/window-managers/sway/lock-fancy.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
no one appears to be against to the solution reached in #87979

closes #87831

###### Things done
add package set `pkgs.sway-contrib` containing
`sway-contrib.grimshot`, a screenshot utility
with an alias for `pkgs.grimshot` as this is a fairly fleshed out tool  

`sway-contrib.inactive-windows-transparency`, a script that makes inactive windows transparent

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `/nix/store/ra8b9q1ihdnp04595ahdl6iczg08drgm-grimshot-2020-05-08	  101551232`
  - `/nix/store/hd48r6ss5lpvgqch663z1alnbf6s4p72-python3.7-sway-inactive-windows-transparency-1.4	  107722384`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notes
`grimshot` may get a rotated screen wrong due to bugs in dependencies that have been fixed upstream
`inactive-windows-transparency` leaves the last active window on a secondary screen active https://github.com/swaywm/sway/issues/5372
