### PR TITLE
treewide: jdk: make it point to latest version

### DIFF
--- a/nixos/modules/programs/java.nix
+++ b/nixos/modules/programs/java.nix
@@ -25,16 +25,16 @@ in
             configuration:
           </para>
           <programlisting>
-            environment.variables.JAVA_HOME = ''${pkgs.jdk.home}/lib/openjdk;
-            environment.systemPackages = [ pkgs.jdk ];
+            environment.variables.JAVA_HOME = ''${pkgs.jdk8.home}/lib/openjdk;
+            environment.systemPackages = [ pkgs.jdk8 ];
           </programlisting>
           </note>
         '';
       };
 
       package = mkOption {
-        default = pkgs.jdk;
-        defaultText = "pkgs.jdk";
+        default = pkgs.jdk8;
+        defaultText = "pkgs.jdk8";
         description = ''
           Java package to install. Typical values are pkgs.jdk or pkgs.jre.
         '';

--- a/nixos/modules/services/amqp/activemq/default.nix
+++ b/nixos/modules/services/amqp/activemq/default.nix
@@ -10,7 +10,7 @@ let
   activemqBroker = stdenv.mkDerivation {
     name = "activemq-broker";
     phases = [ "installPhase" ];
-    buildInputs = [ jdk ];
+    buildInputs = [ jdk8 ];
     installPhase = ''
       mkdir -p $out/lib
       source ${activemq}/lib/classpath.env

--- a/nixos/modules/services/continuous-integration/jenkins/default.nix
+++ b/nixos/modules/services/continuous-integration/jenkins/default.nix
@@ -86,8 +86,8 @@ in {
       };
 
       packages = mkOption {
-        default = [ pkgs.stdenv pkgs.git pkgs.jdk config.programs.ssh.package pkgs.nix ];
-        defaultText = "[ pkgs.stdenv pkgs.git pkgs.jdk config.programs.ssh.package pkgs.nix ]";
+        default = [ pkgs.stdenv pkgs.git pkgs.jdk8 config.programs.ssh.package pkgs.nix ];
+        defaultText = "[ pkgs.stdenv pkgs.git pkgs.jdk8 config.programs.ssh.package pkgs.nix ]";
         type = types.listOf types.package;
         description = ''
           Packages to add to PATH for the jenkins process.
@@ -207,7 +207,7 @@ in {
 
       # For reference: https://wiki.jenkins.io/display/JENKINS/JenkinsLinuxStartupScript
       script = ''
-        ${pkgs.jdk}/bin/java ${concatStringsSep " " cfg.extraJavaOptions} -jar ${cfg.package}/webapps/jenkins.war --httpListenAddress=${cfg.listenAddress} \
+        ${pkgs.jdk8}/bin/java ${concatStringsSep " " cfg.extraJavaOptions} -jar ${cfg.package}/webapps/jenkins.war --httpListenAddress=${cfg.listenAddress} \
                                                   --httpPort=${toString cfg.port} \
                                                   --prefix=${cfg.prefix} \
                                                   -Djava.awt.headless=true \

--- a/nixos/modules/services/monitoring/datadog-agent.nix
+++ b/nixos/modules/services/monitoring/datadog-agent.nix
@@ -243,7 +243,7 @@ in {
 
       dd-jmxfetch = lib.mkIf (lib.hasAttr "jmx" cfg.checks) (makeService {
         description = "Datadog JMX Fetcher";
-        path = [ datadogPkg pkgs.python pkgs.sysstat pkgs.procps pkgs.jdk ];
+        path = [ datadogPkg pkgs.python pkgs.sysstat pkgs.procps pkgs.jdk8 ];
         serviceConfig.ExecStart = "${datadogPkg}/bin/dd-jmxfetch";
       });
 

--- a/nixos/modules/services/monitoring/dd-agent/dd-agent.nix
+++ b/nixos/modules/services/monitoring/dd-agent/dd-agent.nix
@@ -226,7 +226,7 @@ in {
 
       dd-jmxfetch = lib.mkIf (cfg.jmxConfig != null) {
         description = "Datadog JMX Fetcher";
-        path = [ pkgs.dd-agent pkgs.python pkgs.sysstat pkgs.procps pkgs.jdk ];
+        path = [ pkgs.dd-agent pkgs.python pkgs.sysstat pkgs.procps pkgs.jdk8 ];
         serviceConfig.ExecStart = "${pkgs.dd-agent}/bin/dd-jmxfetch";
       };
     };

--- a/nixos/modules/services/monitoring/riemann.nix
+++ b/nixos/modules/services/monitoring/riemann.nix
@@ -17,7 +17,7 @@ let
 
   launcher = writeScriptBin "riemann" ''
     #!/bin/sh
-    exec ${jdk}/bin/java ${concatStringsSep " " cfg.extraJavaOpts} \
+    exec ${jdk8}/bin/java ${concatStringsSep " " cfg.extraJavaOpts} \
       -cp ${classpath} \
       riemann.bin ${cfg.configFile}
   '';

--- a/nixos/modules/services/network-filesystems/xtreemfs.nix
+++ b/nixos/modules/services/network-filesystems/xtreemfs.nix
@@ -12,7 +12,7 @@ let
 
   startupScript = class: configPath: pkgs.writeScript "xtreemfs-osd.sh" ''
     #! ${pkgs.runtimeShell}
-    JAVA_HOME="${pkgs.jdk}"
+    JAVA_HOME="${pkgs.jdk8}"
     JAVADIR="${xtreemfs}/share/java"
     JAVA_CALL="$JAVA_HOME/bin/java -ea -cp $JAVADIR/XtreemFS.jar:$JAVADIR/BabuDB.jar:$JAVADIR/Flease.jar:$JAVADIR/protobuf-java-2.5.0.jar:$JAVADIR/Foundation.jar:$JAVADIR/jdmkrt.jar:$JAVADIR/jdmktk.jar:$JAVADIR/commons-codec-1.3.jar"
     $JAVA_CALL ${class} ${configPath}

--- a/nixos/modules/services/web-servers/tomcat.nix
+++ b/nixos/modules/services/web-servers/tomcat.nix
@@ -164,8 +164,8 @@ in
 
       jdk = mkOption {
         type = types.package;
-        default = pkgs.jdk;
-        defaultText = "pkgs.jdk";
+        default = pkgs.jdk8;
+        defaultText = "pkgs.jdk8";
         description = "Which JDK to use.";
       };
 
@@ -409,7 +409,7 @@ in
         Environment=[
           "CATALINA_BASE=${cfg.baseDir}"
           "CATALINA_PID=/run/tomcat/tomcat.pid"
-          "JAVA_HOME='${cfg.jdk}'"
+          "JAVA_HOME='${cfg.jdk8}'"
           "JAVA_OPTS='${builtins.toString cfg.javaOpts}'"
           "CATALINA_OPTS='${builtins.toString cfg.catalinaOpts}'"
         ] ++ cfg.extraEnvironment;

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -133,7 +133,7 @@ in rec {
         (onFullSupported "nixos.tests.xfce")
         (onSystems ["i686-linux"] "nixos.tests.zfs.installer")
         (onFullSupported "nixpkgs.emacs")
-        (onFullSupported "nixpkgs.jdk")
+        (onFullSupported "nixpkgs.jdk8")
         ["nixpkgs.tarball"]
       ];
     };

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -66,7 +66,7 @@ in rec {
       gettext
       git
       imagemagick
-      jdk
+      jdk8
       linux
       mysql
       nginx

--- a/pkgs/applications/audio/axoloti/default.nix
+++ b/pkgs/applications/audio/axoloti/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchurl, makeWrapper, unzip
 , gnumake, gcc-arm-embedded, binutils-arm-embedded
-, dfu-util-axoloti, jdk, ant, libfaketime }:
+, dfu-util-axoloti, jdk8, ant, libfaketime }:
 
 stdenv.mkDerivation rec {
   version = "1.0.12-2";
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     dfu-util-axoloti
     ant
   ];
-  buildInputs = [jdk libfaketime ];
+  buildInputs = [jdk8 libfaketime ];
 
   patchPhase = ''
     unzip ${chibios}
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
     cp -r doc firmware chibios platform_linux CMSIS *.txt $out/share/axoloti/
     install -vD dist/Axoloti.jar $out/share/axoloti/
 
-    makeWrapper ${jdk}/bin/java $out/bin/axoloti --add-flags "-Daxoloti_release=$out/share/axoloti -Daxoloti_runtime=$out/share/axoloti -jar $out/share/axoloti/Axoloti.jar"
+    makeWrapper ${jdk8}/bin/java $out/bin/axoloti --add-flags "-Daxoloti_release=$out/share/axoloti -Daxoloti_runtime=$out/share/axoloti -jar $out/share/axoloti/Axoloti.jar"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, alsaLib, bzip2, cairo, dpkg, freetype, gdk-pixbuf
-, wrapGAppsHook, gtk2, gtk3, harfbuzz, jdk, lib, xorg
+, wrapGAppsHook, gtk2, gtk3, harfbuzz, jdk8, lib, xorg
 , libbsd, libjack2, libpng, ffmpeg
 , libxkbcommon
 , makeWrapper, pixman, autoPatchelfHook
@@ -45,8 +45,8 @@ stdenv.mkDerivation rec {
     )
 
     # Use our OpenJDK instead of Bitwig’s bundled—and commercial!—one.
-    rm -rf $out/libexec/lib/jre
-    ln -s ${jdk.home}/jre $out/libexec/lib/jre
+    rm -rf $out/libexec/lib/jre8
+    ln -s ${jdk8.home}/jre8 $out/libexec/lib/jre8
 
     mkdir -p $out/bin
     ln -s $out/libexec/bitwig-studio $out/bin/bitwig-studio

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
@@ -16,8 +16,8 @@ bitwig-studio1.overrideAttrs (oldAttrs: rec {
   installPhase = ''
     ${oldAttrs.installPhase}
 
-    # recover commercial jre
-    rm -f $out/libexec/lib/jre
-    cp -r opt/bitwig-studio/lib/jre $out/libexec/lib
+    # recover commercial jre8
+    rm -f $out/libexec/lib/jre8
+    cp -r opt/bitwig-studio/lib/jre8 $out/libexec/lib
   '';
 })

--- a/pkgs/applications/backup/areca/default.nix
+++ b/pkgs/applications/backup/areca/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ant, jre, jdk, swt, acl, attr }:
+{ stdenv, fetchurl, ant, jre8, jdk8, swt, acl, attr }:
 
 stdenv.mkDerivation {
   name = "areca-7.5";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   sourceRoot = ".";
 
-  buildInputs = [ jdk ant acl attr ];
+  buildInputs = [ jdk8 ant acl attr ];
 
   patches = [ ./fix-javah-bug.diff ];
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     substituteInPlace build.xml --replace "/usr/lib/java/swt.jar" "${swt}/jars/swt.jar"
     substituteInPlace build.xml --replace "gcc" "${stdenv.cc}/bin/gcc"
     substituteInPlace areca.sh --replace "bin/" ""
-    substituteInPlace bin/areca_run.sh --replace "/usr/java" "${jre}/lib/openjdk"
+    substituteInPlace bin/areca_run.sh --replace "/usr/java" "${jre8}/lib/openjdk"
     substituteInPlace bin/areca_run.sh --replace "/usr/lib/java/swt.jar" "${swt}/jars/swt.jar"
 
     # Fix for NixOS/nixpkgs/issues/53716

--- a/pkgs/applications/blockchains/ergo/default.nix
+++ b/pkgs/applications/blockchains/ergo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "ergo";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   dontUnpack = true;
 
   installPhase = ''
-    makeWrapper ${jre}/bin/java $out/bin/ergo --add-flags "-jar $src"
+    makeWrapper ${jre8}/bin/java $out/bin/ergo --add-flags "-jar $src"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/blockchains/tessera.nix
+++ b/pkgs/applications/blockchains/tessera.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "tessera";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   dontUnpack = true;
 
   installPhase = ''
-    makeWrapper ${jre}/bin/java $out/bin/tessera --add-flags "-jar $src"
+    makeWrapper ${jre8}/bin/java $out/bin/tessera --add-flags "-jar $src"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/editors/eclipse/build-eclipse.nix
+++ b/pkgs/applications/editors/eclipse/build-eclipse.nix
@@ -1,5 +1,5 @@
 { stdenv, makeDesktopItem, freetype, fontconfig, libX11, libXrender
-, zlib, jdk, glib, gtk, libXtst, gsettings-desktop-schemas, webkitgtk
+, zlib, jdk8, glib, gtk, libXtst, gsettings-desktop-schemas, webkitgtk
 , makeWrapper, ... }:
 
 { name, src ? builtins.getAttr stdenv.hostPlatform.system sources, sources ? null, description }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    fontconfig freetype glib gsettings-desktop-schemas gtk jdk libX11
+    fontconfig freetype glib gsettings-desktop-schemas gtk jdk8 libX11
     libXrender libXtst makeWrapper zlib
   ] ++ stdenv.lib.optional (webkitgtk != null) webkitgtk;
 
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     productVersion=$(sed 's/version=//; t; d' $out/eclipse/.eclipseproduct)
 
     makeWrapper $out/eclipse/eclipse $out/bin/eclipse \
-      --prefix PATH : ${jdk}/bin \
+      --prefix PATH : ${jdk8}/bin \
       --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath ([ glib gtk libXtst ] ++ stdenv.lib.optional (webkitgtk != null) webkitgtk)} \
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
       --add-flags "-configuration \$HOME/.eclipse/''${productId}_$productVersion/configuration"

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, makeDesktopItem, makeWrapper
 , freetype, fontconfig, libX11, libXrender, zlib
-, glib, gtk3, gtk2, libXtst, jdk, jdk8, gsettings-desktop-schemas
+, glib, gtk3, gtk2, libXtst, jdk8, gsettings-desktop-schemas
 , webkitgtk ? null  # for internal web browser
 , buildEnv, runCommand
 , callPackage
@@ -22,7 +22,7 @@ in rec {
 
   buildEclipse = callPackage ./build-eclipse.nix {
     inherit stdenv makeDesktopItem freetype fontconfig libX11 libXrender zlib
-            jdk glib gtk libXtst gsettings-desktop-schemas webkitgtk
+            jdk8 glib gtk libXtst gsettings-desktop-schemas webkitgtk
             makeWrapper;
   };
 
@@ -65,7 +65,7 @@ in rec {
   ### Eclipse Scala SDK
 
   eclipse-scala-sdk =
-    buildEclipse.override { jdk = jdk8; gtk = gtk2; } {
+    buildEclipse.override { gtk = gtk2; } {
       name = "eclipse-scala-sdk-4.7.0";
       description = "Eclipse IDE for Scala Developers";
       src =

--- a/pkgs/applications/editors/jedit/default.nix
+++ b/pkgs/applications/editors/jedit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ant, jdk, commonsBsf, commonsLogging, bsh }:
+{ stdenv, fetchurl, ant, jdk8, commonsBsf, commonsLogging, bsh }:
 
 let
   version = "5.2.0";
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
     sha256 = "03wmbh90rl5lsc35d7jwcp9j5qyyzq1nccxf4fal8bmnx8n4si0x";
   };
 
-  buildInputs = [ ant jdk commonsBsf commonsLogging ];
+  buildInputs = [ ant jdk8 commonsBsf commonsLogging ];
 
   # This patch removes from the build process:
   #  - the automatic download of dependencies (see configurePhase);
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
     patch package-files/linux/jedit << EOF
     5a6,8
     > # specify the correct JAVA_HOME
-    > JAVA_HOME=${jdk.jre.home}/jre
+    > JAVA_HOME=${jdk8.jre.home}/jre8
     > 
     EOF
     sed -i "s|/usr/share/jEdit/@jar.filename@|$out/share/jEdit/jedit.jar|g" package-files/linux/jedit

--- a/pkgs/applications/editors/music/tuxguitar/default.nix
+++ b/pkgs/applications/editors/music/tuxguitar/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, swt, jdk, makeWrapper, alsaLib, jack2, fluidsynth, libpulseaudio }:
+{ stdenv, fetchurl, swt, jdk8, makeWrapper, alsaLib, jack2, fluidsynth, libpulseaudio }:
 
 let metadata = assert stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux";
   if stdenv.hostPlatform.system == "i686-linux" then
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
     ln -s $out/share $out/bin/share
 
     wrapProgram $out/bin/tuxguitar \
-      --set JAVA "${jdk}/bin/java" \
+      --set JAVA "${jdk8}/bin/java" \
       --prefix LD_LIBRARY_PATH : "$out/lib/:${stdenv.lib.makeLibraryPath [ swt alsaLib jack2 fluidsynth libpulseaudio ]}" \
       --prefix CLASSPATH : "${swt}/jars/swt.jar:$out/lib/tuxguitar.jar:$out/lib/itext.jar"
   '';

--- a/pkgs/applications/editors/netbeans/default.nix
+++ b/pkgs/applications/editors/netbeans/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, makeWrapper, makeDesktopItem, which, unzip, libicns, imagemagick
-, jdk, perl, python
+, jdk8, perl, python
 }:
 
 let
@@ -32,9 +32,9 @@ stdenv.mkDerivation {
     mkdir -pv $out/bin
     cp -a netbeans $out
     makeWrapper $out/netbeans/bin/netbeans $out/bin/netbeans \
-      --prefix PATH : ${stdenv.lib.makeBinPath [ jdk which ]} \
-      --prefix JAVA_HOME : ${jdk.home} \
-      --add-flags "--jdkhome ${jdk.home}"
+      --prefix PATH : ${stdenv.lib.makeBinPath [ jdk8 which ]} \
+      --prefix JAVA_HOME : ${jdk8.home} \
+      --add-flags "--jdkhome ${jdk8.home}"
 
     # Extract pngs from the Apple icon image and create
     # the missing ones from the 1024x1024 image.

--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -1,6 +1,6 @@
 { lib, mkDerivation, fetchurl, fetchpatch, fetchFromGitHub, makeDesktopItem, cmake, boost, zlib
 , openssl, R, qtbase, qtxmlpatterns, qtsensors, qtwebengine, qtwebchannel
-, libuuid, hunspellDicts, unzip, ant, jdk, gnumake, makeWrapper, pandoc
+, libuuid, hunspellDicts, unzip, ant, jdk8, gnumake, makeWrapper, pandoc
 , llvmPackages
 }:
 
@@ -17,7 +17,7 @@ mkDerivation rec {
   pname = "RStudio";
   inherit version;
 
-  nativeBuildInputs = [ cmake unzip ant jdk makeWrapper pandoc ];
+  nativeBuildInputs = [ cmake unzip ant jdk8 makeWrapper pandoc ];
 
   buildInputs = [ boost zlib openssl R qtbase qtxmlpatterns qtsensors
                   qtwebengine qtwebchannel libuuid ];

--- a/pkgs/applications/graphics/alchemy/default.nix
+++ b/pkgs/applications/graphics/alchemy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, runtimeShell }:
+{ stdenv, fetchurl, jre8, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "alchemy";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     cat >> $out/bin/alchemy << EOF
     #!${runtimeShell}
     cd $out/share/alchemy
-    ${jre}/bin/java -jar Alchemy.jar "$@"
+    ${jre8}/bin/java -jar Alchemy.jar "$@"
     EOF
     chmod +x $out/bin/alchemy
   '';

--- a/pkgs/applications/graphics/imagej/default.nix
+++ b/pkgs/applications/graphics/imagej/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, unzip, makeWrapper }:
+{ stdenv, fetchurl, jre8, unzip, makeWrapper }:
 
 # Note:
 # - User config dir is hard coded by upstream to $HOME/.imagej on linux systems
@@ -16,7 +16,7 @@ let
       sha256 = "97aba6fc5eb908f5160243aebcdc4965726693cb1353d9c0d71b8f5dd832cb7b";
     };
     buildInputs = [ unzip makeWrapper ];
-    inherit jre;
+    inherit jre8;
 
     # JAR files that are intended to be used by other packages
     # should go to $out/share/java.
@@ -28,7 +28,7 @@ let
       cp ij.jar $out/share/java
       cp -dR luts macros plugins $out/share
       mkdir $out/bin
-      makeWrapper ${jre}/bin/java $out/bin/imagej \
+      makeWrapper ${jre8}/bin/java $out/bin/imagej \
         --add-flags "-jar $out/share/java/ij.jar -ijpath $out/share"
     '';
     meta = with stdenv.lib; {

--- a/pkgs/applications/graphics/processing/default.nix
+++ b/pkgs/applications/graphics/processing/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       --replace 'Messages.showWarning' 'if (false) Messages.showWarning'
 
     ( cd build
-      substituteInPlace build.xml --replace "jre-download," ""  # do not download jre1.8.0_144
+      substituteInPlace build.xml --replace "jre8-download," ""  # do not download jre1.8.0_144
       mkdir -p linux/jre1.8.0_144                               # fake dir to avoid error
       ant build )
   '';

--- a/pkgs/applications/graphics/swingsane/default.nix
+++ b/pkgs/applications/graphics/swingsane/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeDesktopItem, unzip, jre, runtimeShell }:
+{ stdenv, fetchurl, makeDesktopItem, unzip, jre8, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "swingsane";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
     execWrapper = ''
       #!${runtimeShell}
-      exec ${jre}/bin/java -jar $out/share/java/swingsane/swingsane-${version}.jar "$@"
+      exec ${jre8}/bin/java -jar $out/share/java/swingsane/swingsane-${version}.jar "$@"
     '';
 
     desktopItem = makeDesktopItem {

--- a/pkgs/applications/graphics/yed/default.nix
+++ b/pkgs/applications/graphics/yed/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, makeWrapper, unzip, jre }:
+{ stdenv, fetchzip, makeWrapper, unzip, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "yEd";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     cp -r * $out/yed
     mkdir -p $out/bin
 
-    makeWrapper ${jre}/bin/java $out/bin/yed \
+    makeWrapper ${jre8}/bin/java $out/bin/yed \
       --add-flags "-jar $out/yed/yed.jar --"
   '';
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     homepage = "https://www.yworks.com/products/yed";
     description = "A powerful desktop application that can be used to quickly and effectively generate high-quality diagrams";
-    platforms = jre.meta.platforms;
+    platforms = jre8.meta.platforms;
     maintainers = with maintainers; [ abbradar ];
   };
 }

--- a/pkgs/applications/graphics/zgrviewer/default.nix
+++ b/pkgs/applications/graphics/zgrviewer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, unzip, runtimeShell }:
+{ stdenv, fetchurl, jre8, unzip, runtimeShell }:
 stdenv.mkDerivation rec {
   version = "0.9.0";
   pname = "zgrviewer";
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/zvtm/${pname}/${version}/${pname}-${version}.zip";
     sha256 = "1yg2rck81sqqrgfi5kn6c1bz42dr7d0zqpcsdjhicssi1y159f23";
   };
