### PR TITLE
zsh-powerlevel10k: v1.7.0 -> v1.11.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
@@ -1,14 +1,14 @@
 { callPackage, stdenv, fetchFromGitHub, ...}:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "gitstatus";
-  version = "unstable-2020-04-21";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "gitstatus";
-    rev = "3494f25b0b3b2eac241cf669d1fea2b49ea42fb3";
-    sha256 = "0b4g14dkkgih6zps2w1krl9xf44ysj02617zj1k51z127v2lpm1f";
+    rev = "v${version}";
+    sha256 = "16s09d2kpw0v0kyr2ada99qmsi0pqnsiis22mzq69hay0hdg8p1n";
   };
 
   buildInputs = [ (callPackage ./romkatv_libgit2.nix {}) ];
@@ -24,7 +24,6 @@ stdenv.mkDerivation {
     description = "10x faster implementation of `git status` command";
     homepage = "https://github.com/romkatv/gitstatus";
     license = [ licenses.gpl3 ];
-
     maintainers = with maintainers; [ mmlb hexa ];
   };
 }

--- a/pkgs/applications/version-management/git-and-tools/gitstatus/romkatv_libgit2.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/romkatv_libgit2.nix
@@ -6,16 +6,17 @@ libgit2.overrideAttrs (oldAttrs: {
     "-DBUILD_SHARED_LIBS=OFF"
     "-DREGEX_BACKEND=builtin"
     "-DUSE_BUNDLED_ZLIB=ON"
+    "-DUSE_GSSAPI=OFF"
     "-DUSE_HTTPS=OFF"
     "-DUSE_HTTP_PARSER=builtin"  # overwritten from libgit2
-    "-DUSE_ICONV=OFF"
+    "-DUSE_NTLMCLIENT=OFF"
     "-DUSE_SSH=OFF"
     "-DZERO_NSEC=ON"
   ];
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "libgit2";
-    rev = "bb77509f4436901f3958e30272026f63d2247d7d";
-    sha256 = "06iypr0sc6g11xipwfbgm6f039d4qy9krmwb3zww8k4y004s5jcv";
+    rev = "tag-005f77dca6dbe8788e55139fa1199fc94cc04f9a";
+    sha256 = "1h5bnisk4ljdpfzlv8g41m8js9841xyjhfywc5cn8pmyv58c50il";
   };
 })

--- a/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
+++ b/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "powerlevel10k";
-  version = "1.7.0";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "powerlevel10k";
     rev = "v${version}";
-    sha256 = "04j37qmgzj62gixysj3di9dccfib4hx1c4ld9kcms3ag7k403bgj";
+    sha256 = "1z6abvp642n40biya88n86ff1wiry00dlwawqwxp7q5ds55jhbv1";
   };
 
   patches = [
@@ -25,8 +25,7 @@ stdenv.mkDerivation rec {
     install -D powerlevel10k.zsh-theme --target-directory=$out/share/zsh-powerlevel10k
     install -D config/* --target-directory=$out/share/zsh-powerlevel10k/config
     install -D internal/* --target-directory=$out/share/zsh-powerlevel10k/internal
-    rm -r gitstatus/bin
-    install -D gitstatus/* --target-directory=$out/share/zsh-powerlevel10k/gitstatus
+    cp -R gitstatus $out/share/zsh-powerlevel10k/gitstatus
   '';
 
   meta = {

--- a/pkgs/shells/zsh/zsh-powerlevel10k/gitstatusd.patch
+++ b/pkgs/shells/zsh/zsh-powerlevel10k/gitstatusd.patch
@@ -1,8 +1,8 @@
 diff --git a/gitstatus/gitstatus.plugin.zsh b/gitstatus/gitstatus.plugin.zsh
-index 46d0b3c..b082e24 100644
+index b469072..eb1e3be 100644
 --- a/gitstatus/gitstatus.plugin.zsh
 +++ b/gitstatus/gitstatus.plugin.zsh
-@@ -53,6 +53,8 @@
+@@ -44,6 +44,8 @@
  
  [[ -o 'interactive' ]] || 'return'
  
@@ -11,4 +11,3 @@ index 46d0b3c..b082e24 100644
  # Temporarily change options.
  'builtin' 'local' '-a' '_gitstatus_opts'
  [[ ! -o 'aliases'         ]] || _gitstatus_opts+=('aliases')
-


### PR DESCRIPTION
###### Motivation for this change

New upstream releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @maralorn @flokli @andir as users of this package afaik.