### PR TITLE
python3Packages.skein: init at 0.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -313,6 +313,12 @@
     githubId = 2387841;
     name = "Alexander Bakker";
   };
+  alexbiehl = {
+    email = "alexbiehl@gmail.com";
+    github = "alexbiehl";
+    githubId = 1876617;
+    name = "Alex Biehl";
+  };
   alexchapman = {
     email = "alex@farfromthere.net";
     github = "AJChapman";

--- a/pkgs/development/python-modules/skein/default.nix
+++ b/pkgs/development/python-modules/skein/default.nix
@@ -1,0 +1,101 @@
+{ autoPatchelfHook
+, buildPythonPackage
+, coreutils
+, fetchPypi
+, jre
+, lib
+, maven
+, protobuf
+, pythonPackages
+, stdenv
+}:
+
+buildPythonPackage rec {
+  pname = "skein";
+  version = "0.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0nb64p1hzshgi1kfc2jx1v9vn8b0wzs50460wfra3fsxh0ap66ab";
+  };
+
+  skeinRepo = stdenv.mkDerivation rec {
+    name = "${pname}-${version}-maven-repo";
+
+    inherit src;
+
+    nativeBuildInputs = [ maven ] ++ lib.optional stdenv.isLinux autoPatchelfHook;
+
+    buildPhase = "";
+
+    installPhase = ''
+      mkdir -p $out
+
+      archs="${
+        if stdenv.isLinux
+        then "linux-x86_32 linux-x86_64"
+        else "osx-x86_64"
+      }"
+
+      for arch in $archs
+      do
+        mvn -Dmaven.repo.local=$out dependency:get -Dartifact=com.google.protobuf:protoc:3.0.0:exe:$arch
+        mvn -Dmaven.repo.local=$out dependency:get -Dartifact=io.grpc:protoc-gen-grpc-java:1.16.0:exe:$arch
+      done
+
+      if ${ lib.boolToString stdenv.isLinux }
+      then
+        autoPatchelf $out
+      fi
+
+      # We have to use maven package here as dependency:go-offline doesn't
+      # fetch every required jar.
+      mvn -f java/pom.xml -Dmaven.repo.local=$out package
+
+      rm $(find $out -name _remote.repositories)
+      rm $(find $out -name resolver-status.properties)
+    '';
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = if stdenv.isLinux
+      then "12f0q3444qw6y4f6qsa9540a0fz4cgi844zzi8z1phqn3k4dnl6v"
+      else "0bjbwiv17cary1isxca0m2hsvgs1i5fh18z247h1hky73lnhbrz8";
+
+  } // lib.optionalAttrs stdenv.isLinux { dontAutoPatchelf = true; };
+
+  # skein wants to compile a .jar file for Hadoop interaction. We build
+  # it separately as otherwise mvn is called from setup.py and we have
+  # no good way to inject the repository in there.
+  skeinJar = stdenv.mkDerivation rec {
+    name = "${pname}-${version}.jar";
+
+    inherit src;
+
+    nativeBuildInputs = [ maven ];
+
+    buildPhase = ''
+      mvn --offline -f java/pom.xml package -Dmaven.repo.local="${skeinRepo}" -Dskein.version=${version} -Dversion=${version}
+    '';
+
+    installPhase = ''
+      # Making sure skein.jar exists skips the maven build in setup.py
+      mv java/target/skein-*.jar $out
+    '';
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ cryptography grpcio grpcio-tools jupyter pytest pyyaml requests jre ];
+
+  preBuild = ''
+    # Making sure skein.jar exists skips the maven build in setup.py
+    mkdir -p skein/java
+    ln -s ${skeinJar} skein/java/skein.jar
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://jcristharif.com/skein";
+    description = "A tool and library for easily deploying applications on Apache YARN";
+    license = licenses.bsd3;
+  };
+
+}

