### PR TITLE
[haskell-updates] Add maralorn as maintainer for same haskell packages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4695,6 +4695,12 @@
     githubId = 3507;
     name = "Michael Fellinger";
   };
+  maralorn = {
+    email = "malte.brandy@maralorn.de";
+    github = "maralorn";
+    githubId = 1651325;
+    name = "Malte Brandy";
+  };
   marcweber = {
     email = "marco-oweber@gmx.de";
     github = "marcweber";

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2495,6 +2495,15 @@ package-maintainers:
     - icepeak
   terlar:
     - nix-diff
+  maralorn:
+    - ghcide
+    - cabal-fmt
+    - neuron
+    - shh
+    - brittany
+    - hlint
+    - releaser
+    - taskwarrior
 
 unsupported-platforms:
   alsa-mixer:                                   [ x86_64-darwin ]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I found this file to enter me as a maintainer. I just thought maybe it makes sense to enter myself into it. These are packages I care about in the sense that I actually watch the hydra status from my personal prometheus and intend to keep them working in the foreseeable future. For some of them (hlint, brittany) I haven‘t contributed anything yet, because they are just working.
Some of these libraries are very niche, others aren‘t. Not sure if it makes sense to have a maintainer for all of them.
I have no clue what the best practices here are. But I wanna help. Glad for feedback.

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
