### PR TITLE
git: 2.26.2 -> 2.27.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -21,7 +21,7 @@ assert sendEmailSupport -> perlSupport;
 assert svnSupport -> perlSupport;
 
 let
-  version = "2.26.2";
+  version = "2.27.0";
   svn = subversionClient.override { perlBindings = perlSupport; };
 
   gitwebPerlLibs = with perlPackages; [ CGI HTMLParser CGIFast FCGI FCGIProcManager HTMLTagCloud ];
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "0j685w6pzkn926z5nf5r8fij4ziipvw4c9yb0wc577nzf4j16rbd";
+    sha256 = "1ybk39ylvs32lywq7ra4l2kdr5izc80r9461hwfnw8pssxs9gjkk";
   };
 
   outputs = [ "out" "doc" ];
@@ -286,13 +286,14 @@ stdenv.mkDerivation {
         mv t/{,skip-}$test.sh || true
       else
         sed -i t/$test.sh \
-          -e "/^ *test_expect_.*$pattern/,/^ *' *\$/{s/^/#/}"
+          -e "/^\s*test_expect_.*$pattern/,/^\s*' *\$/{s/^/: #/}"
       fi
     }
 
     # Shared permissions are forbidden in sandbox builds.
     disable_test t0001-init shared
     disable_test t1301-shared-repo
+    disable_test t5324-split-commit-graph 'split commit-graph respects core.sharedrepository'
 
     # Our patched gettext never fallbacks
     disable_test t0201-gettext-fallbacks
@@ -343,6 +344,6 @@ stdenv.mkDerivation {
     '';
 
     platforms = stdenv.lib.platforms.all;
-    maintainers = with stdenv.lib.maintainers; [ peti wmertens globin ];
+    maintainers = with stdenv.lib.maintainers; [ primeos peti wmertens globin ];
   };
 }


### PR DESCRIPTION
Announcement: https://lkml.kernel.org/lkml/xmqqzh9mu4my.fsf@gitster.c.googlers.com/

---

disable_test: Use \s instead of ' ' as tabs are used for indentation in
t5324-split-commit-graph.sh. It's also necessary to insert : (no op) in
front of # to prevent Bash syntax errors due to empty loops.

Two newly added tests fail due the usage of shared permissions (outside
of the build sandbox they succeed, actually even with breakpointHook
(cntr attach + cntr exec bash)):
```
t5324-split-commit-graph.sh                      (Wstat: 256 Tests: 29
Failed: 2)
  Failed tests:  28-29
  Non-zero exit status: 1
```

I'm also adding myself as maintainer since there currently doesn't seem
to be a fixed one for regular updates.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

---

File changes:
```diff
+libexec/git-core/git-bugreport
-libexec/git-core/git-legacy-stash
+share/man/man1/git-bugreport.1.gz
+share/man/man7/gitfaq.7.gz
```

`gitFull` also builds successfully. I've tested the core functionality.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
