### PR TITLE
deepin.disomaster: 5.0.0 -> 5.0.1

### DIFF
--- a/pkgs/desktops/deepin/disomaster/default.nix
+++ b/pkgs/desktops/deepin/disomaster/default.nix
@@ -10,13 +10,13 @@
 
 mkDerivation rec {
   pname = "disomaster";
-  version = "5.0.0";
+  version = "5.0.1";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "13144gq0mpbpclzxc79fb1kirh0vvi50jvjnbpla9s8lvh59xl62";
+    sha256 = "1kmhlnw37pdmlf7k9zry657xlhz40m9nzg361kiyisn186pfqpws";
   };
 
   nativeBuildInputs = [
@@ -32,10 +32,11 @@ mkDerivation rec {
 
   postPatch = ''
     searchHardCodedPaths  # debugging
-
-    sed -i '/^QMAKE_PKGCONFIG_DESTDIR/i QMAKE_PKGCONFIG_PREFIX = $$PREFIX' \
-       libdisomaster/libdisomaster.pro
   '';
+
+  qmakeFlags = [
+    "QMAKE_PKGCONFIG_PREFIX=${placeholder "out"}"
+  ];
 
   passthru.updateScript = deepin.updateScript { inherit pname version src; };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [5.0.1](https://github.com/linuxdeepin/disomaster/releases/tag/5.0.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).