### PR TITLE
nixos/home-assistant: allow arbitrary yaml functions

### DIFF
--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -11,9 +11,9 @@ let
     (recursiveUpdate defaultConfig cfg.config) else cfg.config));
   configFile = pkgs.runCommand "configuration.yaml" { preferLocalBuild = true; } ''
     ${pkgs.remarshal}/bin/json2yaml -i ${configJSON} -o $out
-    # Hack to support secrets, that are encoded as custom yaml objects,
-    # https://www.home-assistant.io/docs/configuration/secrets/
-    sed -i -e "s/'\!secret \(.*\)'/\!secret \1/" $out
+    # Hack to support custom yaml objects,
+    # i.e. secrets: https://www.home-assistant.io/docs/configuration/secrets/
+    sed -i -e "s/'\!\([a-z_]\+\) \(.*\)'/\!\1 \2/;s/^\!\!/\!/;" $out
   '';
 
   lovelaceConfigJSON = pkgs.writeText "ui-lovelace.json"
@@ -120,7 +120,9 @@ in {
             unit_system = "metric";
             time_zone = "UTC";
           };
-          frontend = { };
+          frontend = {
+            themes = "!include_dir_merge_named themes";
+          };
           http = { };
           feedreader.urls = [ "https://nixos.org/blogs.xml" ];
         }


### PR DESCRIPTION
###### Motivation for this change

I'm trying to load additional themes without specifying them by hand:

```ǹix
{
  services.home-assistant.config.frontend = {
    themes = "!include_dir_merge_named themes";
  };
}
```

Without this patch the resulting config would quote the function call:

```yaml
frontend:
  themes = '!include_dir_merge_named themes'
```

This prevents the function calls execution. The same workaround has been in place for the `!secret` function, let's now extend it to arbitrary functions.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@Mic92  @dotlambda 