### PR TITLE
mpv: Move all wrappings to a single wrapper Nix function

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -1,4 +1,4 @@
-{ config, stdenv, fetchurl, fetchFromGitHub, makeWrapper, fetchpatch
+{ config, stdenv, fetchurl, fetchFromGitHub, fetchpatch
 , addOpenGLRunpath, docutils, perl, pkgconfig, python3, wafHook, which
 , ffmpeg_4, freefont_ttf, freetype, libass, libpthreadstubs, mujs
 , nv-codec-headers, lua, libuchardet, libiconv ? null
@@ -50,7 +50,6 @@
 , vdpauSupport       ? true,           libvdpau      ? null
 , xineramaSupport    ? stdenv.isLinux, libXinerama   ? null
 , xvSupport          ? stdenv.isLinux, libXv         ? null
-, youtubeSupport     ? true,           youtube-dl    ? null
 , zimgSupport        ? true,           zimg          ? null
 , archiveSupport     ? true,           libarchive    ? null
 , jackaudioSupport   ? false,          libjack2      ? null
@@ -91,7 +90,6 @@ assert waylandSupport     -> all available [ wayland wayland-protocols libxkbcom
 assert x11Support         -> all available [ libGLU libGL libX11 libXext libXxf86vm libXrandr ];
 assert xineramaSupport    -> x11Support && available libXinerama;
 assert xvSupport          -> x11Support && available libXv;
-assert youtubeSupport     -> available youtube-dl;
 assert zimgSupport        -> available zimg;
 
 let
@@ -111,6 +109,20 @@ in stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs ./TOOLS/
   '';
+
+  passthru = {
+    inherit
+    # The wrapper consults luaEnv and lua.version
+    luaEnv
+    lua
+    # In the wrapper, we want to reference vapoursynth which has the
+    # `python3` passthru attribute (which has the `sitePrefix`
+    # attribute). This way we'll be sure that in the wrapper we'll
+    # use the same python3.sitePrefix used to build vapoursynth.
+    vapoursynthSupport
+    vapoursynth
+    ;
+  };
 
   NIX_LDFLAGS = optionalString x11Support "-lX11 -lXext "
               + optionalString stdenv.isDarwin "-framework CoreFoundation";
@@ -135,7 +147,7 @@ in stdenv.mkDerivation rec {
     ++ stdenv.lib.optional (!swiftSupport) "--disable-macos-cocoa-cb";
 
   nativeBuildInputs = [
-    addOpenGLRunpath docutils makeWrapper perl pkgconfig python3 wafHook which
+    addOpenGLRunpath docutils perl pkgconfig python3 wafHook which
   ]
     ++ optional swiftSupport swift;
 
@@ -164,7 +176,6 @@ in stdenv.mkDerivation rec {
     ++ optional vdpauSupport       libvdpau
     ++ optional xineramaSupport    libXinerama
     ++ optional xvSupport          libXv
-    ++ optional youtubeSupport     youtube-dl
     ++ optional zimgSupport        zimg
     ++ optional stdenv.isDarwin    libiconv
     ++ optional stdenv.isLinux     nv-codec-headers
@@ -182,17 +193,6 @@ in stdenv.mkDerivation rec {
     python3 TOOLS/osxbundle.py -s build/mpv
   '';
 
-  # Ensure youtube-dl is available in $PATH for mpv
-  wrapperFlags =
-    ''--prefix LUA_CPATH ';' "${luaEnv}/lib/lua/${lua.luaversion}/?.so" \'' +
-    ''--prefix LUA_PATH ';' "${luaEnv}/share/lua/${lua.luaversion}/?.lua" \'' +
-    ''--prefix PATH : "${luaEnv}/bin" \''
-  + optionalString youtubeSupport ''
-      --prefix PATH : "${youtube-dl}/bin" \
-  '' + optionalString vapoursynthSupport ''
-      --prefix PYTHONPATH : "${vapoursynth}/lib/${python3.libPrefix}/site-packages:$PYTHONPATH"
-  '';
-
   patches = stdenv.lib.optionals stdenv.isDarwin [
     # Fix cocoa backend. Remove with the next release
     (fetchpatch {
@@ -205,24 +205,17 @@ in stdenv.mkDerivation rec {
     # Use a standard font
     mkdir -p $out/share/mpv
     ln -s ${freefont_ttf}/share/fonts/truetype/FreeSans.ttf $out/share/mpv/subfont.ttf
-    wrapProgram "$out/bin/mpv" \
-      ${wrapperFlags}
 
     cp TOOLS/umpv $out/bin
-    wrapProgram $out/bin/umpv \
-      --set MPV "$out/bin/mpv"
-
   '' + optionalString stdenv.isDarwin ''
     mkdir -p $out/Applications
     cp -r build/mpv.app $out/Applications
-    wrapProgram "$out/Applications/mpv.app/Contents/MacOS/mpv" \
-      ${wrapperFlags}
   '';
 
   # Set RUNPATH so that libcuda in /run/opengl-driver(-32)/lib can be found.
   # See the explanation in addOpenGLRunpath.
   postFixup = optionalString stdenv.isLinux ''
-    addOpenGLRunpath $out/bin/.mpv-wrapped
+    addOpenGLRunpath $out/bin/mpv
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/video/mpv/wrapper.nix
+++ b/pkgs/applications/video/mpv/wrapper.nix
@@ -1,14 +1,83 @@
-{ stdenv, symlinkJoin, makeWrapper, mpv, scripts ? [] }:
+# Arguments that this derivation gets when it is created with `callPackage`
+{ stdenv
+, lib
+, symlinkJoin
+, makeWrapper
+, youtube-dl
+}:
 
-symlinkJoin {
-  name = "mpv-with-scripts-${mpv.version}";
+# the unwrapped mpv derivation - 1st argument to `wrapMpv`
+mpv:
 
-  paths = [ mpv ];
+let
+  # arguments to the function (called `wrapMpv` in all-packages.nix)
+  wrapper = {
+    extraMakeWrapperArgs ? [],
+    youtubeSupport ? true,
+    # a set of derivations (probably from `mpvScripts`) where each is
+    # expected to have a `scriptName` passthru attribute that points to the
+    # name of the script that would reside in the script's derivation's
+    # `$out/share/mpv/scripts/`.
+    scripts ? [],
+    extraUmpvWrapperArgs ? []
+  }:
+  let
+    binPath = lib.makeBinPath ([
+      mpv.luaEnv
+    ] ++ lib.optionals youtubeSupport [
+      youtube-dl
+    ] ++ lib.optionals mpv.vapoursynthSupport [
+      mpv.vapoursynth.python3
+    ]);
+    # All arguments besides the input and output binaries (${mpv}/bin/mpv and
+    # $out/bin/mpv). These are used by the darwin specific makeWrapper call
+    # used to wrap $out/Applications/mpv.app/Contents/MacOS/mpv as well.
+    mostMakeWrapperArgs = builtins.concatStringsSep " " ([ "--argv0" "'$0'"
+      # These are always needed (TODO: Explain why)
+      "--prefix" "LUA_CPATH" "\\;" "${mpv.luaEnv}/lib/lua/${mpv.lua.luaversion}/\\?.so"
+      "--prefix" "LUA_PATH" "\\;" "${mpv.luaEnv}/share/lua/${mpv.lua.luaversion}/\\?.lua"
+    ] ++ lib.optionals mpv.vapoursynthSupport [
+      "--prefix" "PYTHONPATH" ":" "${mpv.vapoursynth}/lib/${mpv.vapoursynth.python3.sitePackages}"
+    ] ++ lib.optionals (binPath != "") [
+      "--prefix" "PATH" ":" binPath
+    ] ++ (lib.lists.flatten (map
+      # For every script in the `scripts` argument, add the necessary flags to the wrapper
+      (script:
+        [
+          "--add-flags"
+          # Here we rely on the existence of the `scriptName` passthru
+          # attribute of the script derivation from the `scripts`
+          "--script=${script}/share/mpv/scripts/${script.scriptName}"
+        ]
+      ) scripts
+    )) ++ extraMakeWrapperArgs)
+    ;
+    umpvWrapperArgs = builtins.concatStringsSep " " ([
+      "--argv0" "'$0'"
+      "--set" "MPV" "$out/bin/mpv"
+    ] ++ extraUmpvWrapperArgs)
+    ;
+  in
+    symlinkJoin {
+      name = "mpv-with-scripts-${mpv.version}";
 
-  buildInputs = [ makeWrapper ];
+      paths = [ mpv ];
 
-  postBuild = ''
-    wrapProgram $out/bin/mpv \
-      --add-flags "${stdenv.lib.concatMapStringsSep " " (x: "--script=${x}/share/mpv/scripts/${x.scriptName}") scripts}"
-  '';
-}
+      buildInputs = [ makeWrapper ];
+
+      passthru.unwrapped = mpv;
+
+      postBuild = ''
+        # wrapProgram can't operate on symlinks
+        rm "$out/bin/mpv"
+        makeWrapper "${mpv}/bin/mpv" "$out/bin/mpv" ${mostMakeWrapperArgs}
+        rm "$out/bin/umpv"
+        makeWrapper "${mpv}/bin/umpv" "$out/bin/umpv" ${umpvWrapperArgs}
+      '' + lib.optionalString stdenv.isDarwin ''
+        # wrapProgram can't operate on symlinks
+        rm "$out/Applications/mpv.app/Contents/MacOS/mpv"
+        makeWrapper "${mpv}/Applications/mpv.app/Contents/MacOS/mpv" "$out/Applications/mpv.app/Contents/MacOS/mpv" ${mostMakeWrapperArgs}
+      '';
+    };
+in
+  lib.makeOverridable wrapper

--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -36,6 +36,14 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  passthru = {
+    # If vapoursynth is added to the build inputs of mpv and then
+    # used in the wrapping of it, we want to know once inside the
+    # wrapper, what python3 version was used to build vapoursynth so
+    # the right python3.sitePackages will be used there.
+    inherit python3;
+  };
+
   postInstall = ''
     wrapProgram $out/bin/vspipe \
         --prefix PYTHONPATH : $out/${python3.sitePackages}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -302,6 +302,7 @@ mapAliases ({
   msf = metasploit; # added 2018-04-25
   libmsgpack = msgpack; # added 2018-08-17
   mssys = ms-sys; # added 2015-12-13
+  mpv-with-scripts = throw "Use wrapMpv for editing the environment of mpv"; # added 2012-05-22
   multipath_tools = multipath-tools;  # added 2016-01-21
   mupen64plus1_5 = mupen64plus; # added 2016-02-12
   mysqlWorkbench = mysql-workbench; # added 2017-01-19

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20862,12 +20862,14 @@ in
     libdvdnav = libdvdnav_4_2_1;
   } // (config.mplayer or {}));
 
-  mpv = callPackage ../applications/video/mpv {
+  mpv-unwrapped = callPackage ../applications/video/mpv {
     inherit lua;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Cocoa CoreAudio MediaPlayer;
   };
 
-  mpv-with-scripts = callPackage ../applications/video/mpv/wrapper.nix { };
+  # Wraps without trigerring a rebuild
+  wrapMpv = callPackage ../applications/video/mpv/wrapper.nix { };
+  mpv = wrapMpv mpv-unwrapped {};
 
   mpvScripts = recurseIntoAttrs {
     convert = callPackage ../applications/video/mpv/scripts/convert.nix {};


### PR DESCRIPTION
###### Motivation for this change

In https://github.com/NixOS/nixpkgs/pull/88136 I concluded that mpv's wrapping was done purely - both the "unwrapped" build had done some wrappings to the two executables in `$out/bin/`, while we already had an external wrapper derivation called `mpv-with-scripts`. This was bad because:

1) Users of `mpv-with-scripts` had their executable wrapped twice.
2) disabling `youtubeSupport` caused mpv to be wrapped twice while it was a mere change of including `youtube-dl` in the wrapper's `$PATH` or not.
3) If you'd want `youtubeSupport` enabled, but say you had an override for an updated `youtube-dl`, it was impossible to make mpv use your youtube-dl without recompiling it.

###### Things done

This PR is a rewrite of what was called `mpv-with-scripts` - it's now called `wrapMpv` (inspired by Neovim's `wrapNeovim` Nix function) and it's possible with it to satisfy both "_deterministics_" which want _everything_ to be configured exactly as they want via Nix while it enables everyone to tweak what's possible via an external wrapper which doesn't trigger a rebuild of mpv.

I tested `wrapMpv` with:

- [x] `mpv-unwrapped` was compiled with and without `vapoursynthSupport` enabled - checked that the wrapper got the same environment but:
  - [ ] I haven't tested functionality of this feature.
- [x] A certain script - checked that the necessary flags are added to the wrapper and also tested that the script works.
- [x] Tested that `youtubeSupport` works (of course it works as the exectuable has the same environment).

Besides that, as always:

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @pstch @AndersonTorres @jtojnar 