### PR TITLE
fastd: v18 -> v19

### DIFF
--- a/pkgs/tools/networking/fastd/default.nix
+++ b/pkgs/tools/networking/fastd/default.nix
@@ -1,14 +1,15 @@
-{ stdenv, fetchgit, cmake, bison, pkgconfig
+{ stdenv, fetchFromGitHub, cmake, bison, pkgconfig
 , libuecc, libsodium, libcap, json_c }:
 
 stdenv.mkDerivation rec {
-  version = "18";
   pname = "fastd";
+  version = "19";
 
-  src = fetchgit {
-    url = "git://git.universe-factory.net/fastd";
+  src = fetchFromGitHub {
+    owner  = "Neoraider";
+    repo = "fastd";
     rev = "refs/tags/v${version}";
-    sha256 = "0c9v3igv3812b3jr7jk75a2np658yy00b3i4kpbpdjgvqzc1jrq8";
+    sha256 = "1h3whjvy2n2cyvbkbg4y1z9vlrn790spzbdhj4glwp93xcykhz5i";
   };
 
   postPatch = ''

--- a/pkgs/tools/networking/fastd/default.nix
+++ b/pkgs/tools/networking/fastd/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "Neoraider";
     repo = "fastd";
-    rev = "refs/tags/v${version}";
+    rev = "v${version}";
     sha256 = "1h3whjvy2n2cyvbkbg4y1z9vlrn790spzbdhj4glwp93xcykhz5i";
   };
 

--- a/pkgs/tools/networking/fastd/default.nix
+++ b/pkgs/tools/networking/fastd/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, bison, pkgconfig
-, libuecc, libsodium, libcap, json_c }:
+, libuecc, libsodium, libcap, json_c, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "fastd";
@@ -18,7 +18,11 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkgconfig bison cmake ];
-  buildInputs = [ libuecc libsodium libcap json_c ];
+  buildInputs = [ libuecc libsodium libcap json_c openssl ];
+
+  cmakeFlags = [
+    "-DENABLE_OPENSSL=true"
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream release. The repository moved to GitHub.

https://fastd.readthedocs.io/en/stable/releases/v19.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@fpletz