### PR TITLE
colormake: use fetchFromGitHub

### DIFF
--- a/pkgs/development/tools/build-managers/colormake/default.nix
+++ b/pkgs/development/tools/build-managers/colormake/default.nix
@@ -1,13 +1,14 @@
-{stdenv, fetchgit, perl}:
+{ stdenv, fetchFromGitHub, perl }:
 
 stdenv.mkDerivation {
   pname = "colormake";
   version = "2.1.0";
 
-  buildInputs = [perl];
+  buildInputs = [ perl ];
 
-  src = fetchgit {
-    url = "https://github.com/pagekite/Colormake.git";
+  src = fetchFromGitHub {
+    owner = "pagekite";
+    repo = "Colormake";
     rev = "66544f40d";
     sha256 = "8e714c5540305d169989d9387dbac47b8b9fb2cfb424af7bcd412bfe684dc6d7";
   };
@@ -17,9 +18,11 @@ stdenv.mkDerivation {
     cp -fa colormake.pl colormake colormake-short clmake clmake-short $out/bin
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Simple wrapper around make to colorize the output";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.unix;
+    homepage = "https://bre.klaki.net/programs/colormake/";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ bhipple ];
   };
 }


### PR DESCRIPTION
Verified the sha256 does not change.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).