### PR TITLE
guid: fix compilation of Setup.hs and disable tests

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5310,7 +5310,6 @@ broken-packages:
   - gtksourceview3
   - guarded-rewriting
   - guess-combinator
-  - guid
   - GuiHaskell
   - GuiTV
   - gulcii

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -761,4 +761,12 @@ self: super: builtins.intersectAttrs super {
   rebase_1_6_1 = super.rebase_1_6_1.override {
     selective = super.selective_0_4_1;
   };
+
+  # Fix compilation of Setup.hs by removing the module declaration.
+  # See: https://github.com/tippenein/guid/issues/1
+  guid = overrideCabal (super.guid) (drv: {
+    prePatch = "sed -i '1d' Setup.hs"; # 1st line is module declaration, remove it
+    doCheck = false;
+  });
+
 }


### PR DESCRIPTION
#### Motivation for this change

`haskellPackages.guid` doesn't compile due to the error below:

```
% nix-shell -I. -p haskellPackages.guid                              
these derivations will be built:
  /nix/store/7xz2i3rq5ddh0ns9kbv82f3bv78xydfa-guid-0.1.0.drv
building '/nix/store/7xz2i3rq5ddh0ns9kbv82f3bv78xydfa-guid-0.1.0.drv'...
setupCompilerEnvironmentPhase
Build with /nix/store/blamkv8vbxc4nyzs61llligwi1bz9v4f-ghc-8.8.3.
unpacking sources
unpacking source archive /nix/store/za6hxapidmb06sv17gkgq3dx6y2nw6gj-guid-0.1.0.tar.gz
source root is guid-0.1.0
setting SOURCE_DATE_EPOCH to timestamp 1460276507 of file guid-0.1.0/guid.cabal
patching sources
compileBuildDriverPhase
setupCompileFlags: -package-db=/private/var/folders/b8/hhb93lms7mb097rx6lq3zq1m0000gn/T/nix-build-guid-0.1.0.drv-0/setup-package.conf.d -j8 -threaded -rtsopts
[1 of 1] Compiling Setup            ( Setup.hs, /private/var/folders/b8/hhb93lms7mb097rx6lq3zq1m0000gn/T/nix-build-guid-0.1.0.drv-0/Setup.o )

<no location info>: error:
    output was redirected with -o, but no output will be generated
because there is no Main module.

builder for '/nix/store/7xz2i3rq5ddh0ns9kbv82f3bv78xydfa-guid-0.1.0.drv' failed with exit code 1
error: build of '/nix/store/7xz2i3rq5ddh0ns9kbv82f3bv78xydfa-guid-0.1.0.drv' failed
```

Removing module declaration in `Setup.hs` fixes the problem. Also tests are failing due to the dependency on hspec-discover, I just disabled them since there actually are no tests. 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
