### PR TITLE
libgme: Don't reference gcc-unwrapped

### DIFF
--- a/pkgs/development/libraries/audio/libgme/default.nix
+++ b/pkgs/development/libraries/audio/libgme/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromBitbucket, cmake }:
+{ stdenv, fetchFromBitbucket, cmake, removeReferencesTo }:
 let
   version = "0.6.3";
 in stdenv.mkDerivation {
@@ -21,4 +21,14 @@ in stdenv.mkDerivation {
   };
 
   buildInputs = [ cmake ];
+
+  nativeBuildInputs = [ removeReferencesTo ];
+
+  # It used to reference it, in the past, but thanks to the postFixup hook, now
+  # it doesn't.
+  disallowedReferences = [ stdenv.cc.cc ];
+
+  postFixup = stdenv.lib.optionalString stdenv.isLinux ''
+    remove-references-to -t ${stdenv.cc.cc} "$(readlink -f $out/lib/libgme.so)"
+  '';
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/88953 - make it not reference `gcc-unwrapped`.

###### Things done

I don't know why it references `gcc-unwrapped`, but this patch fixes it. Something in the compilation makes the libraries have the `strings`:

```
/gcc/include/c++/9.3.0/bits/stl_vector.h
/gcc/include/c++/9.3.0/ext/new_allocator.h
/gcc/include/c++/9.3.0/bits/alloc_traits.h
/gcc/include/c++/9.3.0/bits/vector.tcc
/gcc/include/c++/9.3.0/bits/stl_uninitialized.h
/gcc/include/c++/9.3.0/bits/stl_algobase.h
/gcc/include/c++/9.3.0/bits/allocator.h
/gcc/include/c++/9.3.0/bits/stl_construct.h
```

I'm not sure how to actually test that e.g `gst-plugins-bad` is still working. @lheckemann since you have contributed this package originally, perhaps do you know how to do that? I assume I need a certain media type but I'm not sure which...

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
