### PR TITLE
libversion: Fix unsafe concatenation of $LD_LIBRARY_PATH

### DIFF
--- a/pkgs/development/libraries/libversion/default.nix
+++ b/pkgs/development/libraries/libversion/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   preCheck = ''
-    export LD_LIBRARY_PATH=/build/source/build/libversion/:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=/build/source/build/libversion/''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
   '';
   doCheck = true;
   checkTarget = "test";


### PR DESCRIPTION
###### Motivation for this change

Naive concatenation of `$LD_LIBRARY_PATH` can result in an empty colon-delimited segment; this tells glibc to load libraries from the current directory, which is definitely wrong, and may be a security vulnerability if the current directory is untrusted.  This particular case probably has no security relevance, but we should avoid this unsafe pattern anyway in case it gets copied.  See #76804.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
