### PR TITLE
multipath-tools: Fix build failure due to GZIP make var

### DIFF
--- a/pkgs/os-specific/linux/multipath-tools/default.nix
+++ b/pkgs/os-specific/linux/multipath-tools/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
     ' libmultipath/defaults.h
     sed -i -e 's,\$(DESTDIR)/\(usr/\)\?,$(prefix)/,g' \
       kpartx/Makefile libmpathpersist/Makefile
-    sed -i -e "s,GZIP = .*, GZIP = gzip -9n -c," \
-      Makefile.inc
+    sed -i -e "s,GZIP,GZ," \
+      $(find * -name Makefile\*)
   '';
 
   nativeBuildInputs = [ gzip pkgconfig perl ];


### PR DESCRIPTION
###### Motivation for this change

`multipath-tools` fails to build. This is a fix for the problem mentioned in #86348.

The `multipath-tools` makefiles use `GZIP` as a variable name but this is
also the name of the environment variable `gzip` uses to get its default
options.

Normally, this wouldn't get into the environment but nixpkgs exports
`GZIP=-n` in a setup hook. This in turn causes `make` to export its own
value for this variable. `gzip` objects to having `-c` in the environment
variable and aborts, causing the build to fail.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/89367)
<!-- Reviewable:end -->
