### PR TITLE
MuPDF: 1.16.1 -> 1.17, PyMuPDF: 1.16.18 -> 1.17.0, llpp: v31 -> v32, zathura: patch for muPDF 1.17

### DIFF
--- a/pkgs/applications/misc/llpp/default.nix
+++ b/pkgs/applications/misc/llpp/default.nix
@@ -5,12 +5,12 @@ assert lib.versionAtLeast (lib.getVersion ocaml) "4.07";
 
 stdenv.mkDerivation rec {
   pname = "llpp";
-  version = "31";
+  version = "32";
 
   src = fetchgit {
     url = "git://repo.or.cz/llpp.git";
     rev = "v${version}";
-    sha256 = "14ibsm1zzxfidjajcj30b5m9in10q3817izahsjvkmryrvvn6qsg";
+    sha256 = "1h1zysm5cz8laq8li49djl6929cnrjlflag9hw0c1dcr4zaxk32y";
     fetchSubmodules = false;
   };
 

--- a/pkgs/applications/misc/llpp/fix-build-bash.patch
+++ b/pkgs/applications/misc/llpp/fix-build-bash.patch
@@ -17,48 +17,48 @@ index 7c278b6..41494c5 100755
 -keycmd="(cd $mudir && make -q build=$mbt libs && echo); digest $mulibs"
 -isfresh "$mulibs" "$(eval $keycmd)" || (
 -    make -C "$mudir" build=$mbt -j $mjobs libs
--    echo "k='$(eval $keycmd)'" >$mudir/build/$mbt/libmupdf.a.past
+-    eval $keycmd >$mudir/build/$mbt/libmupdf.a.past
 -) && vecho "fresh mupdf"
 -
  oincs() {
      local i=
      local incs1=
-@@ -90,34 +83,6 @@ mflags() {
+@@ -89,34 +82,6 @@ mflags() {
  }
  
  overs="$(ocamlc -vnum 2>/dev/null)" || overs=""
--test "$overs" = "4.08" || {
--    url=https://caml.inria.fr/pub/distrib/ocaml-4.08/ocaml-4.08.0.tar.xz
+-test "$overs" = "4.10.0" || {
+-    url=https://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10.0.tar.xz
 -    txz=$outd/$(basename $url)
--    isfresh $txz $url || {
+-    keycmd="printf $url; digest $txz;"
+-    isfresh $txz "$(eval $keycmd)" || {
 -        executable_p() { command -v "$1" >/dev/null 2>&1; }
 -        if executable_p wget; then dl() { wget -q "$1" -O "$2"; }
 -        elif executable_p curl; then dl() { curl -L "$1" -o "$2"; }
 -        else die "no program to fetch remote urls found"
 -        fi
 -        dl $url $txz
--        echo "k=$url" >$txz.past
+-        eval $keycmd >$txz.past
 -    } && vecho "fresh $txz"
 -    absprefix=$(cd $outd &>/dev/null; pwd -P)
 -    export PATH=$absprefix/bin:$PATH
--    isfresh $absprefix/bin/ocamlc "$url" || (
+-    ocamlc=$absprefix/bin/ocamlc
+-    keycmd="printf $url; digest $ocamlc;"
+-    isfresh $ocamlc "$(eval $keycmd)" || (
 -        tar xf $txz -C $outd
 -        bn=$(basename $url)
 -        cd $outd/${bn%.tar.xz}
--        ./configure --disable-vmthreads --disable-graph-lib \
--                    --disable-ocamldoc --enable-debugger=no \
--                    --disable-flat-float-array              \
--                    --prefix=$absprefix
+-        ./configure --disable-ocamldoc --enable-debugger=no --prefix=$absprefix
 -        make -j $mjobs world
 -        make install
--        echo "k='$url'" >$absprefix/bin/ocamlc.past
+-        eval $keycmd >$absprefix/bin/ocamlc.past
 -    ) && vecho "fresh ocamlc"
 -    overs=$(ocamlc -vnum 2>/dev/null)
 -}
  
- bocaml1() {
-     grep -q "$3" $outd/ordered || {
-@@ -227,7 +192,7 @@ bobjc() {
+ ccomp=${LLPP_CC-$(ocamlc -config | grep "^c_compiler: " | \
+                       { read _ c; echo $c; })}
+@@ -230,7 +195,7 @@ bobjc() {
      } && vecho "fresh $o"
  }
  
@@ -67,7 +67,7 @@ index 7c278b6..41494c5 100755
  
  cmd="(. $srcd/genconfstr.sh >$outd/confstruct.ml)"
  keycmd="digest $srcd/genconfstr.sh $outd/confstruct.ml"
-@@ -281,7 +246,7 @@ for m in ml_gl ml_glarray ml_raw; do
+@@ -284,7 +249,7 @@ for m in ml_gl ml_glarray ml_raw; do
  done
  
  libs="str.cma unix.cma"

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -13,12 +13,12 @@ let
 
 
 in stdenv.mkDerivation rec {
-  version = "1.16.1";
+  version = "1.17.0";
   pname = "mupdf";
 
   src = fetchurl {
     url = "https://mupdf.com/downloads/archive/${pname}-${version}-source.tar.gz";
-    sha256 = "0iz4ickj52fxjp8crg573kjrl4viq279g589isdpgpckslysf7g7";
+    sha256 = "13nl9nrcx2awz9l83mlv2psi1lmn3hdnfwxvwgwiwbxlkjl3zqq0";
   };
 
   patches =

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, meson, ninja, fetchurl
+{ stdenv, lib, meson, ninja, fetchurl, fetchpatch
 , pkgconfig, zathura_core, cairo , gtk-mac-integration, girara, mupdf }:
 
 stdenv.mkDerivation rec {
@@ -9,6 +9,14 @@ stdenv.mkDerivation rec {
     url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
     sha256 = "1pjwsb7zwclxsvz229fl7y2saf1pv3ifwv3ay8viqxgrp9x3z9hq";
   };
+
+  patches = [
+    # compatibility with MuPDF 1.17
+    (fetchpatch {
+      url = "https://git.pwmt.org/pwmt/zathura-pdf-mupdf/-/commit/c7f341addb76d5e6fd8c24c666d8fe97c451a4cb.patch";
+      sha256 = "12rikx2j7dpngfma9x4i504w58a8xx3rc0gmyz183v19hn54c075";
+    })
+  ];
 
   nativeBuildInputs = [ meson ninja pkgconfig ];
 

--- a/pkgs/development/python-modules/pymupdf/default.nix
+++ b/pkgs/development/python-modules/pymupdf/default.nix
@@ -1,11 +1,11 @@
 { stdenv, buildPythonPackage, fetchPypi, mupdf, swig }:
 buildPythonPackage rec {
   pname = "PyMuPDF";
-  version = "1.16.18";
+  version = "1.17.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0gpcmmcjgwc6x4rn6nm3akiijdkpa9nahsw2x8a0i7z7kzj4firk";
+    sha256 = "0de92a8fb65db6e661594cc5865a340a2daac3cb9bb58e030820769ece1343c1";
   };
 
   patchPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

MuPDF version bump including downstream updates due to API changes. Bundled in a single PR to avoid intermediate breakage on master.

Supersedes/Includes https://github.com/NixOS/nixpkgs/pull/87238

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 88919"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
