### PR TITLE
sogo: Add support for SMTP-STARTTLS/SMTP-SSL

### DIFF
--- a/pkgs/development/libraries/sope/default.nix
+++ b/pkgs/development/libraries/sope/default.nix
@@ -1,4 +1,4 @@
-{ gnustep, lib, fetchFromGitHub , libxml2, openssl_1_1
+{ gnustep, lib, fetchFromGitHub, fetchpatch, libxml2, openssl_1_1
 , openldap, mysql, libmysqlclient, postgresql }: with lib; gnustep.stdenv.mkDerivation rec {
   pname = "sope";
   version = "4.3.2";
@@ -15,6 +15,14 @@
     ++ optional (openldap != null) openldap
     ++ optionals (mysql != null) [ libmysqlclient mysql ]
     ++ optional (postgresql != null) postgresql);
+
+  patches = [
+    # SSL/STARTTLS support for SMTP; merged upstream, will be available in next official release
+    (fetchpatch {
+      url = "https://github.com/inverse-inc/sope/commit/45c1819d71bd8c7d14719a687cde5e12ed8800d9.diff";
+      sha256 = "0ybg8y17hzsp3pxg5nc25nihcv4yjsk221cjlbljwvks92gnqihq";
+    })
+  ];
 
   postPatch = ''
     # Exclude NIX_ variables

--- a/pkgs/servers/web-apps/sogo/default.nix
+++ b/pkgs/servers/web-apps/sogo/default.nix
@@ -20,6 +20,11 @@
       url = "https://sources.debian.org/data/main/s/sogo/4.3.0-1/debian/patches/0005-Remove-build-date.patch";
       sha256 = "0lrh3bkfj3r0brahfkyb0g7zx7r2jjd5cxzjl43nqla0fs09wsh8";
     })
+    # SSL/STARTTLS support for SMTP; merged upstream, will be available in next official release
+    (fetchpatch {
+      url = "https://github.com/inverse-inc/sogo/commit/589cfaa2f4957b7b528e80ddc7cf7befbd890e47.diff";
+      sha256 = "151dmp02qqzgm5y3mv37p8bi1j4mcvdn9lws64c69fdwm1q9hjp2";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

SOGo (resp. SOPE) only supports plain-text SMTP to connect to the upstream SMTP server, which is okay as long as both SOGo and SMTPd run on the same machine, but unfortunate if not.

This pulls in the respective merges from upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
