### PR TITLE
nixos/autoUpgrade: add flake support

### DIFF
--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -2,9 +2,9 @@
 
 with lib;
 
-let cfg = config.system.autoUpgrade; in
+let cfg = config.system.autoUpgrade;
 
-{
+in {
 
   options = {
 
@@ -18,6 +18,16 @@ let cfg = config.system.autoUpgrade; in
           version. If enabled, a systemd timer will run
           <literal>nixos-rebuild switch --upgrade</literal> once a
           day.
+        '';
+      };
+
+      flake = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "github:kloenk/nix";
+        description = ''
+          The Flake URI of the NixOS configuration to build.
+          Disables the option <option>system.autoUpgrade.channel</option>.
         '';
       };
 
@@ -35,10 +45,20 @@ let cfg = config.system.autoUpgrade; in
 
       flags = mkOption {
         type = types.listOf types.str;
-        default = [];
-        example = [ "-I" "stuff=/home/alice/nixos-stuff" "--option" "extra-binary-caches" "http://my-cache.example.org/" ];
+        default = [ ];
+        example = [
+          "-I"
+          "stuff=/home/alice/nixos-stuff"
+          "--option"
+          "extra-binary-caches"
+          "http://my-cache.example.org/"
+        ];
         description = ''
           Any additional flags passed to <command>nixos-rebuild</command>.
+
+          If you are using flakes and use a local repo you can add
+          <command>[ "--update-input" "nixpkgs" "--commit-lock-file" ]</command>
+          to update nixpkgs.
         '';
       };
 
@@ -82,11 +102,23 @@ let cfg = config.system.autoUpgrade; in
 
   config = lib.mkIf cfg.enable {
 
-    system.autoUpgrade.flags =
-      [ "--no-build-output" ]
-      ++ (if cfg.channel == null
-          then [ "--upgrade" ]
-          else [ "-I" "nixpkgs=${cfg.channel}/nixexprs.tar.xz" ]);
+    assertions = [{
+      assertion = !((cfg.channel != null) && (cfg.flake != null));
+      message = ''
+        The options 'system.autoUpgrade.channels' and 'system.autoUpgrade.flake' cannot both be set.
+      '';
+    }];
+
+    system.autoUpgrade.flags = [ "--no-build-output" ]
+      ++ (if cfg.flake == null then
+        (if cfg.channel == null then
+          [ "--upgrade" ]
+        else [
+          "-I"
+          "nixpkgs=${cfg.channel}/nixexprs.tar.xz"
+        ])
+      else
+        [ "--flake ${cfg.flake}" ]);
 
     systemd.services.nixos-upgrade = {
       description = "NixOS Upgrade";
@@ -96,33 +128,41 @@ let cfg = config.system.autoUpgrade; in
 
       serviceConfig.Type = "oneshot";
 
-      environment = config.nix.envVars //
-        { inherit (config.environment.sessionVariables) NIX_PATH;
-          HOME = "/root";
-        } // config.networking.proxy.envVars;
+      environment = config.nix.envVars // {
+        inherit (config.environment.sessionVariables) NIX_PATH;
+        HOME = "/root";
+      } // config.networking.proxy.envVars;
 
-      path = with pkgs; [ coreutils gnutar xz.bin gzip gitMinimal config.nix.package.out ];
+      path = with pkgs; [
+        coreutils
+        gnutar
+        xz.bin
+        gzip
+        gitMinimal
+        config.nix.package.out
+      ];
 
       script = let
-          nixos-rebuild = "${config.system.build.nixos-rebuild}/bin/nixos-rebuild";
-        in
-        if cfg.allowReboot then ''
-            ${nixos-rebuild} boot ${toString cfg.flags}
-            booted="$(readlink /run/booted-system/{initrd,kernel,kernel-modules})"
-            built="$(readlink /nix/var/nix/profiles/system/{initrd,kernel,kernel-modules})"
-            if [ "$booted" = "$built" ]; then
-              ${nixos-rebuild} switch ${toString cfg.flags}
-            else
-              /run/current-system/sw/bin/shutdown -r +1
-            fi
-          '' else ''
-            ${nixos-rebuild} switch ${toString cfg.flags}
-        '';
+        nixos-rebuild =
+          "${config.system.build.nixos-rebuild}/bin/nixos-rebuild";
+      in if cfg.allowReboot then ''
+        ${nixos-rebuild} boot ${toString cfg.flags}
+        booted="$(readlink /run/booted-system/{initrd,kernel,kernel-modules})"
+        built="$(readlink /nix/var/nix/profiles/system/{initrd,kernel,kernel-modules})"
+        if [ "$booted" = "$built" ]; then
+          ${nixos-rebuild} switch ${toString cfg.flags}
+        else
+          /run/current-system/sw/bin/shutdown -r +1
+        fi
+      '' else ''
+        ${nixos-rebuild} switch ${toString cfg.flags}
+      '';
 
       startAt = cfg.dates;
     };
 
-    systemd.timers.nixos-upgrade.timerConfig.RandomizedDelaySec = cfg.randomizedDelaySec;
+    systemd.timers.nixos-upgrade.timerConfig.RandomizedDelaySec =
+      cfg.randomizedDelaySec;
 
   };
 


### PR DESCRIPTION
###### Motivation for this change
automatic NixOS upgrades via a flake

###### Things done
added flake option to `system.autoUpgrade`

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
