### PR TITLE
Declare several versions of OCamlformat

### DIFF
--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -32,6 +32,7 @@ let
     };
 
   post_0_11_buildInputs = [
+    base
     cmdliner
     fpath
     ocaml-migrate-parsetree
@@ -43,6 +44,7 @@ let
   ];
 
   post_0_14_buildInputs = [
+    base
     cmdliner
     fpath
     ocaml-migrate-parsetree

--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -57,6 +57,10 @@ let
   ];
 in
 
+# Older versions should be removed when their usage decrease
+# This script scraps Github looking for OCamlformat's options and versions usage:
+#  https://gist.github.com/Julow/110dc94308d6078225e0665e3eccd433
+
 rec {
   ocamlformat_0_11_0 = mkOCamlformat rec {
     version = "0.11.0";

--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -1,19 +1,48 @@
 { lib, fetchurl, ocamlPackages }:
 
-with ocamlPackages; buildDunePackage rec {
-  pname = "ocamlformat";
-  version = "0.15.0";
+with ocamlPackages;
 
-  minimumOCamlVersion = "4.06";
+let
+  mkOCamlformat = {
+      version,
+      sha256,
+      buildInputs,
+      useDune2 ? true,
+      tarballName ? "ocamlformat-${version}.tbz",
+      # The 'url' argument can be removed when 0.11.0 is pruned
+      url ? "https://github.com/ocaml-ppx/ocamlformat/releases/download/${version}/${tarballName}"
+    }:
+    buildDunePackage rec {
+      pname = "ocamlformat";
 
-  useDune2 = true;
+      minimumOCamlVersion = "4.06";
 
-  src = fetchurl {
-    url = "https://github.com/ocaml-ppx/ocamlformat/releases/download/${version}/ocamlformat-${version}.tbz";
-    sha256 = "0190vz59n6ma9ca1m3syl3mc8i1smj1m3d8x1jp21f710y4llfr6";
-  };
+      src = fetchurl {
+        inherit url sha256;
+      };
 
-  buildInputs = [
+      inherit version useDune2 buildInputs;
+
+      meta = {
+        inherit (src.meta) homepage;
+        description = "Auto-formatter for OCaml code";
+        maintainers = [ lib.maintainers.Zimmi48 lib.maintainers.marsam ];
+        license = lib.licenses.mit;
+      };
+    };
+
+  post_0_11_buildInputs = [
+    cmdliner
+    fpath
+    ocaml-migrate-parsetree
+    odoc
+    re
+    stdio
+    uuseg
+    uutf
+  ];
+
+  post_0_14_buildInputs = [
     cmdliner
     fpath
     ocaml-migrate-parsetree
@@ -25,11 +54,55 @@ with ocamlPackages; buildDunePackage rec {
     fix
     menhir
   ];
+in
 
-  meta = {
-    homepage = "https://github.com/ocaml-ppx/ocamlformat";
-    description = "Auto-formatter for OCaml code";
-    maintainers = [ lib.maintainers.Zimmi48 lib.maintainers.marsam ];
-    license = lib.licenses.mit;
+rec {
+  ocamlformat_0_11_0 = mkOCamlformat {
+    version = "0.11.0";
+    url = "https://github.com/ocaml-ppx/ocamlformat/archive/0.11.0.tar.gz";
+    sha256 = "0bl3c7b40wz5slnzcbbjimrnphhgk03vvm8bbb60ybp1k1jyr5lw";
+    useDune2 = false;
+    buildInputs = post_0_11_buildInputs;
   };
+
+  ocamlformat_0_12 = mkOCamlformat {
+    version = "0.12";
+    sha256 = "1zi8x597dhp2822j6j28s84yyiqppl7kykpwqqclx6ybypvlzdpj";
+    useDune2 = false;
+    buildInputs = post_0_11_buildInputs;
+  };
+
+  ocamlformat_0_13_0 = mkOCamlformat rec {
+    version = "0.13.0";
+    sha256 = "0ki2flqi3xkhw9mfridivb6laxm7gml8rj9qz42vqmy9yx76jjxq";
+    tarballName = "ocamlformat-${version}-2.tbz";
+    useDune2 = false;
+    buildInputs = post_0_11_buildInputs;
+  };
+
+  ocamlformat_0_14_0 = mkOCamlformat {
+    version = "0.14.0";
+    sha256 = "070c0x6z5y0lyls56zm34g8lyc093wkr0jfp50dvrkr9fk1sx2wi";
+    buildInputs = post_0_14_buildInputs;
+  };
+
+  ocamlformat_0_14_1 = mkOCamlformat {
+    version = "0.14.1";
+    sha256 = "03wn46xib63748157xchj7gflkw5000fcjw6n89h9g82q9slazaa";
+    buildInputs = post_0_14_buildInputs;
+  };
+
+  ocamlformat_0_14_2 = mkOCamlformat {
+    version = "0.14.2";
+    sha256 = "16phz1sg9b070p6fm8d42j0piizg05vghdjmw8aj7xm82b1pm7sz";
+    buildInputs = post_0_14_buildInputs;
+  };
+
+  ocamlformat_0_15_0 = mkOCamlformat {
+    version = "0.15.0";
+    sha256 = "0190vz59n6ma9ca1m3syl3mc8i1smj1m3d8x1jp21f710y4llfr6";
+    buildInputs = post_0_14_buildInputs;
+  };
+
+  ocamlformat = ocamlformat_0_15_0;
 }

--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, ocamlPackages }:
+{ lib, fetchurl, fetchzip, ocamlPackages }:
 
 with ocamlPackages;
 
@@ -9,19 +9,18 @@ let
       buildInputs,
       useDune2 ? true,
       tarballName ? "ocamlformat-${version}.tbz",
-      # The 'url' argument can be removed when 0.11.0 is pruned
-      url ? "https://github.com/ocaml-ppx/ocamlformat/releases/download/${version}/${tarballName}"
+      # The 'src' argument can be removed when 0.11.0 is pruned
+      src ? fetchurl {
+          url = "https://github.com/ocaml-ppx/ocamlformat/releases/download/${version}/${tarballName}";
+          inherit sha256;
+        }
     }:
     buildDunePackage rec {
       pname = "ocamlformat";
 
       minimumOCamlVersion = "4.06";
 
-      src = fetchurl {
-        inherit url sha256;
-      };
-
-      inherit version useDune2 buildInputs;
+      inherit src version useDune2 buildInputs;
 
       meta = {
         homepage = "https://github.com/ocaml-ppx/ocamlformat";
@@ -59,10 +58,13 @@ let
 in
 
 rec {
-  ocamlformat_0_11_0 = mkOCamlformat {
+  ocamlformat_0_11_0 = mkOCamlformat rec {
     version = "0.11.0";
-    url = "https://github.com/ocaml-ppx/ocamlformat/archive/0.11.0.tar.gz";
-    sha256 = "0bl3c7b40wz5slnzcbbjimrnphhgk03vvm8bbb60ybp1k1jyr5lw";
+    src = fetchzip {
+      url = "https://github.com/ocaml-ppx/ocamlformat/archive/0.11.0.tar.gz";
+      inherit sha256;
+    };
+    sha256 = "0zvjn71jd4d3znnpgh0yphb2w8ggs457b6bl6cg1fmpdgxnds6yx";
     useDune2 = false;
     buildInputs = post_0_11_buildInputs;
   };

--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -24,7 +24,7 @@ let
       inherit version useDune2 buildInputs;
 
       meta = {
-        inherit (src.meta) homepage;
+        homepage = "https://github.com/ocaml-ppx/ocamlformat";
         description = "Auto-formatter for OCaml code";
         maintainers = [ lib.maintainers.Zimmi48 lib.maintainers.marsam ];
         license = lib.licenses.mit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9513,7 +9513,10 @@ in
 
   ocaml-crunch = ocamlPackages.crunch.bin;
 
-  ocamlformat = callPackage ../development/tools/ocaml/ocamlformat { };
+  inherit (callPackage ../development/tools/ocaml/ocamlformat { })
+    ocamlformat # lastest version
+    ocamlformat_0_11_0 ocamlformat_0_12 ocamlformat_0_13_0 ocamlformat_0_14_0
+    ocamlformat_0_14_1 ocamlformat_0_14_2 ocamlformat_0_15_0;
 
   orc = callPackage ../development/compilers/orc { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9514,7 +9514,7 @@ in
   ocaml-crunch = ocamlPackages.crunch.bin;
 
   inherit (callPackage ../development/tools/ocaml/ocamlformat { })
-    ocamlformat # lastest version
+    ocamlformat # latest version
     ocamlformat_0_11_0 ocamlformat_0_12 ocamlformat_0_13_0 ocamlformat_0_14_0
     ocamlformat_0_14_1 ocamlformat_0_14_2 ocamlformat_0_15_0;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

OCamlformat is still a bit unstable and it's common to work on several
projects that each use a different version.

###### Things done

An attribute is added for each version, `ocamlformat` is set to the lastest
version (as before). I didn't add older than 0.11.0 because they were never
added to nixpkgs, except for 0.8 which is too old.

The second commit is unrelated and adds a missing dependency on base. I think this may help
debugging build failures when upgrading dependencies in the future.

The script I used to check that they all build:

```sh
exec 2>/dev/null
nix-shell -I nixpkgs=./. -p ocamlformat_0_11_0 --run 'ocamlformat --version'
nix-shell -I nixpkgs=./. -p ocamlformat_0_12 --run 'ocamlformat --version'
nix-shell -I nixpkgs=./. -p ocamlformat_0_13_0 --run 'ocamlformat --version'
nix-shell -I nixpkgs=./. -p ocamlformat_0_14_0 --run 'ocamlformat --version'
nix-shell -I nixpkgs=./. -p ocamlformat_0_14_1 --run 'ocamlformat --version'
nix-shell -I nixpkgs=./. -p ocamlformat_0_14_2 --run 'ocamlformat --version'
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
