### PR TITLE
mlv-app: init at 1.11

### DIFF
--- a/pkgs/applications/video/mlv-app/aarch64-flags.patch
+++ b/pkgs/applications/video/mlv-app/aarch64-flags.patch
@@ -1,0 +1,13 @@
+diff --git a/platform/qt/MLVApp.pro b/platform/qt/MLVApp.pro
+index ebdc552..3e37573 100644
+--- a/platform/qt/MLVApp.pro
++++ b/platform/qt/MLVApp.pro
+@@ -84,7 +84,7 @@ win32{
+
+ # Linux
+ linux-g++*{
+-    QMAKE_CFLAGS += -O3 -fopenmp -msse4.1 -mssse3 -msse3 -msse2 -msse -std=c99
++    QMAKE_CFLAGS += -O3 -fopenmp -march=native -std=c99
+     QMAKE_CXXFLAGS += -fopenmp
+     LIBS += -lgomp
+ }

--- a/pkgs/applications/video/mlv-app/default.nix
+++ b/pkgs/applications/video/mlv-app/default.nix
@@ -1,0 +1,62 @@
+{ fetchFromGitHub
+, lib
+, mkDerivation
+, qmake
+, qtbase
+, qtmultimedia
+, stdenv
+}:
+
+mkDerivation rec {
+  pname = "mlv-app";
+  version = "1.11";
+
+  src = fetchFromGitHub {
+    owner = "ilia3101";
+    repo = "MLV-App";
+    rev = "QTv${version}";
+    sha256 = "0s5sjdxi8a17ddvih4ara7mlb2xrc9xqx52jmhfaca6ng341gi4x";
+  };
+
+  patches = if stdenv.isAarch64 then ./aarch64-flags.patch else null;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 -t $out/bin                mlvapp
+    install -Dm444 -t $out/share/applications mlvapp.desktop
+    install -Dm444 -t $out/share/icons/hicolor/512x512/apps RetinaIMG/MLVAPP.png
+    runHook postInstall
+  '';
+
+  qmakeFlags = [ "MLVApp.pro" ];
+
+  preConfigure = ''
+    export HOME=$TMPDIR
+    cd platform/qt/
+  '';
+
+  buildInputs = [
+    qtmultimedia
+    qtbase
+  ];
+
+  dontWrapQtApps = true;
+
+  preFixup = ''
+    wrapQtApp "$out/bin/mlvapp"
+  '';
+
+  nativeBuildInputs = [
+    qmake
+  ];
+
+  meta = with lib; {
+    description = "All in one MLV processing app that is pretty great";
+    homepage = "https://mlv.app";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [
+      kiwi
+    ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13757,6 +13757,8 @@ in
 
   mlt = callPackage ../development/libraries/mlt { ffmpeg = ffmpeg_4; };
 
+  mlv-app = libsForQt5.callPackage ../applications/video/mlv-app { };
+
   mono-addins = callPackage ../development/libraries/mono-addins { };
 
   movit = callPackage ../development/libraries/movit { };


### PR DESCRIPTION
###### Motivation for this change
I recently bought a Canon 7D DSLR and with the help of https://www.magiclantern.fm/ it can shoot RAW video in the (magic lantern) MLV format. To actually use the MLV files requires post processing. [MLV App](https://mlv.app) is quite popular for this. We didn't have it so I packaged it.

```What is MLV App? Lightroom, but for Magic Lantern MLV Video (and open source and cross platform)```

###### Things done
Added mlv-app. I haven't done too much testing yet since I just got the camera and haven't done a lot with it yet but so far so good. If I get an installation of macOS working again I'll try and  add the macOS version... since I need to do that for a few other packages I maintain anyway.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
