### PR TITLE
onedrive: 2.3.13 ->! 2.4.2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -156,6 +156,11 @@ services.mysql.initialScript = pkgs.writeText "mariadb-init.sql" ''
    </listitem>
    <listitem>
     <para>
+      The package <package>onedrive</package> needs the end user to reauthorize the client for all the accounts. Details can be found in the upstream package's <link xlink:href="https://github.com/abraunegg/onedrive/issues/835">issue #835</link>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
       The <link linkend="opt-services.supybot.enable">supybot</link> module now uses <literal>/var/lib/supybot</literal>
       as its default <link linkend="opt-services.supybot.stateDir">stateDir</link> path if <literal>stateVersion</literal>
       is 20.09 or higher. It also enables number of

--- a/pkgs/applications/networking/sync/onedrive/default.nix
+++ b/pkgs/applications/networking/sync/onedrive/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "onedrive";
-  version = "2.3.13";
+  version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "abraunegg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0bcsrfh1g7bdlcp0zjn6np88qzpn5frv61lzxz9b2ayxf7wyybvi";
+    sha256 = "10s33p1xzq9c5n1bxv9n7n31afxgx9i6c17w0xgxdrma75micm3a";
   };
 
   nativeBuildInputs = [ dmd pkgconfig ];
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     description = "A complete tool to interact with OneDrive on Linux";
     homepage = "https://github.com/abraunegg/onedrive";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ srgom ianmjones ];
+    maintainers = with maintainers; [];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION

###### Motivation for this change
Version bump

Supersededs:  https://github.com/NixOS/nixpkgs/pull/83280 and https://github.com/NixOS/nixpkgs/pull/86707

New PR because I use shallow nixpkgs and github does't allow me to push on the old branch
###### Things done
 

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @fadenb 