### PR TITLE
python3Packages.cookiecutter: add missing slugify dependency

### DIFF
--- a/pkgs/development/python-modules/cookiecutter/default.nix
+++ b/pkgs/development/python-modules/cookiecutter/default.nix
@@ -1,6 +1,7 @@
 { stdenv, buildPythonPackage, fetchPypi, isPyPy
 , pytest, pytestcov, pytest-mock, freezegun
-, jinja2, future, binaryornot, click, whichcraft, poyo, jinja2_time, requests }:
+, jinja2, future, binaryornot, click, whichcraft, poyo, jinja2_time, requests
+, python-slugify }:
 
 buildPythonPackage rec {
   pname = "cookiecutter";
@@ -16,7 +17,7 @@ buildPythonPackage rec {
 
   checkInputs = [ pytest pytestcov pytest-mock freezegun ];
   propagatedBuildInputs = [
-    jinja2 future binaryornot click whichcraft poyo jinja2_time requests
+    jinja2 future binaryornot click whichcraft poyo jinja2_time requests python-slugify
   ];
   
   # requires network access for cloning git repos


### PR DESCRIPTION
###### Motivation for this change

cookiecutter currently (`cfa5a0c0e09`) does not build, complaining that it can not find python-slugify dependency. This PR adds the dependency to fix the build.

It was working at least until last week, but I do not know what broke it. Probably a transitive dependency used to depend on python-slugify.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).