### PR TITLE
SleepyHead: use qt5.makeDerivation and fix for Darwin

### DIFF
--- a/pkgs/applications/misc/sleepyhead/default.nix
+++ b/pkgs/applications/misc/sleepyhead/default.nix
@@ -3,7 +3,7 @@
 let
   name = "sleepyhead-${version}";
   version = "1.0.0-beta-git";
-in stdenv.mkDerivation {
+in qt5.mkDerivation {
   inherit name;
 
   src = fetchgit {
@@ -22,10 +22,17 @@ in stdenv.mkDerivation {
   patchPhase = ''
     patchShebangs configure
   '';
-
-  installPhase = ''
+  
+  installPhase = if stdenv.isDarwin then ''
+    mkdir -p $out/Applications
+    cp -r sleepyhead/SleepyHead.app $out/Applications
+  '' else ''
     mkdir -p $out/bin
     cp sleepyhead/SleepyHead $out/bin
+  '';
+
+  postFixup = stdenv.lib.optionalString stdenv.isDarwin ''
+    wrapQtApp "$out/Applications/SleepyHead.app/Contents/MacOS/SleepyHead"
   '';
 
   meta = with stdenv.lib; {
@@ -37,7 +44,6 @@ in stdenv.mkDerivation {
     license = licenses.gpl3;
     platforms = platforms.all;
     maintainers = [ maintainers.krav ];
-    broken = true;
   };
 
 }

--- a/pkgs/applications/misc/sleepyhead/default.nix
+++ b/pkgs/applications/misc/sleepyhead/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchgit, qt5, zlib, libGLU, libX11, wrapQtAppsHook }:
+{ lib, stdenv, mkDerivation, fetchgit, zlib, libGLU, libX11, qtbase, qtwebkit, qtserialport, wrapQtAppsHook }:
 
 let
   name = "sleepyhead-${version}";
   version = "1.0.0-beta-git";
-in qt5.mkDerivation {
+in mkDerivation {
   inherit name;
 
   src = fetchgit {
@@ -13,7 +13,7 @@ in qt5.mkDerivation {
   };
 
   buildInputs = [
-    qt5.qtbase qt5.qtwebkit qt5.qtserialport
+    qtbase qtwebkit qtserialport
     zlib
     libGLU
     libX11

--- a/pkgs/applications/misc/sleepyhead/default.nix
+++ b/pkgs/applications/misc/sleepyhead/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, qt5, zlib, libGLU, libX11 }:
+{ stdenv, fetchgit, qt5, zlib, libGLU, libX11, wrapQtAppsHook }:
 
 let
   name = "sleepyhead-${version}";
@@ -18,6 +18,8 @@ in qt5.mkDerivation {
     libGLU
     libX11
   ];
+
+  nativeBuildInputs = [ wrapQtAppsHook ];
 
   patchPhase = ''
     patchShebangs configure

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6658,7 +6658,7 @@ in
 
   sleuthkit = callPackage ../tools/system/sleuthkit {};
 
-  sleepyhead = callPackage ../applications/misc/sleepyhead {};
+  sleepyhead = libsForQt5.callPackage ../applications/misc/sleepyhead {};
 
   slirp4netns = callPackage ../tools/networking/slirp4netns/default.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
I wasn't able to install sleepyhead on my machines.

On NixOS I got:
`qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""`

On Darwin I got:
`qt.qpa.plugin: Could not find the Qt platform plugin "cocoa" in ""`

Additionally package was marked as broken.

Read https://hydra.nixos.org/build/96804884/download/1/nixpkgs/manual.html#sec-language-qt and tinkered with the thing until it worked 😃  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

