### PR TITLE
klavaro: 3.08 -> 3.09

### DIFF
--- a/pkgs/games/klavaro/default.nix
+++ b/pkgs/games/klavaro/default.nix
@@ -2,12 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "klavaro";
-  version = "3.08";
+  version = "3.09";
 
   src = fetchurl {
     url = "mirror://sourceforge/klavaro/${pname}-${version}.tar.bz2";
-    sha256 = "0qmvr6d8wshwp0xvk5wbig4vlzxzcxrakhyhd32v8v3s18nhqsrc";
+    sha256 = "12gml7h45b1w9s318h0d5wxw92h7pgajn2kh57j0ak9saq0yb0wr";
   };
+
+  # Fix for https://sourceforge.net/p/klavaro/bugs/56/
+  patches = [ ./patch1 ];
 
   nativeBuildInputs = [ intltool makeWrapper pkgconfig ];
   buildInputs = [ curl gtk3 ];
@@ -25,6 +28,6 @@ stdenv.mkDerivation rec {
     homepage = "http://klavaro.sourceforge.net/";
     license = stdenv.lib.licenses.gpl3Plus;
     platforms = stdenv.lib.platforms.linux;
-    maintainers = [stdenv.lib.maintainers.mimame];
+    maintainers = [ stdenv.lib.maintainers.mimame ];
   };
 }

--- a/pkgs/games/klavaro/default.nix
+++ b/pkgs/games/klavaro/default.nix
@@ -28,11 +28,11 @@ stdenv.mkDerivation rec {
   # Hack to avoid TMPDIR in RPATHs.
   preFixup = ''rm -rf "$(pwd)" '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Just another free touch typing tutor program";
     homepage = "http://klavaro.sourceforge.net/";
-    license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.mimame ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mimame ];
   };
 }

--- a/pkgs/games/klavaro/default.nix
+++ b/pkgs/games/klavaro/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig, intltool, curl, gtk3 }:
+{ stdenv, fetchurl, makeWrapper, pkgconfig, intltool, curl, file, gtk3 }:
 
 stdenv.mkDerivation rec {
   pname = "klavaro";
@@ -18,6 +18,11 @@ stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram $out/bin/klavaro \
       --prefix LD_LIBRARY_PATH : $out/lib
+  '';
+
+  preConfigure = ''
+    substituteInPlace configure \
+      --replace "/usr/bin/file" "${file}/bin/file"
   '';
 
   # Hack to avoid TMPDIR in RPATHs.

--- a/pkgs/games/klavaro/patch1
+++ b/pkgs/games/klavaro/patch1
@@ -1,0 +1,11 @@
+--- a/src/top10.c
++++ b/src/top10.c
+@@ -845,7 +845,7 @@
+ 		curl_easy_setopt (curl, CURLOPT_WRITEDATA, fh);
+ 		curl_easy_setopt (curl, CURLOPT_SSL_VERIFYPEER, 0L);
+ 		fail = curl_easy_perform (curl);
+-		if (fail) g_message (curl_easy_strerror (fail));
++		if (fail) g_message ("%s", curl_easy_strerror (fail));
+ 		fclose (fh);
+ 	}
+ 	curl_easy_cleanup (curl);


### PR DESCRIPTION
###### Motivation for this change

Update

![Screenshot from 2020-05-28 00 44 18](https://user-images.githubusercontent.com/91113/83080082-ab172b80-a07d-11ea-9a05-28274c60eb62.png)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc maintainer @mimame