### PR TITLE
legendary-gl: init at 0.0.14

### DIFF
--- a/pkgs/games/legendary-gl/default.nix
+++ b/pkgs/games/legendary-gl/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, fetchFromGitHub
+, buildPythonApplication
+, pythonOlder
+, requests
+}:
+
+buildPythonApplication rec {
+  pname = "legendary-gl"; # Name in pypi
+  version = "0.0.14";
+
+  src = fetchFromGitHub {
+    owner = "derrod";
+    repo = "legendary";
+    rev = version;
+    sha256 = "05r88qi8mmbj07wxcpb3fhbl40qscbq1aqb0mnj9bpmi9gf5zll5";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  disabled = pythonOlder "3.8";
+
+  meta = with lib; {
+    description = "A free and open-source Epic Games Launcher alternative";
+    homepage = "https://github.com/derrod/legendary";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ wchresta ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23770,6 +23770,8 @@ in
 
   leela-zero = libsForQt5.callPackage ../games/leela-zero { };
 
+  legendary-gl = python38Packages.callPackage ../games/legendary-gl { };
+
   lgogdownloader = callPackage ../games/lgogdownloader { };
 
   liberal-crime-squad = callPackage ../games/liberal-crime-squad { };


### PR DESCRIPTION
###### Motivation for this change

* Adds requested launcher for EPIC games
* Was requested in #88963

###### Things done

I have started up the binary and authenticated with an empty account. Because I don't own any EPIC games, I couldn't test any of the `real` functionality, but login works, at least.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
