### PR TITLE
libayatana-appindicator: init at 0.5.4 libayatana-indicator: init at 0.6.3 ayatana-ido: init at 0.4.90

### DIFF
--- a/pkgs/development/libraries/ayatana-ido/default.nix
+++ b/pkgs/development/libraries/ayatana-ido/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub
+, pkgconfig, autoreconfHook
+, gtk3, gobject-introspection, gtk-doc, vala
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ayatana-ido";
+  version = "0.4.90";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = pname;
+    rev = version;
+    sha256 = "02vqjryni96zzrpkq5d7kvgw7nf252d2fm2xq8fklvvb2vz3fa0w";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook gtk-doc vala ];
+
+  buildInputs = [ gtk3 gobject-introspection ];
+
+  meta = with stdenv.lib; {
+    description = "Ayatana Display Indicator Objects";
+    homepage = "https://github.com/AyatanaIndicators/ayatana-ido";
+    changelog = "https://github.com/AyatanaIndicators/ayatana-ido/blob/${version}/ChangeLog";
+    license = [ licenses.gpl3 licenses.lgpl21 ];
+    maintainers = [ maintainers.nickhu ];
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/development/libraries/libayatana-appindicator/default.nix
+++ b/pkgs/development/libraries/libayatana-appindicator/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, lib
+, pkgconfig, autoreconfHook , gtk-doc
+, gtkVersion ? "3"
+, gtk2, libayatana-indicator-gtk2, libdbusmenu-gtk2
+, gtk3, libayatana-indicator-gtk3, libdbusmenu-gtk3
+, dbus-glib, python2, python2Packages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libayatana-appindicator-gtk${gtkVersion}";
+  version = "0.5.4";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = "libayatana-appindicator";
+    rev = version;
+    sha256 = "0bqjqb7gabdk7mifk8azi630qw39z978f973fx2ylgdgr4a66j1v";
+  };
+
+  patchPhase = ''
+    substituteInPlace configure.ac \
+      --replace "codegendir pygtk-2.0" "codegendir pygobject-2.0"
+  '';
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook gtk-doc ];
+
+  buildInputs = [ dbus-glib python2 python2Packages.pygtk ]
+    ++ lib.lists.optional (gtkVersion == "2") libayatana-indicator-gtk2
+    ++ lib.lists.optional (gtkVersion == "3") libayatana-indicator-gtk3;
+
+  propagatedBuildInputs =
+    lib.lists.optionals (gtkVersion == "2") [ gtk2 libdbusmenu-gtk2 ]
+    ++ lib.lists.optionals (gtkVersion == "3") [ gtk3 libdbusmenu-gtk3 ];
+
+  preAutoreconf = ''
+    gtkdocize
+  '';
+
+  configureFlags = [ "--with-gtk=${gtkVersion}" ];
+
+  meta = with stdenv.lib; {
+    description = "Ayatana Application Indicators Shared Library";
+    homepage = "https://github.com/AyatanaIndicators/libayatana-appindicator";
+    changelog = "https://github.com/AyatanaIndicators/libayatana-appindicator/blob/${version}/ChangeLog";
+    license = [ licenses.gpl3 licenses.lgpl21 ];
+    maintainers = [ maintainers.nickhu ];
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/development/libraries/libayatana-indicator/default.nix
+++ b/pkgs/development/libraries/libayatana-indicator/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, lib
+, pkgconfig, autoreconfHook
+, gtkVersion ? "3"
+, gtk2
+, gtk3
+, ayatana-ido
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libayatana-indicator-gtk${gtkVersion}";
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = "libayatana-indicator";
+    rev = version;
+    sha256 = "1q9wmaw6pckwyrv0s7wkqzm1yrk031pbz4xbr8cwn75ixqyfcb28";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+
+  buildInputs = [ ayatana-ido ]
+    ++ lib.lists.optionals (gtkVersion == "2") [ gtk2 ]
+    ++ lib.lists.optionals (gtkVersion == "3") [ gtk3 ];
+
+  configureFlags = [ "--with-gtk=${gtkVersion}" ];
+
+  meta = with stdenv.lib; {
+    description = "Ayatana Indicators Shared Library";
+    homepage = "https://github.com/AyatanaIndicators/libayatana-indicator";
+    changelog = "https://github.com/AyatanaIndicators/libayatana-indicator/blob/${version}/ChangeLog";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.nickhu ];
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13010,6 +13010,10 @@ in
   libindicator-gtk3 = libindicator.override { gtkVersion = "3"; };
   libindicator = callPackage ../development/libraries/libindicator { };
 
+  libayatana-indicator-gtk2 = libayatana-indicator.override { gtkVersion = "2"; };
+  libayatana-indicator-gtk3 = libayatana-indicator.override { gtkVersion = "3"; };
+  libayatana-indicator = callPackage ../development/libraries/libayatana-indicator { };
+
   libinotify-kqueue = callPackage ../development/libraries/libinotify-kqueue { };
 
   libiodbc = callPackage ../development/libraries/libiodbc {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12575,6 +12575,10 @@ in
   libappindicator-gtk3 = libappindicator.override { gtkVersion = "3"; };
   libappindicator = callPackage ../development/libraries/libappindicator { };
 
+  libayatana-appindicator-gtk2 = libayatana-appindicator.override { gtkVersion = "2"; };
+  libayatana-appindicator-gtk3 = libayatana-appindicator.override { gtkVersion = "3"; };
+  libayatana-appindicator = callPackage ../development/libraries/libayatana-appindicator { };
+
   libarchive = callPackage ../development/libraries/libarchive { };
 
   libasr = callPackage ../development/libraries/libasr { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11261,6 +11261,8 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreAudio AudioToolbox;
   };
 
+  ayatana-ido = callPackage ../development/libraries/ayatana-ido { };
+
   babl = callPackage ../development/libraries/babl { };
 
   backward-cpp = callPackage ../development/libraries/backward-cpp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds the libayatana-appindicator library, which supersedes the
deprecated libappindicator library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).