### PR TITLE
php: build from github source

### DIFF
--- a/pkgs/development/interpreters/php/7.3.nix
+++ b/pkgs/development/interpreters/php/7.3.nix
@@ -5,7 +5,7 @@ let
 
   base = callPackage generic (_args // {
     version = "7.3.25";
-    sha256 = "1yq2fwpg9jgcafcrq4ffqm52r0f80pi6zy7fj1yb1qwim96mlcb9";
+    sha256 = "039r41zdi97jsxk4chgc87f7rj8ndzg48l2rqj9dpkwly7s16idh";
 
     # https://bugs.php.net/bug.php?id=76826
     extraPatches = lib.optional stdenv.isDarwin ./php73-darwin-isfinite.patch;

--- a/pkgs/development/interpreters/php/7.4.nix
+++ b/pkgs/development/interpreters/php/7.4.nix
@@ -5,7 +5,7 @@ let
 
   base = callPackage generic (_args // {
     version = "7.4.13";
-    sha256 = "1nhzldjp8jfd1hivfyn5wydim5daibz0vkfxgys2xj8igs2kk8qm";
+    sha256 = "1fs7mm8ipjsgr8x29vswk65wh5nlc8i0y0gvm0lvh495c9gdkjxf";
   });
 
 in base.withExtensions ({ all, ... }: with all; ([

--- a/pkgs/development/interpreters/php/8.0.nix
+++ b/pkgs/development/interpreters/php/8.0.nix
@@ -5,7 +5,7 @@ let
 
   base = callPackage generic (_args // {
     version = "8.0.0";
-    sha256 = "02cx3gvxqvkllp54jfvs83kl8bmpcqyzp9jf1d0l9x5bgv1jv0sy";
+    sha256 = "0fhn9dfgczf4g8p3ilw3c38nwdvkbnvz6sa92k8z7gszyjvd5rzv";
   });
 
 in base.withExtensions ({ all, ... }: with all; ([

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -5,7 +5,7 @@
 
 let
   generic =
-    { callPackage, lib, stdenv, nixosTests, config, fetchurl, makeWrapper
+    { callPackage, lib, stdenv, nixosTests, config, fetchFromGitHub, makeWrapper
     , symlinkJoin, writeText, autoconf, automake, bison, flex, libtool
     , pkgconfig, re2c, apacheHttpd, libargon2, libxml2, pcre, pcre2
     , systemd, system-sendmail, valgrind, xcbuild
@@ -238,6 +238,10 @@ let
             substituteInPlace configure --replace "-lstdc++" "-lc++"
           '';
 
+          preInstall = lib.optionalString pearSupport ''
+            cp ${php-pearweb-phars}/install-pear-nozlib.phar $TMPDIR/php-src-${version}/pear/install-pear-nozlib.phar
+          '';
+
           postInstall = ''
             test -d $out/etc || mkdir $out/etc
             cp php.ini-production $out/etc/php.ini
@@ -251,8 +255,11 @@ let
                $dev/share/man/man1/
           '';
 
-          src = fetchurl {
-            url = "https://www.php.net/distributions/php-${version}.tar.bz2";
+          src = fetchFromGitHub {
+            name = "php-src-${version}";
+            owner = "php";
+            repo = "php-src";
+            rev = "php-${version}";
             inherit sha256;
           };
 

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -209,6 +209,11 @@ let
 
           hardeningDisable = [ "bindnow" ];
 
+          postPatch = lib.optionalString (lib.versionOlder version "7.4") ''
+            # https://bugs.php.net/bug.php?id=79159
+            substituteInPlace ./acinclude.m4 --replace "AC_PROG_YACC" "AC_CHECK_PROG(YACC, bison, bison)"
+          '';
+
           preConfigure =
           # Don't record the configure flags since this causes unnecessary
           # runtime dependencies

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -238,12 +238,15 @@ let
               substituteInPlace $i \
                 --replace 'test -x "$PKG_CONFIG"' 'type -P "$PKG_CONFIG" >/dev/null'
             done
-          '' + ''
+          ''
+          # A wrapper around Autoconf that generates files to build PHP on *nix systems
+          + lib.optionalString (lib.versionOlder version "7.4") ''
             ./buildconf --copy --force
-
-            if test -f $src/genfiles; then
-              ./genfiles
-            fi
+            ./genfiles
+          ''
+          + lib.optionalString (lib.versionAtLeast version "7.4") ''
+            ./buildconf --force
+            ./scripts/dev/genfiles
           '';
 
           preInstall = lib.optionalString pearSupport ''

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -253,12 +253,8 @@ let
             cp ${php-pearweb-phars}/install-pear-nozlib.phar $TMPDIR/php-src-${version}/pear/install-pear-nozlib.phar
           '';
 
-          postInstall = ''
-            test -d $out/etc || mkdir $out/etc
-            cp php.ini-production $out/etc/php.ini
-          '';
-
           postFixup = ''
+            cp php.ini-production $out/etc/php.ini
             mkdir -p $dev/bin $dev/share/man/man1
             mv $out/bin/phpize $out/bin/php-config $dev/bin/
             mv $out/share/man/man1/phpize.1.gz \

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -138,6 +138,7 @@ let
         mkWithExtensions = prevArgs: prevExtensionFunctions: extensions:
           mkBuildEnv prevArgs prevExtensionFunctions { inherit extensions; };
 
+        php-pearweb-phars = (callPackage ./pearweb-phars.nix { });
         pcre' = if (lib.versionAtLeast version "7.3") then pcre2 else pcre;
       in
         stdenv.mkDerivation {

--- a/pkgs/development/interpreters/php/pearweb-phars.nix
+++ b/pkgs/development/interpreters/php/pearweb-phars.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl}:
+
+stdenv.mkDerivation rec {
+  version = "1.10.19";
+  pname = "php-pearweb-phars";
+
+  src = fetchurl {
+    url = "http://download.pear.php.net/package/pearweb_phars-${version}.tgz";
+    sha256 = "07mhav3vvg7hwkqb7zn4c2yxrl7s4lck15ggz8h7xm9nc85a1vz2";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    install -Dm0444 install-pear-nozlib.phar $out/install-pear-nozlib.phar
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Separate sub-package just for the .phars, to cut down significantly on the size of the pearweb package";
+    homepage = "https://pear.php.net/package/pearweb_phars";
+    license = licenses.bsd2;
+    maintainers = teams.php.members;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -206,12 +206,9 @@ in
       inherit configureFlags internalDeps buildInputs
         zendExtension doCheck;
 
-      prePatch = "pushd ../..";
-      postPatch = ''
-        popd
-      ''
+      postPatch =
       # https://bugs.php.net/bug.php?id=79159
-      + lib.optionalString (lib.versionOlder php.version "7.4") ''
+        lib.optionalString (lib.versionOlder php.version "7.4") ''
         substituteInPlace ./acinclude.m4 --replace "AC_PROG_YACC" "AC_CHECK_PROG(YACC, bison, bison)"
       '';
 

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -498,7 +498,7 @@ in
       { name = "sysvsem"; }
       { name = "sysvshm"; }
       { name = "tidy"; configureFlags = [ "--with-tidy=${html-tidy}" ]; doCheck = false; }
-      { name = "tokenizer"; }
+      { name = "tokenizer"; doCheck = !(lib.versionOlder php.version "7.4"); }
       { name = "wddx";
         buildInputs = [ libxml2 ];
         internalDeps = [ php.extensions.session ];

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -200,7 +200,7 @@ in
       extensionName = name;
 
       inherit (php.unwrapped) version src;
-      sourceRoot = "php-${php.version}/ext/${name}";
+      sourceRoot = "source/ext/${name}";
 
       enableParallelBuilding = true;
       nativeBuildInputs = [ php.unwrapped autoconf pkgconfig re2c ];

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -207,7 +207,13 @@ in
         zendExtension doCheck;
 
       prePatch = "pushd ../..";
-      postPatch = "popd";
+      postPatch = ''
+        popd
+      ''
+      # https://bugs.php.net/bug.php?id=79159
+      + lib.optionalString (lib.versionOlder php.version "7.4") ''
+        substituteInPlace ./acinclude.m4 --replace "AC_PROG_YACC" "AC_CHECK_PROG(YACC, bison, bison)"
+      '';
 
       preConfigure =
       # A wrapper around Autoconf that generates files to build PHP on *nix systems


### PR DESCRIPTION
###### Motivation for this change
Build php packages from github sources.
The source files on php.net are created using these scripts:
https://github.com/php/php-src/blob/php-7.4.6/scripts/dev/makedist
https://github.com/php/php-src/blob/php-7.4.6/scripts/dev/genfiles
https://github.com/php/php-src/blob/php-7.4.6/buildconf

@NixOS/php 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
