### PR TITLE
imag: init at 0.10.1

### DIFF
--- a/pkgs/applications/misc/imag/default.nix
+++ b/pkgs/applications/misc/imag/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, rustPlatform
+, fetchFromGitHub
+, llvmPackages
+, openssl
+, pkg-config
+, installShellFiles
+, Security
+, gitMinimal
+, utillinuxMinimal
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "imag";
+  version = "0.10.1";
+
+  src = fetchFromGitHub {
+    owner = "matthiasbeyer";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0f9915f083z5qqcxyavj0w6m973c8m1x7kfb89pah5agryy5mkaq";
+  };
+
+  nativeBuildInputs = [ installShellFiles pkg-config ];
+  buildInputs = [ openssl ]
+    ++ stdenv.lib.optional stdenv.isDarwin Security;
+  checkInputs = [ gitMinimal utillinuxMinimal ];
+
+  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
+
+  cargoSha256 = "0n8cw70qh8g4hfwfaxwwxbrrx5hm2z037z8kdhvdpqkxljl9189x";
+
+  checkPhase = ''
+    export HOME=$TMPDIR
+    git config --global user.email "nobody@example.com"
+    git config --global user.name "Nobody"
+
+    # UI tests uses executables directly, so we need to build them before
+    # launching the tests
+    cargo build
+  '' + (
+    # CLI uses the presence of a controlling TTY to check if arguments are
+    # passed in stdin, or in the command-line, so we use script to create
+    # a PTY for us.
+    if !stdenv.isDarwin then ''
+      script -qfec "cargo test --workspace"
+    '' else ''
+      script -q "cargo test --workspace"
+    ''
+  );
+
+  postInstall = ''
+    installShellCompletion target/imag.{bash,fish} --zsh target/_imag
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Commandline personal information management suite";
+    homepage = "https://imag-pim.org/";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ filalex77 minijackson ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20184,6 +20184,10 @@ in
 
   iksemel = callPackage ../development/libraries/iksemel { };
 
+  imag = callPackage ../applications/misc/imag {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   imagej = callPackage ../applications/graphics/imagej { };
 
   imagemagick_light = imagemagick.override {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Based on #77362 by @filalex77 

As discussed there, the differences are:

- Update to 0.10.1, which removes the `Cargo.lock` patch
- Run the tests under a created PTY to make them pass
- Install the shell completion scripts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
