### PR TITLE
runit: Add Darwin Compatibility

### DIFF
--- a/pkgs/tools/system/runit/default.nix
+++ b/pkgs/tools/system/runit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl
+{ stdenv, fetchurl, darwin
 
 # Build runit-init as a static binary
 , static ? false
@@ -23,7 +23,8 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  buildInputs = stdenv.lib.optionals static [ stdenv.cc.libc stdenv.cc.libc.static ];
+  buildInputs = stdenv.lib.optionals static [ stdenv.cc.libc stdenv.cc.libc.static ] ++
+    stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.libs.utmp;
 
   postPatch = ''
     sed -i "s,\(#define RUNIT\) .*,\1 \"$out/bin/runit\"," src/runit.h
@@ -39,7 +40,7 @@ stdenv.mkDerivation rec {
 
     # Both of these are originally hard-coded to gcc
     echo ${stdenv.cc.targetPrefix}cc > conf-cc
-    echo ${stdenv.cc.targetPrefix}cc > conf-ld
+    echo ${stdenv.cc.targetPrefix}cc ${stdenv.lib.optionalString stdenv.isDarwin "-Xlinker -x "}> conf-ld
   '';
 
   installPhase = ''
@@ -55,6 +56,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     homepage = "http://smarden.org/runit";
     maintainers = with maintainers; [ joachifm ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
Not much modification is required to build and run runit on MacOS, all
that was needed was to follow runit's instructions [0] with some
guidance from homebrew's formula. [1]

0: http://smarden.org/runit/install.html
1: https://github.com/Homebrew/homebrew-core/blob/1cf1e61/Formula/runit.rb

I haven't changed the default service directory, although homebrew does. Should I do this for the sake of Catalina users? If so, is there a mechanism similar to homebrew to alert users to this difference?

###### Motivation for this change

A project at work uses runit to manage services in its dev environment, and I'd love to nixify it.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
