### PR TITLE
pythonPackages.bitcoinlib: 0.9.0 -> 0.11.0

### DIFF
--- a/pkgs/development/python-modules/bitcoinlib/default.nix
+++ b/pkgs/development/python-modules/bitcoinlib/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, lib, buildPythonPackage, fetchFromGitHub, openssl }:
+{ stdenv, lib, buildPythonPackage, isPy3k, fetchFromGitHub, openssl }:
 
 let ext = if stdenv.isDarwin then "dylib" else "so";
 in buildPythonPackage rec {
   pname = "bitcoinlib";
-  version = "0.9.0";
+  version = "0.11.0";
+
+  disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner  = "petertodd";
-    rev    = "7a8a47ec6b722339de1d0a8144e55b400216f90f";
     repo   = "python-bitcoinlib";
-    sha256 = "1s1jm2nid7ab7yiwlp1n2v3was9i4q76xmm07wvzpd2zvn5zb91z";
+    rev    = "python-${pname}-v${version}";
+    sha256 = "0pwypd966zzivb37fvg4l6yr7ihplqnr1jwz9zm3biip7x89bdzm";
   };
 
   postPatch = ''
@@ -21,7 +23,7 @@ in buildPythonPackage rec {
   meta = {
     homepage = src.meta.homepage;
     description = "Easy interface to the Bitcoin data structures and protocol";
-    license = with lib.licenses; [ gpl3 ];
+    license = with lib.licenses; [ lgpl3 ];
     maintainers = with lib.maintainers; [ jb55 ];
   };
 }

--- a/pkgs/development/python-modules/opentimestamps/default.nix
+++ b/pkgs/development/python-modules/opentimestamps/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy3k
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch, isPy3k
 , bitcoinlib, GitPython, pysha3, git }:
 
 buildPythonPackage rec {
@@ -14,6 +14,14 @@ buildPythonPackage rec {
     rev = "python-opentimestamps-v${version}";
     sha256 = "0c45ij8absfgwizq6dfgg81siq3y8605sgg184vazp292w8nqmqr";
   };
+
+  patches = [
+    # build against bitcoinlib-0.11
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/opentimestamps/python-opentimestamps/pull/43.patch";
+      sha256 = "0bxzk4pzpqk7zrk2x7vn2bj2n3pc5whf8ijbd225s6674q450zbg";
+    })
+  ];
 
   # Remove a failing test which expects the test source file to reside in the
   # project's Git repo


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->
Switch to py3-only. Also changed the license which seems to be [LGPL3](https://github.com/petertodd/python-bitcoinlib/blob/master/LICENSE).

###### Motivation for this change

Trying to package [bitcoin-prometheus-exporter](https://github.com/jvstein/bitcoin-prometheus-exporter) which needs slightly newer version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @jb55 