### PR TITLE
ardour: add ardour 6 and make it the default

### DIFF
--- a/pkgs/applications/audio/ardour/5.nix
+++ b/pkgs/applications/audio/ardour/5.nix
@@ -4,78 +4,74 @@
 , aubio
 , boost
 , cairomm
-, cppunit
 , curl
-, dbus
 , doxygen
-, fftw
 , fftwSinglePrec
 , flac
-, fluidsynth
 , glibc
 , glibmm
 , graphviz
 , gtkmm2
-, hidapi
-, itstool
-, libarchive
 , libjack2
 , liblo
-, libltc
 , libogg
-, libpulseaudio
-, librdf_raptor
-, librdf_rasqal
 , libsamplerate
 , libsigcxx
 , libsndfile
 , libusb1
-, libuv
-, libwebsockets
+, fluidsynth_1
+, hidapi
+, libltc
+, qm-dsp
 , libxml2
-, libxslt
 , lilv
 , lrdf
 , lv2
-, pango
 , perl
 , pkg-config
-, python3
-, qm-dsp
-, readline
+, itstool
+, python2
 , rubberband
 , serd
 , sord
 , sratom
-, suil
 , taglib
 , vamp-plugin-sdk
+, dbus
+, fftw
+, pango
+, suil
+, libarchive
 , wafHook
 }:
