### PR TITLE
gnuradio: format arguments and inputs

### DIFF
--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -1,18 +1,35 @@
-{ stdenv, fetchFromGitHub, writeText, makeWrapper
+{ stdenv
+, fetchFromGitHub
+, makeWrapper
+, writeText
 # Dependencies documented @ https://gnuradio.org/doc/doxygen/build_guide.html
 # => core dependencies
-, cmake, pkgconfig, git, boost, cppunit, fftw
+, cmake
+, pkgconfig
+, git
+, boost
+, cppunit
+, fftw
 # => python wrappers
 # May be able to upgrade to swig3
-, python, swig2, numpy, scipy, matplotlib
+, python
+, swig2
+, numpy
+, scipy
+, matplotlib
 # => grc - the gnu radio companion
-, Mako, cheetah, pygtk # Note: GR is migrating to Mako. Cheetah should be removed for GR3.8
+, Mako
+, cheetah
+, pygtk # Note: GR is migrating to Mako. Cheetah should be removed for GR3.8
 # => gr-wavelet: collection of wavelet blocks
 , gsl
 # => gr-qtgui: the Qt-based GUI
-, qt4, qwt, pyqt4
+, qt4
+, qwt
+, pyqt4
 # => gr-wxgui: the Wx-based GUI
-, wxPython, lxml
+, wxPython
+, lxml
 # => gr-audio: audio subsystems (system/OS dependent)
 , alsaLib   # linux   'audio-alsa'
 , CoreAudio # darwin  'audio-osx'
@@ -21,7 +38,9 @@
 # => gr-video-sdl: PAL and NTSC display
 , SDL
 # Other
-, libusb1, orc, pyopengl
+, libusb1
+, orc
+, pyopengl
 }:
 
 stdenv.mkDerivation rec {
@@ -37,17 +56,39 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    cmake pkgconfig git makeWrapper cppunit orc
+    cmake
+    pkgconfig
+    git
+    makeWrapper
+    cppunit
+    orc
   ];
 
   buildInputs = [
-    boost fftw python swig2 lxml qt4
-    qwt SDL libusb1 uhd gsl
+    boost
+    fftw
+    python
+    swig2
+    lxml
+    qt4
+    qwt
+    SDL
+    libusb1
+    uhd
+    gsl
   ] ++ stdenv.lib.optionals stdenv.isLinux  [ alsaLib   ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreAudio ];
 
   propagatedBuildInputs = [
-    Mako cheetah numpy scipy matplotlib pyqt4 pygtk wxPython pyopengl
+    Mako
+    cheetah
+    numpy
+    scipy
+    matplotlib
+    pyqt4
+    pygtk
+    wxPython
+    pyopengl
   ];
 
   NIX_LDFLAGS = "-lpthread";


### PR DESCRIPTION
###### Motivation for this change

This PR is a trial at splitting https://github.com/NixOS/nixpkgs/pull/84401#issuecomment-633055424 into easier to review pieces. The changes here have no effect on the result of the gnuradio. As you can check for yourself with the following commands (assuming you have [hub](https://github.com/github/hub) installed).

```
nix show-derivation -f. gnuradio > /tmp/oldgnuradio.json
hub pr checkout 88693
nix show-derivation -f. gnuradio > /tmp/newgnuradio.json
diff /tmp/*gnuradio.json
```

Hence, I'm marking all of the items following as done because this isn't a real change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
