### PR TITLE
makeself: add which to nativeBuildInputs

### DIFF
--- a/pkgs/applications/misc/makeself/default.nix
+++ b/pkgs/applications/misc/makeself/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, which }:
 
 stdenv.mkDerivation rec {
   version = "2.4.2";
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
     sha256 = "07cq7q71bv3fwddkp2863ylry2ivds00f8sjy8npjpdbkailxm21";
   };
+
+  nativeBuildInputs = [ which ];
 
   patchPhase = "patchShebangs test";
 


### PR DESCRIPTION
###### Motivation for this change
The latest release requires `which` for the test runs, add it to
nativeBuildInputs to let the tests succeed.

This should fix https://hydra.nixos.org/build/121138562

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
