### PR TITLE
merge-request-notifier: init at 1.7.0

### DIFF
--- a/pkgs/applications/version-management/merge-request-notifier/default.nix
+++ b/pkgs/applications/version-management/merge-request-notifier/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, atomEnv, at-spi2-core, xlibs, gnutar, lib }:
+let
+  dynamic-linker = stdenv.cc.bintools.dynamicLinker;
+in stdenv.mkDerivation rec {
+  version = "1.7.0";
+  name = "merge-request-notifier";
+  src = fetchurl {
+    url = "https://github.com/codecentric/merge-request-notifier/releases/download/v1.7.0/merge-request-notifier-${version}.tar.xz";
+    sha256 = "1gyx67rad2p08yr2ky5js8g6xj4jq97g0j8vmsgqa9jqwvq2f65x";
+  };
+
+  phases = "unpackPhase fixupPhase";
+
+  targetPath = "$out/opt/merge-request-notifier";
+
+  unpackPhase = ''
+    mkdir -p ${targetPath}
+    ${gnutar}/bin/tar xf "$src" --strip 1 -C ${targetPath}
+  '';
+
+  rpath = lib.concatStringsSep ":" [
+    atomEnv.libPath
+    "${at-spi2-core.out}/lib"
+    "${xlibs.libX11.out}/lib"
+    "${xlibs.libxcb.out}/lib"
+    targetPath
+  ];
+
+  fixupPhase = ''
+    patchelf --set-interpreter "${dynamic-linker}" --set-rpath "${rpath}" ${targetPath}/merge-request-notifier
+    patchelf --set-interpreter "${dynamic-linker}" --set-rpath "${rpath}" ${targetPath}/chrome-sandbox
+    patchelf --set-rpath "${rpath}" ${targetPath}/libGLESv2.so
+
+    mkdir -p $out/bin
+    ln -s ${targetPath}/merge-request-notifier $out/bin/merge-request-notifier
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Merge Request Notifier";
+    longDescription = "This app shows your GitLab merge requests grouped by projects and WIP status. It is accessible from the system tray.";
+    homepage = "https://github.com/codecentric/merge-request-notifier";
+    license = [ licenses.mit ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ robaca ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4733,6 +4733,8 @@ in
 
   memtester = callPackage ../tools/system/memtester { };
 
+  merge-request-notifier = callPackage ../applications/version-management/merge-request-notifier { };
+
   mesa-demos = callPackage ../tools/graphics/mesa-demos { };
 
   mhonarc = perlPackages.MHonArc;


### PR DESCRIPTION
###### Motivation for this change

New package for GitLab [merge-request-notifier](https://github.com/codecentric/merge-request-notifier).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
