### PR TITLE
atk: Fix buildInputs vs nativeBuildInputs

### DIFF
--- a/pkgs/development/libraries/atk/default.nix
+++ b/pkgs/development/libraries/atk/default.nix
@@ -17,9 +17,12 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  buildInputs = stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
+  buildInputs = [
+    gobject-introspection
+    glib
+  ] ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext gobject-introspection glib ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext ];
 
   propagatedBuildInputs = [
     # Required by atk.pc


### PR DESCRIPTION
###### Motivation for this change

This should supposedly make cross-compilation proceed past the configure stage. Otherwise it fails because the library dependencies meant to be for target were in `nativeBuildInputs`.

The cross-compilation still does not work, however, because `gobject-introspection` and `mesa`, both dependencies of atk, fail to cross-compile. See #88961 #88959 and https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/344.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Ericson2314 @7c6f434c