-  buildInputs = [jre unzip];
+  buildInputs = [jre8 unzip];
   buildPhase = "";
   installPhase = ''
     mkdir -p "$out"/{bin,share/java/zvtm/plugins,share/doc/zvtm}
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     cp -r target/* "$out/share/java/zvtm/"
 
     echo '#!${runtimeShell}' > "$out/bin/zgrviewer"
-    echo "${jre}/lib/openjdk/jre/bin/java -jar '$out/share/java/zvtm/zgrviewer-${version}.jar' \"\$@\"" >> "$out/bin/zgrviewer"
+    echo "${jre8}/lib/openjdk/jre8/bin/java -jar '$out/share/java/zvtm/zgrviewer-${version}.jar' \"\$@\"" >> "$out/bin/zgrviewer"
     chmod a+x "$out/bin/zgrviewer"
   '';
   meta = {

--- a/pkgs/applications/misc/dbvisualizer/default.nix
+++ b/pkgs/applications/misc/dbvisualizer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 stdenv.mkDerivation {
   name = "dbvisualizer-9.5.7";
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     cp -a . $out
     ln -sf $out/dbvis $out/bin
-    wrapProgram $out/bin/dbvis --set INSTALL4J_JAVA_HOME ${jre}
+    wrapProgram $out/bin/dbvis --set INSTALL4J_JAVA_HOME ${jre8}
   '';
 
   meta = {

--- a/pkgs/applications/misc/emem/default.nix
+++ b/pkgs/applications/misc/emem/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchurl, jdk }:
+{ stdenv, fetchurl, jdk8 }:
 
 stdenv.mkDerivation rec {
   pname = "emem";
   version = "0.2.50";
 
-  inherit jdk;
+  inherit jdk8;
 
   src = fetchurl {
     url = "https://github.com/ebzzry/${pname}/releases/download/v${version}/${pname}.jar";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
     cat > $out/bin/${pname} << EOF
 #! $SHELL
-$jdk/bin/java -jar $out/share/java/${pname}.jar "\$@"
+$jdk8/bin/java -jar $out/share/java/${pname}.jar "\$@"
 EOF
 
     chmod +x $out/bin/${pname}

--- a/pkgs/applications/misc/freemind/default.nix
+++ b/pkgs/applications/misc/freemind/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jdk, jre, ant }:
+{ stdenv, fetchurl, jdk8, jre8, ant }:
 
 stdenv.mkDerivation rec {
   pname = "freemind";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "06c6pm7hpwh9hbmyah3lj2wp1g957x8znfwc5cwygsi7dc98b0h1";
   };
 
-  buildInputs = [ jdk ant ];
+  buildInputs = [ jdk8 ant ];
 
   preConfigure = ''
     chmod +x check_for_duplicate_resources.sh
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
     cat >$out/bin/freemind <<EOF
     #! ${stdenv.shell}
-    JAVA_HOME=${jre} $out/nix-support/dist/freemind.sh
+    JAVA_HOME=${jre8} $out/nix-support/dist/freemind.sh
     EOF
     chmod +x $out/{bin/freemind,nix-support/dist/freemind.sh}
   '';

--- a/pkgs/applications/misc/ganttproject-bin/default.nix
+++ b/pkgs/applications/misc/ganttproject-bin/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchzip, makeDesktopItem, makeWrapper
-, jre
+, jre8
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
 
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
     mkdir -pv "$out/bin"
     wrapProgram "$out/share/ganttproject/ganttproject" \
-      --set JAVA_HOME "${jre}" \
+      --set JAVA_HOME "${jre8}" \
       --set _JAVA_OPTIONS "${builtins.toString javaOptions}"
 
     mv -v "$out/share/ganttproject/ganttproject" "$out/bin"

--- a/pkgs/applications/misc/ipmiview/default.nix
+++ b/pkgs/applications/misc/ipmiview/default.nix
@@ -29,10 +29,10 @@ stdenv.mkDerivation rec {
       else throw "IPMIView is not supported on this platform";
     in
   ''
-    patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ libX11 libXext libXrender libXtst libXi ]}" ./jre/lib/amd64/libawt_xawt.so
-    patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ freetype ]}" ./jre/lib/amd64/libfontmanager.so
+    patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ libX11 libXext libXrender libXtst libXi ]}" ./jre8/lib/amd64/libawt_xawt.so
+    patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ freetype ]}" ./jre8/lib/amd64/libfontmanager.so
     patchelf --set-rpath "${gcc-unwrapped.lib}/lib" ./libiKVM64.so
-    patchelf --set-rpath "${gcc.cc}/lib:$out/jre/lib/amd64/jli" --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./jre/bin/java
+    patchelf --set-rpath "${gcc.cc}/lib:$out/jre8/lib/amd64/jli" --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./jre8/bin/java
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./BMCSecurity/${stunnelBinary}
   '';
 
@@ -54,9 +54,9 @@ stdenv.mkDerivation rec {
     # PATH: iputils is used for ping, and psmisc is for killall
     # WORK_DIR: unfortunately the ikvm related binaries are loaded from
     #           and user configuration is written to files in the CWD
-    makeWrapper $out/jre/bin/java $out/bin/IPMIView \
+    makeWrapper $out/jre8/bin/java $out/bin/IPMIView \
       --set LD_LIBRARY_PATH "${stdenv.lib.makeLibraryPath [ fontconfig ]}" \
-      --prefix PATH : "$out/jre/bin:${iputils}/bin:${psmisc}/bin" \
+      --prefix PATH : "$out/jre8/bin:${iputils}/bin:${psmisc}/bin" \
       --add-flags "-jar $out/IPMIView20.jar" \
       --run 'WORK_DIR=''${XDG_DATA_HOME:-~/.local/share}/ipmiview
              mkdir -p $WORK_DIR

--- a/pkgs/applications/misc/mkgmap/default.nix
+++ b/pkgs/applications/misc/mkgmap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchsvn, jdk, jre, ant, makeWrapper }:
+{ stdenv, fetchurl, fetchsvn, jdk8, jre8, ant, makeWrapper }:
 
 let
   fastutil = fetchurl {
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   # the automatic download of dependencies (see configurePhase)
   patches = [ ./build.xml.patch ];
 
-  nativeBuildInputs = [ jdk ant makeWrapper ];
+  nativeBuildInputs = [ jdk8 ant makeWrapper ];
 
   configurePhase = ''
     mkdir -p lib/compile
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     install -Dm644 mkgmap.jar $out/share/java/mkgmap/mkgmap.jar
     install -Dm644 doc/mkgmap.1 $out/share/man/man1/mkgmap.1
     cp -r lib/ $out/share/java/mkgmap/
-    makeWrapper ${jre}/bin/java $out/bin/mkgmap \
+    makeWrapper ${jre8}/bin/java $out/bin/mkgmap \
       --add-flags "-jar $out/share/java/mkgmap/mkgmap.jar"
   '';
 

--- a/pkgs/applications/misc/mucommander/default.nix
+++ b/pkgs/applications/misc/mucommander/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gradle_4_10, perl, makeWrapper, jre, gsettings-desktop-schemas }:
+{ stdenv, fetchFromGitHub, gradle_4_10, perl, makeWrapper, jre8, gsettings-desktop-schemas }:
 
 let
   version = "0.9.3-3";
@@ -73,7 +73,7 @@ in stdenv.mkDerivation {
     tar xvf build/distributions/mucommander-${version}.tar --directory=$out --strip=1
     wrapProgram $out/bin/mucommander \
       --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name} \
-      --set JAVA_HOME ${jre}
+      --set JAVA_HOME ${jre8}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/mysql-workbench/default.nix
+++ b/pkgs/applications/misc/mysql-workbench/default.nix
@@ -24,7 +24,7 @@
 , libsecret
 , libssh
 , python2
-, jre
+, jre8
 , boost
 , libsigcxx
 , libX11
@@ -87,7 +87,7 @@ in stdenv.mkDerivation rec {
     cmake
     ninja
     pkgconfig
-    jre
+    jre8
     swig
     wrapGAppsHook
   ];

--- a/pkgs/applications/misc/omegat.nix
+++ b/pkgs/applications/misc/omegat.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, jdk, makeWrapper}:
+{ stdenv, fetchurl, unzip, jdk8, makeWrapper}:
 
 stdenv.mkDerivation {
   version = "4.3.0";
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
     cat > $out/bin/omegat <<EOF
     #! $SHELL -e
     CLASSPATH="$out/lib"
-    exec ${jdk}/bin/java -jar -Xmx1024M $out/OmegaT.jar "\$@"
+    exec ${jdk8}/bin/java -jar -Xmx1024M $out/OmegaT.jar "\$@"
     EOF
     chmod +x $out/bin/omegat
   '';

--- a/pkgs/applications/misc/projectlibre/default.nix
+++ b/pkgs/applications/misc/projectlibre/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, ant, jdk, makeWrapper, jre, coreutils, which }:
+{ stdenv, fetchgit, ant, jdk8, makeWrapper, jre8, coreutils, which }:
 
 stdenv.mkDerivation rec {
   pname = "projectlibre";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0vy5vgbp45ai957gaby2dj1hvmbxfdlfnwcanwqm9f8q16qipdbq";
   };
 
-  buildInputs = [ ant jdk makeWrapper ];
+  buildInputs = [ ant jdk8 makeWrapper ];
   buildPhase = ''
     export ANT_OPTS=-Dbuild.sysclasspath=ignore
     ${ant}/bin/ant -f openproj_build/build.xml
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       --replace "\"/usr/share/projectlibre\"" "\"$out/share/projectlibre\""
     chmod +x $out/bin/projectlibre
     wrapProgram $out/bin/projectlibre \
-     --prefix PATH : "${jre}/bin:${coreutils}/bin:${which}/bin"
+     --prefix PATH : "${jre8}/bin:${coreutils}/bin:${which}/bin"
 
     cp -R openproj_build/dist/* $out/share/projectlibre
     cp -R openproj_build/license $out/share/doc/projectlibre

--- a/pkgs/applications/misc/sweethome3d/default.nix
+++ b/pkgs/applications/misc/sweethome3d/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchsvn, makeWrapper, makeDesktopItem, jdk, jre, ant
+{ lib, stdenv, fetchurl, fetchsvn, makeWrapper, makeDesktopItem, jdk8, jre8, ant
 , gtk3, gsettings-desktop-schemas, p7zip, libXxf86vm }:
 
 let
@@ -34,7 +34,7 @@ let
       patchelf --set-rpath ${libXxf86vm}/lib lib/java3d-1.6/linux/i586/libnativewindow_x11.so
     '';
 
-    buildInputs = [ ant jdk jre makeWrapper p7zip gtk3 gsettings-desktop-schemas ];
+    buildInputs = [ ant jdk8.jre makeWrapper p7zip gtk3 gsettings-desktop-schemas ];
 
     buildPhase = ''
       ant furniture textures help
@@ -51,7 +51,7 @@ let
 
       cp "${sweethome3dItem}/share/applications/"* $out/share/applications
 
-      makeWrapper ${jre}/bin/java $out/bin/$exec \
+      makeWrapper ${jre8}/bin/java $out/bin/$exec \
         --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3.out}/share:${gsettings-desktop-schemas}/share:$out/share:$GSETTINGS_SCHEMAS_PATH" \
         --add-flags "-jar $out/share/java/${module}-${version}.jar -cp $out/share/java/Furniture.jar:$out/share/java/Textures.jar:$out/share/java/Help.jar -d${toString stdenv.hostPlatform.parsed.cpu.bits}"
     '';

--- a/pkgs/applications/misc/sweethome3d/editors.nix
+++ b/pkgs/applications/misc/sweethome3d/editors.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchcvs, makeWrapper, makeDesktopItem, jdk, jre, ant
+{ stdenv, fetchcvs, makeWrapper, makeDesktopItem, jdk8, jre8, ant
 , gtk3, gsettings-desktop-schemas, sweethome3dApp }:
 
 let
@@ -23,7 +23,7 @@ let
       categories = "Application;Graphics;2DGraphics;3DGraphics;";
     };
 
-    buildInputs = [ ant jre jdk makeWrapper gtk3 gsettings-desktop-schemas ];
+    buildInputs = [ ant jre8 jdk8 makeWrapper gtk3 gsettings-desktop-schemas ];
 
     patchPhase = ''
       sed -i -e 's,../SweetHome3D,${application.src},g' build.xml
@@ -31,7 +31,7 @@ let
     '';
 
     buildPhase = ''
-      ant -lib ${application.src}/libtest -lib ${application.src}/lib -lib ${jdk}/lib
+      ant -lib ${application.src}/libtest -lib ${application.src}/lib -lib ${jdk8}/lib
     '';
 
     installPhase = ''
@@ -39,7 +39,7 @@ let
       mkdir -p $out/share/{java,applications}
       cp ${module}-${version}.jar $out/share/java/.
       cp "${editorItem}/share/applications/"* $out/share/applications
-      makeWrapper ${jre}/bin/java $out/bin/$exec \
+      makeWrapper ${jre8}/bin/java $out/bin/$exec \
         --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3.out}/share:${gsettings-desktop-schemas}/share:$out/share:$GSETTINGS_SCHEMAS_PATH" \
         --add-flags "-jar $out/share/java/${module}-${version}.jar -d${toString stdenv.hostPlatform.parsed.cpu.bits}"
     '';

--- a/pkgs/applications/misc/tabula/default.nix
+++ b/pkgs/applications/misc/tabula/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, jre, makeWrapper }:
+{ stdenv, fetchzip, jre8, makeWrapper }:
 
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     mkdir -pv $out/share/tabula
     cp -v * $out/share/tabula
 
-    makeWrapper ${jre}/bin/java $out/bin/tabula --add-flags "-jar $out/share/tabula/tabula.jar"
+    makeWrapper ${jre8}/bin/java $out/bin/tabula --add-flags "-jar $out/share/tabula/tabula.jar"
   '';
 
 

--- a/pkgs/applications/misc/tvbrowser/bin.nix
+++ b/pkgs/applications/misc/tvbrowser/bin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre, makeDesktopItem }:
+{ stdenv, fetchurl, makeWrapper, jre8, makeDesktopItem }:
 
 let
   desktopItem = makeDesktopItem {
@@ -41,7 +41,7 @@ in stdenv.mkDerivation rec {
     done
 
     mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+    makeWrapper ${jre8}/bin/java $out/bin/${pname} \
       --add-flags "-jar $out/share/java/${pname}/${pname}.jar" \
       --run "cd $out/share/java/${pname}"
   '';

--- a/pkgs/applications/misc/vue/default.nix
+++ b/pkgs/applications/misc/vue/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, runtimeShell }:
+{ stdenv, fetchurl, jre8, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "vue";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out"/{share/vue,bin}
     cp ${src} "$out/share/vue/vue.jar"
     echo '#!${runtimeShell}' >> "$out/bin/vue"
-    echo '${jre}/bin/java -jar "'"$out/share/vue/vue.jar"'" "$@"' >> "$out/bin/vue"
+    echo '${jre8}/bin/java -jar "'"$out/share/vue/vue.jar"'" "$@"' >> "$out/bin/vue"
     chmod a+x "$out/bin/vue"
   '';
 

--- a/pkgs/applications/misc/xmind/default.nix
+++ b/pkgs/applications/misc/xmind/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchzip, fetchurl, gtk2, jre, libXtst, makeWrapper, makeDesktopItem, runtimeShell }:
+{ stdenv, lib, fetchzip, fetchurl, gtk2, jre8, libXtst, makeWrapper, makeDesktopItem, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "xmind";
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     EOF
     chmod +x $out/bin/XMind
 
-    ln -s ${jre} $out/libexec/jre
+    ln -s ${jre8} $out/libexec/jre8
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/apache-directory-studio/default.nix
+++ b/pkgs/applications/networking/apache-directory-studio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, xorg, jre, makeWrapper, makeDesktopItem }:
+{ stdenv, fetchurl, xorg, jre8, makeWrapper, makeDesktopItem }:
 
 let
   rpath = stdenv.lib.makeLibraryPath (with xorg; [
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
         "$dest/ApacheDirectoryStudio"
     makeWrapper "$dest/ApacheDirectoryStudio" \
         "$out/bin/ApacheDirectoryStudio" \
-        --prefix PATH : "${jre}/bin" \
+        --prefix PATH : "${jre8}/bin" \
         --prefix LD_LIBRARY_PATH : "${rpath}"
     install -D icon.xpm "$out/share/pixmaps/apache-directory-studio.xpm"
     install -D -t "$out/share/applications" ${desktopItem}/share/applications/*

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -16,7 +16,7 @@
 , libXScrnSaver, libXcursor, libXtst, libGLU, libGL
 , protobuf, speechd, libXdamage, cups
 , ffmpeg, libxslt, libxml2, at-spi2-core
-, jre
+, jre8
 
 # optional dependencies
 , libgcrypt ? null # gnomeSupport || cupsSupport
@@ -131,7 +131,7 @@ let
       glib gtk3 dbus-glib
       libXScrnSaver libXcursor libXtst libGLU libGL
       pciutils protobuf speechd libXdamage at-spi2-core
-      jre
+      jre8
     ] ++ optional useVaapi libva
       ++ optional gnomeKeyringSupport libgnome-keyring3
       ++ optionals gnomeSupport [ gnome.GConf libgcrypt ]

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -43,7 +43,7 @@ let
             "enableVLC"
             "enableDjvu"
             "enableMPlayer"
-            "jre"
+            "jre8"
             "icedtea"
             "enableGoogleTalkPlugin"
             "enableFriBIDPlugin"

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
@@ -16,7 +16,7 @@
 , libXScrnSaver, libXcursor, libXtst, libGLU, libGL
 , protobuf, speechd, libXdamage, cups
 , ffmpeg, libxslt, libxml2, at-spi2-core
-, jre
+, jre8
 
 # optional dependencies
 , libgcrypt ? null # gnomeSupport || cupsSupport
@@ -138,7 +138,7 @@ let
       glib gtk3 dbus-glib
       libXScrnSaver libXcursor libXtst libGLU libGL
       pciutils protobuf speechd libXdamage at-spi2-core
-      jre
+      jre8
     ] ++ optional useVaapi libva
       ++ optional gnomeKeyringSupport libgnome-keyring3
       ++ optionals gnomeSupport [ gnome.GConf libgcrypt ]

--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -3,7 +3,7 @@ stdenv
 , makeWrapper
 , makeDesktopItem
 , fetchurl
-, jre
+, jre8
 }:
 
 let
@@ -31,7 +31,7 @@ let
       buildInputs = [ makeWrapper ];
 
       installPhase = ''
-        makeWrapper ${jre}/bin/java $out/bin/charles \
+        makeWrapper ${jre8}/bin/java $out/bin/charles \
           --add-flags "-Xmx1024M -Dcharles.config='~/.charles.config' -jar $out/share/java/charles.jar"
 
         for fn in lib/*.jar; do

--- a/pkgs/applications/networking/cluster/chronos/default.nix
+++ b/pkgs/applications/networking/cluster/chronos/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, makeWrapper, fetchgit, curl, jdk, maven, nodejs, mesos }:
+{ stdenv, lib, makeWrapper, fetchgit, curl, jdk8, maven, nodejs, mesos }:
 
 stdenv.mkDerivation rec {
   pname = "chronos";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0hrln3ad2g2cq2xqmy5mq32cdxxb9vb6v6jp6kcq03f8km6v3g9c";
   };
 
-  buildInputs = [ makeWrapper curl jdk maven nodejs mesos ];
+  buildInputs = [ makeWrapper curl jdk8 maven nodejs mesos ];
 
   mavenRepo = import ./chronos-deps.nix { inherit stdenv curl; };
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{bin,libexec/chronos}
     cp target/chronos*.jar $out/libexec/chronos/${pname}-${version}.jar
 
-    makeWrapper ${jdk.jre}/bin/java $out/bin/chronos \
+    makeWrapper ${jdk8.jre}/bin/java $out/bin/chronos \
       --add-flags "-Xmx384m -Xms384m -cp $out/libexec/chronos/${pname}-${version}.jar com.airbnb.scheduler.Main" \
       --prefix "MESOS_NATIVE_LIBRARY" : "$MESOS_NATIVE_LIBRARY"
   '';

--- a/pkgs/applications/networking/cluster/flink/default.nix
+++ b/pkgs/applications/networking/cluster/flink/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre
+{ stdenv, fetchurl, makeWrapper, jre8
 , version ? "1.6" }:
 
 let
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   installPhase = ''
     rm bin/*.bat
@@ -34,10 +34,10 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin $out/opt/flink
     mv * $out/opt/flink/
     makeWrapper $out/opt/flink/bin/flink $out/bin/flink \
-      --prefix PATH : ${jre}/bin
+      --prefix PATH : ${jre8}/bin
 
     cat <<EOF >> $out/opt/flink/conf/flink-conf.yaml
-    env.java.home: ${jre}"
+    env.java.home: ${jre8}"
     env.log.dir: /tmp/flink-logs
     EOF
   '';

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig, which, maven, cmake, jre, bash
+{ stdenv, fetchurl, makeWrapper, pkgconfig, which, maven, cmake, jre8, bash
 , coreutils, glibc, protobuf2_5, fuse, snappy, zlib, bzip2, openssl, openssl_1_0_2
 }:
 
@@ -58,7 +58,7 @@ let
         buildPhase = ''
           # 'maven.repo.local' must be writable
           mvn package --offline -Dmaven.repo.local=$(cp -dpR ${fetched-maven-deps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2 ${mavenFlags}
-          # remove runtime dependency on $jdk/jre/lib/amd64/server/libjvm.so
+          # remove runtime dependency on $jdk8.jre/lib/amd64/server/libjvm.so
           patchelf --set-rpath ${stdenv.lib.makeLibraryPath [glibc]} hadoop-dist/target/hadoop-${version}/lib/native/libhadoop.so.1.0.0
           patchelf --set-rpath ${stdenv.lib.makeLibraryPath [glibc]} hadoop-dist/target/hadoop-${version}/lib/native/libhdfs.so.0.0.0
         '';
@@ -86,9 +86,9 @@ let
             if [ -f "$n" ]; then # only regular files
               mv $n $out/bin.wrapped/
               makeWrapper $out/bin.wrapped/$(basename $n) $n \
-                --prefix PATH : "${stdenv.lib.makeBinPath [ which jre bash coreutils ]}" \
+                --prefix PATH : "${stdenv.lib.makeBinPath [ which jre8 bash coreutils ]}" \
                 --prefix JAVA_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ opensslPkg snappy zlib bzip2 ]}" \
-                --set JAVA_HOME "${jre}" \
+                --set JAVA_HOME "${jre8}" \
                 --set HADOOP_PREFIX "$out"
             fi
           done

--- a/pkgs/applications/networking/cluster/marathon/default.nix
+++ b/pkgs/applications/networking/cluster/marathon/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, jdk, mesos, fetchurl }:
+{ stdenv, makeWrapper, jdk8, mesos, fetchurl }:
 
 stdenv.mkDerivation rec {
   pname = "marathon";
@@ -9,13 +9,13 @@ stdenv.mkDerivation rec {
     sha256 = "6eab65a95c87a989e922aca2b49ba872b50a94e46a8fd4831d1ab41f319d6932";
   };
 
-  buildInputs = [ makeWrapper jdk mesos ];
+  buildInputs = [ makeWrapper jdk8 mesos ];
 
   installPhase = ''
     mkdir -p $out/{bin,libexec/marathon}
     cp target/scala-*/marathon*.jar $out/libexec/marathon/${pname}-${version}.jar
 
-    makeWrapper ${jdk.jre}/bin/java $out/bin/marathon \
+    makeWrapper ${jdk8.jre}/bin/java $out/bin/marathon \
       --add-flags "-Xmx512m -jar $out/libexec/marathon/${pname}-${version}.jar" \
       --set "MESOS_NATIVE_JAVA_LIBRARY" "$MESOS_NATIVE_JAVA_LIBRARY"
     '';

--- a/pkgs/applications/networking/cluster/mesos/default.nix
+++ b/pkgs/applications/networking/cluster/mesos/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, makeWrapper, fetchurl, curl, sasl, openssh
-, unzip, gnutar, jdk, python, wrapPython
+, unzip, gnutar, jdk8, python, wrapPython
 , setuptools, boto, pythonProtobuf, apr, subversion, gzip
 , leveldb, glog, perf, utillinux, libnl, iproute, openssl, libevent
 , ethtool, coreutils, which, iptables, maven
@@ -55,7 +55,7 @@ in stdenv.mkDerivation rec {
   ] ++ lib.optionals stdenv.isLinux [
     libnl
   ] ++ lib.optionals withJava [
-    jdk maven
+    jdk8 maven
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/applications/networking/cluster/pig/default.nix
+++ b/pkgs/applications/networking/cluster/pig/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, hadoop, jre, bash }:
+{ stdenv, fetchurl, makeWrapper, hadoop, jre8, bash }:
 
 stdenv.mkDerivation rec {
 
@@ -21,8 +21,8 @@ stdenv.mkDerivation rec {
 
     for n in $out/{bin,sbin}"/"*; do
       wrapProgram $n \
-        --prefix PATH : "${stdenv.lib.makeBinPath [ jre bash ]}" \
-        --set JAVA_HOME "${jre}" --set HADOOP_PREFIX "${hadoop}"
+        --prefix PATH : "${stdenv.lib.makeBinPath [ jre8 bash ]}" \
+        --set JAVA_HOME "${jre8}" --set HADOOP_PREFIX "${hadoop}"
     done
   '';
 

--- a/pkgs/applications/networking/cluster/spark/default.nix
+++ b/pkgs/applications/networking/cluster/spark/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, makeWrapper, jre, pythonPackages, coreutils, hadoop
+{ stdenv, fetchzip, makeWrapper, jre8, pythonPackages, coreutils, hadoop
 , RSupport? true, R
 , mesosSupport ? true, mesos
 }:
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "1a9w5k0207fysgpxx6db3a00fs5hdc2ncx99x4ccy2s0v5ndc66g"; 
   };
 
-  buildInputs = [ makeWrapper jre pythonPackages.python pythonPackages.numpy ]
+  buildInputs = [ makeWrapper jre8 pythonPackages.python pythonPackages.numpy ]
     ++ optional RSupport R
     ++ optional mesosSupport mesos;
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
        $out/lib/${untarDir}/conf/log4j.properties
 
     cat > $out/lib/${untarDir}/conf/spark-env.sh <<- EOF
-    export JAVA_HOME="${jre}"
+    export JAVA_HOME="${jre8}"
     export SPARK_HOME="$out/lib/${untarDir}"
     export SPARK_DIST_CLASSPATH=$(${hadoop}/bin/hadoop classpath)
     export PYSPARK_PYTHON="${pythonPackages.python}/bin/${pythonPackages.python.executable}"

--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, jre, glib, libXtst, gtk2, makeWrapper, unzip }:
+{ fetchurl, stdenv, jre8, glib, libXtst, gtk2, makeWrapper, unzip }:
 
 stdenv.mkDerivation rec {
   pname = "davmail";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/davmail
     cp -vR ./* $out/share/davmail
     makeWrapper $out/share/davmail/davmail $out/bin/davmail \
-      --prefix PATH : ${jre}/bin \
+      --prefix PATH : ${jre8}/bin \
       --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk2 libXtst ]}
   '';
 

--- a/pkgs/applications/networking/instant-messengers/jitsi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jitsi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, makeDesktopItem, unzip, ant, jdk
+{ stdenv, lib, fetchurl, makeDesktopItem, unzip, ant, jdk8
 # Optional, Jitsi still runs without, but you may pass null:
 , alsaLib, dbus, gtk2, libpulseaudio, openssl, xorg
 }:
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   ]);
 
   nativeBuildInputs = [ unzip ];
-  buildInputs = [ ant jdk ];
+  buildInputs = [ ant jdk8 ];
 
   buildPhase = ''ant make'';
 
@@ -50,11 +50,11 @@ stdenv.mkDerivation rec {
     cp resources/install/generic/run.sh $out/bin/jitsi
     chmod +x $out/bin/jitsi
     substituteInPlace $out/bin/jitsi \
-      --subst-var-by JAVA ${jdk}/bin/java \
+      --subst-var-by JAVA ${jdk8}/bin/java \
       --subst-var-by EXTRALIBS ${gtk2.out}/lib
-    sed -e 's,^java\ ,${jdk}/bin/java ,' -i $out/bin/jitsi
+    sed -e 's,^java\ ,${jdk8}/bin/java ,' -i $out/bin/jitsi
     patchShebangs $out
-    libPath="$libPath:${jdk.home}/lib/${jdk.architecture}"
+    libPath="$libPath:${jdk8.home}/lib/${jdk8.architecture}"
     find $out/ -type f -name '*.so' | while read file; do
       patchelf --set-rpath "$libPath" "$file" && \
           patchelf --shrink-rpath "$file"

--- a/pkgs/applications/networking/instant-messengers/signal-cli/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-cli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, makeWrapper, jre_headless, libmatthew_java, dbus, dbus_java }:
+{ stdenv, lib, fetchurl, makeWrapper, jre8_headless, libmatthew_java, dbus, dbus_java }:
 
 stdenv.mkDerivation rec {
   pname = "signal-cli";
@@ -18,15 +18,15 @@ stdenv.mkDerivation rec {
     cp -r lib $out/lib
     cp bin/signal-cli $out/bin/signal-cli
   '' + (if stdenv.isLinux then ''
-    makeWrapper ${jre_headless}/bin/java $out/bin/signal-cli \
-      --set JAVA_HOME "${jre_headless}" \
+    makeWrapper ${jre8_headless}/bin/java $out/bin/signal-cli \
+      --set JAVA_HOME "${jre8_headless}" \
       --add-flags "-classpath '$out/lib/*:${libmatthew_java}/lib/jni'" \
       --add-flags "-Djava.library.path=${libmatthew_java}/lib/jni:${dbus_java}/share/java/dbus:$out/lib" \
       --add-flags "org.asamk.signal.Main"
   '' else ''
     wrapProgram $out/bin/signal-cli \
-      --prefix PATH : ${lib.makeBinPath [ jre_headless ]} \
-      --set JAVA_HOME ${jre_headless}
+      --prefix PATH : ${lib.makeBinPath [ jre8_headless ]} \
+      --set JAVA_HOME ${jre8_headless}
   '');
 
   # Execution in the macOS (10.13) sandbox fails with

--- a/pkgs/applications/networking/jmeter/default.nix
+++ b/pkgs/applications/networking/jmeter/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, jre, makeWrapper, coreutils }:
+{ fetchurl, stdenv, jre8, makeWrapper, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "jmeter";
@@ -19,17 +19,17 @@ stdenv.mkDerivation rec {
 
     substituteInPlace $out/bin/create-rmi-keystore.sh --replace \
       "keytool -genkey" \
-      "${jre}/lib/openjdk/jre/bin/keytool -genkey"
+      "${jre8}/lib/openjdk/jre8/bin/keytool -genkey"
 
     # Prefix some scripts with jmeter to avoid clobbering the namespace
     for i in heapdump.sh mirror-server mirror-server.sh shutdown.sh stoptest.sh create-rmi-keystore.sh; do
       mv $out/bin/$i $out/bin/jmeter-$i
       wrapProgram $out/bin/jmeter-$i \
-        --prefix PATH : "${jre}/bin"
+        --prefix PATH : "${jre8}/bin"
     done
 
-    wrapProgram $out/bin/jmeter --set JAVA_HOME "${jre}"
-    wrapProgram $out/bin/jmeter.sh --set JAVA_HOME "${jre}"
+    wrapProgram $out/bin/jmeter --set JAVA_HOME "${jre8}"
+    wrapProgram $out/bin/jmeter.sh --set JAVA_HOME "${jre8}"
   '';
 
   doInstallCheck = true;

--- a/pkgs/applications/networking/jnetmap/default.nix
+++ b/pkgs/applications/networking/jnetmap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "jnetmap";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0nxsfa600jhazwbabxmr9j37mhwysp0fyrvczhv3f1smiy8rjanl";
   };
 
-  buildInputs = [ jre makeWrapper ];
+  buildInputs = [ jre8 makeWrapper ];
 
   dontUnpack = true;
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/lib"
 
     cp "${src}" "$out/lib/jnetmap.jar"
-    makeWrapper "${jre}/bin/java" "$out/bin/jnetmap" \
+    makeWrapper "${jre8}/bin/java" "$out/bin/jnetmap" \
         --add-flags "-jar \"$out/lib/jnetmap.jar\""
   '';
 

--- a/pkgs/applications/networking/mailreaders/msgviewer/default.nix
+++ b/pkgs/applications/networking/mailreaders/msgviewer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, unzip, jre, runtimeShell }:
+{ stdenv, fetchurl, makeWrapper, unzip, jre8, runtimeShell }:
 
 let
   version = "1.9";
@@ -21,7 +21,7 @@ in stdenv.mkDerivation {
     rmdir $dir/${uname}
     cat <<_EOF > $out/bin/msgviewer
     #!${runtimeShell} -eu
-    exec ${stdenv.lib.getBin jre}/bin/java -jar $dir/MSGViewer.jar "\$@"
+    exec ${stdenv.lib.getBin jre8}/bin/java -jar $dir/MSGViewer.jar "\$@"
     _EOF
     chmod 755 $out/bin/msgviewer
   '';

--- a/pkgs/applications/networking/p2p/freenet/default.nix
+++ b/pkgs/applications/networking/p2p/freenet/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub, ant, jdk, bash, coreutils, substituteAll }:
+{ stdenv, fetchurl, fetchFromGitHub, ant, jdk8, bash, coreutils, substituteAll }:
 
 let
   freenet_ext = fetchurl {
@@ -36,7 +36,7 @@ let
       sed 's/@unknown@/${version}/g' -i build-clean.xml
     '';
 
-    buildInputs = [ ant jdk ];
+    buildInputs = [ ant jdk8 ];
 
     buildPhase = "ant package-only";
 
@@ -56,7 +56,7 @@ in stdenv.mkDerivation {
     src = ./freenetWrapper;
     inherit bash coreutils seednodes bcprov_version;
     freenet = freenet-jars;
-    jre = jdk.jre;
+    jre8 = jdk8.jre;
   };
 
   jars = freenet-jars;

--- a/pkgs/applications/networking/p2p/freenet/freenetWrapper
+++ b/pkgs/applications/networking/p2p/freenet/freenetWrapper
@@ -15,4 +15,4 @@ cp -u @seednodes@ $FREENET_HOME/seednodes.fref
 chmod u+rw $FREENET_HOME/seednodes.fref
 
 cd $FREENET_HOME
-@jre@/bin/java -cp @freenet@/share/freenet/bcprov-@bcprov_version@.jar:@freenet@/share/freenet/freenet-ext.jar:@freenet@/share/freenet/freenet.jar -Xmx1024M freenet.node.NodeStarter
+@jre8@/bin/java -cp @freenet@/share/freenet/bcprov-@bcprov_version@.jar:@freenet@/share/freenet/freenet-ext.jar:@freenet@/share/freenet/freenet.jar -Xmx1024M freenet.node.NodeStarter

--- a/pkgs/applications/networking/p2p/frostwire/default.nix
+++ b/pkgs/applications/networking/p2p/frostwire/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gradle, perl, jre, makeWrapper, makeDesktopItem, mplayer }:
+{ stdenv, fetchFromGitHub, gradle, perl, jre8, makeWrapper, makeDesktopItem, mplayer }:
 
 let
   version = "6.6.7-build-529";
@@ -80,7 +80,7 @@ in stdenv.mkDerivation {
 
     cp -dpR ${desktopItem}/share $out
 
-    makeWrapper ${jre}/bin/java $out/bin/frostwire \
+    makeWrapper ${jre8}/bin/java $out/bin/frostwire \
       --add-flags "-Djava.library.path=$out/lib -jar $out/share/java/frostwire.jar"
   '';
 

--- a/pkgs/applications/networking/p2p/frostwire/frostwire-bin.nix
+++ b/pkgs/applications/networking/p2p/frostwire/frostwire-bin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 with stdenv.lib;
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     mv $(ls */*.jar) $out/share/java
 
     makeWrapper $out/share/java/frostwire $out/bin/frostwire \
-      --prefix PATH : ${jre}/bin/
+      --prefix PATH : ${jre8}/bin/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/p2p/vuze/default.nix
+++ b/pkgs/applications/networking/p2p/vuze/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchsvn, jdk, jre, ant, swt, makeWrapper }:
+{ stdenv, fetchsvn, jdk8, jre8, ant, swt, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "vuze";
@@ -9,13 +9,13 @@ stdenv.mkDerivation rec {
     sha256 = "07w6ipyiy8hi88d6yxbbf3vkv26mj7dcz9yr8141hb2ig03v0h0p";
   };
 
-  buildInputs = [ makeWrapper jdk ant ];
+  buildInputs = [ makeWrapper jdk8 ant ];
 
   buildPhase = "ant";
 
   installPhase = ''
     install -D dist/Vuze_0000-00.jar $out/share/java/Vuze_${version}-00.jar
-    makeWrapper ${jre}/bin/java $out/bin/vuze \
+    makeWrapper ${jre8}/bin/java $out/bin/vuze \
       --add-flags "-Xmx256m -Djava.library.path=${swt}/lib -cp $out/share/java/Vuze_${version}-00.jar:${swt}/jars/swt.jar org.gudy.azureus2.ui.swt.Main"
   '';
 

--- a/pkgs/applications/networking/soapui/default.nix
+++ b/pkgs/applications/networking/soapui/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, writeText, jdk, maven, makeWrapper }:
+{ fetchurl, stdenv, writeText, jdk8, maven, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "soapui";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jdk maven ];
+  buildInputs = [ jdk8 maven ];
 
   installPhase = ''
     mkdir -p $out/share/java
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
        JAVA_OPTS="-Xms128m -Xmx1024m -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -Dsoapui.properties=soapui.properties -Dsoapui.home=$SOAPUI_HOME/bin -splash:SoapUI-Spashscreen.png"
       -JFXRTPATH=`java -cp $SOAPUI_CLASSPATH com.eviware.soapui.tools.JfxrtLocator`
-      +JFXRTPATH=`${jdk}/bin/java -cp $SOAPUI_CLASSPATH com.eviware.soapui.tools.JfxrtLocator`
+      +JFXRTPATH=`${jdk8}/bin/java -cp $SOAPUI_CLASSPATH com.eviware.soapui.tools.JfxrtLocator`
        SOAPUI_CLASSPATH=$JFXRTPATH:$SOAPUI_CLASSPATH
 
        if $darwin
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
        echo ================================
 
       -java $JAVA_OPTS -cp $SOAPUI_CLASSPATH com.eviware.soapui.SoapUI "$@"
-      +${jdk}/bin/java $JAVA_OPTS -cp $SOAPUI_CLASSPATH com.eviware.soapui.SoapUI "$@"
+      +${jdk8}/bin/java $JAVA_OPTS -cp $SOAPUI_CLASSPATH com.eviware.soapui.SoapUI "$@"
     '')
   ];
 

--- a/pkgs/applications/office/atlassian-cli/default.nix
+++ b/pkgs/applications/office/atlassian-cli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, jre }:
+{ stdenv, fetchzip, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "atlassian-cli";
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     do
       substitute ${./wrapper.sh} $out/bin/$tool \
         --subst-var out \
-        --subst-var-by jre ${jre} \
+        --subst-var-by jre8 ${jre8} \
         --subst-var-by tool $tool
       chmod +x $out/bin/$tool
     done
@@ -44,6 +44,6 @@ stdenv.mkDerivation rec {
     homepage = "https://bobswift.atlassian.net/wiki/spaces/ACLI/overview";
     license = licenses.unfreeRedistributable;
     maintainers = with maintainers; [ twey ];
-    inherit (jre.meta) platforms;
+    inherit (jre8.meta) platforms;
   };
 }

--- a/pkgs/applications/office/atlassian-cli/wrapper.sh
+++ b/pkgs/applications/office/atlassian-cli/wrapper.sh
@@ -12,7 +12,7 @@ then
     exit 1
 fi
 
-@jre@/bin/java \
+@jre8@/bin/java \
     -jar @out@/share/java/@tool@-cli-* \
     --server "${!host}" \
     --user "${!user}" \

--- a/pkgs/applications/office/flexibee/default.nix
+++ b/pkgs/applications/office/flexibee/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre8 }:
 
 let
   version = "2019.3.1.3";
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
     cp -R usr/share/flexibee/ $out/
     install -Dm755 usr/bin/flexibee $out/bin/flexibee
     install -Dm755 usr/sbin/flexibee-server $out/bin/flexibee-server
-    wrapProgram $out/bin/flexibee --set JAVA_HOME "${jre}"
-    wrapProgram $out/bin/flexibee-server --set JAVA_HOME "${jre}"
+    wrapProgram $out/bin/flexibee --set JAVA_HOME "${jre8}"
+    wrapProgram $out/bin/flexibee-server --set JAVA_HOME "${jre8}"
     runHook postInstall
   '';
 

--- a/pkgs/applications/office/jabref/default.nix
+++ b/pkgs/applications/office/jabref/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, makeDesktopItem, jdk, jre, wrapGAppsHook, gtk3, gsettings-desktop-schemas }:
+{ stdenv, fetchurl, makeWrapper, makeDesktopItem, jdk8, jre8, wrapGAppsHook, gtk3, gsettings-desktop-schemas }:
 
 stdenv.mkDerivation rec {
   version = "3.8.1";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     exec = "jabref";
   };
 
-  buildInputs = [ makeWrapper jdk wrapGAppsHook gtk3 gsettings-desktop-schemas ];
+  buildInputs = [ makeWrapper jdk8 wrapGAppsHook gtk3 gsettings-desktop-schemas ];
 
   dontUnpack = true;
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     cp images/icons/JabRef-icon-mac.svg $out/share/icons/jabref.svg
 
     ln -s $src $out/share/java/jabref-${version}.jar
-    makeWrapper ${jre}/bin/java $out/bin/jabref \
+    makeWrapper ${jre8}/bin/java $out/bin/jabref \
       --add-flags "-jar $out/share/java/jabref-${version}.jar"
   '';
 

--- a/pkgs/applications/office/jameica/default.nix
+++ b/pkgs/applications/office/jameica/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeDesktopItem, makeWrapper, ant, jdk, jre, gtk2, glib, xorg, Cocoa }:
+{ stdenv, fetchFromGitHub, makeDesktopItem, makeWrapper, ant, jdk8, jre8, gtk2, glib, xorg, Cocoa }:
 
 let
   _version = "2.8.6";
