### PR TITLE
sm64ex: init at unstable-2020-06-19

### DIFF
--- a/pkgs/games/sm64ex/default.nix
+++ b/pkgs/games/sm64ex/default.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, fetchFromGitHub
+, python3
+, pkg-config
+, audiofile
+, SDL2
+, hexdump
+, requireFile
+, compileFlags ? [ ]
+, region ? "us"
+, baseRom ? requireFile {
+    name = "baserom.${region}.z64";
+    message = ''
+      This nix expression requires that baserom.${region}.z64 is
+      already part of the store. To get this file you can dump your Super Mario 64 cartridge's contents
+      and add it to the nix store with nix-store --add-fixed sha256 <FILE>.
+      Note that if you are not using a US baserom, you must overwrite the "region" attribute with either "eu" or "jp".
+    '';
+    sha256 = {
+      "us" = "17ce077343c6133f8c9f2d6d6d9a4ab62c8cd2aa57c40aea1f490b4c8bb21d91";
+      "eu" = "c792e5ebcba34c8d98c0c44cf29747c8ee67e7b907fcc77887f9ff2523f80572";
+      "jp" = "9cf7a80db321b07a8d461fe536c02c87b7412433953891cdec9191bfad2db317";
+    }.${region};
+  }
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sm64ex";
+  version = "unstable-2020-06-19";
+
+  src = fetchFromGitHub {
+    owner = "sm64pc";
+    repo = "sm64ex";
+    rev = "f5005418348cf1a53bfa75ff415a513ef0b9b273";
+    sha256 = "0adyshkqk5c4lxhdxc3j6ax4svfka26486qpa5q2gl2nixwg9zxn";
+  };
+
+  nativeBuildInputs = [ python3 pkg-config ];
+  buildInputs = [ audiofile SDL2 hexdump ];
+
+  makeFlags = [ "VERSION=${region}" ] ++ compileFlags
+    ++ stdenv.lib.optionals stdenv.isDarwin [ "OSX_BUILD=1" ];
+
+  inherit baseRom;
+
+  preBuild = ''
+    patchShebangs extract_assets.py
+    cp $baseRom ./baserom.${region}.z64
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp build/${region}_pc/sm64.${region}.f3dex2e $out/bin/sm64ex
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/sm64pc/sm64ex";
+    description = "Super Mario 64 port based off of decompilation";
+    longDescription = ''
+      Super Mario 64 port based off of decompilation.
+      Note that you must supply a baserom yourself to extract assets from.
+      If you are not using an US baserom, you must overwrite the "region" attribute with either "eu" or "jp".
+      If you would like to use patches sm64ex distributes as makeflags, add them to the "compileFlags" attribute.
+    '';
+    license = licenses.unfree;
+    maintainers = with maintainers; [ ivar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6585,6 +6585,8 @@ in
     conf = config.slstatus.conf or null;
   };
 
+  sm64ex = callPackage ../games/sm64ex { };
+
   smartdns = callPackage ../tools/networking/smartdns { };
 
   smartmontools = callPackage ../tools/system/smartmontools {


### PR DESCRIPTION
###### Motivation for this change
Adds [sm64pc](https://github.com/sm64pc/sm64ex), a PC port of Super Mario 64 based off of decompilation. 

The assets and such (the port itself extracts these) are copyrighted by Nintendo. Hence the need for the user to supply it themselves.

Note that i added an empty list of `makeFlags`, this is so you can easily add them as an end user for subjective patches. You can find two of them in the projects readme. For example, one of them includes a (subjectively) better camera, which the end user can now easily enable using overwrites.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
