### PR TITLE
pytest-factoryboy: init at 2.0.3

### DIFF
--- a/pkgs/development/python-modules/pytest-factoryboy/default.nix
+++ b/pkgs/development/python-modules/pytest-factoryboy/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, fetchFromGitHub
+, buildPythonPackage
+, pytestCheckHook
+, pytest
+, inflection
+, factory_boy
+, pytestcache
+, pytestcov
+, pytestpep8
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-factoryboy";
+  version = "2.0.3";
+
+  src = fetchFromGitHub {
+    owner = "pytest-dev";
+    repo = "pytest-factoryboy";
+    rev = version;
+    sha256 = "0m1snyybq2k51khlydhisq300vzys897vdbsicph628iran950hn";
+  };
+
+  propagatedBuildInputs = [ factory_boy inflection pytest ];
+
+  # The project uses tox, which we can't. So we simply run pytest manually.
+  checkInputs = [
+    mock
+    pytestCheckHook
+    pytestcache
+    pytestcov
+    pytestpep8
+  ];
+  pytestFlagsArray = [ "--ignore=docs" ];
+
+  meta = with stdenv.lib; {
+    description = "Integration of factory_boy into the pytest runner.";
+    homepage = "https://pytest-factoryboy.readthedocs.io/en/latest/";
+    maintainers = with maintainers; [ winpat ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1343,6 +1343,8 @@ in {
 
   pytest-env = callPackage ../development/python-modules/pytest-env { };
 
+  pytest-factoryboy = callPackage ../development/python-modules/pytest-factoryboy { };
+
   pytest-flask = callPackage ../development/python-modules/pytest-flask { };
 
   pytest-mypy = callPackage ../development/python-modules/pytest-mypy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
