### PR TITLE
cmake-language-server: init at 0.1.1

### DIFF
--- a/pkgs/development/python-modules/pygls/default.nix
+++ b/pkgs/development/python-modules/pygls/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, isPy3k, fetchFromGitHub
+, mock, pytest, pytest-asyncio
+}:
+
+buildPythonPackage rec {
+  pname = "pygls";
+  version = "0.8.1";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "openlawlibrary";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1853rfdks5n8nw6ig96j7his5kqd75hrvzvd0win4niycaqsag6m";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pytest==4.5.0" "pytest"
+  '';
+
+  checkInputs = [ mock pytest pytest-asyncio ];
+  checkPhase = "pytest";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/openlawlibrary/pygls";
+    description = "Pythonic generic implementation of the Language Server Protocol";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ metadark ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-datadir/default.nix
+++ b/pkgs/development/python-modules/pytest-datadir/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, setuptools_scm, pytest, cmake
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-datadir";
+  version = "1.3.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "gabrielcnr";
+    repo = pname;
+    rev = version;
+    sha256 = "0kwgp6sqnqnmww5r0dkmyfpi0lmw0iwxz3fnwn2fs8w6bvixzznf";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  preBuild = ''
+    export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
+  '';
+
+  checkInputs = [ pytest ];
+  checkPhase = "pytest";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/gabrielcnr/pytest-datadir";
+    description = "pytest plugin for manipulating test data directories and files";
+    license = licenses.mit;
+    maintainers = with maintainers; [ metadark ];
+  };
+}

--- a/pkgs/development/tools/cmake-language-server/default.nix
+++ b/pkgs/development/tools/cmake-language-server/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub
+, poetry, pygls, pyparsing
+, cmake, pytest, pytest-datadir
+}:
+
+buildPythonApplication rec {
+  pname = "cmake-language-server";
+  version = "0.1.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "regen100";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "09rijjksx07inbwxjinrsqihkxb011l2glysasmwpkhy0rmmhbcm";
+  };
+
+  nativeBuildInputs = [ poetry ];
+  propagatedBuildInputs = [ pygls pyparsing ];
+
+  checkInputs = [ cmake pytest pytest-datadir ];
+  dontUseCmakeConfigure = true;
+  checkPhase = "pytest";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/regen100/cmake-language-server";
+    description = "CMake LSP Implementation";
+    license = licenses.mit;
+    maintainers = with maintainers; [ metadark ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10224,6 +10224,8 @@ in
 
   cmake-format = python3Packages.callPackage ../development/tools/cmake-format { };
 
+  cmake-language-server = python3Packages.callPackage ../development/tools/cmake-language-server { };
+
   # Does not actually depend on Qt 5
   inherit (kdeFrameworks) extra-cmake-modules kapidox kdoctools;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3286,6 +3286,8 @@ in {
 
   pyfxa = callPackage ../development/python-modules/pyfxa { };
 
+  pygls = callPackage ../development/python-modules/pygls {};
+
   pyhomematic = callPackage ../development/python-modules/pyhomematic { };
 
   pylama = callPackage ../development/python-modules/pylama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2482,6 +2482,8 @@ in {
 
   pytest-cram = callPackage ../development/python-modules/pytest-cram { };
 
+  pytest-datadir = callPackage ../development/python-modules/pytest-datadir { };
+
   pytest-datafiles = callPackage ../development/python-modules/pytest-datafiles { };
 
   pytest-dependency = callPackage ../development/python-modules/pytest-dependency { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/80264

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
