### PR TITLE
zerofree: install manpage and COPYING file

### DIFF
--- a/pkgs/tools/filesystems/zerofree/default.nix
+++ b/pkgs/tools/filesystems/zerofree/default.nix
@@ -1,6 +1,11 @@
-{ lib, stdenv, fetchurl, e2fsprogs }:
+{ lib, stdenv, fetchurl, installShellFiles, e2fsprogs }:
 
-stdenv.mkDerivation rec {
+let
+  manpage = fetchurl {
+    url = "https://manpages.ubuntu.com/manpages.gz/xenial/man8/zerofree.8.gz";
+    sha256 = "0y132xmjl02vw41k794psa4nmjpdyky9f6sf0h4f7rvf83z3zy4k";
+  };
+in stdenv.mkDerivation rec {
   pname = "zerofree";
   version = "1.1.1";
 
@@ -9,12 +14,14 @@ stdenv.mkDerivation rec {
     sha256 = "0rrqfa5z103ws89vi8kfvbks1cfs74ix6n1wb6vs582vnmhwhswm";
   };
 
-  buildInputs = [ e2fsprogs ];
+  buildInputs = [ e2fsprogs installShellFiles ];
 
   installPhase = ''
-    mkdir -p $out/bin
+    mkdir -p $out/bin $out/share/zerofree
     cp zerofree $out/bin
-'';
+    cp COPYING $out/share/zerofree/COPYING
+    installManPage ${manpage}
+  '';
 
   meta = {
     homepage = "https://frippery.org/uml/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Install COPYING and manpage from Debian/Ubuntu.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