@@ -23,7 +23,7 @@ in
 stdenv.mkDerivation rec {
   inherit name version;
 
-  nativeBuildInputs = [ ant jdk makeWrapper ];
+  nativeBuildInputs = [ ant jdk8 makeWrapper ];
   buildInputs = stdenv.lib.optionals stdenv.isLinux [ gtk2 glib xorg.libXtst ]
                 ++ stdenv.lib.optional stdenv.isDarwin Cocoa;
 
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     install -Dm644 build/jameica-icon.png $out/share/pixmaps/jameica.png
     cp ${desktopItem}/share/applications/* $out/share/applications/
 
-    makeWrapper ${jre}/bin/java $out/bin/jameica \
+    makeWrapper ${jre8}/bin/java $out/bin/jameica \
       --add-flags "-cp $out/share/java/jameica.jar:$out/share/${name}/* ${
         stdenv.lib.optionalString stdenv.isDarwin ''-Xdock:name="Jameica" -XstartOnFirstThread''
       } de.willuhn.jameica.Main" \

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -2,7 +2,7 @@
 , IOCompress, zlib, libjpeg, expat, freetype, libwpd
 , libxml2, db, curl, fontconfig, libsndfile, neon
 , bison, flex, zip, unzip, gtk3, gtk2, libmspack, getopt, file, cairo, which
-, icu, boost, jdk, ant, cups, xorg, libcmis, fontforge
+, icu, boost, jdk8, ant, cups, xorg, libcmis, fontforge
 , openssl, gperf, cppunit, poppler, utillinux
 , librsvg, libGLU, libGL, bsh, CoinMP, libwps, libabw, libmysqlclient
 , autoconf, automake, openldap, bash, hunspell, librdf_redland, nss, nspr
@@ -289,7 +289,7 @@ in (stdenv.mkDerivation rec {
     "--enable-dbus"
     "--enable-release-build"
     "--enable-epm"
-    "--with-jdk-home=${jdk.home}"
+    "--with-jdk8-home=${jdk8.home}"
     "--with-ant-home=${ant}/lib/ant"
     "--with-system-cairo"
     "--with-system-libs"
@@ -353,7 +353,7 @@ in (stdenv.mkDerivation rec {
     [ ant ArchiveZip boost cairo clucene_core
       IOCompress cppunit cups curl db dbus-glib expat file flex fontconfig
       freetype getopt gperf gtk3 gtk2
-      hunspell icu jdk lcms libcdr libexttextcat unixODBC libjpeg
+      hunspell icu jdk8 lcms libcdr libexttextcat unixODBC libjpeg
       libmspack librdf_redland librsvg libsndfile libvisio libwpd libwpg libX11
       libXaw libXext libXi libXinerama libxml2 libxslt libXtst
       libXdmcp libpthreadstubs libGLU libGL mythes gst_all_1.gstreamer
@@ -368,7 +368,7 @@ in (stdenv.mkDerivation rec {
     ++ lib.optional kdeIntegration kdelibs4;
 
   passthru = {
-    inherit srcs jdk;
+    inherit srcs jdk8;
   };
 
   requiredSystemFeatures = [ "big-parallel" ];

--- a/pkgs/applications/office/libreoffice/wrapper.nix
+++ b/pkgs/applications/office/libreoffice/wrapper.nix
@@ -1,9 +1,9 @@
 { libreoffice, runCommand, dbus, bash }:
 let
-  jdk = libreoffice.jdk;
+  jdk8 = libreoffice.jdk8;
 in
 (runCommand libreoffice.name {
-  inherit dbus libreoffice jdk bash;
+  inherit dbus libreoffice jdk8 bash;
 } ''
   mkdir -p "$out/bin"
   ln -s "${libreoffice}/share" "$out/share"

--- a/pkgs/applications/office/libreoffice/wrapper.sh
+++ b/pkgs/applications/office/libreoffice/wrapper.sh
@@ -1,5 +1,5 @@
 #!@bash@/bin/bash
-export JAVA_HOME="${JAVA_HOME:-@jdk@}"
+export JAVA_HOME="${JAVA_HOME:-@jdk8@}"
 #export SAL_USE_VCLPLUGIN="${SAL_USE_VCLPLUGIN:-gen}"
 
 if uname | grep Linux > /dev/null && 

--- a/pkgs/applications/science/astronomy/astrolabe-generator/default.nix
+++ b/pkgs/applications/science/astronomy/astrolabe-generator/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper, unzip }:
+{ stdenv, fetchurl, jre8, makeWrapper, unzip }:
 
 stdenv.mkDerivation rec {
   pname = "astrolabe-generator";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "141gfmrqa1mf2qas87qig4phym9fg9gbrcfl2idzd5gi91824dn9";
   };
 
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
   nativeBuildInputs = [ makeWrapper unzip ];
   sourceRoot = ".";
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{bin,share/java}
     cp AstrolabeGenerator-${version}.jar $out/share/java
 
-    makeWrapper ${jre}/bin/java $out/bin/AstrolabeGenerator \
+    makeWrapper ${jre8}/bin/java $out/bin/AstrolabeGenerator \
       --add-flags "-jar $out/share/java/AstrolabeGenerator-${version}.jar"
   '';
 

--- a/pkgs/applications/science/biology/bftools/default.nix
+++ b/pkgs/applications/science/biology/bftools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, makeWrapper, fetchzip, jre }:
+{ stdenv, lib, makeWrapper, fetchzip, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "bftools";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    wrapProgram $out/libexec/bf.sh --prefix PATH : "${lib.makeBinPath [ jre ]}"
+    wrapProgram $out/libexec/bf.sh --prefix PATH : "${lib.makeBinPath [ jre8 ]}"
   '';
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/applications/science/biology/igv/default.nix
+++ b/pkgs/applications/science/biology/igv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, jre }:
+{ stdenv, fetchurl, unzip, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "igv";
@@ -9,14 +9,14 @@ stdenv.mkDerivation rec {
     sha256 = "048dgrhxcb854d24kyjkqz12bw04bsv49i5jawb75yzkswwfkb0z";
   };
 
-  buildInputs = [ unzip jre ];
+  buildInputs = [ unzip jre8 ];
 
   installPhase = ''
     mkdir -pv $out/{share,bin}
     cp -Rv * $out/share/
 
     sed -i "s#prefix=.*#prefix=$out/share#g" $out/share/igv.sh
-    sed -i 's#java#${jre}/bin/java#g' $out/share/igv.sh
+    sed -i 's#java#${jre8}/bin/java#g' $out/share/igv.sh
 
     ln -s $out/share/igv.sh $out/bin/igv
 

--- a/pkgs/applications/science/biology/macse/default.nix
+++ b/pkgs/applications/science/biology/macse/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "macse";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
     mkdir -p $out/share/java
     cp -s $src $out/share/java/macse.jar
-    makeWrapper ${jre}/bin/java $out/bin/macse --add-flags "-jar $out/share/java/macse.jar"
+    makeWrapper ${jre8}/bin/java $out/bin/macse --add-flags "-jar $out/share/java/macse.jar"
     runHook postInstall
   '';
 

--- a/pkgs/applications/science/biology/picard-tools/default.nix
+++ b/pkgs/applications/science/biology/picard-tools/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, jre, makeWrapper}:
+{stdenv, fetchurl, jre8, makeWrapper}:
 
 stdenv.mkDerivation rec {
   pname = "picard-tools";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   phases = [ "installPhase" ];
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/libexec/picard
     cp $src $out/libexec/picard/picard.jar
     mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/picard --add-flags "-jar $out/libexec/picard/picard.jar"
+    makeWrapper ${jre8}/bin/java $out/bin/picard --add-flags "-jar $out/libexec/picard/picard.jar"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/biology/snpeff/default.nix
+++ b/pkgs/applications/science/biology/snpeff/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, jre, unzip, makeWrapper}:
+{stdenv, fetchurl, jre8, unzip, makeWrapper}:
 
 stdenv.mkDerivation rec {
   pname = "snpeff";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0i12mv93bfv8xjwc3rs2x73d6hkvi7kgbbbx3ry984l3ly4p6nnm";
   };
 
-  buildInputs = [ unzip jre makeWrapper ];
+  buildInputs = [ unzip jre8 makeWrapper ];
 
   sourceRoot = "snpEff";
 
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
     cp *.jar *.config $out/libexec/snpeff
 
     mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/snpeff --add-flags "-jar $out/libexec/snpeff/snpEff.jar"
-    makeWrapper ${jre}/bin/java $out/bin/snpsift --add-flags "-jar $out/libexec/snpeff/SnpSift.jar"
+    makeWrapper ${jre8}/bin/java $out/bin/snpeff --add-flags "-jar $out/libexec/snpeff/snpEff.jar"
+    makeWrapper ${jre8}/bin/java $out/bin/snpsift --add-flags "-jar $out/libexec/snpeff/SnpSift.jar"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/biology/varscan/default.nix
+++ b/pkgs/applications/science/biology/varscan/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, jre, makeWrapper}:
+{stdenv, fetchurl, jre8, makeWrapper}:
 
 stdenv.mkDerivation rec {
   pname = "varscan";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0cfhshinyqgwc6i7zf8lhbfybyly2x5anrz824zyvdhzz5i69zrl";
   };
 
-  buildInputs = [ jre makeWrapper ];
+  buildInputs = [ jre8 makeWrapper ];
 
   phases = [ "installPhase" ];
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/libexec/varscan
     cp $src $out/libexec/varscan/varscan.jar
     mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/varscan --add-flags "-jar $out/libexec/varscan/varscan.jar"
+    makeWrapper ${jre8}/bin/java $out/bin/varscan --add-flags "-jar $out/libexec/varscan/varscan.jar"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/chemistry/jmol/default.nix
+++ b/pkgs/applications/science/chemistry/jmol/default.nix
@@ -3,7 +3,7 @@
 , fetchurl
 , unzip
 , makeDesktopItem
-, jre
+, jre8
 }:
 
 let
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   patchPhase = ''
-    sed -i -e "4s:.*:command=${jre}/bin/java:" -e "10s:.*:jarpath=$out/share/jmol/Jmol.jar:" -e "11,21d" jmol
+    sed -i -e "4s:.*:command=${jre8}/bin/java:" -e "10s:.*:jarpath=$out/share/jmol/Jmol.jar:" -e "11,21d" jmol
   '';
 
   installPhase = ''

--- a/pkgs/applications/science/chemistry/marvin/default.nix
+++ b/pkgs/applications/science/chemistry/marvin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, dpkg, makeWrapper, coreutils, gawk, gnugrep, gnused, jre }:
+{ stdenv, fetchurl, dpkg, makeWrapper, coreutils, gawk, gnugrep, gnused, jre8 }:
 
 with stdenv.lib;
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     wrapBin() {
       makeWrapper $1 $out/bin/$(basename $1) \
-        --set INSTALL4J_JAVA_HOME "${jre}" \
+        --set INSTALL4J_JAVA_HOME "${jre8}" \
         --prefix PATH : ${makeBinPath [ coreutils gawk gnugrep gnused ]}
     }
     cp -r opt $out

--- a/pkgs/applications/science/logic/cvc4/default.nix
+++ b/pkgs/applications/science/logic/cvc4/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cln, gmp, swig, pkgconfig
-, readline, libantlr3c, boost, jdk, autoreconfHook
+, readline, libantlr3c, boost, jdk8, autoreconfHook
 , python3, antlr3_4
 }:
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ gmp cln readline swig libantlr3c antlr3_4 boost jdk python3 ];
+  buildInputs = [ gmp cln readline swig libantlr3c antlr3_4 boost jdk8 python3 ];
   configureFlags = [
     "--enable-language-bindings=c,c++,java"
     "--enable-gpl"

--- a/pkgs/applications/science/logic/isabelle/default.nix
+++ b/pkgs/applications/science/logic/isabelle/default.nix
@@ -42,14 +42,14 @@ stdenv.mkDerivation rec {
       ML_SOURCES="\$POLYML_HOME/src"
     EOF
 
-    cat >contrib/jdk/etc/settings <<EOF
+    cat >contrib/jdk8/etc/settings <<EOF
       ISABELLE_JAVA_PLATFORM=${stdenv.system}
       ISABELLE_JDK_HOME=${java}
     EOF
 
     echo ISABELLE_LINE_EDITOR=${rlwrap}/bin/rlwrap >>etc/settings
 
-    for comp in contrib/jdk contrib/polyml-* contrib/z3-*; do
+    for comp in contrib/jdk8 contrib/polyml-* contrib/z3-*; do
       rm -rf $comp/x86*
     done
     '' + (if ! stdenv.isLinux then "" else ''

--- a/pkgs/applications/science/logic/logisim/default.nix
+++ b/pkgs/applications/science/logic/logisim/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 let version = "2.7.1"; in
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -pv $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/logisim --add-flags "-jar $src"
+    makeWrapper ${jre8}/bin/java $out/bin/logisim --add-flags "-jar $src"
   '';
   
   meta = {

--- a/pkgs/applications/science/logic/tlaplus/default.nix
+++ b/pkgs/applications/science/logic/tlaplus/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, makeWrapper
-, adoptopenjdk-bin, jre, ant
+, adoptopenjdk-bin, jre8, ant
 }:
 
 stdenv.mkDerivation rec {
@@ -20,13 +20,13 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/java $out/bin
     cp tlatools/org.lamport.tlatools/dist/*.jar $out/share/java
 
-    makeWrapper ${jre}/bin/java $out/bin/tlc2 \
+    makeWrapper ${jre8}/bin/java $out/bin/tlc2 \
       --add-flags "-cp $out/share/java/tla2tools.jar tlc2.TLC"
-    makeWrapper ${jre}/bin/java $out/bin/tla2sany \
+    makeWrapper ${jre8}/bin/java $out/bin/tla2sany \
       --add-flags "-cp $out/share/java/tla2tools.jar tla2sany.SANY"
-    makeWrapper ${jre}/bin/java $out/bin/pcal \
+    makeWrapper ${jre8}/bin/java $out/bin/pcal \
       --add-flags "-cp $out/share/java/tla2tools.jar pcal.trans"
-    makeWrapper ${jre}/bin/java $out/bin/tla2tex \
+    makeWrapper ${jre8}/bin/java $out/bin/tla2tex \
       --add-flags "-cp $out/share/java/tla2tools.jar tla2tex.TLA"
   '';
 

--- a/pkgs/applications/science/logic/workcraft/default.nix
+++ b/pkgs/applications/science/logic/workcraft/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "workcraft";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   cp -r * $out/share
   mkdir $out/bin
   makeWrapper $out/share/workcraft $out/bin/workcraft \
-    --set JAVA_HOME "${jre}" \
+    --set JAVA_HOME "${jre8}" \
     --set _JAVA_OPTIONS '-Dawt.useSystemAAFontSettings=gasp';
   '';
 

--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, bzip2, gfortran, libX11, libXmu, libXt, libjpeg, libpng
 , libtiff, ncurses, pango, pcre2, perl, readline, tcl, texLive, tk, xz, zlib
-, less, texinfo, graphviz, icu, pkgconfig, bison, imake, which, jdk, blas, lapack
+, less, texinfo, graphviz, icu, pkgconfig, bison, imake, which, jdk8, blas, lapack
 , curl, Cocoa, Foundation, libobjc, libcxx, tzdata, fetchpatch
 , withRecommendedPackages ? true
 , enableStrictBarrier ? false
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     bzip2 gfortran libX11 libXmu libXt libXt libjpeg libpng libtiff ncurses
     pango pcre2 perl readline texLive xz zlib less texinfo graphviz icu
-    pkgconfig bison imake which blas lapack curl tcl tk jdk
+    pkgconfig bison imake which blas lapack curl tcl tk jdk8
   ] ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa Foundation libobjc libcxx ];
 
   patches = [
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
       CC=$(type -p cc)
       CXX=$(type -p c++)
       FC="${gfortran}/bin/gfortran" F77="${gfortran}/bin/gfortran"
-      JAVA_HOME="${jdk}"
+      JAVA_HOME="${jdk8}"
       RANLIB=$(type -p ranlib)
       R_SHELL="${stdenv.shell}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''

--- a/pkgs/applications/science/math/cplex/default.nix
+++ b/pkgs/applications/science/math/cplex/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
         --set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive;
     done
 
-    for pgm in $out/cplex/bin/x86-64_linux/cplex $out/cpoptimizer/bin/x86-64_linux/cpoptimizer $out/opl/oplide/jre/bin/*; 
+    for pgm in $out/cplex/bin/x86-64_linux/cplex $out/cpoptimizer/bin/x86-64_linux/cpoptimizer $out/opl/oplide/jre8/bin/*; 
     do
       if grep ELF $pgm > /dev/null;
       then

--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeDesktopItem, makeWrapper, language ? "en_US" }:
+{ stdenv, fetchurl, jre8, makeDesktopItem, makeWrapper, language ? "en_US" }:
 
 stdenv.mkDerivation rec {
   pname = "geogebra";
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     install -D geogebra/* -t "$out/libexec/geogebra/"
 
     makeWrapper "$out/libexec/geogebra/geogebra" "$out/bin/geogebra" \
-      --set JAVACMD "${jre}/bin/java" \
+      --set JAVACMD "${jre8}/bin/java" \
       --set GG_PATH "$out/libexec/geogebra" \
       --add-flags "--language=${language}"
 

--- a/pkgs/applications/science/math/sage/sage-env.nix
+++ b/pkgs/applications/science/math/sage/sage-env.nix
@@ -50,7 +50,7 @@
 , zlib
 , gsl
 , ntl
-, jdk
+, jdk8
 , less
 }:
 
@@ -101,7 +101,7 @@ let
     lcalc
     rubiks
     flintqs
-    jdk # only needed for `jmol` which may be replaced in the future
+    jdk8 # only needed for `jmol` which may be replaced in the future
     less # needed to prevent transient test errors until https://github.com/ipython/ipython/pull/11864 is resolved
   ]
   ));

--- a/pkgs/applications/science/math/weka/default.nix
+++ b/pkgs/applications/science/math/weka/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, unzip, makeWrapper }:
+{ stdenv, fetchurl, jre8, unzip, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "weka";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     mkdir -pv $out/share/weka
     cp -Rv * $out/share/weka
 
-    makeWrapper ${jre}/bin/java $out/bin/weka \
+    makeWrapper ${jre8}/bin/java $out/bin/weka \
       --add-flags "-Xmx1000M -jar $out/share/weka/weka.jar"
   '';
 

--- a/pkgs/applications/science/misc/gephi/default.nix
+++ b/pkgs/applications/science/misc/gephi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jdk, maven, javaPackages }:
+{ stdenv, fetchFromGitHub, jdk8, maven, javaPackages }:
 
 let
   version = "0.9.2";
@@ -14,7 +14,7 @@ let
   deps = stdenv.mkDerivation {
     name = "gephi-${version}-deps";
     inherit src;
-    buildInputs = [ jdk maven ];
+    buildInputs = [ jdk8 maven ];
     buildPhase = ''
       while mvn package -Dmaven.repo.local=$out/.m2 -Dmaven.wagon.rto=5000; [ $? = 1 ]; do
         echo "timeout, restart maven to continue downloading"
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
 
   inherit src;
 
-  buildInputs = [ jdk maven ];
+  buildInputs = [ jdk8 maven ];
 
   buildPhase = ''
     # 'maven.repo.local' must be writable so copy it out of nix store
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
     cp ${javaPackages.jogl_2_3_2}/share/java/jogl*.jar $out/gephi/modules/ext/org.gephi.visualization/org-jogamp-jogl/
     cp ${javaPackages.jogl_2_3_2}/share/java/glue*.jar $out/gephi/modules/ext/org.gephi.visualization/org-jogamp-gluegen/
 
-    echo "jdkhome=${jdk}" >> $out/etc/gephi.conf
+    echo "jdkhome=${jdk8}" >> $out/etc/gephi.conf
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/misc/netlogo/default.nix
+++ b/pkgs/applications/science/misc/netlogo/default.nix
@@ -1,4 +1,4 @@
-{ jre, stdenv, fetchurl, makeWrapper, makeDesktopItem }:
+{ jre8, stdenv, fetchurl, makeWrapper, makeDesktopItem }:
 
 let
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     cp -v readme.md $out/share/doc/
 
     # launcher with `cd` is required b/c otherwise the model library isn't usable
-    makeWrapper "${jre}/bin/java" "$out/bin/netlogo" \
+    makeWrapper "${jre8}/bin/java" "$out/bin/netlogo" \
       --run "cd $out/share/netlogo/app" \
       --add-flags "-jar netlogo-${version}.jar"
 

--- a/pkgs/applications/science/misc/openmodelica/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchgit, fetchsvn, autoconf, automake, libtool, gfortran, clang, cmake, gnumake,
-hwloc, jre, lapack, blas, hdf5, expat, ncurses, readline, qt4, webkitgtk, which,
+hwloc, jre8, lapack, blas, hdf5, expat, ncurses, readline, qt4, webkitgtk, which,
 lp_solve, omniorb, sqlite, libatomic_ops, pkgconfig, file, gettext, flex, bison,
 doxygen, boost, openscenegraph, gnome2, xorg, git, bash, gtk2, makeWrapper }:
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   src = fetchgit (import ./src-main.nix);
 
   buildInputs = [autoconf cmake automake libtool gfortran clang gnumake
-    hwloc jre lapack blas hdf5 expat ncurses readline qt4 webkitgtk which
+    hwloc jre8 lapack blas hdf5 expat ncurses readline qt4 webkitgtk which
     lp_solve omniorb sqlite libatomic_ops pkgconfig file gettext flex bison
     doxygen boost openscenegraph gnome2.gtkglext xorg.libXmu
     git gtk2 makeWrapper];

--- a/pkgs/applications/science/physics/quantomatic/default.nix
+++ b/pkgs/applications/science/physics/quantomatic/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "quantomatic";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   phases = [ "installPhase" ];
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/libexec/quantomatic
     cp $src $out/libexec/quantomatic/quantomatic.jar
     mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/quantomatic --add-flags "-jar $out/libexec/quantomatic/quantomatic.jar"
+    makeWrapper ${jre8}/bin/java $out/bin/quantomatic --add-flags "-jar $out/libexec/quantomatic/quantomatic.jar"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/programming/groove/default.nix
+++ b/pkgs/applications/science/programming/groove/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, makeWrapper, makeDesktopItem, icoutils, jre }:
+{ stdenv, fetchurl, unzip, makeWrapper, makeDesktopItem, icoutils, jre8 }:
 
 let
   desktopItem = makeDesktopItem {
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     for bin in Generator Imager ModelChecker PrologChecker Simulator Viewer; do
-      makeWrapper ${jre}/bin/java $out/bin/groove-''${bin,,} \
+      makeWrapper ${jre8}/bin/java $out/bin/groove-''${bin,,} \
         --add-flags "-jar $out/share/groove/bin/$bin.jar"
     done
 

--- a/pkgs/applications/science/programming/plm/default.nix
+++ b/pkgs/applications/science/programming/plm/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, makeWrapper, jre, gcc, valgrind}:
+{stdenv, fetchurl, makeWrapper, jre8, gcc, valgrind}:
 # gcc and valgrind are not strict dependencies, they could be made
 # optional. They are here because plm can only help you learn C if you
 # have them installed.
@@ -14,14 +14,14 @@ stdenv.mkDerivation rec {
     name = "${pname}-${version}.jar";
   };
 
-  buildInputs = [ makeWrapper jre gcc valgrind ];
+  buildInputs = [ makeWrapper jre8 gcc valgrind ];
 
   phases = [ "installPhase" ];
 
   installPhase = ''
     mkdir -p "$prefix/bin"
 
-    makeWrapper ${jre}/bin/java $out/bin/plm \
+    makeWrapper ${jre8}/bin/java $out/bin/plm \
       --add-flags "-jar $src" \
       --prefix PATH : "$PATH"
   '';

--- a/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 let
   version = "1.13.0";
@@ -15,7 +15,7 @@ in
       sha256 = "1kn84rsvms1v5l1j2xgrk7dc7mnsmxkc6sqd94mnim22vnwvl8mz";
     };
 
-    buildInputs = [ jre makeWrapper ];
+    buildInputs = [ jre8 makeWrapper ];
 
     phases = "installPhase";
 
@@ -23,7 +23,7 @@ in
       mkdir -p $out/share/java
       mkdir -p $out/bin
       cp $src $out/share/java/$jarName
-      makeWrapper "${jre}/bin/java" $out/bin/bfg --add-flags "-cp $out/share/java/$jarName com.madgag.git.bfg.cli.Main"
+      makeWrapper "${jre8}/bin/java" $out/bin/bfg --add-flags "-cp $out/share/java/$jarName com.madgag.git.bfg.cli.Main"
     '';
 
     meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/git-and-tools/subgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/subgit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, makeWrapper, jre }:
+{ stdenv, fetchurl, unzip, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   name = "subgit-3.3.9";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir $out;
     cp -r bin lib $out;
-    wrapProgram $out/bin/subgit --set JAVA_HOME ${jre};
+    wrapProgram $out/bin/subgit --set JAVA_HOME ${jre8};
   '';
 
   src = fetchurl {

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -6,14 +6,14 @@
 , javahlBindings ? false
 , saslSupport ? false
 , stdenv, fetchurl, apr, aprutil, zlib, sqlite, openssl, lz4, utf8proc
-, apacheHttpd ? null, expat, swig ? null, jdk ? null, python ? null, perl ? null
+, apacheHttpd ? null, expat, swig ? null, jdk8 ? null, python ? null, perl ? null
 , sasl ? null, serf ? null
 }:
 
 assert bdbSupport -> aprutil.bdbSupport;
 assert httpServer -> apacheHttpd != null;
 assert pythonBindings -> swig != null && python != null;
-assert javahlBindings -> jdk != null && perl != null;
+assert javahlBindings -> jdk8 != null && perl != null;
 
 let
 
@@ -54,7 +54,7 @@ let
       "--with-sqlite=${sqlite.dev}"
     ] ++ stdenv.lib.optionals javahlBindings [
       "--enable-javahl"
-      "--with-jdk=${jdk}"
+      "--with-jdk8=${jdk8}"
     ];
 
     preBuild = ''

--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -3,7 +3,7 @@
 , libgcrypt, libgpgerror, libunistring
 , boost, avahi, lame, autoreconfHook
 , gettext, pcre-cpp, yajl, fribidi, which
-, openssl, gperf, tinyxml2, taglib, libssh, swig, jre
+, openssl, gperf, tinyxml2, taglib, libssh, swig, jre8
 , libxml2, systemd
 , alsaLib, libGLU, libGL, glew, fontconfig, freetype, ftgl
 , libjpeg, libpng, libtiff
@@ -211,7 +211,7 @@ in stdenv.mkDerivation {
       which
       pkgconfig gnumake
       autoconf automake libtool # still needed for some components. Check if that is the case with 19.0
-      jre yasm gettext python2Packages.python flatbuffers
+      jre8 yasm gettext python2Packages.python flatbuffers
 
       # for TexturePacker
       giflib zlib libpng libjpeg lzo

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -7,7 +7,7 @@
 # the shipped alternative sources (assembly).
 , open-watcom-bin ? null
 , makeself, perl
-, javaBindings ? true, jdk ? null # Almost doesn't affect closure size
+, javaBindings ? true, jdk8 ? null # Almost doesn't affect closure size
 , pythonBindings ? false, python3 ? null
 , extensionPack ? null, fakeroot ? null
 , pulseSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
@@ -56,7 +56,7 @@ in stdenv.mkDerivation {
     [ iasl' dev86 libxslt libxml2 xorgproto libX11 libXext libXcursor libIDL
       libcap glib lvm2 alsaLib curl libvpx pam makeself perl
       libXmu libpng libopus python ]
-    ++ optional javaBindings jdk
+    ++ optional javaBindings jdk8
     ++ optional pythonBindings python # Python is needed even when not building bindings
     ++ optional pulseSupport libpulseaudio
     ++ optionals (headless) [ libXrandr libGL ]
@@ -135,7 +135,7 @@ in stdenv.mkDerivation {
     VBOX_PATH_APP_PRIVATE          := $out/share/virtualbox
     VBOX_PATH_APP_DOCS             := $out/doc
     ${optionalString javaBindings ''
-    VBOX_JAVA_HOME                 := ${jdk}
+    VBOX_JAVA_HOME                 := ${jdk8}
     ''}
     ${optionalString (!headless) ''
     PATH_QT5_X11_EXTRAS_LIB        := ${getLib qtx11extras}/lib

--- a/pkgs/build-support/release/ant-build.nix
+++ b/pkgs/build-support/release/ant-build.nix
@@ -9,7 +9,7 @@
 , antBuildInputs ? []
 , buildfile ? "build.xml"
 , ant ? pkgs.ant
-, jre ? pkgs.jdk
+, jre8 ? pkgs.jdk8
 , hydraAntLogger ? pkgs.hydraAntLogger
 , zip ? pkgs.zip
 , unzip ? pkgs.unzip
@@ -22,7 +22,7 @@ in
 stdenv.mkDerivation (
 
   {
-    inherit jre ant;
+    inherit jre8 ant;
     showBuildStats = true;
 
     postPhases =
@@ -70,8 +70,8 @@ stdenv.mkDerivation (
       mkdir -p $out/bin
       cat >> $out/bin/${w.name} <<EOF
       #!${pkgs.runtimeShell}
-      export JAVA_HOME=$jre
-      $jre/bin/java ${cp w} ${if w ? mainClass then w.mainClass else "-jar ${w.jar}"} \$@
+      export JAVA_HOME=$jre8
+      $jre8/bin/java ${cp w} ${if w ? mainClass then w.mainClass else "-jar ${w.jar}"} \$@
       EOF
 
       chmod a+x $out/bin/${w.name} || exit 1
@@ -108,7 +108,7 @@ stdenv.mkDerivation (
   {
     name = name + (if src ? version then "-" + src.version else "");
 
-    buildInputs = [ant jre zip unzip] ++ stdenv.lib.optional (args ? buildInputs) args.buildInputs ;
+    buildInputs = [ant jre8 zip unzip] ++ stdenv.lib.optional (args ? buildInputs) args.buildInputs ;
 
     postHook = ''
       mkdir -p $out/nix-support

--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchurl, jdk, ant
+{ stdenv, lib, fetchFromGitHub, fetchurl, jdk8, ant
 , libusb-compat-0_1, libusb1, unzip, zlib, ncurses, readline
 , withGui ? false, gtk2 ? null, withTeensyduino ? false
   /* Packages needed for Teensyduino */
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
   };
 
 
