### PR TITLE
pythonPackages.svgwrite: 1.3.1 -> 1.4

### DIFF
--- a/pkgs/development/python-modules/svgwrite/default.nix
+++ b/pkgs/development/python-modules/svgwrite/default.nix
@@ -1,20 +1,25 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, isPy3k
+, pythonOlder
 , pyparsing
 , pytest
 }:
 
 buildPythonPackage rec {
   pname = "svgwrite";
-  version = "1.3.1";
+  version = "1.4";
 
   src = fetchFromGitHub {
     owner = "mozman";
     repo = "svgwrite";
     rev = "v${version}";
-    sha256 = "14wz0y118a5wwfzin6cirr9254p4y825lnrnackihdbpw22gcw11";
+    sha256 = "15xjz5b4dw1sg3a5k4wmzky4h5v1n937id8vl6hha1a2xj42z2s5";
   };
+
+  # svgwrite requires Python 3.6 or newer
+  disabled = !isPy3k || pythonOlder "3.6";
 
   propagatedBuildInputs = [
     pyparsing

--- a/pkgs/development/python-modules/svgwrite/default.nix
+++ b/pkgs/development/python-modules/svgwrite/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , isPy3k
 , pythonOlder
-, pyparsing
 , pytest
 }:
 
@@ -19,11 +18,7 @@ buildPythonPackage rec {
   };
 
   # svgwrite requires Python 3.6 or newer
-  disabled = !isPy3k || pythonOlder "3.6";
-
-  propagatedBuildInputs = [
-    pyparsing
-  ];
+  disabled = pythonOlder "3.6";
 
   checkInputs = [
     pytest


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Upstream update with better support for Python 3.8.
Disabled package for unsupported Python versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
