### PR TITLE
ffmpeg: default to ffmpeg_4

### DIFF
--- a/pkgs/applications/audio/amarok/default.nix
+++ b/pkgs/applications/audio/amarok/default.nix
@@ -3,7 +3,7 @@
 , qca-qt5, qjson, qtquickcontrols2, qtscript, qtwebengine
 , karchive, kcmutils, kconfig, kdnssd, kguiaddons, kinit, kirigami2, knewstuff, knotifyconfig, ktexteditor, kwindowsystem
 , fftw, phonon, plasma-framework, threadweaver
-, curl, ffmpeg, gdk-pixbuf, libaio, libmtp, loudmouth, lzo, lz4, mysql57, pcre, snappy, taglib, taglib_extras
+, curl, ffmpeg_3, gdk-pixbuf, libaio, libmtp, loudmouth, lzo, lz4, mysql57, pcre, snappy, taglib, taglib_extras
 }:
 
 mkDerivation rec {
@@ -26,7 +26,7 @@ mkDerivation rec {
     qca-qt5 qjson qtquickcontrols2 qtscript qtwebengine
     karchive kcmutils kconfig kdnssd kguiaddons kinit kirigami2 knewstuff knotifyconfig ktexteditor kwindowsystem
     phonon plasma-framework threadweaver
-    curl fftw ffmpeg gdk-pixbuf libaio libmtp loudmouth lz4 lzo mysql57.server mysql57.server.static
+    curl fftw ffmpeg_3 gdk-pixbuf libaio libmtp loudmouth lz4 lzo mysql57.server mysql57.server.static
     pcre snappy taglib taglib_extras
   ];
 

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -8,7 +8,7 @@
 , curl
 , dbus
 , doxygen
-, ffmpeg
+, ffmpeg_3
 , fftw
 , fftwSinglePrec
 , flac
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
     cppunit
     curl
     dbus
-    ffmpeg
+    ffmpeg_3
     fftw
     fftwSinglePrec
     flac
@@ -149,8 +149,8 @@ stdenv.mkDerivation rec {
     sed 's|/usr/include/libintl.h|${glibc.dev}/include/libintl.h|' -i wscript
     patchShebangs ./tools/
     substituteInPlace libs/ardour/video_tools_paths.cc \
-      --replace 'ffmpeg_exe = X_("");' 'ffmpeg_exe = X_("${ffmpeg}/bin/ffmpeg");' \
-      --replace 'ffprobe_exe = X_("");' 'ffprobe_exe = X_("${ffmpeg}/bin/ffprobe");'
+      --replace 'ffmpeg_exe = X_("");' 'ffmpeg_exe = X_("${ffmpeg_3}/bin/ffmpeg");' \
+      --replace 'ffprobe_exe = X_("");' 'ffprobe_exe = X_("${ffmpeg_3}/bin/ffprobe");'
   '';
 
   postInstall = ''

--- a/pkgs/applications/audio/audacious/default.nix
+++ b/pkgs/applications/audio/audacious/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, wrapGAppsHook, gettext, glib, gtk3
 , libmowgli, dbus-glib, libxml2, xorg, gnome3, alsaLib
 , libpulseaudio, libjack2, fluidsynth, libmad, libogg, libvorbis
-, libcdio, libcddb, flac, ffmpeg, mpg123, libcue, libmms, libbs2b
+, libcdio, libcddb, flac, ffmpeg_3, mpg123, libcue, libmms, libbs2b
 , libsndfile, libmodplug, libsamplerate, soxr, lirc, curl, wavpack
 , neon, faad2, lame, libnotify, libsidplayfp
 }:
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     gettext glib gtk3 libmowgli dbus-glib libxml2
     xorg.libXcomposite gnome3.adwaita-icon-theme alsaLib libjack2
     libpulseaudio fluidsynth libmad libogg libvorbis libcdio
-    libcddb flac ffmpeg mpg123 libcue libmms libbs2b libsndfile
+    libcddb flac ffmpeg_3 mpg123 libcue libmms libbs2b libsndfile
     libmodplug libsamplerate soxr lirc curl wavpack neon faad2
     lame libnotify libsidplayfp
   ];

--- a/pkgs/applications/audio/audacious/qt-5.nix
+++ b/pkgs/applications/audio/audacious/qt-5.nix
@@ -2,7 +2,7 @@
   mkDerivation, lib, fetchurl, fetchpatch,
   gettext, pkgconfig,
   qtbase,
-  alsaLib, curl, faad2, ffmpeg, flac, fluidsynth, gdk-pixbuf, lame, libbs2b,
+  alsaLib, curl, faad2, ffmpeg_3, flac, fluidsynth, gdk-pixbuf, lame, libbs2b,
   libcddb, libcdio, libcue, libjack2, libmad, libmms, libmodplug,
   libmowgli, libnotify, libogg, libpulseaudio, libsamplerate, libsidplayfp,
   libsndfile, libvorbis, libxml2, lirc, mpg123, neon, qtmultimedia, soxr,
@@ -45,7 +45,7 @@ mkDerivation {
     qtbase
 
     # Plugin dependencies
-    alsaLib curl faad2 ffmpeg flac fluidsynth gdk-pixbuf lame libbs2b libcddb
+    alsaLib curl faad2 ffmpeg_3 flac fluidsynth gdk-pixbuf lame libbs2b libcddb
     libcdio libcue libjack2 libmad libmms libmodplug libmowgli
     libnotify libogg libpulseaudio libsamplerate libsidplayfp libsndfile
     libvorbis libxml2 lirc mpg123 neon qtmultimedia soxr wavpack

--- a/pkgs/applications/audio/audacity/default.nix
+++ b/pkgs/applications/audio/audacity/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchzip, wxGTK30, pkgconfig, file, gettext,
   libvorbis, libmad, libjack2, lv2, lilv, serd, sord, sratom, suil, alsaLib, libsndfile, soxr, flac, lame,
-  expat, libid3tag, ffmpeg, soundtouch, /*, portaudio - given up fighting their portaudio.patch */
+  expat, libid3tag, ffmpeg_3, soundtouch, /*, portaudio - given up fighting their portaudio.patch */
   autoconf, automake, libtool
   }:
 
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     file gettext wxGTK30 expat alsaLib
     libsndfile soxr libid3tag libjack2 lv2 lilv serd sord sratom suil wxGTK30.gtk
-    ffmpeg libmad lame libvorbis flac soundtouch
+    ffmpeg_3 libmad lame libvorbis flac soundtouch
   ]; #ToDo: detach sbsms
 
   enableParallelBuilding = true;

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, alsaLib, bzip2, cairo, dpkg, freetype, gdk-pixbuf
 , wrapGAppsHook, gtk2, gtk3, harfbuzz, jdk, lib, xorg
-, libbsd, libjack2, libpng, ffmpeg
+, libbsd, libjack2, libpng, ffmpeg_3
 , libxkbcommon
 , makeWrapper, pixman, autoPatchelfHook
 , xdg_utils, zenity, zlib }:
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   ];
 
   binPath = lib.makeBinPath [
-    xdg_utils zenity ffmpeg
+    xdg_utils zenity ffmpeg_3
   ];
 
   installPhase = ''

--- a/pkgs/applications/audio/bs1770gain/default.nix
+++ b/pkgs/applications/audio/bs1770gain/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ffmpeg, sox }:
+{ stdenv, fetchurl, ffmpeg_3, sox }:
 
 stdenv.mkDerivation rec {
   pname = "bs1770gain";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1p6yz5q7czyf9ard65sp4kawdlkg40cfscr3b24znymmhs3p7rbk";
   };
 
-  buildInputs = [ ffmpeg sox ];
+  buildInputs = [ ffmpeg_3 sox ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
 

--- a/pkgs/applications/audio/cantata/default.nix
+++ b/pkgs/applications/audio/cantata/default.nix
@@ -10,7 +10,7 @@
 
 , withTaglib ? true, taglib, taglib_extras
 , withHttpStream ? true, qtmultimedia
-, withReplaygain ? true, ffmpeg, speex, mpg123
+, withReplaygain ? true, ffmpeg_3, speex, mpg123
 , withMtp ? true, libmtp
 , withOnlineServices ? true
 , withDevices ? true, udisks2
@@ -50,7 +50,7 @@ in mkDerivation {
 
   buildInputs = [ qtbase qtsvg ]
     ++ lib.optionals withTaglib [ taglib taglib_extras ]
-    ++ lib.optionals withReplaygain [ ffmpeg speex mpg123 ]
+    ++ lib.optionals withReplaygain [ ffmpeg_3 speex mpg123 ]
     ++ lib.optional  withHttpStream qtmultimedia
     ++ lib.optional  withCdda cdparanoia
     ++ lib.optional  withCddb libcddb

--- a/pkgs/applications/audio/carla/default.nix
+++ b/pkgs/applications/audio/carla/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, alsaLib, file, fluidsynth, ffmpeg, jack2,
+{ stdenv, fetchFromGitHub, alsaLib, file, fluidsynth, ffmpeg_3, jack2,
   liblo, libpulseaudio, libsndfile, pkgconfig, python3Packages,
   which, withFrontend ? true,
   withQt ? true, qtbase ? null, wrapQtAppsHook ? null,
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   ] ++ optional withFrontend pyqt5;
 
   buildInputs = [
-    file liblo alsaLib fluidsynth ffmpeg jack2 libpulseaudio libsndfile
+    file liblo alsaLib fluidsynth ffmpeg_3 jack2 libpulseaudio libsndfile
   ] ++ pythonPath
     ++ optional withQt qtbase
     ++ optional withGtk2 gtk2

--- a/pkgs/applications/audio/deadbeef/default.nix
+++ b/pkgs/applications/audio/deadbeef/default.nix
@@ -17,7 +17,7 @@
 , aacSupport ? true, faad2 ? null
 , opusSupport ? true, opusfile ? null
 , wavpackSupport ? false, wavpack ? null
-, ffmpegSupport ? false, ffmpeg ? null
+, ffmpegSupport ? false, ffmpeg_3 ? null
 , apeSupport ? true, yasm ? null
 # misc plugins
 , zipSupport ? true, libzip ? null
@@ -45,7 +45,7 @@ assert cdaSupport -> (libcdio != null && libcddb != null);
 assert aacSupport -> faad2 != null;
 assert opusSupport -> opusfile != null;
 assert zipSupport -> libzip != null;
-assert ffmpegSupport -> ffmpeg != null;
+assert ffmpegSupport -> ffmpeg_3 != null;
 assert apeSupport -> yasm != null;
 assert artworkSupport -> imlib2 != null;
 assert hotkeysSupport -> libX11 != null;
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     ++ optional aacSupport faad2
     ++ optional opusSupport opusfile
     ++ optional zipSupport libzip
-    ++ optional ffmpegSupport ffmpeg
+    ++ optional ffmpegSupport ffmpeg_3
     ++ optional apeSupport yasm
     ++ optional artworkSupport imlib2
     ++ optional hotkeysSupport libX11

--- a/pkgs/applications/audio/dr14_tmeter/default.nix
+++ b/pkgs/applications/audio/dr14_tmeter/default.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
   };
 
   propagatedBuildInputs = with pkgs; [
-    python3Packages.numpy flac vorbis-tools ffmpeg faad2 lame
+    python3Packages.numpy flac vorbis-tools ffmpeg_3 faad2 lame
   ];
 
   # There are no tests

--- a/pkgs/applications/audio/kid3/default.nix
+++ b/pkgs/applications/audio/kid3/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, pkgconfig, cmake, python, ffmpeg, phonon, automoc4
+, pkgconfig, cmake, python, ffmpeg_3, phonon, automoc4
 , chromaprint, docbook_xml_dtd_45, docbook_xsl, libxslt
 , id3lib, taglib, mp4v2, flac, libogg, libvorbis
 , zlib, readline , qtbase, qttools, qtmultimedia, qtquickcontrols
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ wrapQtAppsHook ];
   buildInputs = with stdenv.lib;
-  [ pkgconfig cmake python ffmpeg phonon automoc4
+  [ pkgconfig cmake python ffmpeg_3 phonon automoc4
     chromaprint docbook_xml_dtd_45 docbook_xsl libxslt
     id3lib taglib mp4v2 flac libogg libvorbis zlib readline
     qtbase qttools qtmultimedia qtquickcontrols ];

--- a/pkgs/applications/audio/moc/default.nix
+++ b/pkgs/applications/audio/moc/default.nix
@@ -14,7 +14,7 @@
 , musepackSupport ? true, libmpc, libmpcdec, taglib
 , vorbisSupport ? true, libvorbis
 , speexSupport ? true, speex
-, ffmpegSupport ? true, ffmpeg
+, ffmpegSupport ? true, ffmpeg_3
 , sndfileSupport ? true, libsndfile
 , wavpackSupport ? true, wavpack
 # Misc
@@ -60,7 +60,7 @@ in stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals musepackSupport [ libmpc libmpcdec taglib ]
     ++ opt vorbisSupport libvorbis
     ++ opt speexSupport speex
-    ++ opt (ffmpegSupport && !withffmpeg4) ffmpeg
+    ++ opt (ffmpegSupport && !withffmpeg4) ffmpeg_3
     ++ opt (ffmpegSupport && withffmpeg4) ffmpeg_4
     ++ opt sndfileSupport libsndfile
     ++ opt wavpackSupport wavpack

--- a/pkgs/applications/audio/musikcube/default.nix
+++ b/pkgs/applications/audio/musikcube/default.nix
@@ -4,7 +4,7 @@
 , boost
 , curl
 , fetchFromGitHub
-, ffmpeg
+, ffmpeg_3
 , lame
 , libev
 , libmicrohttpd
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     alsaLib
     boost
     curl
-    ffmpeg
+    ffmpeg_3
     lame
     libev
     libmicrohttpd

--- a/pkgs/applications/audio/pianobar/default.nix
+++ b/pkgs/applications/audio/pianobar/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, libao, json_c, libgcrypt, ffmpeg, curl }:
+{ fetchurl, stdenv, pkgconfig, libao, json_c, libgcrypt, ffmpeg_3, curl }:
 
 stdenv.mkDerivation rec {
   name = "pianobar-2020.04.05";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    libao json_c libgcrypt ffmpeg curl
+    libao json_c libgcrypt ffmpeg_3 curl
   ];
 
   makeFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/applications/audio/qmmp/default.nix
