### PR TITLE
softmaker-office: 976 -> 1014

### DIFF
--- a/pkgs/applications/office/softmaker/softmaker_office.nix
+++ b/pkgs/applications/office/softmaker/softmaker_office.nix
@@ -2,13 +2,13 @@
 
 callPackage ./generic.nix (args // rec {
   pname = "softmaker-office";
-  version = "976";
-  edition = "2018";
+  version = "1014";
+  edition = "2021";
   suiteName = "SoftMaker Office";
 
   src = fetchurl {
     url = "https://www.softmaker.net/down/softmaker-office-${edition}-${version}-amd64.tgz";
-    sha256 = "0j6zm0cbxrcgm7glk84hvvbp4z0ys6v8bkwwhl5r7dbphyi72fw8";
+    sha256 = "0wqaxng6s7lxwz6v2j6y1m5h4g4v63m0lscj7l2fpx5ksjlamp55";
   };
 
   archive = "office${edition}.tar.lzma";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The edition also changed from 2018 to 2021, since this is a major new
release. Changes:

https://www.softmaker.com/en/softmaker-office-whatsnew

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
