### PR TITLE
python3Packages: fix a bunch of broken packages

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -20,6 +20,7 @@ let
       (mkOverride "flaskbabel"  "0.12.2" "11jwp8vvq1gnm31qh6ihy2h393hy18yn9yjp569g60r0wj1x2sii")
       (mkOverride "tornado"     "4.5.3"  "02jzd23l4r6fswmwxaica9ldlyc2p6q8dk6dyff7j58fmdzf853d")
       (mkOverride "psutil"      "5.6.7"  "ffad8eb2ac614518bbe3c0b8eb9dffdb3a8d2e3a7d5da51c5b974fb723a5c5aa")
+      (mkOverride "watchdog"    "0.9.0"  "07cnvvlpif7a6cg4rav39zq8fxa5pfqawchr46433pij0y6napwn")
 
       # Octoprint holds back jinja2 to 2.8.1 due to breaking changes.
       # This old version does not have updated test config for pytest 4,

--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -4,14 +4,16 @@
 
 buildPythonPackage rec {
   pname = "celery";
-  version = "4.4.2";
+  version = "4.4.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0ps1c6ill7q0m5kzb87hisgshdk3kzpa6cvcjch1d1wa07whp2hh";
+    sha256 = "0zk42fxznrhww0dxak9b6nkfqg02z49zr839k6ql7nk3him7n0y2";
   };
 
   postPatch = ''
+    substituteInPlace requirements/default.txt \
+      --replace "kombu>=4.6.10,<4.7" "kombu"
     substituteInPlace requirements/test.txt \
       --replace "moto==1.3.7" moto \
       --replace "pytest>=4.3.1,<4.4.0" pytest
@@ -20,9 +22,13 @@ buildPythonPackage rec {
   # ignore test that's incompatible with pytest5
   # test_eventlet touches network
   # test_mongodb requires pymongo
+  # test_multi tries to create directories under /var
   checkPhase = ''
-    pytest -k 'not restore_current_app_fallback and not msgpack and not on_apply' \
+    pytest -k 'not restore_current_app_fallback and not msgpack and not on_apply and not pytest' \
+      --ignore=t/unit/contrib/test_pytest.py \
       --ignore=t/unit/concurrency/test_eventlet.py \
+      --ignore=t/unit/bin/test_multi.py \
+      --ignore=t/unit/apps/test_multi.py \
       --ignore=t/unit/backends/test_mongodb.py
   '';
 

--- a/pkgs/development/python-modules/clickclick/default.nix
+++ b/pkgs/development/python-modules/clickclick/default.nix
@@ -14,8 +14,10 @@ buildPythonPackage rec {
   checkInputs = [ pytestCheckHook pytestcov ];
   propagatedBuildInputs = [ flake8 click pyyaml six ];
 
-  disabledTests = lib.optionals isPy36 [
+  # test_cli asserts on exact quoting style of output
+  disabledTests = [
     "test_cli"
+  ] ++ lib.optionals isPy36 [
     "test_choice_default"
   ];
 

--- a/pkgs/development/python-modules/flower/default.nix
+++ b/pkgs/development/python-modules/flower/default.nix
@@ -1,22 +1,42 @@
-{ lib, buildPythonPackage, fetchPypi, Babel, celery, importlib-metadata, pytz, tornado, mock }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, Babel
+, celery
+, future
+, humanize
+, importlib-metadata
+, mock
+, pytz
+, tornado
+}:
 
 buildPythonPackage rec {
   pname = "flower";
   version = "0.9.4";
-  
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "25782840f7ffc25dcf478d94535a2d815448de4aa6c71426be6abfa9ca417448";
   };
 
-  propagatedBuildInputs = [ Babel celery importlib-metadata pytz tornado ];
-  
+  # flower and humanize aren't listed in setup.py but imported
+  propagatedBuildInputs = [
+    Babel
+    celery
+    future
+    importlib-metadata
+    pytz
+    tornado
+    humanize
+  ];
+
   checkInputs = [ mock ];
-  
+
   meta = with lib; {
     description = "Celery Flower";
     homepage = "https://github.com/mher/flower";
-    license = licenses.bsdOriginal;    
+    license = licenses.bsdOriginal;
     maintainers = [ maintainers.arnoldfarkas ];
   };
 }

--- a/pkgs/development/python-modules/minio/default.nix
+++ b/pkgs/development/python-modules/minio/default.nix
@@ -1,19 +1,34 @@
 { lib, buildPythonPackage, isPy3k, fetchPypi
-, urllib3, future, python-dateutil , pytz, faker, mock, nose }:
+, configparser
+, faker
+, future
+, mock
+, nose
+, python-dateutil
+, pytz
+, pytestCheckHook
+, urllib3
+}:
 
 buildPythonPackage rec {
   pname = "minio";
   version = "5.0.10";
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "6ecb7637a35f806733e9d112eacfa599a58d7c3d4698fda2b5c86fff5d34b417";
   };
 
