### PR TITLE
haskellPackages.hlint: fix evaluation problems

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1491,16 +1491,16 @@ self: super: {
   });
 
   # stackage right now is not new enough for hlint-3.0
-  ghc-lib-parser-ex_8_10_0_11 = super.ghc-lib-parser-ex_8_10_0_11.override {
+  ghc-lib-parser-ex_8_10_0_13 = super.ghc-lib-parser-ex_8_10_0_13.override {
     ghc-lib-parser = self.ghc-lib-parser_8_10_1_20200523;
   };
 
   hlint = super.hlint.override {
     ghc-lib-parser = self.ghc-lib-parser_8_10_1_20200523;
-    ghc-lib-parser-ex = self.ghc-lib-parser-ex_8_10_0_11;
-    extra = self.extra_1_7_2;
+    ghc-lib-parser-ex = self.ghc-lib-parser-ex_8_10_0_13;
+    extra = self.extra_1_7_3;
     filepattern = self.filepattern.override {
-      extra = self.extra_1_7_2;
+      extra = self.extra_1_7_3;
     };
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`haskell-packages` was failing to evaluate.  This was because of some finicky overrides for the new `hlint`.

I've added some packages to our `extra-packages` so that this problem doesn't happy again in the near future.

I've checked that `haskell-updates` can now safely evaluate with the `nix-env -qa --out-path -f.` command.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
