### PR TITLE
Add {pkgsMusl,pkgsStatic}.stdenv to build on hydra

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -183,6 +183,9 @@ let
       idrisPackages = packagePlatforms pkgs.idrisPackages;
       agdaPackages = packagePlatforms pkgs.agdaPackages;
 
+      pkgsMusl.stdenv = linux;
+      pkgsStatic.stdenv = linux;
+
       tests = packagePlatforms pkgs.tests;
 
       # Language packages disabled in https://github.com/NixOS/nixpkgs/commit/ccd1029f58a3bb9eca32d81bf3f33cb4be25cc66

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -183,8 +183,8 @@ let
       idrisPackages = packagePlatforms pkgs.idrisPackages;
       agdaPackages = packagePlatforms pkgs.agdaPackages;
 
-      pkgsMusl.stdenv = linux;
-      pkgsStatic.stdenv = linux;
+      pkgsMusl.stdenv = [ "x86_64-linux" "aarch64-linux" ];
+      pkgsStatic.stdenv = [ "x86_64-linux" "aarch64-linux" ];
 
       tests = packagePlatforms pkgs.tests;
 


### PR DESCRIPTION
We've broken Musl stdenv quite a few times, so it makes sense to make build it and block the channel.

Musl has become quite mainstream and more and more things depend on it.

I've hit this since I'd like for patchelf to build against musl on CI for regression testing.

Fixes #81137 