### PR TITLE
gnustep: update

### DIFF
--- a/pkgs/desktops/gnustep/back/default.nix
+++ b/pkgs/desktops/gnustep/back/default.nix
@@ -8,13 +8,13 @@
 , libXmu
 }:
 let
-  version = "0.27.0";
+  version = "0.28.0";
 in
 gsmakeDerivation {
   name = "gnustep-back-${version}";
   src = fetchurl {
     url = "ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-back-${version}.tar.gz";
-    sha256 = "0j400892ysxygh50i3918nn87vkxh15h892jwvphmkd34j8wdn9f";
+    sha256 = "1ynd27zwga17mp2qlym90k2xsypdvz24w6gyy2rfvmv0gkvlgrjr";
   };
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ cairo base gui freetype xlibsWrapper libXmu ];

--- a/pkgs/desktops/gnustep/base/default.nix
+++ b/pkgs/desktops/gnustep/base/default.nix
@@ -12,13 +12,13 @@
 , libiberty
 }:
 let
-  version = "1.26.0";
+  version = "1.27.0";
 in
 gsmakeDerivation {
   name = "gnustep-base-${version}";
   src = fetchurl {
     url = "ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-base-${version}.tar.gz";
-    sha256 = "0ws16rwqx0qvqpyjsxbdylfpkgjr19nqc9i3b30wywqcqrkc12zn";
+    sha256 = "10xjrv5d443wzll6lf9y65p6v9kvx7xxklhsm1j05y93vwgzl0w8";
   };
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [

--- a/pkgs/desktops/gnustep/gorm/default.nix
+++ b/pkgs/desktops/gnustep/gorm/default.nix
@@ -1,13 +1,13 @@
 { fetchurl, base, back, gsmakeDerivation, gui }:
 let
-  version = "1.2.24";
+  version = "1.2.26";
 in
 gsmakeDerivation {
   name = "gorm-${version}";
-  
+
   src = fetchurl {
     url = "ftp://ftp.gnustep.org/pub/gnustep/dev-apps/gorm-${version}.tar.gz";
-    sha256 = "1jw7vm5ia7ias1mm5if7vvvb66q50zwiqw0ksj5g14f11v8l61rf";
+    sha256 = "063f8rlz8py931hfrh95jxvr68bzs33bvckfigzbagp73n892jnw";
   };
   buildInputs = [ base back gui ];
 

--- a/pkgs/desktops/gnustep/gui/default.nix
+++ b/pkgs/desktops/gnustep/gui/default.nix
@@ -1,12 +1,12 @@
 { gsmakeDerivation, fetchurl, base }:
 let
-  version = "0.27.0";
+  version = "0.28.0";
 in
 gsmakeDerivation {
   name = "gnustep-gui-${version}";
   src = fetchurl {
     url = "ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-gui-${version}.tar.gz";
-    sha256 = "1m6k3fa2ndxv0kl2fazi76mwa27gn5jyp24q0rk96f2djhsy94br";
+    sha256 = "05wk8kbl75qj0jgawgyv9sp98wsgz5vl1s0d51sads0p0kk2sv8z";
   };
   buildInputs = [ base ];
   patches = [ ./fixup-all.patch ];

--- a/pkgs/desktops/gnustep/make/default.nix
+++ b/pkgs/desktops/gnustep/make/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, clang, which, libobjc }:
 
 let
-  version = "2.7.0";
+  version = "2.8.0";
 in
 
 stdenv.mkDerivation {
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-make-${version}.tar.gz";
-    sha256 = "1khiygfkz0zhh9b5nybn40g0xnnjxchk24n49hff1bwanszir84h";
+    sha256 = "0pfaylrr3xgn5026anmja4rv4l7nzzaqsrkxycyi0p4lvm12kklz";
   };
 
   configureFlags = [

--- a/pkgs/tools/archivers/unar/default.nix
+++ b/pkgs/tools/archivers/unar/default.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation rec {
     for f in Makefile.linux ../UniversalDetector/Makefile.linux ; do
       substituteInPlace $f \
         --replace "= gcc" "=cc" \
-        --replace "= g++" "=c++"
+        --replace "= g++" "=c++" \
+        --replace "-DGNU_RUNTIME=1" "" \
+        --replace "-fgnu-runtime" "-fobjc-nonfragile-abi"
     done
 
     # we need to build inside this directory as well, so we have to make it writeable


### PR DESCRIPTION
This includes #85400 and #85404, but also bumps gnustep.gui, gnustep.back and gnustep.gorm.

The unar build is fixed by modifying some CFLAGS, according to a FreeBSD bugreport.

cc @nh2. SOGo is merged now, including a test.

###### Motivation for this change
Upstream updates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
