### PR TITLE
goldendict: 2020-01-09 -> 2020-05-27

### DIFF
--- a/pkgs/applications/misc/goldendict/default.nix
+++ b/pkgs/applications/misc/goldendict/default.nix
@@ -6,17 +6,17 @@
 , withExtraTiff ? true, libtiff
 , withFFmpeg ? true, libao, ffmpeg
 , withMultimedia ? true
-, withZim ? true }:
+, withZim ? true, zstd }:
 
 mkDerivation rec {
   pname = "goldendict";
-  version = "2020-01-09";
+  version = "2020-05-27";
 
   src = fetchFromGitHub {
     owner = "goldendict";
     repo = pname;
-    rev = "da197ff5cd0e7326124c9240a1853a0e8b1de439";
-    sha256 = "0dlzwjh9wg4bzhhib71jycpp21qw762ww63a37dd50z1ymi61lxc";
+    rev = "ec40c1dcfde6df1dc7950443b46ae22c283b1e52";
+    sha256 = "1zmnwwnpnrqfyf7vmmh38r95q2fl4cqzbkp69bcwkr0xc80wgyz7";
   };
 
   patches = [
@@ -39,7 +39,8 @@ mkDerivation rec {
     ++ stdenv.lib.optional withCC opencc
     ++ stdenv.lib.optional withEpwing libeb
     ++ stdenv.lib.optional withExtraTiff libtiff
-    ++ stdenv.lib.optionals withFFmpeg [ libao ffmpeg ];
+    ++ stdenv.lib.optionals withFFmpeg [ libao ffmpeg ]
+    ++ stdenv.lib.optional withZim zstd;
 
   qmakeFlags = with stdenv.lib; [
     "goldendict.pro"


### PR DESCRIPTION
###### Motivation for this change
* Add Zstd compression support for ZIM format
* Update translations
* Fix Wayland crash

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