-  buildInputs = [ jdk ant libusb-compat-0_1 libusb1 unzip zlib ncurses5 readline
+  buildInputs = [ jdk8 ant libusb-compat-0_1 libusb1 unzip zlib ncurses5 readline
   ] ++ stdenv.lib.optionals withTeensyduino [ upx ];
   downloadSrcList = builtins.attrValues externalDownloads;
   downloadDstList = builtins.attrNames externalDownloads;
@@ -126,7 +126,7 @@ stdenv.mkDerivation rec {
   # This will be patched into `arduino` wrapper script
   # Java loads gtk dynamically, so we need to provide it using LD_LIBRARY_PATH
   dynamicLibraryPath = lib.makeLibraryPath [gtk2];
-  javaPath = lib.makeBinPath [jdk];
+  javaPath = lib.makeBinPath [jdk8];
 
   # Everything else will be patched into rpath
   rpath = (lib.makeLibraryPath [zlib libusb-compat-0_1 libusb1 readline ncurses5 stdenv.cc.cc]);

--- a/pkgs/development/compilers/abcl/default.nix
+++ b/pkgs/development/compilers/abcl/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ant, jre, jdk}:
+{stdenv, fetchurl, ant, jre8, jdk8}:
 stdenv.mkDerivation rec {
   pname = "abcl";
   version = "1.6.1";
@@ -24,10 +24,10 @@ stdenv.mkDerivation rec {
     cp -r dist/*.jar contrib/ "$out/lib/abcl/"
 
     echo "#! ${stdenv.shell}" >> "$out/bin/abcl"
-    echo "${jre}/bin/java -cp \"$out/lib/abcl/abcl.jar:$out/lib/abcl/abcl-contrib.jar:\$CLASSPATH\" org.armedbear.lisp.Main \"\$@\"" >> "$out/bin/abcl"
+    echo "${jre8}/bin/java -cp \"$out/lib/abcl/abcl.jar:$out/lib/abcl/abcl-contrib.jar:\$CLASSPATH\" org.armedbear.lisp.Main \"\$@\"" >> "$out/bin/abcl"
     chmod a+x "$out"/bin/*
   '';
-  buildInputs = [jre ant jdk jre];
+  buildInputs = [jre8 ant jdk8.jre];
   meta = {
     inherit version;
     description = ''A JVM-based Common Lisp implementation'';

--- a/pkgs/development/compilers/aldor/default.nix
+++ b/pkgs/development/compilers/aldor/default.nix
@@ -1,5 +1,5 @@
 { fetchgit, stdenv, gmp, which, flex, bison, makeWrapper
-, autoconf, automake, libtool, jdk, perl }:
+, autoconf, automake, libtool, jdk8, perl }:
 
 stdenv.mkDerivation {
   name = "aldor-1.2.0";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ gmp which flex bison makeWrapper autoconf automake libtool
-                  jdk perl ];
+                  jdk8 perl ];
 
   preConfigure = ''
     cd aldor ;
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     for prog in aldor unicl javagen ;
     do
       wrapProgram $out/bin/$prog --set ALDORROOT $out \
-        --prefix PATH : ${jdk}/bin \
+        --prefix PATH : ${jdk8}/bin \
         --prefix PATH : ${stdenv.cc}/bin ;
     done
   '';

--- a/pkgs/development/compilers/apache-flex-sdk/default.nix
+++ b/pkgs/development/compilers/apache-flex-sdk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre8 }:
 
 let
   playerglobal_ver = "27.0";
@@ -17,14 +17,14 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   buildPhase = ":";
 
   postPatch = ''
     shopt -s extglob
     for i in bin/!(aasdoc|acompc|amxmlc); do
-      substituteInPlace $i --replace "java " "${jre}/bin/java "
+      substituteInPlace $i --replace "java " "${jre8}/bin/java "
     done
   '';
 

--- a/pkgs/development/compilers/aspectj/builder.sh
+++ b/pkgs/development/compilers/aspectj/builder.sh
@@ -1,14 +1,14 @@
 source $stdenv/setup
 
-export JAVA_HOME=$jre
+export JAVA_HOME=$jre8
 
 cat >> props <<EOF
 output.dir=$out
-context.javaPath=$jre
+context.javaPath=$jre8
 EOF
 
 mkdir -p $out
-$jre/bin/java -jar $src -text props
+$jre8/bin/java -jar $src -text props
 
 echo "Removing files at top level"
 for file in $out/*

--- a/pkgs/development/compilers/aspectj/default.nix
+++ b/pkgs/development/compilers/aspectj/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, jre}:
+{stdenv, fetchurl, jre8}:
 
 stdenv.mkDerivation rec {
   name = "aspectj-1.5.2";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1b3mx248dc1xka1vgsl0jj4sm0nfjsqdcj9r9036mvixj1zj3nmh";
   };
 
-  inherit jre;
-  buildInputs = [jre];
+  inherit jre8;
+  buildInputs = [jre8];
 
   meta = {
     homepage = "http://www.eclipse.org/aspectj/";

--- a/pkgs/development/compilers/avian/default.nix
+++ b/pkgs/development/compilers/avian/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, zlib, jdk, CoreServices, Foundation }:
+{ stdenv, fetchFromGitHub, zlib, jdk8, CoreServices, Foundation }:
 
 stdenv.mkDerivation rec {
   pname = "avian";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1j2y45cpqk3x6a743mgpg7z3ivwm7qc9jy6xirvay7ah1qyxmm48";
   };
 
-  buildInputs = [ zlib jdk ]
+  buildInputs = [ zlib jdk8 ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices Foundation ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error";

--- a/pkgs/development/compilers/closure/default.nix
+++ b/pkgs/development/compilers/closure/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "closure-compiler";
@@ -12,12 +12,12 @@ stdenv.mkDerivation rec {
   sourceRoot = ".";
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   installPhase = ''
     mkdir -p $out/share/java $out/bin
     cp closure-compiler-v${version}.jar $out/share/java
-    makeWrapper ${jre}/bin/java $out/bin/closure-compiler \
+    makeWrapper ${jre8}/bin/java $out/bin/closure-compiler \
       --add-flags "-jar $out/share/java/closure-compiler-v${version}.jar"
   '';
 

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -169,7 +169,7 @@ stdenv.mkDerivation rec {
       if [[ $i =~ libcudart ]]; then
         rpath2=
       else
-        rpath2=$rpath:$lib/lib:$out/jre/lib/amd64/jli:$out/lib:$out/lib64:$out/nvvm/lib:$out/nvvm/lib64
+        rpath2=$rpath:$lib/lib:$out/jre8/lib/amd64/jli:$out/lib:$out/lib64:$out/nvvm/lib:$out/nvvm/lib64
       fi
       patchelf --set-rpath "$rpath2" --force-rpath $i
     done < <(find $out $lib $doc -type f -print0)

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -1,5 +1,5 @@
 { emscriptenVersion, stdenv, fetchFromGitHub, emscriptenfastcomp, python, nodejs, closurecompiler
-, jre, binaryen, enableWasm ? true ,  cmake
+, jre8, binaryen, enableWasm ? true ,  cmake
 }:
 
 let
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
     echo "JS_ENGINES = [NODE_JS]" >> $out/${appdir}/config
     echo "COMPILER_ENGINE = NODE_JS" >> $out/${appdir}/config
     echo "CLOSURE_COMPILER = '${closurecompiler}/share/java/closure-compiler-v${closurecompiler.version}.jar'" >> $out/${appdir}/config
-    echo "JAVA = '${jre}/bin/java'" >> $out/${appdir}/config
+    echo "JAVA = '${jre8}/bin/java'" >> $out/${appdir}/config
     # to make the test(s) below work
     echo "SPIDERMONKEY_ENGINE = []" >> $out/${appdir}/config
   ''

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -156,7 +156,7 @@ let
       # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
       # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
       "--enable-java-home"
-      "--with-java-home=\${prefix}/lib/jvm/jre"
+      "--with-java-home=\${prefix}/lib/jvm/jre8"
     ]
     ++ lib.optional javaAwtGtk "--enable-java-awt=gtk"
     ++ lib.optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}"

--- a/pkgs/development/compilers/graalvm/008_remove_jfr.patch
+++ b/pkgs/development/compilers/graalvm/008_remove_jfr.patch
@@ -6,14 +6,14 @@ index 9690c0a38f..fa1d36b7e1 100644
        "workingSets" : "JVMCI,HotSpot,SPARC",
      },
  
--    "jdk.vm.ci.hotspot.jfr" : {
+-    "jdk8.vm.ci.hotspot.jfr" : {
 -      "subDir" : "jvmci",
 -      "sourceDirs" : ["src"],
 -      "dependencies" : [
--        "jdk.vm.ci.hotspot",
+-        "jdk8.vm.ci.hotspot",
 -        "JFR",
 -      ],
--      "checkstyle" : "jdk.vm.ci.hotspot",
+-      "checkstyle" : "jdk8.vm.ci.hotspot",
 -      "javaCompliance" : "1.8",
 -      "profile" : "",
 -      "workingSets" : "JVMCI,HotSpot",
@@ -23,10 +23,10 @@ index 9690c0a38f..fa1d36b7e1 100644
      "hotspot" : {
        "native" : True,
 @@ -354,7 +343,7 @@ suite = {
-         "jdk.vm.ci.hotspot.aarch64",
-         "jdk.vm.ci.hotspot.amd64",
-         "jdk.vm.ci.hotspot.sparc",
--        "jdk.vm.ci.hotspot.jfr",
+         "jdk8.vm.ci.hotspot.aarch64",
+         "jdk8.vm.ci.hotspot.amd64",
+         "jdk8.vm.ci.hotspot.sparc",
+-        "jdk8.vm.ci.hotspot.jfr",
 +
        ],
        "distDependencies" : [

--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -334,7 +334,7 @@ in rec {
       ${if stdenv.isDarwin
         then "mv openjdk1.8.0_*/darwin-amd64/product/* $out"
         else "mv openjdk1.8.0_*/linux-amd64/product/* $out"}
-      install -v -m0555 -D $MX_CACHE_DIR/hsdis*/hsdis.so $out/jre/lib/amd64/hsdis-amd64.so
+      install -v -m0555 -D $MX_CACHE_DIR/hsdis*/hsdis.so $out/jre8/lib/amd64/hsdis-amd64.so
     '';
     # copy-paste openjdk's preFixup
     preFixup = ''
@@ -485,13 +485,13 @@ in rec {
       cp -rf $MX_ALT_OUTPUT_ROOT/vm/linux-amd64/GRAALVM*/graalvm-unknown-${version}/* $out
 
       # BUG workaround http://mail.openjdk.java.net/pipermail/graal-dev/2017-December/005141.html
-      substituteInPlace $out/jre/lib/security/java.security \
+      substituteInPlace $out/jre8/lib/security/java.security \
         --replace file:/dev/random    file:/dev/./urandom \
         --replace NativePRNGBlocking  SHA1PRNG
       # copy static and dynamic libraries needed for static compilation
-      cp -rf ${glibc}/lib/* $out/jre/lib/svm/clibraries/linux-amd64/
-      cp ${glibc.static}/lib/* $out/jre/lib/svm/clibraries/linux-amd64/
-      cp ${zlib.static}/lib/libz.a $out/jre/lib/svm/clibraries/linux-amd64/libz.a
+      cp -rf ${glibc}/lib/* $out/jre8/lib/svm/clibraries/linux-amd64/
+      cp ${glibc.static}/lib/* $out/jre8/lib/svm/clibraries/linux-amd64/
+      cp ${zlib.static}/lib/libz.a $out/jre8/lib/svm/clibraries/linux-amd64/libz.a
     '');
 
     inherit (jvmci8) preFixup;

--- a/pkgs/development/compilers/graalvm/enterprise-edition.nix
+++ b/pkgs/development/compilers/graalvm/enterprise-edition.nix
@@ -75,17 +75,17 @@ let
         installPhase = {
           "8" = ''
             # BUG workaround http://mail.openjdk.java.net/pipermail/graal-dev/2017-December/005141.html
-            substituteInPlace $out/jre/lib/security/java.security \
+            substituteInPlace $out/jre8/lib/security/java.security \
               --replace file:/dev/random    file:/dev/./urandom \
               --replace NativePRNGBlocking  SHA1PRNG
 
             # provide libraries needed for static compilation
             for f in ${glibc}/lib/* ${glibc.static}/lib/* ${zlib.static}/lib/*; do
-              ln -s $f $out/jre/lib/svm/clibraries/linux-amd64/$(basename $f)
+              ln -s $f $out/jre8/lib/svm/clibraries/linux-amd64/$(basename $f)
             done
 
             # allow using external truffle-api.jar and languages not included in the distrubution
-            rm $out/jre/lib/jvmci/parentClassLoader.classpath
+            rm $out/jre8/lib/jvmci/parentClassLoader.classpath
           '';
           "11" = ''
             # BUG workaround http://mail.openjdk.java.net/pipermail/graal-dev/2017-December/005141.html
@@ -112,7 +112,7 @@ let
         '';
 
         postFixup = ''
-          rpath="${ {  "8" = "$out/jre/lib/amd64/jli:$out/jre/lib/amd64/server:$out/jre/lib/amd64";
+          rpath="${ {  "8" = "$out/jre8/lib/amd64/jli:$out/jre8/lib/amd64/server:$out/jre8/lib/amd64";
                       "11" = "$out/lib/jli:$out/lib/server:$out/lib";
                     }.${javaVersion}
                  }:${

--- a/pkgs/development/compilers/jasmin/default.nix
+++ b/pkgs/development/compilers/jasmin/default.nix
@@ -1,10 +1,10 @@
 { stdenv
 , fetchurl
 , unzip
-, jdk
+, jdk8
 , ant
 , makeWrapper
-, jre
+, jre8
 , callPackage
 }:
 
@@ -17,14 +17,14 @@ stdenv.mkDerivation rec {
     sha256 = "17a41vr96glcdrdbk88805wwvv1r6w8wg7if23yhd0n6rrl0r8ga";
   };
 
-  nativeBuildInputs = [ unzip jdk ant makeWrapper ];
+  nativeBuildInputs = [ unzip jdk8 ant makeWrapper ];
 
   buildPhase = "ant all";
   installPhase =
   ''
     install -Dm644 jasmin.jar $out/share/java/jasmin.jar
     mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/jasmin \
+    makeWrapper ${jre8}/bin/java $out/bin/jasmin \
       --add-flags "-jar $out/share/java/jasmin.jar"
   '';
 

--- a/pkgs/development/compilers/jasmin/test-assemble-hello-world/default.nix
+++ b/pkgs/development/compilers/jasmin/test-assemble-hello-world/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, jasmin, jre }:
+{ stdenv, jasmin, jre8 }:
 
 stdenv.mkDerivation {
   name = "jasmin-test-assemble-hello-world";
   meta.timeout = 60;
   buildCommand = ''
     ${jasmin}/bin/jasmin ${./HelloWorld.j}
-    ${jre}/bin/java HelloWorld | grep "Hello World"
+    ${jre8}/bin/java HelloWorld | grep "Hello World"
     touch $out
   '';
 }

--- a/pkgs/development/compilers/kotlin/default.nix
+++ b/pkgs/development/compilers/kotlin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre, unzip }:
+{ stdenv, fetchurl, makeWrapper, jre8, unzip }:
 
 let
   version = "1.3.72";
@@ -11,7 +11,7 @@ in stdenv.mkDerivation {
     sha256 = "0v6c4vjiflwbjjc1lmiyzrilxwbqcz5ll6ls40zhw70zk23xpl6c";
   };
 
-  propagatedBuildInputs = [ jre ] ;
+  propagatedBuildInputs = [ jre8 ] ;
   buildInputs = [ makeWrapper unzip ] ;
 
   installPhase = ''
@@ -20,7 +20,7 @@ in stdenv.mkDerivation {
     mv * $out
 
     for p in $(ls $out/bin/) ; do
-      wrapProgram $out/bin/$p --prefix PATH ":" ${jre}/bin ;
+      wrapProgram $out/bin/$p --prefix PATH ":" ${jre8}/bin ;
     done
 
     if [ -f $out/LICENSE ]; then

--- a/pkgs/development/compilers/mercury/default.nix
+++ b/pkgs/development/compilers/mercury/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gcc, flex, bison, texinfo, jdk, erlang, makeWrapper
+{ stdenv, fetchurl, gcc, flex, bison, texinfo, jdk8, erlang, makeWrapper
 , readline }:
 
 stdenv.mkDerivation rec {
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "084ml6kswgaqjgmib3gq7zjnqsimz3f35w13ff6z0dv4d9csmq4m";
   };
 
-  buildInputs = [ gcc flex bison texinfo jdk erlang makeWrapper
+  buildInputs = [ gcc flex bison texinfo jdk8 erlang makeWrapper
                   readline ];
 
   patchPhase = ''
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     for e in $(ls $out/bin) ; do
       wrapProgram $out/bin/$e \
         --prefix PATH ":" "${gcc}/bin" \
-        --prefix PATH ":" "${jdk}/bin" \
+        --prefix PATH ":" "${jdk8}/bin" \
         --prefix PATH ":" "${erlang}/bin"
     done
   '';

--- a/pkgs/development/compilers/mozart/default.nix
+++ b/pkgs/development/compilers/mozart/default.nix
@@ -10,7 +10,7 @@
 , gmp
 , emacs
 , emacs25-nox
-, jre_headless
+, jre8_headless
 , tcl
 , tk
 }:
@@ -74,7 +74,7 @@ in stdenv.mkDerivation rec {
     llvmPackages_5.clang-unwrapped
     gmp
     emacs25-nox
-    jre_headless
+    jre8_headless
     tcl
     tk
   ];

--- a/pkgs/development/compilers/opa/default.nix
+++ b/pkgs/development/compilers/opa/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, which, perl, jdk
+{ stdenv, fetchFromGitHub, which, perl, jdk8
 , ocamlPackages, openssl
 , coreutils, zlib, ncurses, makeWrapper
 , gcc, binutils, gnumake, nodejs
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "-ocamlfind ${ocamlPackages.findlib}/bin/ocamlfind" ];
 
-  buildInputs = [ which perl jdk openssl coreutils zlib ncurses
+  buildInputs = [ which perl jdk8 openssl coreutils zlib ncurses
     makeWrapper gcc binutils gnumake nodejs
   ] ++ (with ocamlPackages; [
     ocaml findlib ssl cryptokit camlzip ulex ocamlgraph camlp4

--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchFromGitHub, jdk, gmp, readline, openssl, unixODBC, zlib
+{ stdenv, fetchFromGitHub, jdk8, gmp, readline, openssl, unixODBC, zlib
 , libarchive, db, pcre, libedit, libossp_uuid, libXpm
 , libSM, libXt, freetype, pkgconfig, fontconfig
 , cmake, libyaml, Security
 , libjpeg, libX11, libXext, libXft, libXinerama
-, extraLibraries ? [ jdk unixODBC libXpm libSM libXt freetype fontconfig ]
+, extraLibraries ? [ jdk8 unixODBC libXpm libSM libXt freetype fontconfig ]
 , extraPacks     ? []
 , withGui ? false
 }:

--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation {
   pname = "zulu";
 
   src = fetchurl {
-    url = "https://cdn.azul.com/zulu/bin/zulu${version}-jdk${openjdk}-${platform}_x64.${extension}";
+    url = "https://cdn.azul.com/zulu/bin/zulu${version}-jdk8${openjdk}-${platform}_x64.${extension}";
     sha256 = hash;
   };
 
@@ -39,7 +39,7 @@ in stdenv.mkDerivation {
     mkdir -p $out
     cp -r ./* "$out/"
 
-    jrePath="$out/jre"
+    jrePath="$out/jre8"
 
     rpath=$rpath''${rpath:+:}$jrePath/lib/amd64/jli
     rpath=$rpath''${rpath:+:}$jrePath/lib/amd64/server

--- a/pkgs/development/compilers/zulu/default.nix
+++ b/pkgs/development/compilers/zulu/default.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation {
   pname = "zulu";
 
   src = fetchurl {
-    url = "https://cdn.azul.com/zulu/bin/zulu${version}-jdk${openjdk}-${platform}_x64.${extension}";
+    url = "https://cdn.azul.com/zulu/bin/zulu${version}-jdk8${openjdk}-${platform}_x64.${extension}";
     sha256 = hash;
   };
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -161,7 +161,7 @@ self: super: {
     '';
   });
 
-  inline-java = addBuildDepend super.inline-java pkgs.jdk;
+  inline-java = addBuildDepend super.inline-java pkgs.jdk8;
 
   # Upstream notified by e-mail.
   permutation = dontCheck super.permutation;

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -82,7 +82,7 @@ self: super: builtins.intersectAttrs super {
   # jni needs help finding libjvm.so because it's in a weird location.
   jni = overrideCabal super.jni (drv: {
     preConfigure = ''
-      local libdir=( "${pkgs.jdk}/lib/openjdk/jre/lib/"*"/server" )
+      local libdir=( "${pkgs.jdk8}/lib/openjdk/jre8/lib/"*"/server" )
       configureFlags+=" --extra-lib-dir=''${libdir[0]}"
     '';
   });

--- a/pkgs/development/interpreters/clojure/clooj.nix
+++ b/pkgs/development/interpreters/clojure/clooj.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 let version = "0.4.4"; in
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/share/java
     ln -s $jar $out/share/java/clooj.jar
-    makeWrapper ${jre}/bin/java $out/bin/clooj --add-flags "-jar $out/share/java/clooj.jar"
+    makeWrapper ${jre8}/bin/java $out/bin/clooj --add-flags "-jar $out/share/java/clooj.jar"
   '';
 
   meta = {

--- a/pkgs/development/interpreters/clojurescript/lumo/default.nix
+++ b/pkgs/development/interpreters/clojurescript/lumo/default.nix
@@ -4,7 +4,7 @@
 , clojure
 , gnutar
 , nodejs
-, jre
+, jre8
 , unzip
 , nodePackages
 , xcbuild
@@ -152,7 +152,7 @@ stdenv.mkDerivation {
   buildInputs = [
     nodejs
     clojure
-    jre
+    jre8
     unzip
     python
     openssl

--- a/pkgs/development/interpreters/clojurescript/lumo/deps.nix
+++ b/pkgs/development/interpreters/clojurescript/lumo/deps.nix
@@ -252,7 +252,7 @@ in rec {
       artifactId = "guava";
       groupId = "com.google.guava";
       sha512 = "429ceeec0350ba98e2b089b8b70ded2ec570c3a684894a7545d10592c1c7be42dacd1fad8b2cb9123aa3612575ce1b56e1bb54923443fc293f8e9adeac2762ee";
-      version = "25.1-jre";
+      version = "25.1-jre8";
     };
   }
 

--- a/pkgs/development/interpreters/groovy/default.nix
+++ b/pkgs/development/interpreters/groovy/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, unzip, which, makeWrapper, jdk }:
+{ stdenv, fetchurl, unzip, which, makeWrapper, jdk8 }:
 
-# at runtime, need jdk
+# at runtime, need jdk8
 
 stdenv.mkDerivation rec {
   pname = "groovy";
@@ -24,8 +24,8 @@ stdenv.mkDerivation rec {
 
     for p in grape java2groovy groovy{,doc,c,sh,Console}; do
       wrapProgram $out/bin/$p \
-            --set JAVA_HOME "${jdk}" \
-            --prefix PATH ":" "${jdk}/bin"
+            --set JAVA_HOME "${jdk8}" \
+            --prefix PATH ":" "${jdk8}/bin"
     done
   '';
 

--- a/pkgs/development/interpreters/jruby/default.nix
+++ b/pkgs/development/interpreters/jruby/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage, fetchurl, makeWrapper, jre }:
+{ stdenv, callPackage, fetchurl, makeWrapper, jre8 }:
 
 let
 # The version number here is whatever is reported by the RUBY_VERSION string
@@ -23,7 +23,7 @@ jruby = stdenv.mkDerivation rec {
 
      for i in $out/bin/jruby{,.bash}; do
        wrapProgram $i \
-         --set JAVA_HOME ${jre}
+         --set JAVA_HOME ${jre8}
      done
 
      ln -s $out/bin/jruby $out/bin/ruby

--- a/pkgs/development/interpreters/jython/default.nix
+++ b/pkgs/development/interpreters/jython/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "jython";
@@ -17,13 +17,13 @@ stdenv.mkDerivation rec {
   installPhase = ''
      mkdir -pv $out/bin
      cp $src $out/jython.jar
-     makeWrapper ${jre}/bin/java $out/bin/jython --add-flags "-jar $out/jython.jar"
+     makeWrapper ${jre8}/bin/java $out/bin/jython --add-flags "-jar $out/jython.jar"
   '';
 
   meta = {
     description = "Python interpreter written in Java";
     homepage = "https://jython.org/";
     license = stdenv.lib.licenses.psfl;
-    platforms = jre.meta.platforms;
+    platforms = jre8.meta.platforms;
   };
 }

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -35,7 +35,7 @@
 , readline ? null
 # - Build Java interface:
 , enableJava ? true
-, jdk ? null
+, jdk8 ? null
 , python ? null
 , overridePlatforms ? null
 , sundials_2 ? null
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
   ++ (stdenv.lib.optional (hdf5 != null) hdf5)
   ++ (stdenv.lib.optional (glpk != null) glpk)
   ++ (stdenv.lib.optional (suitesparse != null) suitesparse)
-  ++ (stdenv.lib.optional (enableJava) jdk)
+  ++ (stdenv.lib.optional (enableJava) jdk8)
   ++ (stdenv.lib.optional (sundials_2 != null) sundials_2)
   ++ (stdenv.lib.optional (gnuplot != null) gnuplot)
   ++ (stdenv.lib.optional (python != null) python)

--- a/pkgs/development/interpreters/picolisp/default.nix
+++ b/pkgs/development/interpreters/picolisp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jdk, w3m, openssl, makeWrapper }:
+{ stdenv, fetchurl, jdk8, w3m, openssl, makeWrapper }:
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     url = "https://www.software-lab.de/${pname}-${version}.tgz";
     sha256 = "10np0mhihr47r3201617zccrvzpkhdl1jwvz7zimk8kxpriydq2j";
   };
-  buildInputs = [makeWrapper openssl] ++ optional stdenv.is64bit jdk;
+  buildInputs = [makeWrapper openssl] ++ optional stdenv.is64bit jdk8;
   patchPhase = ''
     sed -i "s/which java/command -v java/g" mkAsm
 

--- a/pkgs/development/interpreters/python/graalpython/default.nix
+++ b/pkgs/development/interpreters/python/graalpython/default.nix
@@ -13,7 +13,7 @@ let
     sourceVersion = graalvm8.version;
     pythonVersion = "3.7";
     libPrefix = "graalvm";
-    sitePackages = "jre/languages/python/lib-python/3/site-packages";
+    sitePackages = "jre8/languages/python/lib-python/3/site-packages";
     executable = "graalpython";
     hasDistutilsCxxPatch = false;
     pythonForBuild = pkgs.buildPackages.pythonInterpreters.graalpython37;

--- a/pkgs/development/interpreters/rascal/default.nix
+++ b/pkgs/development/interpreters/rascal/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jdk }:
+{ stdenv, fetchurl, makeWrapper, jdk8 }:
 
 stdenv.mkDerivation rec {
   name = "rascal-0.6.2";
@@ -8,14 +8,14 @@ stdenv.mkDerivation rec {
     sha256 = "1z4mwdbdc3r24haljnxng8znlfg2ihm9bf9zq8apd9a32ipcw4i6";
   };
 
-  buildInputs = [ makeWrapper jdk ];
+  buildInputs = [ makeWrapper jdk8 ];
 
   dontUnpack = true;
 
   installPhase =
     ''
       mkdir -p $out/bin
-      makeWrapper ${jdk}/bin/java $out/bin/rascal \
+      makeWrapper ${jdk8}/bin/java $out/bin/rascal \
         --add-flags "-jar ${src}" \
     '';
 

--- a/pkgs/development/java-modules/jogl/default.nix
+++ b/pkgs/development/java-modules/jogl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, ant, jdk, git, xorg, udev, libGL, libGLU }:
+{ stdenv, fetchgit, ant, jdk8, git, xorg, udev, libGL, libGLU }:
 
 {
   jogl_2_3_2 =
@@ -28,7 +28,7 @@
           -exec sed -i 's@"libGLU.so"@"${libGLU}/lib/libGLU.so"@' {} \;
       '';
 
-      nativeBuildInputs = [ jdk ant git ];
+      nativeBuildInputs = [ jdk8 ant git ];
       buildInputs = [ udev xorg.libX11 xorg.libXrandr xorg.libXcursor xorg.libXt xorg.libXxf86vm xorg.libXrender ];
 
       buildPhase = ''

--- a/pkgs/development/libraries/belle-sip/default.nix
+++ b/pkgs/development/libraries/belle-sip/default.nix
@@ -2,7 +2,7 @@
 , bctoolbox
 , cmake
 , fetchFromGitLab
-, jre
+, jre8
 , libantlr3c
 , mbedtls
 , stdenv
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     sha256 = "0pzxk8mkkg6zsnmj1bwggbdjv864psx89gglfm51h8s501kg11fv";
   };
 
-  nativeBuildInputs = [ jre cmake ];
+  nativeBuildInputs = [ jre8 cmake ];
 
   buildInputs = [ zlib ];
 

--- a/pkgs/development/libraries/freetts/default.nix
+++ b/pkgs/development/libraries/freetts/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, apacheAnt, unzip, sharutils, lib, jdk}:
+{stdenv, fetchurl, apacheAnt, unzip, sharutils, lib, jdk8}:
 
 stdenv.mkDerivation {
   name = "freetts-1.2.2";
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
     url = "mirror://sourceforge/freetts/freetts-1.2.2-src.zip";
     sha256 = "0mnikqhpf4f4jdr0irmibr8yy0dnffx1i257y22iamxi7a6by2r7";
   };
-  buildInputs = [ apacheAnt unzip sharutils jdk ];
+  buildInputs = [ apacheAnt unzip sharutils jdk8 ];
   unpackPhase = ''
     unzip $src -x META-INF/*
   '';

--- a/pkgs/development/libraries/java/cup/default.nix
+++ b/pkgs/development/libraries/java/cup/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jdk, ant } :
+{ stdenv, fetchurl, jdk8, ant } :
 
 stdenv.mkDerivation rec {
   pname = "java-cup";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   sourceRoot = ".";
 
-  nativeBuildInputs = [ jdk ant ];
+  nativeBuildInputs = [ jdk8 ant ];
 
   patches = [ ./javacup-0.11b_beta20160615-build-xml-git.patch ];
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     cp dist/java-cup-11b-runtime.jar $out/share/java/
     cat > $out/bin/javacup <<EOF
     #! $shell
-    exec ${jdk.jre}/bin/java -jar $out/share/java-cup/java-cup-11b.jar "\$@"
+    exec ${jdk8.jre}/bin/java -jar $out/share/java-cup/java-cup-11b.jar "\$@"
     EOF
     chmod a+x $out/bin/javacup
   '';

--- a/pkgs/development/libraries/java/dbus-java/default.nix
+++ b/pkgs/development/libraries/java/dbus-java/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gettext, jdk, libmatthew_java}:
+{stdenv, fetchurl, gettext, jdk8, libmatthew_java}:
 
 stdenv.mkDerivation {
   name = "dbus-java-2.7";
@@ -6,12 +6,12 @@ stdenv.mkDerivation {
     url = "https://dbus.freedesktop.org/releases/dbus-java/dbus-java-2.7.tar.gz";
     sha256 = "0cyaxd8x6sxmi6pklkkx45j311a6w51fxl4jc5j3inc4cailwh5y";
   };
-  JAVA_HOME=jdk;
-  JAVA="${jdk}/bin/java";
+  JAVA_HOME=jdk8;
+  JAVA="${jdk8}/bin/java";
   PREFIX=''''${out}'';
   JAVAUNIXLIBDIR="${libmatthew_java}/lib/jni";
   JAVAUNIXJARDIR="${libmatthew_java}/share/java";
-  buildInputs = [ gettext jdk ];
+  buildInputs = [ gettext jdk8 ];
   # I'm too lazy to build the documentation
   preBuild = ''
     sed -i -e "s|all: bin doc man|all: bin|" \

--- a/pkgs/development/libraries/java/geoipjava/default.nix
+++ b/pkgs/development/libraries/java/geoipjava/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, jdk, unzip}:
+{stdenv, fetchurl, jdk8, unzip}:
 
 stdenv.mkDerivation {
   name = "GeoIPJava-1.2.5";
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
     url = "https://geolite.maxmind.com/download/geoip/api/java/GeoIPJava-1.2.5.zip";
     sha256 = "1gb2d0qvvq7xankz7l7ymbr3qprwk9bifpy4hlgw0sq4i6a55ypd";
   };
-  buildInputs = [ jdk unzip ];
+  buildInputs = [ jdk8 unzip ];
   buildPhase = 
     ''
       cd source

--- a/pkgs/development/libraries/java/hsqldb/default.nix
+++ b/pkgs/development/libraries/java/hsqldb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, makeWrapper, jre }:
+{ stdenv, fetchurl, unzip, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "hsqldb";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ unzip makeWrapper ];
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   installPhase = ''
     runHook preInstall
@@ -19,12 +19,12 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib $out/bin
     cp -R hsqldb/lib/*.jar $out/lib
 
-    makeWrapper ${jre}/bin/java $out/bin/hsqldb --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.server.Server"
-    makeWrapper ${jre}/bin/java $out/bin/runServer --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.server.Server"
-    makeWrapper ${jre}/bin/java $out/bin/runManagerSwing --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.util.DatabaseManagerSwing"
-    makeWrapper ${jre}/bin/java $out/bin/runWebServer --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.server.WebServer"
-    makeWrapper ${jre}/bin/java $out/bin/runManager --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.util.DatabaseManager"
-    makeWrapper ${jre}/bin/java $out/bin/sqltool --add-flags "-jar $out/lib/sqltool.jar"
+    makeWrapper ${jre8}/bin/java $out/bin/hsqldb --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.server.Server"
+    makeWrapper ${jre8}/bin/java $out/bin/runServer --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.server.Server"
+    makeWrapper ${jre8}/bin/java $out/bin/runManagerSwing --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.util.DatabaseManagerSwing"
+    makeWrapper ${jre8}/bin/java $out/bin/runWebServer --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.server.WebServer"
+    makeWrapper ${jre8}/bin/java $out/bin/runManager --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.util.DatabaseManager"
+    makeWrapper ${jre8}/bin/java $out/bin/sqltool --add-flags "-jar $out/lib/sqltool.jar"
 
    runHook postInstall
   '';

--- a/pkgs/development/libraries/java/hydra-ant-logger/default.nix
+++ b/pkgs/development/libraries/java/hydra-ant-logger/default.nix
@@ -1,4 +1,4 @@
-{ fetchgit, stdenv, ant, jdk }:
+{ fetchgit, stdenv, ant, jdk8 }:
 
 stdenv.mkDerivation {
   pname = "hydra-ant-logger";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     sha256 = "01s7m6007rn9107rw5wcgna7i20x6p6kfzl4f79jrvpkjy6kz176";
   };
 
-  buildInputs = [ ant jdk ];
+  buildInputs = [ ant jdk8 ];
 
   buildPhase = "mkdir lib; ant";
 

--- a/pkgs/development/libraries/java/jflex/default.nix
+++ b/pkgs/development/libraries/java/jflex/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, jre} :
+{stdenv, fetchurl, jre8} :
 
 stdenv.mkDerivation rec {
   name = "jflex-1.8.2";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     rm -f $out/bin/jflex.bat
 
     patchShebangs $out
-    sed -i -e '/^JAVA=java/ s#java#${jre}/bin/java#' $out/bin/jflex
+    sed -i -e '/^JAVA=java/ s#java#${jre8}/bin/java#' $out/bin/jflex
     runHook postInstall
   '';
 

--- a/pkgs/development/libraries/java/junixsocket/default.nix
+++ b/pkgs/development/libraries/java/junixsocket/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ant, jdk, junit }:
+{ stdenv, fetchurl, ant, jdk8, junit }:
 
 stdenv.mkDerivation rec {
   name = "junixsocket-1.3";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./darwin.patch ];
 
-  buildInputs = [ ant jdk junit ];
+  buildInputs = [ ant jdk8 junit ];
 
   preConfigure =
     ''

--- a/pkgs/development/libraries/java/jzmq/default.nix
+++ b/pkgs/development/libraries/java/jzmq/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, zeromq3, jdk }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, zeromq3, jdk8 }:
 
 stdenv.mkDerivation rec {
   pname = "jzmq";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ zeromq3 jdk ];
+  buildInputs = [ zeromq3 jdk8 ];
 
   preConfigure = ''
     ${if stdenv.hostPlatform.system == "x86_64-darwin" then

--- a/pkgs/development/libraries/java/libmatthew-java/default.nix
+++ b/pkgs/development/libraries/java/libmatthew-java/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, jdk}:
+{stdenv, fetchurl, jdk8}:
 
 stdenv.mkDerivation {
   name = "libmatthew-java-0.8";
@@ -6,9 +6,9 @@ stdenv.mkDerivation {
     url = "https://src.fedoraproject.org/repo/pkgs/libmatthew-java/libmatthew-java-0.8.tar.gz/8455b8751083ce25c99c2840609271f5/libmatthew-java-0.8.tar.gz";
     sha256 = "1yldkhsdzm0a41a0i881bin2jklhp85y3ah245jd6fz3npcx7l85";
   };
-  JAVA_HOME=jdk;
+  JAVA_HOME=jdk8;
   PREFIX=''''${out}'';
-  buildInputs = [ jdk ];
+  buildInputs = [ jdk8 ];
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;

--- a/pkgs/development/libraries/java/saxon/default.nix
+++ b/pkgs/development/libraries/java/saxon/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, jre }:
+{ stdenv, fetchurl, unzip, jre8 }:
 
 let
   common = { pname, version, src, description
@@ -20,8 +20,8 @@ let
         mv $out/doc $out/share
         cat > $out/bin/${prog'} <<EOF
         #! $shell
-        export JAVA_HOME=${jre}
-        exec ${jre}/bin/java -jar $out/${jar'}.jar "\$@"
+        export JAVA_HOME=${jre8}
+        exec ${jre8}/bin/java -jar $out/${jar'}.jar "\$@"
         EOF
         chmod a+x $out/bin/${prog'}
       '';

--- a/pkgs/development/libraries/java/swt/default.nix
+++ b/pkgs/development/libraries/java/swt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, unzip, jdk, pkgconfig, gtk2
+{ stdenv, lib, fetchurl, unzip, jdk8, pkgconfig, gtk2
 , libXt, libXtst, libXi, libGLU, libGL, webkitgtk, libsoup, xorg
 , pango, gdk-pixbuf, glib
 }:
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
   sourceRoot = ".";
 
   nativeBuildInputs = [ unzip pkgconfig ];
-  buildInputs = [ jdk gtk2 libXt libXtst libXi libGLU libGL webkitgtk libsoup ];
+  buildInputs = [ jdk8 gtk2 libXt libXtst libXi libGLU libGL webkitgtk libsoup ];
 
   NIX_LFLAGS = toString (map (x: "-L${lib.getLib x}/lib") [ xorg.libX11 pango gdk-pixbuf glib ]) +
     " -lX11 -lpango-1.0 -lgdk_pixbuf-2.0 -lglib-2.0";
@@ -46,7 +46,7 @@ in stdenv.mkDerivation rec {
 
     cd src
     sed -i "s#^LFLAGS =#LFLAGS = $NIX_LFLAGS #g"  *.mak
-    export JAVA_HOME=${jdk}
+    export JAVA_HOME=${jdk8}
 
     sh ./build.sh
 

--- a/pkgs/development/libraries/libbluray/default.nix
+++ b/pkgs/development/libraries/libbluray/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, fontconfig, autoreconfHook, DiskArbitration
-, withJava ? false, jdk ? null, ant ? null
+, withJava ? false, jdk8 ? null, ant ? null
 , withAACS ? false, libaacs ? null
 , withBDplus ? false, libbdplus ? null
 , withMetadata ? true, libxml2 ? null
@@ -8,7 +8,7 @@
 
 with stdenv.lib;
 
-assert withJava -> jdk != null && ant != null;
+assert withJava -> jdk8 != null && ant != null;
 assert withAACS -> libaacs != null;
 assert withBDplus -> libbdplus != null;
 assert withMetadata -> libxml2 != null;
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
                       ;
 
   buildInputs = [ fontconfig ]
-                ++ optional withJava jdk
+                ++ optional withJava jdk8
                 ++ optional withMetadata libxml2
                 ++ optional withFonts freetype
                 ++ optional stdenv.isDarwin DiskArbitration
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    ${optionalString withJava ''export JDK_HOME="${jdk.home}"''}
+    ${optionalString withJava ''export JDK_HOME="${jdk8.home}"''}
   '';
 
   configureFlags =  with stdenv.lib;

--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -4,10 +4,10 @@
 , gmp, readline, file, numactl, xen, libapparmor, jansson
 , getopt, perlPackages, ocamlPackages
 , appliance ? null
-, javaSupport ? false, jdk ? null }:
+, javaSupport ? false, jdk8 ? null }:
 
 assert appliance == null || stdenv.lib.isDerivation appliance;
-assert javaSupport -> jdk != null;
+assert javaSupport -> jdk8 != null;
 
 stdenv.mkDerivation rec {
   pname = "libguestfs";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     numactl xen libapparmor getopt perlPackages.ModuleBuild
   ] ++ (with perlPackages; [ perl libintl_perl GetoptLong SysVirt ])
     ++ (with ocamlPackages; [ ocaml findlib ocamlbuild ocaml_libvirt gettext-stub ounit ])
-    ++ stdenv.lib.optional javaSupport jdk;
+    ++ stdenv.lib.optional javaSupport jdk8;
 
   prePatch = ''
     # build-time scripts

--- a/pkgs/development/libraries/martyr/default.nix
+++ b/pkgs/development/libraries/martyr/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ant, jdk}:
+{stdenv, fetchurl, ant, jdk8}:
 
 stdenv.mkDerivation rec {
 	pname = "martyr";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 		sha256 = "1ks8j413bcby345kmq1i7av8kwjvz5vxdn1zpv0p7ywxq54i4z59";
 	};
 
-  buildInputs = [ ant jdk ];
+  buildInputs = [ ant jdk8 ];
 
   buildPhase = "ant";
 

--- a/pkgs/development/libraries/openjpeg/generic.nix
+++ b/pkgs/development/libraries/openjpeg/generic.nix
@@ -9,14 +9,14 @@
 , jp3dSupport ? true # # JP3D comp
 , thirdPartySupport ? false # Third party libraries - OFF: only build when found, ON: always build
 , testsSupport ? true
-, jdk ? null
+, jdk8 ? null
 # Inherit generics
 , branch, version, revision, sha256, patches ? [], extraFlags ? [], ...
 }:
 
 assert jpipServerSupport -> jpipLibSupport && curl != null && fcgi != null;
 #assert opjViewerSupport -> (wxGTK != null);
-assert (openjpegJarSupport || jpipLibSupport) -> jdk != null;
+assert (openjpegJarSupport || jpipLibSupport) -> jdk8 != null;
 
 let
   inherit (stdenv.lib) optional optionals;
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
   buildInputs = [ ]
     ++ optionals jpipServerSupport [ curl fcgi ]
     #++ optional opjViewerSupport wxGTK
-    ++ optional (openjpegJarSupport || jpipLibSupport) jdk;
+    ++ optional (openjpegJarSupport || jpipLibSupport) jdk8;
 
   propagatedBuildInputs = [ libpng libtiff lcms2 ];
 

--- a/pkgs/development/libraries/portmidi/default.nix
+++ b/pkgs/development/libraries/portmidi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, cmake, /*jdk,*/ alsaLib }:
+{ stdenv, fetchurl, unzip, cmake, /*jdk8,*/ alsaLib }:
 
 stdenv.mkDerivation rec {
   pname = "portmidi";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   cmakeFlags = let
-    #base = "${jdk}/jre/lib/${jdk.architecture}";
+    #base = "${jdk8}/jre8/lib/${jdk8.architecture}";
   in [
     "-DPORTMIDI_ENABLE_JAVA=0"
     /* TODO: Fix Java support.
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     ln -s libportmidi.so "$out/lib/libporttime.so"
   '';
 
-  buildInputs = [ unzip cmake /*jdk*/ alsaLib ];
+  buildInputs = [ unzip cmake /*jdk8*/ alsaLib ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/libraries/rabbitmq-java-client/default.nix
+++ b/pkgs/development/libraries/rabbitmq-java-client/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, ant, jdk, jre, python, makeWrapper }:
+{ fetchurl, stdenv, ant, jdk8, jre8, python, makeWrapper }:
 
 stdenv.mkDerivation {
   name = "rabbitmq-java-client-3.3.4";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "03kspkgzzjsbq6f8yl2zj5m30qwgxv3l58hrbf6gcgxb5rpfk6sh";
   };
 
-  buildInputs = [ ant jdk python makeWrapper ];
+  buildInputs = [ ant jdk8 python makeWrapper ];
 
   buildPhase = "ant dist";
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     cp build/lib/*.jar lib/*.jar $out/share/java
 
     # There is a script in the source archive, but ours is cleaner
-    makeWrapper ${jre}/bin/java $out/bin/PerfTest \
+    makeWrapper ${jre8}/bin/java $out/bin/PerfTest \
       --add-flags "-Djava.awt.headless=true -cp $out/share/java/\* com.rabbitmq.examples.PerfTest"
   '';
 

--- a/pkgs/development/mobile/androidenv/build-app.nix
+++ b/pkgs/development/mobile/androidenv/build-app.nix
@@ -1,4 +1,4 @@
-{ composeAndroidPackages, stdenv, lib, ant, jdk, gnumake, gawk }:
+{ composeAndroidPackages, stdenv, lib, ant, jdk8, gnumake, gawk }:
 
 { name
 , release ? false, keyStore ? null, keyAlias ? null, keyStorePassword ? null, keyAliasPassword ? null
@@ -18,7 +18,7 @@ in
 stdenv.mkDerivation ({
   name = lib.replaceChars [" "] [""] name; # Android APKs may contain white spaces in their names, but Nix store paths cannot
   ANDROID_HOME = "${androidsdk}/libexec/android-sdk";
-  buildInputs = [ jdk ant ];
+  buildInputs = [ jdk8 ant ];
   buildPhase = ''
     ${lib.optionalString release ''
       # Provide key singing attributes

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -10,7 +10,7 @@ rec {
   };
 
   buildApp = import ./build-app.nix {
-    inherit (pkgs) stdenv lib jdk ant gnumake gawk;
+    inherit (pkgs) stdenv lib jdk8 ant gnumake gawk;
     inherit composeAndroidPackages;
   };
 

--- a/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
+++ b/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
@@ -1,7 +1,7 @@
 {deployAndroidPackage, lib, package, os, autoPatchelfHook, makeWrapper, pkgs, platform-tools}:
 
 let
-  runtime_paths = lib.makeBinPath [ pkgs.coreutils pkgs.file pkgs.findutils pkgs.gawk pkgs.gnugrep pkgs.gnused pkgs.jdk pkgs.python3 pkgs.which ] + ":${platform-tools}/platform-tools";
+  runtime_paths = lib.makeBinPath [ pkgs.coreutils pkgs.file pkgs.findutils pkgs.gawk pkgs.gnugrep pkgs.gnused pkgs.jdk8 pkgs.python3 pkgs.which ] + ":${platform-tools}/platform-tools";
 in
 deployAndroidPackage {
   inherit package os;

--- a/pkgs/development/mobile/flashtool/default.nix
+++ b/pkgs/development/mobile/flashtool/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, requireFile, p7zip, jre, libusb1, platform-tools, gtk2, glib, libXtst }:
+{ stdenv, requireFile, p7zip, jre8, libusb1, platform-tools, gtk2, glib, libXtst }:
 
 # TODO:
 #
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     sha256 = "0mfjdjj7clz2dhkg7lzy1m8hk8ngla7zgcryf51aki1gnpbb2zc1";
   };
 
-  buildInputs = [ p7zip jre ];
+  buildInputs = [ p7zip jre8 ];
 
   unpackPhase = ''
     7z e ${src}
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
     sed -i \
       -e 's|$(uname -m)|i686|' \
-      -e 's|export JAVA_HOME=.*|export JAVA_HOME=${jre}|' \
+      -e 's|export JAVA_HOME=.*|export JAVA_HOME=${jre8}|' \
       -e 's|export LD_LIBRARY_PATH=.*|export LD_LIBRARY_PATH=${stdenv.lib.makeLibraryPath [ libXtst glib gtk2 ]}:./x10flasher_lib/linux/lib32|' \
       FlashTool FlashToolConsole
   '';

--- a/pkgs/development/mobile/titaniumenv/build-app.nix
+++ b/pkgs/development/mobile/titaniumenv/build-app.nix
@@ -1,4 +1,4 @@
-{stdenv, composeAndroidPackages, composeXcodeWrapper, titaniumsdk, titanium, alloy, jdk, python, nodejs, which, file}:
+{stdenv, composeAndroidPackages, composeXcodeWrapper, titaniumsdk, titanium, alloy, jdk8, python, nodejs, which, file}:
 { name, src, preBuild ? "", target, tiVersion ? null
 , release ? false, androidKeyStore ? null, androidKeyAlias ? null, androidKeyStorePassword ? null
 , iosMobileProvisioningProfile ? null, iosCertificateName ? null, iosCertificate ? null, iosCertificatePassword ? null, iosVersion ? "12.1", iosBuildStore ? false
@@ -36,7 +36,7 @@ in
 stdenv.mkDerivation ({
   name = stdenv.lib.replaceChars [" "] [""] name;
 
-  buildInputs = [ nodejs titanium alloy python which file jdk ];
+  buildInputs = [ nodejs titanium alloy python which file jdk8 ];
 
   buildPhase = ''
     ${preBuild}

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -269,7 +269,7 @@ let
     imager = [ pkgs.x11 ];
     iBMQ = [ pkgs.gsl_1 ];
     igraph = [ pkgs.gmp pkgs.libxml2.dev ];
-    JavaGD = [ pkgs.jdk ];
+    JavaGD = [ pkgs.jdk8 ];
     jpeg = [ pkgs.libjpeg.dev ];
     jqr = [ pkgs.jq.dev ];
     KFKSDS = [ pkgs.gsl_1 ];
@@ -315,7 +315,7 @@ let
     Rhpc = [ pkgs.zlib pkgs.bzip2.dev pkgs.icu pkgs.lzma.dev pkgs.openmpi pkgs.pcre.dev ];
     Rhtslib = [ pkgs.zlib.dev pkgs.automake pkgs.autoconf ];
     rjags = [ pkgs.jags ];
-    rJava = [ pkgs.zlib pkgs.bzip2.dev pkgs.icu pkgs.lzma.dev pkgs.pcre.dev pkgs.jdk pkgs.libzip ];
+    rJava = [ pkgs.zlib pkgs.bzip2.dev pkgs.icu pkgs.lzma.dev pkgs.pcre.dev pkgs.jdk8 pkgs.libzip ];
     Rlibeemd = [ pkgs.gsl_1 ];
     rmatio = [ pkgs.zlib.dev ];
     Rmpfr = [ pkgs.gmp pkgs.mpfr.dev ];
@@ -742,15 +742,15 @@ let
 
     rJava = old.rJava.overrideDerivation (attrs: {
       preConfigure = ''
-        export JAVA_CPPFLAGS=-I${pkgs.jdk}/include/
-        export JAVA_HOME=${pkgs.jdk}
+        export JAVA_CPPFLAGS=-I${pkgs.jdk8}/include/
+        export JAVA_HOME=${pkgs.jdk8}
       '';
     });
 
     JavaGD = old.JavaGD.overrideDerivation (attrs: {
       preConfigure = ''
-        export JAVA_CPPFLAGS=-I${pkgs.jdk}/include/
-        export JAVA_HOME=${pkgs.jdk}
+        export JAVA_CPPFLAGS=-I${pkgs.jdk8}/include/
+        export JAVA_HOME=${pkgs.jdk8}
       '';
     });
 

--- a/pkgs/development/tools/alloy/default.nix
+++ b/pkgs/development/tools/alloy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper, makeDesktopItem }:
+{ stdenv, fetchurl, jre8, makeWrapper, makeDesktopItem }:
 
 let generic = { major, version, src }:
 
@@ -23,7 +23,7 @@ let generic = { major, version, src }:
       install -Dm644 ${src} $jar
 
       mkdir -p $out/bin
-      makeWrapper ${jre}/bin/java $out/bin/${nameMajor} --add-flags \
+      makeWrapper ${jre8}/bin/java $out/bin/${nameMajor} --add-flags \
        "-jar $jar"
 
       install -Dm644 ${./icon.png} $out/share/pixmaps/${nameMajor}.png

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre
+{ stdenv, fetchurl, jre8
 , disableRemoteLogging ? true
 }:
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     install -Dm755 $src $out/bin/amm
-    sed -i '0,/java/{s|java|${jre}/bin/java|}' $out/bin/amm
+    sed -i '0,/java/{s|java|${jre8}/bin/java|}' $out/bin/amm
   '' + optionalString (disableRemoteLogging) ''
     sed -i '0,/ammonite.Main/{s|ammonite.Main|ammonite.Main --no-remote-logging|}' $out/bin/amm
     sed -i '1i #!/bin/sh' $out/bin/amm

--- a/pkgs/development/tools/analysis/checkstyle/default.nix
+++ b/pkgs/development/tools/analysis/checkstyle/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   version = "8.32";
@@ -10,14 +10,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   dontUnpack = true;
 
   installPhase = ''
     runHook preInstall
     install -D $src $out/checkstyle/checkstyle-all.jar
-    makeWrapper ${jre}/bin/java $out/bin/checkstyle \
+    makeWrapper ${jre8}/bin/java $out/bin/checkstyle \
       --add-flags "-jar $out/checkstyle/checkstyle-all.jar"
     runHook postInstall
   '';
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     homepage = "http://checkstyle.sourceforge.net/";
     license = licenses.lgpl21;
     maintainers = with maintainers; [ pSub ];
-    platforms = jre.meta.platforms;
+    platforms = jre8.meta.platforms;
   };
 }

--- a/pkgs/development/tools/analysis/jdepend/default.nix
+++ b/pkgs/development/tools/analysis/jdepend/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ant, jdk, runtimeShell }:
+{ stdenv, fetchFromGitHub, ant, jdk8, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "jdepend";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1lxf3j9vflky7a2py3i59q7cwd1zvjv2b88l3za39vc90s04dz6k";
   };
 
-  nativeBuildInputs = [ ant jdk ];
+  nativeBuildInputs = [ ant jdk8 ];
   buildPhase = "ant jar";
 
   installPhase = ''
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
     cat > "$out/bin/jdepend" <<EOF
     #!${runtimeShell}
-    exec ${jdk.jre}/bin/java -classpath "$out/share/*" "\$@"
+    exec ${jdk8.jre}/bin/java -classpath "$out/share/*" "\$@"
     EOF
     chmod a+x $out/bin/jdepend
   '';

--- a/pkgs/development/tools/apktool/default.nix
+++ b/pkgs/development/tools/apktool/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre, build-tools }:
+{ stdenv, fetchurl, makeWrapper, jre8, build-tools }:
 
 stdenv.mkDerivation rec {
   pname = "apktool";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -D ${src} "$out/libexec/apktool/apktool.jar"
     mkdir -p "$out/bin"
-    makeWrapper "${jre}/bin/java" "$out/bin/apktool" \
+    makeWrapper "${jre8}/bin/java" "$out/bin/apktool" \
         --add-flags "-jar $out/libexec/apktool/apktool.jar" \
         --prefix PATH : "${builtins.head build-tools}/libexec/android-sdk/build-tools/28.0.3"
   '';

--- a/pkgs/development/tools/avro-tools/default.nix
+++ b/pkgs/development/tools/avro-tools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre, lib }:
+{ stdenv, fetchurl, makeWrapper, jre8, lib }:
 
 stdenv.mkDerivation rec {
   pname = "avro-tools";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
   nativeBuildInputs = [ makeWrapper ];
   sourceRoot = ".";
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/libexec/avro-tools
     cp $src $out/libexec/avro-tools/${pname}.jar
 
-    makeWrapper ${jre}/bin/java $out/bin/avro-tools \
+    makeWrapper ${jre8}/bin/java $out/bin/avro-tools \
     --add-flags "-jar $out/libexec/avro-tools/${pname}.jar"
   '';
 

--- a/pkgs/development/tools/build-managers/apache-maven/builder.sh
+++ b/pkgs/development/tools/build-managers/apache-maven/builder.sh
@@ -5,8 +5,8 @@ unpackPhase
 mkdir -p $out/maven
 cp -r $name/* $out/maven
 
-makeWrapper $out/maven/bin/mvn $out/bin/mvn --set-default JAVA_HOME "$jdk"
-makeWrapper $out/maven/bin/mvnDebug $out/bin/mvnDebug --set-default JAVA_HOME "$jdk"
+makeWrapper $out/maven/bin/mvn $out/bin/mvn --set-default JAVA_HOME "$jdk8"
+makeWrapper $out/maven/bin/mvnDebug $out/bin/mvnDebug --set-default JAVA_HOME "$jdk8"
 
 # Add the maven-axis and JIRA plugin by default when using maven 1.x
 if [ -e $out/maven/bin/maven ]

--- a/pkgs/development/tools/build-managers/apache-maven/default.nix
+++ b/pkgs/development/tools/build-managers/apache-maven/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, jdk, makeWrapper }:
+{ stdenv, fetchurl, jdk8, makeWrapper }:
 
-assert jdk != null;
+assert jdk8 != null;
 
 let version = "3.6.3"; in
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ makeWrapper ];
 
-  inherit jdk;
+  inherit jdk8;
 
   meta = with stdenv.lib; {
     description = "Build automation tool (used primarily for Java projects)";

--- a/pkgs/development/tools/build-managers/boot/builder.sh
+++ b/pkgs/development/tools/build-managers/boot/builder.sh
@@ -9,5 +9,5 @@ chmod -v 755 $boot_bin
 patchShebangs $boot_bin
 
 sed -i \
-    -e "s;\${BOOT_JAVA_COMMAND:-java};\${BOOT_JAVA_COMMAND:-${jdk}/bin/java};g" \
+    -e "s;\${BOOT_JAVA_COMMAND:-java};\${BOOT_JAVA_COMMAND:-${jdk8}/bin/java};g" \
     $boot_bin

--- a/pkgs/development/tools/build-managers/boot/default.nix
+++ b/pkgs/development/tools/build-managers/boot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jdk }:
+{ stdenv, fetchurl, jdk8 }:
 
 stdenv.mkDerivation rec {
   version = "2.7.2";
@@ -9,11 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "1hqp3xxmsj5vkym0l3blhlaq9g3w0lhjgmp37g6y3rr741znkk8c";
   };
 
-  inherit jdk;
+  inherit jdk8;
 
   builder = ./builder.sh;
 
-  propagatedBuildInputs = [ jdk ];
+  propagatedBuildInputs = [ jdk8 ];
 
   meta = with stdenv.lib; {
     description = "Build tooling for Clojure";

--- a/pkgs/development/tools/build-managers/buck/default.nix
+++ b/pkgs/development/tools/build-managers/buck/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jdk, ant, python2, python2Packages, watchman, bash, makeWrapper }:
+{ stdenv, fetchFromGitHub, jdk8, ant, python2, python2Packages, watchman, bash, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "buck";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     grep -l -r '/bin/bash' --null | xargs -0 sed -i -e "s!/bin/bash!${bash}/bin/bash!g"
   '';
 
-  buildInputs = [ jdk ant python2 watchman python2Packages.pywatchman ];
+  buildInputs = [ jdk8 ant python2 watchman python2Packages.pywatchman ];
   nativeBuildInputs = [ makeWrapper ];
 
   buildPhase = ''
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     install -D -m755 buck-out/gen/programs/buck.pex $out/bin/buck
     wrapProgram $out/bin/buck \
       --prefix PYTHONPATH : $PYTHONPATH \
-      --prefix PATH : "${stdenv.lib.makeBinPath [jdk watchman]}"
+      --prefix PATH : "${stdenv.lib.makeBinPath [jdk8 watchman]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, jdk, java ? jdk, makeWrapper }:
+{ stdenv, fetchurl, unzip, jdk8, java ? jdk8, makeWrapper }:
 
 rec {
   gradleGen = {name, src, nativeVersion} : stdenv.mkDerivation {

--- a/pkgs/development/tools/build-managers/leiningen/default.nix
+++ b/pkgs/development/tools/build-managers/leiningen/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, makeWrapper
-, coreutils, jdk, rlwrap, gnupg }:
+, coreutils, jdk8, rlwrap, gnupg }:
 
 stdenv.mkDerivation rec {
   pname = "leiningen";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   dontUnpack = true;
 
   buildInputs = [ makeWrapper ];
-  propagatedBuildInputs = [ jdk ];
+  propagatedBuildInputs = [ jdk8 ];
 
   # the jar is not in share/java, because it's a standalone jar and should
   # never be picked up by set-java-classpath.sh
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/lein \
       --prefix PATH ":" "${stdenv.lib.makeBinPath [ rlwrap coreutils ]}" \
       --set LEIN_GPG ${gnupg}/bin/gpg \
-      --set JAVA_CMD ${jdk}/bin/java
+      --set JAVA_CMD ${jdk8}/bin/java
   '';
 
   meta = {

--- a/pkgs/development/tools/build-managers/mill/default.nix
+++ b/pkgs/development/tools/build-managers/mill/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "mill";
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
     install -Dm555 "$src" "$out/bin/.mill-wrapped"
     # can't use wrapProgram because it sets --argv0
     makeWrapper "$out/bin/.mill-wrapped" "$out/bin/mill" \
-      --prefix PATH : "${jre}/bin" \
-      --set JAVA_HOME "${jre}" \
+      --prefix PATH : "${jre8}/bin" \
+      --set JAVA_HOME "${jre8}" \
       --set MILL_VERSION "${version}"
     runHook postInstall
   '';

--- a/pkgs/development/tools/build-managers/sbt-extras/default.nix
+++ b/pkgs/development/tools/build-managers/sbt-extras/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, which, curl, makeWrapper, jdk }:
+{ stdenv, fetchFromGitHub, which, curl, makeWrapper, jdk8 }:
 
 let
   rev = "f0669e9b6745b65fae3ec58c2d6a2bef133db456";
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin
 
-    substituteInPlace bin/sbt --replace 'declare java_cmd="java"' 'declare java_cmd="${jdk}/bin/java"'
+    substituteInPlace bin/sbt --replace 'declare java_cmd="java"' 'declare java_cmd="${jdk8}/bin/java"'
 
     install bin/sbt $out/bin
 

--- a/pkgs/development/tools/build-managers/sbt/default.nix
+++ b/pkgs/development/tools/build-managers/sbt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre }:
+{ stdenv, fetchurl, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "sbt";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   patchPhase = ''
-    echo -java-home ${jre.home} >>conf/sbtopts
+    echo -java-home ${jre8.home} >>conf/sbtopts
   '';
 
   installPhase = ''

--- a/pkgs/development/tools/coursier/default.nix
+++ b/pkgs/development/tools/coursier/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre8 }:
 
 let
   zshCompletion = version: fetchurl {
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   buildCommand = ''
     install -Dm555 $src $out/bin/coursier
     patchShebangs $out/bin/coursier
-    wrapProgram $out/bin/coursier --prefix PATH ":" ${jre}/bin
+    wrapProgram $out/bin/coursier --prefix PATH ":" ${jre8}/bin
 
     # copy zsh completion
     install -Dm755 ${zshCompletion version} $out/share/zsh/site-functions/_coursier

--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper
+{ stdenv, fetchurl, jre8, makeWrapper
 , mysqlSupport ? true, mysql_jdbc ? null }:
 
 assert mysqlSupport -> mysql_jdbc != null;
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "0qasiggaxix3gmmvax00k83q4pd1c1b5wx8ayyplaszkgr9advb8";
   };
 
-  buildInputs = [ jre makeWrapper ];
+  buildInputs = [ jre8 makeWrapper ];
 
   unpackPhase = ''
     tar xfz ${src}
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
       ${addJars "$out/lib"}
       ${concatStringsSep "\n" (map (p: addJars "${p}/share/java") extraJars)}
 
-      ${getBin jre}/bin/java -cp "\$CP" \$JAVA_OPTS \
+      ${getBin jre8}/bin/java -cp "\$CP" \$JAVA_OPTS \
         liquibase.integration.commandline.Main \''${1+"\$@"}
       EOF
       chmod +x $out/bin/liquibase

--- a/pkgs/development/tools/database/schemaspy/default.nix
+++ b/pkgs/development/tools/database/schemaspy/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, jre, makeWrapper, graphviz }:
+{ lib, stdenv, fetchurl, jre8, makeWrapper, graphviz }:
 
 stdenv.mkDerivation rec {
   version = "6.1.0";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   dontUnpack = true;
 
   buildInputs = [
-    jre
+    jre8
   ];
 
   nativeBuildInputs = [
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -D ${src} "$out/share/java/${pname}-${version}.jar"
 
-    makeWrapper ${jre}/bin/java $out/bin/schemaspy \
+    makeWrapper ${jre8}/bin/java $out/bin/schemaspy \
       --add-flags "-jar $out/share/java/${pname}-${version}.jar" \
       --prefix PATH : "$wrappedPath"
   '';

--- a/pkgs/development/tools/database/sqldeveloper/default.nix
+++ b/pkgs/development/tools/database/sqldeveloper/default.nix
@@ -19,7 +19,7 @@ in
   pname = "sqldeveloper";
 
   src = requireFile rec {
-    name = "sqldeveloper-${version}-no-jre.zip";
+    name = "sqldeveloper-${version}-no-jre8.zip";
     url = "https://www.oracle.com/tools/downloads/sqldev-downloads.html";
     message = ''
       This Nix expression requires that ${name} already be part of the store. To

--- a/pkgs/development/tools/database/squirrel-sql/default.nix
+++ b/pkgs/development/tools/database/squirrel-sql/default.nix
@@ -1,7 +1,7 @@
 # To enable specific database drivers, override this derivation and pass the
 # driver packages in the drivers argument (e.g. mysql_jdbc, postgresql_jdbc).
 { stdenv, fetchurl, makeDesktopItem, makeWrapper, unzip
-, jre
+, jre8
 , drivers ? []
 }:
 let
@@ -16,7 +16,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper unzip ];
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   unpackPhase = ''
     runHook preUnpack
@@ -47,7 +47,7 @@ in stdenv.mkDerivation rec {
     done
     makeWrapper $out/share/squirrel-sql/squirrel-sql.sh $out/bin/squirrel-sql \
       --set CLASSPATH "$cp" \
-      --set JAVA_HOME "${jre}"
+      --set JAVA_HOME "${jre8}"
     # Make sure above `CLASSPATH` gets picked up
     substituteInPlace $out/share/squirrel-sql/squirrel-sql.sh --replace "-cp \"\$CP\"" "-cp \"\$CLASSPATH:\$CP\""
 

--- a/pkgs/development/tools/drip/default.nix
+++ b/pkgs/development/tools/drip/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jdk, which, makeWrapper }:
+{ stdenv, fetchFromGitHub, jdk8, which, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "drip";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [ jdk ];
+  buildInputs = [ jdk8 ];
 
   postPatch = ''
     patchShebangs .

--- a/pkgs/development/tools/flyway/default.nix
+++ b/pkgs/development/tools/flyway/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre_headless, makeWrapper }:
+{ stdenv, fetchurl, jre8_headless, makeWrapper }:
   let
     version = "6.4.2";
   in
@@ -16,7 +16,7 @@
         mkdir -p $out/bin $out/share/flyway
         cp -r sql jars drivers conf $out/share/flyway
         install -Dt $out/share/flyway/lib lib/community/*.jar lib/*.jar
-        makeWrapper "${jre_headless}/bin/java" $out/bin/flyway \
+        makeWrapper "${jre8_headless}/bin/java" $out/bin/flyway \
           --add-flags "-Djava.security.egd=file:/dev/../dev/urandom" \
           --add-flags "-classpath '$out/share/flyway/lib/*:$out/share/flyway/drivers/*'" \
           --add-flags "org.flywaydb.commandline.Main" \

--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jdk, maven, makeWrapper, jre_headless, pcsclite }:
+{ stdenv, fetchFromGitHub, jdk8, maven, makeWrapper, jre8_headless, pcsclite }:
 
 # TODO: This is quite a bit of duplicated logic with gephi. Factor it out?
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   deps = stdenv.mkDerivation {
     name = "${pname}-${version}-deps";
     inherit src;
-    nativeBuildInputs = [ jdk maven ];
+    nativeBuildInputs = [ jdk8 maven ];
     installPhase = ''
       # Download the dependencies
       while ! mvn package "-Dmaven.repo.local=$out/.m2" -Dmaven.wagon.rto=5000; do
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     outputHash = "1qwgvz6l5wia8q5824c9f3iwyapfskljhqf1z09fw6jjj1jy3b15";
   };
 
-  nativeBuildInputs = [ jdk maven makeWrapper ];
+  nativeBuildInputs = [ jdk8 maven makeWrapper ];
 
   buildPhase = ''
     cp -dpR "${deps}/.m2" ./
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p "$out/lib/java" "$out/share/java"
     cp target/gp.jar "$out/share/java"
-    makeWrapper "${jre_headless}/bin/java" "$out/bin/gp" \
+    makeWrapper "${jre8_headless}/bin/java" "$out/bin/gp" \
       --add-flags "-jar '$out/share/java/gp.jar'" \
       --prefix LD_LIBRARY_PATH : "${pcsclite.out}/lib"
   '';

--- a/pkgs/development/tools/java/cfr/default.nix
+++ b/pkgs/development/tools/java/cfr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, fetchurl, jre }:
+{ stdenv, makeWrapper, fetchurl, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "cfr";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildCommand = ''
     jar=$out/share/java/cfr_${version}.jar
     install -Dm444 $src $jar
-    makeWrapper ${jre}/bin/java $out/bin/cfr --add-flags "-jar $jar"
+    makeWrapper ${jre8}/bin/java $out/bin/cfr --add-flags "-jar $jar"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/java/dex2jar/default.nix
+++ b/pkgs/development/tools/java/dex2jar/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
 , fetchurl
-, jre
+, jre8
 , makeWrapper
 , unzip
 }:
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     mv * $f
     for i in $f/*.sh; do
       n=$(basename ''${i%.sh})
-      makeWrapper $i $out/bin/$n --prefix PATH : ${lib.makeBinPath [ jre ] }
+      makeWrapper $i $out/bin/$n --prefix PATH : ${lib.makeBinPath [ jre8 ] }
     done
   '';
 

--- a/pkgs/development/tools/java/visualvm/default.nix
+++ b/pkgs/development/tools/java/visualvm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, lib, makeWrapper, makeDesktopItem, jdk, gawk }:
+{ stdenv, fetchzip, lib, makeWrapper, makeDesktopItem, jdk8, gawk }:
 
 stdenv.mkDerivation rec {
   version = "2.0";
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
     substituteInPlace etc/visualvm.conf \
       --replace "#visualvm_jdkhome=" "visualvm_jdkhome=" \
-      --replace "/path/to/jdk" "${jdk.home}" \
+      --replace "/path/to/jdk8" "${jdk8.home}" \
 
     substituteInPlace platform/lib/nbexec \
       --replace /usr/bin/\''${awk} ${gawk}/bin/awk

--- a/pkgs/development/tools/jbake/default.nix
+++ b/pkgs/development/tools/jbake/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, makeWrapper, jre }:
+{ stdenv, fetchzip, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   version = "2.6.5";
@@ -9,18 +9,18 @@ stdenv.mkDerivation rec {
     sha256 = "0ripayv1vf4f4ylxr7h9kad2xhy3y98ca8s4p38z7dn8l47zg0qw";
   };
 
-  buildInputs = [ makeWrapper jre ];
+  buildInputs = [ makeWrapper jre8 ];
 
   postPatch = "patchShebangs .";
 
   installPhase = ''
     mkdir -p $out
     cp -vr * $out
-    wrapProgram $out/bin/jbake --set JAVA_HOME "${jre}"
+    wrapProgram $out/bin/jbake --set JAVA_HOME "${jre8}"
   '';
 
   checkPhase = ''
-    export JAVA_HOME=${jre}
+    export JAVA_HOME=${jre8}
     bin/jbake | grep -q "${version}" || (echo "jbake did not return correct version"; exit 1)
   '';
   doCheck = true;

--- a/pkgs/development/tools/ktlint/default.nix
+++ b/pkgs/development/tools/ktlint/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "ktlint";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  propagatedBuildInputs = [ jre ];
+  propagatedBuildInputs = [ jre8 ];
 
   unpackCmd = ''
     mkdir -p ${pname}-${version}
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    wrapProgram $out/bin/ktlint --prefix PATH : "${jre}/bin"
+    wrapProgram $out/bin/ktlint --prefix PATH : "${jre8}/bin"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/metals/default.nix
+++ b/pkgs/development/tools/metals/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, coursier, jdk, jre, makeWrapper }:
+{ stdenv, lib, coursier, jdk8, jre8, makeWrapper }:
 
 let
   baseName = "metals";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   name = "${baseName}-${version}";
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jdk deps ];
+  buildInputs = [ jdk8 deps ];
 
   phases = [ "installPhase" ];
 
@@ -33,25 +33,25 @@ stdenv.mkDerivation rec {
 
     # This variant is not targeted at any particular client, clients are
     # expected to declare their supported features in initialization options.
-    makeWrapper ${jre}/bin/java $out/bin/metals \
-      --prefix PATH : ${lib.makeBinPath [ jdk ]} \
+    makeWrapper ${jre8}/bin/java $out/bin/metals \
+      --prefix PATH : ${lib.makeBinPath [ jdk8 ]} \
       --add-flags "${extraJavaOpts} -cp $CLASSPATH scala.meta.metals.Main"
 
     # Further variants targeted at clients with featuresets pre-set.
-    makeWrapper ${jre}/bin/java $out/bin/metals-emacs \
-      --prefix PATH : ${lib.makeBinPath [ jdk ]} \
+    makeWrapper ${jre8}/bin/java $out/bin/metals-emacs \
+      --prefix PATH : ${lib.makeBinPath [ jdk8 ]} \
       --add-flags "${extraJavaOpts} -Dmetals.client=emacs -cp $CLASSPATH scala.meta.metals.Main"
 
-    makeWrapper ${jre}/bin/java $out/bin/metals-vim \
-      --prefix PATH : ${lib.makeBinPath [ jdk ]} \
+    makeWrapper ${jre8}/bin/java $out/bin/metals-vim \
+      --prefix PATH : ${lib.makeBinPath [ jdk8 ]} \
       --add-flags "${extraJavaOpts} -Dmetals.client=coc.nvim -cp $CLASSPATH scala.meta.metals.Main"
 
-    makeWrapper ${jre}/bin/java $out/bin/metals-vim-lsc \
-      --prefix PATH : ${lib.makeBinPath [ jdk ]} \
+    makeWrapper ${jre8}/bin/java $out/bin/metals-vim-lsc \
+      --prefix PATH : ${lib.makeBinPath [ jdk8 ]} \
       --add-flags "${extraJavaOpts} -Dmetals.client=vim-lsc -cp $CLASSPATH scala.meta.metals.Main"
 
-    makeWrapper ${jre}/bin/java $out/bin/metals-sublime \
-      --prefix PATH : ${lib.makeBinPath [ jdk ]} \
+    makeWrapper ${jre8}/bin/java $out/bin/metals-sublime \
+      --prefix PATH : ${lib.makeBinPath [ jdk8 ]} \
       --add-flags "${extraJavaOpts} -Dmetals.client=sublime -cp $CLASSPATH scala.meta.metals.Main"
   '';
 

--- a/pkgs/development/tools/micronaut/default.nix
+++ b/pkgs/development/tools/micronaut/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, jdk, makeWrapper, installShellFiles }:
+{ stdenv, fetchzip, jdk8, makeWrapper, installShellFiles }:
 
 stdenv.mkDerivation rec {
   pname = "micronaut";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     rm bin/mn.bat
     cp -r . $out
     wrapProgram $out/bin/mn \
-      --prefix JAVA_HOME : ${jdk} 
+      --prefix JAVA_HOME : ${jdk8} 
     installShellCompletion --bash --name mn.bash bin/mn_completion
     runHook postInstall
   '';

--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre }:
+{ stdenv, fetchurl, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "clojure-lsp";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     install -Dm755 $src $out/bin/clojure-lsp
-    sed -i -e '1 s!java!${jre}/bin/java!' $out/bin/clojure-lsp
+    sed -i -e '1 s!java!${jre8}/bin/java!' $out/bin/clojure-lsp
   '';
 
   # verify shebang patch
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/snoe/clojure-lsp";
     license = licenses.mit;
     maintainers = [ maintainers.ericdallo ];
-    platforms = jre.meta.platforms;
+    platforms = jre8.meta.platforms;
   };
 
 }

--- a/pkgs/development/tools/misc/opengrok/default.nix
+++ b/pkgs/development/tools/misc/opengrok/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, ctags, makeWrapper, coreutils, git, runtimeShell }:
+{ stdenv, fetchurl, jre8, ctags, makeWrapper, coreutils, git, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "opengrok";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/bin/Messages --replace "#!/bin/ksh" "#!${runtimeShell}"
     wrapProgram $out/bin/OpenGrok \
       --prefix PATH : "${stdenv.lib.makeBinPath [ ctags git ]}" \
-      --set JAVA_HOME "${jre}" \
+      --set JAVA_HOME "${jre8}" \
       --set OPENGROK_TOMCAT_BASE "/var/tomcat"
   '';
 

--- a/pkgs/development/tools/misc/stm32cubemx/default.nix
+++ b/pkgs/development/tools/misc/stm32cubemx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, requireFile, makeDesktopItem, libicns, imagemagick, zstd, jre }:
+{ stdenv, requireFile, makeDesktopItem, libicns, imagemagick, zstd, jre8 }:
 
 let
   version = "5.3.0";
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
     cat << EOF > $out/bin/${pname}
     #!${stdenv.shell}
-    ${jre}/bin/java -jar $out/opt/STM32CubeMX/STM32CubeMX.exe
+    ${jre8}/bin/java -jar $out/opt/STM32CubeMX/STM32CubeMX.exe
     EOF
     chmod +x $out/bin/${pname}
 

--- a/pkgs/development/tools/nailgun/default.nix
+++ b/pkgs/development/tools/nailgun/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchMavenArtifact, fetchFromGitHub, jre, makeWrapper }:
+{ stdenv, fetchMavenArtifact, fetchFromGitHub, jre8, makeWrapper }:
 
 let
   version = "1.0.0";
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   postInstall = ''
-    makeWrapper ${jre}/bin/java $out/bin/ng-server \
+    makeWrapper ${jre8}/bin/java $out/bin/ng-server \
       --add-flags '-classpath ${nailgun-server.jar}:$CLASSPATH com.facebook.nailgun.NGServer'
   '';
 

--- a/pkgs/development/tools/neoload/default.nix
+++ b/pkgs/development/tools/neoload/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, writeTextFile, jre, makeWrapper, fontsConf, licenseAccepted ? false }:
+{ stdenv, fetchurl, writeTextFile, jre8, makeWrapper, fontsConf, licenseAccepted ? false }:
 
 # If you happen to use this software on the XMonad window manager, you will have issues with
 # grey windows, no resizing, menus not showing and other glitches.
@@ -52,23 +52,23 @@ in stdenv.mkDerivation {
     # the installer wants to use its internal JRE
     # disable this. The extra spaces are needed because the installer carries
     # a binary payload, so should not change in size
-    sed -e 's/^if \[ -f jre.tar.gz/if false          /' $src > installer
+    sed -e 's/^if \[ -f jre8.tar.gz/if false          /' $src > installer
     chmod a+x installer
 
-    cp ${dotInstall4j jre} .install4j
+    cp ${dotInstall4j jre8} .install4j
     chmod u+w .install4j
 
     sed -e "s|INSTALLDIR|$out|" ${responseVarfile} > response.varfile
 
     export HOME=`pwd`
-    export INSTALL4J_JAVA_HOME=${jre.home}
+    export INSTALL4J_JAVA_HOME=${jre8.home}
     export FONTCONFIG_FILE=${fontsConf}
     bash -ic './installer -q -varfile response.varfile'
 
     sed -i 's/Xmx450m/Xmx900m/;s/Xss192k/Xss384k/' $out/lib/neoload/conf/agent.properties
 
     for i in $out/bin/*; do
-      wrapProgram $i --run 'cp ${dotInstall4j "${jre.home}/jre"} ~/.install4j' \
+      wrapProgram $i --run 'cp ${dotInstall4j "${jre8.home}/jre8"} ~/.install4j' \
                      --run 'chmod u+w ~/.install4j'
     done
 

--- a/pkgs/development/tools/parsing/antlr/2.7.7.nix
+++ b/pkgs/development/tools/parsing/antlr/2.7.7.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jdk, python2 }:
+{ stdenv, fetchurl, jdk8, python2 }:
 
 stdenv.mkDerivation {
   name = "antlr-2.7.7";
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
     sha256 = "1ffvcwdw73id0dk6pj2mlxjvbg0662qacx4ylayqcxgg381fnfl5";
   };
   patches = [ ./2.7.7-fixes.patch ];
-  buildInputs = [ jdk ];
+  buildInputs = [ jdk8 ];
   nativeBuildInputs = [ python2 ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/parsing/antlr/3.4.nix
+++ b/pkgs/development/tools/parsing/antlr/3.4.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, jre}:
+{stdenv, fetchurl, jre8}:
 
 stdenv.mkDerivation rec {
   pname = "antlr";
@@ -15,13 +15,13 @@ stdenv.mkDerivation rec {
     cp "$src" "$out/lib/antlr/antlr-${version}-complete.jar"
 
     echo "#! ${stdenv.shell}" >> "$out/bin/antlr"
-    echo "'${jre}/bin/java' -cp '$out/lib/antlr/antlr-${version}-complete.jar' -Xms200M -Xmx400M org.antlr.Tool \"\$@\"" >> "$out/bin/antlr"
+    echo "'${jre8}/bin/java' -cp '$out/lib/antlr/antlr-${version}-complete.jar' -Xms200M -Xmx400M org.antlr.Tool \"\$@\"" >> "$out/bin/antlr"
 
     chmod a+x "$out/bin/antlr"
     ln -s "$out/bin/antlr"{,3}
   '';
 
-  inherit jre;
+  inherit jre8;
 
   meta = with stdenv.lib; {
     description = "Powerful parser generator";

--- a/pkgs/development/tools/parsing/antlr/3.5.nix
+++ b/pkgs/development/tools/parsing/antlr/3.5.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, fetchFromGitHub, jre}:
+{stdenv, fetchurl, fetchFromGitHub, jre8}:
 
 stdenv.mkDerivation rec {
   pname = "antlr";
@@ -20,13 +20,13 @@ stdenv.mkDerivation rec {
     cp runtime/Cpp/include/* $out/include/
 
     echo "#! ${stdenv.shell}" >> "$out/bin/antlr"
-    echo "'${jre}/bin/java' -cp '$out/lib/antlr/antlr-${version}-complete.jar' -Xms200M -Xmx400M org.antlr.Tool \"\$@\"" >> "$out/bin/antlr"
+    echo "'${jre8}/bin/java' -cp '$out/lib/antlr/antlr-${version}-complete.jar' -Xms200M -Xmx400M org.antlr.Tool \"\$@\"" >> "$out/bin/antlr"
 
     chmod a+x "$out/bin/antlr"
     ln -s "$out/bin/antlr"{,3}
   '';
 
-  inherit jre;
+  inherit jre8;
 
   meta = with stdenv.lib; {
     description = "Powerful parser generator";

--- a/pkgs/development/tools/parsing/antlr/4.7.nix
+++ b/pkgs/development/tools/parsing/antlr/4.7.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre
+{ stdenv, fetchurl, jre8
 , fetchFromGitHub, cmake, ninja, pkgconfig, libuuid, darwin }:
 
 let
@@ -51,16 +51,16 @@ let
       cp "$src" "$out/share/java/antlr-${version}-complete.jar"
 
       echo "#! ${stdenv.shell}" >> "$out/bin/antlr"
-      echo "'${jre}/bin/java' -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' -Xmx500M org.antlr.v4.Tool \"\$@\"" >> "$out/bin/antlr"
+      echo "'${jre8}/bin/java' -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' -Xmx500M org.antlr.v4.Tool \"\$@\"" >> "$out/bin/antlr"
 
       echo "#! ${stdenv.shell}" >> "$out/bin/grun"
-      echo "'${jre}/bin/java' -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' org.antlr.v4.gui.TestRig \"\$@\"" >> "$out/bin/grun"
+      echo "'${jre8}/bin/java' -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' org.antlr.v4.gui.TestRig \"\$@\"" >> "$out/bin/grun"
 
       chmod a+x "$out/bin/antlr" "$out/bin/grun"
       ln -s "$out/bin/antlr"{,4}
     '';
 
-    inherit jre;
+    inherit jre8;
 
     passthru = {
       inherit runtime;

--- a/pkgs/development/tools/parsing/antlr/builder.sh
+++ b/pkgs/development/tools/parsing/antlr/builder.sh
@@ -17,7 +17,7 @@ done
 cat > $out/bin/antlr <<EOF
 #! $SHELL
 
-$jre/bin/java -cp $classpath -Xms200M -Xmx400M org.antlr.Tool \$*
+$jre8/bin/java -cp $classpath -Xms200M -Xmx400M org.antlr.Tool \$*
 EOF
 
 chmod u+x $out/bin/antlr

--- a/pkgs/development/tools/repository-managers/nexus/default.nix
+++ b/pkgs/development/tools/repository-managers/nexus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre_headless, gawk }:
+{ stdenv, fetchurl, makeWrapper, jre8_headless, gawk }:
 
 stdenv.mkDerivation rec {
   pname = "nexus";
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     rm -fv $out/bin/nexus.bat
 
     wrapProgram $out/bin/nexus \
-      --set JAVA_HOME ${jre_headless} \
+      --set JAVA_HOME ${jre8_headless} \
       --set ALTERNATIVE_NAME "nexus" \
       --prefix PATH "${stdenv.lib.makeBinPath [ gawk ]}"
 

--- a/pkgs/development/tools/scalafix/default.nix
+++ b/pkgs/development/tools/scalafix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, jdk, jre, coursier, makeWrapper }:
+{ stdenv, jdk8, jre8, coursier, makeWrapper }:
 
 let
   baseName = "scalafix";
@@ -19,14 +19,14 @@ in
 stdenv.mkDerivation {
   name = "${baseName}-${version}";
 
-  buildInputs = [ jdk makeWrapper deps ];
+  buildInputs = [ jdk8 makeWrapper deps ];
 
   doCheck = true;
 
   phases = [ "installPhase" "checkPhase" ];
 
   installPhase = ''
-    makeWrapper ${jre}/bin/java $out/bin/${baseName} \
+    makeWrapper ${jre8}/bin/java $out/bin/${baseName} \
       --add-flags "-cp $CLASSPATH scalafix.cli.Cli"
   '';
 

--- a/pkgs/development/tools/scalafmt/default.nix
+++ b/pkgs/development/tools/scalafmt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, jdk, jre, coursier, makeWrapper }:
+{ stdenv, jdk8, jre8, coursier, makeWrapper }:
 
 let
   baseName = "scalafmt";
@@ -20,14 +20,14 @@ stdenv.mkDerivation {
   name = "${baseName}-${version}";
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jdk deps ];
+  buildInputs = [ jdk8 deps ];
 
   doCheck = true;
 
   phases = [ "installPhase" "checkPhase" ];
 
   installPhase = ''
-    makeWrapper ${jre}/bin/java $out/bin/${baseName} \
+    makeWrapper ${jre8}/bin/java $out/bin/${baseName} \
       --add-flags "-cp $CLASSPATH org.scalafmt.cli.Cli"
   '';
 

--- a/pkgs/development/tools/selenium/selendroid/default.nix
+++ b/pkgs/development/tools/selenium/selendroid/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jdk, selenium-server-standalone }:
+{ stdenv, fetchurl, makeWrapper, jdk8, selenium-server-standalone }:
 
 with stdenv.lib;
 let
@@ -23,16 +23,16 @@ stdenv.mkDerivation {
 
   dontUnpack = true;
 
-  buildInputs = [ jdk makeWrapper ];
+  buildInputs = [ jdk8 makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/share/lib/selendroid
     cp ${srcs.jar} $out/share/lib/selendroid/${name}.jar
     cp ${srcs.gridPlugin} $out/share/lib/selendroid/${pluginName}.jar
 
-    makeWrapper ${jdk}/bin/java $out/bin/selendroid \
+    makeWrapper ${jdk8}/bin/java $out/bin/selendroid \
       --add-flags "-jar $out/share/lib/selendroid/${name}.jar"
-    makeWrapper ${jdk}/bin/java $out/bin/selendroid-selenium \
+    makeWrapper ${jdk8}/bin/java $out/bin/selendroid-selenium \
       --add-flags "-Dfile.encoding=UTF-8" \
       --add-flags "-cp ${selenium-server-standalone}/share/lib/${selenium-server-standalone.name}/${selenium-server-standalone.name}.jar:$out/share/lib/selendroid/${pluginName}.jar" \
       --add-flags "org.openqa.grid.selenium.GridLauncherV3" \

--- a/pkgs/development/tools/selenium/server/default.nix
+++ b/pkgs/development/tools/selenium/server/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre
+{ stdenv, fetchurl, makeWrapper, jre8
 , htmlunit-driver, chromedriver, chromeSupport ? true }:
 
 with stdenv.lib;
@@ -18,12 +18,12 @@ in stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  buildInputs = [ jre makeWrapper ];
+  buildInputs = [ jre8 makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/share/lib/${pname}-${version}
     cp $src $out/share/lib/${pname}-${version}/${pname}-${version}.jar
-    makeWrapper ${jre}/bin/java $out/bin/selenium-server \
+    makeWrapper ${jre8}/bin/java $out/bin/selenium-server \
       --add-flags "-cp $out/share/lib/${pname}-${version}/${pname}-${version}.jar:${htmlunit-driver}/share/lib/${htmlunit-driver.name}/${htmlunit-driver.name}.jar" \
       --add-flags ${optionalString chromeSupport "-Dwebdriver.chrome.driver=${chromedriver}/bin/chromedriver"} \
       --add-flags "org.openqa.grid.selenium.GridLauncherV3"

--- a/pkgs/development/tools/spring-boot-cli/default.nix
+++ b/pkgs/development/tools/spring-boot-cli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, jdk, makeWrapper, installShellFiles, coreutils }:
+{ stdenv, fetchzip, jdk8, makeWrapper, installShellFiles, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "spring-boot-cli";
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
     rm -r shell-completion
     cp -r . $out
     wrapProgram $out/bin/spring \
-      --set JAVA_HOME ${jdk} \
-      --set PATH /bin:${coreutils}/bin:${jdk}/bin
+      --set JAVA_HOME ${jdk8} \
+      --set PATH /bin:${coreutils}/bin:${jdk8}/bin
     runHook postInstall
   '';
 

--- a/pkgs/development/tools/yuicompressor/default.nix
+++ b/pkgs/development/tools/yuicompressor/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "yuicompressor";
@@ -10,12 +10,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   buildCommand = ''
     mkdir -p $out/{bin,lib}
     ln -s $src $out/lib/yuicompressor.jar
-    makeWrapper ${jre}/bin/java $out/bin/yuicompressor --add-flags \
+    makeWrapper ${jre8}/bin/java $out/bin/yuicompressor --add-flags \
      "-cp $out/lib/yuicompressor.jar com.yahoo.platform.yui.compressor.YUICompressor"
   '';
   

--- a/pkgs/development/web/grails/default.nix
+++ b/pkgs/development/web/grails/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, unzip
-# If jdk is null, require JAVA_HOME in runtime environment, else store
-# JAVA_HOME=${jdk.home} into grails.
+# If jdk8 is null, require JAVA_HOME in runtime environment, else store
+# JAVA_HOME=${jdk8.home} into grails.
 , jdk ? null
 , coreutils, ncurses, gnused, gnugrep  # for purity
 }:

--- a/pkgs/games/dwarf-fortress/legends-browser/default.nix
+++ b/pkgs/games/dwarf-fortress/legends-browser/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, buildEnv, writeShellScriptBin, fetchurl, jre }:
+{ stdenvNoCC, buildEnv, writeShellScriptBin, fetchurl, jre8 }:
 
 let
   name = "legends-browser-${version}";
@@ -18,7 +18,7 @@ let
       echo 'Creating initial configuration for legends-browser'
       echo "last=$(cd ..; pwd)" > legendsbrowser.properties
     fi
-    ${jre}/bin/java -jar ${jar}
+    ${jre8}/bin/java -jar ${jar}
   '';
 in
 

--- a/pkgs/games/dwarf-fortress/wrapper/default.nix
+++ b/pkgs/games/dwarf-fortress/wrapper/default.nix
@@ -2,7 +2,7 @@
 , dwarf-fortress
 , dwarf-therapist
 , enableDFHack ? false, dfhack
-, enableSoundSense ? false, soundSense, jdk
+, enableSoundSense ? false, soundSense, jdk8
 , enableStoneSense ? false
 , enableTWBT ? false, twbt
 , themes ? {}
@@ -114,7 +114,7 @@ stdenv.mkDerivation {
   '' + lib.optionalString enableSoundSense ''
     substitute $runSoundSense $out/bin/soundsense \
       --subst-var-by stdenv_shell ${stdenv.shell} \
-      --subst-var-by jre ${jdk.jre} \
+      --subst-var-by jre8 ${jdk8.jre} \
       --subst-var dfInit
     chmod 755 $out/bin/soundsense
   '';

--- a/pkgs/games/dwarf-fortress/wrapper/soundSense.in
+++ b/pkgs/games/dwarf-fortress/wrapper/soundSense.in
@@ -7,4 +7,4 @@ for p in soundsense/*; do
 done
 
 cd "$DF_DIR"
-PATH=@jre@/bin exec $DF_DIR/soundsense/soundSense.sh
+PATH=@jre8@/bin exec $DF_DIR/soundsense/soundSense.sh

--- a/pkgs/games/gcs/default.nix
+++ b/pkgs/games/gcs/default.nix
@@ -42,7 +42,7 @@ in stdenv.mkDerivation rec {
     cp -r ${library} gcs_library
   '';
 
-  buildInputs = [ jdk8 jre8 ant makeWrapper ];
+  buildInputs = [ jdk8.jre ant makeWrapper ];
   buildPhase = ''
     cd apple_stubs
     ant

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -4,7 +4,7 @@
 , fetchFromGitHub
 , gradle_5
 , perl
-, jre
+, jre8
 , libpulseaudio
 
 # Make the build version easily overridable.
@@ -83,7 +83,7 @@ let
   installClient = ''
     install -Dm644 desktop/build/libs/Mindustry.jar $out/share/mindustry.jar
     mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/mindustry \
+    makeWrapper ${jre8}/bin/java $out/bin/mindustry \
       --prefix LD_LIBRARY_PATH : ${libpulseaudio}/lib \
       --add-flags "-jar $out/share/mindustry.jar"
     install -Dm644 core/assets/icons/icon_64.png $out/share/icons/hicolor/64x64/apps/mindustry.png
@@ -92,7 +92,7 @@ let
   installServer = ''
     install -Dm644 server/build/libs/server-release.jar $out/share/mindustry-server.jar
     mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/mindustry-server \
+    makeWrapper ${jre8}/bin/java $out/bin/mindustry-server \
       --add-flags "-jar $out/share/mindustry-server.jar"
   '';
 

--- a/pkgs/games/minecraft-server/default.nix
+++ b/pkgs/games/minecraft-server/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre_headless }:
+{ stdenv, fetchurl, jre8_headless }:
 stdenv.mkDerivation {
   pname = "minecraft-server";
   version = "1.15.2";
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
     cat > $out/bin/minecraft-server << EOF
     #!/bin/sh
-    exec ${jre_headless}/bin/java \$@ -jar $out/lib/minecraft/server.jar nogui
+    exec ${jre8_headless}/bin/java \$@ -jar $out/lib/minecraft/server.jar nogui
     EOF
 
     chmod +x $out/bin/minecraft-server

--- a/pkgs/games/minecraft/default.nix
+++ b/pkgs/games/minecraft/default.nix
@@ -4,7 +4,7 @@
 , makeWrapper
 , wrapGAppsHook
 , gobject-introspection
-, jre # old or modded versions of the game may require Java 8 (https://aur.archlinux.org/packages/minecraft-launcher/#pinned-674960)
+, jre8 # old or modded versions of the game may require Java 8 (https://aur.archlinux.org/packages/minecraft-launcher/#pinned-674960)
 , xorg
 , zlib
 , nss
@@ -133,7 +133,7 @@ stdenv.mkDerivation rec {
     # Do not create `GPUCache` in current directory
     makeWrapper $out/opt/minecraft-launcher/minecraft-launcher $out/bin/minecraft-launcher \
       --prefix LD_LIBRARY_PATH : ${envLibPath} \
-      --prefix PATH : ${stdenv.lib.makeBinPath [ jre ]} \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ jre8 ]} \
       --run "cd /tmp" \
       "''${gappsWrapperArgs[@]}"
   '';

--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkDerivation, fetchFromGitHub, cmake, jdk, zlib, file, makeWrapper, xorg, libpulseaudio, qtbase }:
+{ stdenv, mkDerivation, fetchFromGitHub, cmake, jdk8, zlib, file, makeWrapper, xorg, libpulseaudio, qtbase }:
 
 let
   libpath = with xorg; stdenv.lib.makeLibraryPath [ libX11 libXext libXcursor libXrandr libXxf86vm libpulseaudio ];
@@ -13,7 +13,7 @@ in mkDerivation rec {
     fetchSubmodules = true;
   };
   nativeBuildInputs = [ cmake file makeWrapper ];
-  buildInputs = [ qtbase jdk zlib ];
+  buildInputs = [ qtbase jdk8 zlib ];
 
   enableParallelBuilding = true;
 
@@ -24,7 +24,7 @@ in mkDerivation rec {
     install -Dm755 ../application/package/linux/multimc.desktop $out/share/applications/multimc.desktop
 
     # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
-    wrapProgram $out/bin/multimc --add-flags "-d \$HOME/.multimc/" --set GAME_LIBRARY_PATH /run/opengl-driver/lib:${libpath} --prefix PATH : ${jdk}/bin/:${xorg.xrandr}/bin/
+    wrapProgram $out/bin/multimc --add-flags "-d \$HOME/.multimc/" --set GAME_LIBRARY_PATH /run/opengl-driver/lib:${libpath} --prefix PATH : ${jdk8}/bin/:${xorg.xrandr}/bin/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/games/papermc/default.nix
+++ b/pkgs/games/papermc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre }:
+{ stdenv, fetchurl, jre8 }:
 let
   mcVersion = "1.15.2";
   buildNum = "161";
@@ -18,7 +18,7 @@ in stdenv.mkDerivation {
     cp ${jar} $out/papermc.jar
     cat > $out/bin/minecraft-server << EOF
     #!/bin/sh
-    exec ${jre}/bin/java \$@ -jar $out/papermc.jar nogui
+    exec ${jre8}/bin/java \$@ -jar $out/papermc.jar nogui
     EOF
     chmod +x $out/bin/minecraft-server
   '';

--- a/pkgs/games/shattered-pixel-dungeon/default.nix
+++ b/pkgs/games/shattered-pixel-dungeon/default.nix
@@ -4,7 +4,7 @@
 , fetchFromGitHub
 , gradle_5
 , perl
-, jre
+, jre8
 , xorg
 , openal
 }:
@@ -61,7 +61,7 @@ in stdenv.mkDerivation rec {
   installPhase = ''
     install -Dm644 desktop/build/libs/desktop-${version}.jar $out/share/shattered-pixel-dungeon.jar
     mkdir $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/shattered-pixel-dungeon \
+    makeWrapper ${jre8}/bin/java $out/bin/shattered-pixel-dungeon \
       --prefix LD_LIBRARY_PATH : ${xorg.libXxf86vm}/lib:${openal}/lib \
       --add-flags "-jar $out/share/shattered-pixel-dungeon.jar"
   '';

--- a/pkgs/games/spring/default.nix
+++ b/pkgs/games/spring/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, lzma, boost, libdevil, zlib, p7zip
 , openal, libvorbis, glew, freetype, xorg, SDL2, libGLU, libGL
 , asciidoc, libxslt, docbook_xsl, docbook_xsl_ns, curl, makeWrapper
-, jdk ? null, python ? null, systemd, libunwind, which, minizip
+, jdk8 ? null, python ? null, systemd, libunwind, which, minizip
 , withAI ? true # support for AI Interfaces and Skirmish AIs
 }:
 
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ cmake lzma boost libdevil zlib p7zip openal libvorbis freetype SDL2
     xorg.libX11 xorg.libXcursor libGLU libGL glew asciidoc libxslt docbook_xsl curl makeWrapper
     docbook_xsl_ns systemd libunwind which minizip ]
-    ++ stdenv.lib.optional withAI jdk
+    ++ stdenv.lib.optional withAI jdk8
     ++ stdenv.lib.optional withAI python;
 
   enableParallelBuilding = true;

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -35,7 +35,7 @@ let
       # Steam VR
       procps
       usbutils
-    ] ++ lib.optional withJava jdk
+    ] ++ lib.optional withJava jdk8
       ++ lib.optional withPrimus primus
       ++ extraPkgs pkgs;
 

--- a/pkgs/games/vassal/default.nix
+++ b/pkgs/games/vassal/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "VASSAL-3.2.17";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     cp -R lib/* $out/share/vassal
     cp -R doc/* $out/doc
 
-    makeWrapper ${jre}/bin/java $out/bin/vassal \
+    makeWrapper ${jre8}/bin/java $out/bin/vassal \
       --add-flags "-Duser.dir=$out -cp $out/share/vassal/Vengine.jar \
       VASSAL.launch.ModuleManager"
   '';

--- a/pkgs/misc/emulators/ccemux/default.nix
+++ b/pkgs/misc/emulators/ccemux/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeDesktopItem, makeWrapper, jre
+{ stdenv, fetchurl, makeDesktopItem, makeWrapper, jre8
 , useCCTweaked ? true
 }:
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   dontUnpack = true;
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   installPhase = ''
     runHook preInstall
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     install -D ${src} $out/share/ccemux/ccemux.jar
     install -D ${desktopIcon} $out/share/pixmaps/ccemux.png
 
-    makeWrapper ${jre}/bin/java $out/bin/ccemux \
+    makeWrapper ${jre8}/bin/java $out/bin/ccemux \
       --add-flags "-jar $out/share/ccemux/ccemux.jar"
 
     runHook postInstall

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper, bash, coreutils, gnugrep, gnused, ps,
+{ stdenv, fetchurl, jre8, makeWrapper, bash, coreutils, gnugrep, gnused, ps,
   majorVersion ? "1.0" }:
 
 let
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  buildInputs = [ jre makeWrapper bash gnugrep gnused coreutils ps ];
+  buildInputs = [ jre8 makeWrapper bash gnugrep gnused coreutils ps ];
 
   installPhase = ''
     mkdir -p $out
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
 
     for p in $out/bin\/*.sh; do
       wrapProgram $p \
-        --set JAVA_HOME "${jre}" \
+        --set JAVA_HOME "${jre8}" \
         --set KAFKA_LOG_DIR "/tmp/apache-kafka-logs" \
         --prefix PATH : "${bash}/bin:${coreutils}/bin:${gnugrep}/bin:${gnused}/bin"
     done

--- a/pkgs/servers/computing/storm/default.nix
+++ b/pkgs/servers/computing/storm/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, zip, unzip
-, jzmq, jdk, python
+, jzmq, jdk8, python
 , confFile ? "", extraLibraryPaths ? [], extraJars ? [] }:
 
 stdenv.mkDerivation rec {
@@ -35,8 +35,8 @@ stdenv.mkDerivation rec {
       -e "s|STORM_CONF_DIR = .*|STORM_CONF_DIR = os.getenv('STORM_CONF_DIR','$out/conf')|" \
       -e 's|STORM_LOG4J2_CONF_DIR =.*|STORM_LOG4J2_CONF_DIR = os.path.join(STORM_CONF_DIR, "log4j2")|' \
         $out/bin/storm.py
-    # Default jdk location
-    sed -i -e 's|#.*export JAVA_HOME=.*|export JAVA_HOME="${jdk.home}"|' \
+    # Default jdk8 location
+    sed -i -e 's|#.*export JAVA_HOME=.*|export JAVA_HOME="${jdk8.home}"|' \
            $out/conf/storm-env.sh
     unzip  $out/lib/storm-core-${version}.jar defaults.yaml;
     zip -d $out/lib/storm-core-${version}.jar defaults.yaml;

--- a/pkgs/servers/confluent-platform/default.nix
+++ b/pkgs/servers/confluent-platform/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, fetchFromGitHub
-, jre, makeWrapper, bash, gnused }:
+, jre8, makeWrapper, bash, gnused }:
 
 stdenv.mkDerivation rec {
   pname = "confluent-platform";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = "18yvp56b8l074qfkgr4afirgd43g8b023n9ija6dnk6p6dib1f4j";
   };
 
-  buildInputs = [ jre makeWrapper bash ];
+  buildInputs = [ jre8 makeWrapper bash ];
 
   installPhase = ''
     cp -R $confluentCli confluent-cli
@@ -45,9 +45,9 @@ stdenv.mkDerivation rec {
 
     for p in $out/bin\/*; do
       wrapProgram $p \
-        --set JAVA_HOME "${jre}" \
+        --set JAVA_HOME "${jre8}" \
         --set KAFKA_LOG_DIR "/tmp/apache-kafka-logs" \
-        --prefix PATH : "${jre}/bin:${bash}/bin:${gnused}/bin"
+        --prefix PATH : "${jre8}/bin:${bash}/bin:${gnused}/bin"
     done
   '';
 

--- a/pkgs/servers/elasticmq-server-bin/default.nix
+++ b/pkgs/servers/elasticmq-server-bin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jdk, jre, makeWrapper }:
+{ stdenv, fetchurl, jdk8, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "elasticmq-server";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   # don't do anything?
-  unpackPhase = "${jdk}/bin/jar xf $src favicon.png";
+  unpackPhase = "${jdk8}/bin/jar xf $src favicon.png";
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     cp $src $out/share/elasticmq-server/elasticmq-server.jar
 
     # TODO: how to add extraArgs? current workaround is to use JAVA_TOOL_OPTIONS environment to specify properties
-    makeWrapper ${jre}/bin/java $out/bin/elasticmq-server \
+    makeWrapper ${jre8}/bin/java $out/bin/elasticmq-server \
       --add-flags "-jar $out/share/elasticmq-server/elasticmq-server.jar"
   '';
 

--- a/pkgs/servers/elasticmq/default.nix
+++ b/pkgs/servers/elasticmq/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper, which }:
+{ stdenv, fetchurl, jre8, makeWrapper, which }:
 
 stdenv.mkDerivation rec {
   name = "elasticmq-0.5";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
       cp bin/run.sh $out/bin/elasticmq
       substituteInPlace $out/bin/elasticmq --replace '-DBASEDIR=$BASEDIR' '-DBASEDIR=''${ELASTICMQ_DATA_PREFIX:-.}'
 
-      wrapProgram $out/bin/elasticmq --prefix PATH : "${stdenv.lib.makeBinPath [ which jre ]}"
+      wrapProgram $out/bin/elasticmq --prefix PATH : "${stdenv.lib.makeBinPath [ which jre8 ]}"
     '';
 
   meta = {

--- a/pkgs/servers/exhibitor/default.nix
+++ b/pkgs/servers/exhibitor/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, maven, jdk, makeWrapper, stdenv, ... }:
+{ fetchFromGitHub, maven, jdk8, makeWrapper, stdenv, ... }:
 stdenv.mkDerivation rec {
   pname = "exhibitor";
   version = "1.5.6";
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     mkdir -p $out/share/java
     mv target/$name.jar $out/share/java/
-    makeWrapper ${jdk}/bin/java $out/bin/startExhibitor.sh --add-flags "-jar $out/share/java/$name.jar" --suffix PATH : ${stdenv.lib.makeBinPath [ jdk ]}
+    makeWrapper ${jdk8}/bin/java $out/bin/startExhibitor.sh --add-flags "-jar $out/share/java/$name.jar" --suffix PATH : ${stdenv.lib.makeBinPath [ jdk8 ]}
   '';
 
 }

--- a/pkgs/servers/h2/default.nix
+++ b/pkgs/servers/h2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, jre, makeWrapper }:
+{ stdenv, fetchzip, jre8, makeWrapper }:
 stdenv.mkDerivation rec {
   pname = "h2";
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
         dir=$(dirname "$0")
 
         if [ -n "$1" ]; then
-          ${jre}/bin/java -cp "$dir/h2-${version}.jar:$H2DRIVERS:$CLASSPATH" $1 "''${@:2}"
+          ${jre8}/bin/java -cp "$dir/h2-${version}.jar:$H2DRIVERS:$CLASSPATH" $1 "''${@:2}"
         else
           echo "You have to provide the full java class path for the h2 tool you want to run. E.g. 'org.h2.tools.Server'"
         fi
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
       echo '${h2ToolScript}' > $out/bin/h2tool.sh
 
-      substituteInPlace $out/bin/h2.sh --replace "java" "${jre}/bin/java"
+      substituteInPlace $out/bin/h2.sh --replace "java" "${jre8}/bin/java"
 
       chmod +x $out/bin/*.sh
     '';

--- a/pkgs/servers/http/apache-modules/tomcat-connectors/default.nix
+++ b/pkgs/servers/http/apache-modules/tomcat-connectors/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, apacheHttpd, jdk }:
+{ stdenv, fetchurl, apacheHttpd, jdk8 }:
 
 stdenv.mkDerivation rec {
   name = "tomcat-connectors-1.2.48";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-apxs=${apacheHttpd.dev}/bin/apxs"
-    "--with-java-home=${jdk}"
+    "--with-java-home=${jdk8}"
   ];
 
   setSourceRoot = ''
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     cp apache-2.0/mod_jk.so $out/modules
   '';
 
-  buildInputs = [ apacheHttpd jdk ];
+  buildInputs = [ apacheHttpd jdk8 ];
 
   meta = with stdenv.lib; {
     description = "Provides web server plugins to connect web servers with Tomcat";

--- a/pkgs/servers/http/jboss/default.nix
+++ b/pkgs/servers/http/jboss/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, jdk }:
+{ stdenv, fetchurl, unzip, jdk8 }:
 
 stdenv.mkDerivation {
   name = "jboss-as-7.1.1.Final";
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   
   installPhase = ''
     mv $PWD $out
-    find $out/bin -name \*.sh -print0 | xargs -0 sed -i -e '/#!\/bin\/sh/aJAVA_HOME=${jdk}'
+    find $out/bin -name \*.sh -print0 | xargs -0 sed -i -e '/#!\/bin\/sh/aJAVA_HOME=${jdk8}'
   '';
   
   meta = with stdenv.lib; {

--- a/pkgs/servers/http/tomcat/axis2/default.nix
+++ b/pkgs/servers/http/tomcat/axis2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, apacheAnt, jdk, unzip }:
+{ stdenv, fetchurl, apacheAnt, jdk8, unzip }:
 
 stdenv.mkDerivation rec {
   pname = "axis2";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0dh0s9bfh95wmmw8nyf2yw95biq7d9zmrbg8k4vzcyz1if228lac";
   };
 
-  buildInputs = [ unzip apacheAnt jdk ];
+  buildInputs = [ unzip apacheAnt jdk8 ];
   builder = ./builder.sh;
 
   meta = {

--- a/pkgs/servers/http/tomcat/tomcat-native.nix
+++ b/pkgs/servers/http/tomcat/tomcat-native.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, apr, jdk, openssl }:
+{ stdenv, fetchurl, apr, jdk8, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "tomcat-native";
@@ -11,11 +11,11 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "${pname}-${version}-src/native";
 
-  buildInputs = [ apr jdk openssl ];
+  buildInputs = [ apr jdk8 openssl ];
 
   configureFlags = [
     "--with-apr=${apr.dev}"
-    "--with-java-home=${jdk}"
+    "--with-java-home=${jdk8}"
     "--with-ssl=${openssl.dev}"
   ];
 

--- a/pkgs/servers/jetbrains/youtrack.nix
+++ b/pkgs/servers/jetbrains/youtrack.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre, gawk }:
+{ stdenv, fetchurl, makeWrapper, jre8, gawk }:
 
 stdenv.mkDerivation rec {
   pname = "youtrack";
@@ -15,10 +15,10 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    makeWrapper ${jre}/bin/java $out/bin/youtrack \
+    makeWrapper ${jre8}/bin/java $out/bin/youtrack \
       --add-flags "\$YOUTRACK_JVM_OPTS -jar $jar" \
       --prefix PATH : "${stdenv.lib.makeBinPath [ gawk ]}" \
-      --set JRE_HOME ${jre}
+      --set JRE_HOME ${jre8}
     runHook postInstall
   '';
 

--- a/pkgs/servers/keycloak/default.nix
+++ b/pkgs/servers/keycloak/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, makeWrapper, jre }:
+{ stdenv, fetchzip, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   pname   = "keycloak";
@@ -21,14 +21,14 @@ stdenv.mkDerivation rec {
 
     chmod +x $out/bin/standalone.sh
     wrapProgram $out/bin/standalone.sh \
-      --prefix PATH ":" ${jre}/bin ;
+      --prefix PATH ":" ${jre8}/bin ;
   '';
 
   meta = with stdenv.lib; {
     homepage    = "https://www.keycloak.org/";
     description = "Identity and access management for modern applications and services";
     license     = licenses.asl20;
-    platforms   = jre.meta.platforms;
+    platforms   = jre8.meta.platforms;
     maintainers = [ maintainers.ngerstle ];
   };
 

--- a/pkgs/servers/ma1sd/default.nix
+++ b/pkgs/servers/ma1sd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jre, git, gradle_5, perl, makeWrapper }:
+{ stdenv, fetchFromGitHub, jre8, git, gradle_5, perl, makeWrapper }:
 
 let
   name = "ma1sd-${version}";
@@ -42,7 +42,7 @@ in
 stdenv.mkDerivation {
   inherit name src version;
   nativeBuildInputs = [ gradle_5 perl makeWrapper ];
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   patches = [ ./0001-gradle.patch ];
 
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     install -D build/libs/source.jar $out/lib/ma1sd.jar
-    makeWrapper ${jre}/bin/java $out/bin/ma1sd --add-flags "-jar $out/lib/ma1sd.jar"
+    makeWrapper ${jre8}/bin/java $out/bin/ma1sd --add-flags "-jar $out/lib/ma1sd.jar"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/metabase/default.nix
+++ b/pkgs/servers/metabase/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "metabase";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   dontUnpack = true;
 
   installPhase = ''
-    makeWrapper ${jre}/bin/java $out/bin/metabase --add-flags "-jar $src"
+    makeWrapper ${jre8}/bin/java $out/bin/metabase --add-flags "-jar $src"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/misc/subsonic/default.nix
+++ b/pkgs/servers/misc/subsonic/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre }:
+{ stdenv, fetchurl, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "subsonic";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "180qdk8mnc147az8v9rmc1kgf8b13mmq88l195gjdwiqpflqzdyz";
   };
 
-  inherit jre;
+  inherit jre8;
 
   # Create temporary directory to extract tarball into to satisfy Nix's need
   # for a directory to be created in the unpack phase.

--- a/pkgs/servers/monitoring/munin/default.nix
+++ b/pkgs/servers/monitoring/munin/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, makeWrapper, which, coreutils, rrdtool, perlPackages
-, python, ruby, jre, nettools, bc
+, python, ruby, jre8, nettools, bc
 }:
 
 stdenv.mkDerivation rec {
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     perlPackages.DBDPg
     python
     ruby
-    jre
+    jre8
     # tests
     perlPackages.TestLongString
     perlPackages.TestDifferences
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
     "PERL=${perlPackages.perl.outPath}/bin/perl"
     "PYTHON=${python.outPath}/bin/python"
     "RUBY=${ruby.outPath}/bin/ruby"
-    "JAVARUN=${jre.outPath}/bin/java"
+    "JAVARUN=${jre8.outPath}/bin/java"
     "PLUGINUSER=munin"
   ];
 

--- a/pkgs/servers/monitoring/prometheus/jmx-httpserver.nix
+++ b/pkgs/servers/monitoring/prometheus/jmx-httpserver.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 let
   version = "0.10";
@@ -14,7 +14,7 @@ in stdenv.mkDerivation {
     sha256 = "1pvqphrirq48xhmx0aa6vkxz6qy1cx2q6jxsh7rin432iap7j62f";
   };
 
-  buildInputs = [ jre makeWrapper ];
+  buildInputs = [ jre8 makeWrapper ];
 
   phases = "installPhase";
 
@@ -22,7 +22,7 @@ in stdenv.mkDerivation {
     mkdir -p $out/libexec
     mkdir -p $out/bin
     cp $src $out/libexec/$jarName
-    makeWrapper "${jre}/bin/java" $out/bin/jmx_prometheus_httpserver --add-flags "-jar $out/libexec/$jarName"
+    makeWrapper "${jre8}/bin/java" $out/bin/jmx_prometheus_httpserver --add-flags "-jar $out/libexec/$jarName"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/monitoring/riemann/default.nix
+++ b/pkgs/servers/monitoring/riemann/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "riemann";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     mv bin/riemann $out/bin/
     mv etc/riemann.config $out/etc/
 
-    wrapProgram "$out/bin/riemann" --prefix PATH : "${jre}/bin"
+    wrapProgram "$out/bin/riemann" --prefix PATH : "${jre8}/bin"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/monitoring/seyren/default.nix
+++ b/pkgs/servers/monitoring/seyren/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "seyren";
@@ -11,11 +11,11 @@ stdenv.mkDerivation rec {
 
   phases = ["installPhase"];
 
-  buildInputs = [ makeWrapper jre ];
+  buildInputs = [ makeWrapper jre8 ];
 
   installPhase = ''
     mkdir -p "$out"/bin
-    makeWrapper "${jre}/bin/java" "$out"/bin/seyren --add-flags "-jar $src"
+    makeWrapper "${jre8}/bin/java" "$out"/bin/seyren --add-flags "-jar $src"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/monitoring/zipkin/default.nix
+++ b/pkgs/servers/monitoring/zipkin/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, makeWrapper, jre}:
+{stdenv, fetchurl, makeWrapper, jre8}:
 stdenv.mkDerivation rec {
   version = "1.28.1";
   pname = "zipkin-server";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/java
     cp ${src} $out/share/java/zipkin-server-${version}-exec.jar
     mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/zipkin-server \
+    makeWrapper ${jre8}/bin/java $out/bin/zipkin-server \
       --add-flags "-cp $out/share/java/zipkin-server-${version}-exec.jar org.springframework.boot.loader.JarLauncher"
   '';
   meta = with stdenv.lib; {

--- a/pkgs/servers/mxisd/default.nix
+++ b/pkgs/servers/mxisd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jre, git, gradle, perl, makeWrapper }:
+{ stdenv, fetchFromGitHub, jre8, git, gradle, perl, makeWrapper }:
 
 let
   name = "mxisd-${version}";
@@ -42,7 +42,7 @@ in
 stdenv.mkDerivation {
   inherit name src version;
   nativeBuildInputs = [ gradle perl makeWrapper ];
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   patches = [ ./0001-gradle.patch ];
 
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     install -D build/libs/source.jar $out/lib/mxisd.jar
-    makeWrapper ${jre}/bin/java $out/bin/mxisd --add-flags "-jar $out/lib/mxisd.jar"
+    makeWrapper ${jre8}/bin/java $out/bin/mxisd --add-flags "-jar $out/lib/mxisd.jar"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/nosql/cassandra/generic.nix
+++ b/pkgs/servers/nosql/cassandra/generic.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python, makeWrapper, gawk, bash, getopt, procps
-, which, jre, version, sha256, coreutils, ...
+, which, jre8, version, sha256, coreutils, ...
 }:
 
 let
@@ -9,7 +9,7 @@ let
     getopt
     gawk
     which
-    jre
+    jre8
     procps
   ]);
 in
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
         wrapProgram $out/bin/$(basename "$cmd") \
           --suffix-each LD_LIBRARY_PATH : ${libPath} \
           --prefix PATH : ${binPath} \
-          --set JAVA_HOME ${jre}
+          --set JAVA_HOME ${jre8}
       fi
     done
 
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
         makeWrapper $out/$cmd $out/bin/$(basename "$cmd") \
           --suffix-each LD_LIBRARY_PATH : ${libPath} \
           --prefix PATH : ${binPath} \
-          --set JAVA_HOME ${jre}
+          --set JAVA_HOME ${jre8}
       fi
     done
 

--- a/pkgs/servers/search/elasticsearch/6.x.nix
+++ b/pkgs/servers/search/elasticsearch/6.x.nix
@@ -3,7 +3,7 @@
 , stdenv
 , fetchurl
 , makeWrapper
-, jre_headless
+, jre8_headless
 , utillinux, gnugrep, coreutils
 , autoPatchelfHook
 , zlib
@@ -35,7 +35,7 @@ stdenv.mkDerivation (rec {
       "ES_CLASSPATH=\"\$ES_CLASSPATH:$out/\$additional_classpath_directory/*\""
   '';
 
-  buildInputs = [ makeWrapper jre_headless utillinux ]
+  buildInputs = [ makeWrapper jre8_headless utillinux ]
              ++ optional enableUnfree zlib;
 
   installPhase = ''
@@ -46,9 +46,9 @@ stdenv.mkDerivation (rec {
 
     wrapProgram $out/bin/elasticsearch \
       --prefix PATH : "${makeBinPath [ utillinux gnugrep coreutils ]}" \
-      --set JAVA_HOME "${jre_headless}"
+      --set JAVA_HOME "${jre8_headless}"
 
-    wrapProgram $out/bin/elasticsearch-plugin --set JAVA_HOME "${jre_headless}"
+    wrapProgram $out/bin/elasticsearch-plugin --set JAVA_HOME "${jre8_headless}"
   '';
 
   passthru = { inherit enableUnfree; };

--- a/pkgs/servers/search/elasticsearch/7.x.nix
+++ b/pkgs/servers/search/elasticsearch/7.x.nix
@@ -3,7 +3,7 @@
 , stdenv
 , fetchurl
 , makeWrapper
-, jre_headless
+, jre8_headless
 , utillinux, gnugrep, coreutils
 , autoPatchelfHook
 , zlib
@@ -46,7 +46,7 @@ stdenv.mkDerivation (rec {
       "ES_CLASSPATH=\"\$ES_CLASSPATH:$out/\$additional_classpath_directory/*\""
   '';
 
-  buildInputs = [ makeWrapper jre_headless utillinux ]
+  buildInputs = [ makeWrapper jre8_headless utillinux ]
              ++ optional enableUnfree zlib;
 
   installPhase = ''
@@ -57,9 +57,9 @@ stdenv.mkDerivation (rec {
 
     wrapProgram $out/bin/elasticsearch \
       --prefix PATH : "${makeBinPath [ utillinux coreutils gnugrep ]}" \
-      --set JAVA_HOME "${jre_headless}"
+      --set JAVA_HOME "${jre8_headless}"
 
-    wrapProgram $out/bin/elasticsearch-plugin --set JAVA_HOME "${jre_headless}"
+    wrapProgram $out/bin/elasticsearch-plugin --set JAVA_HOME "${jre8_headless}"
   '';
 
   passthru = { inherit enableUnfree; };

--- a/pkgs/servers/search/solr/default.nix
+++ b/pkgs/servers/search/solr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper, nixosTests }:
+{ stdenv, fetchurl, jre8, makeWrapper, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "solr";
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
     cp -r example $out/
     cp -r server $out/
 
-    wrapProgram $out/bin/solr --set JAVA_HOME "${jre}"
-    wrapProgram $out/bin/post --set JAVA_HOME "${jre}"
+    wrapProgram $out/bin/solr --set JAVA_HOME "${jre8}"
+    wrapProgram $out/bin/post --set JAVA_HOME "${jre8}"
   '';
 
   passthru.tests = {

--- a/pkgs/servers/ums/default.nix
+++ b/pkgs/servers/ums/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
     # ums >= 9.0.0 ships its own JRE in the package. if we remove it, the `UMS.sh`
     # script will correctly fall back to the JRE specified by JAVA_HOME
-    rm -rf $out/jre
+    rm -rf $out/jre8
 
     makeWrapper "$out/UMS.sh" "$out/bin/ums" \
       --prefix LD_LIBRARY_PATH ":" "${stdenv.lib.makeLibraryPath [ libzen libmediainfo] }" \

--- a/pkgs/servers/xmpp/openfire/default.nix
+++ b/pkgs/servers/xmpp/openfire/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre }:
+{ stdenv, fetchurl, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "openfire";
@@ -9,10 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "0ibzhmh9qw4lmx45ir1i280p30npgwnj7vrkl432kj3zi7hp79q2";
   };
 
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   installPhase = ''
-    sed -e 's@\(common_jvm_locations=\).*@\1${jre}@' -i bin/openfire
+    sed -e 's@\(common_jvm_locations=\).*@\1${jre8}@' -i bin/openfire
     cp -r . $out
     rm -r $out/logs
     mv $out/conf $out/conf.inst

--- a/pkgs/servers/zookeeper/default.nix
+++ b/pkgs/servers/zookeeper/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper, bash, coreutils, runtimeShell }:
+{ stdenv, fetchurl, jre8, makeWrapper, bash, coreutils, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "zookeeper";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0karf13zks3ba2rdmma2lyabvmasc04cjmgxp227f0nj8677kvbw";
   };
 
-  buildInputs = [ makeWrapper jre ];
+  buildInputs = [ makeWrapper jre8 ];
 
   phases = ["unpackPhase" "installPhase"];
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
         --replace /bin/echo ${coreutils}/bin/echo
     for i in $out/bin/{zkCli,zkCleanup,zkServer}.sh; do
       wrapProgram $i \
-        --set JAVA_HOME "${jre}" \
+        --set JAVA_HOME "${jre8}" \
         --prefix PATH : "${bash}/bin"
     done
     chmod -x $out/bin/zkEnv.sh
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     cat << EOF > $out/bin/zooInspector.sh
     #!${runtimeShell}
     cd $out/share/zooinspector
-    exec ${jre}/bin/java -cp $classpath org.apache.zookeeper.inspector.ZooInspector
+    exec ${jre8}/bin/java -cp $classpath org.apache.zookeeper.inspector.ZooInspector
     EOF
     chmod +x $out/bin/zooInspector.sh
   '';

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -6,7 +6,6 @@
 # Attributes needed for tests of the external plugins
 , callPackage, beets
 
-, enableAbsubmit       ? stdenv.lib.elem stdenv.hostPlatform.system essentia-extractor.meta.platforms, essentia-extractor ? null
 , enableAcousticbrainz ? true
 , enableAcoustid       ? true
 , enableBadfiles       ? true, flac ? null, mp3val ? null
@@ -35,7 +34,6 @@
 , bashInteractive, bash-completion
 }:
 
-assert enableAbsubmit    -> essentia-extractor            != null;
 assert enableAcoustid    -> pythonPackages.pyacoustid     != null;
 assert enableBadfiles    -> flac != null && mp3val != null;
 assert enableCheck       -> flac != null && mp3val != null && liboggz != null;
@@ -55,7 +53,6 @@ with stdenv.lib;
 
 let
   optionalPlugins = {
-    absubmit = enableAbsubmit;
     acousticbrainz = enableAcousticbrainz;
     badfiles = enableBadfiles;
     chroma = enableAcoustid;
@@ -135,7 +132,7 @@ in pythonPackages.buildPythonApplication rec {
     pythonPackages.gst-python
     pythonPackages.pygobject3
     gobject-introspection
-  ] ++ optional enableAbsubmit      essentia-extractor
+  ]
     ++ optional enableAcoustid      pythonPackages.pyacoustid
     ++ optional (enableFetchart
               || enableEmbyupdate

--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -144,7 +144,7 @@ buildEnv {
   #   to the so-called "installation directories"
   # * Add symlinks to the "installation directories"
   #   that point to the `dsm.sys` configuration files
-  # * Drop the Java GUI executable unless `jdk` is present
+  # * Drop the Java GUI executable unless `jdk8` is present
   # * Create wrappers for the command-line interface to
   #   prepare `PATH` and `DSM_DIR` environment variables
   postBuild = ''

--- a/pkgs/tools/filesystems/xtreemfs/default.nix
+++ b/pkgs/tools/filesystems/xtreemfs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, boost, fuse, openssl, cmake, attr, jdk, ant, which, file, python
+{ stdenv, boost, fuse, openssl, cmake, attr, jdk8, ant, which, file, python
 , lib, valgrind, makeWrapper, fetchFromGitHub, fetchpatch }:
 
 stdenv.mkDerivation {
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   ];
 
   preConfigure = ''
-    export JAVA_HOME=${jdk}
+    export JAVA_HOME=${jdk8}
     export ANT_HOME=${ant}
 
     export BOOST_INCLUDEDIR=${boost.dev}/include

--- a/pkgs/tools/graphics/briss/default.nix
+++ b/pkgs/tools/graphics/briss/default.nix
@@ -1,6 +1,6 @@
 # The releases of this project are apparently precompiled to .jar files.
 
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 let
 
@@ -21,7 +21,7 @@ in stdenv.mkDerivation {
     mkdir -p "$out/bin";
     mkdir -p "$out/share";
     install -D -m444 -t "$out/share" *.jar
-    makeWrapper "${jre}/bin/java" "$out/bin/briss" --add-flags "-Xms128m -Xmx1024m -cp \"$out/share/\" -jar \"$out/share/briss-${version}.jar\""
+    makeWrapper "${jre8}/bin/java" "$out/bin/briss" --add-flags "-Xms128m -Xmx1024m -cp \"$out/share/\" -jar \"$out/share/briss-${version}.jar\""
   '';
 
   meta = {

--- a/pkgs/tools/graphics/ditaa/default.nix
+++ b/pkgs/tools/graphics/ditaa/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre }:
+{ stdenv, fetchurl, jre8 }:
 
 stdenv.mkDerivation rec {
   name = "ditaa-0.11.0";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
     cat > "$out/bin/ditaa" << EOF
     #!${stdenv.shell}
-    exec ${jre}/bin/java -jar "$out/lib/ditaa.jar" "\$@"
+    exec ${jre8}/bin/java -jar "$out/lib/ditaa.jar" "\$@"
     EOF
 
     chmod a+x "$out/bin/ditaa"

--- a/pkgs/tools/graphics/welkin/default.nix
+++ b/pkgs/tools/graphics/welkin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchsvn, jre, makeWrapper }:
+{ stdenv, fetchsvn, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "welkin";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "welkin-r9638/tags/${version}";
 
-  buildInputs = [ jre makeWrapper ];
+  buildInputs = [ jre8 makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/{bin,share}
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     cp $out/share/welkin.sh $out/bin/welkin
     sed -e 's@\./lib/welkin\.jar@'"$out"'/share/lib/welkin.jar@' -i $out/bin/welkin
     wrapProgram $out/bin/welkin \
-      --set JAVA_HOME ${jre}
+      --set JAVA_HOME ${jre8}
     chmod a+x $out/bin/welkin
   '';
 

--- a/pkgs/tools/graphics/zxing/default.nix
+++ b/pkgs/tools/graphics/zxing/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre }:
+{ stdenv, fetchurl, jre8 }:
 stdenv.mkDerivation rec {
   pname = "zxing";
   version = "3.1.0";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     url = "http://repo1.maven.org/maven2/com/google/zxing/javase/${version}/javase-${version}.jar";
     sha256 = "0fzxvvf5dqyrs5m9rqw4ffm9h1s27bi7q3jb1dam34s80q2rp2zq";
   };
-  inherit jre;
+  inherit jre8;
   dontUnpack = true;
   installPhase = ''
     mkdir -p "$out/lib/java" "$out/bin"

--- a/pkgs/tools/graphics/zxing/java-zxing.sh
+++ b/pkgs/tools/graphics/zxing/java-zxing.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-@jre@/bin/java -cp @out@/lib/java/core-@version@.jar:@out@/lib/java/javase-@version@.jar "$@"
+@jre8@/bin/java -cp @out@/lib/java/core-@version@.jar:@out@/lib/java/javase-@version@.jar "$@"

--- a/pkgs/tools/misc/aws-mturk-clt/default.nix
+++ b/pkgs/tools/misc/aws-mturk-clt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre }:
+{ stdenv, fetchurl, jre8 }:
 
 stdenv.mkDerivation rec {
   name = "aws-mturk-clt-1.3.0";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
       cp -prvd bin $out/
 
       for i in $out/bin/*.sh; do
-        sed -i "$i" -e "s|^MTURK_CMD_HOME=.*|MTURK_CMD_HOME=$out\nexport JAVA_HOME=${jre}|"
+        sed -i "$i" -e "s|^MTURK_CMD_HOME=.*|MTURK_CMD_HOME=$out\nexport JAVA_HOME=${jre8}|"
       done
 
       mkdir -p $out/lib

--- a/pkgs/tools/misc/graylog/default.nix
+++ b/pkgs/tools/misc/graylog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre_headless }:
+{ stdenv, fetchurl, makeWrapper, jre8_headless }:
 
 stdenv.mkDerivation rec {
   pname = "graylog";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   buildInputs = [ makeWrapper ];
-  makeWrapperArgs = [ "--prefix" "PATH" ":" "${jre_headless}/bin" ];
+  makeWrapperArgs = [ "--prefix" "PATH" ":" "${jre8_headless}/bin" ];
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/tools/misc/hdfview/default.nix
+++ b/pkgs/tools/misc/hdfview/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir $out
-    # exclude jre
+    # exclude jre8
     cp -r build/HDF_Group/HDFView/*/{lib,share} $out/
     mkdir $out/bin
     cp -r build/HDF_Group/HDFView/*/hdfview.sh $out/bin/hdfview

--- a/pkgs/tools/misc/ili2c/default.nix
+++ b/pkgs/tools/misc/ili2c/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchFromGitHub, jdk, ant, makeWrapper, jre }:
+{ stdenv, fetchFromGitHub, jdk8, ant, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   pname = "ili2c";
   version = "5.0.8";
 
-  nativeBuildInputs = [ ant jdk makeWrapper ];
+  nativeBuildInputs = [ ant jdk8 makeWrapper ];
 
   src = fetchFromGitHub {
     owner = "claeis";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       cp $build/build/source/build/jar/ili2c.jar $out/share/${pname}
 
       mkdir -p $out/bin
-      makeWrapper ${jre}/bin/java $out/bin/ili2c \
+      makeWrapper ${jre8}/bin/java $out/bin/ili2c \
         --add-flags "-jar $out/share/${pname}/ili2c.jar"
     '';
 

--- a/pkgs/tools/misc/jdiskreport/default.nix
+++ b/pkgs/tools/misc/jdiskreport/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, jre, makeDesktopItem }:
+{ stdenv, fetchurl, unzip, jre8, makeDesktopItem }:
 
 let
   desktopItem = makeDesktopItem {
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ unzip ];
-  inherit jre;
+  inherit jre8;
 
   installPhase = ''
     source $stdenv/setup
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     cat > $out/bin/jdiskreport <<EOF
     #! $SHELL -e
-    exec $jre/bin/java -jar $out/share/java/$(basename $jar)
+    exec $jre8/bin/java -jar $out/share/java/$(basename $jar)
     EOF
     chmod +x $out/bin/jdiskreport
 

--- a/pkgs/tools/misc/jugglinglab/default.nix
+++ b/pkgs/tools/misc/jugglinglab/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jre, makeWrapper, ant, jdk }:
+{ stdenv, fetchFromGitHub, jre8, makeWrapper, ant, jdk8 }:
 stdenv.mkDerivation rec {
   version = "1.2.1";
   name = "jugglinglab";
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     rev = "1908012682d8c39a9b92248a20f285455104c510"; # v1.2.1 does not have a tag on Github
     sha256 = "0dvcyjwynvapqbjchrln59vdskrm3w6kh0knxcn4bx61vcz3171z";
   };
-  buildInputs = [ jre ];
-  nativeBuildInputs = [ ant jdk makeWrapper ];
+  buildInputs = [ jre8 ];
+  nativeBuildInputs = [ ant jdk8 makeWrapper ];
   buildPhase = "ant";
 
   installPhase = ''
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/lib"
     cp bin/JugglingLab.jar $out/lib/
 
-    makeWrapper ${jre}/bin/java $out/bin/jugglinglab \
+    makeWrapper ${jre8}/bin/java $out/bin/jugglinglab \
       --add-flags "-jar $out/lib/JugglingLab.jar"
   '';
 

--- a/pkgs/tools/misc/logstash/6.x.nix
+++ b/pkgs/tools/misc/logstash/6.x.nix
@@ -3,7 +3,7 @@
 , stdenv
 , fetchurl
 , makeWrapper
-, jre
+, jre8
 }:
 
 with stdenv.lib;
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   dontPatchShebangs = true;
 
   buildInputs = [
-    makeWrapper jre
+    makeWrapper jre8
   ];
 
   installPhase = ''
@@ -37,10 +37,10 @@ stdenv.mkDerivation rec {
     patchShebangs $out/bin/logstash-plugin
 
     wrapProgram $out/bin/logstash \
-       --set JAVA_HOME "${jre}"
+       --set JAVA_HOME "${jre8}"
 
     wrapProgram $out/bin/logstash-plugin \
-       --set JAVA_HOME "${jre}"
+       --set JAVA_HOME "${jre8}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/logstash/7.x.nix
+++ b/pkgs/tools/misc/logstash/7.x.nix
@@ -3,7 +3,7 @@
 , stdenv
 , fetchurl
 , makeWrapper
-, jre
+, jre8
 }:
 
 with stdenv.lib;
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   dontPatchShebangs = true;
 
   buildInputs = [
-    makeWrapper jre
+    makeWrapper jre8
   ];
 
   installPhase = ''
@@ -37,10 +37,10 @@ stdenv.mkDerivation rec {
     patchShebangs $out/bin/logstash-plugin
 
     wrapProgram $out/bin/logstash \
-       --set JAVA_HOME "${jre}"
+       --set JAVA_HOME "${jre8}"
 
     wrapProgram $out/bin/logstash-plugin \
-       --set JAVA_HOME "${jre}"
+       --set JAVA_HOME "${jre8}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/opentsdb/default.nix
+++ b/pkgs/tools/misc/opentsdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, autoconf, automake, curl, fetchurl, jdk, jre, makeWrapper, nettools
+{ stdenv, autoconf, automake, curl, fetchurl, jdk8, jre8, makeWrapper, nettools
 , python, git
 }:
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0b0hilqmgz6n1q7irp17h48v8fjpxhjapgw1py8kyav1d51s7mm2";
   };
 
-  buildInputs = [ autoconf automake curl jdk makeWrapper nettools python git ];
+  buildInputs = [ autoconf automake curl jdk8 makeWrapper nettools python git ];
 
   preConfigure = ''
     patchShebangs ./build-aux/
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/tsdb \
-      --set JAVA_HOME "${jre}" \
-      --set JAVA "${jre}/bin/java"
+      --set JAVA_HOME "${jre8}" \
+      --set JAVA "${jre8}/bin/java"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/plantuml/default.nix
+++ b/pkgs/tools/misc/plantuml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jre, graphviz }:
+{ stdenv, fetchurl, makeWrapper, jre8, graphviz }:
 
 stdenv.mkDerivation rec {
   version = "1.2020.10";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     install -Dm644 $src $out/lib/plantuml.jar
 
     mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/plantuml \
+    makeWrapper ${jre8}/bin/java $out/bin/plantuml \
       --argv0 plantuml \
       --set GRAPHVIZ_DOT ${graphviz}/bin/dot \
       --add-flags "-jar $out/lib/plantuml.jar"

--- a/pkgs/tools/misc/smc/default.nix
+++ b/pkgs/tools/misc/smc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, runtimeShell }:
+{ stdenv, fetchurl, jre8, runtimeShell }:
 
 stdenv.mkDerivation {
   name = "smc-6.6.3";
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
 
     cat > "$out/bin/smc" << EOF
     #!${runtimeShell}
-    ${jre}/bin/java -jar "$out/share/java/Smc.jar" "\$@"
+    ${jre8}/bin/java -jar "$out/share/java/Smc.jar" "\$@"
     EOF
     chmod a+x "$out/bin/smc"
   '';

--- a/pkgs/tools/misc/umlet/default.nix
+++ b/pkgs/tools/misc/umlet/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, unzip, runtimeShell }:
+{ stdenv, fetchurl, jre8, unzip, runtimeShell }:
 
 stdenv.mkDerivation rec {
   major = "14";
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
     programDir="$out/lib"
     cd "\$programDir"
     if [ \$# -eq 1 ]
-     then "${jre}/bin/java" -jar "\$programDir/umlet.jar" -filename="\$1"
-     else "${jre}/bin/java" -jar "\$programDir/umlet.jar" "\$@"
+     then "${jre8}/bin/java" -jar "\$programDir/umlet.jar" -filename="\$1"
+     else "${jre8}/bin/java" -jar "\$programDir/umlet.jar" "\$@"
     fi
 
     EOF

--- a/pkgs/tools/networking/burpsuite/default.nix
+++ b/pkgs/tools/networking/burpsuite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, runtimeShell }:
+{ stdenv, fetchurl, jre8, runtimeShell }:
 
 let
   version = "2020.1";
@@ -9,7 +9,7 @@ let
   };
   launcher = ''
     #!${runtimeShell}
-    exec ${jre}/bin/java -jar ${jar} "$@"
+    exec ${jre8}/bin/java -jar ${jar} "$@"
   '';
 in stdenv.mkDerivation {
   pname = "burpsuite";
@@ -33,7 +33,7 @@ in stdenv.mkDerivation {
     homepage = "https://portswigger.net/burp/";
     downloadPage = "https://portswigger.net/burp/freedownload";
     license = [ stdenv.lib.licenses.unfree ];
-    platforms = jre.meta.platforms;
+    platforms = jre8.meta.platforms;
     hydraPlatforms = [];
     maintainers = with stdenv.lib.maintainers; [ bennofs ];
   };

--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, ps, coreutils, fetchurl, jdk, jre, ant, gettext, which }:
+{ stdenv, ps, coreutils, fetchurl, jdk8, jre8, ant, gettext, which }:
 
 let wrapper = stdenv.mkDerivation rec {
   pname = "wrapper";
@@ -9,13 +9,13 @@ let wrapper = stdenv.mkDerivation rec {
     sha256 = "0mjyw9ays9v6lnj21pmfd3qdvd9b6rwxfmw3pg6z0kyf2jadixw2";
   };
 
-  buildInputs = [ jdk ];
+  buildInputs = [ jdk8 ];
 
   buildPhase = ''
     export ANT_HOME=${ant}
-    export JAVA_HOME=${jdk}/lib/openjdk/jre/
+    export JAVA_HOME=${jdk8}/lib/openjdk/jre8/
     export JAVA_TOOL_OPTIONS=-Djava.home=$JAVA_HOME
-    export CLASSPATH=${jdk}/lib/openjdk/lib/tools.jar
+    export CLASSPATH=${jdk8}/lib/openjdk/lib/tools.jar
     sed 's/ testsuite$//' -i src/c/Makefile-linux-x86-64.make
     ${if stdenv.isi686 then "./build32.sh" else "./build64.sh"}
   '';
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     sha256 = "04y71hzkdpjzbac569rhyg1zfx37j0alggbl9gnkaqfbprb2nj1h";
   };
 
-  buildInputs = [ jdk ant gettext which ];
+  buildInputs = [ jdk8 ant gettext which ];
   patches = [ ./i2p.patch ];
 
   buildPhase = ''
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
       -e "s#%INSTALL_PATH#$out#" \
       -e 's#%USER_HOME#$HOME#' \
       -e "s#%SYSTEM_java_io_tmpdir#/tmp#" \
-      -e "s#%JAVA%#${jre}/bin/java#"
+      -e "s#%JAVA%#${jre8}/bin/java#"
     mv $out/runplain.sh $out/bin/i2prouter-plain
     mv $out/man $out/share/
     chmod +x $out/bin/* $out/i2psvc

--- a/pkgs/tools/networking/openapi-generator-cli/default.nix
+++ b/pkgs/tools/networking/openapi-generator-cli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   version = "4.2.2";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -D "$src" "$out/share/java/${jarfilename}"
 
-    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+    makeWrapper ${jre8}/bin/java $out/bin/${pname} \
       --add-flags "-jar $out/share/java/${jarfilename}"
   '';
 

--- a/pkgs/tools/networking/openapi-generator-cli/unstable.nix
+++ b/pkgs/tools/networking/openapi-generator-cli/unstable.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   version = "5.0.0-2020-02-04";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -D "$src" "$out/share/java/${jarfilename}"
 
-    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+    makeWrapper ${jre8}/bin/java $out/bin/${pname} \
       --add-flags "-jar $out/share/java/${jarfilename}"
   '';
 

--- a/pkgs/tools/networking/p2p/azureus/builder.sh
+++ b/pkgs/tools/networking/p2p/azureus/builder.sh
@@ -10,7 +10,7 @@ azureusHome=$out
 if test -n "\$HOME"; then
     azureusHome=\$HOME/.Azureus
 fi
-exec $jdk/bin/java -Xms16m -Xmx128m \
+exec $jdk8/bin/java -Xms16m -Xmx128m \
   -cp $out/jars/azureus.jar:$swt/jars/swt.jar \
   -Djava.library.path=$swt/lib \
   -Dazureus.install.path=\$azureusHome \

--- a/pkgs/tools/networking/p2p/azureus/default.nix
+++ b/pkgs/tools/networking/p2p/azureus/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, jdk, swt}:
+{stdenv, fetchurl, jdk8, swt}:
 
 stdenv.mkDerivation {
   name = "azureus-2.3.0.6";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1hwrh3n0b0jbpsdk15zrs7pw175418phhmg6pn4xi1bvilxq1wrd";
   };
 #  buildInputs = [unzip];
-  inherit jdk swt;
+  inherit jdk8 swt;
 
   meta = {
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/networking/sshoogr/default.nix
+++ b/pkgs/tools/networking/sshoogr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, jdk, makeWrapper }:
+{ stdenv, fetchzip, jdk8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "sshoogr";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     rm bin/sshoogr.bat
     cp -r . $out
     wrapProgram $out/bin/sshoogr \
-      --prefix JAVA_HOME : ${jdk}
+      --prefix JAVA_HOME : ${jdk8}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/networking/swagger-codegen/default.nix
+++ b/pkgs/tools/networking/swagger-codegen/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   version = "2.3.1";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -D "$src" "$out/share/java/${jarfilename}"
 
-    makeWrapper ${jre}/bin/java $out/bin/swagger-codegen \
+    makeWrapper ${jre8}/bin/java $out/bin/swagger-codegen \
       --add-flags "-jar $out/share/java/${jarfilename}"
   '';
 

--- a/pkgs/tools/networking/zap/default.nix
+++ b/pkgs/tools/networking/zap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jdk, ant, runtimeShell }:
+{ stdenv, fetchFromGitHub, jdk8, ant, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "zap";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1bz4pgq66v6kxmgj99llacm1d85vj8z78jlgc2z9hv0ha5i57y32";
   };
 
-  buildInputs = [ jdk ant ];
+  buildInputs = [ jdk8 ant ];
 
   buildPhase = ''
     cd build

--- a/pkgs/tools/package-management/disnix/DisnixWebService/default.nix
+++ b/pkgs/tools/package-management/disnix/DisnixWebService/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, apacheAnt, jdk, axis2, dbus_java }:
+{stdenv, fetchurl, apacheAnt, jdk8, axis2, dbus_java }:
 
 stdenv.mkDerivation {
   name = "DisnixWebService-0.9";
@@ -6,13 +6,13 @@ stdenv.mkDerivation {
     url = "https://github.com/svanderburg/DisnixWebService/releases/download/DisnixWebService-0.9/DisnixWebService-0.9.tar.gz";
     sha256 = "1z7w44bf023c0aqchjfi4mla3qbhsh87mdzx7pqn0sy74cjfgqvl";
   };
-  buildInputs = [ apacheAnt jdk ];
+  buildInputs = [ apacheAnt jdk8 ];
   PREFIX = ''''${env.out}'';
   AXIS2_LIB = "${axis2}/lib";
   AXIS2_WEBAPP = "${axis2}/webapps/axis2";
   DBUS_JAVA_LIB = "${dbus_java}/share/java";
   prePatch = ''
-    sed -i -e "s|#JAVA_HOME=|JAVA_HOME=${jdk}|" \
+    sed -i -e "s|#JAVA_HOME=|JAVA_HOME=${jdk8}|" \
        -e "s|#AXIS2_LIB=|AXIS2_LIB=${axis2}/lib|" \
         scripts/disnix-soap-client
   '';

--- a/pkgs/tools/security/ipscan/default.nix
+++ b/pkgs/tools/security/ipscan/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jdk, jre, swt, makeWrapper, xorg, dpkg }:
+{ stdenv, fetchurl, jdk8, jre8, swt, makeWrapper, xorg, dpkg }:
 
 stdenv.mkDerivation rec {
   pname = "ipscan";
@@ -12,13 +12,13 @@ stdenv.mkDerivation rec {
   sourceRoot = ".";
   unpackCmd = "${dpkg}/bin/dpkg-deb -x $src .";
 
-  buildInputs = [ makeWrapper jdk ];
+  buildInputs = [ makeWrapper jdk8 ];
 
   installPhase = ''
     mkdir -p $out/share
     cp usr/lib/ipscan/ipscan-any-${version}.jar $out/share/${pname}-${version}.jar
 
-    makeWrapper ${jre}/bin/java $out/bin/ipscan \
+    makeWrapper ${jre8}/bin/java $out/bin/ipscan \
       --prefix LD_LIBRARY_PATH : "$out/lib/:${stdenv.lib.makeLibraryPath [ swt xorg.libXtst ]}" \
       --add-flags "-Xmx256m -cp $out/share/${pname}-${version}.jar:${swt}/jars/swt.jar net.azib.ipscan.Main"
 

--- a/pkgs/tools/security/jadx/default.nix
+++ b/pkgs/tools/security/jadx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gradle, jdk, makeWrapper, perl }:
+{ stdenv, fetchFromGitHub, gradle, jdk8, makeWrapper, perl }:
 
 let
   pname = "jadx";
@@ -15,7 +15,7 @@ let
     name = "${pname}-deps";
     inherit src;
 
-    nativeBuildInputs = [ gradle jdk perl ];
+    nativeBuildInputs = [ gradle jdk8 perl ];
 
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d)
@@ -38,7 +38,7 @@ let
 in stdenv.mkDerivation {
   inherit pname version src;
 
-  nativeBuildInputs = [ gradle jdk makeWrapper ];
+  nativeBuildInputs = [ gradle jdk8 makeWrapper ];
 
   buildPhase = ''
     # The installDist Gradle build phase tries to copy some dependency .jar
@@ -86,7 +86,7 @@ in stdenv.mkDerivation {
     cp -R build/jadx/lib $out
     for prog in jadx jadx-gui; do
       cp build/jadx/bin/$prog $out/bin
-      wrapProgram $out/bin/$prog --set JAVA_HOME ${jdk.home}
+      wrapProgram $out/bin/$prog --set JAVA_HOME ${jdk8.home}
     done
   '';
 

--- a/pkgs/tools/security/jd-gui/default.nix
+++ b/pkgs/tools/security/jd-gui/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jre, jdk, gradle, makeDesktopItem, perl, writeText, runtimeShell }:
+{ stdenv, fetchFromGitHub, jre8, jdk8, gradle, makeDesktopItem, perl, writeText, runtimeShell }:
 
 let
   pname = "jd-gui";
@@ -15,7 +15,7 @@ let
     name = "${pname}-deps";
     inherit src;
 
-    nativeBuildInputs = [ jdk perl gradle ];
+    nativeBuildInputs = [ jdk8 perl gradle ];
 
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d);
@@ -71,7 +71,7 @@ in stdenv.mkDerivation rec {
   inherit pname version src;
   name = "${pname}-${version}";
 
-  nativeBuildInputs = [ jdk gradle ];
+  nativeBuildInputs = [ jdk8 gradle ];
 
   buildPhase = ''
     export GRADLE_USER_HOME=$(mktemp -d)
@@ -87,8 +87,8 @@ in stdenv.mkDerivation rec {
 
     cat > $out/bin/jd-gui <<EOF
     #!${runtimeShell}
-    export JAVA_HOME=${jre}
-    exec ${jre}/bin/java -jar ${jar} "\$@"
+    export JAVA_HOME=${jre8}
+    exec ${jre8}/bin/java -jar ${jar} "\$@"
     EOF
     chmod +x $out/bin/jd-gui
 

--- a/pkgs/tools/security/open-ecard/default.nix
+++ b/pkgs/tools/security/open-ecard/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, pcsclite, makeDesktopItem, makeWrapper }:
+{ stdenv, fetchurl, jre8, pcsclite, makeDesktopItem, makeWrapper }:
 
 let
   version = "1.2.4";
@@ -47,7 +47,7 @@ in stdenv.mkDerivation rec {
     cp ${srcs.logo} $out/share/pixmaps/oec_logo_bg-transparent.svg
 
     mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/${appName} \
+    makeWrapper ${jre8}/bin/java $out/bin/${appName} \
       --add-flags "-cp $out/share/java/cifs-${version}.jar" \
       --add-flags "-jar $out/share/java/richclient-${version}.jar" \
       --suffix LD_LIBRARY_PATH ':' ${stdenv.lib.getLib pcsclite}/lib

--- a/pkgs/tools/security/secp256k1/default.nix
+++ b/pkgs/tools/security/secp256k1/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, jdk
+{ stdenv, fetchFromGitHub, autoreconfHook, jdk8
 
 # Enable ECDSA pubkey recovery module
 , enableRecovery ? true
@@ -7,7 +7,7 @@
 # experimental)
 , enableECDH ? false
 
-# Enable libsecp256k1_jni (disabled by default because it requires a jdk,
+# Enable libsecp256k1_jni (disabled by default because it requires a jdk8,
 # which is a large dependency)
 , enableJNI ? false
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
     sha256 = "0bxqmimm627g9klalg1vdbspmn52588v4a6cli3p8bn84ibsnzbm";
   };
 
-  buildInputs = optionals enableJNI [ jdk ];
+  buildInputs = optionals enableJNI [ jdk8 ];
 
   nativeBuildInputs = [ autoreconfHook ];
 

--- a/pkgs/tools/system/awstats/default.nix
+++ b/pkgs/tools/system/awstats/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perlPackages, jdk }:
+{ stdenv, fetchurl, perlPackages, jdk8 }:
 
 perlPackages.buildPerlPackage rec {
   pname = "awstats";
@@ -29,7 +29,7 @@ perlPackages.buildPerlPackage rec {
     (
       cd wwwroot/classes/src
       rm ../*.jar
-      PATH="${jdk}/bin" "$(type -P perl)" Makefile.pl
+      PATH="${jdk8}/bin" "$(type -P perl)" Makefile.pl
       test -f ../*.jar
     )
   '';

--- a/pkgs/tools/system/collectd/plugins.nix
+++ b/pkgs/tools/system/collectd/plugins.nix
@@ -3,7 +3,7 @@
 , darwin
 , hiredis
 , iptables
-, jdk
+, jdk8
 , libatasmart
 , libdbi
 , libgcrypt
@@ -133,7 +133,7 @@ let
     ipvs = {};
     irq = {};
     java = {
-      buildInputs = [ jdk libgcrypt libxml2 ];
+      buildInputs = [ jdk8 libgcrypt libxml2 ];
     };
     load = {};
     logfile = {};

--- a/pkgs/tools/system/java-service-wrapper/default.nix
+++ b/pkgs/tools/system/java-service-wrapper/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, jdk
+, jdk8
 , ant, cunit, ncurses
 }:
 
@@ -12,14 +12,14 @@ stdenv.mkDerivation rec {
     sha256 = "19cx3854rk7b2056z8pvxnf4simsg5js7czsy2bys7jl6vh2x02b";
   };
 
-  buildInputs = [ jdk ];
+  buildInputs = [ jdk8 ];
   nativeBuildInputs = [ ant cunit ncurses ];
 
   buildPhase = ''
     export ANT_HOME=${ant}
-    export JAVA_HOME=${jdk}/lib/openjdk/jre/
+    export JAVA_HOME=${jdk8}/lib/openjdk/jre8/
     export JAVA_TOOL_OPTIONS=-Djava.home=$JAVA_HOME
-    export CLASSPATH=${jdk}/lib/openjdk/lib/tools.jar
+    export CLASSPATH=${jdk8}/lib/openjdk/lib/tools.jar
 
     ${if stdenv.isi686 then "./build32.sh" else "./build64.sh"}
   '';

--- a/pkgs/tools/text/epubcheck/default.nix
+++ b/pkgs/tools/text/epubcheck/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchzip
-, jre, makeWrapper }:
+, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "epubcheck";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     done
 
     mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/epubcheck \
+    makeWrapper ${jre8}/bin/java $out/bin/epubcheck \
       --add-flags "-classpath $classpath com.adobe.epubcheck.tool.Checker"
   '';
 

--- a/pkgs/tools/text/languagetool/default.nix
+++ b/pkgs/tools/text/languagetool/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, jre, makeWrapper }:
+{ stdenv, fetchzip, jre8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "LanguageTool";
@@ -9,18 +9,18 @@ stdenv.mkDerivation rec {
     sha256 = "0hvzckb92yijzmp2vphjp1wgql3xqq0xd83v5x6pbhziq9yxc5yh";
   };
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jre ];
+  buildInputs = [ jre8 ];
 
   installPhase = ''
     mkdir -p $out/share
     mv * $out/share/
 
     for lt in languagetool{,-commandline,-server};do
-      makeWrapper ${jre}/bin/java $out/bin/$lt \
+      makeWrapper ${jre8}/bin/java $out/bin/$lt \
         --add-flags "-cp $out/share/ -jar $out/share/$lt.jar"
     done
 
-    makeWrapper ${jre}/bin/java $out/bin/languagetool-http-server \
+    makeWrapper ${jre8}/bin/java $out/bin/languagetool-http-server \
       --add-flags "-cp $out/share/languagetool-server.jar org.languagetool.server.HTTPServer"
   '';
 

--- a/pkgs/tools/text/xml/basex/default.nix
+++ b/pkgs/tools/text/xml/basex/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, jre, coreutils, makeDesktopItem }:
+{ stdenv, fetchurl, unzip, jre8, coreutils, makeDesktopItem }:
 
 stdenv.mkDerivation rec {
   pname = "basex";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1kws6swisdaa17yhijjvkh2ikwz9rd5cw8mdjvkqw6vlcp1nq6m4";
   };
 
-  buildInputs = [ unzip jre ];
+  buildInputs = [ unzip jre8 ];
 
   desktopItem = makeDesktopItem {
     name = "basex";
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     # Use substitutions instead of wrapper scripts
     for file in "$out"/bin/*; do
         sed -i -e "s|/usr/bin/env bash|${stdenv.shell}|" \
-               -e "s|java|${jre}/bin/java|" \
+               -e "s|java|${jre8}/bin/java|" \
                -e "s|readlink|${coreutils}/bin/readlink|" \
                -e "s|dirname|${coreutils}/bin/dirname|" \
                -e "s|basename|${coreutils}/bin/basename|" \

--- a/pkgs/tools/text/xml/jing-trang/default.nix
+++ b/pkgs/tools/text/xml/jing-trang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jre_headless, jdk, ant, saxon }:
+{ stdenv, fetchFromGitHub, jre8_headless, jdk8, ant, saxon }:
 
 stdenv.mkDerivation {
   pname = "jing-trang";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "1hhn52z9mv1x9nyvyqnmzg5yrs2lzm9xac7i15izppv02wp32qha";
   };
 
-  buildInputs = [ jdk ant saxon ];
+  buildInputs = [ jdk8 ant saxon ];
 
   CLASSPATH = "lib/saxon.jar";
 
@@ -24,8 +24,8 @@ stdenv.mkDerivation {
     for tool in jing trang; do
     cat > "$out/bin/$tool" <<EOF
     #! $SHELL
-    export JAVA_HOME='${jre_headless}'
-    exec '${jre_headless}/bin/java' -jar '$out/share/java/$tool.jar' "\$@"
+    export JAVA_HOME='${jre8_headless}'
+    exec '${jre8_headless}/bin/java' -jar '$out/share/java/$tool.jar' "\$@"
     EOF
     done
 

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -28,7 +28,7 @@
 # unzip is needed to extract filter and backend plugins
 , unzip ? null
 # filters
-, enableDitaaFilter ? false, jre ? null
+, enableDitaaFilter ? false, jre8 ? null
 , enableMscgenFilter ? false, mscgen ? null
 , enableDiagFilter ? false, blockdiag ? null, seqdiag ? null, actdiag ? null, nwdiag ? null
 , enableQrcodeFilter ? false, qrencode ? null
@@ -66,7 +66,7 @@ assert enableStandardFeatures ->
 
 # filters
 assert enableExtraPlugins || enableDitaaFilter || enableMscgenFilter || enableDiagFilter || enableQrcodeFilter || enableAafigureFilter -> unzip != null;
-assert (enableExtraPlugins && enableJava) || enableDitaaFilter -> jre != null;
+assert (enableExtraPlugins && enableJava) || enableDitaaFilter -> jre8 != null;
 assert enableExtraPlugins || enableMscgenFilter -> mscgen != null;
 assert enableExtraPlugins || enableDiagFilter -> blockdiag != null && seqdiag != null && actdiag != null && nwdiag != null;
 assert enableExtraPlugins || enableMatplotlibFilter -> matplotlib != null && numpy != null;
@@ -160,7 +160,7 @@ stdenv.mkDerivation rec {
   '' + optionalString _enableDitaaFilter ''
     echo "Extracting ditaa filter"
     unzip -d "$out/etc/asciidoc/filters/ditaa" "${ditaaFilterSrc}"
-    sed -i -e "s|java -jar|${jre}/bin/java -jar|" \
+    sed -i -e "s|java -jar|${jre8}/bin/java -jar|" \
         "$out/etc/asciidoc/filters/ditaa/ditaa2img.py"
   '' + optionalString _enableMscgenFilter ''
     echo "Extracting mscgen filter"

--- a/pkgs/tools/typesetting/asciidoctorj/default.nix
+++ b/pkgs/tools/typesetting/asciidoctorj/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, jdk, makeWrapper }:
+{ stdenv, fetchzip, jdk8, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "asciidoctorj";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     rm bin/asciidoctorj.bat
     cp -r . $out
     wrapProgram $out/bin/asciidoctorj \
-      --prefix JAVA_HOME : ${jdk}
+      --prefix JAVA_HOME : ${jdk8}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/typesetting/fop/default.nix
+++ b/pkgs/tools/typesetting/fop/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, ant, jdk, runtimeShell }:
+{ fetchurl, stdenv, ant, jdk8, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "fop";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "165rx13q47l6qc29ppr7sg1z26vw830s3rkklj5ap7wgvy0ivbz5";
   };
 
-  buildInputs = [ ant jdk ];
+  buildInputs = [ ant jdk8 ];
 
   buildPhase = "ant";
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     cat > "$out/bin/fop" <<EOF
     #!${runtimeShell}
     java_exec_args="-Djava.awt.headless=true"
-    exec ${jdk.jre}/bin/java \$java_exec_args -classpath "$out/lib/*" org.apache.fop.cli.Main "\$@"
+    exec ${jdk8.jre}/bin/java \$java_exec_args -classpath "$out/lib/*" org.apache.fop.cli.Main "\$@"
     EOF
     chmod a+x $out/bin/fop
   '';

--- a/pkgs/tools/typesetting/pdftk/default.nix
+++ b/pkgs/tools/typesetting/pdftk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, gradle_5, jre, perl, writeText, runtimeShell }:
+{ stdenv, fetchFromGitLab, gradle_5, jre8, perl, writeText, runtimeShell }:
 
 let
   pname = "pdftk";
@@ -78,7 +78,7 @@ in stdenv.mkDerivation rec {
 
     cat  << EOF > $out/bin/pdftk
     #!${runtimeShell}
-    exec ${jre}/bin/java -jar "$out/share/pdftk/pdftk.jar" "\$@"
+    exec ${jre8}/bin/java -jar "$out/share/pdftk/pdftk.jar" "\$@"
     EOF
     chmod a+x "$out/bin/pdftk"
 

--- a/pkgs/tools/virtualization/ec2-api-tools/default.nix
+++ b/pkgs/tools/virtualization/ec2-api-tools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, makeWrapper, jre }:
+{ stdenv, fetchurl, unzip, makeWrapper, jre8 }:
 
 stdenv.mkDerivation rec {
   name = "ec2-api-tools-1.7.5.1";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
           if [ $b = "ec2-cmd" ]; then continue; fi
           makeWrapper $i $out/bin/$(basename $i) \
             --set EC2_HOME $d \
-            --set JAVA_HOME ${jre}
+            --set JAVA_HOME ${jre8}
       done
     ''; # */
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -938,8 +938,6 @@ in
 
   enpass = callPackage ../tools/security/enpass { };
 
-  essentia-extractor = callPackage ../tools/audio/essentia-extractor { };
-
   esh = callPackage ../tools/text/esh { };
 
   ezstream = callPackage ../tools/audio/ezstream { };
@@ -8206,7 +8204,7 @@ in
 
   devpi-server = callPackage ../development/tools/devpi-server {};
 
-  dotty = callPackage ../development/compilers/scala/dotty.nix { jre = jre8;};
+  dotty = callPackage ../development/compilers/scala/dotty.nix { jre = jre8; };
 
   drumstick = callPackage ../development/libraries/drumstick { };
 
@@ -8833,8 +8831,8 @@ in
     else
       openjdk14.override { headless = true; };
 
-  openjdk = openjdk8;
-  openjdk_headless = openjdk8_headless;
+  openjdk = openjdk14;
+  openjdk_headless = openjdk14_headless;
 
   jdk8 = openjdk8;
   jre8 = openjdk8.jre;
@@ -8845,10 +8843,8 @@ in
 
   jdk14 = openjdk14;
   jdk14_headless = openjdk14_headless;
-
-  jdk = jdk8;
-  jre = jre8;
-  jre_headless = jre8_headless;
+  # attribute without version suffix should always point to the Latest version
+  jdk = jdk14;
 
   inherit (callPackages ../development/compilers/graalvm {
     gcc = if stdenv.targetPlatform.isDarwin then gcc8 else gcc;
@@ -9258,8 +9254,8 @@ in
   sbcl_2_0_2 = callPackage ../development/compilers/sbcl {};
   sbcl = callPackage ../development/compilers/sbcl/2.0.0.nix {};
 
-  scala_2_10 = callPackage ../development/compilers/scala/2.10.nix { };
-  scala_2_11 = callPackage ../development/compilers/scala/2.11.nix { };
+  scala_2_10 = callPackage ../development/compilers/scala/2.10.nix { jre = jre8; };
+  scala_2_11 = callPackage ../development/compilers/scala/2.11.nix { jre = jre8; };
   scala_2_12 = callPackage ../development/compilers/scala/2.12.nix { jre = jre8; };
   scala_2_13 = callPackage ../development/compilers/scala/2.13.nix { jre = jre8; };
   scala = scala_2_13;
@@ -14487,8 +14483,8 @@ in
   resolv_wrapper = callPackage ../development/libraries/resolv_wrapper { };
 
   rhino = callPackage ../development/libraries/java/rhino {
-    javac = jdk;
-    jvm = jre;
+    javac = jdk8;
+    jvm = jre8;
   };
 
   rlog = callPackage ../development/libraries/rlog { };
@@ -19250,9 +19246,7 @@ in
 
   echoip = callPackage ../servers/echoip { };
 
-  eclipses = recurseIntoAttrs (callPackage ../applications/editors/eclipse {
-    jdk = jdk11;
-  });
+  eclipses = recurseIntoAttrs (callPackage ../applications/editors/eclipse { });
 
   ecs-agent = callPackage ../applications/virtualization/ecs-agent { };
 
@@ -19914,7 +19908,7 @@ in
   gtkpod = callPackage ../applications/audio/gtkpod { };
 
   jbidwatcher = callPackage ../applications/misc/jbidwatcher {
-    java = if stdenv.isLinux then jre else jdk;
+    java = if stdenv.isLinux then jre8 else jdk8;
   };
 
   qrencode = callPackage ../development/libraries/qrencode { };
@@ -24989,7 +24983,7 @@ in
       configureFlags = [ "--enable-intinf-as-int" "--with-gmp" "--disable-shared" ];
     });
 
-    java = if stdenv.isLinux then jre else jdk;
+    java = if stdenv.isLinux then jre8 else jdk8;
   };
 
   iprover = callPackage ../applications/science/logic/iprover { };

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, fetchFromGitHub, haxe, neko, jdk, mono }:
+{ stdenv, fetchzip, fetchFromGitHub, haxe, neko, jdk8, mono }:
 
 let
   self = haxePackages;
@@ -78,7 +78,7 @@ let
       version = "3.2.0";
       sha256 = "1vgd7qvsdxlscl3wmrrfi5ipldmr4xlsiwnj46jz7n6izff5261z";
       meta.description = "Support library for the Java backend of the Haxe compiler";
-      propagatedBuildInputs = [ jdk ];
+      propagatedBuildInputs = [ jdk8 ];
     };
 
     hxcs = buildHaxeLib {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9783,7 +9783,7 @@ let
 
     propagatedBuildInputs = [ Inline ];
 
-    makeMakerFlags = "J2SDK=${pkgs.jdk}";
+    makeMakerFlags = "J2SDK=${pkgs.jdk8}";
 
     # FIXME: Apparently tests want to access the network.
     doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

I want to encourage contributors to use (or at least try to use) the latest openjdk when they add new derivations that need Java. This change strives to make `jdk` point to the latest `jdk`, while every other derivation that uses `jdk` without an explicit version suffix, now uses `jdk8` explicitly.

I'm still waiting for ofborg to tag this PR as "10.rebuild-linux: 0", that's why it's a draft.

See also https://discourse.nixos.org/t/nixpkgs-policy-regarding-libraries-available-in-multiple-versions/7026 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
