### PR TITLE
zstd: 1.4.4 -> 1.4.5

### DIFF
--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -6,26 +6,26 @@
 
 stdenv.mkDerivation rec {
   pname = "zstd";
-  version = "1.4.4";
+  version = "1.4.5";
 
   src = fetchFromGitHub {
-    sha256 = "0zn7r8d4m8w2lblnjalqpz18na0spzkdiw3fwq2fzb7drhb32v54";
-    rev = "v${version}";
-    repo = "zstd";
     owner = "facebook";
+    repo = "zstd";
+    rev = "v${version}";
+    sha256 = "0ay3qlk4sffnmcl3b34q4zd7mkcmjds023icmib1mdli97qcp38l";
   };
 
   nativeBuildInputs = [ cmake ]
    ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   patches = [
-    # From https://github.com/facebook/zstd/pull/1883
+    ./playtests-darwin.patch
     (fetchpatch {
-      url = "https://github.com/facebook/zstd/commit/106278e7e5fafaea3b7deb4147bdc8071562d2f0.diff";
-      sha256 = "13z7id1qbc05cv1rmak7c8xrchp7jh1i623bq5pwcihg57wzcyr8";
+      url = "https://github.com/facebook/zstd/pull/2163.patch";
+      sha256 = "07mfjc5f9wy0w2xlj36hyf7g5ax9r2rf6ixhkffhnwc6rwy0q54p";
     })
   ] # This I didn't upstream because if you use posix threads with MinGW it will
-    # work find, and I'm not sure how to write the condition.
+    # work fine, and I'm not sure how to write the condition.
     ++ stdenv.lib.optional stdenv.hostPlatform.isWindows ./mcfgthreads-no-pthread.patch;
 
   cmakeFlags = [
@@ -41,12 +41,13 @@ stdenv.mkDerivation rec {
 
   checkInputs = [ file ];
   doCheck = true;
-  preCheck = ''
-    substituteInPlace ../tests/playTests.sh \
-      --replace 'MD5SUM="md5 -r"' 'MD5SUM="md5sum"'
+  checkPhase = ''
+    runHook preCheck
+    ctest -R playTests # The only relatively fast test.
+    runHook postCheck
   '';
 
-  preInstall = stdenv.lib.optionalString enableShared ''
+  preInstall = ''
     substituteInPlace ../programs/zstdgrep \
       --replace ":-grep" ":-${gnugrep}/bin/grep" \
       --replace ":-zstdcat" ":-$out/bin/zstdcat"

--- a/pkgs/tools/compression/zstd/playtests-darwin.patch
+++ b/pkgs/tools/compression/zstd/playtests-darwin.patch
@@ -1,0 +1,18 @@
+--- a/tests/playTests.sh
++++ b/tests/playTests.sh
+@@ -109,5 +109,2 @@ esac
+ case "$UNAME" in
+-  Darwin) MD5SUM="md5 -r" ;;
+-  FreeBSD) MD5SUM="gmd5sum" ;;
+-  OpenBSD) MD5SUM="md5" ;;
+   *) MD5SUM="md5sum" ;;
+@@ -116,5 +113,2 @@ esac
+ MTIME="stat -c %Y"
+-case "$UNAME" in
+-    Darwin | FreeBSD | OpenBSD) MTIME="stat -f %m" ;;
+-esac
+ 
+@@ -752,3 +746,2 @@ zstd -d --rm dirTestDict/*.zst -D tmpDictC  # note : use internal checksum by de
+ case "$UNAME" in
+-  Darwin) println "md5sum -c not supported on OS-X : test skipped" ;;  # not compatible with OS-X's md5
+   *) $MD5SUM -c tmph1 ;;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

A regular update with improved decompression speed.

The previous CMake version did not run any tests, the current version tries to run all tests (I could not await their completion), and the last GNU Make version ran `make -C tests shortest` which ran only playTests.sh, so I've enabled only the playTests test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).