### PR TITLE
gpxsee: 7.29 -> 7.30

### DIFF
--- a/pkgs/applications/misc/gpxsee/default.nix
+++ b/pkgs/applications/misc/gpxsee/default.nix
@@ -1,17 +1,27 @@
-{ stdenv, mkDerivation, fetchFromGitHub, qmake, qttools }:
+{ stdenv, mkDerivation, fetchFromGitHub, qmake, qttools, qttranslations }:
 
 mkDerivation rec {
   pname = "gpxsee";
-  version = "7.29";
+  version = "7.30";
 
   src = fetchFromGitHub {
     owner = "tumic0";
     repo = "GPXSee";
     rev = version;
-    sha256 = "sha256-OTKyxEu7RZZy3JBHTM7YoH+G4lhoRfb1INLtQEKC5p4=";
+    sha256 = "09gajwqc30r9a2sn972qdx3gx0gki9n0zafq986hn6zsr3z43mfs";
   };
 
+  patches = [
+    # See https://github.com/NixOS/nixpkgs/issues/86054
+    ./fix-qttranslations-path.diff
+  ];
+
   nativeBuildInputs = [ qmake qttools ];
+
+  postPatch = ''
+    substituteInPlace src/GUI/app.cpp \
+      --subst-var-by qttranslations ${qttranslations}
+  '';
 
   preConfigure = ''
     lrelease gpxsee.pro

--- a/pkgs/applications/misc/gpxsee/fix-qttranslations-path.diff
+++ b/pkgs/applications/misc/gpxsee/fix-qttranslations-path.diff
@@ -1,0 +1,18 @@
+diff --git i/src/GUI/app.cpp w/src/GUI/app.cpp
+index 10e84d5..1e0abbe 100644
+--- i/src/GUI/app.cpp
++++ w/src/GUI/app.cpp
+@@ -34,11 +34,10 @@ App::App(int &argc, char **argv) : QApplication(argc, argv)
+ 	installTranslator(gpxsee);
+ 
+ 	QTranslator *qt = new QTranslator(this);
+-#if defined(Q_OS_WIN32) || defined(Q_OS_MAC)
++#if defined(Q_OS_WIN32)
+ 	qt->load(QLocale::system(), "qt", "_", ProgramPaths::translationsDir());
+ #else // Q_OS_WIN32 || Q_OS_MAC
+-	qt->load(QLocale::system(), "qt", "_", QLibraryInfo::location(
+-	  QLibraryInfo::TranslationsPath));
++	qt->load(QLocale::system(), "qt", "_", QLatin1String("@qttranslations@/translations"));
+ #endif // Q_OS_WIN32 || Q_OS_MAC
+ 	installTranslator(qt);
+ 


### PR DESCRIPTION
###### Motivation for this change
* [Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)
* Fix qt translations path (https://github.com/NixOS/nixpkgs/issues/86054)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
