### PR TITLE
Revert ".github/CODEOWNERS: add podman team"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -187,9 +187,3 @@
 /pkgs/build-support/build-pecl.nix       @NixOS/php
 /pkgs/development/interpreters/php       @NixOS/php
 /pkgs/top-level/php-packages.nix         @NixOS/php
-
-# Podman, CRI-O modules and related
-/nixos/modules/virtualisation/containers.nix @NixOS/podman
-/nixos/modules/virtualisation/cri-o.nix      @NixOS/podman
-/nixos/modules/virtualisation/podman.nix     @NixOS/podman
-/nixos/tests/podman.nix                      @NixOS/podman


### PR DESCRIPTION
This reverts commit 89b6d5f175e276acdacfdaee2b0bb2e141076ab9.

The team needs write permissions to the repo so it isn't actually useful for us.