### PR TITLE
powerdevil: add DDC support

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -158,6 +158,19 @@ in
         example = "vlc";
         description = "Phonon audio backend to install.";
       };
+
+      supportDDC = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Support setting monitor brightness via DDC.
+          </para>
+          <para>
+          This is not needed for controlling brightness of the internal monitor
+          of a laptop and as it is considered experimental by upstream, it is
+          disabled by default.
+        '';
+      };
     };
 
   };
@@ -183,6 +196,12 @@ in
           capabilities = "cap_sys_nice+ep";
         };
       };
+
+      # DDC support
+      boot.kernelModules = lib.optional cfg.supportDDC "i2c_dev";
+      services.udev.extraRules = lib.optionalString cfg.supportDDC ''
+        KERNEL=="i2c-[0-9]*", TAG+="uaccess"
+      '';
 
       environment.systemPackages = with pkgs; with qt5; with libsForQt5; with plasma5; with kdeApplications;
         [

--- a/pkgs/desktops/plasma-5/powerdevil.nix
+++ b/pkgs/desktops/plasma-5/powerdevil.nix
@@ -3,7 +3,7 @@
   extra-cmake-modules, kdoctools,
   bluez-qt, kactivities, kauth, kconfig, kdbusaddons, kdelibs4support,
   kglobalaccel, ki18n, kidletime, kio, knotifyconfig, kwayland, libkscreen,
-  networkmanager-qt, plasma-workspace, qtx11extras, solid, udev
+  ddcutil, networkmanager-qt, plasma-workspace, qtx11extras, solid, udev
 }:
 
 mkDerivation {
@@ -13,5 +13,9 @@ mkDerivation {
     kconfig kdbusaddons knotifyconfig solid udev bluez-qt kactivities kauth
     kdelibs4support kglobalaccel ki18n kio kidletime kwayland libkscreen
     networkmanager-qt plasma-workspace qtx11extras
+    ddcutil
+  ];
+  cmakeFlags = [
+    "-DHAVE_DDCUTIL=On"
   ];
 }


### PR DESCRIPTION
###### Motivation for this change

This allows you to control the monitor brightness for external monitors
using the plasma "Battery & Brightness" control on desktop
computers.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).