### PR TITLE
mint-x-icons: init at 1.5.5

### DIFF
--- a/pkgs/data/icons/mint-x-icons/default.nix
+++ b/pkgs/data/icons/mint-x-icons/default.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, fetchurl
+, gnome-icon-theme
+, gtk3
+, hicolor-icon-theme
+, humanity-icon-theme
+, ubuntu-themes
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mint-x-icons";
+  version = "1.5.5";
+
+  src = fetchurl {
+    url = "http://packages.linuxmint.com/pool/main/m/${pname}/${pname}_${version}.tar.xz";
+    sha256 = "0nq3si06m98b71f33wism0bvlvib57rm96msf0wx852ginw3a5yd";
+  };
+
+  nativeBuildInputs = [
+    gtk3
+  ];
+
+  propagatedBuildInputs = [
+    gnome-icon-theme
+    hicolor-icon-theme
+    humanity-icon-theme
+    ubuntu-themes # provides the  parent icon theme: ubuntu-mono-dark
+  ];
+
+  dontDropIconThemeCache = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/icons
+    cp -vai usr/share/icons/* $out/share/icons
+
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache $theme
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Mint/metal theme based on mintified versions of Clearlooks Revamp, Elementary and Faenza";
+    homepage = "https://github.com/linuxmint/mint-x-icons";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18187,6 +18187,8 @@ in
 
   medio = callPackage ../data/fonts/medio { };
 
+  mint-x-icons = callPackage ../data/icons/mint-x-icons { };
+
   mno16 = callPackage ../data/fonts/mno16 { };
 
   mnist = callPackage ../data/machine-learning/mnist { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [mint-x-icons](https://github.com/linuxmint/mint-x-icons). Icon theme built for Linux Mint. Uses elements of Faenza and Elementary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
