### PR TITLE
smartmontools-db: 4883 -> 5033

### DIFF
--- a/pkgs/tools/system/smartmontools/default.nix
+++ b/pkgs/tools/system/smartmontools/default.nix
@@ -4,11 +4,11 @@
 let
   version = "7.1";
 
-  dbrev = "5033";
+  dbrev = "5062";
   drivedbBranch = "RELEASE_7_0_DRIVEDB";
   driverdb = fetchurl {
     url    = "https://sourceforge.net/p/smartmontools/code/${dbrev}/tree/branches/${drivedbBranch}/smartmontools/drivedb.h?format=raw";
-    sha256 = "029j118lwiazn56vg6d3i7ayv73wrpv1fypw3ff4nd4hgs2mlcrg";
+    sha256 = "0gggl55h9gq0z846ndhyd7xrpxh8lqfbidblx0598q2wlh9rvlww";
     name   = "smartmontools-drivedb.h";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

There are a lot of new devices added to the Smartmontools DB. Last time we've updated it was about three months ago in #81099.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of running nixpkgs-review (none seems to be related to smartmontools):

```
2 package marked as broken and skipped:
docker-machine-xhyve tlspool

8 package failed to build:
gnome3.gnome-boxes libguestfs libguestfs-with-appliance libvmi python27Packages.guestfs python37Packages.guestfs python38Packages.
guestfs vagrant

73 package built:
ceph ceph-client collectd collectd-data deepin.dde-api deepin.dde-control-center deepin.dde-daemon deepin.dde-dock deepin.dde-file
-manager deepin.dde-kwin deepin.dde-launcher deepin.dde-session-ui deepin.deepin-desktop-base deepin.deepin-desktop-schemas deepin
.deepin-wallpapers deepin.startdde docker-machine-kvm docker-machine-kvm2 easysnap grub2 grub2_efi grub2_pvgrub_image grub2_xen gs
martcontrol libceph libvirt libvirt-glib libvirt_5_9_0 linuxPackages-libre.zfs linuxPackages.zfs linuxPackages_4_14.zfs linuxPacka
ges_4_19.zfs linuxPackages_4_4.zfs linuxPackages_4_9.zfs linuxPackages_5_6.zfs linuxPackages_hardened.zfs linuxPackages_latest-lib
re.zfs linuxPackages_latest_hardened.zfs linuxPackages_latest_xen_dom0.zfs linuxPackages_latest_xen_dom0_hardened.zfs linuxPackage
s_testing_bcachefs.zfs linuxPackages_xen_dom0.zfs linuxPackages_xen_dom0_hardened.zfs minikube minishift nixops nixopsUnstable nix
ops_1_6_1 ocamlPackages.ocaml_libvirt os-prober perl528Packages.SysVirt perl530Packages.SysVirt python27Packages.libvirt python37P
ackages.libvirt python38Packages.libvirt rubyPackages.ruby-libvirt rubyPackages_2_5.ruby-libvirt rubyPackages_2_7.ruby-libvirt sam
ba4Full sanoid smartmontools terraform-full terraform-provider-libvirt terraform_0_11-full terragrunt tlp virtmanager virtmanager-
qt virt-top virtviewer virtlyst zfs zfstools
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/89335)
<!-- Reviewable:end -->