+++ b/pkgs/applications/audio/qmmp/default.nix
@@ -4,7 +4,7 @@
 , curl, libmms
 # input plugins
 , libmad, taglib, libvorbis, libogg, flac, libmpcdec, libmodplug, libsndfile
-, libcdio, cdparanoia, libcddb, faad2, ffmpeg, wildmidi
+, libcdio, cdparanoia, libcddb, faad2, ffmpeg_3, wildmidi
 # output plugins
 , alsaLib, libpulseaudio
 # effect plugins
@@ -44,7 +44,7 @@ mkDerivation rec {
       curl libmms
       # input plugins
       libmad taglib libvorbis libogg flac libmpcdec libmodplug libsndfile
-      libcdio cdparanoia libcddb faad2 ffmpeg wildmidi
+      libcdio cdparanoia libcddb faad2 ffmpeg_3 wildmidi
       # output plugins
       alsaLib libpulseaudio
       # effect plugins

--- a/pkgs/applications/audio/r128gain/default.nix
+++ b/pkgs/applications/audio/r128gain/default.nix
@@ -1,7 +1,7 @@
 { lib
 , fetchFromGitHub
 , substituteAll
-, ffmpeg
+, ffmpeg_3
 , python3Packages
 , sox
 }:
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication rec {
     (
       substituteAll {
         src = ./ffmpeg-location.patch;
-        inherit ffmpeg;
+        ffmpeg = ffmpeg_3;
       }
     )
   ];

--- a/pkgs/applications/audio/squeezelite/default.nix
+++ b/pkgs/applications/audio/squeezelite/default.nix
@@ -2,7 +2,7 @@
 , alsaLib, flac, libmad, libvorbis, mpg123
 , dsdSupport ? true
 , faad2Support ? true, faad2
-, ffmpegSupport ? true, ffmpeg
+, ffmpegSupport ? true, ffmpeg_3
 , opusSupport ? true, opusfile
 , resampleSupport ? true, soxr
 , sslSupport ? true, openssl
@@ -35,7 +35,7 @@ in stdenv.mkDerivation {
 
   buildInputs = [ alsaLib flac libmad libvorbis mpg123 ]
     ++ optional faad2Support faad2
-    ++ optional ffmpegSupport ffmpeg
+    ++ optional ffmpegSupport ffmpeg_3
     ++ optional opusSupport opusfile
     ++ optional resampleSupport soxr
     ++ optional sslSupport openssl;

--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, flex, bison, pkgconfig, zlib, libtiff, libpng, fftw
-, cairo, readline, ffmpeg, makeWrapper, wxGTK30, netcdf, blas
+, cairo, readline, ffmpeg_3, makeWrapper, wxGTK30, netcdf, blas
 , proj, gdal, geos, sqlite, postgresql, libmysqlclient, python2Packages, libLAS, proj-datumgrid
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ flex bison zlib proj gdal libtiff libpng fftw sqlite cairo proj
-  readline ffmpeg makeWrapper wxGTK30 netcdf geos postgresql libmysqlclient blas
+  readline ffmpeg_3 makeWrapper wxGTK30 netcdf geos postgresql libmysqlclient blas
   libLAS proj-datumgrid ]
     ++ (with python2Packages; [ python dateutil wxPython30 numpy ]);
 

--- a/pkgs/applications/graphics/pqiv/default.nix
+++ b/pkgs/applications/graphics/pqiv/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig
-, ffmpeg, gtk3, imagemagick, libarchive, libspectre, libwebp, poppler
+, ffmpeg_3, gtk3, imagemagick, libarchive, libspectre, libwebp, poppler
 }:
 
 stdenv.mkDerivation (rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation (rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ffmpeg gtk3 imagemagick libarchive libspectre libwebp poppler ];
+  buildInputs = [ ffmpeg_3 gtk3 imagemagick libarchive libspectre libwebp poppler ];
 
   prePatch = "patchShebangs .";
 

--- a/pkgs/applications/kde/ffmpegthumbs.nix
+++ b/pkgs/applications/kde/ffmpegthumbs.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib,
   extra-cmake-modules,
-  ffmpeg, kio
+  ffmpeg_3, kio
 }:
 
 mkDerivation {
@@ -11,5 +11,5 @@ mkDerivation {
     maintainers = [ lib.maintainers.ttuegel ];
   };
   nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = [ ffmpeg kio ];
+  buildInputs = [ ffmpeg_3 kio ];
 }

--- a/pkgs/applications/kde/k3b.nix
+++ b/pkgs/applications/kde/k3b.nix
@@ -5,7 +5,7 @@
 , flac, lame, libmad, libmpcdec, libvorbis
 , libsamplerate, libsndfile, taglib
 , cdparanoia, cdrdao, cdrtools, dvdplusrwtools, libburn, libdvdcss, libdvdread, vcdimager
