### PR TITLE
wireshark: Add Bluetooth

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -12,6 +12,7 @@ with stdenv.lib;
 let
   version = "3.2.4";
   variant = if withQt then "qt" else "cli";
+  pcap = libpcap.override { withBluez = stdenv.isLinux; };
 
 in stdenv.mkDerivation {
   pname = "wireshark-${variant}";
@@ -35,7 +36,7 @@ in stdenv.mkDerivation {
   ] ++ optional withQt qt5.wrapQtAppsHook;
 
   buildInputs = [
-    gettext pcre perl libpcap lua5 libssh nghttp2 openssl libgcrypt
+    gettext pcre perl pcap lua5 libssh nghttp2 openssl libgcrypt
     libgpgerror gnutls geoip c-ares python3 glib zlib makeWrapper
   ] ++ optionals withQt  (with qt5; [ qtbase qtmultimedia qtsvg qttools ])
     ++ optionals stdenv.isLinux  [ libcap libnl ]

--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, flex, bison }:
+{ stdenv, fetchurl, flex, bison, bluez, pkgconfig, withBluez ? false }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "libpcap";
@@ -9,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "153h1378diqyc27jjgz6gg5nxmb4ddk006d9xg69nqavgiikflk3";
   };
 
-  nativeBuildInputs = [ flex bison ];
+  nativeBuildInputs = [ flex bison ]
+    ++ optionals withBluez [ bluez.dev pkgconfig ];
 
   # We need to force the autodetection because detection doesn't
   # work in pure build enviroments.
@@ -18,17 +21,16 @@ stdenv.mkDerivation rec {
       linux = "linux";
       darwin = "bpf";
     }.${stdenv.hostPlatform.parsed.kernel.name})
-  ] ++ stdenv.lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
-    "ac_cv_linux_vers=2"
-  ];
+  ] ++ optionals (stdenv.hostPlatform == stdenv.buildPlatform)
+    [ "ac_cv_linux_vers=2" ];
 
   dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
 
-  prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
+  prePatch = optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace " -arch i386" ""
   '';
 
-  meta = with stdenv.lib; {
+  meta = {
     homepage = "https://www.tcpdump.org";
     description = "Packet Capture Library";
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change
Add support for captuing live data from bluetooth interfaces.
Note: This only works on linux and has been appropriately gated.

It is debatable whether or not libpcap should include bluez support by default on linux.
If it's default enabled then no changes are needed for wireshark (or any other application that want to use it) but iptables must disable it (to avoid a libpcap -> bluez -> dbus -> systemd -> iptables -> libpcap cycle).
If it's default disabled then wireshark needs to enable it but iptables needs no changes.

I've implemented the latter but the change is trivial if prefered. 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
