### PR TITLE
doas: add NixOS binary dirs to safe PATH

### DIFF
--- a/pkgs/tools/security/doas/0001-add-NixOS-specific-dirs-to-safe-PATH.patch
+++ b/pkgs/tools/security/doas/0001-add-NixOS-specific-dirs-to-safe-PATH.patch
@@ -1,0 +1,24 @@
+From 9218347b8f833ab05d016dfba5617dcdeb59eb7b Mon Sep 17 00:00:00 2001
+From: Cole Helbling <cole.e.helbling@outlook.com>
+Date: Wed, 27 May 2020 08:02:57 -0700
+Subject: [PATCH] add NixOS-specific dirs to safe PATH
+
+---
+ doas.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/doas.c b/doas.c
+index e253905..2fdb20f 100644
+--- a/doas.c
++++ b/doas.c
+@@ -234,6 +234,7 @@ int
+ main(int argc, char **argv)
+ {
+ 	const char *safepath = "/bin:/sbin:/usr/bin:/usr/sbin:"
++	    "/run/current-system/sw/bin:/run/current-system/sw/sbin:/run/wrappers/bin:"
+ 	    "/usr/local/bin:/usr/local/sbin";
+ 	const char *confpath = NULL;
+ 	char *shargv[] = { NULL, NULL };
+-- 
+2.26.2
+

--- a/pkgs/tools/security/doas/default.nix
+++ b/pkgs/tools/security/doas/default.nix
@@ -26,6 +26,12 @@ stdenv.mkDerivation rec {
     "--pamdir=${placeholder "out"}/etc/pam.d"
   ];
 
+  patches = [
+    # Allow doas to discover binaries in /run/current-system/sw/{s,}bin and
+    # /run/wrappers/bin
+    ./0001-add-NixOS-specific-dirs-to-safe-PATH.patch
+  ];
+
   postPatch = ''
     sed -i '/\(chown\|chmod\)/d' bsd.prog.mk
   '';


### PR DESCRIPTION
I recently tried to give myself passwordless `doas` for `virsh` commands
(starting, stopping, and editing VMs), but `doas` was complaining that
it didn't know what `virsh` was.

This patch adds `/run/current-system/sw/{s,}bin` and `/run/wrappers/bin`
to the safe path, allowing system binaries to be discovered and executed
properly.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

~~A draft because I'd like to know: should I also add `/run/wrappers/bin` to the safe path?~~

EDIT: discussed with @emilazy on IRC, and we determined it should be added (it has things like `ping`!)

EDIT2: We also discussed removing the FHS paths, but it doesn't hurt to keep them in... Additionally, somebody might be using `doas` on non-NixOS (for whatever reason) or in a `buildFHSEnv` (I don't actually know if that's possible but I don't have the desire to test it).