-, ffmpeg, libmusicbrainz3, normalize, sox, transcode, kinit
+, ffmpeg_3, libmusicbrainz3, normalize, sox, transcode, kinit
 }:
 
 mkDerivation {
@@ -28,7 +28,7 @@ mkDerivation {
     # cd/dvd
     cdparanoia libdvdcss libdvdread
     # others
-    ffmpeg libmusicbrainz3 shared-mime-info
+    ffmpeg_3 libmusicbrainz3 shared-mime-info
   ];
   propagatedUserEnvPkgs = [ (lib.getBin kinit) ];
   postFixup =

--- a/pkgs/applications/misc/airtame/default.nix
+++ b/pkgs/applications/misc/airtame/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, fetchurl, makeDesktopItem, makeWrapper
-, alsaLib, atk, cairo, cups, curl, dbus, expat, ffmpeg, fontconfig, freetype
+, alsaLib, atk, cairo, cups, curl, dbus, expat, ffmpeg_3, fontconfig, freetype
 , gdk-pixbuf, glib, glibc, gnome2, gtk2, libX11, libXScrnSaver, libXcomposite
 , libXcursor, libXdamage, libXext, libXfixes, libXi, libXrandr, libXrender
 , libXtst, libopus, libpulseaudio, libxcb, nspr, nss, pango, udev, x264
 }:
 
 let libPath = lib.makeLibraryPath [
-  alsaLib atk cairo cups curl dbus expat ffmpeg fontconfig freetype gdk-pixbuf
+  alsaLib atk cairo cups curl dbus expat ffmpeg_3 fontconfig freetype gdk-pixbuf
   glib glibc gnome2.GConf gtk2 libopus nspr nss pango stdenv.cc.cc udev x264
   libX11 libXScrnSaver libXcomposite libXcursor libXdamage libXext libXfixes
   libXi libXrandr libXrender libXtst libpulseaudio libxcb

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -1,4 +1,4 @@
-{ config, stdenv, lib, fetchurl, boost, cmake, ffmpeg, gettext, glew
+{ config, stdenv, lib, fetchurl, boost, cmake, ffmpeg_3, gettext, glew
 , ilmbase, libXi, libX11, libXext, libXrender
 , libjpeg, libpng, libsamplerate, libsndfile
 , libtiff, libGLU, libGL, openal, opencolorio, openexr, openimagedenoise, openimageio2, openjpeg, python3Packages
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ] ++ optional cudaSupport addOpenGLRunpath;
   buildInputs =
-    [ boost ffmpeg gettext glew ilmbase
+    [ boost ffmpeg_3 gettext glew ilmbase
       freetype libjpeg libpng libsamplerate libsndfile libtiff
       opencolorio openexr openimagedenoise openimageio2 openjpeg python zlib fftw jemalloc
       alembic

--- a/pkgs/applications/misc/get_iplayer/default.nix
+++ b/pkgs/applications/misc/get_iplayer/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchFromGitHub, atomicparsley, flvstreamer, ffmpeg, makeWrapper, perl, perlPackages, rtmpdump}:
+{stdenv, fetchFromGitHub, atomicparsley, flvstreamer, ffmpeg_3, makeWrapper, perl, perlPackages, rtmpdump}:
 
 with stdenv.lib;
 
@@ -26,7 +26,7 @@ perlPackages.buildPerlPackage rec {
   installPhase = ''
     mkdir -p $out/bin $out/share/man/man1
     cp get_iplayer $out/bin
-    wrapProgram $out/bin/get_iplayer --suffix PATH : ${makeBinPath [ atomicparsley ffmpeg flvstreamer rtmpdump ]} --prefix PERL5LIB : $PERL5LIB
+    wrapProgram $out/bin/get_iplayer --suffix PATH : ${makeBinPath [ atomicparsley ffmpeg_3 flvstreamer rtmpdump ]} --prefix PERL5LIB : $PERL5LIB
     cp get_iplayer.1 $out/share/man/man1
   '';
 

--- a/pkgs/applications/misc/goldendict/default.nix
+++ b/pkgs/applications/misc/goldendict/default.nix
@@ -4,7 +4,7 @@
 , withCC ? true, opencc
 , withEpwing ? true, libeb
 , withExtraTiff ? true, libtiff
-, withFFmpeg ? true, libao, ffmpeg
+, withFFmpeg ? true, libao, ffmpeg_3
 , withMultimedia ? true
 , withZim ? true, zstd }:
 
@@ -39,7 +39,7 @@ mkDerivation rec {
     ++ stdenv.lib.optional withCC opencc
     ++ stdenv.lib.optional withEpwing libeb
     ++ stdenv.lib.optional withExtraTiff libtiff
-    ++ stdenv.lib.optionals withFFmpeg [ libao ffmpeg ]
+    ++ stdenv.lib.optionals withFFmpeg [ libao ffmpeg_3 ]
     ++ stdenv.lib.optional withZim zstd;
 
   qmakeFlags = with stdenv.lib; [

--- a/pkgs/applications/misc/lutris/chrootenv.nix
+++ b/pkgs/applications/misc/lutris/chrootenv.nix
@@ -28,7 +28,7 @@ in buildFHSUserEnv {
     # DGen // TODO: libarchive is broken
 
     # Dolphin
-    bluez ffmpeg gettext portaudio wxGTK30 miniupnpc mbedtls lzo sfml gsm
+    bluez ffmpeg_3 gettext portaudio wxGTK30 miniupnpc mbedtls lzo sfml gsm
     wavpack orc nettle gmp pcre vulkan-loader
 
     # DOSBox

--- a/pkgs/applications/misc/megacmd/default.nix
+++ b/pkgs/applications/misc/megacmd/default.nix
@@ -5,7 +5,7 @@
 , cryptopp
 , curl
 , fetchFromGitHub
-, ffmpeg
+, ffmpeg_3
 , freeimage
 , gcc-unwrapped
 , libmediainfo
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     c-ares
     cryptopp
     curl
-    ffmpeg
+    ffmpeg_3
     freeimage
     gcc-unwrapped
     libmediainfo

--- a/pkgs/applications/misc/megasync/default.nix
+++ b/pkgs/applications/misc/megasync/default.nix
@@ -1,5 +1,5 @@
 { stdenv, autoconf, automake, c-ares, cryptopp, curl, doxygen, fetchFromGitHub
-, fetchpatch, ffmpeg, libmediainfo, libraw, libsodium, libtool, libuv, libzen
+, fetchpatch, ffmpeg_3, libmediainfo, libraw, libsodium, libtool, libuv, libzen
 , lsb-release, mkDerivation, pkgconfig, qtbase, qttools, sqlite, swig, unzip
 , wget }:
 
@@ -21,7 +21,7 @@ mkDerivation rec {
     c-ares
     cryptopp
     curl
-    ffmpeg
+    ffmpeg_3
     libmediainfo
     libraw
     libsodium

--- a/pkgs/applications/misc/moonlight-embedded/default.nix
+++ b/pkgs/applications/misc/moonlight-embedded/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, perl
 , alsaLib, libevdev, libopus, udev, SDL2
-, ffmpeg, pkgconfig, xorg, libvdpau, libpulseaudio, libcec
+, ffmpeg_3, pkgconfig, xorg, libvdpau, libpulseaudio, libcec
 , curl, expat, avahi, enet, libuuid, libva
 }:
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [
     alsaLib libevdev libopus udev SDL2
-    ffmpeg pkgconfig xorg.libxcb libvdpau libpulseaudio libcec
+    ffmpeg_3 pkgconfig xorg.libxcb libvdpau libpulseaudio libcec
     xorg.libpthreadstubs curl expat avahi enet libuuid libva
   ];
 

--- a/pkgs/applications/misc/sigal/default.nix
+++ b/pkgs/applications/misc/sigal/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, ffmpeg }:
+{ lib, python3Packages, ffmpeg_3 }:
 
 python3Packages.buildPythonApplication rec {
   version = "2.0";
@@ -20,7 +20,7 @@ python3Packages.buildPythonApplication rec {
     blinker
   ];
 
-  makeWrapperArgs = [ "--prefix PATH : ${ffmpeg}/bin" ];
+  makeWrapperArgs = [ "--prefix PATH : ${ffmpeg_3}/bin" ];
 
   # No tests included
   doCheck = false;

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -16,7 +16,7 @@
 , xorg
 , libXScrnSaver, libXcursor, libXtst, libGLU, libGL
 , protobuf, speechd, libXdamage, cups
-, ffmpeg, libxslt, libxml2, at-spi2-core
+, ffmpeg_3, libxslt, libxml2, at-spi2-core
 , jre
 , pipewire_0_2
 
@@ -93,7 +93,7 @@ let
     libpng libcap
     xdg_utils minizip libwebp
     libusb1 re2 zlib
-    ffmpeg libxslt libxml2
+    ffmpeg_3 libxslt libxml2
     # harfbuzz # in versions over 63 harfbuzz and freetype are being built together
                # so we can't build with one from system and other from source
   ] ++ (if (versionRange "0" "84") then [ yasm ] else [ nasm ]);

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -48,7 +48,7 @@
 , gnused
 , gnugrep
 , gnupg
-, ffmpeg
+, ffmpeg_3
 , runtimeShell
 , systemLocale ? config.i18n.defaultLocale or "en-US"
 }:
@@ -134,7 +134,7 @@ stdenv.mkDerivation {
       libpulseaudio
       (lib.getDev libpulseaudio)
       systemd
-      ffmpeg
+      ffmpeg_3
     ] + ":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" [
       stdenv.cc.cc
     ];

--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchgit, makeDesktopItem
 , pkgconfig, autoconf213, alsaLib, bzip2, cairo
-, dbus, dbus-glib, ffmpeg, file, fontconfig, freetype
+, dbus, dbus-glib, ffmpeg_3, file, fontconfig, freetype
 , gnome2, gnum4, gtk2, hunspell, libevent, libjpeg
 , libnotify, libstartup_notification, makeWrapper
 , libGLU, libGL, perl, python2, libpulseaudio
@@ -11,7 +11,7 @@
 
 let
 
-  libPath = lib.makeLibraryPath [ ffmpeg ];
+  libPath = lib.makeLibraryPath [ ffmpeg_3 ];
   gtkVersion = if withGTK3 then "3" else "2";
 
 in stdenv.mkDerivation rec {
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    alsaLib bzip2 cairo dbus dbus-glib ffmpeg fontconfig freetype
+    alsaLib bzip2 cairo dbus dbus-glib ffmpeg_3 fontconfig freetype
     gnome2.GConf gtk2 hunspell libevent libjpeg libnotify
     libstartup_notification libGLU libGL
     libpulseaudio unzip yasm zip zlib

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -29,7 +29,7 @@
 
 # Media support (implies audio support)
 , mediaSupport ? true
-, ffmpeg
+, ffmpeg_3
 
 , gmp
 
@@ -83,7 +83,7 @@ let
   ]
   ++ optionals pulseaudioSupport [ libpulseaudio ]
   ++ optionals mediaSupport [
-    ffmpeg
+    ffmpeg_3
   ];
 
   # Library search path for the fte transport

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
@@ -15,7 +15,7 @@
 , glibc
 , libXScrnSaver, libXcursor, libXtst, libGLU, libGL
 , protobuf, speechd, libXdamage, cups
-, ffmpeg, libxslt, libxml2, at-spi2-core
+, ffmpeg_3, libxslt, libxml2, at-spi2-core
 , jre
 
 # optional dependencies
@@ -93,7 +93,7 @@ let
     libpng libcap
     xdg_utils yasm minizip libwebp
     libusb1 re2 zlib
-    ffmpeg libxslt libxml2
+    ffmpeg_3 libxslt libxml2
     # harfbuzz # in versions over 63 harfbuzz and freetype are being built together
                # so we can't build with one from system and other from source
   ];

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, zlib, libX11, libXext, libSM, libICE
 , libXfixes, libXt, libXi, libXcursor, libXScrnSaver, libXcomposite, libXdamage, libXtst, libXrandr
-, alsaLib, dbus, cups, libexif, ffmpeg, systemd
+, alsaLib, dbus, cups, libexif, ffmpeg_3, systemd
 , freetype, fontconfig, libXft, libXrender, libxcb, expat
 , libuuid
 , gstreamer, gst-plugins-base, libxml2
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     stdenv.cc.cc stdenv.cc.libc zlib libX11 libXt libXext libSM libICE libxcb
     libXi libXft libXcursor libXfixes libXScrnSaver libXcomposite libXdamage libXtst libXrandr
-    atk at-spi2-atk at-spi2-core alsaLib dbus cups gtk3 gdk-pixbuf libexif ffmpeg systemd
+    atk at-spi2-atk at-spi2-core alsaLib dbus cups gtk3 gdk-pixbuf libexif ffmpeg_3 systemd
     freetype fontconfig libXrender libuuid expat glib nss nspr
     gstreamer libxml2 gst-plugins-base pango cairo gnome2.GConf
     libdrm mesa

--- a/pkgs/applications/networking/instant-messengers/baresip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/baresip/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchurl, zlib, openssl, libre, librem, pkgconfig, gst_all_1
-, cairo, mpg123, alsaLib, SDL, libv4l, celt, libsndfile, srtp, ffmpeg
+, cairo, mpg123, alsaLib, SDL, libv4l, celt, libsndfile, srtp, ffmpeg_3
 , gsm, speex, portaudio, spandsp, libuuid, ccache, libvpx
 }:
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [zlib openssl libre librem cairo mpg123
-    alsaLib SDL libv4l celt libsndfile srtp ffmpeg gsm speex portaudio spandsp libuuid
+    alsaLib SDL libv4l celt libsndfile srtp ffmpeg_3 gsm speex portaudio spandsp libuuid
     ccache libvpx
   ] ++ (with gst_all_1; [ gstreamer gst-libav gst-plugins-base gst-plugins-bad gst-plugins-good ]);
   makeFlags = [

--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -10,7 +10,7 @@
 , cyrus_sasl
 , fetchFromGitLab
 , fetchurl
-, ffmpeg
+, ffmpeg_3
 , gdk-pixbuf
 , glib
 , gnused
@@ -137,7 +137,7 @@ mkDerivation rec {
     bzrtp
     cairo
     cyrus_sasl
-    ffmpeg
+    ffmpeg_3
     gdk-pixbuf
     glib
     gtk2

--- a/pkgs/applications/networking/instant-messengers/qtox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/qtox/default.nix
@@ -2,7 +2,7 @@
 , libtoxcore
 , libpthreadstubs, libXdmcp, libXScrnSaver
 , qtbase, qtsvg, qttools, qttranslations
-, ffmpeg, filter-audio, libexif, libsodium, libopus
+, ffmpeg_3, filter-audio, libexif, libsodium, libopus
 , libvpx, openal, pcre, qrencode, sqlcipher
 , AVFoundation ? null }:
 
@@ -25,7 +25,7 @@ in mkDerivation {
     libtoxcore
     libpthreadstubs libXdmcp libXScrnSaver
     qtbase qtsvg qttranslations
-    ffmpeg filter-audio libexif libopus libsodium
+    ffmpeg_3 filter-audio libexif libopus libsodium
     libvpx openal pcre qrencode sqlcipher
   ] ++ lib.optionals stdenv.isDarwin [ AVFoundation] ;
 

--- a/pkgs/applications/networking/instant-messengers/ring-daemon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ring-daemon/default.nix
@@ -13,7 +13,7 @@
 , libsndfile
 , dbus
 , dbus_cplusplus
-, ffmpeg
+, ffmpeg_3
 , udev
 , pcre
 , gsm
@@ -101,7 +101,7 @@ stdenv.mkDerivation {
     libsndfile
     dbus
     dbus_cplusplus
-    ffmpeg
+    ffmpeg_3
     udev
     pcre
     gsm

--- a/pkgs/applications/networking/instant-messengers/sky/default.nix
+++ b/pkgs/applications/networking/instant-messengers/sky/default.nix
@@ -4,7 +4,7 @@
 , curl, sqlite, openssl
 , libuuid, openh264, libv4l, libxkbfile, libXv, zlib, libXmu
 , libXtst, libXdamage, pam, libXfixes, libXrender, libjpeg_original
-, ffmpeg
+, ffmpeg_3
 }:
  let
    # Sky is linked to the libjpeg 8 version and checks for the version number in the code.
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     file
     qt5.qtbase
     SDL
-    ffmpeg
+    ffmpeg_3
     sqlite
     openssl
     openh264

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib, fetchFromGitHub, pkg-config, python3, cmake, ninja
-, qtbase, qtimageformats, libsForQt5, hunspell, xdg_utils, ffmpeg, openalSoft
+, qtbase, qtimageformats, libsForQt5, hunspell, xdg_utils, ffmpeg_3, openalSoft
 , lzma, lz4, xxHash, zlib, minizip, openssl, libtgvoip, microsoft_gsl, tl-expected
 , range-v3
 }:
@@ -21,7 +21,7 @@ mkDerivation rec {
   nativeBuildInputs = [ pkg-config python3 cmake ninja ];
 
   buildInputs = [
-    qtbase qtimageformats ffmpeg openalSoft lzma lz4 xxHash libsForQt5.libdbusmenu
+    qtbase qtimageformats ffmpeg_3 openalSoft lzma lz4 xxHash libsForQt5.libdbusmenu
     zlib minizip openssl hunspell libtgvoip microsoft_gsl tl-expected range-v3
   ];
 

--- a/pkgs/applications/networking/p2p/retroshare/default.nix
+++ b/pkgs/applications/networking/p2p/retroshare/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, libupnp, gpgme, gnome3, glib, libssh, pkgconfig, protobuf, bzip2
-, libXScrnSaver, speex, curl, libxml2, libxslt, sqlcipher, libmicrohttpd, opencv, qmake, ffmpeg
+, libXScrnSaver, speex, curl, libxml2, libxslt, sqlcipher, libmicrohttpd, opencv, qmake, ffmpeg_3
 , qtmultimedia, qtx11extras, qttools }:
 
 stdenv.mkDerivation rec {
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig qmake ];
   buildInputs = [
     speex libupnp gpgme gnome3.libgnome-keyring glib libssh qtmultimedia qtx11extras qttools
-    protobuf bzip2 libXScrnSaver curl libxml2 libxslt sqlcipher libmicrohttpd opencv ffmpeg
+    protobuf bzip2 libXScrnSaver curl libxml2 libxslt sqlcipher libmicrohttpd opencv ffmpeg_3
   ];
 
   preConfigure = ''

--- a/pkgs/applications/networking/remote/freerdp/default.nix
+++ b/pkgs/applications/networking/remote/freerdp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig, alsaLib, ffmpeg, glib, openssl
+{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig, alsaLib, ffmpeg_3, glib, openssl
 , pcre, zlib, libX11, libXcursor, libXdamage, libXext, libXi, libXinerama
 , libXrandr, libXrender, libXv, libXtst, libxkbcommon, libxkbfile, wayland
 , gstreamer, gst-plugins-base, gst-plugins-good, libunwind, orc, libxslt
@@ -50,7 +50,7 @@ in stdenv.mkDerivation rec {
     [
       alsaLib
       cups
-      ffmpeg
+      ffmpeg_3
       glib
       gst-plugins-base
       gst-plugins-good

--- a/pkgs/applications/video/aegisub/default.nix
+++ b/pkgs/applications/video/aegisub/default.nix
@@ -12,7 +12,7 @@
 , libass
 , fftw
 , ffms
-, ffmpeg
+, ffmpeg_3
 , pkg-config
 , zlib
 , icu
@@ -85,7 +85,7 @@ stdenv.mkDerivation
     libass
     fftw
     ffms
-    ffmpeg
+    ffmpeg_3
     zlib
     icu
     boost

--- a/pkgs/applications/video/avxsynth/default.nix
+++ b/pkgs/applications/video/avxsynth/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
-, cairo, ffmpeg, ffms, libjpeg, log4cpp, pango
+, cairo, ffmpeg_3, ffms, libjpeg, log4cpp, pango
 , avxeditSupport ? false, qt4 ? null
 }:
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
-  buildInputs = [ cairo ffmpeg ffms libjpeg log4cpp pango ]
+  buildInputs = [ cairo ffmpeg_3 ffms libjpeg log4cpp pango ]
     ++ optional avxeditSupport qt4;
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/video/bombono/default.nix
+++ b/pkgs/applications/video/bombono/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, wrapGAppsHook, gtk2, boost, gtkmm2, scons,
-mjpegtools, libdvdread, dvdauthor, gettext, dvdplusrwtools, libxmlxx, ffmpeg,
+mjpegtools, libdvdread, dvdauthor, gettext, dvdplusrwtools, libxmlxx, ffmpeg_3,
 enca, pkgconfig, fetchpatch }:
 
 let fetchPatchFromAur = {name, sha256}:
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk2 gtkmm2 mjpegtools libdvdread dvdauthor boost dvdplusrwtools
-    libxmlxx ffmpeg enca
+    libxmlxx ffmpeg_3 enca
     ];
 
   prefixKey = "PREFIX=";

--- a/pkgs/applications/video/clipgrab/default.nix
+++ b/pkgs/applications/video/clipgrab/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeDesktopItem, ffmpeg
+{ stdenv, fetchurl, makeDesktopItem, ffmpeg_3
 , qmake, qttools, mkDerivation
 , qtbase, qtdeclarative, qtlocation, qtquickcontrols2, qtwebchannel, qtwebengine
 }:
@@ -13,13 +13,13 @@ mkDerivation rec {
     url = "https://download.clipgrab.org/${pname}-${version}.tar.gz";
   };
 
-  buildInputs = [ ffmpeg qtbase qtdeclarative qtlocation qtquickcontrols2 qtwebchannel qtwebengine ];
+  buildInputs = [ ffmpeg_3 qtbase qtdeclarative qtlocation qtquickcontrols2 qtwebchannel qtwebengine ];
   nativeBuildInputs = [ qmake qttools ];
 
-  postPatch = stdenv.lib.optionalString (ffmpeg != null) ''
+  postPatch = stdenv.lib.optionalString (ffmpeg_3 != null) ''
   substituteInPlace converter_ffmpeg.cpp \
-    --replace '"ffmpeg"' '"${ffmpeg.bin}/bin/ffmpeg"' \
-    --replace '"ffmpeg ' '"${ffmpeg.bin}/bin/ffmpeg '
+    --replace '"ffmpeg"' '"${ffmpeg_3.bin}/bin/ffmpeg"' \
+    --replace '"ffmpeg ' '"${ffmpeg_3.bin}/bin/ffmpeg '
   '';
 
   qmakeFlags = [ "clipgrab.pro" ];

--- a/pkgs/applications/video/devede/default.nix
+++ b/pkgs/applications/video/devede/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3Packages, ffmpeg, mplayer, vcdimager, cdrkit, dvdauthor
+{ stdenv, fetchFromGitHub, python3Packages, ffmpeg_3, mplayer, vcdimager, cdrkit, dvdauthor
 , gtk3, gettext, wrapGAppsHook, gdk-pixbuf, gobject-introspection }:
 
 let
@@ -30,11 +30,11 @@ in buildPythonApplication {
   ];
 
   buildInputs = [
-    ffmpeg
+    ffmpeg_3
   ];
 
   propagatedBuildInputs = [
-    gtk3 pygobject3 gdk-pixbuf dbus-python ffmpeg mplayer dvdauthor vcdimager cdrkit urllib3 setuptools
+    gtk3 pygobject3 gdk-pixbuf dbus-python ffmpeg_3 mplayer dvdauthor vcdimager cdrkit urllib3 setuptools
   ];
 
   postPatch = ''

--- a/pkgs/applications/video/dvd-slideshow/default.nix
+++ b/pkgs/applications/video/dvd-slideshow/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, fetchurl, writeScript, cdrtools, dvdauthor, ffmpeg, imagemagick, lame, mjpegtools, sox, transcode, vorbis-tools, runtimeShell }:
+{ stdenv, lib, fetchurl, writeScript, cdrtools, dvdauthor, ffmpeg_3, imagemagick, lame, mjpegtools, sox, transcode, vorbis-tools, runtimeShell }:
 
 let
-  binPath = lib.makeBinPath [ cdrtools dvdauthor ffmpeg imagemagick lame mjpegtools sox transcode vorbis-tools ];
+  binPath = lib.makeBinPath [ cdrtools dvdauthor ffmpeg_3 imagemagick lame mjpegtools sox transcode vorbis-tools ];
 
   wrapper = writeScript "dvd-slideshow.sh" ''
       #!${runtimeShell}

--- a/pkgs/applications/video/ffmpeg-normalize/default.nix
+++ b/pkgs/applications/video/ffmpeg-normalize/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonApplication
 , fetchPypi
-, ffmpeg
+, ffmpeg_3
 , tqdm
 }:
 
