### PR TITLE
Fix building of emacsWithPackages not findind subdirs.el

### DIFF
--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -174,7 +174,7 @@ runCommand
 
     mkdir -p $out/share
     # Link icons and desktop files into place
-    for dir in applications icons info man; do
+    for dir in applications icons info man emacs; do
       ln -s $emacs/share/$dir $out/share/$dir
     done
   ''


### PR DESCRIPTION
###### Motivation for this change

When building emacs, it complains of not finding `subdirs.el` in `emacs-packages-deps/share/emacs/site-lisp`. Turns out that it is present as a broken sublink to the same file in `emacs-with-packages`, where the share subdirectory is full of links to the share subdirectory of `emacs`, which included the desired file.

I'm not sure if this fix is actually what we want, since the other file in `emacs-packages-deps/share/emacs/site-lisp` is shipped with nixpkgs, so maybe something similar should be done for subdirs. But adding the missing link step made it build, and emacs seems to work.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
