### PR TITLE
kwin: applying @tildearrow 's low latency patch

### DIFF
--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -11,7 +11,9 @@
   kcoreaddons, kcrash, kdeclarative, kdecoration, kglobalaccel, ki18n,
   kiconthemes, kidletime, kinit, kio, knewstuff, knotifications, kpackage,
   kscreenlocker, kservice, kwayland, kwidgetsaddons, kwindowsystem, kxmlgui,
-  plasma-framework, qtsensors, libcap, libdrm, mesa
+  plasma-framework, qtsensors, libcap, libdrm, mesa, fetchpatch,
+
+  lowLatencyPatch ? true
 }:
 
 # TODO (ttuegel): investigate qmlplugindump failure
@@ -35,7 +37,13 @@ mkDerivation {
   patches = [
     ./0001-follow-symlinks.patch
     ./0002-xwayland.patch
-  ];
+  ] ++ lib.optional lowLatencyPatch (fetchpatch {
+    # WARNING: we can't depend the url on the version as 5.17.5 gives 404
+    # so we must update  this url+hash on plasma version update as described in
+    # "https://github.com/tildearrow/kwin-lowlatency#patch-format (branch depending on the Plasma version)
+    url = "https://tildearrow.zapto.org/storage/kwin-lowlatency/kwin-lowlatency-5.17.0.patch";
+    hash = "sha256-bS0pDA6TJC+PHTMeeWs2jCZz24mL69PVKPhF897U66M=";
+  });
   CXXFLAGS = [
     ''-DNIXPKGS_XWAYLAND=\"${lib.getBin xwayland}/bin/Xwayland\"''
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
On my personal laptop adding
```
kwin=prev.kwin.override(old:{
        patches=old.patches++[(
          final.fetchpatch{
            hash="sha256-bS0pDA6TJC+PHTMeeWs2jCZz24mL69PVKPhF897U66M=";
            url="https://tildearrow.zapto.org/storage/kwin-lowlatency/kwin-lowlatency-5.17.0.patch";
          }
        )];
      });
```
to `nixpkgs.overlays` drammatically improved performance and removed almost all suttering,including audio(?) suttering.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
