### PR TITLE
corerad: 0.2.4 -> 0.2.5

### DIFF
--- a/pkgs/tools/networking/corerad/default.nix
+++ b/pkgs/tools/networking/corerad/default.nix
@@ -2,24 +2,22 @@
 
 buildGoModule rec {
   pname = "corerad";
-  version = "0.2.4";
+  version = "0.2.5";
 
   src = fetchFromGitHub {
     owner = "mdlayher";
     repo = "corerad";
     rev = "v${version}";
-    sha256 = "1r9kvz1ylrnfc7y5c4knqhx6xngh1p8j1axb8bd7h7p51c4i7jz2";
+    sha256 = "0fi9wgv5aj3ds3r5qjyi4pxnd56psrpdy2sz84jd0sz2w48x4k4p";
   };
 
-  vendorSha256 = "0ncwf197dx6mqzg69mnyp0iyad585izmydm0yj8ikd0y8ngpx7a3";
+  vendorSha256 = "11r3vpimhik7y09gwb3p6pl0yf53hpaw24ry4a833fw8060rqp3q";
 
   buildFlagsArray = ''
     -ldflags=
-    -X github.com/mdlayher/corerad/internal/build.linkTimestamp=1589133047
+    -X github.com/mdlayher/corerad/internal/build.linkTimestamp=1590182656
     -X github.com/mdlayher/corerad/internal/build.linkVersion=v${version}
   '';
-
-  deleteVendor = true;
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/mdlayher/corerad";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New beta release of CoreRAD, removal of in-tree vendor directory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Built and tested on NixOS:

```
[matt@servnerr-3:~/src/nixpkgs]$ nix-build -A corerad                
these derivations will be built:                                                                 
  /nix/store/4ll04g86abqs54lrlxyzjq47qi1d93wj-corerad-0.2.5.drv                                                                                                                                    
building '/nix/store/4ll04g86abqs54lrlxyzjq47qi1d93wj-corerad-0.2.5.drv'...                      
unpacking sources       
...
[matt@servnerr-3:~/src/nixpkgs]$ ./result/bin/corerad -h
CoreRAD v0.2.5 BETA (2020-05-22)
flags:                                                                                           
  -c string                                                                                      
        path to configuration file (default "corerad.toml")
  -init                                    
        write out a default configuration file to "corerad.toml" and exit
```

I have also removed the `deleteVendor` directive which was added in https://github.com/NixOS/nixpkgs/pull/86376 because we no longer have a vendor directory in the CoreRAD tree. I understand the new buildGoModule behavior is to assemble its own using Go modules, so I believe this change is correct.

/cc @c00w @jonringer @marsam 