### PR TITLE
cached-nix-shell: 0.1.2 -> 0.1.3

### DIFF
--- a/pkgs/tools/nix/cached-nix-shell/default.nix
+++ b/pkgs/tools/nix/cached-nix-shell/default.nix
@@ -1,25 +1,25 @@
 { stdenv, fetchFromGitHub, openssl, pkgconfig, ronn, rustPlatform }:
 
-let 
+let
   blake3-src = fetchFromGitHub {
     owner = "BLAKE3-team";
     repo = "BLAKE3";
-    rev = "0.3.1";
-    sha256 = "0wkxx2w56hsng28p8zpndsy288ix4s5qg6xqjzgjz53fbyk46hda";
+    rev = "0.3.3";
+    sha256 = "0av41ld0gqf3g60gcllpz59nqlr7r62v99mgfq9gs0p8diw5gi7x";
   };
 
 in rustPlatform.buildRustPackage rec {
   pname = "cached-nix-shell";
-  version = "0.1.2";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "xzfc";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0pzwknpc4qrh9pv5z0xvldql2dkj9ddksvaci86a4f8cnd86p2l6";
+    sha256 = "1ni671wr2lrvyz6myaz3v4llrjvq4jc1ygw1m7rvnadzyf3va3lw";
   };
 
-  cargoSha256 = "1n88gcnrfdrk025hb54igc83cn5vlv8n6ndyx1ydmzhd95vhbznf";
+  cargoSha256 = "19i39b1yqdf81ql4psr3nfah6ci2mw3ljkv740clqmz088j2av8g";
 
   # The BLAKE3 C library is intended to be built by the project depending on it
   # rather than as a standalone library.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
