### PR TITLE
opentoonz: Init at 1.4.0

### DIFF
--- a/pkgs/applications/graphics/opentoonz/default.nix
+++ b/pkgs/applications/graphics/opentoonz/default.nix
@@ -1,0 +1,51 @@
+{ boost, cmake, fetchFromGitHub, freeglut, freetype, glew, libjpeg, libmypaint
+, libpng, libtiff, libusb1, lz4, lzma, lzo, openblas, pkgconfig, qtbase
+, qtmultimedia, qtscript, stdenv, superlu, wrapQtAppsHook, }:
+let source = import ./source.nix { inherit fetchFromGitHub; };
+in stdenv.mkDerivation rec {
+  inherit (source) src;
+
+  pname = "opentoonz";
+  version = source.versions.opentoonz;
+
+  nativeBuildInputs = [ cmake pkgconfig wrapQtAppsHook ];
+
+  buildInputs = [
+    boost
+    freeglut
+    freetype
+    glew
+    libjpeg
+    libmypaint
+    libpng
+    libtiff
+    libusb1
+    lz4
+    lzma
+    lzo
+    openblas
+    qtbase
+    qtmultimedia
+    qtscript
+    superlu
+  ];
+
+  postUnpack = "sourceRoot=$sourceRoot/toonz";
+
+  cmakeDir = "../sources";
+  cmakeFlags = [
+    "-DTIFF_INCLUDE_DIR=${libtiff.dev}/include"
+    "-DTIFF_LIBRARY=${libtiff.out}/lib/libtiff.so"
+  ];
+
+  postInstall = ''
+    sed -i '/cp -r .*stuff/a\    chmod -R u+w $HOME/.config/OpenToonz/stuff' $out/bin/opentoonz
+  '';
+
+  meta = {
+    description = "Full-featured 2D animation creation software";
+    homepage = "https://opentoonz.github.io/";
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ chkno ];
+  };
+}

--- a/pkgs/applications/graphics/opentoonz/libtiff.nix
+++ b/pkgs/applications/graphics/opentoonz/libtiff.nix
@@ -1,0 +1,21 @@
+# Per https://github.com/opentoonz/opentoonz/blob/master/doc/how_to_build_linux.md ,
+# opentoonz requires its own modified version of libtiff.  We still build it as
+# a separate package
+#  1. For visibility for tools like vulnix, and
+#  2. To avoid a diamond-dependency problem with qt linking the normal libtiff
+#     and opentoonz linking qt and this modified libtiff, we build a qt against
+#     this modified libtiff as well.
+
+{ fetchFromGitHub, libtiff }:
+let source = import ./source.nix { inherit fetchFromGitHub; };
+in libtiff.overrideAttrs (old: {
+  inherit (source) src;
+  version = source.versions.libtiff + "-opentoonz";
+  postUnpack = (old.postUnpack or "") + ''
+    sourceRoot="$sourceRoot/thirdparty/tiff-${source.versions.libtiff}"
+  '';
+  # opentoonz uses internal libtiff headers
+  postInstall = (old.postInstall or "") + ''
+    cp libtiff/{tif_config,tif_dir,tiffiop}.h $dev/include
+  '';
+})

--- a/pkgs/applications/graphics/opentoonz/source.nix
+++ b/pkgs/applications/graphics/opentoonz/source.nix
@@ -1,0 +1,16 @@
+# opentoonz's source archive contains both opentoonz's source and a modified
+# version of libtiff that opentoonz requires.
+
+{ fetchFromGitHub, }: rec {
+  versions = {
+    opentoonz = "1.4.0";
+    libtiff = "4.0.3";
+  };
+
+  src = fetchFromGitHub {
+    owner = "opentoonz";
+    repo = "opentoonz";
+    rev = "v${versions.opentoonz}";
+    sha256 = "0vgclx2yydsm5i2smff3fj8m750nhf35wfhva37kywgws01s189b";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21227,6 +21227,10 @@ in
 
   opentimestamps-client = python3Packages.callPackage ../tools/misc/opentimestamps-client {};
 
+  opentoonz = (qt5.overrideScope' (_: _: {
+    libtiff = callPackage ../applications/graphics/opentoonz/libtiff.nix { };
+  })).callPackage ../applications/graphics/opentoonz { };
+
   opentx = libsForQt5.callPackage ../applications/misc/opentx { };
 
   opera = callPackage ../applications/networking/browsers/opera {};


### PR DESCRIPTION
###### Motivation for this change
Make opentoonz available.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
