### PR TITLE
graphql_ppx: init at 0.7.1

### DIFF
--- a/pkgs/development/ocaml-modules/graphql_ppx/default.nix
+++ b/pkgs/development/ocaml-modules/graphql_ppx/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildDunePackage, fetchFromGitHub, alcotest, cppo
+, ocaml-migrate-parsetree, ppx_tools_versioned, reason, result, yojson }:
+
+buildDunePackage rec {
+  pname = "graphql_ppx";
+  version = "0.7.1";
+
+  minimumOCamlVersion = "4.06";
+
+  src = fetchFromGitHub {
+    owner = "reasonml-community";
+    repo = "graphql_ppx";
+    rev = "v${version}";
+    sha256 = "0gpzwcnss9c82whncyxfm6gwlkgh9hy90329hrazny32ybb470zh";
+  };
+
+  propagatedBuildInputs =
+    [ cppo ocaml-migrate-parsetree ppx_tools_versioned reason result yojson ];
+
+  checkInputs = lib.optional doCheck alcotest;
+
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/reasonml-community/graphql_ppx";
+    description = "GraphQL PPX rewriter for Bucklescript/ReasonML";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ Zimmi48 jtcoolen ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -367,6 +367,8 @@ let
 
     graphql_parser = callPackage ../development/ocaml-modules/graphql/parser.nix { };
 
+    graphql_ppx = callPackage ../development/ocaml-modules/graphql_ppx { };
+
     gtktop = callPackage ../development/ocaml-modules/gtktop { };
 
     hex = callPackage ../development/ocaml-modules/hex { };


### PR DESCRIPTION
###### Motivation for this change
GraphQL PPX rewriter for Bucklescript/ReasonML written in ReasonML.
See: https://github.com/reasonml-community/graphql_ppx

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