-  disabled = !isPy3k;
+  propagatedBuildInputs = [
+    configparser
+    future
+    python-dateutil
+    pytz
+    urllib3
+  ];
 
-  checkInputs = [ faker mock nose ];
-  propagatedBuildInputs = [ urllib3 python-dateutil pytz future ];
+  checkInputs = [ faker mock nose pytestCheckHook ];
 
   meta = with lib; {
     description = "Simple APIs to access any Amazon S3 compatible object storage server";

--- a/pkgs/development/python-modules/zope-hookable/default.nix
+++ b/pkgs/development/python-modules/zope-hookable/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "zope-hookable";
-  version = "4.2.0";
+  version = "5.0.1";
 
   src = fetchPypi {
     pname = "zope.hookable";
     inherit version;
-    sha256 = "c1df3929a3666fc5a0c80d60a0c1e6f6ef97c7f6ed2f1b7cf49f3e6f3d4dde15";
+    sha256 = "0hc82lfr7bk53nvbxvjkibkarngyrzgfk2i6bg8wshl0ly0pdl19";
   };
 
   checkInputs = [ zope_testing ];

--- a/pkgs/development/python-modules/zope_i18nmessageid/default.nix
+++ b/pkgs/development/python-modules/zope_i18nmessageid/default.nix
@@ -2,6 +2,8 @@
 , buildPythonPackage
 , fetchPypi
 , six
+, coverage
+, zope_testrunner
 }:
 
 buildPythonPackage rec {
@@ -14,6 +16,8 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ six ];
+
+  checkInputs = [ coverage zope_testrunner ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/zopefoundation/zope.i18nmessageid";

--- a/pkgs/development/python-modules/zope_lifecycleevent/default.nix
+++ b/pkgs/development/python-modules/zope_lifecycleevent/default.nix
@@ -1,8 +1,10 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy3k
 , zope_event
 , zope_component
+, zope_interface
 }:
 
 buildPythonPackage rec {
@@ -15,6 +17,15 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ zope_event zope_component ];
+
+  # namespace colides with local directory
+  doCheck = false;
+
+  # zope uses pep 420 namespaces for python3, doesn't work with nix + python2
+  pythonImportsCheck = stdenv.lib.optionals isPy3k [
+    "zope.lifecycleevent"
+    "zope.interface"
+  ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/zopefoundation/zope.lifecycleevent";

--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -21,15 +21,15 @@
 , wheel
 , git
 , mercurial
-} :
+}:
 
 buildPythonApplication rec {
   pname = "devpi-client";
-  version = "5.0.0";
+  version = "5.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0hyj3xc5c6658slk5wgcr9rh7hwi5r3hzxk1p6by61sqx5r38v3q";
+    sha256 = "1y8r1pjav0gyrbnyqjnc202sa962n1gasi8233xj7jc39lv3iq40";
   };
 
   buildInputs = [ glibcLocales pkginfo check-manifest ];
@@ -42,21 +42,9 @@ buildPythonApplication rec {
     sphinx wheel git mercurial
   ];
 
+  # --fast skips tests which try to start a devpi-server improperly
   checkPhase = ''
-    export PATH=$PATH:$out/bin
-    export HOME=$TMPDIR # fix tests failing in sandbox due to "/homeless-shelter"
-
-    # test_pypi_index_attributes: tries to connect to upstream pypi
-    # test_test: setuptools does not get propagated into the tox call (cannot import setuptools), also no detox
-    # test_index: hangs forever
-    # test_upload: fails multiple times with
-    # > assert args[0], args
-    # F AssertionError: [None, local('/build/pytest-of-nixbld/pytest-0/test_export_attributes_git_set0/repo2/setupdir/setup.py'), '--name']
-
-    py.test -k 'not test_pypi_index_attributes \
-                and not test_test \
-                and not test_index \
-                and not test_upload' testing
+    HOME=$TMPDIR py.test --fast
   '';
 
   LC_ALL = "en_US.UTF-8";

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -2,11 +2,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "devpi-server";
-  version = "5.2.0";
+  version = "5.5.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1dapd0bis7pb4fzq5yva7spby5amcsgl1970z5nq1rlprf6qbydg";
+    sha256 = "0lily4a0k13bygx07x2f2q4nkwny0fj34hpac9i6mc70ysdn1hhi";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -32,12 +32,17 @@ python3Packages.buildPythonApplication rec {
     webtest
   ] ++ stdenv.lib.optionals isPy27 [ mock ];
 
