### PR TITLE
WIP: pythonPackages.virtualenv: 16.7.9 -> 20.0.21 fix #66366

### DIFF
--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -42,6 +42,13 @@ buildPythonPackage rec {
     importlib-metadata
   ];
 
+  # TODO: remove this once https://github.com/NixOS/nixpkgs/issues/81441 is solved
+  postCheck = ''
+    for pycache in $(find $out -name __pycache__) ; do
+      rm -fr ''${pycache}
+    done
+  '';
+
   meta = {
     description = "A tool to create isolated Python environments";
     homepage = "http://www.virtualenv.org";

--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     six
   ] ++ lib.optionals (pythonOlder "3.3") [
     contextlib2
-  ] ++ lib.optionals (pythonOlder "3.4" && !stdenv.isCygwin) [
+  ] ++ lib.optionals (pythonOlder "3.4" && !stdenv.hostPlatform.isWindows) [
     pathlib2
   ] ++ lib.optionals (pythonOlder "3.7") [
     importlib-resources

--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -1,6 +1,7 @@
 { buildPythonPackage
 , fetchPypi
 , lib
+, pythonOlder
 , appdirs
 , contextlib2
 , distlib
@@ -22,16 +23,23 @@ buildPythonPackage rec {
 
   };
 
+  buildInputs = [
+    setuptools_scm
+  ];
+
   propagatedBuildInputs = [
     appdirs
-    contextlib2
     distlib
     filelock
-    importlib-metadata
-    importlib-resources
-    pathlib2
-    setuptools_scm
     six
+  ] ++ lib.optionals (pythonOlder "3.3") [
+    contextlib2
+  ] ++ lib.optionals (pythonOlder "3.4" && !lib.stdenv.isWindows) [
+    pathlib2
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    importlib-resources
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
   ];
 
   meta = {

--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -1,6 +1,7 @@
 { buildPythonPackage
 , fetchPypi
 , lib
+, stdenv
 , pythonOlder
 , appdirs
 , contextlib2
@@ -34,7 +35,7 @@ buildPythonPackage rec {
     six
   ] ++ lib.optionals (pythonOlder "3.3") [
     contextlib2
-  ] ++ lib.optionals (pythonOlder "3.4" && !lib.stdenv.isWindows) [
+  ] ++ lib.optionals (pythonOlder "3.4" && !stdenv.isCygwin) [
     pathlib2
   ] ++ lib.optionals (pythonOlder "3.7") [
     importlib-resources

--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -1,25 +1,38 @@
 { buildPythonPackage
 , fetchPypi
 , lib
-, recursivePthLoader
+, appdirs
+, contextlib2
+, distlib
+, filelock
+, importlib-metadata
+, importlib-resources
+, pathlib2
+, setuptools_scm
+, six
 }:
 
 buildPythonPackage rec {
   pname = "virtualenv";
-  version = "16.7.9";
+  version = "20.0.21";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0d62c70883c0342d59c11d0ddac0d954d0431321a41ab20851facf2b222598f3";
+    sha256 = "1kxnxxwa25ghlkpyrxa8pi49v87b7ps2gyla7d1h6kbz9sfn45m1";
+
   };
 
-  # Doubt this is needed - FRidh 2017-07-07
-  pythonPath = [ recursivePthLoader ];
-
-  patches = [ ./virtualenv-change-prefix.patch ];
-
-  # Tarball doesn't contain tests
-  doCheck = false;
+  propagatedBuildInputs = [
+    appdirs
+    contextlib2
+    distlib
+    filelock
+    importlib-metadata
+    importlib-resources
+    pathlib2
+    setuptools_scm
+    six
+  ];
 
   meta = {
     description = "A tool to create isolated Python environments";

--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -3,6 +3,7 @@
 , lib
 , stdenv
 , pythonOlder
+, isPy27
 , appdirs
 , contextlib2
 , distlib
@@ -33,9 +34,9 @@ buildPythonPackage rec {
     distlib
     filelock
     six
-  ] ++ lib.optionals (pythonOlder "3.3") [
+  ] ++ lib.optionals isPy27 [
     contextlib2
-  ] ++ lib.optionals (pythonOlder "3.4" && !stdenv.hostPlatform.isWindows) [
+  ] ++ lib.optionals (isPy27 && !stdenv.hostPlatform.isWindows) [
     pathlib2
   ] ++ lib.optionals (pythonOlder "3.7") [
     importlib-resources

--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     setuptools_scm
   ];
 

--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -43,13 +43,6 @@ buildPythonPackage rec {
     importlib-metadata
   ];
 
-  # TODO: remove this once https://github.com/NixOS/nixpkgs/issues/81441 is solved
-  postCheck = ''
-    for pycache in $(find $out -name __pycache__) ; do
-      rm -fr ''${pycache}
-    done
-  '';
-
   meta = {
     description = "A tool to create isolated Python environments";
     homepage = "http://www.virtualenv.org";


### PR DESCRIPTION
###### Motivation for this change
fixes #66366 in that the newer version no longer checks if `sys.prefix` matches the virtualenv.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

before:
`python2.7-virtualenv-16.7.9 102.6M`
`python3.7-virtualenv-16.7.9 104.9M`
after:
`python2.7-virtualenv-20.0.21 107.1M`
`python3.7-virtualenv-20.0.21 108.2M`