### PR TITLE
wip: postfix: refactored tls certificate configuration

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -20,6 +20,25 @@
   <itemizedlist>
    <listitem>
     <para>
+     <varname>services.postfix.sslCACert</varname>, <varname>services.postfix.sslCert</varname> and <varname>services.postfix.sslKey</varname> were deprecated since
+     they were used to configure tls for incoming as well as outgoing traffic which is most likely not intended.
+    </para>
+    <para>
+     <varname>services.postfix.sslCACert</varname> was replaced by <varname>services.postfix.clientTlsCAFile</varname> which now defaults to system certifcate authorities.
+     In addition opportunistic tls was enabled for outgoing mail traffic.
+    </para>
+    <para>
+     <varname>services.postfix.sslCert</varname> was replaced by <varname>services.postfix.tlsChainFiles</varname> to configure server tls certifcates. Note in case certifcate and key are seperate files list key file first.
+    </para>
+    <para>
+     <varname>services.postfix.sslKey</varname> was replaced by <varname>services.postfix.tlsChainFiles</varname> to configure server tls key. Note in case certifcate and key are seperate files list key file first.
+    </para>
+    <para>
+     Note: Client certificates were not replaced since this kind of configuration is rarely used. If there's a need to configure client certifactes use <varname>services.postfix.extraConfig</varname>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      Support is planned until the end of April 2021, handing over to 21.03.
     </para>
    </listitem>


### PR DESCRIPTION
###### Motivation for this change

The change fixes #88817 and can be separated into following tasks:

## Encourage usage of encrypted connections for outgoing traffic
This was done by configuring a trust store and enabling opportunistic usage of tls for outgoing traffic.

## Depreaction of old configuration

## Removed client certificate configuration on server certificate configuration
Previously the ssl certificate and key were used for smtpd (incoming mail) and for smtp (ougoing) mail.
Using a certifcate for outgoing mail traffic is quite uncommon and most likely not wanted when setting `sslCert`. The postfix documentation request to configure certificates for outgoing traffic only when you "must present client TLS certificates".

`smtpd_tls_chain_files` was used in favour of `smtpd_tls_cert` and `smtpd_tls_key` since this is the postfix recommended configuration since `3.4`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
 ✘ asbachb@nixos  ~/dev/src/nix/nixpkgs   88817-postfix-tls-certs  nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
these paths will be fetched (0.03 MiB download, 0.13 MiB unpacked):
  /nix/store/gwhk0z7brxyl0sn8gl44rlsyf0n1xhx9-nixpkgs-review-2.3.1
copying path '/nix/store/gwhk0z7brxyl0sn8gl44rlsyf0n1xhx9-nixpkgs-review-2.3.1' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 2001, done.
remote: Counting objects: 100% (2001/2001), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 4252 (delta 1997), reused 1998 (delta 1997), pack-reused 2251
Receiving objects: 100% (4252/4252), 1.54 MiB | 2.94 MiB/s, done.
Resolving deltas: 100% (3039/3039), completed with 762 local objects.
From https://github.com/NixOS/nixpkgs
   4c1bab50578..3bc5b8593be  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-f9a73e18aea3270837649f0853d103b90eee0454-dirty/nixpkgs 3bc5b8593be638dd9fc7d0f427eccdb2a6c8485b
Preparing worktree (detached HEAD 3bc5b8593be)
Updating files: 100% (21804/21804), done.
HEAD is now at 3bc5b8593be gpsd: clarify license
$ nix-env -f /home/asbachb/.cache/nixpkgs-review/rev-f9a73e18aea3270837649f0853d103b90eee0454-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
`May 29 16:55:54 nixos postfix/smtp[123634]: Trusted TLS connection established to gmail-smtp-in.l.google.com[2a00:1450:400c:c00::1b]:25: TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits) key-exchange X25519 server-signature ECDSA (P-256) server-digest SHA256`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