-  # test_genconfig.py needs devpi-server on PATH
   # root_passwd_hash tries to write to store
+  # TestMirrorIndexThings tries to write to /var through ngnix
+  # nginx tests try to write to /var
   checkPhase = ''
     PATH=$PATH:$out/bin HOME=$TMPDIR pytest \
       ./test_devpi_server --slow -rfsxX \
-      -k 'not root_passwd_hash_option'
+      --ignore=test_devpi_server/test_nginx_replica.py \
+      --ignore=test_devpi_server/test_streaming_nginx.py \
+      --ignore=test_devpi_server/test_streaming_replica_nginx.py \
+      -k 'not root_passwd_hash_option \
+          and not TestMirrorIndexThings'
   '';
 
   meta = with stdenv.lib;{


### PR DESCRIPTION
###### Motivation for this change
fixes builds

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/89376
4 packages failed to build:
python27Packages.zope_i18n python37Packages.rl-coach python37Packages.zope_i18n python38Packages.zope_i18n

102 packages built:
buildbot buildbot-full buildbot-ui certbot cura devpi-client devpi-server gitAndTools.bump2version mailman octoprint python27Packages.celery python27Packages.clickclick python27Packages.connexion python27Packages.flower python27Packages.zope-hookable python27Packages.zope_component python27Packages.zope_configuration python27Packages.zope_i18nmessageid python27Packages.zope_lifecycleevent python27Packages.zope_size python37Packages.celery python37Packages.clickclick python37Packages.connexion python37Packages.cornice python37Packages.django-raster python37Packages.django-simple-captcha python37Packages.djmail python37Packages.flower python37Packages.mailman python37Packages.mailman-hyperkitty python37Packages.minio python37Packages.praw python37Packages.prawcore python37Packages.pyjade python37Packages.pyramid python37Packages.pyramid_beaker python37Packages.pyramid_chameleon python37Packages.pyramid_exclog python37Packages.pyramid_hawkauth python37Packages.pyramid_jinja2 python37Packages.pyramid_mako python37Packages.pyramid_multiauth python37Packages.scrapy python37Packages.sentry-sdk python37Packages.sopel python37Packages.stups-cli-support python37Packages.stups-fullstop python37Packages.stups-pierone python37Packages.stups-zign python37Packages.testfixtures python37Packages.zope-hookable python37Packages.zope_component python37Packages.zope_configuration python37Packages.zope_i18nmessageid python37Packages.zope_lifecycleevent python37Packages.zope_size python38Packages.buildbot python38Packages.buildbot-full python38Packages.buildbot-ui python38Packages.celery python38Packages.clickclick python38Packages.cornice python38Packages.django-raster python38Packages.django-simple-captcha python38Packages.djmail python38Packages.flower python38Packages.mailman python38Packages.mailman-hyperkitty python38Packages.minio python38Packages.praw python38Packages.prawcore python38Packages.pyjade python38Packages.pyramid python38Packages.pyramid_beaker python38Packages.pyramid_chameleon python38Packages.pyramid_exclog python38Packages.pyramid_hawkauth python38Packages.pyramid_jinja2 python38Packages.pyramid_mako python38Packages.pyramid_multiauth python38Packages.scrapy python38Packages.sopel python38Packages.stups-cli-support python38Packages.stups-fullstop python38Packages.stups-pierone python38Packages.stups-zign python38Packages.testfixtures python38Packages.zope-hookable python38Packages.zope_component python38Packages.zope_configuration python38Packages.zope_i18nmessageid python38Packages.zope_lifecycleevent python38Packages.zope_size sourcehut.buildsrht sourcehut.dispatchsrht sourcehut.gitsrht sourcehut.hgsrht sourcehut.listssrht sourcehut.mansrht sourcehut.metasrht sourcehut.pastesrht sourcehut.todosrht
```