### PR TITLE
idris2: 0.2.0-840e020 -> 0.2.0

### DIFF
--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -3,15 +3,15 @@
 }:
 
 # Uses scheme to bootstrap the build of idris2
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "idris2";
-  version = "0.2.0-840e020";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "idris-lang";
     repo = "Idris2";
-    rev = "840e020d8ccc332135e86f855ad78053ca15d603";
-    sha256 = "1l6pdjiglwd13pf56xwzbjzyyxgz48ypfggjgsgqk2w57rmbfy90";
+    rev = "v${version}";
+    sha256 = "153z6zgb90kglw8rspk8ph5gh5nkplhi27mxai6yqbbjs2glx5d4";
   };
 
   strictDeps = true;
@@ -20,19 +20,18 @@ stdenv.mkDerivation {
 
   prePatch = ''
     patchShebangs --build tests
-
-    # Do not run tests as part of the build process
-    substituteInPlace bootstrap.sh --replace "make test" "# make test"
   '';
 
   makeFlags = [ "PREFIX=$(out)" ];
 
   # The name of the main executable of pkgs.chez is `scheme`
-  buildFlags = [ "bootstrap" "SCHEME=scheme" ];
+  buildFlags = [ "bootstrap-build" "SCHEME=scheme" ];
+
+  checkTarget = "bootstrap-test";
 
   # idris2 needs to find scheme at runtime to compile
   postInstall = ''
-    wrapProgram "$out/bin/idris2" --prefix PATH : "${chez}/bin"
+    wrapProgram "$out/bin/idris2" --set CHEZ "${chez}/bin/scheme"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
* Upgrade to release version of idris2
* Add config for proper testing phase

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
