### PR TITLE
docker-compose: fix zsh completion

### DIFF
--- a/pkgs/applications/virtualization/docker-compose/default.nix
+++ b/pkgs/applications/virtualization/docker-compose/default.nix
@@ -1,4 +1,5 @@
 { stdenv, buildPythonApplication, fetchPypi, pythonOlder
+, installShellFiles
 , mock, pytest, nose
 , pyyaml, backports_ssl_match_hostname, colorama, docopt
 , dockerpty, docker, ipaddress, jsonschema, requests
@@ -17,6 +18,7 @@ buildPythonApplication rec {
 
   # lots of networking and other fails
   doCheck = false;
+  nativeBuildInputs = [ installShellFiles ];
   checkInputs = [ mock pytest nose ];
   propagatedBuildInputs = [
     pyyaml backports_ssl_match_hostname colorama dockerpty docker
@@ -33,11 +35,8 @@ buildPythonApplication rec {
   '';
 
   postInstall = ''
-    install -D -m 0444 contrib/completion/bash/docker-compose \
-      $out/share/bash-completion/completions/docker-compose
-
-    install -D -m 0444 contrib/completion/zsh/_docker-compose \
-      $out/share/zsh-completion/zsh/site-functions/_docker-compose
+    installShellCompletion --bash contrib/completion/bash/docker-compose
+    installShellCompletion --zsh contrib/completion/zsh/_docker-compose
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Was installed to the wrong folder

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
