### PR TITLE
gcc: optimize cross-compiled libraries

### DIFF
--- a/pkgs/development/compilers/gcc/common/extra-target-flags.nix
+++ b/pkgs/development/compilers/gcc/common/extra-target-flags.nix
@@ -5,9 +5,12 @@ let
 in
 
 {
+  # For non-cross builds these flags are currently assigned in builder.sh.
+  # It would be good to consolidate the generation of makeFlags
+  # ({C,CXX,LD}FLAGS_FOR_{BUILD,TARGET}, etc...) at some point.
   EXTRA_TARGET_FLAGS = let
       mkFlags = dep: langD: lib.optionals (targetPlatform != hostPlatform && dep != null && !langD) ([
-        "-idirafter ${lib.getDev dep}${dep.incdir or "/include"}"
+        "-O2 -idirafter ${lib.getDev dep}${dep.incdir or "/include"}"
       ] ++ stdenv.lib.optionals (! crossStageStatic) [
         "-B${lib.getLib dep}${dep.libdir or "/lib"}"
       ]);


### PR DESCRIPTION
`libstdc++` and a few other libraries are comiled with the options set in `EXTRA_TARGET_FLAGS`. Normally, this is filled form `EXTRA_FLAGS` inside of `builder.sh`, from which it inherits its optimization option. 
For cross compilers `EXTRA_TARGET_FLAGS` is set by a dedicated function that does not specify any optimization, leading to sub-par runtime performance of many C++ programs.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Ericson2314 @matthewbauer 
