### PR TITLE
python3Packages.nipype: 1.4.2 -> 1.5.0

### DIFF
--- a/pkgs/development/python-modules/ci-info/default.nix
+++ b/pkgs/development/python-modules/ci-info/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, isPy27, fetchPypi, pytest, pytestCheckHook }:
+
+buildPythonPackage rec {
+  version = "0.2.0";
+  pname = "ci-info";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05j6pamk8sd51qmvpkl3f7sxajmncrqm0cz6n6bqgsvzjwn66w6x";
+  };
+
+  checkInputs = [ pytest pytestCheckHook ];
+
+  doCheck = false;  # both tests access network
+
+  pythonImportsCheck = [ "ci_info" ];
+
+  meta = with lib; {
+    description = "Gather continuous integration information on the fly";
+    homepage = "https://github.com/mgxd/ci-info";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/ci-py/default.nix
+++ b/pkgs/development/python-modules/ci-py/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, pytest, pytestrunner, pytestCheckHook }:
+
+buildPythonPackage rec {
+  version = "1.0.0";
+  pname = "ci-py";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12ax07n81vxbyayhwzi1q6x7gfmwmvrvwm1n4ii6qa6fqlp9pzj7";
+  };
+
+  checkInputs = [ pytest pytestrunner pytestCheckHook ];
+
+  pythonImportsCheck = [ "ci" ];
+
+  meta = with lib; {
+    description = "Library for working with Continuous Integration services";
+    homepage = "https://github.com/grantmcconnaughey/ci.py";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/etelemetry/default.nix
+++ b/pkgs/development/python-modules/etelemetry/default.nix
@@ -1,15 +1,17 @@
-{ lib, buildPythonPackage, fetchPypi, requests, pytest }:
+{ lib, buildPythonPackage, isPy27, fetchPypi, requests, ci-info, ci-py, pytest }:
 
 buildPythonPackage rec {
-  version = "0.1.2";
+  version = "0.2.1";
   pname = "etelemetry";
+
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0m3dqvs3xbckmjiwppy366qmgzx0z917j1d7dadfl3bprgipy51j";
+    sha256 = "1rw8im09ppnb7z7p7rx658rp5ib8zca8byxg1kiflqwgx5c8zddz";
   };
 
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [ ci-info ci-py requests ];
 
   # all 2 of the tests both try to pull down from a url
   doCheck = false;

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -2,16 +2,13 @@
 , buildPythonPackage
 , fetchPypi
 , isPy3k
-, isPy38
 # python dependencies
 , click
-, configparser ? null
 , dateutil
 , etelemetry
 , filelock
 , funcsigs
 , future
-, futures
 , mock
 , networkx
 , nibabel
@@ -39,8 +36,6 @@
 , callPackage
 }:
 
-assert !isPy3k -> configparser != null;
-
 let
 
  # This is a temporary convenience package for changes waiting to be merged into the primary rdflib repo.
@@ -50,11 +45,13 @@ in
 
 buildPythonPackage rec {
   pname = "nipype";
-  version = "1.4.2";
+  version = "1.5.0";
+
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1nr0z0k4xx1vswkp03g1lf8141mr4j2fbwd7wmpay4vz46qcp786";
+    sha256 = "1a9xapw2cvpbs9dvrg5bzx7hw8fr5j50r8mc27cqb3m6vappx0wc";
   };
 
   postPatch = ''
@@ -85,10 +82,6 @@ buildPythonPackage rec {
     simplejson
     traits
     xvfbwrapper
-  ] ++ stdenv.lib.optionals (!isPy3k) [
-    configparser
-    futures
-    pathlib2 # darwin doesn't receive this transitively, but it is in install_requires
   ];
 
   checkInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1987,6 +1987,8 @@ in {
 
   chevron = callPackage ../development/python-modules/chevron {};
 
+  ci-info = callPackage ../development/python-modules/ci-info { };
+
   cli-helpers = callPackage ../development/python-modules/cli-helpers {};
 
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1989,6 +1989,8 @@ in {
 
   ci-info = callPackage ../development/python-modules/ci-info { };
 
+  ci-py = callPackage ../development/python-modules/ci-py { };
+
   cli-helpers = callPackage ../development/python-modules/cli-helpers {};
 
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };


### PR DESCRIPTION
python3Packages.ci-info: init at 0.2.0
python3Packages.ci-py: init at 1.0.0
python3Packages.etelemetry: 0.1.2 -> 0.2.1

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - only `heudiconv`; builds fine with 3.7 and disabled with 3.8
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
