### PR TITLE
kdeFrameworks.qqc2-desktop-style: init at 5.68 (backport to stable)

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -105,8 +105,10 @@ let
       kdbusaddons = callPackage ./kdbusaddons.nix {};
       kdnssd = callPackage ./kdnssd.nix {};
       kguiaddons = callPackage ./kguiaddons.nix {};
+      kholidays = callPackage ./kholidays.nix {};
       ki18n = callPackage ./ki18n.nix {};
       kidletime = callPackage ./kidletime.nix {};
+      kirigami2 = callPackage ./kirigami2.nix {};
       kitemmodels = callPackage ./kitemmodels.nix {};
       kitemviews = callPackage ./kitemviews.nix {};
       kplotting = callPackage ./kplotting.nix {};
@@ -117,12 +119,11 @@ let
       networkmanager-qt = callPackage ./networkmanager-qt.nix {};
       oxygen-icons5 = callPackage ./oxygen-icons5.nix {};
       prison = callPackage ./prison.nix {};
+      qqc2-desktop-style = callPackage ./qqc2-desktop-style.nix {};
       solid = callPackage ./solid.nix {};
       sonnet = callPackage ./sonnet.nix {};
       syntax-highlighting = callPackage ./syntax-highlighting.nix {};
       threadweaver = callPackage ./threadweaver.nix {};
-      kirigami2 = callPackage ./kirigami2.nix {};
-      kholidays = callPackage ./kholidays.nix {};
 
     # TIER 2
       kactivities = callPackage ./kactivities.nix {};

--- a/pkgs/development/libraries/kde-frameworks/qqc2-desktop-style.nix
+++ b/pkgs/development/libraries/kde-frameworks/qqc2-desktop-style.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, lib
+, extra-cmake-modules
+, qtquickcontrols2
+, qtx11extras
+, kconfig
+, kiconthemes
+, kirigami2
+}:
+
+mkDerivation {
+  name = "qqc2-desktop-style";
+  meta = { maintainers = with lib.maintainers; [ ttuegel ]; };
+  nativeBuildInputs = [ extra-cmake-modules ];
+  buildInputs = [ qtx11extras qtquickcontrols2 kconfig kiconthemes kirigami2 ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13910,7 +13910,7 @@ in
       knotifyconfig kpackage kparts kpeople kplotting kpty kross krunner
       kservice ktexteditor ktextwidgets kunitconversion kwallet kwayland
       kwidgetsaddons kwindowsystem kxmlgui kxmlrpcclient modemmanager-qt
-      networkmanager-qt plasma-framework prison solid sonnet syntax-highlighting
+      networkmanager-qt plasma-framework prison qqc2-desktop-style solid sonnet syntax-highlighting
       syndication threadweaver kirigami2 kholidays kpurpose kcontacts;
 
     ### KDE PLASMA 5


### PR DESCRIPTION
(cherry picked from commit 9cc24aa9f0dd9f2d65fd56fd0fdac31555eaa23c)

###### Motivation for this change

Fixes #79713

Cc: @schmittlauch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
