### PR TITLE
qv2ray: Init at 2.6.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6953,6 +6953,18 @@
     githubId = 138074;
     name = "Pedro Pombeiro";
   };
+  poscat = {
+    email = "poscat@mail.poscat.moe";
+    github = "poscat0x04";
+    githubId = 53291983;
+    name = "Poscat Tarski";
+    keys = [
+      {
+        longkeyid = "rsa4096/2D2595A00D08ACE0";
+        fingerprint = "48AD DE10 F27B AFB4 7BB0  CCAF 2D25 95A0 0D08 ACE0";
+      }
+    ];
+  };
   pradeepchhetri = {
     email = "pradeep.chhetri89@gmail.com";
     github = "pradeepchhetri";

--- a/pkgs/applications/networking/qv2ray/default.nix
+++ b/pkgs/applications/networking/qv2ray/default.nix
@@ -1,0 +1,66 @@
+{ stdenv
+, mkDerivation
+, fetchFromGitHub
+, qmake
+, qttools
+, cmake
+, clang
+, grpc
+, protobuf
+, openssl
+, pkgconfig
+, c-ares
+, abseil-cpp
+, libGL
+, zlib
+}:
+
+mkDerivation rec {
+  pname = "qv2ray";
+  version = "2.6.3";
+
+  src = fetchFromGitHub {
+    owner = "Qv2ray";
+    repo = "Qv2ray";
+    rev = "v${version}";
+    sha256 = "sha256-zf3IlpRbZGDZMEny0jp7S+kWtcE1Z10U9GzKC0W0mZI=";
+    fetchSubmodules = true;
+  };
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DQV2RAY_DISABLE_AUTO_UPDATE=on"
+    "-DQV2RAY_TRANSLATION_PATH=${placeholder "out"}/share/qv2ray/lang"
+  ];
+
+  preConfigure = ''
+    export _QV2RAY_BUILD_INFO_="Qv2ray Nixpkgs"
+    export _QV2RAY_BUILD_EXTRA_INFO_="(Nixpkgs build) nixpkgs"
+  '';
+
+  buildInputs = [
+    libGL
+    zlib
+    grpc
+    protobuf
+    openssl
+    abseil-cpp
+    c-ares
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    clang
+    pkgconfig
+    qmake
+    qttools
+  ];
+
+  meta = with stdenv.lib; {
+    description = "An GUI frontend to v2ray";
+    homepage = "https://qv2ray.github.io/en/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15536,6 +15536,8 @@ in
 
   quicksynergy = callPackage ../applications/misc/quicksynergy { };
 
+  qv2ray = libsForQt5.callPackage ../applications/networking/qv2ray {};
+
   qwt = callPackage ../development/libraries/qwt {};
 
   qwt6_qt4 = callPackage ../development/libraries/qwt/6_qt4.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

qv2ray is a GUI frontend to the network proxying tool v2ray.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
