### PR TITLE
python3Packages.pyatv: 0.3.13 -> 0.6.1

### DIFF
--- a/pkgs/development/python-modules/pyatv/default.nix
+++ b/pkgs/development/python-modules/pyatv/default.nix
@@ -1,19 +1,49 @@
-{ stdenv, buildPythonPackage, fetchPypi, srptools, aiohttp, zeroconf
-, ed25519, cryptography, curve25519-donna, pytest, pytestrunner
-, netifaces, asynctest, virtualenv, toml, filelock, tox }:
+{ stdenv, buildPythonPackage, fetchPypi
+, aiohttp
+, aiozeroconf
+, asynctest
+, cryptography
+, deepdiff
+, netifaces
+, protobuf
+, pytest
+, pytest-aiohttp
+, pytest-asyncio
+, pytestrunner
+, srptools
+}:
 
 buildPythonPackage rec {
   pname = "pyatv";
-  version = "0.3.13";
+  version = "0.6.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8fc1a903a9d666e4109127410d35a83458559a86bc0de3fe1ffb3f15d2d653b3";
+    sha256 = "0f9wj1ggllwpjd9nh6nsrck7m4gbz29q6vqbrhbkc2kz6waqkgwc";
   };
 
-  propagatedBuildInputs = [ srptools aiohttp zeroconf ed25519 cryptography curve25519-donna tox ];
+  nativeBuildInputs = [ pytestrunner];
 
-  checkInputs = [ pytest pytestrunner netifaces asynctest virtualenv toml filelock ];
+  propagatedBuildInputs = [
+    aiozeroconf
+    srptools
+    aiohttp
+    protobuf
+    cryptography
+    netifaces
+  ];
+
+  checkInputs = [
+    deepdiff
+    pytest
+    pytest-aiohttp
+    pytest-asyncio
+  ];
+
+  # just run vanilla pytest to avoid inclusion of coverage reports and xdist
+  checkPhase = ''
+    pytest
+  '';
 
   meta = with stdenv.lib; {
     description = "A python client library for the Apple TV";


### PR DESCRIPTION
###### Motivation for this change
noticed it was failing when revieing another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
