### PR TITLE
gitlab: 12.10.8 -> 12.10.9

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,11 +1,11 @@
 {
-  "version": "12.10.8",
-  "repo_hash": "189l6l47s5lz0y2qjbai1n9l6yq513d38apyv88c3by3r41m86y1",
+  "version": "12.10.9",
+  "repo_hash": "0mhvw09rvvq4iq18s6xfnl17irg305pxkwjgrsn7k06k0zf4dx5l",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v12.10.8-ee",
+  "rev": "v12.10.9-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "12.10.8",
+    "GITALY_SERVER_VERSION": "12.10.9",
     "GITLAB_PAGES_VERSION": "1.17.0",
     "GITLAB_SHELL_VERSION": "12.2.0",
     "GITLAB_WORKHORSE_VERSION": "8.30.2"

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -19,14 +19,14 @@ let
       };
   };
 in buildGoPackage rec {
-  version = "12.10.8";
+  version = "12.10.9";
   pname = "gitaly";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "02dih35j97q80kzi46pkf9f9r1sffw11i5zmpjs2rr96al426g8q";
+    sha256 = "0rcds6shwmqv2acjdj1i0jhjcp3ww8b1aysqqsyvsgfaa160n9s9";
   };
 
   # Fix a check which assumes that hook files are writeable by their

--- a/pkgs/applications/version-management/gitlab/gitaly/deps.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/deps.nix
@@ -10,6 +10,15 @@
     };
   }
   {
+    goPackagePath = "dmitri.shuralyov.com/gpu/mtl";
+    fetch = {
+      type = "git";
+      url = "https://dmitri.shuralyov.com/gpu/mtl";
+      rev = "666a987793e9";
+      sha256 = "1isd03hgiwcf2ld1rlp0plrnfz7r4i7c5q4kb6hkcd22axnmrv0z";
+    };
+  }
+  {
     goPackagePath = "github.com/BurntSushi/toml";
     fetch = {
       type = "git";
@@ -1427,8 +1436,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/ugorji/go";
-      rev = "v1.1.4";
-      sha256 = "0ma2qvn5wqvjidpdz74x832a813qnr1cxbx6n6n125ak9b3wbn5w";
+      rev = "d75b2dcb6bc8";
+      sha256 = "0di1k35gpq9bp958ywranpbskx2vdwlb38s22vl9rybm3wa5g3ps";
     };
   }
   {

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/deps.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/deps.nix
@@ -10,6 +10,15 @@
     };
   }
   {
+    goPackagePath = "dmitri.shuralyov.com/gpu/mtl";
+    fetch = {
+      type = "git";
+      url = "https://dmitri.shuralyov.com/gpu/mtl";
+      rev = "666a987793e9";
+      sha256 = "1isd03hgiwcf2ld1rlp0plrnfz7r4i7c5q4kb6hkcd22axnmrv0z";
+    };
+  }
+  {
     goPackagePath = "github.com/BurntSushi/toml";
     fetch = {
       type = "git";


### PR DESCRIPTION
###### Motivation for this change
https://about.gitlab.com/releases/2020/06/03/critical-security-release-13-0-4-released

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
