### PR TITLE
lumina: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/desktops/lumina/lumina-calculator/default.nix
+++ b/pkgs/desktops/lumina/lumina-calculator/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, qmake, qtbase, qttools }:
+{ stdenv, mkDerivation, fetchFromGitHub, qmake, qtbase, qttools }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lumina-calculator";
   version = "1.6.0";
 

--- a/pkgs/desktops/lumina/lumina-calculator/default.nix
+++ b/pkgs/desktops/lumina/lumina-calculator/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lumina-calculator";
-  version = "2019-04-27";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "lumina-desktop";
     repo = pname;
-    rev = "ccb792fc713aa7163fffd37fc20c83ffe9ca7523";
-    sha256 = "0cdyz94znycsc3qxg5bmg51bwms7586d4ja1bsmj8cb9pd3lv980";
+    rev = "v${version}";
+    sha256 = "1238d1m0mjkwkdpgq165a4ql9aql0aji5f41rzdzny6m7ws9nm2y";
   };
   
   sourceRoot = "source/src-qt5";

--- a/pkgs/desktops/lumina/lumina-pdf/default.nix
+++ b/pkgs/desktops/lumina/lumina-pdf/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, qmake, qtbase, qttools, poppler }:
+{ stdenv, mkDerivation, fetchFromGitHub, qmake, qtbase, qttools, poppler }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lumina-pdf";
   version = "1.6.0";
 

--- a/pkgs/desktops/lumina/lumina-pdf/default.nix
+++ b/pkgs/desktops/lumina/lumina-pdf/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lumina-pdf";
-  version = "2019-04-27";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "lumina-desktop";
     repo = pname;
-    rev = "645ed591ef91c3607d3ab87dd86f7acfd08b05c9";
-    sha256 = "0gl943jb9c9rcgb5wksx3946hwlifghfd27r97skm9is8ih6k0vn";
+    rev = "v${version}";
+    sha256 = "08caj4nashp79fbvj94rabn0iaa1hymifqmb782x03nb2vkn38r6";
   };
   
   sourceRoot = "source/src-qt5";

--- a/pkgs/desktops/lumina/lumina/default.nix
+++ b/pkgs/desktops/lumina/lumina/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lumina";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "lumina-desktop";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0rj2gzifr98db7i82cg3hg7l5yfik810pjpawg6n54qbzq987z25";
+    sha256 = "0bvs12c9pkc6fnkfcr7rrxc8jfbzbslch4nlfjrzwi203fcv4avw";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lumina/lumina/default.nix
+++ b/pkgs/desktops/lumina/lumina/default.nix
@@ -1,4 +1,5 @@
 { stdenv,
+  mkDerivation,
   fetchFromGitHub,
   desktop-file-utils,
   fluxbox,
@@ -14,7 +15,7 @@
   wrapGAppsHook
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lumina";
   version = "1.6.0";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Update lumina to version [1.6.0](https://github.com/lumina-desktop/lumina/releases/tag/v1.6.0).
- Use `mkDerivation` from `libsForQt5`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).