### PR TITLE
tamzen: 1.11.4 -> 1.11.5

### DIFF
--- a/pkgs/data/fonts/tamzen/default.nix
+++ b/pkgs/data/fonts/tamzen/default.nix
@@ -1,28 +1,22 @@
-{ fetchFromGitHub, fontforge, mkfontscale, stdenv }:
+{ fetchFromGitHub, mkfontscale, stdenv }:
 
 stdenv.mkDerivation rec {
   pname = "tamzen-font";
-  version = "1.11.4";
+  version = "1.11.5";
 
   src = fetchFromGitHub {
     owner = "sunaku";
     repo = "tamzen-font";
     rev = "Tamzen-${version}";
-    sha256 = "17kgmvg6q32mqhx9g44hjvzv0si0mnpprga4z7na930g2zdd8846";
+    sha256 = "00x5fipzqimglvshhqwycdhaqslbvn3rl06jnswhyxfvz16ymj7s";
   };
 
-  nativeBuildInputs = [ fontforge mkfontscale ];
+  nativeBuildInputs = [ mkfontscale ];
 
   installPhase = ''
-    # convert pcf fonts to otb
-    for i in pcf/*.pcf; do
-      name=$(basename "$i" .pcf)
-      fontforge -lang=ff -c "Open(\"$i\"); Generate(\"$name.otb\")"
-    done
-
     install -m 644 -D pcf/*.pcf -t "$out/share/fonts/misc"
     install -m 644 -D psf/*.psf -t "$out/share/consolefonts"
-    install -m 644 -D *.otb     -t "$otb/share/fonts/misc"
+    install -m 644 -D otb/*.otb -t "$otb/share/fonts/misc"
     mkfontdir "$out/share/fonts/misc"
     mkfontdir "$otb/share/fonts/misc"
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Tamzen was newly updated. It also now [provides its own OTB fonts](https://github.com/sunaku/tamzen-font/issues/25), so we don't have to make our own.

@jonringer, do we still need a stdenv? If not, how should I go on about removing it?


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
