### PR TITLE
boolector: 3.0.0 -> 3.2.1

### DIFF
--- a/pkgs/applications/science/logic/boolector/cmake-gtest.patch
+++ b/pkgs/applications/science/logic/boolector/cmake-gtest.patch
@@ -1,0 +1,16 @@
+diff --git a/cmake/googletest-download.cmake b/cmake/googletest-download.cmake
+index 0ec4d558..d0910313 100644
+--- a/cmake/googletest-download.cmake
++++ b/cmake/googletest-download.cmake
+@@ -9,10 +9,7 @@ ExternalProject_Add(
+   googletest
+   SOURCE_DIR "@GOOGLETEST_DOWNLOAD_ROOT@/googletest-src"
+   BINARY_DIR "@GOOGLETEST_DOWNLOAD_ROOT@/googletest-build"
+-  GIT_REPOSITORY
+-    https://github.com/google/googletest.git
+-  GIT_TAG
+-    release-1.10.0
++  URL REPLACEME
+   CONFIGURE_COMMAND ""
+   BUILD_COMMAND ""
+   INSTALL_COMMAND ""

--- a/pkgs/applications/science/logic/boolector/default.nix
+++ b/pkgs/applications/science/logic/boolector/default.nix
@@ -1,37 +1,31 @@
-{ stdenv, fetchFromGitHub, fetchpatch
-, cmake, lingeling, btor2tools
+{ stdenv, fetchFromGitHub, lib, python3
+, cmake, lingeling, btor2tools, gtest, gmp
 }:
 
 stdenv.mkDerivation rec {
   pname = "boolector";
-  version = "3.0.0";
+  version = "3.2.1";
 
   src = fetchFromGitHub {
     owner  = "boolector";
     repo   = "boolector";
     rev    = "refs/tags/${version}";
-    sha256 = "15i3ni5klss423m57wcy1gx0m5wfrjmglapwg85pm7fb3jj1y7sz";
+    sha256 = "0jkmaw678njqgkflzj9g374yk1mci8yqvsxkrqzlifn6bwhwb7ci";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "CVE-2019-7560.patch";
-      url = "https://github.com/Boolector/boolector/commit/8d979d02e0482c7137c9f3a34e6d430dbfd1f5c5.patch";
-      sha256 = "1a1g02mk8b0azzjcigdn5zpshn0dn05fciwi8sd5q38yxvnvpbbi";
-    })
-  ];
+  postPatch = ''
+    sed s@REPLACEME@file://${gtest.src}@ ${./cmake-gtest.patch} | patch -p1
+  '';
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ lingeling btor2tools ];
+  buildInputs = [ lingeling btor2tools gmp ];
 
   cmakeFlags =
-    [ "-DSHARED=ON"
+    [ "-DBUILD_SHARED_LIBS=ON"
       "-DUSE_LINGELING=YES"
-      "-DBTOR2_INCLUDE_DIR=${btor2tools.dev}/include"
-      "-DBTOR2_LIBRARIES=${btor2tools.lib}/lib/libbtor2parser.so"
-      "-DLINGELING_INCLUDE_DIR=${lingeling.dev}/include"
-      "-DLINGELING_LIBRARIES=${lingeling.lib}/lib/liblgl.a"
-    ];
+      "-DBtor2Tools_INCLUDE_DIR=${btor2tools.dev}/include"
+      "-DBtor2Tools_LIBRARIES=${btor2tools.lib}/lib/libbtor2parser.so"
+    ] ++ (lib.optional (gmp != null) "-DUSE_GMP=YES");
 
   installPhase = ''
     mkdir -p $out/bin $lib/lib $dev/include
@@ -39,11 +33,20 @@ stdenv.mkDerivation rec {
     cp -vr bin/* $out/bin
     cp -vr lib/* $lib/lib
 
-    rm -rf $out/bin/{examples,test}
+    rm -rf $out/bin/{examples,tests}
+    # we don't care about gtest related libs
+    rm -rf $lib/lib/libg*
 
     cd ../src
     find . -iname '*.h' -exec cp --parents '{}' $dev/include \;
     rm -rf $dev/include/tests
+  '';
+
+  checkInputs = [ python3 ];
+  doCheck = true;
+  preCheck = ''
+    export LD_LIBRARY_PATH=$(readlink -f lib)
+    patchShebangs ..
   '';
 
   outputs = [ "out" "dev" "lib" ];

--- a/pkgs/applications/science/logic/btor2tools/default.nix
+++ b/pkgs/applications/science/logic/btor2tools/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, cmake, fetchFromGitHub }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "btor2tools";
-  version = "pre55_8c150b39";
+  version = "1.0.0-pre_${src.rev}";
 
   src = fetchFromGitHub {
     owner  = "boolector";
     repo   = "btor2tools";
-    rev    = "8c150b39cdbcdef4247344acf465d75ef642365d";
-    sha256 = "1r5pid4x567nms02ajjrz3v0zj18k0fi5pansrmc2907rnx2acxx";
+    rev    = "9831f9909fb283752a3d6d60d43613173bd8af42";
+    sha256 = "0mfqmkgvyw8fa2c09kww107dmk180ch1hp98r5kv41vnc04iqb0s";
   };
 
-  configurePhase = "./configure.sh -shared";
+  nativeBuildInputs = [ cmake ];
 
   installPhase = ''
     mkdir -p $out $dev/include/btor2parser/ $lib/lib
 
     cp -vr bin $out
-    cp -v  src/btor2parser/btor2parser.h $dev/include/btor2parser
-    cp -v  build/libbtor2parser.* $lib/lib
+    cp -v  ../src/btor2parser/btor2parser.h $dev/include/btor2parser
+    cp -v  lib/libbtor2parser.* $lib/lib
   '';
 
   outputs = [ "out" "dev" "lib" ];


### PR DESCRIPTION
##### Motivation for this change

update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) -> I only tested `boolector`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
