### PR TITLE
klavaro: 3.08 -> 3.10 

### DIFF
--- a/pkgs/games/klavaro/default.nix
+++ b/pkgs/games/klavaro/default.nix
@@ -1,12 +1,20 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig, intltool, curl, gtk3 }:
+{ stdenv
+, fetchurl
+, makeWrapper
+, curl
+, file
+, gtk3
+, intltool
+, pkgconfig
+}:
 
 stdenv.mkDerivation rec {
   pname = "klavaro";
-  version = "3.08";
+  version = "3.10";
 
   src = fetchurl {
     url = "mirror://sourceforge/klavaro/${pname}-${version}.tar.bz2";
-    sha256 = "0qmvr6d8wshwp0xvk5wbig4vlzxzcxrakhyhd32v8v3s18nhqsrc";
+    sha256 = "0jnzdrndiq6m0bwgid977z5ghp4q61clwdlzfpx4fd2ml5x3iq95";
   };
 
   nativeBuildInputs = [ intltool makeWrapper pkgconfig ];
@@ -17,14 +25,20 @@ stdenv.mkDerivation rec {
       --prefix LD_LIBRARY_PATH : $out/lib
   '';
 
+  # Fixes /usr/bin/file: No such file or directory
+  preConfigure = ''
+    substituteInPlace configure \
+      --replace "/usr/bin/file" "${file}/bin/file"
+  '';
+
   # Hack to avoid TMPDIR in RPATHs.
   preFixup = ''rm -rf "$(pwd)" '';
 
-  meta = {
-    description = "Just another free touch typing tutor program";
+  meta = with stdenv.lib; {
+    description = "Free touch typing tutor program";
     homepage = "http://klavaro.sourceforge.net/";
-    license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [stdenv.lib.maintainers.mimame];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mimame davidak ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update and fixes

![Screenshot from 2020-05-28 00 44 18](https://user-images.githubusercontent.com/91113/83080082-ab172b80-a07d-11ea-9a05-28274c60eb62.png)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc maintainer @mimame