### PR TITLE
poezio: 0.12 -> 0.13

### DIFF
--- a/pkgs/applications/networking/instant-messengers/poezio/default.nix
+++ b/pkgs/applications/networking/instant-messengers/poezio/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonApplication, fetchFromGitHub, pythonOlder
-, pytest, aiodns, slixmpp, pyinotify, potr, mpd2, cffi, pkgconfig }:
+, pytest, aiodns, slixmpp, pyinotify, potr, mpd2, cffi, pkgconfig, setuptools }:
 buildPythonApplication rec {
     pname = "poezio";
     version = "0.13";
@@ -7,7 +7,7 @@ buildPythonApplication rec {
     disabled = pythonOlder "3.4";
 
     checkInputs = [ pytest ];
-    propagatedBuildInputs = [ aiodns slixmpp pyinotify potr mpd2 cffi ];
+    propagatedBuildInputs = [ aiodns slixmpp pyinotify potr mpd2 cffi setuptools ];
     nativeBuildInputs = [ pkgconfig ];
 
     src = fetchFromGitHub {

--- a/pkgs/applications/networking/instant-messengers/poezio/default.nix
+++ b/pkgs/applications/networking/instant-messengers/poezio/default.nix
@@ -2,7 +2,7 @@
 , pytest, aiodns, slixmpp, pyinotify, potr, mpd2, cffi, pkgconfig }:
 buildPythonApplication rec {
     pname = "poezio";
-    version = "0.12.1";
+    version = "0.13";
 
     disabled = pythonOlder "3.4";
 
@@ -14,7 +14,7 @@ buildPythonApplication rec {
       owner = pname;
       repo = pname;
       rev = "v${version}";
-      sha256 = "04qnsr0l12i55k6xl4q4akx317gai9wv5f1wpkfkq01wp181i5ll";
+      sha256 = "14ig7va0yf5wdhi8hk00f1wni8pj37agggdnvsicvcw2rz1cdw0x";
     };
 
     checkPhase = ''

--- a/pkgs/development/python-modules/slixmpp/default.nix
+++ b/pkgs/development/python-modules/slixmpp/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "slixmpp";
-  version = "1.4.2";
+  version = "1.5.2";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0rqpmscxjznxyz3dyxpc56gib319k01vl837r8g8w57dinz4y863";
+    sha256 = "0c5g4r5c6zm5fgvk6dd0dbx9gl3ws2swajc5knlacnpfykwzp5b4";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Replaces  https://github.com/NixOS/nixpkgs/pull/87416 and https://github.com/NixOS/nixpkgs/pull/87416

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
