### PR TITLE
pipenv: refactor runtimeDeps

### DIFF
--- a/pkgs/development/tools/pipenv/default.nix
+++ b/pkgs/development/tools/pipenv/default.nix
@@ -6,7 +6,7 @@ with python3.pkgs;
 
 let
 
-  runtimeDeps = [
+  runtimeDeps = ps: with ps; [
     certifi
     setuptools
     pip
@@ -14,7 +14,7 @@ let
     virtualenv-clone
   ];
 
-  pythonEnv = python3.withPackages(ps: with ps; runtimeDeps);
+  pythonEnv = python3.withPackages runtimeDeps;
 
 in buildPythonApplication rec {
   pname = "pipenv";
@@ -36,7 +36,7 @@ in buildPythonApplication rec {
       --replace "sys.executable" "'${pythonEnv.interpreter}'"
   '';
 
-  propagatedBuildInputs = runtimeDeps;
+  propagatedBuildInputs = runtimeDeps python3.pkgs;
 
   doCheck = true;
   checkPhase = ''


### PR DESCRIPTION
Make `runtimeDeps` a function, so that it will return a selection of the packages in the set passed to it by `python3.withPackages`, rather than the same packages taken directly from `python3.pkgs`.

###### Motivation for this change

Follow up to https://github.com/NixOS/nixpkgs/pull/89164#issuecomment-636502935

As mentioned in https://github.com/NixOS/nixpkgs/pull/89164#issuecomment-636504168, I'm unsure whether ignoring the packages `python3.withPackages` passes to its argument and instead using packages taken directly from `python3.pkgs` is good style:

https://github.com/NixOS/nixpkgs/blob/5e8e887e0e8b3284c97c4c52309887f70c54be6d/pkgs/development/tools/pipenv/default.nix#L5-L17

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
    except for:
    - `.pipenv-resolver-wrapped`
    - `.pipenv-wrapped`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
(empty)