### PR TITLE
gmt: init at 6.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7942,6 +7942,12 @@
     githubId = 699403;
     name = "Tomas Vestelind";
   };
+  tviti = {
+    email = "tviti@hawaii.edu";
+    github = "tviti";
+    githubId = 2251912;
+    name = "Taylor Viti";
+  };
   tvorog = {
     email = "marszaripov@gmail.com";
     github = "tvorog";

--- a/pkgs/applications/gis/gmt/dcw.nix
+++ b/pkgs/applications/gis/gmt/dcw.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "dcw-gmt";
+  version = "1.1.4";
+  src = fetchurl {
+    url = "ftp://ftp.soest.hawaii.edu/gmt/dcw-gmt-${version}.tar.gz";
+    sha256 = "8d47402abcd7f54a0f711365cd022e4eaea7da324edac83611ca035ea443aad3";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/dcw-gmt
+    cp -rv ./* $out/share/dcw-gmt
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.soest.hawaii.edu/pwessel/dcw/";
+    description = "Vector basemap of the world, for use with GMT";
+    longDescription = ''
+      DCW-GMT is an enhancement to the original 1:1,000,000 scale vector basemap
+      of the world, available from the Princeton University Digital Map and
+      Geospatial Information Center. It contains more state boundaries (the
+      largest 8 countries are now represented) than the original data
+      source. Information about DCW can be found on Wikipedia
+      (https://en.wikipedia.org/wiki/Digital_Chart_of_the_World). This data is
+      for use by GMT, the Generic Mapping Tools.
+    '';
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ tviti ];
+  };
+
+}

--- a/pkgs/applications/gis/gmt/default.nix
+++ b/pkgs/applications/gis/gmt/default.nix
@@ -1,0 +1,73 @@
+{ stdenv, fetchurl, cmake, curl, Accelerate, CoreGraphics, CoreVideo
+, fftwSinglePrec, netcdf, pcre, gdal, blas, lapack, glibc, ghostscript, dcw-gmt
+, gshhg-gmt }:
+
+/* The onus is on the user to also install:
+    - ffmpeg for webm or mp4 output
+    - graphicsmagick for gif output
+*/
+
+stdenv.mkDerivation rec {
+  pname = "gmt";
+  version = "6.1.0";
+  src = fetchurl {
+    url = "https://github.com/GenericMappingTools/gmt/releases/download/${version}/gmt-${version}-src.tar.gz";
+    sha256 = "0vzxzpvbf1sqma2airsibxvqb9m4sajm7jsfr7rrv6q7924c7ijw";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ curl gdal netcdf pcre dcw-gmt gshhg-gmt ]
+    ++ (if stdenv.isDarwin then [
+      Accelerate
+      CoreGraphics
+      CoreVideo
+    ] else [
+      glibc
+      fftwSinglePrec
+      blas
+      lapack
+    ]);
+
+  propagatedBuildInputs = [ ghostscript ];
+
+  cmakeFlags = [
+    "-DGMT_DOCDIR=share/doc/gmt"
+    "-DGMT_MANDIR=share/man"
+    "-DGMT_LIBDIR=lib"
+    "-DCOPY_GSHHG:BOOL=FALSE"
+    "-DGSHHG_ROOT=${gshhg-gmt.out}/share/gshhg-gmt"
+    "-DCOPY_DCW:BOOL=FALSE"
+    "-DDCW_ROOT=${dcw-gmt.out}/share/dcw-gmt"
+    "-DGDAL_ROOT=${gdal.out}"
+    "-DNETCDF_ROOT=${netcdf.out}"
+    "-DPCRE_ROOT=${pcre.out}"
+    "-DGMT_INSTALL_TRADITIONAL_FOLDERNAMES:BOOL=FALSE"
+    "-DGMT_ENABLE_OPENMP:BOOL=TRUE"
+    "-DGMT_INSTALL_MODULE_LINKS:BOOL=FALSE"
+    "-DLICENSE_RESTRICTED=LGPL" # "GPL" and "no" also valid
+  ] ++ (with stdenv;
+    lib.optional (!isDarwin) [
+      "-DFFTW3_ROOT=${fftwSinglePrec.dev}"
+      "-DLAPACK_LIBRARY=${lapack}/lib/liblapack.so"
+      "-DBLAS_LIBRARY=${blas}/lib/libblas.so"
+    ]);
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.generic-mapping-tools.org";
+    description = "Tools for manipulating geographic and cartesian data sets";
+    longDescription = ''
+      GMT is an open-source collection of command-line tools for manipulating
+      geographic and Cartesian data sets (including filtering, trend fitting,
+      gridding, projecting, etc.) and producing high-quality illustrations
+      ranging from simple x–y plots via contour maps to artificially illuminated
+      surfaces and 3D perspective views. It supports many map projections and
+      transformations and includes supporting data such as coastlines, rivers,
+      and political boundaries and optionally country polygons.
+    '';
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ tviti ];
+  };
+
+}

--- a/pkgs/applications/gis/gmt/gshhg.nix
+++ b/pkgs/applications/gis/gmt/gshhg.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "gshhg-gmt";
+  version = "2.3.7";
+  src = fetchurl {
+    url = "ftp://ftp.soest.hawaii.edu/gmt/gshhg-gmt-${version}.tar.gz";
+    sha256 = "9bb1a956fca0718c083bef842e625797535a00ce81f175df08b042c2a92cfe7f";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/gshhg-gmt
+    cp -rv ./* $out/share/gshhg-gmt
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.soest.hawaii.edu/pwessel/gshhg/";
+    description = "High-resolution shoreline data set, for use with GMT";
+    longDescription = ''
+      GSHHG is a high-resolution shoreline data set amalgamated from two
+      databases: Global Self-consistent Hierarchical High-resolution Shorelines
+      (GSHHS) and CIA World Data Bank II (WDBII). GSHHG contains vector
+      descriptions at five different resolutions of land outlines, lakes,
+      rivers, and political boundaries. This data is for use by GMT, the Generic
+      Mapping Tools.
+    '';
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ tviti ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1618,6 +1618,8 @@ in
 
   dconf = callPackage ../development/libraries/dconf { };
 
+  dcw-gmt = callPackage ../applications/gis/gmt/dcw.nix { };
+
   ddar = callPackage ../tools/backup/ddar { };
 
   ddate = callPackage ../tools/misc/ddate { };
@@ -1882,6 +1884,11 @@ in
 
   gmic-qt-krita = gmic-qt.override {
     variant = "krita";
+  };
+
+  gmt = callPackage ../applications/gis/gmt {
+    inherit (darwin.apple_sdk.frameworks)
+      Accelerate CoreGraphics CoreVideo;
   };
 
   goa = callPackage ../development/tools/goa { };
@@ -23589,6 +23596,8 @@ in
   gscrabble = python3Packages.callPackage ../games/gscrabble {};
 
   gshogi = python3Packages.callPackage ../games/gshogi {};
+
+  gshhg-gmt = callPackage ../applications/gis/gmt/gshhg.nix { };
 
   qtads = qt5.callPackage ../games/qtads { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds v6.0.0 of the Generic Mapping Tools (GMT) and support coastline/basemap datasets.

Build is restricted to LGPL licensed code (although GPL and non-free are also possible).

Users interested in movie making functionality will need to also install FFmpeg (for webm and mp4 support) and/or graphicsmagick (for gif support).

ghostscript is included as a runtime dep, since I suspect most users would want this functionality out-of-the-box (w/o ghostscript, postscript is the only available output format). Not sure if it is preferable to make a wrapper v.s. using `propagatedBuildInputs`?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
