### PR TITLE
hplip: don't reference gcc in binaries from /share and other locations

### DIFF
--- a/pkgs/misc/drivers/hplip/3.18.5.nix
+++ b/pkgs/misc/drivers/hplip/3.18.5.nix
@@ -199,6 +199,11 @@ python2Packages.buildPythonApplication {
     done
   '';
 
+  # There are some binaries there, which reference gcc-unwrapped otherwise.
+  stripDebugList = [
+    "share/hplip"
+  ];
+
   postFixup = ''
     substituteInPlace $out/etc/hp/hplip.conf --replace /usr $out
     # Patch udev rules:

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -4,6 +4,8 @@
 , dbus, file, ghostscript, usbutils
 , net-snmp, openssl, perl, nettools
 , bash, coreutils, utillinux
+# To remove references to gcc-unwrapped
+, removeReferencesTo
 , withQt5 ? true
 , withPlugin ? false
 , withStaticPPDInstall ? false
@@ -65,7 +67,7 @@ python3Packages.buildPythonApplication {
     zlib
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig removeReferencesTo ];
 
   pythonPath = with python3Packages; [
     dbus
@@ -216,7 +218,13 @@ python3Packages.buildPythonApplication {
       --replace /usr/bin/nohup "" \
       --replace {,${utillinux}/bin/}logger \
       --replace {/usr,$out}/bin
+    remove-references-to -t ${stdenv.cc.cc} $(readlink -f $out/lib/*.so)
   '';
+
+  # There are some binaries there, which reference gcc-unwrapped otherwise.
+  stripDebugList = [
+    "share/hplip" "lib/cups/backend" "lib/cups/filter" "lib/python3.7/site-packages" "lib/sane"
+  ];
 
   meta = with stdenv.lib; {
     description = "Print, scan and fax HP drivers for Linux";


### PR DESCRIPTION
###### Motivation for this change

Make hplip packages not reference `gcc-unwrapped`,

###### Things done

Removed reference of all hplip variants to `gcc-unwrapped`. It was mostly easy with a `stripDebugList` attribute, but for the default `hplip` `removeReferencesTo` was needed.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
