### PR TITLE
deepin.deepin-icon-theme: 15.12.71 -> 2020.05.21

### DIFF
--- a/pkgs/desktops/deepin/deepin-icon-theme/default.nix
+++ b/pkgs/desktops/deepin/deepin-icon-theme/default.nix
@@ -3,19 +3,19 @@
 , gtk3
 , xcursorgen
 , papirus-icon-theme
-, deepin
 , hicolor-icon-theme
+, deepin
 }:
 
 stdenv.mkDerivation rec {
   pname = "deepin-icon-theme";
-  version = "15.12.71";
+  version = "2020.05.21";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "12rzzjp906np95ckbxrd4mb345lm198wz69kxy48f8q1zg78q8iw";
+    sha256 = "0b1s6kf0q804zbbghly981wzacy1spi8168shf3x8w95rqj6463p";
   };
 
   nativeBuildInputs = [
@@ -30,22 +30,29 @@ stdenv.mkDerivation rec {
 
   dontDropIconThemeCache = true;
 
-  postPatch = ''
-    patchShebangs tools/hicolor.links
-    patchShebangs tools/display_unused_links.sh
-    patchShebangs cursors-src/cursors/bitmaps/make.sh
-    patchShebangs cursors-src/render-cursors.sh
+  buildTargets = "all hicolor-links";
 
-    # keep icon-theme.cache
-    sed -i -e 's|\(-rm -f .*/icon-theme.cache\)|# \1|g' Makefile
+  postPatch = ''
+    # fix: hicolor links should follow the deepin -> bloom naming change
+    # https://github.com/linuxdeepin/deepin-icon-theme/pull/24
+    substituteInPlace tools/hicolor.links --replace deepin bloom
+
+    substituteInPlace Sea/index.theme --replace Inherits=deepin Inherits=bloom
   '';
 
-  buildTargets = "all hicolor-links";
-  installTargets = [ "install-icons" "install-cursors" ];
-  installFlags = [ "PREFIX=${placeholder "out"}" ];
+  installPhase = ''
+    runHook preInstall
 
-  postInstall = ''
-    cp -a ./Sea ./usr/share/icons/hicolor "$out"/share/icons/
+    mkdir -p $out/share/icons
+    cp -vai bloom* Sea $out/share/icons
+
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache $theme
+    done
+
+    cp -vai usr/share/icons/hicolor $out/share/icons
+
+    runHook postInstall
   '';
 
   passthru.updateScript = deepin.updateScript { inherit pname version src; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [2020.05.21](https://github.com/linuxdeepin/deepin-icon-theme/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).