### PR TITLE
tensorflow-haskell: Remove tensorflow-mnist

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2586,6 +2586,9 @@ dont-distribute-packages:
   - Obsidian
   - odpic-raw
   - patch-image
+  # license for input data unclear, dependency not on Hackage
+  # see https://github.com/NixOS/nixpkgs/pull/88604
+  - tensorflow-mnist
   - yices-easy
   - yices-painless
 

--- a/pkgs/development/haskell-modules/configuration-tensorflow.nix
+++ b/pkgs/development/haskell-modules/configuration-tensorflow.nix
@@ -32,47 +32,6 @@ in
 
   tensorflow-logging = setTensorflowSourceRoot "tensorflow-logging" super.tensorflow-logging;
 
-  tensorflow-mnist = (setTensorflowSourceRoot "tensorflow-mnist" super.tensorflow-mnist).override {
-    # https://github.com/tensorflow/haskell/issues/215
-    tensorflow-mnist-input-data = self.tensorflow-mnist-input-data;
-  };
-
-  tensorflow-mnist-input-data = setTensorflowSourceRoot "tensorflow-mnist-input-data" (super.callPackage (
-    { mkDerivation, base, bytestring, Cabal, cryptonite, directory
-    , filepath, HTTP, network-uri, stdenv
-    }:
-
-    let
-      fileInfos = {
-        "train-images-idx3-ubyte.gz" = "440fcabf73cc546fa21475e81ea370265605f56be210a4024d2ca8f203523609";
-        "train-labels-idx1-ubyte.gz" = "3552534a0a558bbed6aed32b30c495cca23d567ec52cac8be1a0730e8010255c";
-        "t10k-images-idx3-ubyte.gz"  = "8d422c7b0a1c1c79245a5bcf07fe86e33eeafee792b84584aec276f5a2dbc4e6";
-        "t10k-labels-idx1-ubyte.gz"  = "f7ae60f92e00ec6debd23a6088c31dbd2371eca3ffa0defaefb259924204aec6";
-      };
-      downloads = with pkgs.lib; flip mapAttrsToList fileInfos (name: sha256:
-                    pkgs.fetchurl {
-                      url = "http://yann.lecun.com/exdb/mnist/${name}";
-                      inherit sha256;
-                    });
-    in
-    mkDerivation {
-      pname = "tensorflow-mnist-input-data";
-      version = "0.1.0.0";
-      enableSeparateDataOutput = true;
-      setupHaskellDepends = [
-        base bytestring Cabal cryptonite directory filepath HTTP
-        network-uri
-      ];
-      preConfigure = pkgs.lib.strings.concatStringsSep "\n" (
-          map (x: "ln -s ${x} data/$(stripHash ${x})") downloads
-        );
-      libraryHaskellDepends = [ base ];
-      homepage = "https://github.com/tensorflow/haskell#readme";
-      description = "Downloader of input data for training MNIST";
-      license = stdenv.lib.licenses.asl20;
-    }
-  ) {});
-
   tensorflow-opgen = setTensorflowSourceRoot "tensorflow-opgen" super.tensorflow-opgen;
 
   tensorflow-ops = setTensorflowSourceRoot "tensorflow-ops" super.tensorflow-ops;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

tensorflow-mnist was marked broken as its dependency, tensorflow-mnist-input-data, was not on Hackage. That in turn was because the license conditions are unclear.

See also this discussion here:
https://github.com/NixOS/nixpkgs/pull/88604

Also here over on tensorflow-haskell:
https://github.com/tensorflow/haskell/issues/260

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
