### PR TITLE
Parallel building fixes

### DIFF
--- a/pkgs/development/libraries/intel-media-sdk/default.nix
+++ b/pkgs/development/libraries/intel-media-sdk/default.nix
@@ -23,7 +23,6 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
-  enableParallelBuild = true;
 
   meta = with stdenv.lib; {
     description = "Intel Media SDK.";

--- a/pkgs/tools/X11/alttab/default.nix
+++ b/pkgs/tools/X11/alttab/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     xorg.libXrender
   ];
 
-  enableParallelBuild = true;
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/sagb/alttab";


### PR DESCRIPTION
###### Motivation for this change
Found 2 derivations using `enableParallelBuild`. The attribute is actually called `enableParallelBuilding`. Fixed that.

For `intel-media-sdk`, this shouldn't change anything because `cmake` already enables parallel building by default.

---

@midchildan Entirely unrelated to this change, but is there any reason in particular you didn't use `fetchFromGitHub` for `src`?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
