### PR TITLE
rcon: init at 0.5

### DIFF
--- a/pkgs/tools/networking/rcon/default.nix
+++ b/pkgs/tools/networking/rcon/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake, pkg-config, glib, libbsd, check, pcre }:
+
+stdenv.mkDerivation rec {
+  pname = "rcon";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "n0la";
+    repo = "rcon";
+    rev = version;
+    sha256 = "1jsnmsm2qkiv8dan1yncx0qp6zfkcbyvf81c7xwpv6r499ijw1nb";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [
+    glib
+    libbsd
+    check
+    pcre
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/n0la/rcon";
+    description = "Source RCON client for command line";
+    maintainers = with maintainers; [ f4814n ];
+    platforms = with platforms; linux ++ darwin;
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6571,6 +6571,8 @@ in
 
   rc = callPackage ../shells/rc { };
 
+  rcon = callPackage ../tools/networking/rcon { };
+
   rdbtools = callPackage ../development/tools/rdbtools { python = python3; };
 
   rdma-core = callPackage ../os-specific/linux/rdma-core { };


### PR DESCRIPTION
###### Motivation for this change
There is no source RCON client in the repository.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