-stdenv.mkDerivation rec {
-  pname = "ardour";
-  version = "6.0";
+let
+  # Ardour git repo uses a mix of annotated and lightweight tags. Annotated
+  # tags are used for MAJOR.MINOR versioning, and lightweight tags are used
+  # in-between; MAJOR.MINOR.REV where REV is the number of commits since the
+  # last annotated tag. A slightly different version string format is needed
+  # for the 'revision' info that is built into the binary; it is the format of
+  # "git describe" when _not_ on an annotated tag(!): MAJOR.MINOR-REV-HASH.
 
-  # don't fetch releases from the GitHub mirror, they are broken
+  # Version to build.
+  tag = "5.12";
+in stdenv.mkDerivation rec {
+  pname = "ardour_5";
+  version = "5.12";
+
   src = fetchgit {
     url = "git://git.ardour.org/ardour/ardour.git";
-    rev = version;
-    sha256 = "162jd96zahl05fdmjwvpdfjxbhd6ifbav6xqa0vv6rsdl4zk395q";
+    rev = "ae0dcdc0c5d13483271065c360e378202d20170a";
+    sha256 = "0mla5lm51ryikc2rrk53max2m7a5ds6i1ai921l2h95wrha45nkr";
   };
 
-  patches = [
-    # AS=as in the environment causes build failure https://tracker.ardour.org/view.php?id=8096
-    ./as-flags.patch
-  ];
-
   nativeBuildInputs = [
+    wafHook
+    pkg-config
+    itstool
     doxygen
     graphviz # for dot
-    itstool
     perl
-    pkg-config
-    python3
-    wafHook
+    python2
   ];
 
   buildInputs = [
@@ -83,41 +79,29 @@ stdenv.mkDerivation rec {
     aubio
     boost
     cairomm
-    cppunit
     curl
     dbus
     fftw
     fftwSinglePrec
     flac
-    fluidsynth
     glibmm
     gtkmm2
-    hidapi
-    itstool
-    libarchive
     libjack2
     liblo
-    libltc
     libogg
-    libpulseaudio
-    librdf_raptor
-    librdf_rasqal
     libsamplerate
     libsigcxx
     libsndfile
     libusb1
-    libuv
-    libwebsockets
+    fluidsynth_1
+    hidapi
+    libltc
+    qm-dsp
     libxml2
-    libxslt
     lilv
     lrdf
     lv2
     pango
-    perl
-    python3
-    qm-dsp
-    readline
     rubberband
     serd
     sord
@@ -125,26 +109,24 @@ stdenv.mkDerivation rec {
     suil
     taglib
     vamp-plugin-sdk
+    libarchive
   ];
 
   wafConfigureFlags = [
-    "--cxx11"
-    "--docs"
-    "--freedesktop"
-    "--no-phone-home"
     "--optimize"
-    "--ptformat"
-    "--qm-dsp-include=${qm-dsp}/include/qm-dsp"
-    "--run-tests"
-    "--test"
+    "--docs"
     "--use-external-libs"
+    "--freedesktop"
+    "--with-backends=jack,alsa,dummy"
   ];
 
-  # Ardour's wscript requires git revision and date to be available.
-  # Since they are not, let's generate the file manually.
+  NIX_CFLAGS_COMPILE = "-I${qm-dsp}/include/qm-dsp";
+
+  # ardour's wscript has a "tarball" target but that required the git revision
+  # be available. Since this is an unzipped tarball fetched from github we
+  # have to do that ourself.
   postPatch = ''
-    printf '#include "libs/ardour/ardour/revision.h"\nnamespace ARDOUR { const char* revision = "${version}"; const char* date = ""; }\n' > libs/ardour/revision.cc
-    sed 's|/usr/include/libintl.h|${glibc.dev}/include/libintl.h|' -i wscript
+    printf '#include "libs/ardour/ardour/revision.h"\nnamespace ARDOUR { const char* revision = \"${tag}-${builtins.substring 0 8 src.rev}\"; }\n' > libs/ardour/revision.cc
     patchShebangs ./tools/
   '';
 
@@ -152,16 +134,14 @@ stdenv.mkDerivation rec {
     # wscript does not install these for some reason
     install -vDm 644 "build/gtk2_ardour/ardour.xml" \
       -t "$out/share/mime/packages"
-    install -vDm 644 "build/gtk2_ardour/ardour6.desktop" \
+    install -vDm 644 "build/gtk2_ardour/ardour5.desktop" \
       -t "$out/share/applications"
     for size in 16 22 32 48 256 512; do
       install -vDm 644 "gtk2_ardour/resources/Ardour-icon_''${size}px.png" \
-        "$out/share/icons/hicolor/''${size}x''${size}/apps/ardour6.png"
+        "$out/share/icons/hicolor/''${size}x''${size}/apps/ardour5.png"
     done
     install -vDm 644 "ardour.1"* -t "$out/share/man/man1"
   '';
-
-  LINKFLAGS = "-lpthread";
 
   meta = with stdenv.lib; {
     description = "Multi-track hard disk recording software";
@@ -177,6 +157,6 @@ stdenv.mkDerivation rec {
     homepage = "https://ardour.org/";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ goibhniu magnetophon ];
+    maintainers = with maintainers; [ goibhniu fps ];
   };
 }

--- a/pkgs/applications/audio/ardour/as-flags.patch
+++ b/pkgs/applications/audio/ardour/as-flags.patch
@@ -1,0 +1,12 @@
+--- a/libs/ardour/wscript
++++ b/libs/ardour/wscript
+@@ -379,8 +379,7 @@ def build(bld):
+
+     # remove '${DEFINES_ST:DEFINES}' from run_str.
+     # x86_64-w64-mingw32-as (mingw) -D flag is for debug messages
+-    if bld.env['build_target'] == 'mingw':
+-        class asm(Task.classes['asm']): run_str = '${AS} ${ASFLAGS} ${ASMPATH_ST:INCPATHS} ${AS_SRC_F}${SRC} ${AS_TGT_F}${TGT}'
++    class asm(Task.classes['asm']): run_str = '${AS} ${ASFLAGS} ${ASMPATH_ST:INCPATHS} ${AS_SRC_F}${SRC} ${AS_TGT_F}${TGT}'
+
+     # operate on copy to avoid adding sources twice
+     sources = list(libardour_sources)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18634,6 +18634,8 @@ in
 
   ardour = callPackage ../applications/audio/ardour { };
 
+  ardour_5 = callPackage ../applications/audio/ardour/5.nix { };
+
   arelle = with python3Packages; toPythonApplication arelle;
 
   argo = callPackage ../applications/networking/cluster/argo { };


### PR DESCRIPTION
We leave Ardour 5 in, since Ardour 6 has a new latency compensation
algorithm, so your mixes might end up sounding different in the new version.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
