### PR TITLE
Mailman updates

### DIFF
--- a/pkgs/development/python-modules/django-mailman3/default.nix
+++ b/pkgs/development/python-modules/django-mailman3/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "django-mailman3";
-  version = "1.3.2";
+  version = "1.3.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1vq5qa136h4rz4hjznnk6y8l443i41yh4w4wxg20f9b059xrsld1";
+    sha256 = "1q9ciy2yawgvbha5kwlzwdmdqvas287dc0i60ygp2799jnfr5dr6";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/importlib-metadata/default.nix
+++ b/pkgs/development/python-modules/importlib-metadata/default.nix
@@ -13,12 +13,12 @@
 
 buildPythonPackage rec {
   pname = "importlib-metadata";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchPypi {
     pname = "importlib_metadata";
     inherit version;
-    sha256 = "00ikdj4gjhankdljnz7g5ggak4k9lql2926x0x117ir9j2lv7x86";
+    sha256 = "07icyggasn38yv2swdrd8z6i0plazmc9adavsdkbqqj91j53ll9l";
   };
 
   nativeBuildInputs = [ setuptools_scm ];
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ zipp ]
     ++ lib.optionals (!isPy3k) [ pathlib2 contextlib2 configparser ];
 
-  checkInputs = [ importlib-resources packaging ];
+  doCheck = false; # Cyclic dependencies.
 
   # removing test_main.py - it requires 'pyflakefs'
   # and adding `pyflakefs` to `checkInputs` causes infinite recursion.

--- a/pkgs/development/python-modules/importlib-resources/default.nix
+++ b/pkgs/development/python-modules/importlib-resources/default.nix
@@ -1,24 +1,28 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pathlib2
+, setuptools_scm
+, toml
+, importlib-metadata
 , typing
-, isPy3k
+, singledispatch
 , pythonOlder
 , python
 }:
 
 buildPythonPackage rec {
   pname = "importlib_resources";
-  version = "1.0.2";
+  version = "1.5.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078";
+    sha256 = "1jilyxyb2z7hzcjhx1ddni52mq00i728wqh8f5k4469yhdkdz1vg";
   };
 
+  nativeBuildInputs = [ setuptools_scm toml ];
   propagatedBuildInputs = [
-  ] ++ lib.optional (!isPy3k) pathlib2
+    importlib-metadata
+  ] ++ lib.optional (pythonOlder "3.4") singledispatch
     ++ lib.optional (pythonOlder "3.5") typing
   ;
 

--- a/pkgs/development/python-modules/mailmanclient/default.nix
+++ b/pkgs/development/python-modules/mailmanclient/default.nix
@@ -2,19 +2,15 @@
 
 buildPythonPackage rec {
   pname = "mailmanclient";
-  version = "3.3.0";
+  version = "3.3.1";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c8736cbe152ae1bd58b46ccfbcafb6a1e301513530772e7fda89f91d1e5c1ae9";
+    sha256 = "0pjgzpvhdb6ql8asb20xr8d01m646zpghmcp9fmscks0n1k4di4g";
   };
 
   propagatedBuildInputs = [ six httplib2 requests ];
-
-  # no tests with Pypi tar ball, checkPhase removes setup.py which invalidates import check
-  doCheck = false;
-  pythonImportsCheck = [ "mailmanclient" ];
 
   meta = with stdenv.lib; {
     homepage = "https://www.gnu.org/software/mailman/";

--- a/pkgs/development/python-modules/zope_interface/default.nix
+++ b/pkgs/development/python-modules/zope_interface/default.nix
@@ -6,14 +6,16 @@
 
 buildPythonPackage rec {
   pname = "zope.interface";
-  version = "4.7.2";
-  
+  version = "5.1.0";
+
   src = fetchPypi {
     inherit pname version;
-    sha256 = "fd1101bd3fcb4f4cf3485bb20d6cb0b56909b94d3bd2a53a6cb9d381c3da3365";
+    sha256 = "03nrl6b8cb600dnnh46y149awvrm0gxyqgwq5hdw3lvys8mw9r20";
   };
 
   propagatedBuildInputs = [ zope_event ];
+
+  doCheck = false; # Circular deps.
 
   meta = with stdenv.lib; {
     description = "Zope.Interface";

--- a/pkgs/servers/mail/mailman/default.nix
+++ b/pkgs/servers/mail/mailman/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "mailman";
-  version = "3.3.0";
+  version = "3.3.1";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1qph9i93ndahfxi3bb2sd0kjm2c0pkh844ai6zacfmvihl1k3pvy";
+    sha256 = "0idfiv48jjgc0jq4731094ddhraqq8bxnwmjk6sg5ask0jss9kxq";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/mail/mailman/hyperkitty.nix
+++ b/pkgs/servers/mail/mailman/hyperkitty.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "HyperKitty";
-  version = "1.3.2";
+  version = "1.3.3";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "092fkv0xyf5vgj33xwq0mh9h5c5d56ifwimaqbfpx5cwc6yivb88";
+    sha256 = "0p85r9q6mn5as5b39xp9hkkipnk0156acx540n2ygk3qb3jd4a5n";
   };
 
   nativeBuildInputs = [ isort ];

--- a/pkgs/servers/mail/mailman/postorius.nix
+++ b/pkgs/servers/mail/mailman/postorius.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "postorius";
-  version = "1.3.2";
+  version = "1.3.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0wrm0hda7ym9qaygxirqaaii66ndmgyy7gx8wqdg07pfx14zcyja";
+    sha256 = "08jn23gblbkfl09qlykbpsmp39mmach3sl69h1j5cd5kkx839rwa";
   };
 
   propagatedBuildInputs = [ django-mailman3 readme_renderer ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

Targeting staging because some dependencies needed updating and cause a mass rebuild.

importlib-resources no longer build on Python 2.

Upgraded mailman running fine for me.

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
