### PR TITLE
lxappearance: default to Gtk3

### DIFF
--- a/pkgs/desktops/lxde/core/lxappearance/default.nix
+++ b/pkgs/desktops/lxde/core/lxappearance/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, libX11, gtk2, withGtk3 ? false, gtk3 }:
+{ stdenv, fetchurl, intltool, pkgconfig, libX11, gtk2, withGtk3 ? true, gtk3 }:
 
 stdenv.mkDerivation rec {
   name = "lxappearance-0.6.3";

--- a/pkgs/desktops/lxde/core/lxappearance/default.nix
+++ b/pkgs/desktops/lxde/core/lxappearance/default.nix
@@ -1,26 +1,42 @@
-{ stdenv, fetchurl, intltool, pkgconfig, libX11, gtk2, withGtk3 ? true, gtk3 }:
+{ stdenv
+, fetchurl
+, intltool
+, pkg-config
+, libX11
+, gtk2
+, gtk3
+, withGtk3 ? true
+}:
 
 stdenv.mkDerivation rec {
   name = "lxappearance-0.6.3";
 
-  src = fetchurl{
+  src = fetchurl {
     url = "mirror://sourceforge/project/lxde/LXAppearance/${name}.tar.xz";
     sha256 = "0f4bjaamfxxdr9civvy55pa6vv9dx1hjs522gjbbgx7yp1cdh8kj";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool ];
+  nativeBuildInputs = [
+    pkg-config
+    intltool
+  ];
 
-  buildInputs = [ libX11 (if withGtk3 then gtk3 else gtk2) ];
+  buildInputs = [
+    libX11
+    (if withGtk3 then gtk3 else gtk2)
+  ];
 
-  patches = [ ./lxappearance-0.6.3-xdg.system.data.dirs.patch ];
+  patches = [
+    ./lxappearance-0.6.3-xdg.system.data.dirs.patch
+  ];
 
   configureFlags = stdenv.lib.optional withGtk3 "--enable-gtk3";
 
-  meta = {
-    description = "A lightweight program for configuring the theme and fonts of gtk applications";
+  meta = with stdenv.lib; {
+    description = "Lightweight program for configuring the theme and fonts of gtk applications";
     homepage = "https://lxde.org/";
-    maintainers = [ stdenv.lib.maintainers.hinton ];
-    platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.gpl2;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ hinton romildo ];
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -275,6 +275,7 @@ mapAliases ({
   lua5_1_sockets = lua51Packages.luasocket; # added 2017-05-02
   lua5_expat = luaPackages.luaexpat; # added 2017-05-02
   lua5_sec = luaPackages.luasec; # added 2017-05-02
+  lxappearance-gtk3 = throw "lxappearance-gtk3 has been removed. Use lxappearance instead, which now defaults to Gtk3";  # added 2020-06-03
   m3d-linux = m33-linux; # added 2016-08-13
   man_db = man-db; # added 2016-05
   manpages = man-pages; # added 2015-12-06

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9536,12 +9536,11 @@ in
     nodejs = nodejs-13_x;
   };
 
-  lxappearance = callPackage ../desktops/lxde/core/lxappearance {
-    gtk2 = gtk2-x11;
-  };
+  lxappearance = callPackage ../desktops/lxde/core/lxappearance { };
 
-  lxappearance-gtk3 = lxappearance.override {
-    withGtk3 = true;
+  lxappearance-gtk2 = callPackage ../desktops/lxde/core/lxappearance {
+    gtk2 = gtk2-x11;
+    withGtk3 = false;
   };
 
   lxmenu-data = callPackage ../desktops/lxde/core/lxmenu-data.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- make Gtk3 the default
- remove `lxappearance-gtk3`
- add `lxappearance-gtk2`
- format with `nixpkgs-fmt`
- use pkg-config instead of the alias `pkgconfig`
- add romildo as maintainer

See also https://github.com/NixOS/nixpkgs/issues/26909#issuecomment-459002407

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).