### PR TITLE
bitcoin: 0.19.1 -> 0.20.0

### DIFF
--- a/pkgs/applications/blockchains/bitcoin.nix
+++ b/pkgs/applications/blockchains/bitcoin.nix
@@ -1,59 +1,74 @@
-{ stdenv, fetchurl, pkgconfig, autoreconfHook, openssl, db48, boost, zeromq, rapidcheck, hexdump
-, zlib, miniupnpc, qtbase ? null, qttools ? null, wrapQtAppsHook ? null, utillinux, python3, qrencode, libevent
-, withGui }:
+{ stdenv
+, fetchurl
+, pkgconfig
+, autoreconfHook
+, db48
+, boost
+, zeromq
+, hexdump
+, zlib
+, miniupnpc
+, qtbase ? null
+, qttools ? null
+, wrapQtAppsHook ? null
+, utillinux
+, python3
+, qrencode
+, libevent
+, withGui
+}:
 
 with stdenv.lib;
-
 let
-  version = "0.19.1";
+  version = "0.20.0";
   majorMinorVersion = versions.majorMinor version;
-
   desktop = fetchurl {
     url = "https://raw.githubusercontent.com/bitcoin-core/packaging/${majorMinorVersion}/debian/bitcoin-qt.desktop";
     sha256 = "0cpna0nxcd1dw3nnzli36nf9zj28d2g9jf5y0zl9j18lvanvniha";
   };
-
   pixmap = fetchurl {
     url = "https://raw.githubusercontent.com/bitcoin/bitcoin/v${version}/share/pixmaps/bitcoin128.png";
     sha256 = "08p7j7dg50jlj783kkgdw037klmx0spqjikaprmbkzgcb620r25d";
   };
-
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = if withGui then "bitcoin" else "bitcoind";
   inherit version;
 
   src = fetchurl {
-    urls = [ "https://bitcoincore.org/bin/bitcoin-core-${version}/bitcoin-${version}.tar.gz"
-             "https://bitcoin.org/bin/bitcoin-core-${version}/bitcoin-${version}.tar.gz"
-           ];
-    sha256 = "f2591d555b8e8c2e1bd780e40d53a91e165d8b3c7e0391ae2d24a0c0f23a7cc0";
+    urls = [
+      "https://bitcoincore.org/bin/bitcoin-core-${version}/bitcoin-${version}.tar.gz"
+      "https://bitcoin.org/bin/bitcoin-core-${version}/bitcoin-${version}.tar.gz"
+    ];
+    sha256 = "ec5a2358ee868d845115dc4fc3ed631ff063c57d5e0a713562d083c5c45efb28";
   };
 
   nativeBuildInputs =
     [ pkgconfig autoreconfHook ]
     ++ optional stdenv.isDarwin hexdump
     ++ optional withGui wrapQtAppsHook;
-  buildInputs = [ openssl db48 boost zlib zeromq
-                  miniupnpc libevent]
-                  ++ optionals stdenv.isLinux [ utillinux ]
-                  ++ optionals withGui [ qtbase qttools qrencode ];
+  buildInputs = [ db48 boost zlib zeromq miniupnpc libevent ]
+    ++ optionals stdenv.isLinux [ utillinux ]
+    ++ optionals withGui [ qtbase qttools qrencode ];
 
   postInstall = optional withGui ''
     install -Dm644 ${desktop} $out/share/applications/bitcoin-qt.desktop
     install -Dm644 ${pixmap} $out/share/pixmaps/bitcoin128.png
   '';
 
-  configureFlags = [ "--with-boost-libdir=${boost.out}/lib"
-                     "--disable-bench"
-                   ] ++ optionals (!doCheck) [
-                     "--disable-tests"
-                     "--disable-gui-tests"
-                   ]
-                     ++ optionals withGui [ "--with-gui=qt5"
-                                            "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
-                                          ];
+  configureFlags = [
+    "--with-boost-libdir=${boost.out}/lib"
+    "--disable-bench"
+  ] ++ optionals (!doCheck) [
+    "--disable-tests"
+    "--disable-gui-tests"
+  ]
+  ++ optionals withGui [
+    "--with-gui=qt5"
+    "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
+  ];
 
-  checkInputs = [ rapidcheck python3 ];
+  checkInputs = [ python3 ];
 
   doCheck = true;
 
@@ -67,13 +82,15 @@ in stdenv.mkDerivation rec {
 
   meta = {
     description = "Peer-to-peer electronic cash system";
-    longDescription= ''
+    longDescription = ''
       Bitcoin is a free open source peer-to-peer electronic cash system that is
       completely decentralized, without the need for a central server or trusted
       parties. Users hold the crypto keys to their own money and transact directly
       with each other, with the help of a P2P network to check for double-spending.
     '';
     homepage = "https://bitcoin.org/";
+    downloadPage = "https://bitcoincore.org/bin/bitcoin-core-${version}/";
+    changelog = "https://bitcoincore.org/en/releases/${version}/";
     maintainers = with maintainers; [ roconnor AndersonTorres ];
     license = licenses.mit;
     platforms = platforms.unix;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

* bitcoin: 0.19.1 -> 0.20.0 - https://bitcoincore.org/en/releases/0.20.0/
* drop openssl from buildInputs as it is no longer used by the project
* drop rapidcheck from check checkInputs as it is no longer used by the project
* reformat with nixpkgs-fmt
* add meta.downloadPage and meta.changelog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