@@ -14,7 +14,7 @@ buildPythonApplication rec {
     sha256 = "18dpck9grnr3wgbjvdh4mjlx0zfwcxpy4rnpmc39in0yk3w7li2x";
   };
 
-  propagatedBuildInputs = [ ffmpeg tqdm ];
+  propagatedBuildInputs = [ ffmpeg_3 tqdm ];
 
   checkPhase = ''
     $out/bin/ffmpeg-normalize --help > /dev/null

--- a/pkgs/applications/video/gnomecast/default.nix
+++ b/pkgs/applications/video/gnomecast/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, gtk3, gobject-introspection, ffmpeg, wrapGAppsHook }:
+{ lib, python3Packages, gtk3, gobject-introspection, ffmpeg_3, wrapGAppsHook }:
 
 with python3Packages;
 buildPythonApplication rec {
@@ -17,7 +17,7 @@ buildPythonApplication rec {
   ];
 
   preFixup = ''
-    gappsWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ ffmpeg ]})
+    gappsWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ ffmpeg_3 ]})
   '';
 
   meta = with lib; {

--- a/pkgs/applications/video/makemkv/default.nix
+++ b/pkgs/applications/video/makemkv/default.nix
@@ -1,5 +1,5 @@
 { stdenv, mkDerivation, fetchurl, autoPatchelfHook
-, ffmpeg, openssl, qtbase, zlib, pkgconfig
+, ffmpeg_3, openssl, qtbase, zlib, pkgconfig
 }:
 
 let
@@ -29,7 +29,7 @@ in mkDerivation {
 
   nativeBuildInputs = [ autoPatchelfHook pkgconfig ];
 
-  buildInputs = [ ffmpeg openssl qtbase zlib ];
+  buildInputs = [ ffmpeg_3 openssl qtbase zlib ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/video/manim/default.nix
+++ b/pkgs/applications/video/manim/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonApplication, fetchFromGitHub, pythonOlder, file, fetchpatch
-, cairo, ffmpeg, sox, xdg_utils, texlive
+, cairo, ffmpeg_3, sox, xdg_utils, texlive
 , colour, numpy, pillow, progressbar, scipy, tqdm, opencv , pycairo, pydub
 , pbr, fetchPypi
 }:
@@ -28,14 +28,14 @@ buildPythonApplication rec {
     pycairo
     pydub
 
-    cairo sox ffmpeg xdg_utils
+    cairo sox ffmpeg_3 xdg_utils
   ];
 
   # Test with texlive to see whether it works but don't propagate
   # because it's huge and optional
   # TODO: Use smaller TexLive distribution
   #       Doesn't need everything but it's hard to figure out what it needs
-  checkInputs = [ cairo sox ffmpeg xdg_utils texlive.combined.scheme-full ];
+  checkInputs = [ cairo sox ffmpeg_3 xdg_utils texlive.combined.scheme-full ];
 
   # Simple test and complex test with LaTeX
   checkPhase = ''

--- a/pkgs/applications/video/motion/default.nix
+++ b/pkgs/applications/video/motion/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
-, ffmpeg, libjpeg, libmicrohttpd }:
+, ffmpeg_3, libjpeg, libmicrohttpd }:
 
 stdenv.mkDerivation rec {
   pname = "motion";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
-  buildInputs = [ ffmpeg libjpeg libmicrohttpd ];
+  buildInputs = [ ffmpeg_3 libjpeg libmicrohttpd ];
 
   meta = with stdenv.lib; {
     description = "Monitors the video signal from cameras";

--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -1,4 +1,4 @@
-{ config, stdenv, fetchurl, pkgconfig, freetype, yasm, ffmpeg
+{ config, stdenv, fetchurl, pkgconfig, freetype, yasm, ffmpeg_3
 , aalibSupport ? true, aalib ? null
 , fontconfigSupport ? true, fontconfig ? null, freefont_ttf ? null
 , fribidiSupport ? true, fribidi ? null
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ pkgconfig yasm ];
   buildInputs = with stdenv.lib;
-    [ freetype ffmpeg ]
+    [ freetype ffmpeg_3 ]
     ++ optional aalibSupport aalib
     ++ optional fontconfigSupport fontconfig
     ++ optional fribidiSupport fribidi

--- a/pkgs/applications/video/natron/default.nix
+++ b/pkgs/applications/video/natron/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, qt4, pkgconfig, boost, expat, cairo, python2Packages,
   cmake, flex, bison, pango, librsvg, librevenge, libxml2, libcdr, libzip,
-  poppler, imagemagick, openexr, ffmpeg, opencolorio, openimageio,
+  poppler, imagemagick, openexr, ffmpeg_3, opencolorio, openimageio,
   qmake4Hook, libpng, libGL, lndir }:
 
 let
@@ -68,7 +68,7 @@ let
       sha256 = "0s196i9fkgr9iw92c94mxgs1lkxbhynkf83vmsgrldflmf0xjky7";
       nativeBuildInputs = [ pkgconfig ];
       buildInputs = [
-        libpng ffmpeg openexr opencolorio openimageio boost libGL
+        libpng ffmpeg_3 openexr opencolorio openimageio boost libGL
         seexpr
       ];
     })

--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , pkgconfig, cmake, doxygen
-, libopenshot-audio, imagemagick, ffmpeg
+, libopenshot-audio, imagemagick, ffmpeg_3
 , swig, python3
 , unittest-cpp, cppzmq, zeromq
 , qtbase, qtmultimedia }:
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig cmake doxygen ];
 
   buildInputs =
-  [ imagemagick ffmpeg swig python3 unittest-cpp
+  [ imagemagick ffmpeg_3 swig python3 unittest-cpp
     cppzmq zeromq qtbase qtmultimedia ];
 
   LIBOPENSHOT_AUDIO_DIR = libopenshot-audio;

--- a/pkgs/applications/video/peek/default.nix
+++ b/pkgs/applications/video/peek/default.nix
@@ -15,7 +15,7 @@
 , glib
 , cairo
 , keybinder3
-, ffmpeg
+, ffmpeg_3
 , python3
 , libxml2
 , gst_all_1
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    gappsWrapperArgs+=(--prefix PATH : ${stdenv.lib.makeBinPath [ which ffmpeg gifski ]})
+    gappsWrapperArgs+=(--prefix PATH : ${stdenv.lib.makeBinPath [ which ffmpeg_3 gifski ]})
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/video/qstopmotion/default.nix
+++ b/pkgs/applications/video/qstopmotion/default.nix
@@ -6,7 +6,7 @@
 , qtquickcontrols
 , qtimageformats
 , qtxmlpatterns
-, ffmpeg
+, ffmpeg_3
 , guvcview
 , cmake
 , ninja
@@ -40,7 +40,7 @@ mkDerivation rec {
     v4l-utils
     libv4l
     pcre
-    ffmpeg
+    ffmpeg_3
     guvcview
     qwt
   ];

--- a/pkgs/applications/video/simplescreenrecorder/default.nix
+++ b/pkgs/applications/video/simplescreenrecorder/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkDerivation, fetchurl, alsaLib, ffmpeg, libjack2, libX11, libXext, qtx11extras
+{ stdenv, mkDerivation, fetchurl, alsaLib, ffmpeg_3, libjack2, libX11, libXext, qtx11extras
 , libXfixes, libGLU, libGL, pkgconfig, libpulseaudio, qtbase, cmake, ninja
 }:
 
@@ -25,7 +25,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig cmake ninja ];
   buildInputs = [
-    alsaLib ffmpeg libjack2 libX11 libXext libXfixes libGLU libGL
+    alsaLib ffmpeg_3 libjack2 libX11 libXext libXfixes libGLU libGL
     libpulseaudio qtbase qtx11extras
   ];
 

