### PR TITLE
nixos/testing: Add support for specialArgs

### DIFF
--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -3,8 +3,10 @@
   minimal ? false
 , # Ignored
   config ? null
-  # Nixpkgs, for qemu, lib and more
-, pkgs
+, # Nixpkgs, for qemu, lib and more
+  pkgs
+, # !!! See comment about args in lib/modules.nix
+  specialArgs ? {}
 , # NixOS configuration to add to the VMs
   extraConfigurations ? []
 }:
@@ -31,7 +33,7 @@ rec {
     nodes: configurations:
 
     import ./eval-config.nix {
-      inherit system;
+      inherit system specialArgs;
       modules = configurations ++ extraConfigurations;
       baseModules =  (import ../modules/module-list.nix) ++
         [ ../modules/virtualisation/qemu-vm.nix

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -4,10 +4,12 @@
 , minimal ? false
   # Ignored
 , config ? {}
+  # !!! See comment about args in lib/modules.nix
+, specialArgs ? {}
   # Modules to add to each VM
 , extraConfigurations ? [] }:
 
-with import ./build-vms.nix { inherit system pkgs minimal extraConfigurations; };
+with import ./build-vms.nix { inherit system pkgs minimal specialArgs extraConfigurations; };
 with pkgs;
 
 rec {


### PR DESCRIPTION
Since using flakes disallows the usage of `<unstable>` (which I use in
some tests), this adds an alternative. By setting specialArgs, all VMs
can get the `unstable` flake input as an arg. This is not possible with
extraConfigurations, as that would lead to infinite recursions.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
