### PR TITLE
tuptime: 4.1.0 -> 5.0.0

### DIFF
--- a/nixos/modules/services/monitoring/tuptime.nix
+++ b/nixos/modules/services/monitoring/tuptime.nix
@@ -32,7 +32,10 @@ in {
 
     environment.systemPackages = [ pkgs.tuptime ];
 
-    users.users.tuptime.description = "tuptime database owner";
+    users = {
+      groups._tuptime.members = [ "_tuptime" ];
+      users._tuptime.description = "tuptime database owner";
+    };
 
     systemd = {
       services = {
@@ -45,7 +48,7 @@ in {
           serviceConfig = {
             StateDirectory = "tuptime";
             Type = "oneshot";
-            User = "tuptime";
+            User = "_tuptime";
             RemainAfterExit = true;
             ExecStart = "${pkgs.tuptime}/bin/tuptime -x";
             ExecStop = "${pkgs.tuptime}/bin/tuptime -xg";
@@ -57,7 +60,7 @@ in {
           serviceConfig = {
             StateDirectory = "tuptime";
             Type = "oneshot";
-            User = "tuptime";
+            User = "_tuptime";
             ExecStart = "${pkgs.tuptime}/bin/tuptime -x";
           };
         };


### PR DESCRIPTION
###### Motivation for this change
a new major version was released

##### Notes
the database format has changed, though it seems it keeps working without manual intervention
it either converted the database by itself, or it can parse the old version as well
a script to update the database format is included, this adds the `sqlite` dependency

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - was `106428288`, is `107888720` (increased due to adding sqlite to the database update script?)
- [x] Ensured that relevant documentation is up to date
  - this package/module isn't in 20.03 so no release note about the database change is required?
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
