### PR TITLE
linux: fix kernel config options

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -274,7 +274,7 @@ let
       SND_SOC_SOF_ELKHARTLAKE_SUPPORT   = yes;
       SND_SOC_SOF_GEMINILAKE_SUPPORT    = yes;
       SND_SOC_SOF_HDA_AUDIO_CODEC       = yes;
-      SND_SOC_SOF_HDA_COMMON_HDMI_CODEC = yes;
+      SND_SOC_SOF_HDA_COMMON_HDMI_CODEC = whenOlder "5.7" yes;
       SND_SOC_SOF_HDA_LINK              = yes;
       SND_SOC_SOF_ICELAKE_SUPPORT       = yes;
       SND_SOC_SOF_INTEL_TOPLEVEL        = yes;

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -63,7 +63,7 @@ let
       PM_WAKELOCKS                     = yes;
       # Power-capping framework and support for INTEL RAPL
       POWERCAP                         = yes;
-      INTEL_RAPL                       = module;
+      INTEL_RAPL                       = whenAtLeast "5.3" module;
     };
 
     external-firmware = {
@@ -120,7 +120,7 @@ let
       HAVE_EBPF_JIT      = whenPlatformHasEBPFJit yes;
       BPF_STREAM_PARSER  = whenAtLeast "4.19" yes;
       XDP_SOCKETS        = whenAtLeast "4.19" yes;
-      XDP_SOCKETS_DIAG   = whenAtLeast "4.19" yes;
+      XDP_SOCKETS_DIAG   = whenAtLeast "5.1" yes;
       WAN                = yes;
       TCP_CONG_CUBIC     = yes; # This is the default congestion control algorithm since 2.6.19
       # Required by systemd per-cgroup firewalling
@@ -167,13 +167,18 @@ let
       NF_CONNTRACK_TIMEOUT        = yes;
       NF_CONNTRACK_TIMESTAMP      = yes;
       NETFILTER_NETLINK_GLUE_CT   = yes;
-      NF_TABLES_INET              = whenAtLeast "4.19" yes;
-      NF_TABLES_NETDEV            = whenAtLeast "4.19" yes;
+      NF_TABLES_INET              = mkMerge [ (whenOlder "4.17" module)
+                                              (whenAtLeast "4.17" yes) ];
+      NF_TABLES_NETDEV            = mkMerge [ (whenOlder "4.17" module)
+                                              (whenAtLeast "4.17" yes) ];
       # IP: Netfilter Configuration
-      NF_TABLES_IPV4              = yes;
-      NF_TABLES_ARP               = whenAtLeast "4.19" yes;
+      NF_TABLES_IPV4              = mkMerge [ (whenOlder "4.17" module)
+                                              (whenAtLeast "4.17" yes) ];
+      NF_TABLES_ARP               = mkMerge [ (whenOlder "4.17" module)
+                                              (whenAtLeast "4.17" yes) ];
       # IPv6: Netfilter Configuration
-      NF_TABLES_IPV6              = yes;
+      NF_TABLES_IPV6              = mkMerge [ (whenOlder "4.17" module)
+                                              (whenAtLeast "4.17" yes) ];
       # Bridge Netfilter Configuration
       NF_TABLES_BRIDGE            = mkMerge [ (whenBetween "4.19" "5.3" yes)
                                               (whenAtLeast "5.3" module) ];
@@ -183,7 +188,8 @@ let
       NET_DROP_MONITOR = yes;
 
       # needed for ss
-      INET_DIAG         = yes;
+      INET_DIAG         = module;
+      INET_TCP_DIAG     = module;
       INET_UDP_DIAG     = module;
       INET_RAW_DIAG     = whenAtLeast "4.14" module;
       INET_DIAG_DESTROY = whenAtLeast "4.9" yes;
@@ -364,7 +370,7 @@ let
       CIFS_STATS        = whenOlder "4.19" yes;
       CIFS_WEAK_PW_HASH = yes;
       CIFS_UPCALL       = yes;
-      CIFS_ACL          = option yes;
+      CIFS_ACL          = whenOlder "5.3" yes;
       CIFS_DFS_UPCALL   = yes;
       CIFS_SMB2         = whenOlder "4.13" yes;
 
@@ -395,7 +401,7 @@ let
       DEBUG_SET_MODULE_RONX            = { optional = true; tristate = whenOlder "4.11" "y"; };
       RANDOMIZE_BASE                   = option yes;
       STRICT_DEVMEM                    = option yes; # Filter access to /dev/mem
-      SECURITY_SELINUX_BOOTPARAM_VALUE = option (freeform "0"); # Disable SELinux by default
+      SECURITY_SELINUX_BOOTPARAM_VALUE = whenOlder "5.1" (freeform "0"); # Disable SELinux by default
       # Prevent processes from ptracing non-children processes
       SECURITY_YAMA                    = option yes;
       DEVKMEM                          = mkIf (!features.grsecurity) no; # Disable /dev/kmem
@@ -707,8 +713,9 @@ let
       KEXEC_FILE      = option yes;
       KEXEC_JUMP      = option yes;
 
+      PARTITION_ADVANCED    = yes; # Needed for LDM_PARTITION
       # Windows Logical Disk Manager (Dynamic Disk) support
-      LDM_PARTITION         = option yes;
+      LDM_PARTITION         = yes;
       LOGIRUMBLEPAD2_FF     = yes; # Logitech Rumblepad 2 force feedback
       LOGO                  = no; # not needed
       MEDIA_ATTACH          = yes;
@@ -793,7 +800,7 @@ let
       SUN8I_DE2_CCU = whenAtLeast "4.13" yes;
 
       # See comments on https://github.com/NixOS/nixpkgs/commit/9b67ea9106102d882f53d62890468071900b9647
-      CRYPTO_AEGIS128_SIMD = no;
+      CRYPTO_AEGIS128_SIMD = whenAtLeast "5.4" no;
     };
   };
 in


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Some of the options didn't have correct kernel version constraints, others had been removed or made optional unnecessarily in #84032.

cc @teto
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
