### PR TITLE
transcribe: include libXxf86vm, change sources

### DIFF
--- a/pkgs/applications/audio/transcribe/default.nix
+++ b/pkgs/applications/audio/transcribe/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchzip, wrapGAppsHook, alsaLib, atk, cairo, gdk-pixbuf
-, glib, gst_all_1,  gtk3, libSM, libX11, libpng12, pango, zlib }:
+, glib, gst_all_1,  gtk3, libSM, libX11, libXxf86vm, libpng12, pango, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "transcribe";
@@ -7,13 +7,13 @@ stdenv.mkDerivation rec {
 
   src = if stdenv.hostPlatform.system == "i686-linux" then
     fetchzip {
-      url = "https://www.seventhstring.com/xscribe/downlinux32/xscsetup.tar.gz";
-      sha256 = "1h5l7ry9c9awpxfnd29b0wm973ifrhj17xl5d2fdsclw2swsickb";
+      url = "https://www.seventhstring.com/xscribe/xsc32setup.tar.gz";
+      sha256 = "02z244mvwd8fdcdj62pzv34i2q7yr77z7jh9i5gn1fp3q6g9x2gc";
     }
   else if stdenv.hostPlatform.system == "x86_64-linux" then
     fetchzip {
-      url = "https://www.seventhstring.com/xscribe/downlinux64/xsc64setup.tar.gz";
-      sha256 = "1rpd3ppnx5i5yrnfbjrx7h7dk48kwl99i9lnpa75ap7nxvbiznm0";
+      url = "https://www.seventhstring.com/xscribe/xsc64setup.tar.gz";
+      sha256 = "01vysym52vbly7rss9c6i6wac4lbnfgz37xa5nz8ikqvwnmn34c3";
     }
   else throw "Platform not supported";
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   libPath = with gst_all_1; stdenv.lib.makeLibraryPath [
     stdenv.cc.cc glib gtk3 atk pango cairo gdk-pixbuf alsaLib
-    libX11 libSM libpng12 gstreamer gst-plugins-base zlib
+    libX11 libXxf86vm libSM libpng12 gstreamer gst-plugins-base zlib
   ];
 
   installPhase = ''
@@ -68,6 +68,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     platforms = platforms.linux;
     maintainers = with maintainers; [ michalrus ];
-    broken = true;
+    broken = false;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
`transcribe` used to fail when downloading, since the source of the binary has changed.  In addition, when the sources were corrected, running the binary revealed that the `libXxf86vm` shared libary was missing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
