### PR TITLE
Nextcloud: use php.ini for cron job as well

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -466,7 +466,7 @@ in {
           environment.NEXTCLOUD_CONFIG_DIR = "${cfg.home}/config";
           serviceConfig.Type = "oneshot";
           serviceConfig.User = "nextcloud";
-          serviceConfig.ExecStart = "${phpPackage}/bin/php -f ${cfg.package}/cron.php";
+          serviceConfig.ExecStart = "${phpPackage}/bin/php -c ${config.services.phpfpm.pools.nextcloud.phpIni} -f ${cfg.package}/cron.php";
         };
         nextcloud-update-plugins = mkIf cfg.autoUpdateApps.enable {
           serviceConfig.Type = "oneshot";


### PR DESCRIPTION
###### Motivation for this change
The cron jobs will sometimes fail because not enough memory is available. Enough memory _would_ be available if the php.ini for nextcloud's fpm pool were used, so use it.

###### Things done

- [x] Deployed a nextcloud using this and checked that the cronjob now succeeds where it used to fail
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
