### PR TITLE
maxcso: init at 1.12.0

### DIFF
--- a/pkgs/tools/archivers/maxcso/default.nix
+++ b/pkgs/tools/archivers/maxcso/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, libuv, lz4, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "maxcso";
+  version = "1.12.0";
+
+  src = fetchFromGitHub {
+    owner = "unknownbrackets";
+    repo = "maxcso";
+    rev = "v${version}";
+    sha256 = "10r0vb3ndpq1pw5224d48nim5xz8jj94zhlfy29br6h6jblq8zap";
+  };
+
+  buildInputs = [ libuv lz4 zlib ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/unknownbrackets/maxcso";
+    description =
+      "A fast ISO to CSO compression program for use with PSP and PS2 emulators, which uses multiple algorithms for best compression ratio";
+    maintainers = with maintainers; [ david-sawatzke ];
+    platforms = platforms.linux ++ platforms.darwin;
+    license = licenses.isc;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2046,6 +2046,8 @@ in
 
   massren = callPackage ../tools/misc/massren { };
 
+  maxcso = callPackage ../tools/archivers/maxcso {};
+
   medusa = callPackage ../tools/security/medusa { };
 
   megasync = libsForQt5.callPackage ../applications/misc/megasync { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