--- a/pkgs/applications/video/streamlink/default.nix
+++ b/pkgs/applications/video/streamlink/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pythonPackages, fetchFromGitHub, rtmpdump, ffmpeg }:
+{ stdenv, pythonPackages, fetchFromGitHub, rtmpdump, ffmpeg_3 }:
 
 pythonPackages.buildPythonApplication rec {
   version = "1.4.1";
@@ -13,7 +13,7 @@ pythonPackages.buildPythonApplication rec {
 
   checkInputs = with pythonPackages; [ pytest mock requests-mock freezegun ];
 
-  propagatedBuildInputs = (with pythonPackages; [ pycryptodome requests iso-639 iso3166 websocket_client isodate ]) ++ [ rtmpdump ffmpeg ];
+  propagatedBuildInputs = (with pythonPackages; [ pycryptodome requests iso-639 iso3166 websocket_client isodate ]) ++ [ rtmpdump ffmpeg_3 ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/streamlink/streamlink";

--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchgit, vdr, alsaLib, fetchFromGitHub
-, libvdpau, libxcb, xcbutilwm, graphicsmagick, libav, pcre, xorgserver, ffmpeg
+, libvdpau, libxcb, xcbutilwm, graphicsmagick, libav, pcre, xorgserver, ffmpeg_3
 , libiconv, boost, libgcrypt, perl, utillinux, groff, libva, xorg, ncurses
 , callPackage
 }: let
@@ -52,7 +52,7 @@ in {
     name = "vdr-vaapidevice-0.7.0";
 
     buildInputs = [
-      vdr libxcb xcbutilwm ffmpeg
+      vdr libxcb xcbutilwm ffmpeg_3
       alsaLib
       libvdpau # vdpau
       libva # va-api

--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, autoreconfHook
 , libarchive, perl, xorg, libdvdnav, libbluray
-, zlib, a52dec, libmad, faad2, ffmpeg, alsaLib
+, zlib, a52dec, libmad, faad2, ffmpeg_3, alsaLib
 , pkgconfig, dbus, fribidi, freefont_ttf, libebml, libmatroska
 , libvorbis, libtheora, speex, lua5, libgcrypt, libgpgerror, libupnp
 , libcaca, libpulseaudio, flac, schroedinger, libxml2, librsvg
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   # which are not included here for no other reason that nobody has mentioned
   # needing them
   buildInputs = [
-    zlib a52dec libmad faad2 ffmpeg alsaLib libdvdnav libdvdnav.libdvdread
+    zlib a52dec libmad faad2 ffmpeg_3 alsaLib libdvdnav libdvdnav.libdvdread
     libbluray dbus fribidi libvorbis libtheora speex lua5 libgcrypt libgpgerror
     libupnp libcaca libpulseaudio flac schroedinger libxml2 librsvg mpeg2dec
     systemd gnutls avahi libcddb SDL SDL_image libmtp unzip taglib libarchive

--- a/pkgs/applications/video/vokoscreen/default.nix
+++ b/pkgs/applications/video/vokoscreen/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, mkDerivation
 , pkgconfig, qtbase, qttools, qmake, qtmultimedia, qtx11extras, alsaLib, libv4l, libXrandr
-, ffmpeg
+, ffmpeg_3
 }:
 
 mkDerivation rec {
@@ -35,7 +35,7 @@ mkDerivation rec {
   '';
 
   postConfigure = ''
-    substituteInPlace settings/QvkSettings.cpp --subst-var-by ffmpeg ${ffmpeg}
+    substituteInPlace settings/QvkSettings.cpp --subst-var-by ffmpeg ${ffmpeg_3}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/video/xscast/default.nix
+++ b/pkgs/applications/video/xscast/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper, ffmpeg, imagemagick, dzen2, xorg }:
+{ stdenv, fetchFromGitHub, makeWrapper, ffmpeg_3, imagemagick, dzen2, xorg }:
 
 stdenv.mkDerivation {
   pname = "xscast-unstable";
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     patchShebangs $out/bin
 
     wrapProgram "$out/bin/xscast" \
-      --prefix PATH : ${stdenv.lib.makeBinPath [ ffmpeg dzen2 xorg.xwininfo xorg.xinput xorg.xmodmap imagemagick ]}
+      --prefix PATH : ${stdenv.lib.makeBinPath [ ffmpeg_3 dzen2 xorg.xwininfo xorg.xinput xorg.xmodmap imagemagick ]}
 
     runHook postInstall
   '';

--- a/pkgs/desktops/deepin/deepin-movie-reborn/default.nix
+++ b/pkgs/desktops/deepin/deepin-movie-reborn/default.nix
@@ -8,7 +8,7 @@
 , qtx11extras
 , dtkcore
 , dtkwidget
-, ffmpeg
+, ffmpeg_3
 , ffmpegthumbnailer
 , mpv
 , pulseaudio
@@ -41,7 +41,7 @@ mkDerivation rec {
   buildInputs = [
     dtkcore
     dtkwidget
-    ffmpeg
+    ffmpeg_3
     ffmpegthumbnailer
     libdvdnav
     libdvdread

--- a/pkgs/development/compilers/graalvm/enterprise-edition.nix
+++ b/pkgs/development/compilers/graalvm/enterprise-edition.nix
@@ -1,4 +1,4 @@
-{ stdenv, requireFile, perl, unzip, glibc, zlib, bzip2, gdk-pixbuf, xorg, glib, fontconfig, freetype, cairo, pango, gtk3, gtk2, ffmpeg, libGL, atk, alsaLib, libav_0_8, setJavaClassPath }:
+{ stdenv, requireFile, perl, unzip, glibc, zlib, bzip2, gdk-pixbuf, xorg, glib, fontconfig, freetype, cairo, pango, gtk3, gtk2, ffmpeg_3, libGL, atk, alsaLib, libav_0_8, setJavaClassPath }:
 
 let
   common = javaVersion:
@@ -117,7 +117,7 @@ let
                     }.${javaVersion}
                  }:${
             stdenv.lib.strings.makeLibraryPath [ glibc xorg.libXxf86vm xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXrender
-                                                 glib zlib bzip2 alsaLib fontconfig freetype pango gtk3 gtk2 cairo gdk-pixbuf atk ffmpeg libGL ]}"
+                                                 glib zlib bzip2 alsaLib fontconfig freetype pango gtk3 gtk2 cairo gdk-pixbuf atk ffmpeg_3 libGL ]}"
 
           for f in $(find $out -type f -perm -0100); do
             patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$f" || true

--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, writeText, gradleGen, pkgconfig, perl, cmake
-, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsaLib, ffmpeg, python, ruby
+, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsaLib, ffmpeg_3, python, ruby
 , openjdk11-bootstrap }:
 
 let
@@ -19,7 +19,7 @@ let
       sha256 = "1h7qsylr7rnwnbimqjyn3whszp9kv4h3gpicsrb3mradxc9yv194";
     };
 
-    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsaLib ffmpeg ];
+    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsaLib ffmpeg_3 ];
     nativeBuildInputs = [ gradle_ perl pkgconfig cmake gperf python ruby ];
 
     dontUseCmakeConfigure = true;

--- a/pkgs/development/compilers/openjdk/openjfx/14.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/14.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, writeText, openjdk11_headless, gradleGen
 , pkgconfig, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsaLib
-, ffmpeg, python, ruby }:
+, ffmpeg_3, python, ruby }:
 
 let
   major = "14";
@@ -21,7 +21,7 @@ let
       sha256 = "16aj15xksc266gv3y42m0g277pfvp71901lrngndcnpr7i2zshnr";
     };
 
-    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsaLib ffmpeg ];
+    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsaLib ffmpeg_3 ];
     nativeBuildInputs = [ gradle_ perl pkgconfig cmake gperf python ruby ];
 
     dontUseCmakeConfigure = true;

--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -19,7 +19,7 @@
 , glib
 , libxml2
 , libav_0_8
-, ffmpeg
+, ffmpeg_3
 , libxslt
 , libGL
 , freetype
@@ -171,7 +171,7 @@ let result = stdenv.mkDerivation rec {
    * libXt is only needed on amd64
    */
   libraries =
-    [stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg libxslt libGL xorg.libXxf86vm alsaLib fontconfig freetype pango gtk2 cairo gdk-pixbuf atk] ++
+    [stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg_3 libxslt libGL xorg.libXxf86vm alsaLib fontconfig freetype pango gtk2 cairo gdk-pixbuf atk] ++
     (if swingSupport then [xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXp xorg.libXt xorg.libXrender stdenv.cc.cc] else []);
 
   rpath = stdenv.lib.strings.makeLibraryPath libraries;

--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, unzip, makeWrapper, setJavaClassPath
-, zulu, glib, libxml2, libav_0_8, ffmpeg, libxslt, libGL, alsaLib
+, zulu, glib, libxml2, libav_0_8, ffmpeg_3, libxslt, libGL, alsaLib
 , fontconfig, freetype, gnome2, cairo, gdk-pixbuf, atk, xorg
 , swingSupport ? true }:
 
