### PR TITLE
hikari: init at 2.0.2

### DIFF
--- a/pkgs/applications/window-managers/hikari/default.nix
+++ b/pkgs/applications/window-managers/hikari/default.nix
@@ -1,0 +1,75 @@
+{ stdenv, fetchzip,
+  pkgconfig, bmake,
+  cairo, glib, libevdev, libinput, libxkbcommon, linux-pam, pango, pixman,
+  libucl, wayland, wayland-protocols, wlroots,
+  features ? {
+    gammacontrol = true;
+    layershell   = true;
+    screencopy   = true;
+    xwayland     = true;
+  }
+}:
+
+let
+  pname = "hikari";
+  version = "2.0.2";
+in
+
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchzip {
+    url = "https://hikari.acmelabs.space/releases/${pname}-${version}.tar.gz";
+    sha256 = "1a3i01936pw11hrmjmrhzzwpndl1jqjgx376m5m724wd1j9awm68";
+  };
+
+  nativeBuildInputs = [ pkgconfig bmake ];
+
+  buildInputs = [
+    cairo
+    glib
+    libevdev
+    libinput
+    libxkbcommon
+    linux-pam
+    pango
+    pixman
+    libucl
+    wayland
+    wayland-protocols
+    wlroots
+  ];
+
+  enableParallelBuilding = true;
+
+  # Must replace GNU Make by bmake
+  buildPhase = with stdenv.lib; concatStringsSep " " (
+    [ "bmake" "-j$NIX_BUILD_CORES" "PREFIX=$out" ]
+    ++ optional stdenv.isLinux "WITH_POSIX_C_SOURCE=YES"
+    ++ mapAttrsToList (feat: enabled:
+         optionalString enabled "WITH_${toUpper feat}=YES"
+       ) features
+  );
+
+  # Can't suid in nix store
+  # Run hikari as root (it will drop privileges as early as possible), or create
+  # a systemd unit to give it the necessary permissions/capabilities.
+  patchPhase = ''
+    substituteInPlace Makefile --replace '4555' '555'
+  '';
+
+  installPhase = ''
+    bmake \
+      PREFIX=$out \
+      install
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Stacking Wayland compositor which is actively developed on FreeBSD but also supports Linux";
+    homepage    = "https://hikari.acmelabs.space";
+    license     = licenses.bsd2;
+    platforms   = platforms.linux ++ platforms.freebsd;
+    maintainers = with maintainers; [ jpotier ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20205,6 +20205,8 @@ in
     pulseSupport = config.pulseaudio or false;
   };
 
+  hikari = callPackage ../applications/window-managers/hikari { };
+
   i3 = callPackage ../applications/window-managers/i3 {
     xcb-util-cursor = if stdenv.isDarwin then xcb-util-cursor-HEAD else xcb-util-cursor;
   };


### PR DESCRIPTION
~~**This is waiting on https://github.com/NixOS/nixpkgs/pull/89408 to be merged first.**~~

###### Motivation for this change

New compositor for wayland

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
