### PR TITLE
python2.pkgs.flask-autoindex: fix build

### DIFF
--- a/pkgs/development/python-modules/flask-autoindex/default.nix
+++ b/pkgs/development/python-modules/flask-autoindex/default.nix
@@ -1,9 +1,11 @@
-{ stdenv
+{ lib
 , buildPythonPackage
+, pythonOlder
 , fetchPypi
 , flask
 , flask-silk
 , future
+, pathlib
 }:
 
 buildPythonPackage rec {
@@ -19,9 +21,11 @@ buildPythonPackage rec {
     flask
     flask-silk
     future
+  ] ++ lib.optionals (pythonOlder "3.4") [
+    pathlib
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "The mod_autoindex for Flask";
     longDescription = ''
       Flask-AutoIndex generates an index page for your Flask application automatically.


### PR DESCRIPTION
###### Motivation for this change

pathlib is now required, which is part of the standard library in python
3.4+ but not in python 2.7. Broken by
ec12a5fd1e9379b359871efadeb245e8734f59a8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
