### PR TITLE
autotalent: init at 0.2

### DIFF
--- a/pkgs/applications/audio/autotalent/default.nix
+++ b/pkgs/applications/audio/autotalent/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  pname = "autotalent";
+  version = "0.2";
+
+  src = fetchzip {
+    url = "http://tombaran.info/${pname}-${version}.tar.gz";
+    sha256 = "19srnkghsdrxxlv2c7qimvyslxz63r97mkxfq78vbg654l3qz1a6";
+  };
+
+  makeFlags = [
+    "INSTALL_PLUGINS_DIR=$(out)/lib/ladspa"
+  ];
+
+  # To avoid name clashes, plugins should be compiled with symbols hidden, except for `ladspa_descriptor`:
+  preConfigure = ''
+    sed -r 's/^CFLAGS.*$/\0 -fvisibility=hidden/' -i Makefile
+
+    sed -r 's/^const LADSPA_Descriptor \*/__attribute__ ((visibility ("default"))) \0/' -i autotalent.c
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://tombaran.info/autotalent.html";
+    description = "A real-time pitch correction LADSPA plugin (no MIDI control)";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.michalrus ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18664,6 +18664,8 @@ in
 
   autokey = callPackage ../applications/office/autokey { };
 
+  autotalent = callPackage ../applications/audio/autotalent { };
+
   autotrace = callPackage ../applications/graphics/autotrace {};
 
   avocode = callPackage ../applications/graphics/avocode {};


### PR DESCRIPTION
###### Motivation for this change

No harmonizer plugin in Nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
