### PR TITLE
tailscale: 0.97-219 -> 0.99.1-0

### DIFF
--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -2,15 +2,16 @@
 
 buildGoModule rec {
   pname = "tailscale";
-  version = "0.97-219";
+  # Tailscale uses "git describe" as version numbers. 0.99.1-0 means
+  # "tag v0.99.1 plus 0 commits", which corresponds to rev="v0.99.1"
+  # below.
+  version = "0.99.1-0";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    # Tailscale uses "git describe" as version numbers. v0.97-219
-    # means "tag v0.97 plus 219 commits", which is what this rev is.
-    rev = "afbfe4f217a2a202f0eefe943c7c1ef648311339";
-    sha256 = "1an897ys3gycdmclqd0yqs9f7q88zxqxyc6r0gcgs4678svxhb68";
+    rev = "v0.99.1";
+    sha256 = "1kq4x5xknv0qq6n78xj5wjbf6svbdyw4nzs7z5gjb3ylj2vl97pb";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -18,14 +19,7 @@ buildGoModule rec {
   CGO_ENABLED = 0;
 
   goPackagePath = "tailscale.com";
-  overrideModAttrs = (_: {
-    preBuild = ''
-    rm ipn/e2e_test.go
-    rm control/controlclient/auto_test.go
-    rm control/controlclient/direct_test.go
-    '';
-  });
-  vendorSha256 = "1v90lbwgrc2m4kvpglf2jykrm8rry3pbhqqbc3mcysrzmqlw84yl";
+  vendorSha256 = "0yf2zdpd12w4qf4sbv7bkr40hw5faqynr6lb84v7w6v0az0nfzds";
   subPackages = [ "cmd/tailscale" "cmd/tailscaled" ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Upstream stable release.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
