### PR TITLE
pipenv: 2018.11.26 -> 2020.5.28

### DIFF
--- a/pkgs/development/tools/pipenv/default.nix
+++ b/pkgs/development/tools/pipenv/default.nix
@@ -14,28 +14,27 @@ let
     virtualenv-clone
   ];
 
-  pythonEnv = python3.withPackages(ps: with ps; [ virtualenv ]);
+  pythonEnv = python3.withPackages(ps: with ps; runtimeDeps);
 
 in buildPythonApplication rec {
   pname = "pipenv";
-  version = "2018.11.26";
+  version = "2020.5.28";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0ip8zsrwmhrankrix0shig9g8q2knmr7b63sh7lqa8a5x03fcwx6";
+    sha256 = "072lc4nywcf9q9irvanwcz7w0sd9dcyannz208jm6glyj8a271l1";
   };
 
   LC_ALL = "en_US.UTF-8";
 
   postPatch = ''
     # pipenv invokes python in a subprocess to create a virtualenv
-    # it uses sys.executable which will point in our case to a python that
-    # does not have virtualenv.
+    # and to call setup.py.
+    # It would use sys.executable, which in our case points to a python that
+    # does not have the required dependencies.
     substituteInPlace pipenv/core.py \
-      --replace "vistir.compat.Path(sys.executable).absolute().as_posix()" "vistir.compat.Path('${pythonEnv.interpreter}').absolute().as_posix()"
+      --replace "sys.executable" "'${pythonEnv.interpreter}'"
   '';
-
-  nativeBuildInputs = [ invoke parver ];
 
   propagatedBuildInputs = runtimeDeps;
 


### PR DESCRIPTION
###### Motivation for this change
https://github.com/pypa/pipenv/releases/tag/v2020.5.28
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