--- a/pkgs/development/python-modules/skein/default.nix
+++ b/pkgs/development/python-modules/skein/default.nix
@@ -1,93 +1,27 @@
-{ autoPatchelfHook
-, buildPythonPackage
-, coreutils
+{ buildPythonPackage
+, callPackage
 , fetchPypi
 , jre
 , lib
-, maven
-, protobuf
 , pythonPackages
 , stdenv
 }:
-
-buildPythonPackage rec {
+let
   pname = "skein";
   version = "0.8.0";
-
   src = fetchPypi {
     inherit pname version;
     sha256 = "0nb64p1hzshgi1kfc2jx1v9vn8b0wzs50460wfra3fsxh0ap66ab";
   };
-
-  skeinRepo = stdenv.mkDerivation rec {
-    name = "${pname}-${version}-maven-repo";
-
-    inherit src;
-
-    nativeBuildInputs = [ maven ] ++ lib.optional stdenv.isLinux autoPatchelfHook;
-
-    buildPhase = "";
-
-    installPhase = ''
-      mkdir -p $out
-
-      archs="${
-        if stdenv.isLinux
-        then "linux-x86_32 linux-x86_64"
-        else "osx-x86_64"
-      }"
-
-      for arch in $archs
-      do
-        mvn -Dmaven.repo.local=$out dependency:get -Dartifact=com.google.protobuf:protoc:3.0.0:exe:$arch
-        mvn -Dmaven.repo.local=$out dependency:get -Dartifact=io.grpc:protoc-gen-grpc-java:1.16.0:exe:$arch
-      done
-
-      if ${ lib.boolToString stdenv.isLinux }
-      then
-        autoPatchelf $out
-      fi
-
-      # We have to use maven package here as dependency:go-offline doesn't
-      # fetch every required jar.
-      mvn -f java/pom.xml -Dmaven.repo.local=$out package
-
-      rm $(find $out -name _remote.repositories)
-      rm $(find $out -name resolver-status.properties)
-    '';
-
-    outputHashMode = "recursive";
-    outputHashAlgo = "sha256";
-    outputHash = if stdenv.isLinux
-      then "12f0q3444qw6y4f6qsa9540a0fz4cgi844zzi8z1phqn3k4dnl6v"
-      else "0bjbwiv17cary1isxca0m2hsvgs1i5fh18z247h1hky73lnhbrz8";
-
-  } // lib.optionalAttrs stdenv.isLinux { dontAutoPatchelf = true; };
-
-  # skein wants to compile a .jar file for Hadoop interaction. We build
-  # it separately as otherwise mvn is called from setup.py and we have
-  # no good way to inject the repository in there.
-  skeinJar = stdenv.mkDerivation rec {
-    name = "${pname}-${version}.jar";
-
-    inherit src;
-
-    nativeBuildInputs = [ maven ];
-
-    buildPhase = ''
-      mvn --offline -f java/pom.xml package -Dmaven.repo.local="${skeinRepo}" -Dskein.version=${version} -Dversion=${version}
-    '';
-
-    installPhase = ''
-      # Making sure skein.jar exists skips the maven build in setup.py
-      mv java/target/skein-*.jar $out
-    '';
-  };
+  skeinJar = callPackage ./skeinjar.nix { inherit src version; };
+in
+buildPythonPackage rec {
+  inherit pname version src;
 
   propagatedBuildInputs = with pythonPackages; [ cryptography grpcio grpcio-tools jupyter pytest pyyaml requests jre ];
 
   preBuild = ''
-    # Making sure skein.jar exists skips the maven build in setup.py
+    # Ensure skein.jar exists skips the maven build in setup.py
     mkdir -p skein/java
     ln -s ${skeinJar} skein/java/skein.jar
   '';

--- a/pkgs/development/python-modules/skein/default.nix
+++ b/pkgs/development/python-modules/skein/default.nix
@@ -96,6 +96,7 @@ buildPythonPackage rec {
     homepage = "https://jcristharif.com/skein";
     description = "A tool and library for easily deploying applications on Apache YARN";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ alexbiehl ];
   };
 
 }

--- a/pkgs/development/python-modules/skein/default.nix
+++ b/pkgs/development/python-modules/skein/default.nix
@@ -1,11 +1,13 @@
 { buildPythonPackage
 , callPackage
 , fetchPypi
+, isPy27
 , jre
 , lib
 , pythonPackages
 , stdenv
 }:
