### PR TITLE
Calculate sha256 on the fly on dockerTools.buildLayeredImage

### DIFF
--- a/pkgs/build-support/docker/store-path-to-layer.sh
+++ b/pkgs/build-support/docker/store-path-to-layer.sh
@@ -39,6 +39,7 @@ tarhash=$(
       --transform 's,^nix/store$,/\0,' \
       --transform 's,^[^/],/nix/store/\0,rS' |
     tee "$layerPath/layer.tar" |
+    tee >(sha256sum | cut -d ' ' -f 1 > $layerPath/sha256) |
     tarsum
 )
 


### PR DESCRIPTION
###### Motivation for this change

Previously, we were calculating layer checksums at a separate pass after
the creation of the tarball. This is not ideal when packaging containers
with large layers, since it requires reading the whole tarball again
from disk in order to create the checksum.

This commit calculates the sha256 in parallel when creating the tarball
and saves it to a file for later use by buildLayeredImage function.

###### Things done

Relevant NixOS tests (`nixosTests.docker-tools`) pass.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).