### PR TITLE
python: Google API updates (google_{auth,api_core,api_python_client})

### DIFF
--- a/pkgs/development/python-modules/google-api-python-client/default.nix
+++ b/pkgs/development/python-modules/google-api-python-client/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "google-api-python-client";
-  version = "1.8.4";
+  version = "1.9.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "06csvbpdv3kl806nqvh5hpag86wpafp1q9r07m7kc1fw3xhi5qmv";
+    sha256 = "0nfqf62g3l7ij779ind41p800ahdjijkhqx8nq6y029p98672c52";
   };
 
   # No tests included in archive

--- a/pkgs/development/python-modules/google_api_core/default.nix
+++ b/pkgs/development/python-modules/google_api_core/default.nix
@@ -1,14 +1,16 @@
 { lib, buildPythonPackage, fetchPypi, pythonOlder, isPy27
-, google_auth, protobuf, googleapis_common_protos, requests, setuptools, grpcio, mock }:
+, google_auth, protobuf, googleapis_common_protos, requests, setuptools, grpcio
+, mock
+}:
 
 buildPythonPackage rec {
   pname = "google-api-core";
-  version = "1.16.0";
+  version = "1.17.0";
   disabled = isPy27; # google namespace no longer works on python2
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1qh30ji399gngv2j1czzvi3h0mgx3lfdx2n8qp8vii7ihyh65scj";
+    sha256 = "12fn05x2fdhqmcaspjkkny2lh66hnnl0xf6pz3idxhlx8w5jl274";
   };
 
   propagatedBuildInputs = [
@@ -27,8 +29,13 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "This library is not meant to stand-alone. Instead it defines common helpers used by all Google API clients.";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    description = "Core Library for Google Client Libraries";
+    longDescription = ''
+      This library is not meant to stand-alone. Instead it defines common
+      helpers used by all Google API clients.
+    '';
+    homepage = "https://github.com/googleapis/python-api-core";
+    changelog = "https://github.com/googleapis/python-api-core/blob/v${version}/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/google_auth/default.nix
+++ b/pkgs/development/python-modules/google_auth/default.nix
@@ -17,11 +17,11 @@
 
 buildPythonPackage rec {
   pname = "google-auth";
-  version = "1.11.3";
+  version = "1.16.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "05av4clwv7kdk1v55ibcv8aim6dwfg1mi4wy0vv91fr6wq3205zc";
+    sha256 = "1xd7fi7vhqbbkvwjg5fgj8bkbfjwxx4f2bb0zsnj8wci46qk4dqv";
   };
 
   propagatedBuildInputs = [ six pyasn1-modules cachetools rsa setuptools ];
@@ -43,8 +43,14 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "This library simplifies using Google’s various server-to-server authentication mechanisms to access Google APIs.";
-    homepage = "https://google-auth.readthedocs.io/en/latest/";
+    description = "Google Auth Python Library";
+    longDescription = ''
+      This library simplifies using Google’s various server-to-server
+      authentication mechanisms to access Google APIs.
+    '';
+    homepage = "https://github.com/googleapis/google-auth-library-python";
+    changelog = "https://github.com/googleapis/google-auth-library-python/blob/v${version}/CHANGELOG.md";
+    # Documentation: https://googleapis.dev/python/google-auth/latest/index.html
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`python3Packages.google_api_python_client: 1.8.3 -> 1.9.1` which requires the other updates as well. I've also started a `nix-review` job that is currently rebuilding 118 packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
