### PR TITLE
Add bitbox02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6440,6 +6440,12 @@
     githubId = 1973389;
     name = "Reuben D'Netto";
   };
+  reardencode = {
+    email = "freedom@reardencode.com";
+    github = "reardencode";
+    githubId = 730881;
+    name = "Brandon Black";
+  };
   redbaron = {
     email = "ivanov.maxim@gmail.com";
     github = "redbaron";

--- a/pkgs/development/python-modules/base58/default.nix
+++ b/pkgs/development/python-modules/base58/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, fetchPypi, buildPythonPackage, pytest, pyhamcrest }:
+{ stdenv, fetchPypi, isPy27, buildPythonPackage, pytest, pyhamcrest }:
 
 buildPythonPackage rec {
   pname = "base58";
-  version = "1.0.3";
+  version = "2.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9a793c599979c497800eb414c852b80866f28daaed5494703fc129592cc83e60";
+    sha256 = "0zhp8iwgiapaqwpy67agzfg1lwnj59zi61s3cgfm5p0pp6l88df8";
   };
 
   checkInputs = [ pytest pyhamcrest ];
   checkPhase = ''
     pytest
   '';
+
+  disabled = isPy27;
 
   meta = with stdenv.lib; {
     description = "Base58 and Base58Check implementation";

--- a/pkgs/development/python-modules/bitbox02/default.nix
+++ b/pkgs/development/python-modules/bitbox02/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, hidapi
+, noiseprotocol
+, protobuf
+, ecdsa
+, semver
+, typing-extensions
+, base58
+, pyserial
+, fetchPypi
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "bitbox02";
+  version = "2.0.3";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mcbg7bvlsii1kj2mm5686z01pwcc36qbqlhz4a8syjrzjm6pl2k";
+  };
+
+  doCheck = false; # No tests present, which causes check phase to fail
+
+  propagatedBuildInputs = [ hidapi noiseprotocol protobuf ecdsa semver typing-extensions base58 pyserial ];
+
+  meta = with stdenv.lib; {
+    description = "Communicate with your BitBox02 using Python";
+    homepage = "https://github.com/digitalbitbox/bitbox02-firmware";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ reardencode ];
+  };
+}

--- a/pkgs/development/python-modules/noiseprotocol/default.nix
+++ b/pkgs/development/python-modules/noiseprotocol/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, buildPythonPackage
+, lib
+, pytest
+, scapy
+, cryptography
+, fetchFromGitHub
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "noiseprotocol";
+  version = "0.3.1";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "plizonczyk";
+    repo = "noiseprotocol";
+    rev = "73375448c55af85df0230841af868b7f31942f0a";
+    sha256 = "1mk0rqpjifdv3v1cjwkdnjbrfmzzjm9f3qqs1r8vii4j2wvhm6am";
+  };
+
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    pytest
+  '';
+
+  buildInputs = [ scapy ];
+  propagatedBuildInputs = [ cryptography ];
+
+  meta = with stdenv.lib; {
+    description = "Python Implementation of Noise Protocol Framework";
+    homepage = "https://github.com/plizonczyk/noiseprotocol";
+    license = licenses.mit;
+    maintainers = with maintainers; [ reardencode ];
+  };
+}

--- a/pkgs/development/python-modules/py-multihash/default.nix
+++ b/pkgs/development/python-modules/py-multihash/default.nix
@@ -21,6 +21,8 @@ buildPythonPackage rec {
     sha256 = "f0ade4de820afdc4b4aaa40464ec86c9da5cae3a4578cda2daab4b0eb7e5b18d";
   };
 
+  patches = [ ./relax-base58.patch ];
+
   nativeBuildInputs = [
     pytestrunner
   ];

--- a/pkgs/development/python-modules/py-multihash/relax-base58.patch
+++ b/pkgs/development/python-modules/py-multihash/relax-base58.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 8fbacf8..bb1affd 100644
+--- a/setup.py
++++ b/setup.py
+@@ -15,7 +15,7 @@ requirements = [
+     'varint>=1.0.2,<2.0',
+     'six>=1.10.0,<2.0',
+     'morphys>=1.0,<2.0',
+-    'base58>=1.0.2,<2.0',
++    'base58>=1.0.2,<3.0',
+ ]
+ 
+ setup_requirements = ['pytest-runner', ]

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4716,6 +4716,8 @@ in {
 
   nodeenv = callPackage ../development/python-modules/nodeenv { };
 
+  noiseprotocol = callPackage ../development/python-modules/noiseprotocol { };
+
   nose = callPackage ../development/python-modules/nose { };
 
   nose-cov = callPackage ../development/python-modules/nose-cov { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -518,6 +518,8 @@ in {
 
   bitarray = callPackage ../development/python-modules/bitarray { };
 
+  bitbox02 = callPackage ../development/python-modules/bitbox02 { };
+
   bitcoinlib = callPackage ../development/python-modules/bitcoinlib { };
 
   bitcoin-price-api = callPackage ../development/python-modules/bitcoin-price-api { };


### PR DESCRIPTION
###### Motivation for this change

Preparatory work for supporting BitBox02 in electrum whenever electrum 4.0 comes out.

Removes python2 support from `block-io`, `streamlit`, and `zeronet`, hopefully we're not caring about losing python2 support these days?

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
