### PR TITLE
nginxMainline: 1.18.0 -> 1.19.0

### DIFF
--- a/pkgs/servers/http/nginx/mainline.nix
+++ b/pkgs/servers/http/nginx/mainline.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  version = "1.18.0";
-  sha256 = "16azscl74ym1far0s0p6xsjin1k1cm4wk80i9x5d74dznmx3wdsc";
+  version = "1.19.0";
+  sha256 = "1j1n3rlvan6l9j3vw8axbbdm96w7s0x6ygmgqvbplzfd3wbid9j4";
 }


### PR DESCRIPTION
###### Motivation for this change
Update nginxMainline to 1.19.0

Changes with nginx 1.19.0:
 *) Feature: client certificate validation with OCSP.
 *) Bugfix: "upstream sent frame for closed stream" errors might occur when working with gRPC backends.
 *) Bugfix: OCSP stapling might not work if the "resolver" directive was not specified.
 *) Bugfix: connections with incorrect HTTP/2 preface were not logged.

cc @Mic92
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
