### PR TITLE
datasette: add setuptools to propagatedBuildInputs

### DIFF
--- a/pkgs/development/python-modules/datasette/default.nix
+++ b/pkgs/development/python-modules/datasette/default.nix
@@ -18,6 +18,7 @@
 , aiohttp
 , beautifulsoup4
 , asgiref
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -43,6 +44,7 @@ buildPythonPackage rec {
     pint
     pluggy
     uvicorn
+    setuptools
   ];
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change

Installed datasette via `nix-shell -p python37Packages.datasette` and even it installed fine, running gave the ['no module named pkg_resources'](https://nixos.wiki/wiki/Packaging/Python#ModuleNotFoundError:_No_module_named_.27pkg_resources.27).

It's my first contribution to nixpkgs and I'm quite noob and I'm still trying to figure out how to tick some of the checkboxes below.

###### Things done

```
nix repl
:l /path/to/my/nixpkgs
:b python37Packages.datasette
:i python37Packages.datasette
c-d
datasette # <- runs ok
```

- [ ] Tested using sandboxing [](([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox)) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
