### PR TITLE
talentedhack: init at 1.86

### DIFF
--- a/pkgs/applications/audio/talentedhack/default.nix
+++ b/pkgs/applications/audio/talentedhack/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, lv2, fftwFloat, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "talentedhack";
+  version = "1.86";
+
+  src = fetchFromGitHub {
+    owner = "jeremysalwen";
+    repo = "talentedhack";
+    rev = "v${version}";
+    sha256 = "0kwvayalysmk7y49jq0k16al252md8d45z58hphzsksmyz6148bx";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ lv2 fftwFloat ];
+
+  # To avoid name clashes, plugins should be compiled with symbols hidden, except for `lv2_descriptor`:
+  preConfigure = ''
+    sed -r 's/^CFLAGS.*$/\0 -fvisibility=hidden/' -i Makefile
+  '';
+
+  installPhase = ''
+    d=$out/lib/lv2/talentedhack.lv2
+    mkdir -p $d
+    cp *.so *.ttl $d
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/jeremysalwen/TalentedHack";
+    description = "LV2 port of Autotalent pitch correction plugin";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.michalrus ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22191,6 +22191,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  talentedhack = callPackage ../applications/audio/talentedhack { };
+
   tambura = callPackage ../applications/audio/tambura { };
 
   teams = callPackage ../applications/networking/instant-messengers/teams { };


### PR DESCRIPTION
###### Motivation for this change

LV2 port of `autotalent`, but with some new artifacts present.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
