### PR TITLE
deadd-notification-center: init at 1.7.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5866,6 +5866,12 @@
     githubId = 1449319;
     name = "Pacien Tran-Girard";
   };
+  pacman99 = {
+    email = "pachum99@gmail.com";
+    github = "Pacman99";
+    githubId = 16345849;
+    name = "Parthiv Seetharaman";
+  };
   paddygord = {
     email = "pgpatrickgordon@gmail.com";
     github = "paddygord";

--- a/pkgs/applications/misc/deadd-notification-center/default.nix
+++ b/pkgs/applications/misc/deadd-notification-center/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, fetchurl
+, autoPatchelfHook
+, gtk3
+, gobject-introspection
+, libxml2
+}:
+
+let
+  version = "1.7.2";
+
+  dbusService = fetchurl {
+    url = "https://github.com/phuhl/linux_notification_center/raw/${version}/com.ph-uhl.deadd.notification.service.in";
+    sha256 = "0jvmi1c98hm8x1x7kw9ws0nbf4y56yy44c3bqm6rjj4lrm89l83s";
+  };
+in
+stdenv.mkDerivation rec {
+  inherit version;
+  pname = "deadd-notification-center";
+
+  src = fetchurl {
+    url = "https://github.com/phuhl/linux_notification_center/releases/download/${version}/${pname}";
+    sha256 = "13f15slkjiw2n5dnqj13dprhqm3nf1k11jqaqda379yhgygyp9zm";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    gtk3
+    gobject-introspection
+    libxml2
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/dbus-1/services
+    cp $src $out/bin/deadd-notification-center
+    chmod +x $out/bin/deadd-notification-center
+
+    sed "s|##PREFIX##|$out|g" ${dbusService} > $out/share/dbus-1/services/com.ph-uhl.deadd.notification.service 
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A haskell-written notification center for users that like a desktop with style";
+    homepage = "https://github.com/phuhl/linux_notification_center";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.pacman99 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19819,6 +19819,8 @@ in
 
   linssid = libsForQt5.callPackage ../applications/networking/linssid { };
 
+  deadd-notification-center = callPackage ../applications/misc/deadd-notification-center/default.nix { };
+
   lollypop = callPackage ../applications/audio/lollypop { };
 
   m32edit = callPackage ../applications/audio/midas/m32edit.nix {};


### PR DESCRIPTION
###### Motivation for this change
Adds linux_notification-center, a notification daemon that also provides a toggle for a notification center
https://github.com/phuhl/linux_notification_center

I could not figure out how to compile from source. Stack tried to create a directory in '/' when compiling. The binary was much easier to package, so I chose to do that and get just the dbus service file from the github repository. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
