### PR TITLE
idris2: init at version 0.2.0-840e020

### DIFF
--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, makeWrapper
+, clang, chez
+}:
+
+# Uses scheme to bootstrap the build of idris2
+stdenv.mkDerivation {
+  name = "idris2";
+  version = "0.2.0-840e020";
+
+  src = fetchFromGitHub {
+    owner = "idris-lang";
+    repo = "Idris2";
+    rev = "840e020d8ccc332135e86f855ad78053ca15d603";
+    sha256 = "1l6pdjiglwd13pf56xwzbjzyyxgz48ypfggjgsgqk2w57rmbfy90";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ makeWrapper clang chez ];
+  buildInputs = [ chez ];
+
+  prePatch = ''
+    patchShebangs --build tests
+
+    # Do not run tests as part of the build process
+    substituteInPlace bootstrap.sh --replace "make test" "# make test"
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  # The name of the main executable of pkgs.chez is `scheme`
+  buildFlags = [ "bootstrap" "SCHEME=scheme" ];
+
+  # idris2 needs to find scheme at runtime to compile
+  postInstall = ''
+    wrapProgram "$out/bin/idris2" --prefix PATH : "${chez}/bin"
+  '';
+
+  meta = {
+    description = "A purely functional programming language with first class types";
+    homepage = https://github.com/idris-lang/Idris2;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ wchresta ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8705,6 +8705,8 @@ in
 
   idris = idrisPackages.with-packages [ idrisPackages.base ] ;
 
+  idris2 = callPackage ../development/compilers/idris2 { };
+
   intel-graphics-compiler = callPackage ../development/compilers/intel-graphics-compiler { };
 
   intercal = callPackage ../development/compilers/intercal { };


### PR DESCRIPTION
A purely functional programming language with first class types

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add a new derivation for `Idris2`, the successor of Idris.

This is my first *new* derivation. It does not have the fancy *infrastructure* that idris or haskell have, and it does not add any of the tooling that should be there. But I figured it's better than nothing.

I'm more than happy to edit this to support best practices, if anyone has suggestions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
