### PR TITLE
ubuntu-themes: init at 19.04

### DIFF
--- a/pkgs/data/themes/ubuntu-themes/default.nix
+++ b/pkgs/data/themes/ubuntu-themes/default.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, fetchurl
+, fetchpatch
+, gnome-icon-theme
+, gnome3
+, gtk-engine-murrine
+, gtk3
+, hicolor-icon-theme
+, humanity-icon-theme
+, python2Packages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ubuntu-themes";
+  version = "19.04";
+
+  src = fetchurl {
+    url = "https://launchpad.net/ubuntu/+archive/primary/+files/${pname}_${version}.orig.tar.gz";
+    sha256 = "1dy2dmiq2dj80nl2y4mf4ks0c7qmmnpk25wzv2rynwa3s2gkxgih";
+  };
+
+  nativeBuildInputs = [
+    gtk3
+    python2Packages.python
+  ];
+
+  propagatedBuildInputs = [
+    gnome-icon-theme
+    gnome3.adwaita-icon-theme
+    humanity-icon-theme
+    hicolor-icon-theme
+  ];
+
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine
+  ];
+
+  dontDropIconThemeCache = true;
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/themes
+    cp -a Ambiance $out/share/themes
+    cp -a Radiance $out/share/themes
+
+    mkdir -p $out/share/icons
+    cp -a LoginIcons        $out/share/icons
+    cp -a suru-icons        $out/share/icons
+    cp -a ubuntu-mobile     $out/share/icons
+    cp -a ubuntu-mono-dark  $out/share/icons
+    cp -a ubuntu-mono-light $out/share/icons
+
+    mv $out/share/icons/{suru-icons,suru}
+
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache $theme
+    done
+
+    mkdir -p $out/share/icons/hicolor/48x48/apps
+    cp -a distributor-logo.png $out/share/icons/hicolor/48x48/apps
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Ubuntu monochrome and Suru icon themes, Ambiance and Radiance themes, and Ubuntu artwork";
+    homepage = "https://launchpad.net/ubuntu-themes";
+    license = with licenses; [ cc-by-sa-40 gpl3 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18495,6 +18495,8 @@ in
 
   tzdata = callPackage ../data/misc/tzdata { };
 
+  ubuntu-themes = callPackage ../data/themes/ubuntu-themes { };
+
   ubuntu_font_family = callPackage ../data/fonts/ubuntu-font-family { };
 
   ucs-fonts = callPackage ../data/fonts/ucs-fonts


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [ubuntu-themes](https://launchpad.net/ubuntu-themes), with the Ubuntu monochrome and Suru icon themes, Ambiance and Radiance themes, and Ubuntu artwork

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).