### PR TITLE
intel-gpa: init at 20.1.1585397060

### DIFF
--- a/pkgs/development/tools/intel-gpa/default.nix
+++ b/pkgs/development/tools/intel-gpa/default.nix
@@ -1,0 +1,54 @@
+{stdenv, fetchurl, dpkg, bash, glibc, libglvnd, zlib, glib, xorg, libxkbcommon, fontconfig, freetype, dbus}:
+
+let
+  rpath = stdenv.lib.makeLibraryPath [
+    zlib libglvnd glib dbus fontconfig freetype
+    xorg.libX11 xorg.libxcb xorg.libXrender xorg.libXext libxkbcommon
+  ] + ":${stdenv.cc.cc.lib}/lib";
+in stdenv.mkDerivation rec {
+  pname = "intel-gpa";
+  version = "20.1.1585397060";
+
+  src = fetchurl {
+    url = "https://software.intel.com/sites/products/gpa/downloads/linux/gpa_${version}_release_m64_deb_install.sh";
+    sha256 ="0w56w0l7n63qp4jq65ij41nhdlvxil2n2yg4gisw71yhshlw81fm";
+  };
+
+  unpackPhase = ''
+    LINE_NUMBER=$(grep --text --line-number '^PAYLOAD:$' $src | cut -d ':' -f 1)
+    tail -n +$((LINE_NUMBER + 1)) $src | ${dpkg}/bin/dpkg-deb -x - .
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    mv opt "$out"
+    mv usr/share "$out"
+    ln -s "$out/opt/intel/gpa/FrameAnalyzer" "$out/bin/gpa-frame-analyzer"
+    ln -s "$out/opt/intel/gpa/SystemAnalyzer" "$out/bin/gpa-system-analyzer"
+    ln -s "$out/opt/intel/gpa/gpa_console_client" "$out/bin/gpa-console-client"
+    ln -s "$out/opt/intel/gpa/TraceAnalyzer" "$out/bin/gpa-trace-analyzer"
+    ln -s "$out/opt/intel/gpa/GpaMonitor" "$out/bin/gpa-monitor"
+  '';
+
+  preFixup = ''
+    substituteInPlace "$out/opt/intel/gpa/FrameAnalyzer.sh" --replace '#!/bin/sh' '#!${bash}/bin/sh'
+    rpath="${rpath}:$out/opt/intel/gpa/python3/lib:$out/opt/intel/gpa"
+    for binary in GpaMonitor GpaRemotePlayer GpaServer GpaPlayer FrameAnalyzer SystemAnalyzer gpa_console_client TraceAnalyzer; do
+        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$out/opt/intel/gpa/$binary"
+        patchelf --set-rpath "$rpath" "$out/opt/intel/gpa/$binary"
+    done
+    find $out -type f \( -name '*.so' -or -name '*.so.*' \) | while read lib; do
+        patchelf --set-rpath "$rpath" "$lib"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Intel Graphics Performance Analyzers";
+    homepage = "https://software.intel.com/content/www/us/en/develop/tools/graphics-performance-analyzers.html";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ ralith ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16675,6 +16675,8 @@ in
 
   intel-compute-runtime = callPackage ../os-specific/linux/intel-compute-runtime { };
 
+  intel-gpa = callPackage ../development/tools/intel-gpa { };
+
   intel-ocl = callPackage ../os-specific/linux/intel-ocl { };
 
   iomelt = callPackage ../os-specific/linux/iomelt { };


### PR DESCRIPTION
The Intel Graphics Performance Analyzers are a set of tools for profiling OpenGL/Vulkan applications on Intel hardware. Some judicious patchelf gets them seemingly working, but I haven't managed to get them to do anything for Vulkan applications yet.

There's a macos build of these tools as well, but I'm not equipped to develop a package for it, and I'm not sure it'd have anything in common (or even be particularly useful).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
