### PR TITLE
convos: init at 4.22

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -831,6 +831,7 @@
   ./services/web-apps/atlassian/crowd.nix
   ./services/web-apps/atlassian/jira.nix
   ./services/web-apps/codimd.nix
+  ./services/web-apps/convos.nix
   ./services/web-apps/cryptpad.nix
   ./services/web-apps/documize.nix
   ./services/web-apps/dokuwiki.nix

--- a/nixos/modules/services/web-apps/convos.nix
+++ b/nixos/modules/services/web-apps/convos.nix
@@ -1,0 +1,72 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.convos;
+in
+{
+  options.services.convos = {
+    enable = mkEnableOption "Convos";
+    listenPort = mkOption {
+      type = types.port;
+      default = 3000;
+      example = 8080;
+      description = "Port the web interface should listen on";
+    };
+    listenAddress = mkOption {
+      type = types.str;
+      default = "*";
+      example = "127.0.0.1";
+      description = "Address or host the web interface should listen on";
+    };
+    reverseProxy = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enables reverse proxy support. This will allow Convos to automatically
+        pick up the <literal>X-Forwarded-For</literal> and
+        <literal>X-Request-Base</literal> HTTP headers set in your reverse proxy
+        web server. Note that enabling this option without a reverse proxy in
+        front will be a security issue.
+      '';
+    };
+  };
+  config = mkIf cfg.enable {
+    systemd.services.convos = {
+      description = "Convos Service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "networking.target" ];
+      environment = {
+        CONVOS_HOME = "%S/convos";
+        CONVOS_REVERSE_PROXY = if cfg.reverseProxy then "1" else "0";
+        MOJO_LISTEN = "http://${toString cfg.listenAddress}:${toString cfg.listenPort}";
+      };
+      serviceConfig = {
+        ExecStart = "${pkgs.convos}/bin/convos daemon";
+        Restart = "on-failure";
+        StateDirectory = "convos";
+        WorkingDirectory = "%S/convos";
+        DynamicUser = true;
+        MemoryDenyWriteExecute = true;
+        ProtectHome = true;
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateUsers = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        RestrictNamespaces = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6"];
+        SystemCallFilter = "@system-service";
+        SystemCallArchitectures = "native";
+        CapabilityBoundingSet = "";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -65,6 +65,7 @@ in
   containers-portforward = handleTest ./containers-portforward.nix {};
   containers-restart_networking = handleTest ./containers-restart_networking.nix {};
   containers-tmpfs = handleTest ./containers-tmpfs.nix {};
+  convos = handleTest ./convos.nix {};
   corerad = handleTest ./corerad.nix {};
   couchdb = handleTest ./couchdb.nix {};
   deluge = handleTest ./deluge.nix {};

--- a/nixos/tests/convos.nix
+++ b/nixos/tests/convos.nix
@@ -1,0 +1,30 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }:
+
+with lib;
+let
+  port = 3333;
+in
+{
+  name = "convos";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ sgo ];
+  };
+
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        services.convos = {
+          enable = true;
+          listenPort = port;
+        };
+      };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("convos")
+    machine.wait_for_open_port("${toString port}")
+    machine.succeed("journalctl -u convos | grep -q 'Listening at.*${toString port}'")
+    machine.succeed("curl http://localhost:${toString port}/")
+  '';
+})

