### PR TITLE
sslyze: init at 3.0.7

### DIFF
--- a/pkgs/development/python-modules/nassl/default.nix
+++ b/pkgs/development/python-modules/nassl/default.nix
@@ -1,0 +1,120 @@
+{ lib
+, fetchFromGitHub
+, fetchurl
+, buildPythonPackage
+, pkgsStatic
+, openssl
+, invoke
+, pytest
+, tls-parser
+, cacert
+}:
+
+let
+  zlibStatic = pkgsStatic.zlib;
+  nasslOpensslArgs = {
+    static = true;
+    enableSSL2 = true;
+  };
+  nasslOpensslFlagsCommon = [
+    "zlib"
+    "no-zlib-dynamic"
+    "no-shared"
+    "--with-zlib-lib=${zlibStatic.out}/lib"
+    "--with-zlib-include=${zlibStatic.out.dev}/include"
+    "enable-rc5"
+    "enable-md2"
+    "enable-gost"
+    "enable-cast"
+    "enable-idea"
+    "enable-ripemd"
+    "enable-mdc2"
+    "-fPIC"
+  ];
+  opensslStatic = (openssl.override nasslOpensslArgs).overrideAttrs (
+    oldAttrs: rec {
+      name = "openssl-${version}";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://www.openssl.org/source/${name}.tar.gz";
+        sha256 = "0gbab2fjgms1kx5xjvqx8bxhr98k4r8l2fa8vw7kvh491xd8fdi8";
+      };
+      configureFlags = oldAttrs.configureFlags ++ nasslOpensslFlagsCommon ++ [
+        "enable-weak-ssl-ciphers"
+        "enable-tls1_3"
+        "no-async"
+      ];
+      patches = [ ./nix-ssl-cert-file.patch ];
+      buildInputs = oldAttrs.buildInputs ++ [ zlibStatic cacert ];
+    }
+  );
+  opensslLegacyStatic = (openssl.override nasslOpensslArgs).overrideAttrs (
+    oldAttrs: rec {
+      name = "openssl-${version}";
+      version = "1.0.2e";
+      src = fetchurl {
+        url = "https://www.openssl.org/source/${name}.tar.gz";
+        sha256 = "1zqb1rff1wikc62a7vj5qxd1k191m8qif5d05mwdxz2wnzywlg72";
+      };
+      configureFlags = oldAttrs.configureFlags ++ nasslOpensslFlagsCommon;
+      patches = [ ];
+      buildInputs = oldAttrs.buildInputs ++ [ zlibStatic ];
+      # openssl_1_0_2 needs `withDocs = false`
+      outputs = lib.remove "doc" oldAttrs.outputs;
+    }
+  );
+in
+buildPythonPackage rec {
+  pname = "nassl";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "nabla-c0d3";
+    repo = pname;
+    rev = version;
+    sha256 = "1dhgkpldadq9hg5isb6mrab7z80sy5bvzad2fb54pihnknfwhp8z";
+  };
+
+  postPatch = ''
+    mkdir -p deps/openssl-OpenSSL_1_0_2e/
+    cp ${opensslLegacyStatic.out}/lib/libssl.a \
+      ${opensslLegacyStatic.out}/lib/libcrypto.a \
+      deps/openssl-OpenSSL_1_0_2e/
+    ln -s ${opensslLegacyStatic.out.dev}/include deps/openssl-OpenSSL_1_0_2e/include 
+    ln -s ${opensslLegacyStatic.bin}/bin deps/openssl-OpenSSL_1_0_2e/apps
+
+    mkdir -p deps/openssl-OpenSSL_1_1_1/
+    cp ${opensslStatic.out}/lib/libssl.a \
+      ${opensslStatic.out}/lib/libcrypto.a \
+      deps/openssl-OpenSSL_1_1_1/
+    ln -s ${opensslStatic.out.dev}/include deps/openssl-OpenSSL_1_1_1/include 
+    ln -s ${opensslStatic.bin}/bin deps/openssl-OpenSSL_1_1_1/apps
+
+    mkdir -p deps/zlib-1.2.11/
+    cp ${zlibStatic.out}/lib/libz.a deps/zlib-1.2.11/
+  '';
+
+  propagatedBuildInputs = [ tls-parser ];
+
+  nativeBuildInputs = [ invoke ];
+
+  buildPhase = ''
+    invoke build.nassl
+    invoke package.wheel
+  '';
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    # Skip online tests
+    pytest -k 'not Online'
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/nabla-c0d3/nassl";
+    description = "Low-level OpenSSL wrapper for Python 3.7+";
+    platforms = with platforms; linux ++ darwin;
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ veehaitch ];
+  };
+}