+
 let
   pname = "skein";
   version = "0.8.0";
@@ -17,6 +19,7 @@ let
 in
 buildPythonPackage rec {
   inherit pname version src;
+  disabled = isPy27;
 
   propagatedBuildInputs = with pythonPackages; [ cryptography grpcio grpcio-tools jupyter pytest pyyaml requests jre ];
 

--- a/pkgs/development/python-modules/skein/skeinjar.nix
+++ b/pkgs/development/python-modules/skein/skeinjar.nix
@@ -1,0 +1,21 @@
+{ callPackage, stdenv, maven, src, version }:
+
+let
+  skeinRepo = callPackage ./skeinrepo.nix { inherit src version; };
+in
+stdenv.mkDerivation rec {
+  name = "skein-${version}.jar";
+
+  inherit src;
+
+  nativeBuildInputs = [ maven ];
+
+  buildPhase = ''
+    mvn --offline -f java/pom.xml package -Dmaven.repo.local="${skeinRepo}" -Dskein.version=${version} -Dversion=${version}
+  '';
+
+  installPhase = ''
+    # Making sure skein.jar exists skips the maven build in setup.py
+    mv java/target/skein-*.jar $out
+  '';
+}

--- a/pkgs/development/python-modules/skein/skeinrepo.nix
+++ b/pkgs/development/python-modules/skein/skeinrepo.nix
@@ -1,0 +1,46 @@
+{ autoPatchelfHook, lib, maven, stdenv, src, version }:
+
+stdenv.mkDerivation rec {
+  name = "skein-${version}-maven-repo";
+
+  inherit src;
+
+  nativeBuildInputs = [ maven ] ++ lib.optional stdenv.isLinux autoPatchelfHook;
+
+  doBuild = false;
+
+  installPhase = ''
+    mkdir -p $out
+
+    archs="${
+      if stdenv.isLinux
+      then "linux-x86_32 linux-x86_64"
+      else "osx-x86_64"
+    }"
+
+    for arch in $archs
+    do
+      mvn -Dmaven.repo.local=$out dependency:get -Dartifact=com.google.protobuf:protoc:3.0.0:exe:$arch
+      mvn -Dmaven.repo.local=$out dependency:get -Dartifact=io.grpc:protoc-gen-grpc-java:1.16.0:exe:$arch
+    done
+
+    if ${ lib.boolToString stdenv.isLinux }
+    then
+      autoPatchelf $out
+    fi
+
+    # We have to use maven package here as dependency:go-offline doesn't
+    # fetch every required jar.
+    mvn -f java/pom.xml -Dmaven.repo.local=$out package
+
+    rm $(find $out -name _remote.repositories)
+    rm $(find $out -name resolver-status.properties)
+  '';
+
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  outputHash = if stdenv.isLinux
+    then "12f0q3444qw6y4f6qsa9540a0fz4cgi844zzi8z1phqn3k4dnl6v"
+    else "0bjbwiv17cary1isxca0m2hsvgs1i5fh18z247h1hky73lnhbrz8";
+
+} // lib.optionalAttrs stdenv.isLinux { dontAutoPatchelf = true; }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6338,7 +6338,7 @@ in {
 
   python_statsd = callPackage ../development/python-modules/python_statsd { };
 
-  skein = disabledIf isPy27 (callPackage ../development/python-modules/skein { });
+  skein = callPackage ../development/python-modules/skein { };
 
   stompclient = callPackage ../development/python-modules/stompclient { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6338,6 +6338,8 @@ in {
 
   python_statsd = callPackage ../development/python-modules/python_statsd { };
 
+  skein = disabledIf isPy27 (callPackage ../development/python-modules/skein { });
+
   stompclient = callPackage ../development/python-modules/stompclient { };
 
   subdownloader = callPackage ../development/python-modules/subdownloader { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds the skein package to python3Modules. The build process is a bit hairy as it depends on an integrated Maven build from within the setup.py. I pulled it out and build the JAR separately and made the fetching of the Java dependencies into a fixed output derivation.

The Maven build downloads some native executables for dealing with ProtocolBuffer generation and thus needs some patchelf magic which further complicates the build. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
