### PR TITLE
geekbench5: add compute benchmark support

### DIFF
--- a/pkgs/tools/misc/geekbench/default.nix
+++ b/pkgs/tools/misc/geekbench/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper }:
+{ stdenv, fetchurl, makeWrapper, ocl-icd, vulkan-loader, linuxPackages }:
 
 stdenv.mkDerivation rec {
   pname = "geekbench";
@@ -15,12 +15,19 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
-    mkdir -p $out/bin
+    mkdir -p $out/bin $out/lib
     cp -r geekbench.plar geekbench5 geekbench_x86_64 $out/bin
+
+    # needed for compute benchmark
+    ln -s ${linuxPackages.nvidia_x11}/lib/libcuda.so $out/lib/
+    ln -s ${ocl-icd}/lib/libOpenCL.so $out/lib/
+    ln -s ${ocl-icd}/lib/libOpenCL.so.1 $out/lib/
+    ln -s ${vulkan-loader}/lib/libvulkan.so $out/lib/
+    ln -s ${vulkan-loader}/lib/libvulkan.so.1 $out/lib/
 
     for f in geekbench5 geekbench_x86_64 ; do
       patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) $out/bin/$f
-      wrapProgram $out/bin/$f --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
+      wrapProgram $out/bin/$f --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib ]}:$out/lib/"
     done
   '';
 


### PR DESCRIPTION
##### Motivation for this change

I want to use the compute benchmark.

Fixes https://github.com/NixOS/nixpkgs/issues/87990

Devices are detected now:

```
OpenCL
0 0 AMD Radeon (TM) RX 480 Graphics (POLARIS10, DRM 3.36.0, 5.6.13, LLVM 9.0.1)
Vulkan
0 0 AMD RADV POLARIS10 (LLVM 9.0.1)
```

OpenCL benchmark fails, but Vulkan works.

cc maintainer @michalrus

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size: Closure size difference is 328.81 MB (189.28%).
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
