### PR TITLE
fix secp256k1 broken package

### DIFF
--- a/pkgs/development/python-modules/secp256k1/default.nix
+++ b/pkgs/development/python-modules/secp256k1/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   '';
 
   postPatch = ''
-    substituteInPlace setup.py --replace "[int(i) for i in setuptools_version.split('.')] < [3, 3]" "setuptools_version < '3.3'"
+    substituteInPlace setup.py --replace "int(i)" "int(i) if i.isdigit() else 0"
     substituteInPlace setup.py --replace ", 'pytest-runner==2.6.2'" ""
   '';
 

--- a/pkgs/development/python-modules/secp256k1/default.nix
+++ b/pkgs/development/python-modules/secp256k1/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   '';
 
   postPatch = ''
-    substituteInPlace setup.py --replace "int(i)" "int(i) if i.isdigit() else 0"
+    sed -i '38,45d' setup.py
     substituteInPlace setup.py --replace ", 'pytest-runner==2.6.2'" ""
   '';
 

--- a/pkgs/development/python-modules/secp256k1/default.nix
+++ b/pkgs/development/python-modules/secp256k1/default.nix
@@ -36,6 +36,7 @@ buildPythonPackage rec {
   '';
 
   postPatch = ''
+    substituteInPlace setup.py --replace "[int(i) for i in setuptools_version.split('.')] < [3, 3]" "setuptools_version < '3.3'"
     substituteInPlace setup.py --replace ", 'pytest-runner==2.6.2'" ""
   '';
 


### PR DESCRIPTION
The way setup_version is checked generated errors. I fixed it via postPatch by using string comparison (don't know if it's optimal).