### PR TITLE
pim6sd: init at unstable-2019-05-31

### DIFF
--- a/pkgs/servers/pim6sd/default.nix
+++ b/pkgs/servers/pim6sd/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, lib, autoreconfHook, yacc, flex }:
+
+stdenv.mkDerivation rec {
+  pname = "pim6sd";
+  version = "unstable-2019-05-31";
+
+  src = fetchFromGitHub {
+    owner = "troglobit";
+    repo = "pim6sd";
+    rev = "fa3909529981dd705ba9ead0517222c30c581a4e";
+    sha256 = "0x7dyark2mp9xqz9cnmmgaf0z143vxn2835clllpji4ylg77zdjw";
+  };
+
+  nativeBuildInputs = [ autoreconfHook yacc flex ];
+
+  meta = with lib; {
+    description = "PIM for IPv6 sparse mode daemon";
+    homepage = "https://github.com/troglobit/pim6sd";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ hexa ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5955,6 +5955,8 @@ in
 
   phodav = callPackage ../tools/networking/phodav { };
 
+  pim6sd = callPackage ../servers/pim6sd { };
+
   pinentry = libsForQt5.callPackage ../tools/security/pinentry {
     libcap = if stdenv.isDarwin then null else libcap;
   };


### PR DESCRIPTION
###### Motivation for this change

> PIM for IPv6 sparse mode daemon

PIM stands for protocol independent multicast and allows for IPv6 multicast routing in sparse mode.

https://github.com/troglobit/pim6sd

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
