### PR TITLE
.github/stale.yml: fix formatting

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,25 +9,17 @@ exemptLabels:
 # Label to use when marking an issue as stale
 staleLabel: "2.status: stale"
 # Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: >
+markComment: |
   Thank you for your contributions.
 
-  This has been automatically marked as stale because it has had no
-  activity for 180 days.
+  This has been automatically marked as stale because it has had no activity for 180 days.
 
-  If this is still important to you, we ask that you leave a
-  comment below. Your comment can be as simple as "still important
-  to me". This lets people see that at least one person still cares
-  about this. Someone will have to do this at most twice a year if
-  there is no other activity.
+  If this is still important to you, we ask that you leave a comment below. Your comment can be as simple as "still important to me". This lets people see that at least one person still cares about this. Someone will have to do this at most twice a year if there is no other activity.
 
   Here are suggestions that might help resolve this more quickly:
 
-  1. Search for maintainers and people that previously touched the
-     related code and @ mention them in a comment.
+  1. Search for maintainers and people that previously touched the related code and @ mention them in a comment.
   2. Ask on the [NixOS Discourse](https://discourse.nixos.org/).
-  3. Ask on the [#nixos channel](irc://irc.freenode.net/#nixos) on
-     [irc.freenode.net](https://freenode.net).
-
+  3. Ask on the [#nixos channel](irc://irc.freenode.net/#nixos) on [irc.freenode.net](https://freenode.net).
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
Before this, the message being written is:
```
Thank you for your contributions.
This has been automatically marked as stale because it has had no activity for 180 days.
If this is still important to you, we ask that you leave a comment below. Your comment can be as simple as "still important to me". This lets people see that at least one person still cares about this. Someone will have to do this at most twice a year if there is no other activity.
Here are suggestions that might help resolve this more quickly:
1. Search for maintainers and people that previously touched the
   related code and @ mention them in a comment.
2. Ask on the [NixOS Discourse](https://discourse.nixos.org/). 3. Ask on the [#nixos channel](irc://irc.freenode.net/#nixos) on
   [irc.freenode.net](https://freenode.net).
```
For some reason the newline after the 2nd suggestion is gone. This
attempts to force a newline there.

cc @zowoq since you seem to know about stalebot!

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
