### PR TITLE
openresty: disable perl module by default

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -233,6 +233,7 @@ in
   nginx-pubhtml = handleTest ./nginx-pubhtml.nix {};
   nginx-sandbox = handleTestOn ["x86_64-linux"] ./nginx-sandbox.nix {};
   nginx-sso = handleTest ./nginx-sso.nix {};
+  nginx-variants = handleTest ./nginx-variants.nix {};
   nix-ssh-serve = handleTest ./nix-ssh-serve.nix {};
   nixos-generate-config = handleTest ./nixos-generate-config.nix {};
   novacomd = handleTestOn ["x86_64-linux"] ./novacomd.nix {};

--- a/nixos/tests/nginx-variants.nix
+++ b/nixos/tests/nginx-variants.nix
@@ -1,0 +1,33 @@
+{ system ? builtins.currentSystem,
+  config ? {},
+  pkgs ? import ../.. { inherit system config; }
+}:
+
+with import ../lib/testing-python.nix { inherit system pkgs; };
+
+builtins.listToAttrs (
+  builtins.map
+    (nginxName:
+      {
+        name = nginxName;
+        value = makeTest {
+          name = "nginx-variant-${nginxName}";
+
+          machine = { pkgs, ... }: {
+            services.nginx = {
+              enable = true;
+              virtualHosts.localhost.locations."/".return = "200 'foo'";
+              package = pkgs."${nginxName}";
+            };
+          };
+
+          testScript = ''
+            machine.wait_for_unit("nginx")
+            machine.wait_for_open_port(80)
+            machine.succeed('test "$(curl -fvvv http://localhost/)" = foo')
+          '';
+        };
+      }
+    )
+    [ "nginxStable" "nginxUnstable" "nginxShibboleth" "openresty" "tengine" ]
+)

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -4,6 +4,7 @@
 , withDebug ? false
 , withStream ? true
 , withMail ? false
+, withPerl ? true
 , modules ? []
 , ...
 }:
