### PR TITLE
ssldump: 0.9b3 -> 1.1

### DIFF
--- a/pkgs/tools/networking/ssldump/default.nix
+++ b/pkgs/tools/networking/ssldump/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "ssldump";
-  version = "0.9b3";
+  version = "1.1";
 
   src = fetchFromGitHub {
     owner = "adulau";
     repo = "ssldump";
-    rev = "4529d03a50d39d3697c3e39a3d6f6c9b29448aa0";
-    sha256 = "0wwsamzxabfxcil5y2g4v2261vdspxlp12wz4xhji8607jbyjwr1";
+    rev = "7491b9851505acff95b2c68097e9b9f630d418dc";
+    sha256 = "1j3rln86khdnc98v50hclvqaq83a24c1rfzbcbajkbfpr4yxpnpd";
   };
 
   buildInputs = [ libpcap openssl ];


### PR DESCRIPTION


###### Motivation for this change

Version bump 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
