### PR TITLE
rtl88xxau-aircrack: init

### DIFF
--- a/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation rec {
+  name = "rtl88xxau-aircrack-${kernel.version}-${version}";
+  rev = "fc0194c1d90453bf4943089ca237159ef19a7374";
+  version = "${builtins.substring 0 6 rev}";
+
+  src = fetchFromGitHub {
+    owner = "aircrack-ng";
+    repo = "rtl8812au";
+    inherit rev;
+    sha256 = "0hf7mrvxaskc6qcjar5w81y9xc7s2rlsxp34achyqly2hjg7fgmy";
+  };
+
+  buildInputs = kernel.moduleBuildDependencies;
+
+  hardeningDisable = [ "pic" ];
+
+  NIX_CFLAGS_COMPILE="-Wno-error=incompatible-pointer-types";
+
+  prePatch = ''
+    substituteInPlace ./Makefile \
+      --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
+      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
+      --replace /sbin/depmod \# \
+      --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  preInstall = ''
+    mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Aircrack-ng kernel module for Realtek 88XXau network cards\n(8811au, 8812au, 8814au and 8821au chipsets) with monitor mode and injection support.";
+    homepage = "https://github.com/aircrack-ng/rtl8812au";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.jethro ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17005,6 +17005,8 @@ in
 
     rtl8814au = callPackage ../os-specific/linux/rtl8814au { };
 
+    rtl88xxau-aircrack = callPackage ../os-specific/linux/rtl88xxau-aircrack { };
+
     rtl8821au = callPackage ../os-specific/linux/rtl8821au { };
 
     rtl8821ce = callPackage ../os-specific/linux/rtl8821ce { };


### PR DESCRIPTION
###### Motivation for this change

This installs the network drivers for rtl8812au, rtl8814au, and rtl8821au.

I have a Tplink T9UH that required this driver to get working. The T9UH uses the rtl8814au driver, but the current package at https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/rtl8814au/default.nix is broken, and bumping it to master of that repo allows it to build but does not get the card working. As per, Arch's AUR the aircrack-ng repo worked instead.

https://aur.archlinux.org/packages/rtl88xxau-aircrack-dkms-git

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
