### PR TITLE
pinnwand: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/pygments-better-html/default.nix
+++ b/pkgs/development/python-modules/pygments-better-html/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pygments
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "pygments_better_html";
+  version = "0.1.4";
+  disabled = ! isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "028szd3k295yhz943bj19i4kx6f0pfh1fd2q14id0g84dl4i49dm";
+  };
+
+  propagatedBuildInputs = [ pygments ];
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pygments_better_html" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Kwpolska/pygments_better_html";
+    description = "Improved line numbering for Pygments’ HTML formatter.";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/pinnwand/default.nix
+++ b/pkgs/servers/pinnwand/default.nix
@@ -1,0 +1,45 @@
+{ lib, python3, fetchFromGitHub }:
+
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      tornado = super.tornado.overridePythonAttrs (oldAttrs: rec {
+        version = "6.0.4";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "1p5n7sw4580pkybywg93p8ddqdj9lhhy72rzswfa801vlidx9qhg";
+        };
+      });
+    };
+  };
+in with python.pkgs; buildPythonApplication rec {
+  pname = "pinnwand";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0j5fbdma9zahx8d4xdj167gqkshzn7c98587awrzxv7wwbmlazxd";
+  };
+
+  propagatedBuildInputs = [
+    click
+    docutils
+    tornado
+    pygments-better-html
+    toml
+    sqlalchemy
+  ];
+
+  # tests are only available when fetching from GitHub, where they in turn don't have a setup.py :(
+  checkPhase = ''
+    $out/bin/pinnwand --help > /dev/null
+  '';
+
+  meta = with lib; {
+    homepage = "https://supakeen.com/project/pinnwand/";
+    license = licenses.mit;
+    description = "A Python pastebin that tries to keep it simple.";
+    maintainers = with maintainers; [ hexa ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5974,6 +5974,8 @@ in
 
   pingtcp = callPackage ../tools/networking/pingtcp { };
 
+  pinnwand = callPackage ../servers/pinnwand { };
+
   pirate-get = callPackage ../tools/networking/pirate-get { };
 
   pipreqs = callPackage ../tools/misc/pipreqs { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6967,6 +6967,8 @@ in {
 
   ansi = callPackage ../development/python-modules/ansi { };
 
+  pygments-better-html = callPackage ../development/python-modules/pygments-better-html { };
+
   pygments-markdown-lexer = callPackage ../development/python-modules/pygments-markdown-lexer { };
 
   telegram = callPackage ../development/python-modules/telegram { };


### PR DESCRIPTION
###### Motivation for this change

> A Python pastebin that tries to keep it simple. https://supakeen.com/project/pinnwand

https://github.com/supakeen/pinnwand

This is the pastebin software used at https://bpa.st/.

Had to <s>introduce `tornado_6` and<&s> package `pygments-better-html` (has no tests) as dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
