### PR TITLE
ashuffle: init at version 3.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8133,6 +8133,12 @@
     githubId = 863327;
     name = "Tyler Benster";
   };
+  tcbravo = {
+    email = "tomas.bravo@protonmail.ch";
+    github = "tcbravo";
+    githubId = 66133083;
+    name = "Tomas Bravo";
+  };
   tckmn = {
     email = "andy@tck.mn";
     github = "tckmn";

--- a/pkgs/applications/audio/ashuffle/default.nix
+++ b/pkgs/applications/audio/ashuffle/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, cmake, pkg-config, mpd_clientlib, meson, ninja }:
+
+stdenv.mkDerivation rec {
+  pname = "ashuffle";
+  version = "3.4.0";
+
+  src = fetchFromGitHub {
+    owner = "joshkunz";
+    repo = "ashuffle";
+    rev = "v${version}";
+    sha256 = "09q6lwgc1dc8bg1mb9js9qz3xcsxph3548nxzvyb4v8111gixrp7";
+    fetchSubmodules = true;
+  };
+
+  dontUseCmakeConfigure = true;
+  nativeBuildInputs = [ cmake pkg-config meson ninja ];
+  buildInputs = [ mpd_clientlib ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/joshkunz/ashuffle";
+    description = "Automatic library-wide shuffle for mpd";
+    maintainers = [ maintainers.tcbravo ];
+    platforms = platforms.unix;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -763,6 +763,8 @@ in
 
   asciiquarium = callPackage ../applications/misc/asciiquarium {};
 
+  ashuffle = callPackage ../applications/audio/ashuffle {};
+
   asls = callPackage ../development/tools/misc/asls { };
 
   asymptote = callPackage ../tools/graphics/asymptote {


### PR DESCRIPTION
##### Motivation for this change

[`ashuffle`](https://github.com/joshkunz/ashuffle) automatically shuffles the contents of an `mpd` music library when the playlist runs out of tracks. It has a grouping feature which can be used to shuffle tracks based on their tags (in other words, you can shuffle artists or albums).

I use it to keep my `mpd` playlist supplied with music, even when I am not controlling it directly.

I also added myself to the maintainers list for this package.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
