### PR TITLE
lazarus: fix linking by the IDE; 

### DIFF
--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, makeWrapper
 , fpc, gtk2, glib, pango, atk, gdk-pixbuf
 , libXi, xorgproto, libX11, libXext
+, gdb, gnumake, binutils
 }:
 stdenv.mkDerivation rec {
   pname = "lazarus";
@@ -34,8 +35,12 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    wrapProgram $out/bin/startlazarus --prefix NIX_LDFLAGS ' ' "'$NIX_LDFLAGS'" \
-      --prefix LCL_PLATFORM ' ' "'$LCL_PLATFORM'"
+    wrapProgram $out/bin/startlazarus --prefix NIX_LDFLAGS ' ' \
+      "$(echo "$NIX_LDFLAGS" | sed -re 's/-rpath [^ ]+//g')" \
+      --prefix NIX_${binutils.infixSalt}_LDFLAGS ' ' \
+      "$(echo "$NIX_LDFLAGS" | sed -re 's/-rpath [^ ]+//g')" \
+      --prefix LCL_PLATFORM ' ' "$LCL_PLATFORM" \
+      --prefix PATH ':' "${fpc}/bin:${gdb}/bin:${gnumake}/bin:${binutils}/bin"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
using the results of an investigation by @deliciouslytyped

will self-merge at some point

###### Motivation for this change

#48871 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- (N/A) Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
