### PR TITLE
Nixpkgs support for `dhall-to-nixpkgs`

### DIFF
--- a/pkgs/development/dhall-modules/Prelude.nix
+++ b/pkgs/development/dhall-modules/Prelude.nix
@@ -1,26 +1,17 @@
-{ buildDhallPackage, fetchFromGitHub, lib }:
+{ buildDhallGitHubPackage, lib }:
 
 let
   makePrelude =
-    version:
-    lib.makeOverridable
-      ( { rev, sha256, file ? "package.dhall" }:
-          buildDhallPackage {
-            name = "Prelude-${version}";
+    version: { rev, sha256 }:
+      buildDhallGitHubPackage {
+        name      = "Prelude-${version}";
+        owner     = "dhall-lang";
+        repo      = "dhall-lang";
+        directory = "Prelude";
+        file      = "package.dhall";
 
-            code =
-              let
-                src = fetchFromGitHub {
-                  owner = "dhall-lang";
-                  repo  = "dhall-lang";
-
-                  inherit rev sha256;
-                };
-
-              in
-                "${src}/Prelude/${file}";
-          }
-      );
+        inherit rev sha256;
+      };
 
 in
   lib.mapAttrs makePrelude {

--- a/pkgs/development/dhall-modules/dhall-kubernetes.nix
+++ b/pkgs/development/dhall-modules/dhall-kubernetes.nix
@@ -1,29 +1,16 @@
-{ buildDhallPackage, fetchFromGitHub, lib }:
+{ buildDhallGitHubPackage, lib }:
 
 let
   makeDhallKubernetes =
-    version:
-    lib.makeOverridable
-      ( { rev
-        , sha256
-        , file ? "package.dhall"
-        }:
-          buildDhallPackage {
-            name = "dhall-kubernetes-${version}";
+    version: { rev, sha256 }:
+      buildDhallGitHubPackage {
+        name  = "dhall-kubernetes-${version}";
+        owner = "dhall-lang";
+        repo  = "dhall-kubernetes";
+        file  = "package.dhall";
 
-            code =
-              let
-                src = fetchFromGitHub {
-                  owner = "dhall-lang";
-                  repo  = "dhall-kubernetes";
-
-                  inherit rev sha256;
-                };
-
-              in
-                "${src}/${file}";
-          }
-      );
+        inherit rev sha256;
+      };
 
 in
   lib.mapAttrs makeDhallKubernetes {

--- a/pkgs/development/dhall-modules/dhall-packages.nix
+++ b/pkgs/development/dhall-modules/dhall-packages.nix
@@ -1,47 +1,32 @@
-{ buildDhallPackage, dhall-kubernetes, fetchFromGitHub, lib, Prelude }:
+{ buildDhallGitHubPackage, dhall-kubernetes, lib, Prelude }:
 
 let
   makeDhallPackages =
-    version:
-    lib.makeOverridable
-      ( { rev
-        , sha256
-        , dependencies
-        }:
-          buildDhallPackage {
-            name = "dhall-packages-${version}";
+    version: { rev, sha256, dependencies }:
+      buildDhallGitHubPackage {
+        name  = "dhall-packages-${version}";
+        owner = "EarnestResearch";
+        repo  = "dhall-packages";
+        file  = "package.dhall";
 
-            inherit dependencies;
-
-            code =
-              let
-                src = fetchFromGitHub {
-                  owner = "EarnestResearch";
-                  repo  = "dhall-packages";
-
-                  inherit rev sha256;
-                };
-
-              in
-                "${src}/package.dhall";
-          }
-      );
+        inherit rev sha256 dependencies;
+      };
 
 in
   lib.mapAttrs makeDhallPackages {
     "0.11.1" =
       let
-        k8s_6a47bd = dhall-kubernetes."3.0.0".override {
+        k8s_6a47bd = dhall-kubernetes.override {
           rev    = "6a47bd50c4d3984a13570ea62382a3ad4a9919a4";
           sha256 = "1azqs0x2kia3xw93rfk2mdi8izd7gy9aq6qzbip32gin7dncmfhh";
         };
 
-        k8s_4ad581 = dhall-kubernetes."3.0.0".override {
+        k8s_4ad581 = dhall-kubernetes.override {
           rev    = "4ad58156b7fdbbb6da0543d8b314df899feca077";
           sha256 = "12fm70qbhcainxia388svsay2cfg9iksc6mss0nvhgxhpypgp8r0";
         };
 
-        k8s_fee24c = dhall-kubernetes."3.0.0".override {
+        k8s_fee24c = dhall-kubernetes.override {
           rev    = "fee24c0993ba0b20190e2fdb94e386b7fb67252d";
           sha256 = "11d93z8y0jzrb8dl43gqha9z96nxxqkl7cbxpz8hw8ky9x6ggayk";
         };

--- a/pkgs/development/interpreters/dhall/build-dhall-directory-package.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-directory-package.nix
@@ -1,0 +1,25 @@
+{ buildDhallPackage, lib }:
+
+# This is a minor variation on `buildDhallPackage` that splits the `code`
+# argument into `src` and `file` in such a way that you can easily override
+# the `file`
+#
+# This function is used by `dhall-to-nixpkgs` when given a directory
+lib.makeOverridable
+  ( { # Arguments passed through to `buildDhallPackage`
+      name
+    , dependencies ? []
+    , source ? false
+
+    , src
+    , # The file to import, relative to the root directory
+      file ? "package.dhall"
+    }:
+
+    buildDhallPackage {
+      inherit name dependencies source;
+
+      code = "${src}/${file}";
+    }
+  )
+

--- a/pkgs/development/interpreters/dhall/build-dhall-github-package.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-github-package.nix
@@ -1,0 +1,50 @@
+{ buildDhallPackage, fetchFromGitHub, lib }:
+
+# This function is used by `dhall-to-nixpkgs` when given a GitHub repository
+lib.makeOverridable
+  ( { # Arguments passed through to `buildDhallPackage`
+      name
+    , dependencies ? []
+    , source ? false
+
+    , # The directory containing the Dhall files, if other than the root of the
+      # repository
+      directory ? ""
+    , # The file to import, relative to the above directory
+      file ? "package.dhall"
+
+      # Arguments passed through to `fetchFromGitHub`
+    , owner
+    , repo
+    , rev
+      # Extra arguments passed through to `fetchFromGitHub`, such as the hash
+      # or `fetchSubmodules`
+    , ...
+    }@args:
+
+    buildDhallPackage {
+      inherit name dependencies source;
+
+      code =
+        let
+          src = fetchFromGitHub ({
+            name = "${name}-source";
+
+            inherit owner repo rev;
+          } // removeAttrs args [
+            "name"
+            "dependencies"
+            "source"
+            "directory"
+            "file"
+            "owner"
+            "repo"
+            "rev"
+          ]);
+
+          prefix = lib.optionalString (directory != "") "${directory}/";
+
+        in
+          "${src}/${prefix}${file}";
+    }
+  )

--- a/pkgs/top-level/dhall-packages.nix
+++ b/pkgs/top-level/dhall-packages.nix
@@ -8,20 +8,40 @@ let
     let
       callPackage = newScope self;
 
+      prefer = version: path:
+        let
+          packages = callPackage path { };
+
+        in
+          packages."${version}".overrideAttrs (_: {
+              passthru = packages;
+            }
+          );
+
       buildDhallPackage =
         callPackage ../development/interpreters/dhall/build-dhall-package.nix { };
 
+      buildDhallGitHubPackage =
+        callPackage ../development/interpreters/dhall/build-dhall-github-package.nix { };
+
+      buildDhallDirectoryPackage =
+        callPackage ../development/interpreters/dhall/build-dhall-directory-package.nix { };
+
     in
-      { inherit buildDhallPackage;
+      { inherit
+          buildDhallPackage
+          buildDhallGitHubPackage
+          buildDhallDirectoryPackage
+        ;
 
         dhall-kubernetes =
-          callPackage ../development/dhall-modules/dhall-kubernetes.nix { };
+          prefer "3.0.0" ../development/dhall-modules/dhall-kubernetes.nix;
 
         dhall-packages =
-          callPackage ../development/dhall-modules/dhall-packages.nix { };
+          prefer "0.11.1" ../development/dhall-modules/dhall-packages.nix;
 
         Prelude =
-          callPackage ../development/dhall-modules/Prelude.nix { };
+          prefer "13.0.0" ../development/dhall-modules/Prelude.nix;
       };
 
 in


### PR DESCRIPTION
The motivation for this change is to enable a new Dhall command-line
utility called `dhall-to-nixpkgs` which converts Dhall packages to
buildable Nix packages.  You can think of `dhall-to-nixpkgs` as the
Dhall analog of `cabal2nix`.

You can find the matching pull request for `dhall-to-nixpkgs` here:

https://github.com/dhall-lang/dhall-haskell/pull/1826

The two main changes required to support `dhall-to-nixpkgs` are:

* Two new `buildDhall{Directory,GitHub}Package` utilities are added

  `dhall-to-nixpkgs` uses these in the generated output

* `pkgs.dhallPackages` now selects a default version for each package
  using the `prefer` utility

  All other versions are still buildable via a `passthru` attribute

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I also verified that all of `pkgs.dhallPackages` still builds and I also verified that several
representative Nix packages generated by `dhall-to-nixpkgs` successfully build with
these changes.