### PR TITLE
vocproc: init at 0.2.1

### DIFF
--- a/pkgs/applications/audio/lv2-cpp-tools/default.nix
+++ b/pkgs/applications/audio/lv2-cpp-tools/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchzip, pkgconfig, lv2, gtkmm2, boost }:
+
+stdenv.mkDerivation rec {
+  pname = "lv2-cpp-tools";
+  version = "1.0.5";
+
+  src = fetchzip {
+    url = "http://deb.debian.org/debian/pool/main/l/lv2-c++-tools/lv2-c++-tools_${version}.orig.tar.bz2";
+    sha256 = "039bq7d7s2bhfcnlsfq0mqxr9a9iqwg5bwcpxfi24c6yl6krydsi";
+  };
+
+  preConfigure = ''
+    sed -r 's,/bin/bash,${stdenv.shell},g' -i ./configure
+    sed -r 's,/sbin/ldconfig,ldconfig,g' -i ./Makefile.template
+  '';
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ lv2 gtkmm2 boost ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://ll-plugins.nongnu.org/hacking.html";
+    description = "Tools and libraries that may come in handy when writing LV2 plugins in C++";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.michalrus ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/audio/vocproc/default.nix
+++ b/pkgs/applications/audio/vocproc/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchzip, pkgconfig, lvtk, lv2, fftw, lv2-cpp-tools, gtkmm2 }:
+
+stdenv.mkDerivation rec {
+  pname = "vocproc";
+  version = "0.2.1";
+
+  src = fetchzip {
+    url = "https://hyperglitch.com/files/vocproc/${pname}-${version}.default.tar.gz";
+    sha256 = "07a1scyz14mg2jdbw6fpv4qg91zsw61qqii64n9qbnny9d5pn8n2";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ lv2 fftw lv2-cpp-tools gtkmm2 ];
+
+  makeFlags = [
+    "INSTALL_DIR=$(out)/lib/lv2"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://hyperglitch.com/dev/VocProc";
+    description = "An LV2 plugin for pitch shifting (with or without formant correction), vocoding, automatic pitch correction and harmonizing of singing voice (harmonizer)";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.michalrus ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20654,6 +20654,8 @@ in
 
   lv2bm = callPackage ../applications/audio/lv2bm { };
 
+  lv2-cpp-tools = callPackage ../applications/audio/lv2-cpp-tools { };
+
   lynx = callPackage ../applications/networking/browsers/lynx { };
 
   lyx = libsForQt5.callPackage ../applications/misc/lyx { };
@@ -22589,6 +22591,8 @@ in
   vlc_qt5 = vlc;
 
   vmpk = callPackage ../applications/audio/vmpk { };
+
+  vocproc = callPackage ../applications/audio/vocproc { };
 
   vnstat = callPackage ../applications/networking/vnstat { };
 


### PR DESCRIPTION
###### Motivation for this change

Another vocal harmonizer

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
