### PR TITLE
nixos/terraria: allow dataDir to be configured

### DIFF
--- a/nixos/modules/services/games/terraria.nix
+++ b/nixos/modules/services/games/terraria.nix
@@ -115,7 +115,7 @@ in
         type        = types.str;
         default     = "/var/lib/terraria";
         example     = "/srv/terraria";
-        description = "Home directory for terraria.";
+        description = "Path to variable state data directory for terraria.";
       };
     };
   };

--- a/nixos/modules/services/games/terraria.nix
+++ b/nixos/modules/services/games/terraria.nix
@@ -25,7 +25,7 @@ let
       exit 0
     fi
 
-    ${getBin pkgs.tmux}/bin/tmux -S /var/lib/terraria/terraria.sock send-keys Enter exit Enter
+    ${getBin pkgs.tmux}/bin/tmux -S ${cfg.dataDir}/terraria.sock send-keys Enter exit Enter
     ${getBin pkgs.coreutils}/bin/tail --pid="$1" -f /dev/null
   '';
 in
@@ -36,7 +36,7 @@ in
         type        = types.bool;
         default     = false;
         description = ''
-          If enabled, starts a Terraria server. The server can be connected to via <literal>tmux -S /var/lib/terraria/terraria.sock attach</literal>
+          If enabled, starts a Terraria server. The server can be connected to via <literal>tmux -S ${cfg.dataDir}/terraria.sock attach</literal>
           for administration by users who are a part of the <literal>terraria</literal> group (use <literal>C-b d</literal> shortcut to detach again).
         '';
       };
@@ -111,13 +111,19 @@ in
         default     = false;
         description = "Disables automatic Universal Plug and Play.";
       };
+      dataDir = mkOption {
+        type        = types.str;
+        default     = "/var/lib/terraria";
+        example     = "/srv/terraria";
+        description = "Home directory for terraria.";
+      };
     };
   };
 
   config = mkIf cfg.enable {
     users.users.terraria = {
       description = "Terraria server service user";
-      home        = "/var/lib/terraria";
+      home        = cfg.dataDir;
       createHome  = true;
       uid         = config.ids.uids.terraria;
     };
@@ -136,13 +142,13 @@ in
         User    = "terraria";
         Type = "forking";
         GuessMainPID = true;
-        ExecStart = "${getBin pkgs.tmux}/bin/tmux -S /var/lib/terraria/terraria.sock new -d ${pkgs.terraria-server}/bin/TerrariaServer ${concatStringsSep " " flags}";
+        ExecStart = "${getBin pkgs.tmux}/bin/tmux -S ${cfg.dataDir}/terraria.sock new -d ${pkgs.terraria-server}/bin/TerrariaServer ${concatStringsSep " " flags}";
         ExecStop = "${stopScript} $MAINPID";
       };
 
       postStart = ''
-        ${pkgs.coreutils}/bin/chmod 660 /var/lib/terraria/terraria.sock
-        ${pkgs.coreutils}/bin/chgrp terraria /var/lib/terraria/terraria.sock
+        ${pkgs.coreutils}/bin/chmod 660 ${cfg.dataDir}/terraria.sock
+        ${pkgs.coreutils}/bin/chgrp terraria ${cfg.dataDir}/terraria.sock
       '';
     };
   };


### PR DESCRIPTION
###### Motivation for this change
add `dataDir` option to terraria module

This was requested [on IRC](https://logs.nix.samueldr.com/nixos/2020-05-27#3523335;), and since the `minecraft` module has a [dataDir](https://github.com/NixOS/nixpkgs/blob/711890f1313ac0d77314c9e2b73b3737af47899a/nixos/modules/services/games/minecraft-server.nix#L78) option, I figured this would be appropriate for the terraria module as well.

___

To test this, I used a basic configuration with `nixos-generators`

<details open>
<summary>configuration.nix</summary>

``` nix
{ config, lib, pkgs, ... }:
{
  services.sshd.enable = true;
  services.terraria = {
    enable = true;
    dataDir = "/srv/terraria";
  };
  nixpkgs.config.allowUnfree = true;

  networking.firewall.allowedTCPPorts = [ 80 ];
  
  users.users.root.password = "nixos";
  services.openssh.permitRootLogin = lib.mkDefault "yes";
  #services.mingetty.autologinUser = lib.mkDefault "root";
}
```

</details>

___

I built the image with `./nixos-generate -c configuration.nix -f vm-nogui --run -I nixpkgs=/home/evanjs/src/nixpkgs` (against a local nixpkgs with my changes)

The vm launches and the terraria service is activated as expected.

<details>
<summary>systemctl status terraria</summary>

``` bash
[root@nixos:~]# systemctl status terraria
● terraria.service - Terraria Server Service
     Loaded: loaded (/nix/store/73rrg3mkc1c4wk5fndlb1x4jlhyml76c-unit-terraria.service/terraria.service; enabled; vendor preset: enabled)
     Active: active (running) since Wed 2020-05-27 16:28:01 UTC; 32s ago
    Process: 729 ExecStart=/nix/store/h72ypgl2sg7p57fj3y2iac6ksvxi3haw-tmux-3.1b/bin/tmux -S /srv/terraria/terraria.sock new -d /nix/store/55h0lqna1fyp4j4sgi0m4zydkqdfigp8-terraria-server-1.4.0.4/bin/TerrariaServer -port 7777 -maxPlayers >
    Process: 737 ExecStartPost=/nix/store/nfirs0yp8vzvg43wg81xym85hqmndhfc-unit-script-terraria-post-start/bin/terraria-post-start (code=exited, status=0/SUCCESS)
   Main PID: 735 (tmux: server)
         IP: 0B in, 0B out
      Tasks: 4 (limit: 411)
     Memory: 267.1M
        CPU: 1.730s
     CGroup: /system.slice/terraria.service
             ├─735 /nix/store/h72ypgl2sg7p57fj3y2iac6ksvxi3haw-tmux-3.1b/bin/tmux -S /srv/terraria/terraria.sock new -d /nix/store/55h0lqna1fyp4j4sgi0m4zydkqdfigp8-terraria-server-1.4.0.4/bin/TerrariaServer -port 7777 -maxPlayers 255 -aut>
             └─736 /nix/store/55h0lqna1fyp4j4sgi0m4zydkqdfigp8-terraria-server-1.4.0.4/bin/TerrariaServer -port 7777 -maxPlayers 255 -autocreate 2

May 27 16:28:01 nixos systemd[1]: Starting Terraria Server Service...
May 27 16:28:01 nixos systemd[1]: Started Terraria Server Service.
```

</details>

`terraria.sock`, the only variable (that I can see) that is affected by the location of the `home` option is also present.
``` bash
[root@nixos:~]# ls /srv/terraria/
terraria.sock
``` 