### PR TITLE
deepin.qt5dxcb-plugin: 5.0.1 -> 5.0.11

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -54,8 +54,8 @@ let
     go-gir-generator = callPackage ./go-gir-generator { };
     go-lib = callPackage ./go-lib { };
     qcef = callPackage ./qcef { };
-    qt5dxcb-plugin = callPackage ./qt5dxcb-plugin { };
     qt5integration = callPackage ./qt5integration { };
+    qt5platform-plugins = callPackage ./qt5platform-plugins { };
     startdde = callPackage ./startdde { };
     udisks2-qt5 = callPackage ./udisks2-qt5 { };
 

--- a/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
+++ b/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
@@ -51,8 +51,6 @@ mkDerivation rec {
     "INSTALL_PATH=${placeholder "out"}/${qtbase.qtPluginPrefix}/platforms"
   ];
 
-  enableParallelBuilding = true;
-
   passthru.updateScript = deepin.updateScript { inherit pname version; src = (builtins.head srcs); };
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
+++ b/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
@@ -13,14 +13,14 @@
 
 mkDerivation rec {
   pname = "qt5dxcb-plugin";
-  version = "5.0.1";
+  version = "5.0.11";
 
   srcs = [
     (fetchFromGitHub {
       owner = "linuxdeepin";
       repo = pname;
       rev = version;
-      sha256 = "1pkhbx4hzjv7n4mscv7dng9ymjcc1csdc82iy62yxshhq32bcfja";
+      sha256 = "14xkr3p49716jc9v7ksj6jgcmfa65qicqrmablizfi71srg3z2pr";
     })
     qtbase.src
   ];

--- a/pkgs/desktops/deepin/qt5integration/default.nix
+++ b/pkgs/desktops/deepin/qt5integration/default.nix
@@ -8,7 +8,7 @@
 , qtx11extras
 , qtmultimedia
 , qtsvg
-, qt5dxcb-plugin
+, qt5platform-plugins
 , qtstyleplugins
 , dtkcore
 , dtkwidget
@@ -34,7 +34,7 @@ mkDerivation rec {
   buildInputs = [
     dtkcore
     dtkwidget
-    qt5dxcb-plugin
+    qt5platform-plugins
     mtdev
     lxqt.libqtxdg
     qtstyleplugins

--- a/pkgs/desktops/deepin/qt5platform-plugins/default.nix
+++ b/pkgs/desktops/deepin/qt5platform-plugins/default.nix
@@ -12,7 +12,7 @@
 }:
 
 mkDerivation rec {
-  pname = "qt5dxcb-plugin";
+  pname = "qt5platform-plugins";
   version = "5.0.11";
 
   srcs = [
@@ -55,7 +55,7 @@ mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Qt platform theme integration plugin for DDE";
-    homepage = "https://github.com/linuxdeepin/qt5dxcb-plugin";
+    homepage = "https://github.com/linuxdeepin/qt5platform-plugins";
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ romildo ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Update to version [5.0.11](https://github.com/linuxdeepin/qt5platform-plugins/tags)
- Rename to `qt5platform-plugins` (following upstream).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
