### PR TITLE
unit: Expose PHP expressions used so it can easily be accessed for configs

### DIFF
--- a/nixos/tests/web-servers/unit-php.nix
+++ b/nixos/tests/web-servers/unit-php.nix
@@ -23,7 +23,10 @@ in {
               "user": "testuser",
               "group": "testgroup",
               "root": "${testdir}/www",
-              "index": "info.php"
+              "index": "info.php",
+              "options": {
+                "file": "${pkgs.unit.usedPhp74}/lib/php.ini"
+              }
             }
           }
         }
@@ -42,6 +45,13 @@ in {
   };
   testScript = ''
     machine.wait_for_unit("unit.service")
-    assert "PHP Version ${pkgs.php74.version}" in machine.succeed("curl -vvv -s http://127.0.0.1:9074/")
+
+    # Check so we get an evaluated PHP back
+    response = machine.succeed("curl -vvv -s http://127.0.0.1:9074/")
+    assert "PHP Version ${pkgs.unit.usedPhp74.version}" in response, "PHP version not detected"
+
+    # Check so we have database and some other extensions loaded
+    for ext in ["json", "opcache", "pdo_mysql", "pdo_pgsql", "pdo_sqlite"]:
+        assert ext in response, f"Missing {ext} extension"
   '';
 })

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -49,7 +49,7 @@ in stdenv.mkDerivation rec {
     ++ optionals withPython3 [ python3 ncurses ]
     ++ optional withPHP72 php72-unit
     ++ optional withPHP73 php73-unit
-    ++ optional withPHP73 php74-unit
+    ++ optional withPHP74 php74-unit
     ++ optional withPerl528 perl528
     ++ optional withPerl530 perl530
     ++ optional withPerldevel perldevel
@@ -66,6 +66,11 @@ in stdenv.mkDerivation rec {
   ] ++ optional withSSL     "--openssl"
     ++ optional (!withIPv6) "--no-ipv6"
     ++ optional withDebug   "--debug";
+
+  # Optionally add the PHP derivations used so they can be addressed in the configs
+  usedPhp72 = optionals withPHP72 php72-unit;
+  usedPhp73 = optionals withPHP73 php73-unit;
+  usedPhp74 = optionals withPHP74 php74-unit;
 
   postConfigure = ''
     ${optionalString withPython2    "./configure python --module=python2  --config=${python2}/bin/python2-config  --lib-path=${python2}/lib"}


### PR DESCRIPTION
###### Motivation for this change
Since the used PHP derivation contains all the extensions and the configuration of the extensions it kinda makes sense which PHP is used to be able to access this.

Another way would be to symlink in this ini file into the `unit` derivation for easy access. But I kinda like this way...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