@@ -15,7 +15,7 @@ let
   extension = if stdenv.isDarwin then "zip" else "tar.gz";
 
   libraries = [
-    stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg libxslt libGL
+    stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg_3 libxslt libGL
     xorg.libXxf86vm alsaLib fontconfig freetype gnome2.pango
     gnome2.gtk cairo gdk-pixbuf atk
   ] ++ (lib.optionals swingSupport (with xorg; [

--- a/pkgs/development/compilers/zulu/default.nix
+++ b/pkgs/development/compilers/zulu/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, unzip, makeWrapper, setJavaClassPath
-, zulu, glib, libxml2, libav_0_8, ffmpeg, libxslt, libGL, alsaLib
+, zulu, glib, libxml2, libav_0_8, ffmpeg_3, libxslt, libGL, alsaLib
 , fontconfig, freetype, gnome2, cairo, gdk-pixbuf, atk, xorg, zlib
 , swingSupport ? true }:
 
@@ -15,7 +15,7 @@ let
   extension = if stdenv.isDarwin then "zip" else "tar.gz";
 
   libraries = [
-    stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg libxslt libGL
+    stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg_3 libxslt libGL
     xorg.libXxf86vm alsaLib fontconfig freetype gnome2.pango
     gnome2.gtk cairo gdk-pixbuf atk zlib
   ] ++ (lib.optionals swingSupport (with xorg; [

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -724,7 +724,7 @@ self: super: builtins.intersectAttrs super {
   dhall_1_32_0 = dontCheck super.dhall_1_32_0;
 
   cut-the-crap =
-    let path = pkgs.stdenv.lib.makeBinPath [ pkgs.ffmpeg ];
+    let path = pkgs.stdenv.lib.makeBinPath [ pkgs.ffmpeg_3 ];
     in overrideCabal (addBuildTool super.cut-the-crap pkgs.makeWrapper) (_drv: {
       postInstall = ''
         wrapProgram $out/bin/cut-the-crap \

--- a/pkgs/development/interpreters/renpy/default.nix
+++ b/pkgs/development/interpreters/renpy/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python2Packages, pkgconfig, SDL2
-, libpng, ffmpeg, freetype, glew, libGL, libGLU, fribidi, zlib
+, libpng, ffmpeg_3, freetype, glew, libGL, libGLU, fribidi, zlib
 , glib
 }:
 
@@ -32,13 +32,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     python cython wrapPython tkinter
-    SDL2 libpng ffmpeg freetype glew libGLU libGL fribidi zlib pygame_sdl2 glib
+    SDL2 libpng ffmpeg_3 freetype glew libGLU libGL fribidi zlib pygame_sdl2 glib
   ];
 
   pythonPath = [ pygame_sdl2 tkinter ];
 
   RENPY_DEPS_INSTALL = stdenv.lib.concatStringsSep "::" (map (path: path) [
-    SDL2 SDL2.dev libpng ffmpeg ffmpeg.out freetype glew.dev glew.out libGLU libGL fribidi zlib
+    SDL2 SDL2.dev libpng ffmpeg_3 ffmpeg_3.out freetype glew.dev glew.out libGLU libGL fribidi zlib
   ]);
 
   buildPhase = ''

--- a/pkgs/development/libraries/chromaprint/default.nix
+++ b/pkgs/development/libraries/chromaprint/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, boost, ffmpeg }:
+{ stdenv, fetchurl, cmake, boost, ffmpeg_3 }:
 
 stdenv.mkDerivation rec {
   pname = "chromaprint";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ boost ffmpeg ];
+  buildInputs = [ boost ffmpeg_3 ];
 
   cmakeFlags = [ "-DBUILD_EXAMPLES=ON" "-DBUILD_TOOLS=ON" ];
 

--- a/pkgs/development/libraries/ffmpegthumbnailer/default.nix
+++ b/pkgs/development/libraries/ffmpegthumbnailer/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, stdenv, ffmpeg, cmake, libpng, pkgconfig, libjpeg
+{ fetchFromGitHub, stdenv, ffmpeg_3, cmake, libpng, pkgconfig, libjpeg
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ ffmpeg libpng libjpeg ];
+  buildInputs = [ ffmpeg_3 libpng libjpeg ];
 
   meta = with stdenv.lib;  {
     homepage = "https://github.com/dirkvdb/ffmpegthumbnailer";

--- a/pkgs/development/libraries/ffms/default.nix
+++ b/pkgs/development/libraries/ffms/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, zlib, ffmpeg, pkgconfig }:
+{ stdenv, fetchFromGitHub, zlib, ffmpeg_3, pkgconfig }:
 
 stdenv.mkDerivation rec {
   pname = "ffms";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-fPIC";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ zlib ffmpeg ];
+  buildInputs = [ zlib ffmpeg_3 ];
 
   # ffms includes a built-in vapoursynth plugin, see:
   # https://github.com/FFMS/ffms2#avisynth-and-vapoursynth-plugin

--- a/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib, copyPathsToStore,
   extra-cmake-modules,
-  attr, ebook_tools, exiv2, ffmpeg, karchive, kcoreaddons, ki18n, poppler, qtbase, qtmultimedia, taglib
+  attr, ebook_tools, exiv2, ffmpeg_3, karchive, kcoreaddons, ki18n, poppler, qtbase, qtmultimedia, taglib
 }:
 
 mkDerivation {
@@ -9,7 +9,7 @@ mkDerivation {
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
-    attr ebook_tools exiv2 ffmpeg karchive kcoreaddons ki18n poppler qtbase qtmultimedia
+    attr ebook_tools exiv2 ffmpeg_3 karchive kcoreaddons ki18n poppler qtbase qtmultimedia
     taglib
   ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);

--- a/pkgs/development/libraries/libextractor/default.nix
+++ b/pkgs/development/libraries/libextractor/default.nix
@@ -13,11 +13,11 @@
 # '';
 # See also <https://nixos.org/nixpkgs/manual/#sec-language-gnome>.
 , gtkSupport ? true, glib ? null, gtk3 ? null
-, videoSupport ? true, ffmpeg ? null, libmpeg2 ? null}:
+, videoSupport ? true, ffmpeg_3 ? null, libmpeg2 ? null}:
 
 assert gstreamerSupport -> gst_all_1 != null && builtins.isList (gstPlugins gst_all_1);
 assert gtkSupport -> glib != null && gtk3 != null;
-assert videoSupport -> ffmpeg != null && libmpeg2 != null;
+assert videoSupport -> ffmpeg_3 != null && libmpeg2 != null;
 
 stdenv.mkDerivation rec {
   name = "libextractor-1.9";
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
    ] ++ stdenv.lib.optionals gstreamerSupport
           ([ gst_all_1.gstreamer ] ++ gstPlugins gst_all_1)
      ++ stdenv.lib.optionals gtkSupport [ glib gtk3 ]
-     ++ stdenv.lib.optionals videoSupport [ ffmpeg libmpeg2 ];
+     ++ stdenv.lib.optionals videoSupport [ ffmpeg_3 libmpeg2 ];
 
   configureFlags = [
     "--disable-ltdl-install"

--- a/pkgs/development/libraries/liblinphone/default.nix
+++ b/pkgs/development/libraries/liblinphone/default.nix
@@ -11,7 +11,7 @@
 , doxygen
 , fetchFromGitLab
 , fetchurl
-, ffmpeg
+, ffmpeg_3
 , gdk-pixbuf
 , git
 , glib
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
     bzrtp
     cairo
     cyrus_sasl
-    ffmpeg
+    ffmpeg_3
     gdk-pixbuf
     git
     glib

--- a/pkgs/development/libraries/libqtav/default.nix
+++ b/pkgs/development/libraries/libqtav/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, fetchFromGitHub, extra-cmake-modules
 , qtbase, qtmultimedia, qtquick1, qttools
 , libGL, libX11
-, libass, openal, ffmpeg, libuchardet
+, libass, openal, ffmpeg_3, libuchardet
 , alsaLib, libpulseaudio, libva
 }:
 
@@ -15,7 +15,7 @@ mkDerivation rec {
   buildInputs = [
     qtbase qtmultimedia qtquick1
     libGL libX11
-    libass openal ffmpeg libuchardet
+    libass openal ffmpeg_3 libuchardet
     alsaLib libpulseaudio libva
   ];
 

--- a/pkgs/development/libraries/libvdpau-va-gl/default.nix
+++ b/pkgs/development/libraries/libvdpau-va-gl/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, libX11, libpthreadstubs, libXau, libXdmcp
-, libXext, libvdpau, glib, libva, ffmpeg, libGLU }:
+, libXext, libvdpau, glib, libva, ffmpeg_3, libGLU }:
 
 stdenv.mkDerivation rec {
   pname = "libvdpau-va-gl";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ libX11 libpthreadstubs libXau libXdmcp libXext libvdpau glib libva ffmpeg libGLU ];
+  buildInputs = [ libX11 libpthreadstubs libXau libXdmcp libXext libvdpau glib libva ffmpeg_3 libGLU ];
 
   doCheck = false; # fails. needs DRI access
 

--- a/pkgs/development/libraries/mediastreamer/default.nix
+++ b/pkgs/development/libraries/mediastreamer/default.nix
@@ -5,7 +5,7 @@
 , doxygen
 , fetchFromGitLab
 , fetchpatch
-, ffmpeg
+, ffmpeg_3
 , glew
 , gsm
 , intltool
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     alsaLib
     bctoolbox
     bzrtp
-    ffmpeg
+    ffmpeg_3
     glew
     gsm
     libGL

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -23,7 +23,7 @@
 , enableGtk2      ? false, gtk2
 , enableGtk3      ? false, gtk3
 , enableVtk       ? false, vtk
-, enableFfmpeg    ? false, ffmpeg
+, enableFfmpeg    ? false, ffmpeg_3
 , enableGStreamer ? false, gst_all_1
 , enableTesseract ? false, tesseract, leptonica
 , enableTbb       ? false, tbb
@@ -188,7 +188,7 @@ stdenv.mkDerivation {
     ++ lib.optional enableWebP libwebp
     ++ lib.optionals enableEXR [ openexr ilmbase ]
     ++ lib.optional enableJPEG2K jasper
-    ++ lib.optional enableFfmpeg ffmpeg
+    ++ lib.optional enableFfmpeg ffmpeg_3
     ++ lib.optionals (enableFfmpeg && stdenv.isDarwin)
                      [ VideoDecodeAcceleration bzip2 ]
     ++ lib.optionals enableGStreamer (with gst_all_1; [ gstreamer gst-plugins-base ])

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -23,7 +23,7 @@
 , enableGtk2      ? false, gtk2
 , enableGtk3      ? false, gtk3
 , enableVtk       ? false, vtk
-, enableFfmpeg    ? false, ffmpeg
+, enableFfmpeg    ? false, ffmpeg_3
 , enableGStreamer ? false, gst_all_1
 , enableTesseract ? false, tesseract, leptonica
 , enableTbb       ? false, tbb
@@ -204,7 +204,7 @@ stdenv.mkDerivation {
     ++ lib.optional enableWebP libwebp
     ++ lib.optionals enableEXR [ openexr ilmbase ]
     ++ lib.optional enableJPEG2K jasper
-    ++ lib.optional enableFfmpeg ffmpeg
+    ++ lib.optional enableFfmpeg ffmpeg_3
     ++ lib.optionals (enableFfmpeg && stdenv.isDarwin)
                      [ VideoDecodeAcceleration bzip2 ]
     ++ lib.optionals enableGStreamer (with gst_all_1; [ gstreamer gst-plugins-base ])

--- a/pkgs/development/libraries/opencv/default.nix
+++ b/pkgs/development/libraries/opencv/default.nix
@@ -7,7 +7,7 @@
 , enableTIFF ? true, libtiff
 , enableEXR ? (!stdenv.isDarwin), openexr, ilmbase
 , enableJPEG2K ? false, jasper  # disable jasper by default (many CVE)
-, enableFfmpeg ? false, ffmpeg
+, enableFfmpeg ? false, ffmpeg_3
 , enableGStreamer ? false, gst_all_1
 , enableEigen ? true, eigen
 , Cocoa, QTKit
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableTIFF libtiff
     ++ lib.optionals enableEXR [ openexr ilmbase ]
     ++ lib.optional enableJPEG2K jasper
-    ++ lib.optional enableFfmpeg ffmpeg
+    ++ lib.optional enableFfmpeg ffmpeg_3
     ++ lib.optionals enableGStreamer (with gst_all_1; [ gstreamer gst-plugins-base ])
     ++ lib.optional enableEigen eigen
     ++ lib.optionals stdenv.isDarwin [ Cocoa QTKit ]

--- a/pkgs/development/libraries/openscenegraph/default.nix
+++ b/pkgs/development/libraries/openscenegraph/default.nix
@@ -11,7 +11,7 @@
   curlSupport ? true, curl,
   colladaSupport ? false, opencollada,
   opencascadeSupport ? false, opencascade,
-  ffmpegSupport ? false, ffmpeg,
+  ffmpegSupport ? false, ffmpeg_3,
   nvttSupport ? false, nvidia-texture-tools,
   freetypeSupport ? true, freetype,
   svgSupport ? false, librsvg,
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional curlSupport curl
     ++ lib.optional colladaSupport opencollada
     ++ lib.optional opencascadeSupport opencascade
-    ++ lib.optional ffmpegSupport ffmpeg
+    ++ lib.optional ffmpegSupport ffmpeg_3
     ++ lib.optional nvttSupport nvidia-texture-tools
     ++ lib.optional freetypeSupport freetype
     ++ lib.optional svgSupport librsvg

--- a/pkgs/development/libraries/pangolin/default.nix
+++ b/pkgs/development/libraries/pangolin/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkgconfig, doxygen, libGL, glew
-, xorg , ffmpeg, python3 , libjpeg, libpng, libtiff, eigen
+, xorg , ffmpeg_3, python3 , libjpeg, libpng, libtiff, eigen
 , Carbon ? null, Cocoa ? null
 }:
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     libGL 
     glew 
     xorg.libX11 
-    ffmpeg 
+    ffmpeg_3 
     python3 
     libjpeg 
     libpng 

--- a/pkgs/development/libraries/pipewire/0.2.nix
+++ b/pkgs/development/libraries/pipewire/0.2.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, meson, ninja, pkgconfig, doxygen, graphviz, valgrind
-, glib, dbus, gst_all_1, alsaLib, ffmpeg, libjack2, udev, libva, xorg
+, glib, dbus, gst_all_1, alsaLib, ffmpeg_3, libjack2, udev, libva, xorg
 , sbc, SDL2, makeFontsConf
 }:
 
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
   ];
   buildInputs = [
     glib dbus gst_all_1.gst-plugins-base gst_all_1.gstreamer
-    alsaLib ffmpeg libjack2 udev libva xorg.libX11 sbc SDL2
+    alsaLib ffmpeg_3 libjack2 udev libva xorg.libX11 sbc SDL2
   ];
 
   mesonFlags = [

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -11,7 +11,7 @@
 , dbus
 , gst_all_1
 , alsaLib
-, ffmpeg
+, ffmpeg_3
 , libjack2
 , udev
 , libva
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
     alsaLib
     bluez
     dbus
-    ffmpeg
+    ffmpeg_3
     glib
     gst_all_1.gst-plugins-base
     gst_all_1.gstreamer

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -14,7 +14,7 @@
 , enableProprietaryCodecs ? true
 , gn
 , cups, darwin, openbsm, runCommand, xcbuild
-, ffmpeg ? null
+, ffmpeg_3 ? null
 , lib, stdenv
 }:
 
@@ -152,7 +152,7 @@ EOF
 
     libevent
   ] ++ optionals (stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64) [
-    ffmpeg
+    ffmpeg_3
   ] ++ optionals (!stdenv.isDarwin) [
     dbus zlib minizip snappy nss protobuf jsoncpp
 

--- a/pkgs/development/libraries/wxSVG/default.nix
+++ b/pkgs/development/libraries/wxSVG/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl
 , pkgconfig, wxGTK
-, ffmpeg, libexif
+, ffmpeg_3, libexif
 , cairo, pango }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  propagatedBuildInputs = [ wxGTK ffmpeg libexif ];
+  propagatedBuildInputs = [ wxGTK ffmpeg_3 libexif ];
 
   buildInputs = [ cairo pango ];
 

--- a/pkgs/development/libraries/xine-lib/default.nix
+++ b/pkgs/development/libraries/xine-lib/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, xorg, alsaLib, libGLU, libGL, aalib
-, libvorbis, libtheora, speex, zlib, perl, ffmpeg
+, libvorbis, libtheora, speex, zlib, perl, ffmpeg_3
 , flac, libcaca, libpulseaudio, libmng, libcdio, libv4l, vcdimager
 , libmpcdec
 }:
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     xorg.libX11 xorg.libXv xorg.libXinerama xorg.libxcb xorg.libXext
-    alsaLib libGLU libGL aalib libvorbis libtheora speex perl ffmpeg flac
+    alsaLib libGLU libGL aalib libvorbis libtheora speex perl ffmpeg_3 flac
     libcaca libpulseaudio libmng libcdio libv4l vcdimager libmpcdec
   ];
 

--- a/pkgs/development/python-modules/ffmpeg-python/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-python/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , substituteAll
-, ffmpeg
+, ffmpeg_3
 , future
 , pytest
 , pytestrunner
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     (
       substituteAll {
         src = ./ffmpeg-location.patch;
-        inherit ffmpeg;
+        ffmpeg = ffmpeg_3;
       }
     )
   ];

--- a/pkgs/development/python-modules/ha-ffmpeg/default.nix
+++ b/pkgs/development/python-modules/ha-ffmpeg/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi, isPy3k
-, ffmpeg, async-timeout }:
+, ffmpeg_3, async-timeout }:
 
 buildPythonPackage rec {
   pname = "ha-ffmpeg";
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     sha256 = "230f2fa990c9caaff1c67c2227b64756062248083849651a9bec7d599e519a42";
   };
 
-  buildInputs = [ ffmpeg ];
+  buildInputs = [ ffmpeg_3 ];
 
   propagatedBuildInputs = [ async-timeout ];
 

--- a/pkgs/development/python-modules/imageio/default.nix
+++ b/pkgs/development/python-modules/imageio/default.nix
@@ -8,7 +8,7 @@
 , pytest
 , numpy
 , isPy3k
-, ffmpeg
+, ffmpeg_3
 , futures
 , enum34
 }:
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytest psutil ] ++ stdenv.lib.optionals isPy3k [
-    imageio-ffmpeg ffmpeg
+    imageio-ffmpeg ffmpeg_3
     ];
   propagatedBuildInputs = [ numpy pillow ] ++ stdenv.lib.optionals (!isPy3k) [
     futures

--- a/pkgs/development/python-modules/infoqscraper/default.nix
+++ b/pkgs/development/python-modules/infoqscraper/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   buildInputs = [ html5lib ];
-  propagatedBuildInputs = [ six beautifulsoup4 pkgs.ffmpeg pkgs.swftools pkgs.rtmpdump ];
+  propagatedBuildInputs = [ six beautifulsoup4 pkgs.ffmpeg_3 pkgs.swftools pkgs.rtmpdump ];
 
   meta = with stdenv.lib; {
     description = "Discover presentations and/or create a movie consisting of slides and audio track from an infoq url";

--- a/pkgs/development/python-modules/sipsimple/default.nix
+++ b/pkgs/development/python-modules/sipsimple/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [ pkgs.pkgconfig ];
-  buildInputs = with pkgs; [ alsaLib ffmpeg libv4l sqlite libvpx ];
+  buildInputs = with pkgs; [ alsaLib ffmpeg_3 libv4l sqlite libvpx ];
   propagatedBuildInputs = [ cython pkgs.openssl dnspython dateutil xcaplib msrplib lxml python-otr ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/stytra/default.nix
+++ b/pkgs/development/python-modules/stytra/default.nix
@@ -8,7 +8,7 @@
 , pandas
 , tables
 , git
-, ffmpeg
+, ffmpeg_3
 , scikitimage
 , matplotlib
 , qdarkstyle
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     pandas
     tables
     git
-    ffmpeg
+    ffmpeg_3
     scikitimage
     matplotlib
     qdarkstyle

--- a/pkgs/development/python-modules/thumbor/default.nix
+++ b/pkgs/development/python-modules/thumbor/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
       gifsicle = "${pkgs.gifsicle}/bin/gifsicle";
       exiftool = "${pkgs.exiftool}/bin/exiftool";
       jpegtran = "${pkgs.libjpeg}/bin/jpegtran";
-      ffmpeg = "${pkgs.ffmpeg}/bin/ffmpeg";
+      ffmpeg = "${pkgs.ffmpeg_3}/bin/ffmpeg";
     })
   ];
 

--- a/pkgs/development/tools/nwjs/default.nix
+++ b/pkgs/development/tools/nwjs/default.nix
@@ -3,7 +3,7 @@
 , xorg, alsaLib, dbus, glib, gtk3, atk, pango, freetype, fontconfig
 , gdk-pixbuf, cairo, nss, nspr, gconf, expat, systemd, libcap
 , libnotify
-, ffmpeg, libxcb, cups
+, ffmpeg_3, libxcb, cups
 , sqlite, udev
 , libuuid
 , sdk ? false
@@ -22,7 +22,7 @@ let
       xorg.libXScrnSaver cups
       libcap libnotify
       # libnw-specific (not chromium dependencies)
-      ffmpeg libxcb
+      ffmpeg_3 libxcb
       # chromium runtime deps (dlopen’d)
       sqlite udev
       libuuid

--- a/pkgs/games/chiaki/default.nix
+++ b/pkgs/games/chiaki/default.nix
@@ -1,5 +1,5 @@
 { lib, mkDerivation, fetchFromGitHub
-, cmake, ffmpeg, libopus, qtbase, qtmultimedia, qtsvg, pkgconfig, protobuf
+, cmake, ffmpeg_3, libopus, qtbase, qtmultimedia, qtsvg, pkgconfig, protobuf
 , python3Packages, SDL2 }:
 
 mkDerivation rec {
@@ -17,7 +17,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake pkgconfig protobuf python3Packages.python python3Packages.protobuf
   ];
