### PR TITLE
libssh2: fix broken patch hash

### DIFF
--- a/pkgs/development/libraries/libssh2/CVE-2019-17498.patch
+++ b/pkgs/development/libraries/libssh2/CVE-2019-17498.patch
@@ -1,0 +1,210 @@
+From b9aa7c2495694d0527e4e7fd560a3f0f18556c72 Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Thu, 29 Aug 2019 15:14:19 -0700
+Subject: [PATCH 1/5] packet.c: improve parsing of packets
+
+file: packet.c
+
+notes:
+Use _libssh2_get_string API in SSH_MSG_DEBUG, additional uint32 bounds check in SSH_MSG_GLOBAL_REQUEST
+---
+ src/packet.c | 30 +++++++++++++++---------------
+ 1 file changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/src/packet.c b/src/packet.c
+index 38ab62944..ac69768cd 100644
+--- a/src/packet.c
++++ b/src/packet.c
+@@ -537,26 +537,26 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+         case SSH_MSG_DEBUG:
+             if(datalen >= 2) {
+                 int always_display = data[1];
+-
++            
+                 if(datalen >= 6) {
+-                    message_len = _libssh2_ntohu32(data + 2);
+-
+-                    if(message_len <= (datalen - 10)) {
+-                        /* 6 = packet_type(1) + display(1) + message_len(4) */
+-                        message = (char *) data + 6;
+-                        language_len = _libssh2_ntohu32(data + 6 +
+-                                                        message_len);
+-
+-                        if(language_len <= (datalen - 10 - message_len))
+-                            language = (char *) data + 10 + message_len;
+-                    }
++                    struct string_buf buf;
++                    buf.data = (unsigned char *)data;
++                    buf.dataptr = buf.data;
++                    buf.len = datalen;
++                    buf.dataptr += 2; /* advance past type & always display */
++
++                    _libssh2_get_string(&buf, &message, &message_len);
++                    _libssh2_get_string(&buf, &language, &language_len);
+                 }
+ 
+                 if(session->ssh_msg_debug) {
+-                    LIBSSH2_DEBUG(session, always_display, message,
+-                                  message_len, language, language_len);
++                    LIBSSH2_DEBUG(session, always_display,
++                                  (const char *)message,
++                                  message_len, (const char *)language,
++                                  language_len);
+                 }
+             }
++
+             /*
+              * _libssh2_debug will actually truncate this for us so
+              * that it's not an inordinate about of data
+@@ -579,7 +579,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+                 uint32_t len = 0;
+                 unsigned char want_reply = 0;
+                 len = _libssh2_ntohu32(data + 1);
+-                if(datalen >= (6 + len)) {
++                if((len <= (UINT_MAX - 6) && (datalen >= (6 + len))) {
+                     want_reply = data[5 + len];
+                     _libssh2_debug(session,
+                                    LIBSSH2_TRACE_CONN,
+
+From 8b3cf0b17c1b84a138bed9423a9e0743452b4de9 Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Thu, 29 Aug 2019 15:15:33 -0700
+Subject: [PATCH 2/5] stray whitespace
+
+---
+ src/packet.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/packet.c b/src/packet.c
+index ac69768cd..8908b2c5a 100644
+--- a/src/packet.c
++++ b/src/packet.c
+@@ -537,7 +537,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+         case SSH_MSG_DEBUG:
+             if(datalen >= 2) {
+                 int always_display = data[1];
+-            
++
+                 if(datalen >= 6) {
+                     struct string_buf buf;
+                     buf.data = (unsigned char *)data;
+
+From 1c6fa92b77e34d089493fe6d3e2c6c8775858b94 Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Thu, 29 Aug 2019 15:24:22 -0700
+Subject: [PATCH 3/5] fixed type issue, updated SSH_MSG_DISCONNECT
+
+SSH_MSG_DISCONNECT now also uses  _libssh2_get API.
+---
+ src/packet.c | 40 +++++++++++++++-------------------------
+ 1 file changed, 15 insertions(+), 25 deletions(-)
+
+diff --git a/src/packet.c b/src/packet.c
+index 8908b2c5a..97f0cdd4b 100644
+--- a/src/packet.c
++++ b/src/packet.c
+@@ -419,8 +419,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+                     size_t datalen, int macstate)
+ {
+     int rc = 0;
+-    char *message = NULL;
+-    char *language = NULL;
++    unsigned char *message = NULL;
++    unsigned char *language = NULL;
+     size_t message_len = 0;
+     size_t language_len = 0;
+     LIBSSH2_CHANNEL *channelp = NULL;
+@@ -472,33 +472,23 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+ 
+         case SSH_MSG_DISCONNECT:
+             if(datalen >= 5) {
+-                size_t reason = _libssh2_ntohu32(data + 1);
++                uint32_t reason = 0;
++                struct string_buf buf;
++                buf.data = (unsigned char *)data;
++                buf.dataptr = buf.data;
++                buf.len = datalen;
++                buf.dataptr++; /* advance past type */
+ 
+-                if(datalen >= 9) {
+-                    message_len = _libssh2_ntohu32(data + 5);
++                _libssh2_get_u32(&buf, &reason);
++                _libssh2_get_string(&buf, &message, &message_len);
++                _libssh2_get_string(&buf, &language, &language_len);
+ 
+-                    if(message_len < datalen-13) {
+-                        /* 9 = packet_type(1) + reason(4) + message_len(4) */
+-                        message = (char *) data + 9;
+-
+-                        language_len =
+-                            _libssh2_ntohu32(data + 9 + message_len);
+-                        language = (char *) data + 9 + message_len + 4;
+-
+-                        if(language_len > (datalen-13-message_len)) {
+-                            /* bad input, clear info */
+-                            language = message = NULL;
+-                            language_len = message_len = 0;
+-                        }
+-                    }
+-                    else
+-                        /* bad size, clear it */
+-                        message_len = 0;
+-                }
+                 if(session->ssh_msg_disconnect) {
+-                    LIBSSH2_DISCONNECT(session, reason, message,
+-                                       message_len, language, language_len);
++                    LIBSSH2_DISCONNECT(session, reason, (const char *)message,
++                                       message_len, (const char *)language,
++                                       language_len);
+                 }
++
+                 _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
+                                "Disconnect(%d): %s(%s)", reason,
+                                message, language);
+
+From 77616117cc9dbbdd0fe1157098435bff73a83a0f Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Thu, 29 Aug 2019 15:26:32 -0700
+Subject: [PATCH 4/5] fixed stray (
+
+bad paste
+---
+ src/packet.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/packet.c b/src/packet.c
+index 97f0cdd4b..bd4c39e46 100644
+--- a/src/packet.c
++++ b/src/packet.c
+@@ -569,7 +569,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+                 uint32_t len = 0;
+                 unsigned char want_reply = 0;
+                 len = _libssh2_ntohu32(data + 1);
+-                if((len <= (UINT_MAX - 6) && (datalen >= (6 + len))) {
++                if(len <= (UINT_MAX - 6) && datalen >= (6 + len)) {
+                     want_reply = data[5 + len];
+                     _libssh2_debug(session,
+                                    LIBSSH2_TRACE_CONN,
+
+From 436c45dc143cadc8c59afac6c4255be332856581 Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Thu, 29 Aug 2019 15:29:00 -0700
+Subject: [PATCH 5/5] added additional parentheses for clarity
+
+---
+ src/packet.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/packet.c b/src/packet.c
+index bd4c39e46..2e01bfc5d 100644
+--- a/src/packet.c
++++ b/src/packet.c
+@@ -569,7 +569,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+                 uint32_t len = 0;
+                 unsigned char want_reply = 0;
+                 len = _libssh2_ntohu32(data + 1);
+-                if(len <= (UINT_MAX - 6) && datalen >= (6 + len)) {
++                if((len <= (UINT_MAX - 6)) && (datalen >= (6 + len))) {
+                     want_reply = data[5 + len];
+                     _libssh2_debug(session,
+                                    LIBSSH2_TRACE_CONN,

--- a/pkgs/development/libraries/libssh2/default.nix
+++ b/pkgs/development/libraries/libssh2/default.nix
@@ -15,12 +15,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional stdenv.hostPlatform.isMinGW windows.mingw_w64;
 
   patches = [
-    # not able to use fetchpatch here: infinite recursion
-    (fetchurl {
-      name = "CVE-2019-17498.patch";
-      url = "https://github.com/libssh2/libssh2/pull/402.patch";
-      sha256 = "1n9s2mcz5dkw0xpm3c5x4hzj8bar4i6z0pr1rmqjplhfg888vdvc";
-    })
+    # Not able to use fetchpatch here: infinite recursion
+    ./CVE-2019-17498.patch
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Patches from direct URLs on github are not stable (comment headers change w/
server settings), hence why we usually use `fetchpatch`. In lieu of that, vendor
the unstable patch.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).