### PR TITLE
utf8cpp: init at 3.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3646,6 +3646,12 @@
     githubId = 1102396;
     name = "Jussi Maki";
   };
+  jobojeha = {
+    email = "jobojeha@jeppener.de";
+    github = "jobojeha";
+    githubId = 60272884;
+    name = "Jonathan Jeppener-Haltenhoff";
+  };
   joelburget = {
     email = "joelburget@gmail.com";
     github = "joelburget";

--- a/pkgs/development/libraries/utf8cpp/default.nix
+++ b/pkgs/development/libraries/utf8cpp/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "utf8cpp";
+  version = "3.1.1";
+
+  src = fetchFromGitHub {
+    owner = "nemtrif";
+    repo = "utfcpp";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "1s2pda75488z7c3w3a6qv31bj239248696yk5j2a1drbg2x1dpfh";
+  };
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=None"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DINSTALL_GTEST=OFF"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/nemtrif/utfcpp";
+    description = "UTF-8 with C++ in a Portable Way";
+    license = licenses.free;
+    maintainers = with maintainers; [ jobojeha ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26254,6 +26254,8 @@ in
 
   urbit = callPackage ../misc/urbit { };
 
+  utf8cpp = callPackage ../development/libraries/utf8cpp { };
+
   utf8proc = callPackage ../development/libraries/utf8proc { };
 
   unicode-paracode = callPackage ../tools/misc/unicode { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adds UTF8-CPP, a  simple, portable and lightweight generic library for handling UTF-8 encoded strings. Required as a dependency for ParaView > 5.7.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
