### PR TITLE
clipit: enable appindicator support

### DIFF
--- a/pkgs/applications/misc/clipit/default.nix
+++ b/pkgs/applications/misc/clipit/default.nix
@@ -1,6 +1,6 @@
 { fetchFromGitHub, fetchpatch, stdenv
 , autoreconfHook, intltool, pkgconfig
-, gtk3, xdotool, which, wrapGAppsHook }:
+, gtk3, libayatana-appindicator, xdotool, which, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "clipit";
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook autoreconfHook intltool ];
-  configureFlags = [ "--with-gtk3" ];
-  buildInputs = [ gtk3 ];
+  configureFlags = [ "--with-gtk3" "--enable-appindicator=yes" ];
+  buildInputs = [ gtk3 libayatana-appindicator ];
 
   gappsWrapperArgs = [
     "--prefix" "PATH" ":" "${stdenv.lib.makeBinPath [ xdotool which ]}"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Makes libayatana-appindicator available to clipit. This pull request depends on #88783.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
