### PR TITLE
mpvScripts.simple-mpv-webui: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1616,6 +1616,12 @@
     githubId = 12202789;
     name = "CrazedProgrammer";
   };
+  cript0nauta = {
+    email = "shareman1204@gmail.com";
+    github = "cript0nauta";
+    githubId = 1222362;
+    name = "Matías Lang";
+  };
   cryptix = {
     email = "cryptix@riseup.net";
     github = "cryptix";

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -39,7 +39,7 @@
 , libpngSupport      ? true,           libpng        ? null
 , pulseSupport       ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 , rubberbandSupport  ? stdenv.isLinux, rubberband    ? null
-, sambaSupport       ? stdenv.isLinux, samba         ? null
+, sambaSupport       ? false,          samba         ? null
 , screenSaverSupport ? true,           libXScrnSaver ? null
 , sdl2Support        ? true,           SDL2          ? null
 , sndioSupport       ? true,           sndio         ? null

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -39,6 +39,9 @@
 , libpngSupport      ? true,           libpng        ? null
 , pulseSupport       ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 , rubberbandSupport  ? stdenv.isLinux, rubberband    ? null
+# NOTE: samba support should be removed on the next mpv release, see also:
+# https://github.com/NixOS/nixpkgs/pull/89145#issuecomment-636424362
+# Please remove this line on the next mpv release.
 , sambaSupport       ? false,          samba         ? null
 , screenSaverSupport ? true,           libXScrnSaver ? null
 , sdl2Support        ? true,           SDL2          ? null

--- a/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
+++ b/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  pname = "simple-mpv-ui";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "open-dynaMIX";
+    repo = "simple-mpv-webui";
+    rev = "v${version}";
+    sha256 = "1glrnnl1slcl0ri0zs4j64lc9aa52p9ffh6av0d81fk95nm98917";
+  };
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/share/mpv/scripts
+    cp -r webui.lua webui-page $out/share/mpv/scripts/
+  '';
+  passthru.scriptName = "webui.lua";
+
+  meta = with stdenv.lib; {
+    description = "A web based user interface with controls for the mpv mediaplayer";
+    homepage = "https://github.com/open-dynaMIX/simple-mpv-webui";
+    maintainers = [ maintainers.cript0nauta ];
+    longDescription = ''
+      You can access the webui when accessing http://127.0.0.1:8080 or
+      http://[::1]:8080 in your webbrowser. By default it listens on
+      0.0.0.0:8080 and [::0]:8080
+    '';
+    license = licenses.mit;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20967,6 +20967,7 @@ in
   mpvScripts = recurseIntoAttrs {
     convert = callPackage ../applications/video/mpv/scripts/convert.nix {};
     mpris = callPackage ../applications/video/mpv/scripts/mpris.nix {};
+    simple-mpv-webui = callPackage ../applications/video/mpv/scripts/simple-mpv-webui.nix {};
   };
 
   mrpeach = callPackage ../applications/audio/pd-plugins/mrpeach { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adding the simple-mpv-webui mpv plugin and fix #88584


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
