### PR TITLE
ATS2: add support for Darwin platform with a GCC toolchain

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -950,6 +950,12 @@
     githubId = 354741;
     name = "Austin Butler";
   };
+  avanov = {
+    email = "maxim.avanov@gmail.com";
+    github = "avanov";
+    githubId = 601955;
+    name = "Maxim Avanov";
+  };
   avaq = {
     email = "nixpkgs@account.avaq.it";
     github = "avaq";

--- a/pkgs/development/compilers/ats2/default.nix
+++ b/pkgs/development/compilers/ats2/default.nix
@@ -3,11 +3,11 @@
 , withContrib ? true }:
 
 let
-  versionPkg = "0.4.1" ;
+  versionPkg = "0.4.2" ;
 
   contrib = fetchurl {
     url = "mirror://sourceforge/ats2-lang/ATS2-Postiats-contrib-${versionPkg}.tgz";
-    sha256 = "184m4hz2xszhcfc6w9fw9qibhmcvgjmikwfwkb345xypr59jm93d";
+    sha256 = "19ykjacq1cx04z981p3dd2qr9mb6ps18lp2b4bd24dhspc25yj4v";
   };
 
   postInstallContrib = lib.optionalString withContrib
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/ats2-lang/ATS2-Postiats-gmp-${version}.tgz";
-    sha256 = "0c4nqp6yzmpj0mcpg7ibmwyqi8hjw3sza8myvy4nzq3fa6wldy5l";
+    sha256 = "100vgrninbshq3rs57psl9aqi2bphrjfbizmmrjhs5yzh0a4zikk";
   };
 
   buildInputs = [ gmp ];
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     description = "Functional programming language with dependent types";
     homepage    = "http://www.ats-lang.org";
     license     = licenses.gpl3Plus;
-    platforms   = platforms.linux;
-    maintainers = with maintainers; [ thoughtpolice ttuegel bbarker ];
+    platforms   = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ thoughtpolice ttuegel bbarker avanov ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10127,7 +10127,9 @@ in
   aspectj = callPackage ../development/compilers/aspectj { };
 
   ats = callPackage ../development/compilers/ats { };
-  ats2 = callPackage ../development/compilers/ats2 { };
+  ats2 = callPackage ../development/compilers/ats2 {
+    stdenv = if stdenv.isDarwin then gccStdenv else stdenv;
+  };
 
   avra = callPackage ../development/compilers/avra { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Current master branch doesn't contain a derivation for the current stable ATS2 (0.4.0), and MacOS is exempt from supported platforms

###### Things done

* ATS2 version is upgraded to 0.4.0
* ATS2-Contrib and ATS2 tarballs have appropriate sha256 checksums
* metadata now contains `platforms.darwin` - this is possible through explicit passing of `gccStdenv` to the derivation on Darwin.
* as I use Jetbrains' IDEs heavily, a corresponding gitignore entry was added.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
