### PR TITLE
androidenv: add missing emulator dynamic libraries

### DIFF
--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -36,9 +36,12 @@ deployAndroidPackage {
     addAutoPatchelfSearchPath ${pkgs.libuuid.out}/lib
     autoPatchelf $out
 
-    # Wrap emulator so that it can load libdbus-1.so at runtime and it no longer complains about XKB keymaps
+    # Wrap emulator so that it can load required libraries at runtime
     wrapProgram $out/libexec/android-sdk/emulator/emulator \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ pkgs.dbus ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ 
+        pkgs.dbus
+        pkgs.systemd
+      ]} \
       --set QT_XKB_CONFIG_ROOT ${pkgs.xkeyboard_config}/share/X11/xkb \
       --set QTCOMPOSE ${pkgs.xorg.libX11.out}/share/X11/locale
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
On Linux accessing the Android emulator sidebar causes the program to crash. This is because the emulator attempts to load udev at runtime when accessing the sidebar and none is available.

This PR addresses that issue by adding systemd to the LD_LIBRARY_PATH when running the emulator, which provides udev.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
