### PR TITLE
Keepass

### DIFF
--- a/pkgs/applications/misc/keepass-plugins/keeagent/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/keeagent/default.nix
@@ -1,14 +1,14 @@
 { stdenv, buildEnv, fetchzip, mono }:
 
 let
-  version = "0.10.1";
+  version = "0.12.0";
   drv = stdenv.mkDerivation {
     pname = "keeagent";
     inherit version;
 
     src = fetchzip {
-      url = "https://lechnology.com/wp-content/uploads/2018/04/KeeAgent_v0.10.1.zip";
-      sha256 = "0j7az6l9wcr8z66mfplkxwydd4bgz2p2vd69xncf0nxlfb0lshh7";
+      url = "https://lechnology.com/wp-content/uploads/2020/05/KeeAgent_v0.12.0.zip";
+      sha256 = "0fcfbj3yikiv3dmp69236h9r3c416amdq849kn131w1129gb68xd";
       stripRoot = false;
     };
 

--- a/pkgs/applications/misc/keepass/fix-paths.patch
+++ b/pkgs/applications/misc/keepass/fix-paths.patch
@@ -56,24 +56,6 @@ diff --git a/KeePass/Util/ClipboardUtil.Unix.cs b/KeePass/Util/ClipboardUtil.Uni
 index ab49ee2..7f6c50f 100644
 --- a/KeePass/Util/ClipboardUtil.Unix.cs
 +++ b/KeePass/Util/ClipboardUtil.Unix.cs
-@@ -42,7 +42,7 @@ namespace KeePass.Util
- 			// string strGtk = GtkGetString();
- 			// if(strGtk != null) return strGtk;
- 
--			return (NativeLib.RunConsoleApp("pbpaste", "-pboard general") ??
-+			return (NativeLib.RunConsoleApp("@pbpaste@", "-pboard general") ??
- 				string.Empty);
- 		}
- 
-@@ -50,7 +50,7 @@ namespace KeePass.Util
- 		{
- 			// if(GtkSetString(str)) return;
- 
--			NativeLib.RunConsoleApp("pbcopy", "-pboard general", str);
-+			NativeLib.RunConsoleApp("@pbcopy@", "-pboard general", str);
- 		}
- 
- 		private static string GetStringU()
 @@ -62,7 +62,7 @@ namespace KeePass.Util
  			//	"-out -selection clipboard");
  			// if(str != null) return str;

--- a/pkgs/applications/misc/keepass/keepass-plugins-load.patch
+++ b/pkgs/applications/misc/keepass/keepass-plugins-load.patch
@@ -1,1 +1,1 @@
-+			m_pluginManager.LoadAllPlugins("$PATH$/lib/dotnet/keepass", SearchOption.TopDirectoryOnly, new string[] {});
++			m_pluginManager.LoadAllPlugins("$PATH$/lib/dotnet/keepass", System.IO.SearchOption.TopDirectoryOnly, new string[] {});

--- a/pkgs/applications/misc/keepass/keepass-plugins.patch
+++ b/pkgs/applications/misc/keepass/keepass-plugins.patch
@@ -11,7 +11,7 @@ diff --git a/KeePass/Forms/MainForm.cs b/KeePass/Forms/MainForm.cs
 index 347eaf5..b92e1e2 100644
 --- a/KeePass/Forms/MainForm.cs
 +++ b/KeePass/Forms/MainForm.cs
-@@ -440,7 +440,7 @@ namespace KeePass.Forms
+@@ -440,7 +440,$OUTPUT_LC$ @@ namespace KeePass.Forms
  				ToolStripItemCollection tsicT = m_ctxTray.Items;
  				ToolStripItem tsiPrevT = m_ctxTrayOptions;
  


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/88999
https://github.com/NixOS/nixpkgs/pull/88157#pullrequestreview-420659712

With my previous PR i broke the way keepass load plugins.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
