### PR TITLE
deepin.udisks2-qt5: 5.0.0 -> 5.0.3

### DIFF
--- a/pkgs/desktops/deepin/udisks2-qt5/default.nix
+++ b/pkgs/desktops/deepin/udisks2-qt5/default.nix
@@ -8,13 +8,13 @@
 
 mkDerivation rec {
   pname = "udisks2-qt5";
-  version = "5.0.0";
+  version = "5.0.3";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "0mqxm6ixzpbg0rr6ly2kvnkpag8gjza67ya7jv4i4rihbq1d0wzi";
+    sha256 = "0c87ks9glwhk4m2s7kf7mb43q011yi6l3qjq2ammmfqwl8xal69a";
   };
 
   nativeBuildInputs = [
@@ -27,11 +27,15 @@ mkDerivation rec {
   ];
 
   postPatch = ''
-    searchHardCodedPaths
+    searchHardCodedPaths # debugging
   '';
 
+  qmakeFlags = [
+    "QMAKE_PKGCONFIG_PREFIX=${placeholder "out"}"
+  ];
+
   postFixup = ''
-    searchHardCodedPaths $out
+    searchHardCodedPaths $out # debugging
   '';
 
   passthru.updateScript = deepin.updateScript { inherit pname version src; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [5.0.3](https://github.com/linuxdeepin/udisks2-qt5/tags)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
