### PR TITLE
snort: 2.9.11.1 -> 2.9.16

### DIFF
--- a/pkgs/applications/networking/ids/snort/default.nix
+++ b/pkgs/applications/networking/ids/snort/default.nix
@@ -1,16 +1,16 @@
-{stdenv, fetchurl, libpcap, pcre, libdnet, daq, zlib, flex, bison, makeWrapper}:
+{stdenv, pkgconfig, luajit, openssl, fetchurl, libpcap, pcre, libdnet, daq, zlib, flex, bison, makeWrapper}:
 
 stdenv.mkDerivation rec {
-  version = "2.9.11.1";
+  version = "2.9.16";
   pname = "snort";
   
   src = fetchurl {
     name = "${pname}-${version}.tar.gz";
     url = "https://snort.org/downloads/archive/snort/${pname}-${version}.tar.gz";
-    sha256 = "1ka67zrrhs32c729v4h76mvv2723mij0adxx0iaza2d1qpm3lswz";
+    sha256 = "1mxspk0060f62xp631w589b9ryb21qygn020az3dw2fsy7nxi24n";
   };
   
-  buildInputs = [ makeWrapper libpcap pcre libdnet daq zlib flex bison ];
+  buildInputs = [ makeWrapper pkgconfig luajit openssl libpcap pcre libdnet daq zlib flex bison ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