-  buildInputs = [ ffmpeg libopus qtbase qtmultimedia qtsvg protobuf SDL2 ];
+  buildInputs = [ ffmpeg_3 libopus qtbase qtmultimedia qtsvg protobuf SDL2 ];
 
   doCheck = true;
 

--- a/pkgs/games/hedgewars/default.nix
+++ b/pkgs/games/hedgewars/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, SDL2_image, SDL2_ttf, SDL2_net, fpc, ghcWithPackages, ffmpeg, freeglut
+{ mkDerivation, SDL2_image, SDL2_ttf, SDL2_net, fpc, ghcWithPackages, ffmpeg_3, freeglut
 , lib, fetchurl, cmake, pkgconfig, lua5_1, SDL2, SDL2_mixer
 , zlib, libpng, libGL, libGLU, physfs
 , qtbase, qttools
@@ -27,7 +27,7 @@ mkDerivation rec {
   buildInputs = [
     SDL2_ttf SDL2_net SDL2 SDL2_mixer SDL2_image
     fpc lua5_1
-    ffmpeg freeglut physfs
+    ffmpeg_3 freeglut physfs
     qtbase
   ] ++ lib.optional withServer ghc;
 

--- a/pkgs/games/openmw/default.nix
+++ b/pkgs/games/openmw/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkDerivationWith, fetchFromGitHub, qtbase, openscenegraph, mygui, bullet, ffmpeg
+{ stdenv, mkDerivationWith, fetchFromGitHub, qtbase, openscenegraph, mygui, bullet, ffmpeg_3
 , boost, cmake, SDL2, unshield, openal, libXt, pkgconfig }:
 
 let
@@ -24,7 +24,7 @@ in mkDerivationWith stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake boost ffmpeg bullet mygui openscenegraph_ SDL2 unshield openal libXt qtbase ];
+  buildInputs = [ cmake boost ffmpeg_3 bullet mygui openscenegraph_ SDL2 unshield openal libXt qtbase ];
 
   cmakeFlags = [
     "-DDESIRED_QT_VERSION:INT=5"

--- a/pkgs/games/openrw/default.nix
+++ b/pkgs/games/openrw/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, cmake, sfml, libGLU, libGL, bullet, glm, libmad, xlibsWrapper, openal
-, SDL2, boost, ffmpeg, Cocoa, OpenAL }:
+, SDL2, boost, ffmpeg_3, Cocoa, OpenAL }:
 
 stdenv.mkDerivation {
   version = "2019-10-26";
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [
-    sfml libGLU libGL bullet glm libmad xlibsWrapper openal SDL2 boost ffmpeg
+    sfml libGLU libGL bullet glm libmad xlibsWrapper openal SDL2 boost ffmpeg_3
   ] ++ stdenv.lib.optionals stdenv.isDarwin [ OpenAL Cocoa ];
 
   meta = with stdenv.lib; {

--- a/pkgs/games/privateer/default.nix
+++ b/pkgs/games/privateer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchsvn, boost, cmake, ffmpeg, freeglut, glib,
+{ stdenv, fetchsvn, boost, cmake, ffmpeg_3, freeglut, glib,
   gtk2, libjpeg, libpng, libpthreadstubs, libvorbis, libXau, libXdmcp,
   libXmu, libGLU, libGL, openal, pixman, pkgconfig, python27, SDL }:
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs =
-    [ boost cmake ffmpeg freeglut glib gtk2 libjpeg libpng
+    [ boost cmake ffmpeg_3 freeglut glib gtk2 libjpeg libpng
       libpthreadstubs libvorbis libXau libXdmcp libXmu libGLU libGL openal
       pixman pkgconfig python27 SDL ];
 

--- a/pkgs/misc/emulators/attract-mode/default.nix
+++ b/pkgs/misc/emulators/attract-mode/default.nix
@@ -1,4 +1,4 @@
-{ expat, fetchFromGitHub, ffmpeg, fontconfig, freetype, libarchive, libjpeg
+{ expat, fetchFromGitHub, ffmpeg_3, fontconfig, freetype, libarchive, libjpeg
 , libGLU, libGL, openal, pkgconfig, sfml, stdenv, zlib
 }:
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    expat ffmpeg fontconfig freetype libarchive libjpeg libGLU libGL openal sfml zlib
+    expat ffmpeg_3 fontconfig freetype libarchive libjpeg libGLU libGL openal sfml zlib
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/misc/emulators/dolphin-emu/default.nix
+++ b/pkgs/misc/emulators/dolphin-emu/default.nix
@@ -4,7 +4,7 @@
 , pkgconfig
 , cmake
 , bluez
-, ffmpeg
+, ffmpeg_3
 , libao
 , gtk2
 , glib
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     bluez
-    ffmpeg
+    ffmpeg_3
     libao
     libGLU
     libGL

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, makeDesktopItem, pkgconfig, cmake
-, wrapQtAppsHook, qtbase, bluez, ffmpeg, libao, libGLU, libGL, pcre, gettext
+, wrapQtAppsHook, qtbase, bluez, ffmpeg_3, libao, libGLU, libGL, pcre, gettext
 , libXrandr, libusb1, lzo, libpthreadstubs, libXext, libXxf86vm, libXinerama
 , libSM, libXdmcp, readline, openal, udev, libevdev, portaudio, curl, alsaLib
 , miniupnpc, enet, mbedtls, soundtouch, sfml
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
   ++ lib.optional stdenv.isLinux wrapQtAppsHook;
 
   buildInputs = [
-    curl ffmpeg libao libGLU libGL pcre gettext libpthreadstubs libpulseaudio
+    curl ffmpeg_3 libao libGLU libGL pcre gettext libpthreadstubs libpulseaudio
     libXrandr libXext libXxf86vm libXinerama libSM readline openal libXdmcp lzo
     portaudio libusb1 libpng hidapi miniupnpc enet mbedtls soundtouch sfml
     qtbase

--- a/pkgs/misc/emulators/mgba/default.nix
+++ b/pkgs/misc/emulators/mgba/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, makeDesktopItem, wrapQtAppsHook, pkgconfig
-, cmake, epoxy, libzip, libelf, libedit, ffmpeg, SDL2, imagemagick
+, cmake, epoxy, libzip, libelf, libedit, ffmpeg_3, SDL2, imagemagick
 , qtbase, qtmultimedia, qttools, minizip }:
 
 let
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ wrapQtAppsHook pkgconfig cmake ];
 
   buildInputs = [
-    epoxy libzip libelf libedit ffmpeg SDL2 imagemagick
+    epoxy libzip libelf libedit ffmpeg_3 SDL2 imagemagick
     qtbase qtmultimedia qttools minizip
   ];
 

--- a/pkgs/misc/emulators/ppsspp/default.nix
+++ b/pkgs/misc/emulators/ppsspp/default.nix
@@ -1,7 +1,7 @@
 { SDL2
 , cmake
 , fetchFromGitHub
-, ffmpeg
+, ffmpeg_3
 , glew
 , lib
 , libzip
@@ -37,7 +37,7 @@ mkDerivation rec {
 
   buildInputs = [
     SDL2
-    ffmpeg
+    ffmpeg_3
     glew
     libzip
     qtbase

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, fetchFromGitHub, fetchFromGitLab, cmake, pkgconfig, makeWrapper, python27, python37, retroarch
 , alsaLib, fluidsynth, curl, hidapi, libGLU, gettext, glib, gtk2, portaudio, SDL, SDL_net, SDL2, SDL2_image, libGL
-, ffmpeg, pcre, libevdev, libpng, libjpeg, libzip, udev, libvorbis, snappy, which, hexdump
+, ffmpeg_3, pcre, libevdev, libpng, libjpeg, libzip, udev, libvorbis, snappy, which, hexdump
 , miniupnpc, sfml, xorg, zlib, nasm, libpcap, boost, icu, openssl
 , buildPackages }:
 
@@ -834,7 +834,7 @@ in with stdenv.lib.licenses;
     description = "ppsspp libretro port";
     license = gpl2;
     extraNativeBuildInputs = [ cmake pkgconfig ];
-    extraBuildInputs = [ libGLU libGL libzip ffmpeg python37 snappy xorg.libX11 ];
+    extraBuildInputs = [ libGLU libGL libzip ffmpeg_3 python37 snappy xorg.libX11 ];
     makefile = "Makefile";
     cmakeFlags = [ "-DLIBRETRO=ON -DUSE_SYSTEM_FFMPEG=ON -DUSE_SYSTEM_SNAPPY=ON -DUSE_SYSTEM_LIBZIP=ON -DOpenGL_GL_PREFERENCE=GLVND" ];
     postBuild = "mv lib/ppsspp_libretro${stdenv.hostPlatform.extensions.sharedLibrary} ppsspp_libretro${stdenv.hostPlatform.extensions.sharedLibrary}";

--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, which, pkgconfig, makeWrapper
-, ffmpeg, libGLU, libGL, freetype, libxml2, python3
+, ffmpeg_3, libGLU, libGL, freetype, libxml2, python3
 , libobjc, AppKit, Foundation
 , alsaLib ? null
 , libdrm ? null
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig wayland ]
                       ++ optional withVulkan makeWrapper;
 
-  buildInputs = [ ffmpeg freetype libxml2 libGLU libGL python3 SDL2 which ]
+  buildInputs = [ ffmpeg_3 freetype libxml2 libGLU libGL python3 SDL2 which ]
                 ++ optional enableNvidiaCgToolkit nvidia_cg_toolkit
                 ++ optional withVulkan vulkan-loader
                 ++ optionals stdenv.isDarwin [ libobjc AppKit Foundation ]

--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib, fetchgit, cmake, pkgconfig, git
-, qtbase, qtquickcontrols, openal, glew, vulkan-loader, libpng, ffmpeg, libevdev, python3
+, qtbase, qtquickcontrols, openal, glew, vulkan-loader, libpng, ffmpeg_3, libevdev, python3
 , pulseaudioSupport ? true, libpulseaudio
 , waylandSupport ? true, wayland
 , alsaSupport ? true, alsaLib
@@ -36,7 +36,7 @@ mkDerivation {
   nativeBuildInputs = [ cmake pkgconfig git ];
 
   buildInputs = [
-    qtbase qtquickcontrols openal glew vulkan-loader libpng ffmpeg libevdev python3
+    qtbase qtquickcontrols openal glew vulkan-loader libpng ffmpeg_3 libevdev python3
   ] ++ lib.optional pulseaudioSupport libpulseaudio
     ++ lib.optional alsaSupport alsaLib
     ++ lib.optional waylandSupport wayland;

--- a/pkgs/misc/lightspark/default.nix
+++ b/pkgs/misc/lightspark/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake, curl, zlib, ffmpeg, glew, pcre
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, curl, zlib, ffmpeg_3, glew, pcre
 , rtmpdump, cairo, boost, SDL2, SDL2_mixer, libjpeg, gnome2, lzma, nasm
 , llvm, glibmm
 }:
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig cmake ];
 
   buildInputs = [
-    curl zlib ffmpeg glew pcre rtmpdump cairo boost SDL2 SDL2_mixer libjpeg
+    curl zlib ffmpeg_3 glew pcre rtmpdump cairo boost SDL2 SDL2_mixer libjpeg
     gnome2.pango lzma nasm llvm glibmm
   ];
 

--- a/pkgs/misc/scrcpy/default.nix
+++ b/pkgs/misc/scrcpy/default.nix
@@ -5,7 +5,7 @@
 , fetchpatch
 
 , platform-tools
-, ffmpeg
+, ffmpeg_3
 , SDL2
 }:
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper meson ninja pkg-config ];
 
-  buildInputs = [ ffmpeg SDL2 ];
+  buildInputs = [ ffmpeg_3 SDL2 ];
 
   # Manually install the server jar to prevent Meson from "fixing" it
   preConfigure = ''

--- a/pkgs/os-specific/linux/guvcview/default.nix
+++ b/pkgs/os-specific/linux/guvcview/default.nix
@@ -5,7 +5,7 @@
 , pkgconfig
 , portaudio
 , SDL2
-, ffmpeg
+, ffmpeg_3
 , udev
 , libusb1
 , libv4l
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     SDL2
     alsaLib
-    ffmpeg
+    ffmpeg_3
     libusb1
     libv4l
     portaudio

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -413,7 +413,7 @@ in
       rev = "0.9.0";
       sha256 = "1b0v471mzbcys73pzr7gpvzzhff0cva0l5ff32cv7z1v9c0ypji7";
     };
-    inputs = [ pkgs.ffmpeg ];
+    inputs = [ pkgs.ffmpeg_3 ];
   };
 
   vts = {

--- a/pkgs/servers/livepeer/default.nix
+++ b/pkgs/servers/livepeer/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, buildGoPackage
-, pkgconfig, ffmpeg
+, pkgconfig, ffmpeg_3
 }:
 
 buildGoPackage rec {
@@ -18,7 +18,7 @@ buildGoPackage rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ ffmpeg ];
+  buildInputs = [ ffmpeg_3 ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/servers/mediatomb/default.nix
+++ b/pkgs/servers/mediatomb/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit
-, sqlite, expat, mp4v2, flac, spidermonkey, taglib, libexif, curl, ffmpeg, file
+, sqlite, expat, mp4v2, flac, spidermonkey, taglib, libexif, curl, ffmpeg_3, file
 , pkgconfig, autoreconfHook }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1mimslr4q6mky865y6561rr64cbn4gf0qc2dhgb31hxp4rc1kmzd";
   };
 
