### PR TITLE
Group packages by language/builder via dummy maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5826,6 +5826,14 @@
     githubId = 16385648;
     name = "Niko Pavlinek";
   };
+  nixpkgs-go = {
+    email = "go@nixpkgs";
+    name = "Nixpkgs Go Packages";
+  };
+  nixpkgs-rust = {
+    email = "rust@nixpkgs";
+    name = "Nixpkgs Rust Packages";
+  };
   nixy = {
     email = "nixy@nixy.moe";
     github = "nixy";

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -241,5 +241,9 @@ stdenv.mkDerivation (args // {
   meta = {
     # default to Rust's platforms
     platforms = rustc.meta.platforms;
-  } // meta;
+  } // meta // {
+      # add an extra maintainer to every package
+      maintainers = (meta.maintainers or []) ++
+                    [ stdenv.lib.maintainers.nixpkgs-rust ];
+  };
 })

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -236,7 +236,7 @@ let
     } // meta // {
       # add an extra maintainer to every package
       maintainers = (meta.maintainers or []) ++
-                    [ lib.maintainers.kalbasit ];
+                    [ lib.maintainers.kalbasit lib.maintainers.nixpkgs-go ];
     };
   });
 in if disabled then

--- a/pkgs/development/go-packages/generic/default.nix
+++ b/pkgs/development/go-packages/generic/default.nix
@@ -239,7 +239,11 @@ let
       # Add default meta information
       homepage = "https://${goPackagePath}";
       platforms = go.meta.platforms or lib.platforms.all;
-    } // meta;
+    } // meta // {
+      # add an extra maintainer to every package
+      maintainers = (meta.maintainers or []) ++
+                    [ lib.maintainers.nixpkgs-go ];
+    };
   });
 in if disabled then
   throw "${package.name} not supported for go ${go.meta.branch}"


### PR DESCRIPTION
I'd like to sort these by language/builder for repology, e.g. being able to see which rust packages are outdated.

cc @grahamc @Infinisil 

I don't think this will cause any problems with ofborg, rfc33 or the github id checks?