### PR TITLE
Guile setup hook, use compiled files

### DIFF
--- a/pkgs/development/interpreters/guile/setup-hook-2.0.sh
+++ b/pkgs/development/interpreters/guile/setup-hook-2.0.sh
@@ -8,6 +8,16 @@ addGuileLibPath () {
         export GUILE_LOAD_PATH="${GUILE_LOAD_PATH-}${GUILE_LOAD_PATH:+:}$1/share/guile/site"
         export GUILE_LOAD_COMPILED_PATH="${GUILE_LOAD_COMPILED_PATH-}${GUILE_LOAD_COMPILED_PATH:+:}$1/share/guile/site"
     fi
+
+    if test -d "$1/lib/guile/2.0/ccache"
+    then
+        export GUILE_LOAD_COMPILED_PATH="${GUILE_LOAD_COMPILED_PATH-}${GUILE_LOAD_COMPILED_PATH:+:}$1/lib/guile/2.0/ccache"
+    fi
+
+    if test -d "$1/lib/guile/2.0/site-ccache"
+    then
+        export GUILE_LOAD_COMPILED_PATH="${GUILE_LOAD_COMPILED_PATH-}${GUILE_LOAD_COMPILED_PATH:+:}$1/lib/guile/2.0/site-ccache"
+    fi
 }
 
 addEnvHooks "$hostOffset" addGuileLibPath

--- a/pkgs/development/interpreters/guile/setup-hook-2.2.sh
+++ b/pkgs/development/interpreters/guile/setup-hook-2.2.sh
@@ -8,6 +8,16 @@ addGuileLibPath () {
         export GUILE_LOAD_PATH="${GUILE_LOAD_PATH-}${GUILE_LOAD_PATH:+:}$1/share/guile/site"
         export GUILE_LOAD_COMPILED_PATH="${GUILE_LOAD_COMPILED_PATH-}${GUILE_LOAD_COMPILED_PATH:+:}$1/share/guile/site"
     fi
+
+    if test -d "$1/lib/guile/2.2/ccache"
+    then
+        export GUILE_LOAD_COMPILED_PATH="${GUILE_LOAD_COMPILED_PATH-}${GUILE_LOAD_COMPILED_PATH:+:}$1/lib/guile/2.2/ccache"
+    fi
+
+    if test -d "$1/lib/guile/2.2/site-ccache"
+    then
+        export GUILE_LOAD_COMPILED_PATH="${GUILE_LOAD_COMPILED_PATH-}${GUILE_LOAD_COMPILED_PATH:+:}$1/lib/guile/2.2/site-ccache"
+    fi
 }
 
 addEnvHooks "$hostOffset" addGuileLibPath


### PR DESCRIPTION
Often packages install the compiled files to
`$(libdir)/guile/$(GUILE_EFFECTIVE_VERSION)/ccache` (e.g. see
guile-opengl). This path is not explicitly given in the info page, but
is used in a couple of places, and is also part of `%load-compiled-path`
variable in guile (for `"${guile}/lib/guile/2.2/ccache`).

Similarly, the site-ccache is also part of `%load-compiled-path` in
guile.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
