### PR TITLE
1password: 0.10.0 -> 1.0.0

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -2,24 +2,24 @@
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.10.0";
+  version = "1.0.0";
   src =
     if stdenv.hostPlatform.system == "i686-linux" then
       fetchzip {
         url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_386_v${version}.zip";
-        sha256 = "07j11ikd0rzsj4d8rv74rfy497svq6l2q94ndf3b0a0mr8riyazj";
+        sha256 = "1d1lxmrmirh3837zib91dmxblb4imdz8gbq56pb7kgbff3zf96ql";
         stripRoot = false;
       }
     else if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchzip {
         url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_amd64_v${version}.zip";
-        sha256 = "177cl4x7rj3d74kzrpmiwps5n31axmlhqdwrdpkmay2gk9inswbs";
+        sha256 = "0pscm61dc69vmkrzrnxi531d37ig9y48w8q1lvzsg13zvvwaw8hs";
         stripRoot = false;
       }
     else if stdenv.hostPlatform.system == "x86_64-darwin" then
       fetchurl {
         url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_darwin_amd64_v${version}.pkg";
-        sha256 = "13yxmnh77g6zvl2gqf77m5i3v5706p2plgbgsn5hqrrf3g8ql63b";
+        sha256 = "1sb5qdssasqm7z7j4xzgkmkgf132zhgm93d7rkx3y5j0rac98y0g";
       }
     else throw "Architecture not supported";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

From their release notes:

In this release, we add the ability to choose which fields are returned by "get item". When a single field is requested, its data is returned as a simple string. For multiple fields, data is returned in a JSON object or in CSV format.

New:

- You can specify which fields are returned by "get item" with the "--fields" and "--format" flags.
- You can customize the "--generate-password" option for "create/edit item". Use a password recipe to specify the length and characters included.

Improvements:

- Using "reactivate" on an active user no longer returns an error.
- Various error messages have been clarified.

Fixed:

- Fixed a panic caused by using "--shorthand" when signing in after the first time.
- Fixed problem where session files could become corrupted when running multiple "op" commands concurrently.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
