### PR TITLE
rbenv: init at 1.1.2

### DIFF
--- a/pkgs/development/ruby-modules/rbenv/default.nix
+++ b/pkgs/development/ruby-modules/rbenv/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, bash, installShellFiles }:
+
+stdenv.mkDerivation rec {
+  pname = "rbenv";
+  version = "1.1.2";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  src = fetchFromGitHub {
+    owner = "rbenv";
+    repo = "rbenv";
+    rev = "v${version}";
+    sha256 = "12i050vs35iiblxga43zrj7xwbaisv3mq55y9ikagkr8pj1vmq53";
+  };
+
+  postPatch = ''
+     patchShebangs src/configure
+     pushd src
+  '';
+
+  installPhase = ''
+    popd
+    mkdir -p $out/bin
+    mv libexec $out
+    ln -s $out/libexec/rbenv $out/bin/rbenv
+
+    installShellCompletion completions/rbenv.{bash,zsh}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Groom your app’s Ruby environment";
+    longDescription = ''
+      Use rbenv to pick a Ruby version for your application and guarantee that your development environment matches production.
+      Put rbenv to work with Bundler for painless Ruby upgrades and bulletproof deployments.
+    '';
+    homepage = "https://github.com/rbenv/rbenv";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fzakaria ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10646,6 +10646,8 @@ in
 
   solargraph = callPackage ../development/ruby-modules/solargraph { };
 
+  rbenv = callPackage ../development/ruby-modules/rbenv { };
+
   inherit (callPackage ../development/interpreters/ruby {
     inherit (darwin) libiconv libobjc libunwind;
     inherit (darwin.apple_sdk.frameworks) Foundation;


### PR DESCRIPTION
Add new derivation for rbenv -- a ruby environment manager.

###### Motivation for this change

Add an additional package _rbenv_

###### Things done

I am a newcommer to Nix; so some of these _Things done_ are a bit unknown to me.
I'm happy to help resolve any requests though.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
