### PR TITLE
pirate-get: 0.3.7 -> 0.4.0

### DIFF
--- a/pkgs/tools/networking/pirate-get/default.nix
+++ b/pkgs/tools/networking/pirate-get/default.nix
@@ -4,16 +4,14 @@ with python3Packages;
 
 buildPythonApplication rec {
   pname = "pirate-get";
-  version = "0.3.7";
-
-  doCheck = false;
+  version = "0.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0i87g7f25dzsi5b3swr9gny2zpmrrgygxmr1ps71rjr1n540si9n";
+    sha256 = "07s5ss9dxccx1mip7pyga1fagywkqchxmzz55ng47ac9053ffxkq";
   };
 
-  propagatedBuildInputs = [ colorama veryprettytable beautifulsoup4 pyperclip ];
+  propagatedBuildInputs = [ colorama veryprettytable pyperclip ];
 
   meta = with stdenv.lib; {
     description = "A command line interface for The Pirate Bay";


### PR DESCRIPTION
###### Motivation for this change
Version bump with bug fixes

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