--- a/pkgs/applications/networking/irc/convos/default.nix
+++ b/pkgs/applications/networking/irc/convos/default.nix
@@ -1,0 +1,71 @@
+{ stdenv, fetchFromGitHub, perl, perlPackages, makeWrapper, shortenPerlShebang }:
+
+with stdenv.lib;
+
+perlPackages.buildPerlPackage rec {
+  pname = "convos";
+  version = "4.22";
+
+  src = fetchFromGitHub rec {
+    owner = "Nordaaker";
+    repo = pname;
+    rev = version;
+    sha256 = "0a5wq88ncbn7kwcw3z4wdl1wxmx5vq5a7crb1bvbvskgwwy8zfx8";
+  };
+
+  nativeBuildInputs = [ makeWrapper ]
+    ++ optional stdenv.isDarwin [ shortenPerlShebang ];
+  
+  buildInputs = with perlPackages; [
+    CryptEksblowfish FileHomeDir FileReadBackwards
+    IOSocketSSL IRCUtils JSONValidator LinkEmbedder ModuleInstall
+    Mojolicious MojoliciousPluginOpenAPI MojoliciousPluginWebpack
+    ParseIRC TextMarkdown TimePiece UnicodeUTF8
+    CpanelJSONXS EV
+  ];
+
+  checkInputs = with perlPackages; [ TestDeep TestMore ];
+
+  postPatch = ''
+    patchShebangs script/convos
+  '';
+
+  # A test fails since gethostbyaddr(127.0.0.1) fails to resolve to localhost in
+  # the sandbox, we replace the this out from a substitution expression
+  #
+  # Module::Install is a runtime dependency not covered by the tests, so we add
+  # a test for it.
+  #
+  preCheck = ''
+    substituteInPlace t/web-register-open-to-public.t \
+      --replace '!127.0.0.1!' '!localhost!'
+
+    echo "use Test::More tests => 1;require_ok('Module::Install')" \
+      > t/00_nixpkgs_module_install.t
+  '';
+
+  # Convos expects to find assets in both auto/share/dist/Convos, and $MOJO_HOME
+  # which is set to $out
+  #
+  postInstall = ''
+    AUTO_SHARE_PATH=$out/${perl.libPrefix}/auto/share/dist/Convos
+    mkdir -p $AUTO_SHARE_PATH
+    cp -vR public assets $AUTO_SHARE_PATH/
+    ln -s $AUTO_SHARE_PATH/public/asset $out/asset
+    cp -vR templates $out/templates
+    cp cpanfile $out/cpanfile
+  '' + optionalString stdenv.isDarwin ''
+    shortenPerlShebang $out/bin/convos
+  '' + ''
+    wrapProgram $out/bin/convos --set MOJO_HOME $out
+  '';
+
+  passthru.tests = nixosTests.convos;
+
+  meta = {
+    homepage = "https://convos.chat";
+    description = "Convos is the simplest way to use IRC in your browser";
+    license = stdenv.lib.licenses.artistic2;
+    maintainers = with maintainers; [ sgo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19156,6 +19156,8 @@ in
   codeblocks = callPackage ../applications/editors/codeblocks { };
   codeblocksFull = codeblocks.override { contribPlugins = true; };
 
+  convos = callPackage ../applications/networking/irc/convos { };
+
   comical = callPackage ../applications/graphics/comical { };
 
   containerd = callPackage ../applications/virtualization/containerd { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9698,6 +9698,21 @@ let
     };
   };
 
+  IRCUtils = buildPerlPackage {
+    pname = "IRC-Utils";
+    version = "0.12";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/H/HI/HINRIK/IRC-Utils-0.12.tar.gz";
+      sha256 = "c7d6311eb6c79e983833c9e6b4e8d426d07a9874d20f4bc641b313b99c9bc8a0";
+    };
+    meta = {
+      homepage = "http://metacpan.org/release/IRC-Utils";
+      description = "Common utilities for IRC-related tasks";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = with maintainers; [ sgo ];
+    };
+  };
+
   # TODO: use CPAN version
   ImageExifTool = buildPerlPackage {
     pname = "Image-ExifTool";
@@ -10300,6 +10315,23 @@ let
       sha256 = "113f91d8fc2c630437153a49fb7a52b023af8f6278ed96c070b1f60824b8eae1";
     };
     doCheck = false;
+  };
+
+  LinkEmbedder = buildPerlPackage {
+    pname = "LinkEmbedder";
+    version = "1.12";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/LinkEmbedder-1.12.tar.gz";
+      sha256 = "1fd25bd6047b45cdcb1ab71a3d3bb0b36c71ec844a8742dee0bb34f8587fbd08";
+    };
+    buildInputs = [ TestDeep ];
+    propagatedBuildInputs = [ Mojolicious ];
+    meta = {
+      homepage = "https://github.com/jhthorsen/linkembedder";
+      description = "Embed / expand oEmbed resources and other URL / links";
+      license = stdenv.lib.licenses.artistic2;
+      maintainers = with maintainers; [ sgo ];
+    };
   };
 
   LinuxACL = buildPerlPackage {
@@ -12359,6 +12391,22 @@ let
       description = "Render exceptions as text in command line user agents";
       license = stdenv.lib.licenses.artistic2;
       maintainers = [ maintainers.sgo ];
+    };
+  };
+
+  MojoliciousPluginWebpack = buildPerlPackage {
+    pname = "Mojolicious-Plugin-Webpack";
+    version = "0.12";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojolicious-Plugin-Webpack-0.12.tar.gz";
+      sha256 = "2a0856e68446fc22b46692d9a6737f78467654f31e58ad1935e708bddf806d2c";
+    };
+    propagatedBuildInputs = [ Mojolicious ];
+    meta = {
+      homepage = "https://github.com/jhthorsen/mojolicious-plugin-webpack";
+      description = "Mojolicious <3 Webpack";
+      license = stdenv.lib.licenses.artistic2;
+      maintainers = with maintainers; [ sgo ];
     };
   };
 
