### PR TITLE
kicad: link through /lib and /share from kicad.base

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -39,8 +39,6 @@ in
 stdenv.mkDerivation rec {
 
   passthru.libraries = callPackages ./libraries.nix versionConfig.libVersion;
-  # a link to this exists as python3.pkgs.[kicad|kicad-unstable]
-  passthru.py = python.pkgs.toPythonModule base;
   base = callPackage ./base.nix {
     inherit versions stable baseName;
     inherit wxGTK python wxPython;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3181,9 +3181,9 @@ in {
 
   jsonwatch = callPackage ../development/python-modules/jsonwatch { };
 
-  kicad = disabledIf isPy27 (toPythonModule (pkgs.kicad.override {
-    python3 = python;
-  }).src);
+  # kicad's built with python3 only
+  kicad = disabledIf isPy27 pkgs.kicad.py;
+  kicad-unstable = disabledIf isPy27 pkgs.kicad-unstable.py;
 
   latexcodec = callPackage ../development/python-modules/latexcodec {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3181,9 +3181,13 @@ in {
 
   jsonwatch = callPackage ../development/python-modules/jsonwatch { };
 
-  # kicad's built with python3 only
-  kicad = disabledIf isPy27 pkgs.kicad.py;
-  kicad-unstable = disabledIf isPy27 pkgs.kicad-unstable.py;
+  kicad = disabledIf isPy27 (toPythonModule (pkgs.kicad.override {
+    python3 = python;
+  }).src);
+  kicad-unstable = disabledIf isPy27
+    (toPythonModule (pkgs.kicad-unstable.override {
+      python3 = python;
+    }).src);
 
   latexcodec = callPackage ../development/python-modules/latexcodec {};
 


### PR DESCRIPTION
###### Motivation for this change
https://discourse.nixos.org/t/7317
and #40835

###### Things done

- add a `kicad.py` attribute which is `toPythonModule kicad.base` (this yields the same as `kicad.base`, does it add context?)
  - change `python.pkgs.kicad` to point to that, add `python.pkgs.kicad-unstable`
- link through to `kicad.base`'s `/lib`
  - exposes the python bindings and some .so files
- link through to `kicad.base`'s `/share`
  - exposes some `.desktop` files, `MIME` info
    - and a whole bunch more stuff i'm not sure need to be
- bump `kicad-unstable` to the latest version

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
