### PR TITLE
bpython: substituteAll the path to `which`

### DIFF
--- a/pkgs/development/python-modules/bpython/clipboard-make-which-substitutable.patch
+++ b/pkgs/development/python-modules/bpython/clipboard-make-which-substitutable.patch
@@ -1,0 +1,27 @@
+From 6f544a5bd43446859754cb80e012af933b843db9 Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Wed, 3 Jun 2020 22:05:34 +0200
+Subject: [PATCH] clipboard: make which substitutable
+
+This is used to detect the presence of xclip and other clipboard
+handling tools.
+---
+ bpython/clipboard.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bpython/clipboard.py b/bpython/clipboard.py
+index aee429b..f346429 100644
+--- a/bpython/clipboard.py
++++ b/bpython/clipboard.py
+@@ -58,7 +58,7 @@ class OSXClipboard(object):
+ 
+ def command_exists(command):
+     process = subprocess.Popen(
+-        ["which", command], stderr=subprocess.STDOUT, stdout=subprocess.PIPE
++        ["@which@", command], stderr=subprocess.STDOUT, stdout=subprocess.PIPE
+     )
+     process.communicate()
+ 
+-- 
+2.26.2
+

--- a/pkgs/development/python-modules/bpython/default.nix
+++ b/pkgs/development/python-modules/bpython/default.nix
@@ -1,4 +1,14 @@
-{ stdenv, buildPythonPackage, fetchPypi, pygments, greenlet, curtsies, urwid, requests, mock }:
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, curtsies
+, greenlet
+, mock
+, pygments
+, requests
+, substituteAll
+, urwid
+, which }:
 
 buildPythonPackage rec {
   pname = "bpython";
@@ -8,6 +18,11 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1764ikgj24jjq46s50apwkydqvy5a13adb2nbszk8kbci6df0v27";
   };
+
+  patches = [ (substituteAll {
+    src = ./clipboard-make-which-substitutable.patch;
+    which = "${which}/bin/which";
+  })];
 
   propagatedBuildInputs = [ curtsies greenlet pygments requests urwid ];
 


### PR DESCRIPTION
This is used to detect the presence of xclip and other clipboard
handling tools.

Tested by actually copying something to the clipboard :-)

###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/56941.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @memberbetty 