### PR TITLE
pythonPackages.nodeenv: add setuptools to propagatedBuildInputs

### DIFF
--- a/pkgs/development/python-modules/nodeenv/default.nix
+++ b/pkgs/development/python-modules/nodeenv/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, fetchPypi, setuptools }:
 
 buildPythonPackage rec {
   pname = "nodeenv";
@@ -8,6 +8,10 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "ad8259494cf1c9034539f6cced78a1da4840a4b157e23640bc4a0c0546b0cb7a";
   };
+
+  propagatedBuildInputs = [
+    setuptools
+  ];
 
   # Tests not included in PyPI tarball
   doCheck = false;


### PR DESCRIPTION

###### Motivation for this change

Was working on https://github.com/NixOS/nixpkgs/pull/88456 and found that nodeenv doesn't work, that PR is a fix proposed by @FRidh in https://github.com/NixOS/nixpkgs/pull/88456#issuecomment-633957718

Problem:

```
❯ nodeenv
Traceback (most recent call last):
  File "/nix/store/li46lf445jpcj451c5rq6pd5hhj4frg3-python3.7-nodeenv-1.3.3/bin/.nodeenv-wrapped", line 6, in <module>
    from nodeenv import main
  File "/nix/store/li46lf445jpcj451c5rq6pd5hhj4frg3-python3.7-nodeenv-1.3.3/lib/python3.7/site-packages/nodeenv.py", line 43, in <module>
    from pkg_resources import parse_version
ModuleNotFoundError: No module named 'pkg_resources'

```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
