### PR TITLE
gopacked - init at 0.4.1

### DIFF
--- a/pkgs/applications/misc/gopacked/default.nix
+++ b/pkgs/applications/misc/gopacked/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "gopacked";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "tulir";
+    repo = "gopacked";
+    rev = "v${version}";
+    sha256 = "03qr8rlnipziy16nbcpf631jh42gsyv2frdnh8yzsh8lm0p8p4ry";
+  };
+
+  vendorSha256 = "0fklr3lxh8g7gda65wf2wdkqv15869h7m1bwbzbiv8pasrf5b352";
+
+  meta = with lib; {
+    description = "A simple text-based Minecraft modpack manager";
+    license = licenses.agpl3;
+    homepage = src.meta.homepage;
+    maintainers = with maintainers; [ foxit64 ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -986,6 +986,8 @@ in
 
   gomatrix = callPackage ../applications/misc/gomatrix { };
 
+  gopacked = callPackage ../applications/misc/gopacked { };
+
   gucci = callPackage ../tools/text/gucci { };
 
   grc = callPackage ../tools/misc/grc { };


### PR DESCRIPTION
###### Motivation for this change
This tool is not yet available at nixpkgs. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
