### PR TITLE
ocamlPackages.cohttp-async: init at 2.5.1

### DIFF
--- a/pkgs/development/ocaml-modules/cohttp/async.nix
+++ b/pkgs/development/ocaml-modules/cohttp/async.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildDunePackage, async, cohttp, conduit-async, uri, ppx_sexp_conv
+, logs, magic-mime }:
+
+if !stdenv.lib.versionAtLeast cohttp.version "0.99" then
+	cohttp
+else if !stdenv.lib.versionAtLeast async.version "0.13" then
+	throw "cohttp-async needs async-0.13 (hence OCaml >= 4.08)"
+else
+
+	buildDunePackage {
+		pname = "cohttp-async";
+		inherit (cohttp) version src;
+
+		buildInputs = [ ppx_sexp_conv ];
+
+		propagatedBuildInputs = [ async cohttp conduit-async logs magic-mime uri ];
+
+		meta = cohttp.meta // {
+			description = "CoHTTP implementation for the Async concurrency library";
+		};
+	}

--- a/pkgs/development/ocaml-modules/cohttp/async.nix
+++ b/pkgs/development/ocaml-modules/cohttp/async.nix
@@ -9,6 +9,7 @@ else
 
 	buildDunePackage {
 		pname = "cohttp-async";
+		useDune2 = true;
 		inherit (cohttp) version src;
 
 		buildInputs = [ ppx_sexp_conv ];

--- a/pkgs/development/ocaml-modules/conduit/async.nix
+++ b/pkgs/development/ocaml-modules/conduit/async.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildDunePackage, async, ppx_sexp_conv, conduit }:
+
+if !stdenv.lib.versionAtLeast conduit.version "1.0"
+then conduit
+else
+
+buildDunePackage {
+	pname = "conduit-async";
+	inherit (conduit) version src;
+
+	buildInputs = [ ppx_sexp_conv ];
+
+	propagatedBuildInputs = [ async conduit ];
+
+	meta = conduit.meta // {
+		description = "A network connection establishment library for Async";
+	};
+}

--- a/pkgs/development/ocaml-modules/conduit/async.nix
+++ b/pkgs/development/ocaml-modules/conduit/async.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildDunePackage, async, ppx_sexp_conv, conduit }:
+{ stdenv, buildDunePackage, async, async_ssl, ppx_sexp_conv, conduit }:
 
 if !stdenv.lib.versionAtLeast conduit.version "1.0"
 then conduit
@@ -6,11 +6,12 @@ else
 
 buildDunePackage {
 	pname = "conduit-async";
+	useDune2 = true;
 	inherit (conduit) version src;
 
 	buildInputs = [ ppx_sexp_conv ];
 
-	propagatedBuildInputs = [ async conduit ];
+	propagatedBuildInputs = [ async async_ssl conduit ];
 
 	meta = conduit.meta // {
 		description = "A network connection establishment library for Async";

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -18,7 +18,7 @@ buildDunePackage rec {
   propagatedBuildInputs = [ astring ipaddr ipaddr-sexp sexplib uri ];
 
   meta = {
-    description = "Network connection library for TCP and SSL";
+    description = "A network connection establishment library";
     license = stdenv.lib.licenses.isc;
     maintainers = with stdenv.lib.maintainers; [ alexfmpe vbgl ];
     homepage = "https://github.com/mirage/ocaml-conduit";

--- a/pkgs/development/ocaml-modules/janestreet/0.13.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.13.nix
@@ -1,5 +1,6 @@
 { janePackage
 , ctypes
+, dune-configurator
 , num
 , octavius
 , ppxlib
@@ -415,6 +416,15 @@ rec {
     hash = "0bfxyvdmyv23zfr49pb4c3bgfkjr4s3nb3z07xrw6szia3j1kp4j";
     meta.description = "Shell helpers for Async";
     propagatedBuildInputs = [ async shell ];
+  };
+
+  async_ssl = janePackage {
+    pname = "async_ssl";
+    useDune2 = true;
+    hash = "0z5dbiam5k7ipx9ph4r8nqv0a1ldx1ymxw3xjxgrdjda90lmwf2k";
+    meta.description = "Async wrappers for SSL";
+    buildInputs = [ dune-configurator ];
+    propagatedBuildInputs = [ async ctypes openssl ];
   };
 
   core_bench = janePackage {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -137,6 +137,8 @@ let
 
     cohttp = callPackage ../development/ocaml-modules/cohttp { };
 
+    cohttp-async = callPackage ../development/ocaml-modules/cohttp/async.nix { };
+
     cohttp-lwt = callPackage ../development/ocaml-modules/cohttp/lwt.nix { };
 
     cohttp-lwt-unix = callPackage ../development/ocaml-modules/cohttp/lwt-unix.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -991,7 +991,7 @@ let
     janeStreet =
     if lib.versionOlder "4.08" ocaml.version
     then import ../development/ocaml-modules/janestreet/0.13.nix {
-      inherit ctypes janePackage num octavius ppxlib re;
+      inherit ctypes dune-configurator janePackage num octavius ppxlib re;
       inherit (pkgs) openssl;
     }
     else if lib.versionOlder "4.07" ocaml.version

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -143,6 +143,8 @@ let
 
     conduit = callPackage ../development/ocaml-modules/conduit { };
 
+    conduit-async = callPackage ../development/ocaml-modules/conduit/async.nix { };
+
     conduit-lwt = callPackage ../development/ocaml-modules/conduit/lwt.nix { };
 
     conduit-lwt-unix = callPackage ../development/ocaml-modules/conduit/lwt-unix.nix { };


### PR DESCRIPTION
###### Motivation for this change

Add cohttp-async, upgrading cohttp and conduit to make this possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
