### PR TITLE
swtpm: init at 0.3.1

### DIFF
--- a/pkgs/applications/virtualization/swtpm/default.nix
+++ b/pkgs/applications/virtualization/swtpm/default.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, fetchFromGitHub
+, expect
+, fuse
+, nettools
+, python3Packages
+, trousers
+, tpm-tools
+, gnutls
+, openssl
+, glib
+, socat
+, pkgconfig
+, autoconf
+, automake
+, autoreconfHook
+, libtool
+, libtpms
+, libtasn1
+, libseccomp
+, file
+}:
+
+stdenv.mkDerivation rec {
+  pname = "swtpm";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "stefanberger";
+    repo = "swtpm";
+    rev = "v${version}";
+    sha256 = "06frkaxdsnxy4a71ym9wd933fl7mvvnmxcm2jbqb8k5niz135p1x";
+  };
+
+  buildInputs = [
+    expect
+    fuse
+    nettools
+    python3Packages.python
+    python3Packages.twisted
+    trousers
+    tpm-tools
+    gnutls
+    openssl
+    glib
+    socat
+  ];
+  nativeBuildInputs = [
+    pkgconfig
+    autoconf
+    automake
+    autoreconfHook
+
+    libtool
+    libtpms
+    libtasn1
+    libseccomp
+
+    file
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Libtpms-based TPM emulator with socket, character device, and Linux CUSE interface.";
+    homepage = "https://github.com/stefanberger/swtpm";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/libraries/libtpms/default.nix
+++ b/pkgs/development/libraries/libtpms/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, fetchFromGitHub
+, openssl
+, libtool
+, perl
+, autoconf
+, automake
+, autoreconfHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libtpms";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "stefanberger";
+    repo = "libtpms";
+    rev = "v${version}";
+    sha256 = "182i75igc6khwkidaqy8rbvxdz30z1p9g126mi3a0mvnwhg6g8rq";
+  };
+
+  configureFlags = [
+    "--with-tpm2"
+    "--with-openssl"
+  ];
+
+  buildInputs = [
+    openssl
+    libtool
+  ];
+  nativeBuildInputs = [
+    perl
+    autoconf
+    automake
+    autoreconfHook
+  ];
+
+  meta = with stdenv.lib; {
+    description = "The libtpms library provides software emulation of a Trusted Platform Module (TPM 1.2 and TPM 2.0)";
+    homepage = "https://github.com/stefanberger/libtpms";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15198,6 +15198,8 @@ in
 
   swiftclient = python3.pkgs.callPackage ../tools/admin/swiftclient { };
 
+  swtpm = callPackage ../applications/virtualization/swtpm { };
+
   sword = callPackage ../development/libraries/sword { };
 
   biblesync = callPackage ../development/libraries/biblesync { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13813,6 +13813,8 @@ in
 
   libtgvoip = callPackage ../development/libraries/libtgvoip { };
 
+  libtpms = callPackage ../development/libraries/libtpms { };
+
   libtsm = callPackage ../development/libraries/libtsm { };
 
   libgeotiff = callPackage ../development/libraries/libgeotiff { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->
Works as far as I can tell for the Windows VM I pulled up? Not sure how to explicitly test it.
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
