### PR TITLE
deepin.dde-qt-dbus-factory: 5.0.1 -> 5.1.0.1

### DIFF
--- a/pkgs/desktops/deepin/dde-qt-dbus-factory/default.nix
+++ b/pkgs/desktops/deepin/dde-qt-dbus-factory/default.nix
@@ -33,8 +33,6 @@ stdenv.mkDerivation rec {
     "QMAKE_PKGCONFIG_PREFIX=${placeholder "out"}"
   ];
 
-  enableParallelBuilding = true;
-
   passthru.updateScript = deepin.updateScript { inherit pname version src; };
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/deepin/dde-qt-dbus-factory/default.nix
+++ b/pkgs/desktops/deepin/dde-qt-dbus-factory/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "dde-qt-dbus-factory";
-  version = "5.0.1";
+  version = "5.1.0.1";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1wbh4jgvy3c09ivy0vvfk0azkg4d2sv37y23c9rq49jb3sakcjgm";
+    sha256 = "1bfl8dhm5ms93kxlfdvn08ax8h7ab64z8hsdfdrn86mwhlkvm1lq";
   };
 
   nativeBuildInputs = [
@@ -28,6 +28,10 @@ stdenv.mkDerivation rec {
       libdframeworkdbus/DFrameworkdbusConfig.in \
       libdframeworkdbus/libdframeworkdbus.pro
   '';
+
+  qmakeFlags = [
+    "QMAKE_PKGCONFIG_PREFIX=${placeholder "out"}"
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [5.1.0.1](https://github.com/linuxdeepin/dde-qt-dbus-factory/tags)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
