### PR TITLE
mpv: don't use generated luasocket

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -93,7 +93,7 @@ assert xvSupport          -> x11Support && available libXv;
 assert zimgSupport        -> available zimg;
 
 let
-  luaEnv = lua.withPackages (ps: with ps; [ luasocket ]);
+  luaEnv = lua.withPackages (ps: with ps; [ luasocket-git ]);
 
 in stdenv.mkDerivation rec {
   pname = "mpv";

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -99,6 +99,45 @@ with self; {
 
   luarocks-nix = callPackage ../development/tools/misc/luarocks/luarocks-nix.nix { };
 
+  luasocket-git = buildLuaPackage rec {
+    name = "socket-${version}";
+    version = "3.0-rc1";
+
+    src = fetchFromGitHub {
+      owner = "diegonehab";
+      repo = "luasocket";
+      rev = "v${version}";
+      sha256 = "1chs7z7a3i3lck4x7rz60ziwbf793gw169hpjdfca8y4yf1hzsxk";
+    };
+
+    patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+      substituteInPlace src/makefile \
+        --replace 10.3 10.5
+    '';
+
+    preBuild = ''
+      makeFlagsArray=(
+        LUAV=${lua.luaversion}
+        PLAT=${platformString}
+        CC=''${CC}
+        LD=''${CC}
+        prefix=$out
+      );
+    '';
+
+    doCheck = false; # fails to find itself
+
+    installTargets = [ "install" "install-unix" ];
+
+    meta = with stdenv.lib; {
+      description = "Network support for Lua";
+      homepage = "http://w3.impa.br/~diego/software/luasocket/";
+      license = licenses.mit;
+      maintainers = with maintainers; [ ];
+      platforms = with platforms; darwin ++ linux ++ freebsd ++ illumos;
+    };
+  };
+
   luxio = buildLuaPackage rec {
     name = "luxio-${version}";
     version = "13";


### PR DESCRIPTION
The luarocks version of luasocket crashes if the host program has
symbols with the same name as luasocket, such as "socket_create".

This change makes mpv use a custom luasocket derivation that isn't built
from luarocks. This new derivation has the same code as
"luaPackages.luasocket" before commit
274715cbc355e9d50e07a2f60a65a183f7d9855d.

Closes #88584

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

mpv compiled with samba support crashed when using a luasocket script. See #88584. This PR fixes the issue without disabling samba.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
