### PR TITLE
keeweb: init at 1.15.7

### DIFF
--- a/pkgs/applications/misc/keeweb/default.nix
+++ b/pkgs/applications/misc/keeweb/default.nix
@@ -1,0 +1,65 @@
+{ stdenv, fetchurl, appimageTools, undmg, libsecret }:
+let
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+
+  pname = "keeweb";
+  version = "1.15.7";
+  name = "${pname}-${version}";
+
+  suffix = {
+    x86_64-linux = "linux.AppImage";
+    x86_64-darwin = "mac.dmg";
+  }.${system} or throwSystem;
+
+  src = fetchurl {
+    url = "https://github.com/keeweb/keeweb/releases/download/v${version}/KeeWeb-${version}.${suffix}";
+    sha256 = {
+      x86_64-linux = "0cy0avl0m07xs523xm0rzsmifl28sv4rjb2jj3x492qmr2v64ckk";
+      x86_64-darwin = "0r8c3zi0ibj0bb0gfc1axfn0y4qpjqfr0xpcxf810d65kaz6wic4";
+    }.${system} or throwSystem;
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit name src;
+  };
+
+  meta = with stdenv.lib; {
+    description = "Free cross-platform password manager compatible with KeePass";
+    homepage = "https://keeweb.info/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+
+  linux = appimageTools.wrapType2 rec {
+    inherit name src meta;
+
+    extraPkgs = pkgs: with pkgs; [ libsecret ];
+
+    extraInstallCommands = ''
+      mv $out/bin/{${name},${pname}}
+      install -Dm644 ${appimageContents}/keeweb.desktop -t $out/share/applications
+      install -Dm644 ${appimageContents}/keeweb.png -t $out/share/icons/hicolor/256x256/apps
+      install -Dm644 ${appimageContents}/usr/share/mime/keeweb.xml -t $out/share/mime
+      substituteInPlace $out/share/applications/keeweb.desktop \
+        --replace 'Exec=AppRun' 'Exec=${pname}'
+    '';
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit pname version src meta;
+
+    nativeBuildInputs = [ undmg ];
+
+    sourceRoot = "KeeWeb.app";
+
+    installPhase = ''
+      mkdir -p $out/Applications/KeeWeb.app
+      cp -R . $out/Applications/KeeWeb.app
+    '';
+  };
+in
+if stdenv.isDarwin
+then darwin
+else linux

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19878,6 +19878,8 @@ in
   keepassx2 = callPackage ../applications/misc/keepassx/2.0.nix { };
   keepassxc = libsForQt5.callPackage ../applications/misc/keepassx/community.nix { };
 
+  keeweb = callPackage ../applications/misc/keeweb { };
+
   inherit (gnome3) evince;
   evolution-data-server = gnome3.evolution-data-server;
   evolution-ews = callPackage ../applications/networking/mailreaders/evolution/evolution-ews { };


### PR DESCRIPTION
###### Motivation for this change
[**keeweb**](https://github.com/keeweb/keeweb) - Free cross-platform password manager compatible with KeePass.
Resolves https://github.com/NixOS/nixpkgs/issues/76931.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
