### PR TITLE
linux: CONFIG_MOUSE_ELAN_I2C_SMBUS=y

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -721,6 +721,7 @@ let
       PSI = whenAtLeast "4.20" yes;
 
       MODVERSIONS        = whenOlder "4.9" yes;
+      MOUSE_ELAN_I2C_SMBUS = yes;
       MOUSE_PS2_ELANTECH = yes; # Elantech PS/2 protocol extension
       MTRR_SANITIZER     = yes;
       NET_FC             = yes; # Fibre Channel driver support


### PR DESCRIPTION
###### Motivation for this change

Without [`CONFIG_MOUSE_ELAN_I2C_SMBUS`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/input/mouse/Kconfig?h=v5.6#n294), the kernel [warns](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/input/mouse/elantech.c?h=v5.6#n2052)

`psmouse serio1: elantech: The touchpad can support a better bus than the too old PS/2 protocol. Make sure MOUSE_PS2_ELANTECH_SMBUS and MOUSE_ELAN_I2C_SMBUS are enabled to get a better touchpad experience.`

and it is quite correct, at least on this laptop (ThinkPad Yoga 14 20FY), where `CONFIG_MOUSE_ELAN_I2C_SMBUS=y` in conjunction with `boot.extraModprobeConfig="options psmouse elantech_smbus=1"` are necessary to eliminate an annoying [sticky touchpad button issue](https://bugs.freedesktop.org/show_bug.cgi?id=98733).

`CONFIG_MOUSE_ELAN_I2C_SMBUS` is enabled in [Arch](https://git.archlinux.org/svntogit/packages.git/tree/trunk/config?h=packages/linux), [CentOS](https://git.centos.org/rpms/kernel/blob/c8/f/SOURCES/kernel-x86_64.config), [Fedora](https://src.fedoraproject.org/rpms/kernel/blob/master/f/kernel-x86_64-fedora.config), and [Ubuntu](https://kernel.ubuntu.com/git/ubuntu/ubuntu-focal.git/tree/debian.master/config/config.common.ubuntu). ([Debian](https://salsa.debian.org/kernel-team/linux/blob/master/debian/config/config) lacks its prerequisite `CONFIG_MOUSE_ELAN_I2C` entirely.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
