### PR TITLE
haskell: Fix with-packages-wrapper MacOS linker hack for GHC 8.8

### DIFF
--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -113,7 +113,7 @@ symlinkJoin {
     # Clean up the old links that may have been (transitively) included by
     # symlinkJoin:
     rm -f $dynamicLinksDir/*
-    for d in $(grep dynamic-library-dirs $packageConfDir/*|awk '{print $2}'|sort -u); do
+    for d in $(grep -Poz "dynamic-library-dirs:\s*\K .+\n" $packageConfDir/*|awk '{print $2}'|sort -u); do
       ln -s $d/*.dylib $dynamicLinksDir
     done
     for f in $packageConfDir/*.conf; do
@@ -123,7 +123,7 @@ symlinkJoin {
       # $dynamicLinksDir
       cp $f $f-tmp
       rm $f
-      sed "s,dynamic-library-dirs: .*,dynamic-library-dirs: $dynamicLinksDir," $f-tmp > $f
+      sed "N;s,dynamic-library-dirs:\s*.*,dynamic-library-dirs: $dynamicLinksDir," $f-tmp > $f
       rm $f-tmp
     done
   '') + ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`with-packages-wrapper.nix` has a hack to workaround the linker limit in MacOS Sierra. However that is now broken with GHC 8.8, because of slight change in the format of the package config. In short, the package config produced by GHC 8.8 has a new line between the key and list of values, while earlier versions have them separated by a single space.

For example, in GHC 8.6 the entry is formatted as:

```
dynamic-library-dirs: /nix/store/8s2jg442gk2p2z2mhlrqh163m7ajqq2m-extra-1.6.21/lib/ghc-8.6.5/x86_64-linux-ghc-8.6.5
                      /nix/store/fn92v9h7gxj9w4z0s2qxsjxb4awczl3h-ncurses-6.2/lib
                      /nix/store/1cygbkyil4flvw8q1fpxn6m783xkxbdq-libffi-3.3/lib
                      /nix/store/3hkj53lkmaz332zv7kcap0rlr5g6vich-gmp-6.2.0/lib
```

While in GHC 8.8, the entry is formatted as:

```
dynamic-library-dirs:
    /nix/store/xlvjnm7qkdaib25lxpwdadihjicj72gs-extra-1.6.21/lib/ghc-8.8.3/x86_64-linux-ghc-8.8.3
    /nix/store/fn92v9h7gxj9w4z0s2qxsjxb4awczl3h-ncurses-6.2/lib
    /nix/store/1cygbkyil4flvw8q1fpxn6m783xkxbdq-libffi-3.3/lib
    /nix/store/3hkj53lkmaz332zv7kcap0rlr5g6vich-gmp-6.2.0/lib
```



This PR fixes the linker hack by modifying the `grep` and `sed` commands to pattern match on either space or new line, so that the hack can work on all versions of GHC.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/89156)
<!-- Reviewable:end -->
