### PR TITLE
ibus-bamboo: init at 0.6.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8035,6 +8035,12 @@
     githubId = 65870;
     name = "Сухарик";
   };
+  superbo = {
+    email = "supernbo@gmail.com";
+    github = "SuperBo";
+    githubId = 2666479;
+    name = "Y Nguyen";
+  };
   SuperSandro2000 = {
     email = "sandro.jaeckel@gmail.com";
     github = "SuperSandro2000";

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-bamboo/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-bamboo/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, fetchFromGitHub
+, gettext
+, xorg
+, pkgconfig
+, wrapGAppsHook
+, ibus
+, gtk3
+, go
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ibus-bamboo";
+  version = "0.6.6";
+
+  src = fetchFromGitHub {
+    owner = "BambooEngine";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0bjcc2dm6c6s0v271nyslmwf5z0xxpcbvmk4lyirs48hc1bzv3n6";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    pkgconfig
+    wrapGAppsHook
+    go
+  ];
+
+  buildInputs = [
+    xorg.libX11
+    xorg.xorgproto
+    xorg.libXtst
+    xorg.libXi
+  ];
+
+  preConfigure = ''
+    export GOCACHE="$TMPDIR/go-cache"
+    sed -i "s,/usr,$out," bamboo.xml
+  '';
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+
+  meta = with stdenv.lib; {
+    isIbusEngine = true;
+    description = "A Vietnamese IME for IBus";
+    homepage = "https://github.com/BambooEngine/ibus-bamboo";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ superbo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2806,6 +2806,8 @@ in
   ibus-engines = recurseIntoAttrs {
     anthy = callPackage ../tools/inputmethods/ibus-engines/ibus-anthy { };
 
+    bamboo = callPackage ../tools/inputmethods/ibus-engines/ibus-bamboo { };
+
     hangul = callPackage ../tools/inputmethods/ibus-engines/ibus-hangul { };
 
     kkc = callPackage ../tools/inputmethods/ibus-engines/ibus-kkc { };


### PR DESCRIPTION
Add IBus Bamboo engine for Vietnamese

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Currenty, NixOS doesn't have any support for typing Vietnamese. ibus-unikey and ibus-bamboo are two popular engines for Vietnamese input. However, ibus-bamboo is more updated than the old ibus-unikey.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
