### PR TITLE
patchelf: increase the page size alignment on Aarch64 to support 64K pages

### DIFF
--- a/pkgs/development/tools/misc/patchelf/default.nix
+++ b/pkgs/development/tools/misc/patchelf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, lib }:
 
 stdenv.mkDerivation rec {
   name = "patchelf-0.9";
@@ -7,6 +7,15 @@ stdenv.mkDerivation rec {
     url = "https://nixos.org/releases/patchelf/${name}/${name}.tar.bz2";
     sha256 = "a0f65c1ba148890e9f2f7823f4bedf7ecad5417772f64f994004f59a39014f83";
   };
+
+  # Aarch64 supports page sizes up to 64K. GCC, binutils, etc. generate ELF
+  # files with segments aligned to 64K so that the generated binaries can run
+  # on systems with any page size configuration. However, patchelf defaults to
+  # "whatever the builder's kernel is using", which is currently 4K.
+  #
+  # Match the default from the rest of the toolchain ecosystem to support
+  # kernels with larger page sizes.
+  configureFlags = lib.optional stdenv.isAarch64 "--with-page-size=65536";
 
   setupHook = [ ./setup-hook.sh ];
 


### PR DESCRIPTION
###### Motivation for this change

NixOS built binaries currently do not work on ARMv8 systems configured for 64K wide pages (the more common default is 4K pages, like x86). This is because even though the usual compiler toolchains properly generate ELF files with 64K segment alignment, patchelf will sometimes rewrite segments and align them to 4K instead. The 4K value comes from the fact that the current Hydra ARMv8 builder uses 4K pages, which in itself is kind of undesirable (leaking details of the build infrastructure into packages).

I currently lack enough system diversity to test this (my only ARMv8 box is the one that's broken...), so feedback welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
