### PR TITLE
ocamlPackages.owl: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/development/ocaml-modules/biocaml/default.nix
+++ b/pkgs/development/ocaml-modules/biocaml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildDunePackage, fetchFromGitHub
+{ stdenv, buildDunePackage, fetchFromGitHub, fetchpatch
 , ounit, async, base64, camlzip, cfstream
 , core, ppx_jane, ppx_sexp_conv, rresult, uri, xmlm }:
 
@@ -16,6 +16,12 @@ buildDunePackage rec {
     rev    = "v${version}";
     sha256 = "1f19nc8ld0iv45jjnsvaah3ddj88s2n9wj8mrz726kzg85cfr8xj";
   };
+
+  # fix compilation without and disable -unsafe-string, needed for Ocaml 4.10:
+  patches = [ (fetchpatch {
+      url = "https://github.com/biocaml/biocaml/commit/597fa7b0d203684e45ffe03f56c74335b6173ffc.patch";
+      sha256 = "0b8jdg215cv2k4y3ww7vak2ag5v6v9w8b76qjivr5d1qxz47mqxv";
+  }) ];
 
   buildInputs = [ ppx_jane ppx_sexp_conv ];
   checkInputs = [ ounit ];

--- a/pkgs/development/ocaml-modules/owl-base/default.nix
+++ b/pkgs/development/ocaml-modules/owl-base/default.nix
@@ -2,24 +2,25 @@
 
 buildDunePackage rec {
   pname = "owl-base";
-  version = "0.8.0";
+  version = "0.9.0";
 
   useDune2 = true;
 
   src = fetchFromGitHub {
-    owner  = "owlbarn";
-    repo   = "owl";
-    rev    = version;
-    sha256 = "1j3xmr4izfznmv8lbn8vkx9c77py2xr6fqyn6ypjlf5k9b8g4mmw";
+    owner = "owlbarn";
+    repo = "owl";
+    rev  = version;
+    sha256 = "0xxchsymmdbwszs6barqq8x4vqz5hbap64yxq82c2la9sdxgk0vv";
   };
 
   propagatedBuildInputs = [ stdlib-shims ];
 
-  minimumOCamlVersion = "4.06";
+  minimumOCamlVersion = "4.10";
 
   meta = with stdenv.lib; {
     description = "Numerical computing library for Ocaml";
     homepage = "https://ocaml.xyz";
+    changelog = "https://github.com/owlbarn/owl/releases";
     platforms = platforms.x86_64;
     maintainers = [ maintainers.bcdarwin ];
     license = licenses.mit;


### PR DESCRIPTION
ocamlPackages.biocaml: patch for -safe-string compilation with Ocaml 4.10

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

0.9.0 drops support for Ocaml < 4.10, but Nixpkgs now defaults to 4.10 as of #88605.

Also allows `ctypes` version bump.

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  also built `biocaml` and `phylogenetics`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
