### PR TITLE
Request ZFS/LUKS passwords via Plymouth

### DIFF
--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -143,8 +143,7 @@ in
       sed -i '/loginctl/d' $out/71-seat.rules
     '';
 
-    # We use `mkAfter` to ensure that LUKS password prompt would be shown earlier than the splash screen.
-    boot.initrd.preLVMCommands = mkAfter ''
+    boot.initrd.preLogCommands = ''
       mkdir -p /etc/plymouth
       ln -s ${configFile} /etc/plymouth/plymouthd.conf
       ln -s $extraUtils/share/plymouth/plymouthd.defaults /etc/plymouth/plymouthd.defaults
@@ -154,6 +153,10 @@ in
 
       plymouthd --mode=boot --pid-file=/run/plymouth/pid --attach-to-session
       plymouth show-splash
+
+      askPassword() {
+          plymouth ask-for-password --prompt="$1"
+      }
     '';
 
     boot.initrd.postMountCommands = ''

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -280,7 +280,7 @@ let
     inherit (config.system.build) earlyMountScript;
 
     inherit (config.boot.initrd) checkJournalingFS
-      preLVMCommands preDeviceCommands postDeviceCommands postMountCommands preFailCommands kernelModules;
+      preLVMCommands preLogCommands preDeviceCommands postDeviceCommands postMountCommands preFailCommands kernelModules;
 
     resumeDevices = map (sd: if sd ? device then sd.device else "/dev/disk/by-label/${sd.label}")
                     (filter (sd: hasPrefix "/dev/" sd.device && !sd.randomEncryption.enable
@@ -435,6 +435,14 @@ in
       type = types.lines;
       description = ''
         Shell commands to be executed immediately before LVM discovery.
+      '';
+    };
+
+    boot.initrd.preLogCommands = mkOption {
+      default = "";
+      type = types.lines;
+      description = ''
+        Shell commands to be executed immediately before setting up logging.
       '';
     };
 

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -7,18 +7,13 @@ let
   bootFs = filterAttrs (n: fs: (fs.fsType == "bcachefs") && (utils.fsNeededForBoot fs)) config.fileSystems;
 
   commonFunctions = ''
-    prompt() {
-        local name="$1"
-        printf "enter passphrase for $name: "
-    }
     tryUnlock() {
         local name="$1"
         local path="$2"
         if bcachefs unlock -c $path > /dev/null 2> /dev/null; then    # test for encryption
-            prompt $name
-            until bcachefs unlock $path 2> /dev/null; do              # repeat until sucessfully unlocked
+            # repeat until sucessfully unlocked
+            until askPassword "Enter passphrase for $name: " | bcachefs unlock $path; do
                 printf "unlocking failed!\n"
-                prompt $name
             done
             printf "unlocking successful.\n"
         fi


### PR DESCRIPTION
Plymouth currently starts after FDE passphrases have been entered, which is not very useful on modern systems, where booting takes less than 10 seconds. This PR contains a few (partially untested, but works for plymouth + ZFS for me) commits that move Plymouth to earlier in the boot process, and then handle passwords via the bootsplash.

**To be done**:
- [ ] Test with more obscure LUKS setups (the `luksroot` test worked, but that doesn't guarantee yubikey / GPG card do, and I'm not entirely sure how to test those in a VM.)
- [ ] Clean up some of the commits
- [ ] Figure out if `cryptsetup-askpass` was actually used

If anyone wants to help with testing this out, that'd be highly appreciated!

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
