### PR TITLE
scikit-optimize: 0.6 -> 0.7.4

### DIFF
--- a/pkgs/development/python-modules/scikit-optimize/default.nix
+++ b/pkgs/development/python-modules/scikit-optimize/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, isPy27
+, matplotlib
 , numpy
 , scipy
 , scikitlearn
@@ -10,16 +12,18 @@
 
 buildPythonPackage rec {
   pname = "scikit-optimize";
-  version = "0.6";
+  version = "0.7.4";
+  disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "scikit-optimize";
     repo = "scikit-optimize";
     rev = "v${version}";
-    sha256 = "1srbb20k8ddhpcfxwdflapfh6xfyrd3dnclcg3bsfq1byrcmv0d4";
+    sha256 = "1wjvcvlgan9gps70ghgj42y4v3lhp0r65rwpp1fs4impzqkaxsia";
   };
 
   propagatedBuildInputs = [
+    matplotlib
     numpy
     scipy
     scikitlearn
@@ -30,9 +34,8 @@ buildPythonPackage rec {
     pytest
   ];
 
-  # remove --ignore at next release > 0.6
   checkPhase = ''
-    pytest skopt --ignore skopt/tests/test_searchcv.py
+    pytest skopt
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Updates scikit-optimize to 0.7.4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
