### PR TITLE
lnch: init at 2017-02-16

### DIFF
--- a/pkgs/tools/misc/lnch/default.nix
+++ b/pkgs/tools/misc/lnch/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, buildGoPackage }:
+
+buildGoPackage rec {
+  pname = "lnch";
+  version = "2017-02-16";
+
+  goPackagePath = "github.com/oem/${pname}";
+
+  src = fetchFromGitHub {
+    owner = "oem";
+    repo = pname;
+    rev = "f24eed5392f01d2c8a9cfe9cdf70dcfbbf4b6b36";
+    sha256 = "0skzrjnbxq1yj7y64cq7angp4wqnrgw1xp9v8vw9zp8f8zwmpy0y";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mitchellh/gox";
+    description = "A small go app that launches a process and moves it out of the process group";
+    platforms = platforms.all;
+    license = licenses.publicDomain; # really I don't know
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4648,6 +4648,8 @@ in
 
   lnav = callPackage ../tools/misc/lnav { };
 
+  lnch = callPackage ../tools/misc/lnch { };
+
   loadlibrary = callPackage ../tools/misc/loadlibrary { };
 
   loc = callPackage ../development/misc/loc { };


### PR DESCRIPTION
###### Motivation for this change


lnch is a small go app that launches a process and moves it out of the process
group. It is useful to some scripts that need to launch a process without
killing the previous one, like custom script app launchers for lightweight
window managers.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
