### PR TITLE
mpvmenu: init at unstable-2018-10-23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8827,4 +8827,14 @@
     github = "cpcloud";
     githubId = 417981;
   };
+  berbiche = {
+    name = "Nicolas Berbiche";
+    email = "nicolas@normie.dev";
+    github = "berbiche";
+    githubId = 20448408;
+    keys = [{
+      longkeyid = "rsa4096/0xB461292445C6E696";
+      fingerprint = "D446 E58D 87A0 31C7 EC15  88D7 B461 2924 45C6 E696";
+    }];
+  };
 }

--- a/pkgs/applications/misc/mpvmenu/default.nix
+++ b/pkgs/applications/misc/mpvmenu/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub
+, gtk3, gobject-introspection, python3, wrapGAppsHook
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "mpvmenu";
+  version = "unstable-2018-10-23";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "nezumisama";
+    repo = "mpvmenu";
+    rev = "a1bc2e803c3b00a614282dde48d1c38547578eb2";
+    sha256 = "0sk5xsdzz30nn8mzx6mc2krm960sjw3gdl48dr0jmglxfp0snz09";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  buildInputs = [ gobject-introspection gtk3 ];
+
+  propagatedBuildInputs = with python3.pkgs; [ pygobject3 ];
+
+  # To use wrapGAppsHook
+  strictDeps = false;
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    cp mpvmenu $out/bin
+  '';
+  passthru.scriptName = "mpvmenu";
+
+  # Avoid double-wrapping
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Pop-up menu for mpv on X11";
+    homepage = "https://github.com/nezumisama/mpvmenu";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.berbiche ];
+    platforms = platforms.linux;
+    longDescription = ''
+      Requires the `input-ipc-server` option of mpv to be enabled
+      and set to `/run/user/$UID/mpv.sock` where `$UID` is your
+      user id (the result of `id -u` or `$UID`).
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26737,4 +26737,6 @@ in
   vpsfree-client = callPackage ../tools/virtualization/vpsfree-client {};
 
   gpio-utils = callPackage ../os-specific/linux/kernel/gpio-utils.nix { };
+
+  mpvmenu = callPackage ../applications/misc/mpvmenu {};
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add a popup-menu to mpv.

This package cannot live under `mpvScripts` because it connects to mpv through ipc and is not loaded by mpv. It must be started externally.

Testing:
1. Start mpv with `--input-ipc-server=/var/run/user/$UID/mpv.sock` (hardcoded path in the package)
2. Add the following to input.conf `MOUSE_BTN2 script_message popup_menu` to have right-click trigger the popup-menu
3. Start the binary with `mpvmenu --log-level debug`

I have tested the binary on Gnome with X11 and Wayland as well as Sway.
It only worked on X11.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