-  buildInputs = [ sqlite expat spidermonkey taglib libexif curl ffmpeg file mp4v2 flac
+  buildInputs = [ sqlite expat spidermonkey taglib libexif curl ffmpeg_3 file mp4v2 flac
                   pkgconfig autoreconfHook ];
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -4,7 +4,7 @@
 # Archive support
 , bzip2, zziplib
 # Codecs
-, audiofile, faad2, ffmpeg, flac, fluidsynth, game-music-emu
+, audiofile, faad2, ffmpeg_3, flac, fluidsynth, game-music-emu
 , libmad, libmikmod, mpg123, libopus, libvorbis, lame
 # Filters
 , libsamplerate
@@ -46,7 +46,7 @@ let
     # Decoder plugins
     audiofile     = [ audiofile ];
     faad          = [ faad2 ];
-    ffmpeg        = [ ffmpeg ];
+    ffmpeg        = [ ffmpeg_3 ];
     flac          = [ flac ];
     fluidsynth    = [ fluidsynth ];
     gme           = [ game-music-emu ];

--- a/pkgs/servers/roon-server/default.nix
+++ b/pkgs/servers/roon-server/default.nix
@@ -1,4 +1,4 @@
-{ alsaLib, alsaUtils, cifs-utils, fetchurl, ffmpeg, libav, mono, stdenv }:
+{ alsaLib, alsaUtils, cifs-utils, fetchurl, ffmpeg_3, libav, mono, stdenv }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -14,11 +14,11 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     # Check script
-    sed -i '3i PATH=$PATH:${makeBinPath [ cifs-utils ffmpeg libav ]}' check.sh
+    sed -i '3i PATH=$PATH:${makeBinPath [ cifs-utils ffmpeg_3 libav ]}' check.sh
     sed -i '/check_ulimit$/d' check.sh
 
     # Start script
-    sed -i '3i PATH=$PATH:${makeBinPath [ alsaUtils cifs-utils ffmpeg libav ]}' start.sh
+    sed -i '3i PATH=$PATH:${makeBinPath [ alsaUtils cifs-utils ffmpeg_3 libav ]}' start.sh
 
     # Debug logging
     sed -i '/--debug--gc=sgen --server/exec "$HARDLINK" --debug --gc=sgen --server "$SCRIPT.exe" "$@" -storagetrace -watchertrace' Appliance/RoonAppliance

--- a/pkgs/servers/tvheadend/default.nix
+++ b/pkgs/servers/tvheadend/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, makeWrapper, pkgconfig
-, avahi, dbus, gettext, git, gnutar, gzip, bzip2, ffmpeg, libiconv, openssl, python
+, avahi, dbus, gettext, git, gnutar, gzip, bzip2, ffmpeg_3, libiconv, openssl, python
 , which, zlib }:
 
 let
@@ -17,7 +17,7 @@ in stdenv.mkDerivation {
   };
 
   buildInputs = [
-    avahi dbus gettext git gnutar gzip bzip2 ffmpeg libiconv openssl python
+    avahi dbus gettext git gnutar gzip bzip2 ffmpeg_3 libiconv openssl python
     which zlib
   ];
 

--- a/pkgs/servers/zoneminder/default.nix
+++ b/pkgs/servers/zoneminder/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, fetchurl, substituteAll, cmake, makeWrapper, pkgconfig
-, curl, ffmpeg, glib, libjpeg, libselinux, libsepol, mp4v2, libmysqlclient, mysql, pcre, perl, perlPackages
+, curl, ffmpeg_3, glib, libjpeg, libselinux, libsepol, mp4v2, libmysqlclient, mysql, pcre, perl, perlPackages
 , polkit, utillinuxMinimal, x264, zlib
 , coreutils, procps, psmisc, nixosTests }:
 
@@ -138,7 +138,7 @@ in stdenv.mkDerivation rec {
 
     for f in includes/Event.php views/image.php ; do
       substituteInPlace web/$f \
-        --replace "'ffmpeg " "'${ffmpeg}/bin/ffmpeg "
+        --replace "'ffmpeg " "'${ffmpeg_3}/bin/ffmpeg "
     done
 
     substituteInPlace web/includes/functions.php \
@@ -147,7 +147,7 @@ in stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    curl ffmpeg glib libjpeg libselinux libsepol mp4v2 libmysqlclient mysql.client pcre perl polkit x264 zlib
+    curl ffmpeg_3 glib libjpeg libselinux libsepol mp4v2 libmysqlclient mysql.client pcre perl polkit x264 zlib
     utillinuxMinimal # for libmount
   ] ++ (with perlPackages; [
     # build-time dependencies

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -10,7 +10,7 @@
 , enableAcousticbrainz ? true
 , enableAcoustid       ? true
 , enableBadfiles       ? true, flac ? null, mp3val ? null
-, enableConvert        ? true, ffmpeg ? null
+, enableConvert        ? true, ffmpeg_3 ? null
 , enableDiscogs        ? true
 , enableEmbyupdate     ? true
 , enableFetchart       ? true
@@ -39,7 +39,7 @@ assert enableAbsubmit    -> essentia-extractor            != null;
 assert enableAcoustid    -> pythonPackages.pyacoustid     != null;
 assert enableBadfiles    -> flac != null && mp3val != null;
 assert enableCheck       -> flac != null && mp3val != null && liboggz != null;
-assert enableConvert     -> ffmpeg != null;
+assert enableConvert     -> ffmpeg_3 != null;
 assert enableDiscogs     -> pythonPackages.discogs_client != null;
 assert enableFetchart    -> pythonPackages.responses      != null;
 assert enableGmusic      -> pythonPackages.gmusicapi      != null;
@@ -146,7 +146,7 @@ in pythonPackages.buildPythonApplication rec {
               || enableAcousticbrainz)
                                     pythonPackages.requests
     ++ optional enableCheck         plugins.check
-    ++ optional enableConvert       ffmpeg
+    ++ optional enableConvert       ffmpeg_3
     ++ optional enableDiscogs       pythonPackages.discogs_client
     ++ optional enableGmusic        pythonPackages.gmusicapi
     ++ optional enableKeyfinder     keyfinder-cli
@@ -200,7 +200,7 @@ in pythonPackages.buildPythonApplication rec {
       s,"mp3val","${mp3val}/bin/mp3val",
     }' beetsplug/badfiles.py
   '' + optionalString enableConvert ''
-    sed -i -e 's,\(util\.command_output(\)\([^)]\+\)),\1[b"${ffmpeg.bin}/bin/ffmpeg" if args[0] == b"ffmpeg" else args[0]] + \2[1:]),' beetsplug/convert.py
+    sed -i -e 's,\(util\.command_output(\)\([^)]\+\)),\1[b"${ffmpeg_3.bin}/bin/ffmpeg" if args[0] == b"ffmpeg" else args[0]] + \2[1:]),' beetsplug/convert.py
   '' + optionalString enableReplaygain ''
     sed -i -re '
       s!^( *cmd *= *b?['\'''"])(bs1770gain['\'''"])!\1${bs1770gain}/bin/\2!

--- a/pkgs/tools/graphics/cfdg/default.nix
+++ b/pkgs/tools/graphics/cfdg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, libpng, bison, flex, ffmpeg, icu }:
+{ stdenv, fetchFromGitHub, libpng, bison, flex, ffmpeg_3, icu }:
 
 stdenv.mkDerivation rec {
   pname = "cfdg";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "13m8npccacmgxbs4il45zw53dskjh53ngv2nxahwqw8shjrws4mh";
   };
 
-  buildInputs = [ libpng bison flex ffmpeg icu ];
+  buildInputs = [ libpng bison flex ffmpeg_3 icu ];
 
   postPatch = ''
     sed -e "/YY_NO_UNISTD/a#include <stdio.h>" -i src-common/cfdg.l

--- a/pkgs/tools/graphics/yaxg/default.nix
+++ b/pkgs/tools/graphics/yaxg/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, makeWrapper,
-  maim, slop, ffmpeg, byzanz, libnotify, xdpyinfo }:
+  maim, slop, ffmpeg_3, byzanz, libnotify, xdpyinfo }:
 
 stdenv.mkDerivation rec {
   pname = "yaxg";
@@ -13,13 +13,13 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ maim slop ffmpeg byzanz libnotify xdpyinfo ];
+  buildInputs = [ maim slop ffmpeg_3 byzanz libnotify xdpyinfo ];
 
   installPhase = ''
     mkdir -p $out/bin/
     mv yaxg $out/bin/
     chmod +x $out/bin/yaxg
-    wrapProgram $out/bin/yaxg --prefix PATH : ${ stdenv.lib.makeBinPath [ maim slop ffmpeg byzanz libnotify xdpyinfo ]}
+    wrapProgram $out/bin/yaxg --prefix PATH : ${ stdenv.lib.makeBinPath [ maim slop ffmpeg_3 byzanz libnotify xdpyinfo ]}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/capture/default.nix
+++ b/pkgs/tools/misc/capture/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, slop, ffmpeg, fetchFromGitHub, makeWrapper}:
+{ stdenv, slop, ffmpeg_3, fetchFromGitHub, makeWrapper}:
 
 stdenv.mkDerivation {
   pname = "capture-unstable";
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
     patchShebangs $out/bin/capture
     wrapProgram $out/bin/capture \
-      --prefix PATH : '${stdenv.lib.makeBinPath [ slop ffmpeg ]}'
+      --prefix PATH : '${stdenv.lib.makeBinPath [ slop ffmpeg_3 ]}'
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/gif-for-cli/default.nix
+++ b/pkgs/tools/misc/gif-for-cli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3Packages, ffmpeg, zlib, libjpeg }:
+{ stdenv, fetchFromGitHub, python3Packages, ffmpeg_3, zlib, libjpeg }:
 
 python3Packages.buildPythonApplication {
   pname = "gif-for-cli";
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication {
   };
 
   checkInputs = [ python3Packages.coverage ];
-  buildInputs = [ ffmpeg zlib libjpeg ];
+  buildInputs = [ ffmpeg_3 zlib libjpeg ];
   propagatedBuildInputs = with python3Packages; [ pillow requests x256 ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/yle-dl/default.nix
+++ b/pkgs/tools/misc/yle-dl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rtmpdump, php, pythonPackages, ffmpeg }:
+{ stdenv, fetchFromGitHub, rtmpdump, php, pythonPackages, ffmpeg_3 }:
 
 pythonPackages.buildPythonApplication rec {
   pname = "yle-dl";
@@ -12,7 +12,7 @@ pythonPackages.buildPythonApplication rec {
   };
 
   propagatedBuildInputs = with pythonPackages; [
-    lxml pyamf pycrypto requests future ffmpeg setuptools
+    lxml pyamf pycrypto requests future ffmpeg_3 setuptools
   ];
   pythonPath = [ rtmpdump php ];
 

--- a/pkgs/tools/networking/minidlna/default.nix
+++ b/pkgs/tools/networking/minidlna/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ffmpeg, flac, libvorbis, libogg, libid3tag, libexif, libjpeg, sqlite, gettext }:
+{ stdenv, fetchurl, ffmpeg_3, flac, libvorbis, libogg, libid3tag, libexif, libjpeg, sqlite, gettext }:
 
 let version = "1.2.1"; in
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     export makeFlags="INSTALLPREFIX=$out"
   '';
 
-  buildInputs = [ ffmpeg flac libvorbis libogg libid3tag libexif libjpeg sqlite gettext ];
+  buildInputs = [ ffmpeg_3 flac libvorbis libogg libid3tag libexif libjpeg sqlite gettext ];
 
   postInstall = ''
     mkdir -p $out/share/man/man{5,8}

--- a/pkgs/tools/text/ripgrep-all/default.nix
+++ b/pkgs/tools/text/ripgrep-all/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, rustPlatform, makeWrapper, ffmpeg
+{ stdenv, lib, fetchFromGitHub, rustPlatform, makeWrapper, ffmpeg_3
 , pandoc, poppler_utils, ripgrep, Security, imagemagick, tesseract
 }:
 
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     wrapProgram $out/bin/rga \
-      --prefix PATH ":" "${lib.makeBinPath [ ffmpeg pandoc poppler_utils ripgrep imagemagick tesseract ]}"
+      --prefix PATH ":" "${lib.makeBinPath [ ffmpeg_3 pandoc poppler_utils ripgrep imagemagick tesseract ]}"
   '';
 
   # Use upstream's example data to run a couple of queries to ensure the dependencies

--- a/pkgs/tools/video/gopro/default.nix
+++ b/pkgs/tools/video/gopro/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, ffmpeg
+, ffmpeg_3
 , imagemagick
 , makeWrapper
 , mplayer
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
     install -Dm755 gopro -t $out/bin
     wrapProgram $out/bin/gopro \
-      --prefix PATH ":" "${stdenv.lib.makeBinPath [ ffmpeg imagemagick mplayer ]}"
+      --prefix PATH ":" "${stdenv.lib.makeBinPath [ ffmpeg_3 imagemagick mplayer ]}"
 
     runHook postInstall
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11707,7 +11707,9 @@ in
   # Aliases
   ffmpeg_2 = ffmpeg_2_8;
   ffmpeg_3 = ffmpeg_3_4;
-  ffmpeg = ffmpeg_3;
+  # Please make sure this is updated to the latest version on the next major
+  # update to ffmpeg
+  ffmpeg = ffmpeg_4;
 
   ffmpeg-full = callPackage ../development/libraries/ffmpeg-full {
     ffmpeg = ffmpeg_4;


### PR DESCRIPTION
###### Motivation for this change

Libraries without a version suffix should point to their latest version upstream! See https://discourse.nixos.org/t/nixpkgs-policy-regarding-libraries-available-in-multiple-versions/7026

This PR intends to make `ffmpeg` point to `ffmpeg4`. To make the review easier, I renamed the inputs where necessary for all derivations that used `ffmpeg` (without a version suffix) and as seen by the PR's labels, ofborg didn't detect any paths changed, besides of course `ffmpeg` itself.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
