### PR TITLE
[haskell-updates] ghc.withPackages: Add wrapper for ghcide

### DIFF
--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -105,6 +105,15 @@ symlinkJoin {
         --set "NIX_${ghcCommandCaps}_LIBDIR" "${libDir}"
     fi
 
+    # ghcide does package discovery without calling our ghc wrapper.
+    if [[ -x "$out/bin/ghcide" ]]; then
+      wrapProgram $out/bin/ghcide  \
+          --set "NIX_${ghcCommandCaps}"        "$out/bin/${ghcCommand}"     \
+          --set "NIX_${ghcCommandCaps}PKG"     "$out/bin/${ghcCommand}-pkg" \
+          --set "NIX_${ghcCommandCaps}_DOCDIR" "${docDir}"                  \
+          --set "NIX_${ghcCommandCaps}_LIBDIR" "${libDir}"
+    fi
+
   '' + (lib.optionalString (stdenv.targetPlatform.isDarwin && !isGhcjs && !stdenv.targetPlatform.isiOS) ''
     # Work around a linker limit in macOS Sierra (see generic-builder.nix):
     local packageConfDir="$out/lib/${ghc.name}/package.conf.d";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This might be controversial. So I am open to different approaches.

###### This is the problem:

When installing packages via `ghc.withPackages`, `ghcide` will not work on projects relying on this. Because the cabal in that project will choose the version of a dependency provided by ghc.withPackages` which then `ghcide` which does package discovery on it‘s own can‘t find, because it can‘t find packages from the wrapped `ghc`.

###### What I did

When building `ghc.withPackages` with `ghcide` as a package. The `ghcide` binary will be wrapped with the same environment variables as `ghc`.

###### Alternatives
The alternative is to tell users to grep the variables from the ghc wrapper used. But users will probably not find that documentation early and in between they have a broken ghcide which is hard to debug.

###### Problems
The problem with this approach is, that this will only help, if the user installs `ghcide` via `ghc.withPackages`. It wont work if `ghcide` is installed separately as `haskellPackages.ghcide`.

Yet I think that is useful setup that would be nice to support.

Of course special casing for certain packages in withPackages should be limited. If there is another more modular approach to achieve this, I would be open to that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
