### PR TITLE
Keysmith Init at v0.1 (resquashed)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6980,6 +6980,12 @@
     githubId = 1588288;
     name = "Shahrukh Khan";
   };
+  shamilton = {
+    email = "sgn.hamilton@protonmail.com";
+    github = "SCOTT-HAMILTON";
+    githubId = 24496705;
+    name = "Scott Hamilton";
+  };
   shanemikel = {
     email = "shanepearlman@pm.me";
     github = "shanemikel";

--- a/pkgs/tools/security/keysmith/default.nix
+++ b/pkgs/tools/security/keysmith/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, qtbase
+, qtquickcontrols2
+, kirigami2
+, oathToolkit
+}:
+mkDerivation rec {
+
+  pname = "keysmith";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "KDE";
+    repo = "keysmith";
+    rev = "v${version}";
+    sha256 = "15fzf0bvarivm32zqa5w71mscpxdac64ykiawc5hx6kplz93bsgx";
+  };
+
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+
+  buildInputs = [ oathToolkit kirigami2 qtquickcontrols2 qtbase ];
+
+  meta = with lib; {
+    description = "OTP client for Plasma Mobile and Desktop";
+    license = licenses.gpl3;
+    homepage = "https://github.com/KDE/keysmith";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4849,6 +4849,8 @@ in
 
   kea = callPackage ../tools/networking/kea { };
 
+  keysmith = libsForQt5.callPackage ../tools/security/keysmith { };
+
   ispell = callPackage ../tools/text/ispell {};
 
   jumanpp = callPackage ../tools/text/jumanpp {};


### PR DESCRIPTION
###### Motivation for this change
A clean, squashed commit history for keysmith as asked here https://github.com/NixOS/nixpkgs/pull/88614#pullrequestreview-423222781 

###### Things done
Packaged Keysmith at v0.1

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
