### PR TITLE
pythonPackages.django2_2: 2.2.11 -> 2.2.13

### DIFF
--- a/pkgs/development/python-modules/django/2_2.nix
+++ b/pkgs/development/python-modules/django/2_2.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "Django";
-  version = "2.2.11";
+  version = "2.2.13";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0l0gndky4nwc1jk68b31m583a9g0fhmll903p0xislyyddz3iqk5";
+    sha256 = "103db5gmny6bkq9jgr2m6gdfy1n29bj2v87184y1zgpdmkv71ww4";
   };
 
   patches = stdenv.lib.optional withGdal


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes: CVE-2020-13254, CVE-2020-13596

> https://www.djangoproject.com/weblog/2020/jun/03/security-releases/ <https://www.djangoproject.com/weblog/2020/jun/03/security-releases/>
> 
> In accordance with `our security release policy <https://docs.djangoproject.com/en/dev/internals/security/>`_, the Django team is issuing `Django 3.0.7 <https://docs.djangoproject.com/en/dev/releases/3.0.7/>`_ and `Django 2.2.13 <https://docs.djangoproject.com/en/dev/releases/2.2.13/>`_. These releases address the security issue detailed below. We encourage all users of Django to upgrade as soon as possible.
> 
> CVE-2020-13254: Potential data leakage via malformed memcached keys
> ===================================================================
> 
> In cases where a memcached backend does not perform key validation, passing
> malformed cache keys could result in a key collision, and potential data
> leakage. In order to avoid this vulnerability, key validation is added to the
> memcached cache backends.
> 
> Thank you to Dan Palmer for the report and patch.
> 
> CVE-2020-13596: Possible XSS via admin ``ForeignKeyRawIdWidget``
> ================================================================
> 
> Query parameters for the admin ``ForeignKeyRawIdWidget`` were not properly URL
> encoded, posing an XSS attack vector. ``ForeignKeyRawIdWidget`` now
> ensures query parameters are correctly URL encoded.
> 
> Thank you to Jon Dufresne for the report and patch.
> 
> Affected supported versions
> ===========================
> 
> * Django master branch
> * Django 3.1 (currently at alpha status)
> * Django 3.0
> * Django 2.2
> 
> Resolution
> ==========
> 
> Patches to resolve the issue have been applied to Django's master branch and
> the 3.1, 3.0, and 2.2 release branches. The patches may be obtained from the following changesets:
> 
> CVE-2020-13254:
> 
> * On the `master branch <https://github.com/django/django/commit/2c82414914ae6476be5a166be9ff49c24d0d9069>`__
> * On the `3.1 release branch <https://github.com/django/django/commit/580bd64c0482ae9b7c05715390e25f4405a12719>`__
> * On the `3.0 release branch <https://github.com/django/django/commit/84b2da5552e100ae3294f564f6c862fef8d0e693>`__
> * On the `2.2 release branch <https://github.com/django/django/commit/07e59caa02831c4569bbebb9eb773bdd9cb4b206>`__
> 
> CVE-2020-13596:
> 
> * On the `master branch <https://github.com/django/django/commit/2dd4d110c159d0c81dff42eaead2c378a0998735>`__
> * On the `3.1 release branch <https://github.com/django/django/commit/49d7cc19e33a104bb23f7ae1dbb1240b4f6c40f9>`__
> * On the `3.0 release branch <https://github.com/django/django/commit/1f2dd37f6fcefdd10ed44cb233b2e62b520afb38>`__
> * On the `2.2 release branch <https://github.com/django/django/commit/6d61860b22875f358fac83d903dc629897934815>`__
> 
> The following releases have been issued:
> 
> * Django 3.0.7 (`download Django 3.0.7 <https://www.djangoproject.com/m/releases/3.0/Django-3.0.7.tar.gz>`_ | `3.0.7 checksums <https://www.djangoproject.com/m/pgp/Django-3.0.7.checksum.txt>`_)
> * Django 2.2.13 (`download Django 2.2.13 <https://www.djangoproject.com/m/releases/2.2/Django-2.2.13.tar.gz>`_ | `2.2.13 checksums <https://www.djangoproject.com/m/pgp/Django-2.2.13.checksum.txt>`_)
> 
> The PGP key ID used for these releases is Carlton Gibson: E17DF5C82B4F9D00.
> 
> General notes regarding security reporting
> ==========================================
> 
> As always, we ask that potential security issues be reported via
> private email to ``security@djangoproject.com``, and not via Django's
> Trac instance or the django-developers list. Please see `our security
> policies <https://www.djangoproject.com/security/>`_ for further
> information.
> 

via https://seclists.org/oss-sec/2020/q2/159

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@lsix @georgewhewell 