@@ -14715,6 +14763,21 @@ let
     propagatedBuildInputs = [ IOStringy LWP ];
     meta = with stdenv.lib; {
       license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  ParseIRC = buildPerlPackage {
+    pname = "Parse-IRC";
+    version = "1.22";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Parse-IRC-1.22.tar.gz";
+      sha256 = "457b09897f37d38a7054f9563247365427fe24101622ed4c7f054723a45b58d5";
+    };
+    meta = {
+      homepage = "https://github.com/bingos/parse-irc";
+      description = "A parser for the IRC protocol";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = with maintainers; [ sgo ];
     };
   };
 
@@ -20374,6 +20437,21 @@ let
     };
   };
 
+  TimePiece = buildPerlPackage {
+    pname = "Time-Piece";
+    version = "1.3401";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/ES/ESAYM/Time-Piece-1.3401.tar.gz";
+      sha256 = "4b55b7bb0eab45cf239a54dfead277dfa06121a43e63b3fce0853aecfdb04c27";
+    };
+    meta = {
+      description = "Object Oriented time objects";
+      homepage = "https://metacpan.org/release/Time-Piece";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = with maintainers; [ sgo ];
+    };
+  };
+
   Tirex = buildPerlPackage rec {
     pname = "Tirex";
     version = "0.6.1";
@@ -20632,6 +20710,22 @@ let
       description = "Preparation of Internationalized Strings (RFC 3454)";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
+    };
+  };
+
+  UnicodeUTF8 = buildPerlPackage {
+    pname = "Unicode-UTF8";
+    version = "0.62";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Unicode-UTF8-0.62.tar.gz";
+      sha256 = "fa8722d0b74696e332fddd442994436ea93d3bfc7982d4babdcedfddd657d0f6";
+    };
+    buildInputs = [ TestFatal ];
+    meta = {
+      homepage = "https://github.com/chansen/p5-unicode-utf8";
+      description = "Encoding and decoding of UTF-8 encoding form";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = with maintainers; [ sgo ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12316,10 +12316,10 @@ let
 
   MojoliciousPluginOpenAPI = buildPerlPackage {
     pname = "Mojolicious-Plugin-OpenAPI";
-    version = "2.21";
+    version = "3.33";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojolicious-Plugin-OpenAPI-2.21.tar.gz";
-      sha256 = "34b1f42d846c26d8be3a3556dc5a02dd7ab47c5612b41d3caf1ce6bc16101dc2";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojolicious-Plugin-OpenAPI-3.33.tar.gz";
+      sha256 = "0lccvanc3cici83j6fx7gg3wdcsvgv8d7hzd06r0q1mp8329sbv4";
     };
     propagatedBuildInputs = [ JSONValidator ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12285,10 +12285,10 @@ let
 
   Mojolicious = buildPerlPackage {
     pname = "Mojolicious";
-    version = "8.32";
+    version = "8.55";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-8.32.tar.gz";
-      sha256 = "11fyz534syihisl8498655bqq4y8c73a6xhvl1wlq4axdgkm0d2h";
+      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-8.55.tar.gz";
+      sha256 = "116f79a8jvdk0zfj34gp3idhxgk4l8qq4ka6pwhdp8pmks969w0x";
     };
     meta = {
       homepage = "https://mojolicious.org";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12294,7 +12294,7 @@ let
       homepage = "https://mojolicious.org";
       description = "Real-time web framework";
       license = stdenv.lib.licenses.artistic2;
-      maintainers = [ maintainers.thoughtpolice ];
+      maintainers = with maintainers; [ thoughtpolice sgo ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9931,10 +9931,10 @@ let
 
   JSONValidator = buildPerlPackage {
     pname = "JSON-Validator";
-    version = "3.23";
+    version = "4.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/JSON-Validator-3.23.tar.gz";
-      sha256 = "1fzy2z7mkg5vgcjvykh5ay8yg6q496wi14x9wp5hc9agplsq7f0s";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/JSON-Validator-4.00.tar.gz";
+      sha256 = "09p6n5ahsa13fmxb01siz9hcmyswgb05ac2njbhzim6cnx9d6cwj";
     };
     buildInputs = [ TestDeep ];
     propagatedBuildInputs = [ DataValidateDomain DataValidateIP Mojolicious NetIDNEncode YAMLLibYAML ];


### PR DESCRIPTION
This PR add the web based IRC client `convos`, including nixos module and tests.

Several perlPackage dependencies are added, and some are updated.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