@@ -87,7 +88,7 @@ stdenv.mkDerivation {
   ] ++ optionals withMail [
     "--with-mail"
     "--with-mail_ssl_module"
-  ] ++ optional (perl != null) [
+  ] ++ optionals withPerl [
     "--with-http_perl_module"
     "--with-perl=${perl}/bin/perl"
     "--with-perl_modules_path=lib/perl5"

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -34,6 +34,8 @@ callPackage ../nginx/generic.nix args rec {
   postInstall = ''
     ln -s $out/luajit/bin/luajit-2.1.0-beta3 $out/bin/luajit-openresty
     ln -s $out/nginx/sbin/nginx $out/bin/nginx
+    ln -s $out/nginx/conf $out/conf
+    ln -s $out/nginx/html $out/html
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15884,7 +15884,9 @@ in
   openafs = callPackage ../servers/openafs/1.6 { tsmbac = null; ncurses = null; };
   openafs_1_8 = callPackage ../servers/openafs/1.8 { tsmbac = null; ncurses = null; };
 
-  openresty = callPackage ../servers/http/openresty { };
+  openresty = callPackage ../servers/http/openresty {
+    withPerl = false;
+  };
 
   opensmtpd = callPackage ../servers/mail/opensmtpd { };
   opensmtpd-extras = callPackage ../servers/mail/opensmtpd/extras.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15847,14 +15847,14 @@ in
   nginx = nginxStable;
 
   nginxStable = callPackage ../servers/http/nginx/stable.nix {
-    perl = null;
+    withPerl = false;
     # We don't use `with` statement here on purpose!
     # See https://github.com/NixOS/nixpkgs/pull/10474/files#r42369334
     modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders ];
   };
 
   nginxMainline = callPackage ../servers/http/nginx/mainline.nix {
-    perl = null;
+    withPerl = false;
     # We don't use `with` statement here on purpose!
     # See https://github.com/NixOS/nixpkgs/pull/10474/files#r42369334
     modules = [ nginxModules.dav nginxModules.moreheaders ];


### PR DESCRIPTION
##### Motivation for this change

This creates consistency with the other nginx packages.

Additionally, I have been receiving intermittent segfaults during config loading caused by the perl module (albeit on 20.03), despite there being no reference to perl in my configs:

```
#0  0x00007f03deb51a63 in Perl__invlist_intersection_maybe_complement_2nd () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#1  0x00007f03deb520a5 in S_populate_ANYOF_from_invlist.part.0 () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#2  0x00007f03deb61adf in S_regclass () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#3  0x00007f03deb683bf in S_regpiece () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#4  0x00007f03deb6ce13 in S_regbranch () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#5  0x00007f03deb6d3b4 in S_reg () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#6  0x00007f03deb722fc in Perl_re_op_compile () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#7  0x00007f03deb0731d in Perl_pmruntime () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#8  0x00007f03deb4371b in Perl_yyparse () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#9  0x00007f03debe4347 in S_doeval_compile () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#10 0x00007f03debe9cad in Perl_pp_require () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#11 0x00007f03deb9f336 in Perl_runops_standard () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#12 0x00007f03deb0d33c in Perl_call_sv () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#13 0x00007f03deb0ff38 in Perl_call_list () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#14 0x00007f03deaed720 in S_process_special_blocks.isra.0 () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#15 0x00007f03deb060ef in Perl_newATTRSUB_x () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#16 0x00007f03deb0967e in Perl_utilize () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#17 0x00007f03deb43bb9 in Perl_yyparse () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#18 0x00007f03debe4347 in S_doeval_compile () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#19 0x00007f03debe9cad in Perl_pp_require () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#20 0x00007f03deb9f336 in Perl_runops_standard () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#21 0x00007f03deb0d33c in Perl_call_sv () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#22 0x00007f03deb0ff38 in Perl_call_list () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#23 0x00007f03deaed720 in S_process_special_blocks.isra.0 () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#24 0x00007f03deb060ef in Perl_newATTRSUB_x () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#25 0x00007f03deb0967e in Perl_utilize () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#26 0x00007f03deb43bb9 in Perl_yyparse () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#27 0x00007f03deb14053 in perl_parse () from /nix/nix/store/...-perl-5.30.1/lib/perl5/5.30.1/x86_64-linux-thread-multi/CORE/libperl.so
#28 0x0000562f8df614ed in ngx_http_perl_create_interpreter (pmcf=0x562f8f4f3920, pmcf=0x562f8f4f3920, cf=0x7ffed953fa50) at src/http/modules/perl/ngx_http_perl_module.c:605
#29 ngx_http_perl_init_interpreter (cf=0x7ffed953fa50, pmcf=0x562f8f4f3920) at src/http/modules/perl/ngx_http_perl_module.c:524
#30 0x0000562f8df61d49 in ngx_http_perl_init_main_conf (conf=<optimized out>, cf=<optimized out>) at src/http/modules/perl/ngx_http_perl_module.c:819
#31 ngx_http_perl_init_main_conf (cf=<optimized out>, conf=<optimized out>) at src/http/modules/perl/ngx_http_perl_module.c:814
#32 0x0000562f8def8729 in ngx_http_block (cmd=<optimized out>, conf=<optimized out>, cf=<optimized out>) at src/http/ngx_http.c:263
#33 ngx_http_block (cf=0x7ffed953fa50, cmd=<optimized out>, conf=<optimized out>) at src/http/ngx_http.c:121
#34 0x0000562f8ded8109 in ngx_conf_handler (last=1, cf=0x7ffed953fa50) at src/core/ngx_conf_file.c:463
#35 ngx_conf_parse (cf=cf@entry=0x7ffed953fa50, filename=filename@entry=0x562f8f4efda0) at src/core/ngx_conf_file.c:319
#36 0x0000562f8ded5959 in ngx_init_cycle (old_cycle=old_cycle@entry=0x562f8f7bfe00) at src/core/ngx_cycle.c:275
#37 0x0000562f8deec25d in ngx_master_process_cycle (cycle=<optimized out>) at src/os/unix/ngx_process_cycle.c:242
#38 0x0000562f8dec31de in main (argc=<optimized out>, argv=<optimized out>) at src/core/nginx.c:382
```

The change from specifying `perl = null` to `withPerl` is necessary due to openresty's use of perl in its configure script.

I have tested `nginxStable`, `nginxUnstable`, `nginxShibboleth`, and `openresty` using my unmerged nginx-variant tests from #89342.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
