### PR TITLE
hash_extender: 2017-04-10 -> unstable-2020-03-24

### DIFF
--- a/pkgs/tools/security/hash_extender/default.nix
+++ b/pkgs/tools/security/hash_extender/default.nix
@@ -2,16 +2,19 @@
 
 stdenv.mkDerivation {
   pname = "hash_extender";
-  version = "2017-04-10";
+  version = "unstable-2020-03-24";
 
   src = fetchFromGitHub {
     owner = "iagox86";
     repo = "hash_extender";
-    rev = "d27581e062dd0b534074e11d7d311f65a6d7af21";
-    sha256 = "1npwbgqaynjh5x39halw43i116v89sxkpa1g1bbvc1lpi8hkhhcb";
+    rev = "cb8aaee49f93e9c0d2f03eb3cafb429c9eed723d";
+    sha256 = "1fj118566hr1wv03az2w0iqknazsqqkak0mvlcvwpgr6midjqi9b";
   };
 
   buildInputs = [ openssl ];
+
+  doCheck = true;
+  checkPhase = "./hash_extender --test";
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The latest version contains support for the Tiger hash function, some small bugfixes and includes tests within the derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
