### PR TITLE
airwindows: init at unstable-2020-08-24

### DIFF
--- a/pkgs/applications/audio/airwindows/default.nix
+++ b/pkgs/applications/audio/airwindows/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, fetchFromGitHub, requireFile, unzip, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "airwindows-${version}";
+  version = "2020-05-25";
+
+  src = fetchFromGitHub {
+    owner = "airwindows";
+    repo = "airwindows";
+    rev = "897c0830e603a950e838a3753f89334bdf56bb71";
+    sha256 = "1mh7c176fdl5y5ixkgzj2j2b7qifp3lgnxmbn6b7bvg3sv5wsxg3";
+  };
+
+  vst-sdk = stdenv.mkDerivation rec {
+    name = "vstsdk366_27_06_2016_build_61";
+    src = requireFile {
+      name = "${name}.zip";
+      url = "https://www.steinberg.net/sdk_downloads/vstsdk366_27_06_2016_build_61.zip";
+      sha256 = "05gsr13bpi2hhp34rvhllsvmn44rqvmjdpg9fsgfzgylfkz0kiki";
+    };
+    nativeBuildInputs = [ unzip ];
+    installPhase = "cp -r . $out";
+  };
+
+  airwindows-ports = stdenv.mkDerivation rec {
+    name = "airwindows-ports";
+    src = fetchFromGitHub {
+      owner = "ech2";
+      repo = "airwindows-ports";
+      rev = "0.4.0";
+      sha256 = "1ya4qbc63sb52nzisdapsydrnnpqnjsl5kgxibbr3dxf32474g89";
+    };
+    installPhase = "cp -r . $out";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  patchPhase = ''
+    cd plugins/LinuxVST
+    rm build/CMakeCache.txt
+    mkdir -p include/vstsdk
+    cp -r ${airwindows-ports}/include/vstsdk/CMakeLists.txt include/vstsdk/
+    cp -r ${vst-sdk}/pluginterfaces include/vstsdk/pluginterfaces
+    cp -r ${vst-sdk}/public.sdk/source/vst2.x/* include/vstsdk/
+    chmod -R 777 include/vstsdk/pluginterfaces
+  '';
+
+  installPhase = ''
+    for so_file in *.so; do
+      install -vDm 644 $so_file -t "$out/lib/lxvst"
+    done;
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Handsewn bespoke linuxvst plugins";
+    homepage = http://www.airwindows.com/airwindows-linux/;
+    # airwindows is mit, but the vst sdk is unfree
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.magnetophon ];
+  };
+}

--- a/pkgs/applications/audio/airwindows/default.nix
+++ b/pkgs/applications/audio/airwindows/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "airwindows-${version}";
-  version = "2020-05-25";
+  version = "2020-08-24";
 
   src = fetchFromGitHub {
     owner = "airwindows";
     repo = "airwindows";
-    rev = "897c0830e603a950e838a3753f89334bdf56bb71";
-    sha256 = "1mh7c176fdl5y5ixkgzj2j2b7qifp3lgnxmbn6b7bvg3sv5wsxg3";
+    rev = "3022096e8c0e82abdefbc7cae240dd8d0cac5147";
+    sha256 = "1pvnzl486630qhdc6qjgddglgq89lxjh2kgnyl4q2ia9mn36iisx";
   };
 
   vst-sdk = stdenv.mkDerivation rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19309,6 +19309,8 @@ in
 
   airwave = callPackage ../applications/audio/airwave { };
 
+  airwindows = callPackage ../applications/audio/airwindows { };
+
   akira-unstable = callPackage ../applications/graphics/akira { };
 
   alembic = callPackage ../development/libraries/alembic {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
