### PR TITLE
Fix missing dependency for cookiecutter

### DIFF
--- a/pkgs/development/python-modules/cookiecutter/default.nix
+++ b/pkgs/development/python-modules/cookiecutter/default.nix
@@ -1,6 +1,7 @@
 { stdenv, buildPythonPackage, fetchPypi, isPyPy
 , pytest, pytestcov, pytest-mock, freezegun
-, jinja2, future, binaryornot, click, whichcraft, poyo, jinja2_time, requests }:
+, jinja2, future, binaryornot, click, whichcraft, poyo, jinja2_time, requests
+, python-slugify }:
 
 buildPythonPackage rec {
   pname = "cookiecutter";
@@ -17,8 +18,9 @@ buildPythonPackage rec {
   checkInputs = [ pytest pytestcov pytest-mock freezegun ];
   propagatedBuildInputs = [
     jinja2 future binaryornot click whichcraft poyo jinja2_time requests
+    python-slugify
   ];
-  
+
   # requires network access for cloning git repos
   doCheck = false;
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Cookiecutter fails to be built due to a missing dependency, I'm not sure why it built at some point (possibly the PyPI package was replaced)

###### Things done
- Add missing dependency: python-slugify
- Test executable after building using Nix in Arch Linux
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
