### PR TITLE
nix-prefetch-github: 2.3.2 -> 2.4

### DIFF
--- a/pkgs/development/python-modules/nix-prefetch-github/default.nix
+++ b/pkgs/development/python-modules/nix-prefetch-github/default.nix
@@ -9,12 +9,16 @@
 
 buildPythonPackage rec {
   pname = "nix-prefetch-github";
-  version = "2.3.2";
+  version = "2.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "18xj618zjs13ib7f996fnl0xiqig0w48yns45nvy3xab55wximdx";
+    sha256 = "sha256-PVB/cL0NVB5pHxRMjg8TLatvIvHjfCvaRWBanVHYT+E=";
   };
+
+  # The tests for this package require nix and network access.  That's
+  # why we cannot execute them inside the building process.
+  doCheck = false;
 
   propagatedBuildInputs = [
     attrs


### PR DESCRIPTION
###### Motivation for this change
A new version of nix-prefetch-github was released upstream. A bug was fixed and a feature added.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
