### PR TITLE
Add keysmith

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6986,6 +6986,12 @@
     githubId = 1588288;
     name = "Shahrukh Khan";
   };
+  shamilton = {
+    email = "sgn.hamilton@protonmail.com";
+    github = "SCOTT-HAMILTON";
+    githubId = 24496705;
+    name = "Scott Hamilton";
+  };
   shanemikel = {
     email = "shanepearlman@pm.me";
     github = "shanemikel";

--- a/pkgs/tools/security/keysmith/default.nix
+++ b/pkgs/tools/security/keysmith/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, mkDerivation
+, makeWrapper
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, qtbase
+, qtquickcontrols2
+, qtdeclarative
+, qtgraphicaleffects
+, kirigami2
+, oathToolkit
+}:
+mkDerivation rec {
+
+  pname = "keysmith";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "KDE";
+    repo = "keysmith";
+    rev = "v${version}";
+    sha256 = "15fzf0bvarivm32zqa5w71mscpxdac64ykiawc5hx6kplz93bsgx";
+  };
+
+  nativeBuildInputs = [ cmake extra-cmake-modules makeWrapper ];
+
+  buildInputs = [ oathToolkit kirigami2 qtquickcontrols2 qtbase ];
+
+  postInstall = ''
+    mv $out/bin/org.kde.keysmith $out/bin/.org.kde.keysmith-wrapped
+    makeWrapper $out/bin/.org.kde.keysmith-wrapped $out/bin/org.kde.keysmith \
+      --set QML2_IMPORT_PATH "${lib.getLib kirigami2}/lib/qt-5.12.7/qml:${lib.getBin qtquickcontrols2}/lib/qt-5.12.7/qml:${lib.getBin qtdeclarative}/lib/qt-5.12.7/qml:${qtgraphicaleffects}/lib/qt-5.12.7/qml" \
+      --set QT_PLUGIN_PATH "${lib.getBin qtbase}/lib/qt-5.12.7/plugins"
+    ln -s $out/bin/org.kde.keysmith $out/bin/keysmith
+  '';
+
+  meta = with lib; {
+    description = "OTP client for Plasma Mobile and Desktop";
+    license = licenses.gpl3;
+    homepage = "https://github.com/KDE/keysmith";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4849,6 +4849,8 @@ in
 
   kea = callPackage ../tools/networking/kea { };
 
+  keysmith = libsForQt5.callPackage ../tools/security/keysmith { };
+
   ispell = callPackage ../tools/text/ispell {};
 
   jumanpp = callPackage ../tools/text/jumanpp {};


### PR DESCRIPTION
###### Motivation for this change
Needed a simple otp client, while otpgen is still in stand-by.

###### Things done
Successfully build, tested and added to all-packages.nix

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
