### PR TITLE
go-bindata: use fetchFromGitHub

### DIFF
--- a/pkgs/development/tools/go-bindata/default.nix
+++ b/pkgs/development/tools/go-bindata/default.nix
@@ -1,25 +1,25 @@
-{ stdenv, buildGoPackage, fetchgit }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoPackage {
   pname = "go-bindata";
-  version = "20151023-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "a0ff2567cfb70903282db057e799fd826784d41d";
-  
+  version = "unstable-2015-10-23";
+
   goPackagePath = "github.com/jteeuwen/go-bindata";
 
-  src = fetchgit {
-    inherit rev;
-    url = "https://github.com/jteeuwen/go-bindata";
+  src = fetchFromGitHub {
+    owner = "jteeuwen";
+    repo = "go-bindata";
+    rev = "a0ff2567cfb70903282db057e799fd826784d41d";
     sha256 = "0d6zxv0hgh938rf59p1k5lj0ymrb8kcps2vfrb9kaarxsvg7y69v";
   };
 
   excludedPackages = "testdata";
 
   meta = with stdenv.lib; {
-    homepage    = "https://github.com/jteeuwen/go-bindata";
+    homepage = "https://github.com/jteeuwen/go-bindata";
     description = "A small utility which generates Go code from any file, useful for embedding binary data in a Go program";
     maintainers = with maintainers; [ cstrahan ];
-    license     = licenses.cc0 ;
-    platforms   = platforms.all;
+    license = licenses.cc0;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
Cleaned up expression as well. Verified sha256 is reproducible and unchanged.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).