### PR TITLE
coqPackages.Verdi: 20190202 → 20200131

### DIFF
--- a/pkgs/development/coq-modules/Cheerios/default.nix
+++ b/pkgs/development/coq-modules/Cheerios/default.nix
@@ -2,9 +2,9 @@
 
 let param =
   {
-      version = "20181102";
-      rev = "04da309304bdd28a1f7dacca9fdf8696204a4ff2";
-      sha256 = "1xfa78p70c90favds1mv1vj5sr9bv0ad3dsgg05v3v72006g2f1q";
+      version = "20200201";
+      rev = "9c7f66e57b91f706d70afa8ed99d64ed98ab367d";
+      sha256 = "1h55s6lk47bk0lv5ralh81z55h799jbl9mhizmqwqzy57y8wqgs1";
   };
 in
 
@@ -27,6 +27,6 @@ stdenv.mkDerivation {
   installFlags = [ "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" "8.8" "8.9" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" "8.8" "8.9" "8.10" "8.11" ];
  };
 }

--- a/pkgs/development/coq-modules/InfSeqExt/default.nix
+++ b/pkgs/development/coq-modules/InfSeqExt/default.nix
@@ -2,9 +2,9 @@
 
 let param =
   {
-      version = "20180918";
-      rev = "243d6be45666da73a9da6c37d451327165275798";
-      sha256 = "1nh2psb4pcppy1akk24ilb4p08m35cba357i4xyymmarmbwqpxmn";
+      version = "20200131";
+      rev = "203d4c20211d6b17741f1fdca46dbc091f5e961a";
+      sha256 = "0xylkdmb2dqnnqinf3pigz4mf4zmczcbpjnn59g5g76m7f2cqxl0";
   };
 in
 
@@ -26,6 +26,6 @@ stdenv.mkDerivation {
   installFlags = [ "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" "8.9" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" "8.9" "8.10" "8.11" ];
  };
 }

--- a/pkgs/development/coq-modules/Verdi/default.nix
+++ b/pkgs/development/coq-modules/Verdi/default.nix
@@ -3,9 +3,9 @@
 let param =
   if stdenv.lib.versionAtLeast coq.coq-version "8.7" then
   {
-      version = "20190202";
-      rev = "bc193be9ea8485add7646a0f72e2aa76a9c7e01f";
-      sha256 = "1adkwxnmc9qfah2bya0hpd2vzkmk1y212z4n7fcmvr1a85ykgd7z";
+      version = "20200131";
+      rev = "fdb4ede19d2150c254f0ebcfbed4fb9547a734b0";
+      sha256 = "1a2k19f9q5k5djbxplqmmpwck49kw3lrm3aax920h4yb40czkd8m";
   } else {
       version = "20181102";
       rev = "25b79cf1be5527ab8dc1b8314fcee93e76a2e564";
@@ -32,6 +32,6 @@ stdenv.mkDerivation {
   installFlags = [ "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" "8.8" "8.9" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" "8.8" "8.9" "8.10" "8.11" ];
  };
 }


### PR DESCRIPTION
###### Motivation for this change

Compatibility with Coq ≥ 8.10

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
