### PR TITLE
gotools: update comments regarding gopls

### DIFF
--- a/pkgs/development/tools/gotools/default.nix
+++ b/pkgs/development/tools/gotools/default.nix
@@ -11,12 +11,16 @@ buildGoModule rec {
     sha256 = "0a8c7j4w784w441j3j3bh640vy1g6g214641qv485wyi0xj49anf";
   };
 
-  # Build of golang.org/x/tools/gopls fails with:
-  #   can't load package: package golang.org/x/tools/gopls: unknown import path "golang.org/x/tools/gopls": cannot find module providing package golang.org/x/tools/gopls
-  # That is most probably caused by golang.org/x/tools/gopls containing a separate Go module.
-  # In order to fix this, we simply remove the module.
-  # Note that build of golang.org/x/tools/cmd/gopls provides identical binary as golang.org/x/tools/gopls.
-  # See https://github.com/NixOS/nixpkgs/pull/64335.
+  # The gopls folder has its own module definition which causes a build failure.
+  # Given that, we can't have the gopls binary be part of the gotools
+  # derivation.
+  #
+  # We have a seperate derivation to build the gopls tool.
+  #
+  # Related
+  #
+  # * https://github.com/NixOS/nixpkgs/pull/85868
+  # * https://github.com/NixOS/nixpkgs/issues/88716
   postPatch = ''
     rm -rf gopls
   '';

--- a/pkgs/development/tools/gotools/default.nix
+++ b/pkgs/development/tools/gotools/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
   # Given that, we can't have the gopls binary be part of the gotools
   # derivation.
   #
-  # We have a seperate derivation to build the gopls tool.
+  # The attribute "gopls" provides the gopls binary.
   #
   # Related
   #

--- a/pkgs/development/tools/gotools/default.nix
+++ b/pkgs/development/tools/gotools/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "0a8c7j4w784w441j3j3bh640vy1g6g214641qv485wyi0xj49anf";
   };
 
-  # The gopls folder has its own module definition which causes a build failure.
+  # The gopls folder contains a Go submodule which causes a build failure.
   # Given that, we can't have the gopls binary be part of the gotools
   # derivation.
   #


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update documentation of the gotools derivation to inform users that were relying this derivation to get the gopls binary where to get it now.

Closes #88716

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

NOTE: Given the changes are only documentation, I did not bother the derivation result is misbehaving.
