### PR TITLE
bazel: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/applications/virtualization/gvisor/default.nix
+++ b/pkgs/applications/virtualization/gvisor/default.nix
@@ -76,7 +76,7 @@ in buildBazelPackage rec {
       rm -f "$bazelOut"/java.log "$bazelOut"/java.log.*
     '';
 
-    sha256 = "1nghj9gjdx2nfi1k98nsfsjnglbfmqrcbn73zvb8ii5j7hdm7392";
+    sha256 = "164r8m95g7njh232xfc7zcn1nssaw9bnin9k7ssj9mk6z7z9zy5v";
   };
 
   buildAttrs = {

--- a/pkgs/development/python-modules/dm-sonnet/default.nix
+++ b/pkgs/development/python-modules/dm-sonnet/default.nix
@@ -36,7 +36,7 @@ let
     bazelTarget = ":install";
 
     fetchAttrs = {
-      sha256 = "1v5wwlg5v95fz2qg96pdkxlnvw029fxcbsjl906lxdgdi3f8xmmz";
+      sha256 = "1xwrha692if7rwqc0qalgpx9b8indgdan8ppwlcs2v47wjvgg6h3";
     };
 
     bazelFlags = [

--- a/pkgs/development/python-modules/tensorflow-probability/default.nix
+++ b/pkgs/development/python-modules/tensorflow-probability/default.nix
@@ -61,7 +61,7 @@ let
     bazelTarget = ":pip_pkg";
 
     fetchAttrs = {
-      sha256 = "1rnbxgfhrv4rq8kc0ryxn6i5aqwx51cys0vd5r2m7mqz53aypawk";
+      sha256 = "1snj7fxfxzvrqv9cpir1daxcg3fip6cvbk94y3mi2h50k3ni826i";
     };
 
     buildAttrs = {

--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -60,7 +60,7 @@ buildBazelPackage rec {
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
     '';
 
-    sha256 = "0qx641bxwpkg42sps67k1x1r68ql42qalpn7irf85vn634rw4r8v";
+    sha256 = "0i77nnbd1sd39qw4vm3n5mwkag3dskqjhzr7qs4w1arbiih45zd4";
   };
 
   buildAttrs = {

--- a/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
@@ -64,7 +64,7 @@ buildBazelPackage rec {
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
     '';
 
-    sha256 = "16rb9kgv1izqnv80lvfrd7dxrmgnjrlknv1396w6q2qanskh3cjv";
+    sha256 = "0rfjyvw370yn4rp1f2772b2h3jbycymdw26zx38krzy5zq0iajyp";
   };
 
   buildAttrs = {

--- a/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
@@ -25,11 +25,11 @@
 }:
 
 let
-  version = "3.1.0";
+  version = "3.2.0";
 
   src = fetchurl {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    sha256 = "d7f40d0cac95a06cea6cb5b7f7769085257caebc3ee84269dd9298da760d5615";
+    sha256 = "1ylbfdcb6rhnc3sr292c6shl754i0h0i050f4gr4bppn6sa15v24";
   };
 
   # Update with `eval $(nix-build -A bazel.updater)`,
@@ -54,7 +54,7 @@ let
       srcs."coverage_output_generator-v2.1.zip"
       srcs.build_bazel_rules_nodejs
       srcs."android_tools_pkg-0.16.0.tar.gz"
-      srcs."2.1.0.tar.gz"
+      srcs."3.1.0.tar.gz"
       srcs.rules_pkg
       srcs.rules_cc
       srcs.rules_java

--- a/pkgs/development/tools/build-managers/bazel/bazel_3/src-deps.json
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/src-deps.json
@@ -7,20 +7,20 @@
             "https://github.com/bazelbuild/rules_sass/archive/1.25.0.zip"
         ]
     },
-    "2.1.0.tar.gz": {
-        "name": "2.1.0.tar.gz",
-        "sha256": "4d348abfaddbcee0c077fc51bb1177065c3663191588ab3d958f027cbfe1818b",
-        "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/2.1.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-toolchains/releases/download/2.1.0/bazel-toolchains-2.1.0.tar.gz"
-        ]
-    },
     "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": {
         "name": "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz",
         "sha256": "c00ceec469dbcf7929972e3c79f20c14033824538038a554952f5c31d8832f96",
         "urls": [
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz",
             "https://github.com/bazelbuild/bazel-skylib/archive/2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz"
+        ]
+    },
+    "3.1.0.tar.gz": {
+        "name": "3.1.0.tar.gz",
+        "sha256": "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.1.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz"
         ]
     },
     "46993efdd33b73649796c5fc5c9efb193ae19d51.zip": {
@@ -111,11 +111,11 @@
         "patch_cmds_win": [
             "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
         ],
-        "sha256": "4d348abfaddbcee0c077fc51bb1177065c3663191588ab3d958f027cbfe1818b",
-        "strip_prefix": "bazel-toolchains-2.1.0",
+        "sha256": "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
+        "strip_prefix": "bazel-toolchains-3.1.0",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/2.1.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-toolchains/releases/download/2.1.0/bazel-toolchains-2.1.0.tar.gz"
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.1.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz"
         ]
     },
     "build_bazel_rules_nodejs": {
@@ -157,7 +157,7 @@
             "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
         ],
         "patches": [
-            "@io_bazel//third_party/protobuf:3.11.3.patch"
+            "//third_party/protobuf:3.11.3.patch"
         ],
         "sha256": "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
         "strip_prefix": "protobuf-3.11.3",
@@ -661,8 +661,8 @@
         "name": "rules_nodejs-1.3.0.tar.gz",
         "sha256": "b6670f9f43faa66e3009488bbd909bc7bc46a5a9661a33f6bc578068d1837f37",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/archive/rules_nodejs-1.3.0.tar.gz",
-            "https://github.com/bazelbuild/rules_nodejs/archive/rules_nodejs-1.3.0.tar.gz"
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz",
+            "https://github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz"
         ]
     },
     "rules_pkg": {

--- a/pkgs/development/tools/build-managers/bazel/update-srcDeps.py
+++ b/pkgs/development/tools/build-managers/bazel/update-srcDeps.py
@@ -45,6 +45,7 @@ def rules_pkg_dependencies(*args, **kw): pass
 def winsdk_configure(*args, **kw): pass
 def register_local_rc_exe_toolchains(*args, **kw): pass
 def register_toolchains(*args, **kw): pass
+def debian_deps(): pass
 
 # execute the WORKSPACE like it was python code in this module,
 # using all the function stubs from above.


### PR DESCRIPTION
###### Motivation for this change

Bazel 3.2.0 was released a few days ago.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