--- a/pkgs/development/python-modules/nassl/nix-ssl-cert-file.patch
+++ b/pkgs/development/python-modules/nassl/nix-ssl-cert-file.patch
@@ -1,0 +1,14 @@
+diff -ru -x '*~' openssl-1.0.2j-orig/crypto/x509/by_file.c openssl-1.0.2j/crypto/x509/by_file.c
+--- openssl-1.0.2j-orig/crypto/x509/by_file.c	2016-09-26 11:49:07.000000000 +0200
++++ openssl-1.0.2j/crypto/x509/by_file.c	2016-10-13 16:54:31.400288302 +0200
+@@ -97,7 +97,9 @@
+     switch (cmd) {
+     case X509_L_FILE_LOAD:
+         if (argl == X509_FILETYPE_DEFAULT) {
+-            file = getenv(X509_get_default_cert_file_env());
++            file = getenv("NIX_SSL_CERT_FILE");
++            if (!file)
++                file = getenv(X509_get_default_cert_file_env());
+             if (file)
+                 ok = (X509_load_cert_crl_file(ctx, file,
+                                               X509_FILETYPE_PEM) != 0);

--- a/pkgs/development/python-modules/sslyze/default.nix
+++ b/pkgs/development/python-modules/sslyze/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, fetchFromGitHub
+, pytest
+, buildPythonPackage
+, nassl
+, cryptography
+, typing-extensions
+, faker
+}:
+
+buildPythonPackage rec {
+  pname = "sslyze";
+  version = "3.0.7";
+
+  src = fetchFromGitHub {
+    owner = "nabla-c0d3";
+    repo = pname;
+    rev = version;
+    sha256 = "1ahwldsh3xvagin09dy5q73bdw5k4siqy2qqgxwj4wdyd7pjb4p9";
+  };
+
+  patchPhase = ''
+    substituteInPlace setup.py \
+      --replace "cryptography>=2.6,<=2.9" "cryptography>=2.6,<=3"
+  '';
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    # Most of the tests are online; hence, applicable tests are listed
+    # explicitly here
+    pytest \
+      tests/test_main.py \
+      tests/test_scanner.py \
+      tests/cli_tests/test_console_output.py \
+      tests/cli_tests/test_json_output.py \
+      tests/cli_tests/test_server_string_parser.py \
+      tests/plugins_tests/test_scan_commands.py \
+      tests/plugins_tests/certificate_info/test_certificate_utils.py \
+      -k "not (TestScanner and test_client_certificate_missing)"
+  '';
+
+  propagatedBuildInputs = [ nassl cryptography typing-extensions faker ];
+
+  meta = with lib; {
+    homepage = "https://github.com/nabla-c0d3/sslyze";
+    description = "Fast and powerful SSL/TLS scanning library";
+    platforms = platforms.linux ++ platforms.darwin;
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ veehaitch ];
+  };
+}

--- a/pkgs/development/python-modules/tls-parser/default.nix
+++ b/pkgs/development/python-modules/tls-parser/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, isPy27
+, fetchFromGitHub
+, buildPythonPackage
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "tls-parser";
+  version = "1.2.2";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "nabla-c0d3";
+    repo = "tls_parser";
+    rev = version;
+    sha256 = "12qj3vg02r5a51w6gbgb1gcxicqc10lbbsdi57jkkfvbqiindbd0";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    homepage = "https://github.com/nabla-c0d3/tls_parser";
+    description = "Small library to parse TLS records";
+    platforms = with platforms; linux ++ darwin;
+    license = licenses.mit;
+    maintainers = with maintainers; [ veehaitch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22253,6 +22253,8 @@ in
     git = gitMinimal;
   };
 
+  sslyze = with python3Packages; toPythonApplication sslyze;
+
   ssr = callPackage ../applications/audio/soundscape-renderer {};
 
   ssrc = callPackage ../applications/audio/ssrc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -969,6 +969,8 @@ in {
 
   nanomsg-python = callPackage ../development/python-modules/nanomsg-python { inherit (pkgs) nanomsg; };
 
+  nassl = callPackage ../development/python-modules/nassl { };
+
   nbsmoke = callPackage ../development/python-modules/nbsmoke { };
 
   nbsphinx = callPackage ../development/python-modules/nbsphinx { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1555,6 +1555,8 @@ in {
 
   sslib = callPackage ../development/python-modules/sslib { };
 
+  sslyze = callPackage ../development/python-modules/sslyze { };
+
   statistics = callPackage ../development/python-modules/statistics { };
 
   stm32loader = callPackage ../development/python-modules/stm32loader { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1583,6 +1583,8 @@ in {
 
   tesserocr = callPackage ../development/python-modules/tesserocr { };
 
+  tls-parser = callPackage ../development/python-modules/tls-parser { };
+
   trueskill = callPackage ../development/python-modules/trueskill { };
 
   trustme = callPackage ../development/python-modules/trustme {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds the Python package / application `sslyze`: [SSLyze is a fast and powerful SSL/TLS scanning library](https://github.com/nabla-c0d3/sslyze/).

SSLyze relies on [Nassl](https://github.com/nabla-c0d3/nassl) which uses OpenSSL 1.1. but also OpenSSL 1.0.2e. This legacy version of OpenSSL is—with good reason—marked as insecure in Nixpkgs. In this particular case, however, it is unwanted that OpenSSL 1.0.2e refuses to evaluate due to the known vulnerabilities attribute; SSLyze is a security scanner which leverages OpenSSL 1.0.2e on purpose. As a result, to install Nassl or SSLyze, one has to explicitly allow the evaluation of OpenSSL 1.0.2e _globally_. It would be great if we could allow evaluation just for the Nassl Python package. I'm not sure, however, if this is possible at all without duplicating the derivation of OpenSSL 1.0.2e.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
