### PR TITLE
musescore: Add missing inputs qtgraphicaleffects, qtquickcontrols2

### DIFF
--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -1,6 +1,7 @@
 { stdenv, mkDerivation, lib, fetchzip, cmake, pkgconfig
 , alsaLib, freetype, libjack2, lame, libogg, libpulseaudio, libsndfile, libvorbis
-, portaudio, portmidi, qtbase, qtdeclarative, qtscript, qtsvg, qttools
+, portaudio, portmidi, qtbase, qtdeclarative, qtgraphicaleffects
+, qtquickcontrols2, qtscript, qtsvg, qttools
 , qtwebengine, qtxmlpatterns
 }:
 
@@ -26,7 +27,8 @@ mkDerivation rec {
   buildInputs = [
     alsaLib libjack2 freetype lame libogg libpulseaudio libsndfile libvorbis
     portaudio portmidi # tesseract
-    qtbase qtdeclarative qtscript qtsvg qttools qtwebengine qtxmlpatterns
+    qtbase qtdeclarative qtgraphicaleffects qtquickcontrols2
+    qtscript qtsvg qttools qtwebengine qtxmlpatterns
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Although MuseScore builds and starts without these, it’s unusable because the left palette fails to render, with these errors:

```
qrc:/qml/palettes/PalettesWidget.qml:21:1: module "QtQuick.Controls" version 2.1 is not installed
```

or

```
qrc:/qml/palettes/PalettesWidget.qml:47:5: Type PalettesWidgetHeader unavailable
qrc:/qml/palettes/PalettesWidgetHeader.qml:37:5: Type StyledButton unavailable
qrc:/qml/palettes/StyledButton.qml:22:1: module "QtGraphicalEffects" is not installed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
