### PR TITLE
pythonPackages.pulp: 2.0 -> 2.1

### DIFF
--- a/pkgs/development/python-modules/pulp/default.nix
+++ b/pkgs/development/python-modules/pulp/default.nix
@@ -1,18 +1,23 @@
-{ stdenv, fetchPypi, buildPythonPackage, pyparsing }:
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+, pyparsing
+}:
 
 buildPythonPackage rec {
   pname = "PuLP";
-  version = "2.0";
+  version = "2.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "fb0b0e8073aa82f3459c4241b9625e0ccd26c0838ad8253c6bc67e041901b765";
+    sha256 = "06swbi7wygh7y0kxc85q1pdhzk662375d9a5jnahgr76hkwwkybn";
   };
 
   propagatedBuildInputs = [ pyparsing ];
 
   # only one test that requires an extra
   doCheck = false;
+  pythonImportsCheck = [ "pulp" ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/coin-or/pulp";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update pulp to 2.1. This also allows me to use pulp+cbc, which I couldn't with v2.0.

###### Things done
I debated adding `cbc` as a `buildInput` since it's the default solver, but ultimately didn't. Let me know if this would be a good idea and I'll add it.

FYI: adding `cbc` as a `checkInput` got some of the tests working, but not all, so I've left it as false.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
