### PR TITLE
coz: fix python shebang

### DIFF
--- a/pkgs/development/tools/analysis/coz/default.nix
+++ b/pkgs/development/tools/analysis/coz/default.nix
@@ -3,6 +3,7 @@
 , libelfin
 , ncurses
 , python3
+, python3Packages
 , makeWrapper
 }:
 stdenv.mkDerivation rec {
@@ -28,6 +29,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     ncurses
     makeWrapper
+    python3Packages.wrapPython
   ];
 
   buildInputs = [
@@ -42,9 +44,7 @@ stdenv.mkDerivation rec {
     # fix executable includes
     chmod -x $out/include/coz.h
 
-    # make sure that PYTHONPATH doesn't leak from the environment
-    wrapProgram $out/bin/coz \
-      --unset PYTHONPATH
+    wrapPythonPrograms
   '';
 
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Currently, the `coz` package installs the [`coz`](https://github.com/plasma-umass/coz/blob/master/coz) script directly, which uses the environment's Python. This should make the closure depend on Python 3 and fixes the shebang.

Note: while the script uses Python2.7, the README says that Python 3 is recommended, and I've tested the script with Python 3 a bit, and seems to run just fine.

This also removes the unset of `PYTHONPATH`, which is *not* done by `wrapPythonPrograms`, so I'm paging @zimbatm to ask if he still has the same issue with this method.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
