### PR TITLE
[haskell-updates] haskellPackages.ghcide: 0.1.0 -> 0.2.0 (fix build) 

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1479,15 +1479,17 @@ self: super: {
   };
 
   # Needed for ghcide
-  haskell-lsp_0_19_0_0 = super.haskell-lsp_0_19_0_0.override {
-    haskell-lsp-types = self.haskell-lsp-types_0_19_0_0;
+  haskell-lsp_0_22_0_0 = super.haskell-lsp_0_22_0_0.override {
+    haskell-lsp-types = self.haskell-lsp-types_0_22_0_0;
   };
 
   # this will probably need to get updated with every ghcide update,
   # we need an override because ghcide is tracking haskell-lsp closely.
   ghcide = dontCheck (super.ghcide.override rec {
-    haskell-lsp-types = self.haskell-lsp-types_0_19_0_0;
-    haskell-lsp = self.haskell-lsp_0_19_0_0;
+    haskell-lsp-types = self.haskell-lsp-types_0_22_0_0;
+    haskell-lsp = self.haskell-lsp_0_22_0_0;
+    hie-bios = self.hie-bios_0_5_0;
+    ghc-check = self.ghc-check_0_3_0_1;
   });
 
   # stackage right now is not new enough for hlint-3.0

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2396,6 +2396,7 @@ extra-packages:
   - dhall == 1.29.0                     # required for spago 0.14.0.
   - doctemplates == 0.8                 # required by pandoc-2.9.x
   - generic-deriving == 1.10.5.*        # new versions don't compile with GHC 7.10.x
+  - ghc-check == 0.3.0.1                # only version compatible with ghcide 0.2.0
   - ghc-tcplugins-extra ==0.3.2         # required for polysemy-plugin 0.2.5.0
   - gloss < 1.9.3                       # new versions don't compile with GHC 7.8.x
   - haddock == 2.22.*                   # required on GHC 8.0.x
@@ -2405,8 +2406,8 @@ extra-packages:
   - happy <1.19.6                       # newer versions break Agda
   - happy == 1.19.9                     # for purescript
   - haskell-gi-overloading == 0.0       # gi-* packages use this dependency to disable overloading support
-  - haskell-lsp == 0.19.*               # required for ghcide 0.1.0
-  - haskell-lsp-types == 0.19.*         # required for ghcide 0.1.0
+  - haskell-lsp == 0.22.*               # required for ghcide 0.2.0
+  - haskell-lsp-types == 0.22.*         # required for ghcide 0.2.0
   - haskell-src-exts == 1.19.*          # required by hindent and structured-haskell-mode
   - hinotify == 0.3.9                   # for xmonad-0.26: https://github.com/kolmodin/hinotify/issues/29
   - hoogle == 5.0.14                    # required by hie-hoogle

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -734,6 +734,7 @@ self: super: builtins.intersectAttrs super {
 
   # Tests access homeless-shelter.
   hie-bios = dontCheck super.hie-bios;
+  hie-bios_0_5_0 = dontCheck super.hie-bios_0_5_0;
 
   # Compiling the readme throws errors and has no purpose in nixpkgs
   aeson-gadt-th =


### PR DESCRIPTION
I decided to leave haskell-lsp and haskell-lsp-types as extra packages,
because they will get bumped before the next ghcide release, and then
the version pinned by ghcide would be missing again.

Also I have run hackage2nix to automatically generate the changes.

If desired I can split the second part into its own commit, would that be better?
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix new ghcide version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
