### PR TITLE
dvb_apps: fix broken package

### DIFF
--- a/pkgs/applications/video/dvb-apps/0001-dvbdate-Remove-Obsoleted-stime-API-calls.patch
+++ b/pkgs/applications/video/dvb-apps/0001-dvbdate-Remove-Obsoleted-stime-API-calls.patch
@@ -1,0 +1,32 @@
+From d6817dbaf407f65dd4af12c51736153fae8b217f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 21 Dec 2019 08:36:11 -0800
+Subject: [PATCH] dvbdate: Remove Obsoleted stime API calls
+
+stime() has been deprecated in glibc 2.31+ its recommended to
+replaced with clock_settime()
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ util/dvbdate/dvbdate.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/util/dvbdate/dvbdate.c b/util/dvbdate/dvbdate.c
+index f0df437..492ed79 100644
+--- a/util/dvbdate/dvbdate.c
++++ b/util/dvbdate/dvbdate.c
+@@ -309,7 +309,10 @@ int atsc_scan_date(time_t *rx_time, unsigned int to)
+  */
+ int set_time(time_t * new_time)
+ {
+-	if (stime(new_time)) {
++	struct timespec ts;
++	ts.tv_sec = &new_time;
++	ts.tv_nsec = 0;
++	if (clock_settime(CLOCK_REALTIME, &ts)) {
+ 		perror("Unable to set time");
+ 		return -1;
+ 	}
+-- 
+2.24.1
+

--- a/pkgs/applications/video/dvb-apps/0003-handle-static-shared-only-build.patch
+++ b/pkgs/applications/video/dvb-apps/0003-handle-static-shared-only-build.patch
@@ -1,0 +1,44 @@
+From a826c7c722db40bfedf00e51ce38411550ae8216 Mon Sep 17 00:00:00 2001
+From: Romain Naour <romain.naour@openwide.fr>
+Date: Thu, 25 Dec 2014 19:22:16 +0100
+Subject: [PATCH] Make.rules: Handle static/shared only build
+
+Do not build .a library when enable_static is set to "no"
+Do not build .so library when enable_shared is set to "no"
+
+Signed-off-by: Romain Naour <romain.naour@openwide.fr>
+---
+ Make.rules | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/Make.rules b/Make.rules
+index 3410d7b..d274e16 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -9,7 +9,13 @@ ifneq ($(lib_name),)
+ CFLAGS_LIB ?= -fPIC
+ CFLAGS += $(CFLAGS_LIB)
+ 
+-libraries = $(lib_name).so $(lib_name).a
++ifneq ($(enable_static),no)
++libraries += $(lib_name).a
++endif
++
++ifneq ($(enable_shared),no)
++libraries += $(lib_name).so
++endif
+ 
+ .PHONY: library
+ 
+@@ -23,7 +29,7 @@ prerequisites = $(subst .o,.d,$(objects)) $(addsuffix .d,$(binaries))
+ 
+ .PHONY: clean install
+ 
+-ifeq ($(static),1)
++ifneq ($(enable_static),no)
+ LDFLAGS += -static
+ endif
+ 
+-- 
+1.9.3
+

--- a/pkgs/applications/video/dvb-apps/0005-utils-fix-build-with-kernel-headers-4.14.patch
+++ b/pkgs/applications/video/dvb-apps/0005-utils-fix-build-with-kernel-headers-4.14.patch
@@ -1,0 +1,52 @@
+# HG changeset patch
+# User "Yann E. MORIN" <yann.morin.1998@free.fr>
+# Date 1511772629 -3600
+#      Mon Nov 27 09:50:29 2017 +0100
+# Branch yem/fixes
+# Node ID 0848fa96c6eb13cf37249d317eff12cbd2f59ff7
+# Parent  3d43b280298c39a67d1d889e01e173f52c12da35
+utils: fix build with kernel headers >= 4.14
+
+In kernel 4.14, CA_SET_PID was removed, in commit 833ff5e7feda (media:
+ca.h: get rid of CA_SET_PID).
+
+Fix dst-util to not fail the build when this is missing.
+
+Fiuxes build failures such as:
+    http://autobuild.buildroot.org/results/708/708f11809b2cafc2a3375dc515803c87b376ed4d/build-end.log
+    http://autobuild.buildroot.org/results/e39/e3939d44376e92e8a35fb179d9890510334d8304/build-end.log
+
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
+
+diff --git a/util/dst-utils/dst_test.c b/util/dst-utils/dst_test.c
+--- a/util/dst-utils/dst_test.c
++++ b/util/dst-utils/dst_test.c
+@@ -111,6 +111,7 @@
+ 	return 0;
+ }
+ 
++#if defined CA_SET_PID
+ static int dst_set_pid(int cafd)
+ {
+ 	if ((ioctl(cafd, CA_SET_PID)) < 0) {
+@@ -120,6 +121,7 @@
+ 
+ 	return 0;
+ }
++#endif
+ 
+ static int dst_get_descr(int cafd)
+ {
+@@ -230,8 +232,12 @@
+ 				dst_reset(cafd);
+ 				break;
+ 			case 'p':
++#if defined CA_SET_PID
+ 				printf("%s: PID\n", __FUNCTION__);
+ 				dst_set_pid(cafd);
++#else
++				printf("%s: PID not supported\n", __FUNCTION__);
++#endif
+ 				break;
+ 			case 'g':
+ 				printf("%s: Get Desc\n", __FUNCTION__);

--- a/pkgs/applications/video/dvb-apps/default.nix
+++ b/pkgs/applications/video/dvb-apps/default.nix
@@ -1,14 +1,21 @@
-{ stdenv, fetchurl, perl }:
+{ stdenv, fetchurl, perl, pkgsi686Linux }:
 
-stdenv.mkDerivation {
-  name = "dvb-apps-7f68f9c8d311";
+pkgsi686Linux.stdenv.mkDerivation {
+  name = "dvb-apps-3d43b280298c";
 
   src = fetchurl {
-    url = "https://linuxtv.org/hg/dvb-apps/archive/7f68f9c8d311.tar.gz";
-    sha256 = "0a6c5jjq6ad98bj0r954l3n7zjb2syw9m19jksg06z4zg1z8yg82";
+    url = "https://www.linuxtv.org/hg/dvb-apps/archive/3d43b280298c.tar.bz2";
+    sha256 = "0mz02mz4j945c53vdwaxrpy6fks19nnn482jhg72pqyppq72z7pk";
   };
 
-  buildInputs = [ perl ];
+  buildInputs = [ perl pkgsi686Linux.glibc.static ];
+
+  patches = [
+    ./0003-handle-static-shared-only-build.patch
+    ./0005-utils-fix-build-with-kernel-headers-4.14.patch
+    ./linuxtv-dvb-apps-1.1.1.20100223-perl526.patch
+    ./0001-dvbdate-Remove-Obsoleted-stime-API-calls.patch
+  ];
 
   dontConfigure = true; # skip configure
 
@@ -19,6 +26,5 @@ stdenv.mkDerivation {
     homepage = "https://linuxtv.org/";
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl2;
-    broken = true; # 2018-04-10
   };
 }

--- a/pkgs/applications/video/dvb-apps/linuxtv-dvb-apps-1.1.1.20100223-perl526.patch
+++ b/pkgs/applications/video/dvb-apps/linuxtv-dvb-apps-1.1.1.20100223-perl526.patch
@@ -1,0 +1,12 @@
+diff -ruN linuxtv-dvb-apps-1.1.1.20100223.orig/util/scan/section_generate.pl linuxtv-dvb-apps-1.1.1.20100223/util/scan/section_generate.pl
+--- linuxtv-dvb-apps-1.1.1.20100223.orig/util/scan/section_generate.pl	2010-02-14 12:21:19.000000000 -0000
++++ linuxtv-dvb-apps-1.1.1.20100223/util/scan/section_generate.pl	2017-08-06 08:35:19.625688435 -0000
+@@ -4,7 +4,7 @@
+ 
+ die "no section perl file given" unless @ARGV;
+ 
+-my $h = require($ARGV[0]);
++my $h = require("./".$ARGV[0]);
+ 
+ our $basename;
+ our $debug = $ARGV[1];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Package dvb_apps was broken and quite old.
This PR upgrades it to its latest version and applies the same patches applied by ArchLinux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I've updated the package and applied patches, according to https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=linuxtv-dvb-apps.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
