### PR TITLE
lieer: 1.1 -> 1.2

### DIFF
--- a/pkgs/applications/networking/lieer/default.nix
+++ b/pkgs/applications/networking/lieer/default.nix
@@ -28,6 +28,6 @@ python3Packages.buildPythonApplication rec {
     homepage         = "https://lieer.gaute.vetsj.com/";
     repositories.git = "https://github.com/gauteh/lieer.git";
     license          = licenses.gpl3Plus;
-    maintainers      = with maintainers; [ kaiha ];
+    maintainers      = with maintainers; [ flokli kaiha ];
   };
 }

--- a/pkgs/applications/networking/lieer/default.nix
+++ b/pkgs/applications/networking/lieer/default.nix
@@ -1,14 +1,12 @@
-{ stdenv, fetchFromGitHub, python3Packages }:
+{ stdenv, python3Packages }:
 
 python3Packages.buildPythonApplication rec {
   pname = "lieer";
-  version = "1.1";
+  version = "1.2";
 
-  src = fetchFromGitHub {
-    owner = "gauteh";
-    repo = "lieer";
-    rev = "v${version}";
-    sha256 = "19jx3sm925nrzl26km1bxbp6y5gk1mzwadd79vip2jl70b3xk9f8";
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "1cz0zi85sm3ffbrfn3nap3ad9krfwb1a9apfn0cb6fp2w0kcqrda";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
###### Motivation for this change
`gmi send` supporting `-t`, thus being compatible with neomutt (https://github.com/gauteh/lieer/pull/154)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
