### PR TITLE
k6: 0.24.0 -> 0.26.2

### DIFF
--- a/pkgs/development/tools/k6/default.nix
+++ b/pkgs/development/tools/k6/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "k6";
-  version = "0.24.0";
+  version = "0.26.2";
 
   goPackagePath = "github.com/loadimpact/k6";
 
@@ -10,14 +10,15 @@ buildGoPackage rec {
     owner = "loadimpact";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1riyyi4lxdaqilzzkxzzw3hzcrjjcylq2jh3p3656f99wiisvj28";
+    sha256 = "0s5haycpfnfyvxxhhm7205gzylsbjndx9f134f245p4xm5bxhxbf";
   };
 
   subPackages = [ "./" ];
 
   meta = with stdenv.lib; {
-    homepage = "https://k6.io/";
     description = "A modern load testing tool, using Go and JavaScript";
+    homepage = "https://k6.io/";
+    changelog = "https://github.com/loadimpact/k6/releases/tag/v${version}";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ offline ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

[v0.25.0](https://github.com/loadimpact/k6/blob/master/release%20notes/v0.25.0.md)
[v0.26.0](https://github.com/loadimpact/k6/blob/master/release%20notes/v0.26.0.md)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
