### PR TITLE
eliot-tree: init at 19.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2170,6 +2170,16 @@
     githubId = 974130;
     name = "David Pätzel";
   };
+  dpausp = {
+    email = "dpausp@posteo.de";
+    github = "dpausp";
+    githubId = 1965950;
+    name = "Tobias Stenzel";
+    keys = [{
+      longkeyid = "rsa2048/0x78C7DD40DF23FB16";
+      fingerprint = "4749 0887 CF3B 85A1 6355  C671 78C7 DD40 DF23 FB16";
+    }];
+  };
   dpflug = {
     email = "david@pflug.email";
     github = "dpflug";

--- a/pkgs/development/python-modules/eliot/default.nix
+++ b/pkgs/development/python-modules/eliot/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, aiocontextvars
+, boltons
+, hypothesis
+, pyrsistent
+, pytest
+, setuptools
+, six
+, testtools
+, zope_interface
+}:
+
+buildPythonPackage rec {
+  pname = "eliot";
+  version = "1.12.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wabv7hk63l12881f4zw02mmj06583qsx2im0yywdjlj8f56vqdn";
+  };
+
+  checkInputs = [
+    hypothesis
+    testtools
+    pytest
+   ];
+
+  propagatedBuildInputs = [
+    aiocontextvars
+    boltons
+    pyrsistent
+    setuptools
+    six
+    zope_interface
+  ];
+
+  pythonImportsCheck = [ "eliot" ];
+
+  # Tests run eliot-prettyprint in out/bin.
+  # test_parse_stream is broken, skip it.
+  checkPhase = ''
+    export PATH=$out/bin:$PATH
+    pytest -k 'not test_parse_stream'
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://eliot.readthedocs.io";
+    description = "Logging library that tells you why it happened";
+    license = licenses.asl20;
+    maintainers = [ maintainers.dpausp ];
+  };
+}

--- a/pkgs/development/tools/eliot-tree/default.nix
+++ b/pkgs/development/tools/eliot-tree/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "eliot-tree";
+  version = "19.0.1";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "18gvijsm0vh3x83mv8dd80c3mpm80r7i111qsg4y7rj4i590phma";
+  };
+
+  checkInputs = with python3Packages; [
+    testtools
+    pytest
+   ];
+
+  propagatedBuildInputs = with python3Packages; [
+    colored
+    eliot
+    iso8601
+    jmespath
+    setuptools
+    toolz
+  ];
+
+  # Tests run eliot-tree in out/bin.
+  checkPhase = ''
+    export PATH=$out/bin:$PATH
+    pytest
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/jonathanj/eliottree";
+    description = "Render Eliot logs as an ASCII tree";
+    license = licenses.mit;
+    maintainers = [ maintainers.dpausp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10614,6 +10614,8 @@ in
 
   elfutils = callPackage ../development/tools/misc/elfutils { };
 
+  eliot-tree = callPackage ../development/tools/eliot-tree { };
+
   emma = callPackage ../development/tools/analysis/emma { };
 
   epm = callPackage ../development/tools/misc/epm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -728,6 +728,8 @@ in {
 
   diff-match-patch = callPackage ../development/python-modules/diff-match-patch { };
 
+  eliot = callPackage ../development/python-modules/eliot {};
+
   entrance = callPackage ../development/python-modules/entrance { routerFeatures = false; };
 
   entrance-with-router-features = callPackage ../development/python-modules/entrance { routerFeatures = true; };


### PR DESCRIPTION
dependencies:

* eliot: init at 1.12.0


###### Motivation for this change

[eliot-tree](https://github.com/jonathanj/eliottree) is a command line tool for formatting JSON log messages produced by the [eliot](https://github.com/itamarst/eliot) logging library for Python. Also adds eliot itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
