### PR TITLE
python3Packages.pyspice: init at 1.4.3

### DIFF
--- a/pkgs/development/python-modules/pyspice/default.nix
+++ b/pkgs/development/python-modules/pyspice/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, libngspice
+, numpy
+, ply
+, scipy
+, pyyaml
+, cffi
+, requests
+, matplotlib
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "PySpice";
+  version = "1.4.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0mnyy8nr06d1al99kniyqcm0p9a8dvkg719s42sajl8yf51sayc9";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    requests
+    pyyaml
+    cffi
+    matplotlib
+    numpy
+    ply
+    scipy
+    libngspice
+  ];
+
+  doCheck = false;
+  pythonImportsCheck = [ "PySpice" ];
+
+  postPatch = ''
+    substituteInPlace PySpice/Spice/NgSpice/Shared.py --replace \
+        "ffi.dlopen(self.library_path)" \
+        "ffi.dlopen('${libngspice}/lib/libngspice${stdenv.hostPlatform.extensions.sharedLibrary}')"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simulate electronic circuit using Python and the Ngspice / Xyce simulators";
+    homepage = "https://github.com/FabriceSalvaire/PySpice";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ matthuszagh ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5383,6 +5383,8 @@ in {
 
   pyspf = callPackage ../development/python-modules/pyspf { };
 
+  pyspice = callPackage ../development/python-modules/pyspice { };
+
   pyspinel = callPackage ../development/python-modules/pyspinel { };
 
   pyspotify = callPackage ../development/python-modules/pyspotify { };


### PR DESCRIPTION
###### Motivation for this change
Adds [PySpice](https://github.com/FabriceSalvaire/PySpice). I tested this on some of the [examples in the doc](https://pyspice.fabrice-salvaire.fr/examples/index.html) and everything worked.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
