### PR TITLE
streamlink-twitch-gui-bin: init at 1.10.0

### DIFF
--- a/pkgs/applications/video/streamlink-twitch-gui/bin.nix
+++ b/pkgs/applications/video/streamlink-twitch-gui/bin.nix
@@ -1,0 +1,100 @@
+{ autoPatchelfHook, fetchurl, lib, makeDesktopItem, makeWrapper, stdenv, wrapGAppsHook
+, at-spi2-core, atk, alsaLib, cairo, cups, dbus, expat, gcc-unwrapped
+, gdk-pixbuf, glib, gnome2, gtk3-x11, libudev0-shim, libuuid, nss, nspr, xorg
+, streamlink }:
+
+let
+  basename = "streamlink-twitch-gui";
+  runtimeLibs = lib.makeLibraryPath [ libudev0-shim ];
+  arch =
+    if stdenv.hostPlatform.system == "x86_64-linux"
+    then
+      "linux64"
+    else
+      "linux32";
+
+in
+stdenv.mkDerivation rec {
+  pname = "${basename}-bin";
+  version = "1.10.0";
+
+  src = fetchurl {
+    url = "https://github.com/streamlink/${basename}/releases/download/v${version}/${basename}-v${version}-${arch}.tar.gz";
+    sha256 =
+      if arch == "linux64"
+      then
+        "17s9zbzj4pgz9mxxwjbp3788afkddc9s3p7xp28y5084z9wwzph2"
+      else
+        "1pww05hr48m6v0g1sz48g1c7p615lig3s12l21xgyz4gkjzmjy22";
+  };
+
+  nativeBuildInputs = with xorg; [
+    at-spi2-core
+    atk
+    alsaLib
+    autoPatchelfHook
+    cairo
+    cups.lib
+    dbus.daemon.lib
+    expat
+    gcc-unwrapped
+    gdk-pixbuf
+    glib
+    gnome2.pango
+    gtk3-x11
+    nss
+    nspr
+    libuuid
+    libX11
+    libxcb
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXScrnSaver
+    libXtst
+    makeWrapper
+    wrapGAppsHook
+  ];
+
+  buildInputs = [ streamlink ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    mkdir -p $out/{bin,opt/${basename},share}
+
+    # Install all files, remove unnecessary ones
+    cp -a . $out/opt/${basename}/
+    rm -r $out/opt/${basename}/{{add,remove}-menuitem.sh,credits.html,icons/}
+
+    wrapProgram $out/opt/${basename}/${basename} --add-flags "--no-version-check" --prefix LD_LIBRARY_PATH : ${runtimeLibs}
+
+    ln -s "$out/opt/${basename}/${basename}" $out/bin/
+    ln -s "${desktopItem}/share/applications" $out/share/
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = basename;
+    exec = basename;
+    icon = basename;
+    desktopName = "Streamlink Twitch GUI";
+    genericName = meta.description;
+    categories = "AudioVideo;Network;";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Twitch.tv browser for Streamlink";
+    longDescription = "Browse Twitch.tv and watch streams in your videoplayer of choice";
+    homepage = "https://streamlink.github.io/streamlink-twitch-gui/";
+    downloadPage = https://github.com/streamlink/streamlink-twitch-gui/releases;
+    license = licenses.mit;
+    maintainers = with maintainers; [ rileyinman ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14635,6 +14635,7 @@ in
   stlport = callPackage ../development/libraries/stlport { };
 
   streamlink = callPackage ../applications/video/streamlink { pythonPackages = python3Packages; };
+  streamlink-twitch-gui-bin = callPackage ../applications/video/streamlink-twitch-gui/bin.nix {};
 
   strigi = callPackage ../development/libraries/strigi { clucene_core = clucene_core_2; };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I wanted to be able to use streamlink-twitch-gui, and it doesn't seem anyone else has taken a crack at packaging it. I tried getting the yarn build to work but kept running into problems, as I'm not that experienced with yarn or the node ecosystem on NixOS. Repackaging the binary seems to work fine though. With help from the developer, it even correctly runs with the streamlink wrapper script out of the box starting with version 1.10.0!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
