### PR TITLE
Add proper descriptions to some `settings` option types

### DIFF
--- a/nixos/modules/services/networking/pdns-recursor.nix
+++ b/nixos/modules/services/networking/pdns-recursor.nix
@@ -9,8 +9,16 @@ let
   cfg = config.services.pdns-recursor;
 
   oneOrMore  = type: with types; either type (listOf type);
-  valueType  = with types; oneOf [ int str bool path ];
-  configType = with types; attrsOf (nullOr (oneOrMore valueType));
+  valueType  = with types; oneOf [ int str bool path ]
+    // { description = "setting type (integer, string, bool or path)"; };
+  configType = with types; attrsOf (nullOr (oneOrMore valueType))
+    // { description = ''
+          recursor.conf configuration type. The format consists of an
+          attribute set of settings. Each setting can be either `null`,
+          one value or a list of values. The allowed values are integers,
+          strings, booleans or paths.
+         '';
+       };
 
   toBool    = val: if val then "yes" else "no";
   serialize = val: with types;
@@ -149,7 +157,7 @@ in {
       type = types.lines;
       default = "";
       description = ''
-        The content Lua configuration file for PowerDNS Recursor. See
+        The content of the Lua configuration file for PowerDNS Recursor. See
         <link xlink:href="https://doc.powerdns.com/recursor/lua-config/index.html"/>.
       '';
     };

--- a/nixos/modules/services/networking/smartdns.nix
+++ b/nixos/modules/services/networking/smartdns.nix
@@ -30,8 +30,13 @@ in {
 
     settings = mkOption {
       type =
-      let atom = oneOf [ str int bool ];
-      in attrsOf (coercedTo atom toList (listOf atom));
+      let
+        atom = oneOf [ str int bool ];
+        oneOrMore = t: coercedTo t toList (listOf t) //
+          { description = "one or a list of ${lib.types.showsPrec 1 t}";
+            precedence = 1;
+          };
+      in attrsOf (oneOrMore atom);
       example = literalExample ''
         {
           bind = ":5353 -no-rule -group example";

--- a/nixos/modules/services/web-apps/gerrit.nix
+++ b/nixos/modules/services/web-apps/gerrit.nix
@@ -7,11 +7,24 @@ let
   # NixOS option type for git-like configs
   gitIniType = with types;
     let
-      primitiveType = either str (either bool int);
-      multipleType = either primitiveType (listOf primitiveType);
+      primitiveType = oneOf [ str bool int ] //
+        { description = "primitive type: string, boolean or integer";
+          precedence = 1;
+        };
+      multipleType = either primitiveType (listOf primitiveType) //
+        { description = "one or a list of primitive values";
+          precedence = 1;
+        };
       sectionType = lazyAttrsOf multipleType;
       supersectionType = lazyAttrsOf (either multipleType sectionType);
-    in lazyAttrsOf supersectionType;
+    in lazyAttrsOf supersectionType //
+      { description = ''
+          Git configuration: a (lazy) attribute set of either top-level
+          settings or nested attribute sets (sections) of settings.
+          Each setting can be ${multipleType.description}, meaning
+          strings, booleans or integer numbers.
+        '';
+      };
 
   gerritConfig = pkgs.writeText "gerrit.conf" (
     lib.generators.toGitINI cfg.settings

--- a/nixos/modules/services/x11/clight.nix
+++ b/nixos/modules/services/x11/clight.nix
@@ -49,11 +49,26 @@ in {
     };
 
     settings = let
-      validConfigTypes = with types; either int (either str (either bool float));
+      oneOrMore  = type: with types; either type (listOf type);
+      validConfigTypes = with types; oneOf [int str bool float]
+        // { description = "setting type (integer, string, bool or floating point)"; };
+      configType = with types; attrsOf (nullOr (oneOrMore validConfigTypes))
+        // { description = ''
+              clight.conf configuration type. The format consists of an
+              attribute set of settings. Each setting can be either `null`,
+              one value or a list of values. The allowed values are integers,
+              strings, booleans or floating points.
+             '';
+           };
     in mkOption {
-      type = with types; attrsOf (nullOr (either validConfigTypes (listOf validConfigTypes)));
+      type = configType;
       default = {};
-      example = { captures = 20; gamma_long_transition = true; ac_capture_timeouts = [ 120 300 60 ]; };
+      example = literalExample ''
+        { captures = 20;
+          gamma_long_transition = true;
+          ac_capture_timeouts = [ 120 300 60 ];
+        };
+      '';
       description = ''
         Additional configuration to extend clight.conf. See
         <link xlink:href="https://github.com/FedeDP/Clight/blob/master/Extra/clight.conf"/> for a


### PR DESCRIPTION
###### Motivation for this change
Add proper descriptions to some `settings` option types. See https://github.com/NixOS/nixpkgs/issues/86402#issuecomment-624516647

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [x] Built the NixOS manual
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
