### PR TITLE
Update gitAndTools.gita and add bash completion

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gita/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gita/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonApplication
 , fetchFromGitHub
+, git
+, pytest
 , pyyaml
 , setuptools
 , installShellFiles
@@ -23,6 +25,23 @@ buildPythonApplication rec {
   ];
 
   nativeBuildInputs = [ installShellFiles ];
+
+  postUnpack = ''
+    for case in "\n" ""; do
+        substituteInPlace source/tests/test_main.py \
+         --replace "'gita$case'" "'source$case'"
+    done
+  '';
+
+  checkInputs = [
+    git
+    pytest
+  ];
+
+  checkPhase = ''
+    git init
+    pytest tests
+  '';
 
   postInstall = ''
     installShellCompletion --bash --name gita ${src}/.gita-completion.bash

--- a/pkgs/applications/version-management/git-and-tools/gita/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gita/default.nix
@@ -1,23 +1,32 @@
 { lib
 , buildPythonApplication
-, fetchPypi
+, fetchFromGitHub
 , pyyaml
 , setuptools
+, installShellFiles
 }:
 
 buildPythonApplication rec {
   version = "0.10.9";
   pname = "gita";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0fbzk9rj895s5fpbnsyy3gxwbf5spqycisx5cqwzxgm0n5qkz9dk";
+  src = fetchFromGitHub {
+    sha256 = "0wilyf4nnn2jyxrfqs8krya3zvhj6x36szsp9xhb6h08g1ihzp5i";
+    rev = "v${version}";
+    repo = "gita";
+    owner = "nosarthur";
   };
 
   propagatedBuildInputs = [
     pyyaml
     setuptools
   ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --bash --name gita ${src}/.gita-completion.bash
+  '';
 
   meta = with lib; {
     description = "A command-line tool to manage multiple git repos";

--- a/pkgs/applications/version-management/git-and-tools/gita/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gita/default.nix
@@ -6,12 +6,12 @@
 }:
 
 buildPythonApplication rec {
-  version = "0.10.5";
+  version = "0.10.9";
   pname = "gita";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1xggslmrrfszpl190klkc97fnl88gml1bnkmkzp6aimdch66g4jg";
+    sha256 = "0fbzk9rj895s5fpbnsyy3gxwbf5spqycisx5cqwzxgm0n5qkz9dk";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
This package updates gitAndTools.gita and installs bash completion.

###### Motivation for this change

Missing bash completion for gita.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
