### PR TITLE
sway: deterministic .desktop file

### DIFF
--- a/pkgs/applications/window-managers/sway/wrapper.nix
+++ b/pkgs/applications/window-managers/sway/wrapper.nix
@@ -45,6 +45,11 @@ in symlinkJoin {
       --prefix PATH : "${swaybg}/bin" \
       ${optionalString withGtkWrapper ''"''${gappsWrapperArgs[@]}"''} \
       ${optionalString (extraOptions != []) "${concatMapStrings (x: " --add-flags " + x) extraOptions}"}
+
+    # Not possible to use substituteInPlace because is a symlink to the unwrapped derivation
+    substitute $out/share/wayland-sessions/sway.desktop $out/sway-tmp.desktop \
+      --replace "Exec=sway" "Exec=$out/bin/sway"
+    mv $out/sway-tmp.desktop $out/share/wayland-sessions/sway.desktop
   '';
 
   passthru.providedSessions = [ "sway" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
If I use the sway.desktop from this derivation, I'd expect to use the sway binary generated by the derivation, not the one in my path.

I was bitten by this because I'm installing sway with the NixOS option `programs.sway.enable` and `programs.sway.extraSessionCommands`, but to manage the sway config file (on `~/.config/sway/config`), I use `home-manager`. Since `home-manager` is also installing sway in your nix profile, this version has preference, and the commands I specified on the `programs.sway.extraSessionCommands` were ignored
 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
