### PR TITLE
[backport] nix-build-uncached: init at 0.1.1

### DIFF
--- a/pkgs/development/tools/misc/nix-build-uncached/default.nix
+++ b/pkgs/development/tools/misc/nix-build-uncached/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoModule, fetchFromGitHub, nix, makeWrapper }:
+
+buildGoModule rec {
+  pname = "nix-build-uncached";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "nix-build-uncached";
+    rev = "v${version}";
+    sha256 = "0jkpg3ab56lg2kdms9w9ka9ba89py3ajksjsi1rd3iqi74zz2mmh";
+  };
+
+  goPackagePath = "github.com/Mic92/nix-build-uncached";
+  modSha256 = "1fl0wb1xj4v4whqm6ivzqjpac1iwpq7m12g37gr4fpgqp8kzi6cn";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/nix-build-uncached \
+      --prefix PATH ":" ${lib.makeBinPath [ nix ]}
+  '';
+
+  meta = with lib; {
+    description = "A CI friendly wrapper around nix-build";
+    license = licenses.mit;
+    homepage = "https://github.com/Mic92/nix-build-uncached";
+    maintainers = [ maintainers.mic92 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10413,6 +10413,8 @@ in
     pythonPackages = python3Packages;
   };
 
+  nix-build-uncached = callPackage ../development/tools/misc/nix-build-uncached { };
+
   nexus = callPackage ../development/tools/repository-managers/nexus { };
 
   nwjs = callPackage ../development/tools/nwjs {


### PR DESCRIPTION
(cherry picked from commit 021662cf1357b204af3f66f65d5c72876ebdc32c)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

People want to do CI builds for 20.03 as well.
This has been tested for a while in master.
cc @domenkozar 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
