### PR TITLE
libucl: init at 0.8.1

### DIFF
--- a/pkgs/development/libraries/libucl/default.nix
+++ b/pkgs/development/libraries/libucl/default.nix
@@ -1,0 +1,58 @@
+{ stdenv
+, fetchFromGitHub
+, pkg-config
+, autoreconfHook
+, curl
+, lua
+, openssl
+, features ? {
+    urls = false;
+    # Upstream enables regex by default
+    regex = true;
+    # Signature support is broken with openssl 1.1.1: https://github.com/vstakhov/libucl/issues/203
+    signatures = false;
+    lua = false;
+    utils = false;
+  }
+}:
+
+let
+  featureDeps = {
+    urls = [ curl ];
+    signatures = [ openssl ];
+    lua = [ lua ];
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "libucl";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "vstakhov";
+    repo = pname;
+    rev = version;
+    sha256 = "1h52ldxankyhbbm1qbqz1f2q0j03c1b4mig7343bs3mc6fpm18gf";
+  };
+
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+
+  buildInputs = with stdenv.lib;
+    concatLists (
+      mapAttrsToList (feat: enabled:
+        optionals enabled (featureDeps."${feat}" or [])
+      ) features
+    );
+
+  enableParallelBuilding = true;
+
+  configureFlags = with stdenv.lib;
+    mapAttrsToList (feat: enabled: strings.enableFeature enabled feat) features;
+
+  meta = with stdenv.lib; {
+    description = "Universal configuration library parser";
+    homepage = "https://github.com/vstakhov/libucl";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jpotier ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5008,6 +5008,8 @@ in
 
   libiberty = callPackage ../development/libraries/libiberty { };
 
+  libucl = callPackage ../development/libraries/libucl { };
+
   libxc = callPackage ../development/libraries/libxc { };
 
   libxcomp = callPackage ../development/libraries/libxcomp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

libucl is a dependency for Hikari (https://github.com/NixOS/nixpkgs/pull/89414)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
