### PR TITLE
raspberrypi-eeprom: Init at 2020-10-05

### DIFF
--- a/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
+++ b/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
@@ -1,0 +1,56 @@
+{ stdenvNoCC, lib, fetchFromGitHub, makeWrapper
+, python3, binutils-unwrapped, findutils, kmod, pciutils, raspberrypi-tools
+}:
+stdenvNoCC.mkDerivation {
+  pname = "raspberrypi-eeprom";
+  version = "unstable-2020-10-05";
+
+  src = fetchFromGitHub {
+    owner = "raspberrypi";
+    repo = "rpi-eeprom";
+    rev = "718820bcebd21d4a619fa262d9b9cf3acbf110f8";
+    sha256 = "1277jsiyv34dqpandva8kxy1s0y5ql344pl9gk84avzp1mqjnv4g";
+  };
+
+  buildInputs = [ python3 ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    # Don't try to verify md5 signatures from /var/lib/dpkg and
+    # fix path to the configuration.
+    substituteInPlace rpi-eeprom-update \
+      --replace 'IGNORE_DPKG_CHECKSUMS=$LOCAL_MODE' 'IGNORE_DPKG_CHECKSUMS=1' \
+      --replace '/etc/default' '/etc'
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/rpi-eeprom
+
+    cp rpi-eeprom-config rpi-eeprom-update $out/bin
+    cp -r firmware/{beta,critical,old,stable} $out/share/rpi-eeprom
+    cp -r firmware/vl805 $out/bin
+  '';
+
+  fixupPhase = ''
+    patchShebangs $out/bin
+    wrapProgram $out/bin/rpi-eeprom-update \
+      --set FIRMWARE_ROOT $out/share/rpi-eeprom \
+      ${lib.optionalString stdenvNoCC.isAarch64 "--set VCMAILBOX ${raspberrypi-tools}/bin/vcmailbox"} \
+      --prefix PATH : "${lib.makeBinPath ([
+        binutils-unwrapped
+        findutils
+        kmod
+        pciutils
+        (placeholder "out")
+      ] ++ lib.optionals stdenvNoCC.isAarch64 [
+        raspberrypi-tools
+      ])}"
+  '';
+
+  meta = with lib; {
+    description = "Installation scripts and binaries for the closed sourced Raspberry Pi 4 EEPROMs";
+    homepage = "https://www.raspberrypi.org/documentation/hardware/raspberrypi/booteeprom.md";
+    license = with licenses; [ bsd3 unfreeRedistributableFirmware ];
+    maintainers = with maintainers; [ das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18529,6 +18529,8 @@ in
   raspberrypifw = callPackage ../os-specific/linux/firmware/raspberrypi {};
   raspberrypiWirelessFirmware = callPackage ../os-specific/linux/firmware/raspberrypi-wireless { };
 
+  raspberrypi-eeprom = callPackage ../os-specific/linux/raspberrypi-eeprom {};
+
   raspberrypi-tools = callPackage ../os-specific/linux/firmware/raspberrypi/tools.nix {};
 
   regionset = callPackage ../os-specific/linux/regionset { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

cc @cleverca22

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
