### PR TITLE
ocamlPackages: default to OCaml 4.10

### DIFF
--- a/pkgs/development/ocaml-modules/lens/default.nix
+++ b/pkgs/development/ocaml-modules/lens/default.nix
@@ -1,4 +1,8 @@
-{ lib, fetchzip, ppx_deriving, ppxfind, buildDunePackage }:
+{ lib, ocaml, fetchzip, ppx_deriving, ppxfind, buildDunePackage }:
+
+if lib.versionAtLeast ocaml.version "4.10"
+then throw "lens is not available for OCaml ${ocaml.version}"
+else
 
 buildDunePackage rec {
   pname = "lens";

--- a/pkgs/development/ocaml-modules/sodium/default.nix
+++ b/pkgs/development/ocaml-modules/sodium/default.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, ctypes, libsodium }:
 
+if stdenv.lib.versionAtLeast ocaml.version "4.10"
+then throw "sodium is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-sodium";
   version = "0.6.0";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22375,6 +22375,7 @@ in
   unigine-valley = callPackage ../applications/graphics/unigine-valley { };
 
   unison = callPackage ../applications/networking/sync/unison {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_09;
     enableX11 = config.unison.enableX11 or true;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20556,7 +20556,9 @@ in
 
   linuxsampler = callPackage ../applications/audio/linuxsampler { };
 
-  llpp = ocamlPackages.callPackage ../applications/misc/llpp { };
+  llpp = callPackage ../applications/misc/llpp {
+    inherit (ocaml-ng.ocamlPackages_4_09) ocaml;
+  };
 
   lmms = libsForQt5.callPackage ../applications/audio/lmms {
     lame = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24802,7 +24802,7 @@ in
   cadical = callPackage ../applications/science/logic/cadical {};
 
   inherit (callPackage ./coq-packages.nix {
-    inherit (ocaml-ng) ocamlPackages_4_05;
+    inherit (ocaml-ng) ocamlPackages_4_05 ocamlPackages_4_09;
   }) mkCoqPackages
     coqPackages_8_5  coq_8_5
     coqPackages_8_6  coq_8_6

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, newScope, recurseIntoAttrs, ocamlPackages_4_05 }:
+{ lib, callPackage, newScope, recurseIntoAttrs, ocamlPackages_4_05, ocamlPackages_4_09 }:
 
 let
   mkCoqPackages' = self: coq:
@@ -100,15 +100,19 @@ in rec {
     version = "8.6.1";
   };
   coq_8_7 = callPackage ../applications/science/logic/coq {
+    ocamlPackages = ocamlPackages_4_09;
     version = "8.7.2";
   };
   coq_8_8 = callPackage ../applications/science/logic/coq {
+    ocamlPackages = ocamlPackages_4_09;
     version = "8.8.2";
   };
   coq_8_9 = callPackage ../applications/science/logic/coq {
+    ocamlPackages = ocamlPackages_4_09;
     version = "8.9.1";
   };
   coq_8_10 = callPackage ../applications/science/logic/coq {
+    ocamlPackages = ocamlPackages_4_09;
     version = "8.10.2";
   };
   coq_8_11 = callPackage ../applications/science/logic/coq {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1221,5 +1221,5 @@ in let inherit (pkgs) callPackage; in rec
 
   ocamlPackages_latest = ocamlPackages_4_10;
 
-  ocamlPackages = ocamlPackages_4_09;
+  ocamlPackages = ocamlPackages_4_10;
 }


### PR DESCRIPTION
###### Motivation for this change

nixpkgs is ready

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
