### PR TITLE
nixos/lumina: use xsession provided

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/lumina.nix
+++ b/nixos/modules/services/x11/desktop-managers/lumina.nix
@@ -23,12 +23,9 @@ in
 
   config = mkIf cfg.enable {
 
-    services.xserver.desktopManager.session = singleton {
-      name = "lumina";
-      start = ''
-        exec ${pkgs.lumina.lumina}/bin/start-lumina-desktop
-      '';
-    };
+    services.xserver.displayManager.sessionPackages = [
+      pkgs.lumina.lumina
+    ];
 
     environment.systemPackages =
       pkgs.lumina.preRequisitePackages ++

--- a/pkgs/desktops/lumina/lumina/default.nix
+++ b/pkgs/desktops/lumina/lumina/default.nix
@@ -1,18 +1,18 @@
-{ stdenv,
-  mkDerivation,
-  fetchFromGitHub,
-  desktop-file-utils,
-  fluxbox,
-  numlockx,
-  qmake,
-  qtbase,
-  qtmultimedia,
-  qtsvg,
-  qttools,
-  qtx11extras,
-  xorg,
-  xscreensaver,
-  wrapGAppsHook
+{ stdenv
+, mkDerivation
+, fetchFromGitHub
+, desktop-file-utils
+, fluxbox
+, numlockx
+, qmake
+, qtbase
+, qtmultimedia
+, qtsvg
+, qttools
+, qtx11extras
+, xorg
+, xscreensaver
+, wrapGAppsHook
 }:
 
 mkDerivation rec {
@@ -33,19 +33,19 @@ mkDerivation rec {
   ];
 
   buildInputs = [
-    xorg.libxcb
+    desktop-file-utils
+    fluxbox # window manager for Lumina DE
+    numlockx # required for changing state of numlock at login
+    qtbase
+    qtmultimedia
+    qtsvg
+    qtx11extras
     xorg.libXcursor
     xorg.libXdamage
-    xorg.xcbutilwm
+    xorg.libxcb
     xorg.xcbutilimage
-    qtbase
-    qtsvg
-    qtmultimedia
-    qtx11extras
-    fluxbox
+    xorg.xcbutilwm
     xscreensaver
-    desktop-file-utils
-    numlockx
   ];
 
   patches = [

--- a/pkgs/desktops/lumina/lumina/default.nix
+++ b/pkgs/desktops/lumina/lumina/default.nix
@@ -67,6 +67,12 @@ mkDerivation rec {
     # Fix location of fluxbox styles
     substituteInPlace src-qt5/core-utils/lumina-config/pages/page_fluxbox_settings.cpp \
       --replace 'LOS::AppPrefix()+"share/fluxbox' "\"${fluxbox}/share/fluxbox"
+
+    # Fix desktop files
+    for i in $(grep -lir 'OnlyShowIn=Lumina' src-qt5); do
+      echo ===== $i
+      substituteInPlace $i --replace 'OnlyShowIn=Lumina' 'OnlyShowIn=X-Lumina'
+    done
   '';
 
   qmakeFlags = [

--- a/pkgs/desktops/lumina/lumina/default.nix
+++ b/pkgs/desktops/lumina/lumina/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , mkDerivation
 , fetchFromGitHub
-, desktop-file-utils
 , fluxbox
 , numlockx
 , qmake
@@ -33,7 +32,6 @@ mkDerivation rec {
   ];
 
   buildInputs = [
-    desktop-file-utils
     fluxbox # window manager for Lumina DE
     numlockx # required for changing state of numlock at login
     qtbase

--- a/pkgs/desktops/lumina/lumina/default.nix
+++ b/pkgs/desktops/lumina/lumina/default.nix
@@ -79,6 +79,8 @@ mkDerivation rec {
     "LRELEASE=${stdenv.lib.getDev qttools}/bin/lrelease"
   ];
 
+  passthru.providedSessions = [ "Lumina-DE" ];
+
   meta = with stdenv.lib; {
     description = "A lightweight, portable desktop environment";
     longDescription = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- lumina.lumina: format with nixpkgs-fmt and sort dependence list
- lumina.lumina: fix desktop files
- lumina.lumina: desktop-file-utils is not needed
- nixos/lumina: use xsession provided

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).