### PR TITLE
appimage: replace radare2+jq with readelf+awk+sha256sum

### DIFF
--- a/pkgs/build-support/appimage/appimage-exec.sh
+++ b/pkgs/build-support/appimage/appimage-exec.sh
@@ -6,58 +6,55 @@ fi
 PATH="@path@:$PATH"
 apprun_opt=true
 
-#DEBUG=0
-
 # src : AppImage
 # dest : let's unpack() create the directory
 unpack() {
-  local src=$1
-  local out=$2
-  local appimageSignature=""
-  local appimageType=0
+  local src="$1"
+  local out="$2"
 
   # https://github.com/AppImage/libappimage/blob/ca8d4b53bed5cbc0f3d0398e30806e0d3adeaaab/src/libappimage/utils/MagicBytesChecker.cpp#L45-L63
-  eval "$(r2 -nn -Nqc "p8j 3 @ 8" "$src"|
-    jq -r '{appimageSignature: (.[:-1]|implode), appimageType: .[-1]}|
-      @sh "appimageSignature=\(.appimageSignature) appimageType=\(.appimageType)"')"
+  local appimageSignature=$(readelf -h "$src" | awk 'NR==2{print $10$11;}')
+  local appimageType=$(readelf -h "$src" | awk 'NR==2{print $12;}')
 
   # check AppImage signature
-  if [[ "$appimageSignature" != "AI" ]]; then
-    echo "Not an appimage."
+  if [ "$appimageSignature" != "4149" ]; then
+    echo "Not an AppImage file"
     exit
   fi
 
   case "$appimageType" in
-    1 ) echo "Uncompress $(basename "$src") of type $appimageType."
-        mkdir "$out"
-        pv "$src" | bsdtar -x -C "$out" -f -
-        ;;
-    2)
-        # This method avoid issues with non executable appimages,
-        # non-native packer, packer patching and squashfs-root destination prefix.
+    "01")
+      echo "Uncompress $(basename "$src") of type $appimageType"
+      mkdir "$out"
+      pv "$src" | bsdtar -x -C "$out" -f -
+      ;;
 
-        # multiarch offset one-liner using same method as AppImage
-        # see https://gist.github.com/probonopd/a490ba3401b5ef7b881d5e603fa20c93
-        offset=$(r2 -nn -Nqc "pfj.elf_header @ 0" "$src"|\
-          jq 'map({(.name): .value}) | add | .shoff + (.shnum * .shentsize)')
+    "02")
+      # This method avoid issues with non executable appimages,
+      # non-native packer, packer patching and squashfs-root destination prefix.
 
-        echo "Uncompress $(basename "$src") of type $appimageType @ offset $offset."
-        unsquashfs -q -d "$out" -o "$offset" "$src"
-        chmod go-w "$out"
-        ;;
+      # multiarch offset one-liner using same method as AppImage
+      # see https://gist.github.com/probonopd/a490ba3401b5ef7b881d5e603fa20c93
+      offset=$(readelf -h "$src" | awk 'NR==13{e_shoff=$5} NR==18{e_shentsize=$5} NR==19{e_shnum=$5} END{print e_shoff+e_shentsize*e_shnum}')
+      echo "Uncompress $(basename "$src") of type $appimageType @ offset $offset"
+      unsquashfs -q -d "$out" -o "$offset" "$src"
+      chmod go-w "$out"
+      ;;
 
-    # 3) get ready, https://github.com/TheAssassin/type3-runtime
-    *)  echo Unsupported AppImage Type: "$appimageType"
-        exit
-        ;;
+    # "03")
+    #   get ready, https://github.com/TheAssassin/type3-runtime
+
+    *)
+      echo Unsupported AppImage Type: "$appimageType"
+      exit
+      ;;
   esac
   echo "$(basename "$src") is now installed in $out"
 }
 
 apprun() {
 
-  eval "$(rahash2 "$APPIMAGE" -j | jq -r '.[] | @sh "SHA256=\(.hash)"')"
-  echo sha256 = \""$SHA256"\"\;
+  SHA256=$(sha256sum "$APPIMAGE" | awk '{print $1}')
   export APPDIR="${XDG_CACHE_HOME:-$HOME/.cache}/appimage-run/$SHA256"
 
   #compatibility
@@ -102,27 +99,26 @@ EOF
 }
 
 while getopts "x:w:dh" option; do
-    case "${option}" in
-        d)  set -x
-            ;;
-        x)  # eXtract
-            unpack_opt=true
-            APPDIR=${OPTARG}
-            ;;
-        w)  # WrapAppImage
-            export APPDIR=${OPTARG}
-            wrap_opt=true
-            ;;
-        h)  usage
-            ;;
-        *)
-            usage
-            ;;
-    esac
+  case "${option}" in
+    d)  set -x
+        ;;
+    x)  # eXtract
+        unpack_opt=true
+        APPDIR=${OPTARG}
+        ;;
+    w)  # WrapAppImage
+        export APPDIR=${OPTARG}
+        wrap_opt=true
+        ;;
+    h)  usage
+        ;;
+    *)  usage
+        ;;
+  esac
 done
-shift $((OPTIND-1))
+shift "$((OPTIND-1))"
 
-if [[ $wrap_opt = true ]] && [[ -d "$APPDIR" ]]; then
+if [ -n "$wrap_opt" ] && [ -d "$APPDIR" ]; then
   wrap "$@"
   exit
 else
@@ -130,12 +126,12 @@ else
   shift
 fi
 
-if [[ $unpack_opt = true ]] && [[ -f "$APPIMAGE" ]]; then
+if [ -n "$unpack_opt" ] && [ -f "$APPIMAGE" ]; then
   unpack "$APPIMAGE" "$APPDIR"
   exit
 fi
 
-if [[ $apprun_opt = true ]] && [[ -f "$APPIMAGE" ]]; then
+if [ -n "$apprun_opt" ] && [ -f "$APPIMAGE" ]; then
   apprun
   wrap "$@"
   exit


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

radare2 does not play nicely with filenames containing spaces: https://github.com/radareorg/radare2/issues/16958

so I replaced radare2+jq with readelf+awk+sha256sum

I also cleaned up default.nix with nixpkgs-fmt and removed bashisms from appimage-exec.sh


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
