### PR TITLE
 thunderbird, thunderbird-bin: 68.8.1 -> 68.9.0 [High security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,615 +1,615 @@
 {
-  version = "68.8.1";
+  version = "68.9.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/ar/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ar/thunderbird-68.9.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "0f604cf3e5efff225cc544b3f289056be05ec430cf1481162f3ab1a84234660802c2777de1552f2900ca9cbf43ff13a468d3c97a44896ea02189471676243d22";
+      sha512 = "7e0a07631f2130d2876e020f7f28817cbca343e0666abd156d8f5c48a7f4bb0f4775f6366deeffdcd0676172e3b75c48c02635d018a5f1050f635f334834908d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/ast/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ast/thunderbird-68.9.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "4c5a5dfdc6d81577df445cee8e4f875c95394f87037feffd47fa22bf4e153fc260f48676e8ff005d3248c31aa346b6756ba9468ae95e542e5814c5a98cfcf7e3";
+      sha512 = "47ef45548aeb20dc8dbd4f35bf12913b642986cf6071f060611696da99da30a2b10c9c8aaff8974f4fc02403026146b516e84f8f2244932f290202ef2aa59853";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/be/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/be/thunderbird-68.9.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "fca5948534a7de3c8a6dafab22e45478b79c20d1722d58fc3f423e3c792d754bcf63993b9a8c1f1c6758ea1585dd700b1ce7631a21274b0f8a05e631992ae5ed";
+      sha512 = "c704c3e4be866d70c098b07bacdd4a1020ec109e92eb85c9c04d20d90db668a36bfef711acbe8bacb897543e3b8d499d35e54875bbe10fb3fc5436f8759828c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/bg/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/bg/thunderbird-68.9.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "907d252bdc8cf65b8d42ca5ee95cd7f43efe48f44d822558139ee04cee2b628966e11599f1d6db0ef5cff33a8ae424d514dc1df4e049a36432647dd3fa1039bf";
+      sha512 = "ac31e7ceb3042c2f2ac4c833687a9a44b6ec593b2d50da2edf9f11fa9bba378dea192cd472470cb7cdb2a0b708b84de688f2988f6161447cf00e5a13fe6cdd9f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/br/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/br/thunderbird-68.9.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "ca82cbb9f61c6ee285a7b075c79aaf4ae09a86b009ea004818fffb7abd8a12708943e5f2edeb89362f7841ed5f6b9099c9e15f6a7efb2dc261a1e63e569d83c9";
+      sha512 = "1c3342c2cca3061d07be17f57d967b1e9e478f5ff91cac1df1dbc901e102e2fbeb68375af20ccc0b6922364c62fcc44a6d7715aee43fef0b2165ac091427708c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/ca/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ca/thunderbird-68.9.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "3cc29b0a077b48ea0ab0d3cde6fb9cf6fe6cdcb1ea914be6ed6d38e1bf382f910fad7920e918d2c9c9131845bb24b2818cfc45349270ff636e8bc216fd2b3059";
+      sha512 = "2a0bca4b9fe58bb7872265384151ae7d2ed87122a9372ffd52752a11bec29b24a8d28f0e3102c0d6f84e545ccc6004fdace3bba7d68de206a3be5c72962c1a9e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/cak/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/cak/thunderbird-68.9.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "184f74a10722a72ad622c54f221b62193259cdd54cd9dc4d71326219fd6dc533c723d5e926bfa0e7a3231a41864fefe578030329f0e24765ddad7459945cc75d";
+      sha512 = "ef27a17f5a44072596b753cd110ed4d24d7355649ddfae988a2d6622871421088d1502866226fc1f18bf8233478b5c00e98f10cf3f920ad6b4a7bad9c5e9cae2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/cs/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/cs/thunderbird-68.9.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "1f76a6f2e9a4804c697d2842389d9fe0aaf1e8b30eaaf0aaf9ccd252c64a20d10b876011ec6cf54e4d6778d03a51673f4d941d1875ba66d31946bd446006daf8";
+      sha512 = "1a68ecf3ae228078c67b296a1642578d8e5a7808707e8a7eab4cbe8191a6b19057fca8e3c4faa660d6a64732ca3a052579fa652bbe5bb30a85d577f7b702e55e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/cy/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/cy/thunderbird-68.9.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "28f9314997024728691ea43b4bb2eec51a8ce8a0da26025c1f6213eb2f20c140dee0c87950a325589c7af8b037f7378025dc05346a7156ee8ea200e89705ed84";
+      sha512 = "4d3cc4a57f3e210129ba47c2fc0798d852e4369a62dfefaf3b9a8fc77939431a7cc5839c667a062231ccf49e6eeedfc60c5492fdbf5eec080233b851203305f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/da/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/da/thunderbird-68.9.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "d65d1b71b93b08bf783a691b26d39a6749c3b0ece109889ea9342f8dce681e47d4785010548f388d943e10632e9539f9747eb4b9ec7da524d8087300961fe3df";
+      sha512 = "79e655f62bc95b65640e3556d2690725ff012a16b2cbe656223a118294915c5619563fbdef9b88fd5db3f982cea5e8ad85a9bc389776ea95ab155539d6a4c217";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/de/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/de/thunderbird-68.9.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "e140fe5153f3c2eadc5bac3891d4c2d2e03e0823da146d78c21884a28bbaa1fc1ea394c726bceaa20ffd2bfd8c1f841966de22fedd3e789b39b8dfabc2bbd930";
+      sha512 = "cad5d0c08e07f6d1247cae9737d0747875b9b35036892093230423d92530fe2de2975174dfd6ec0d2e2d7ddf86027601d37d3fce14343ad4cb89be5d68052785";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/dsb/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/dsb/thunderbird-68.9.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "6c17e859826e48d59777a022273540696ec9c1da026922b46f4538067e34561d3717d2e4d092eae8de9c98bdf7d06a76ddc1af7f2832cd690a466a05d0e0e317";
+      sha512 = "15ca27de99125e4be3f6cf79ebe5e897efea14ea469040ab39ef2e0ab4a6ce61bb22f9afe95a670fcf9e1cf077512b8214226946e4f4a02e7bb04d136390bf6e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/el/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/el/thunderbird-68.9.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "c6d830ad93e67262e22dfc1b2551bd40034a3867fa61e5a4bba773db98405fc8c7683c5f606c591242ce95f1c520d754fbeb3eebb36458e3d78a4b8b19c5a3cf";
+      sha512 = "8fdda97681d04d9247d8030535d15888d24f3462ee8d91ac86ae9b0489ca4a2c759bbbcb151548786febed90de2ff4bf6e77fa55b8bc2b1cd4c8faef374fcc45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/en-GB/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/en-GB/thunderbird-68.9.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "b39dc8f17de38c94332ed3dabfcd29bd8d8334e83010630cf2fc19f2a601dba9d6db64140a604dd4e1fb401d4d5dca718795503345a4e7bdab666e6fa7776d9b";
+      sha512 = "51ccb86fc17862c9264823568fb2453318a8b6625f1d51eecaa150358a9efe4a15126c1a132bc57834645ba3d5799f75dd48e7cacc6305970698bdcad85c0bfd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/en-US/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/en-US/thunderbird-68.9.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "ba1a090f72aa286d94dded8edfbadc7b9c05c4a7f37d485d0d91275dd97ec40322241b3c74f3c183ed13a6cdf6b1d8667858539fba130514eed72dc54e1f4a90";
+      sha512 = "ed6caacf356c6487a489e983275a2c3d00eac3b2282445667a1f26ac9ce217afb8261a929ccc9aa2bdf7a89101a86faee2ef87c16f0677ecf5abcc727397275f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/es-AR/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/es-AR/thunderbird-68.9.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "8b280a3329421c9949821d78c891b7a0b9f7ac6e7ad40f99e49233ad6b3848188e7ed42c40bbaa67a31b270cb19644b033d4046ebeed0b1031567a2988ba98ce";
+      sha512 = "b8e75f5579740c8d0ae7ef30afb133b827c2e217bf9b0acdc8f117b6ffbd6c2674ff8670db87ede6db3c842af8d6f820bfa4370c0d611b7e74e99e8ad67a31b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/es-ES/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/es-ES/thunderbird-68.9.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "4f103d329c694c6b9d676739936ecb1fc61e23d7210252d8c87a28c916f063ef15437cb57949b5935269c922bc0221e2e9c6d536152503b087f0f00ea0946777";
+      sha512 = "e51df8034b18c8dc0d7fa024c3e58317a614f4da4d286c837efac3d21c59d1e58a786cc2ae0afae8730f81e96a4f0263e4fa09b552df3b58f915fd0cad133c62";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/et/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/et/thunderbird-68.9.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "a3e61bfd84ac0c2087abdd2c311c53533ebcc79a87289469aa1708e4d276d44f41ddd657afec21b93d0b499a003014d500939af9d6bd0d4773072019cc19f59c";
+      sha512 = "a81e2bf12df9ba23b8d330599eb9d32d25cb862d3cbd109183c0164ccfd2036bd327aaba36248e85f738d02d15d59f9fcaa837101b154834b53b04d2925ad666";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/eu/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/eu/thunderbird-68.9.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "898add1a1d7315993b18b2e0d0851f07379c346efe905ca1ef8ee9e5fb249f819b720a1de127ce558b576c0c6b4916c52069d117a0d050414ccdeee239e04e11";
+      sha512 = "98a3b4e765683a9fdb9f1b128354ddc8f81ffb7bcdfb3ecc04431e84862d65184f220cddf86ba2a3442f87c27ea990a2868ebf68dce7328857718f9e02ecd474";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/fi/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/fi/thunderbird-68.9.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "d8e6a78f615af1d99c5d23ad050e49add43b06e3cccc727dae512a066d348adda414869adebcce1a4d6b32b0bf666e3a793c9150f521591fd53ab3bb2df04f25";
+      sha512 = "75d0523e83f9f95fdef45fb8b6de632eedb8b274225ac5c6d6d460cc7c129f7e34f735262cbc44e8f99957358e33eb8c8e2ce0cdbbd59d237dde468991139e6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/fr/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/fr/thunderbird-68.9.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "67541072216f3362d81bd0f2894a735562ad6703f583b51cfd114e9f591b3f4f7bf9ba70573f124e5209ff805e192d19ab37df6068306ed34ac98ef9292e7edd";
+      sha512 = "c7b070e1b5dbb682e6dd119436512c5e2200105294f1c4e84c88fc8326f342196da1abaf8b7b4882397cf797070a524c19b640fc41d532885b9ce867de46d055";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/fy-NL/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/fy-NL/thunderbird-68.9.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "1a2be59965ab12c8380373e0dfff660b62d6f9121549799055cb0318dc40bb517b64d203b7c18c80814f0f1a1426db04781ddc896bdcc5c679f7de234fe35068";
+      sha512 = "bd93c4d482231c0c5444b653c045f4951d73c0c4c1ef9126757c41b30280f0009fddec38d8532af2c2e379a26128fe3b5e8db2857709fd2ed226d2fa73f0d88b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/ga-IE/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ga-IE/thunderbird-68.9.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "37159206d5d6533b431ed445bd0fe7d22b654531a4f0f9313db35b8c2c55345d1f6cad18a1711aab6042a082324a843e3362a1399ecb20b3595575dea356b220";
+      sha512 = "f6da6b1635d44f217b1ffe9e446d4ce8fbc82ecd5fa8a0421abdf83a0bdaf46db35343a5345b009fdf09a8237475b393d2cf0cd3f52fa16cd2cca63b792a546b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/gd/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/gd/thunderbird-68.9.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "b42fe49465f0bfc3d950006be6d6422f60572ad3e6be69e0bf78123e4672d5e93bc1abffc51226608a23a8786cd8689f46819cd1e098f38d94b201038ee7bf5b";
+      sha512 = "d6e4c7e51432c4bc81a9470615349624f2d8eea0d6092e53afb833a2cb4a9e770ea4c373fbef424e9139a1668cb695841fe2cf8c752befb650d0e72185693c5c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/gl/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/gl/thunderbird-68.9.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "58be0afc433eb4ea47a2467efe8470cb710b56624cb64c308a7e54955b2792fef72b2f697e3055f86faee51f17a4e111f25f23e88e2e48f2377474e59a555d21";
+      sha512 = "763f2dc852ac4ecc4accd7140ea9c1945bc343342a01efe8b09470cc41f76fad4f61ec25c9456b10a16f9db528fc6aed802d949252b12e0d73c89c299ee813be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/he/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/he/thunderbird-68.9.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "15c24a2abfc20cd8ce7207f45707bb691b742ff07aa90cce1a79dbc20199ee06bb6f80d2db7cae521672678f37b824c567cc21844e234bb4e132866da490389d";
+      sha512 = "82d66c85f843978d9b2e3e0353e831c7779a16cc3a977f225ef93c92cd8eb8ac98afd255e40b1da0c21a356a7f290027b7f2c1c2ecce656524f21d3f8d962a4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/hr/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/hr/thunderbird-68.9.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "c4bd90516b22c77ea3fe667d198dc9e304b06495bad96715ea90172488b09083920099d282768d11ff86b1518cf0a9d56613c9243ab7416b0495addd85081822";
+      sha512 = "7c013aff2eb1d4d2330df3ec81dd4e6bc99f4ec9b620fd13cc487a02825669f7fbab84d8f9a2cb76cc34290dc301522505352b0985f75b7f26133cc0987d30e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/hsb/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/hsb/thunderbird-68.9.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "e1ff1afdbb83579308927301e683d8c515928ce3dc50ca45391c81d9f66c0af8a61ca4ae140634760e0c0e4f3420a560e837d8490444282b480aea6c23ed92f8";
+      sha512 = "707059d39c02b2c95f18817757a4ab5fcdef4eba63645c93a8e1cdb37dd013633aaa7b67628d357e8c530a7d9394448d61fde9fae32befdb351502c27db3cd93";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/hu/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/hu/thunderbird-68.9.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "aaed51d4181ff7bd6eccd9801a21a653926ea448d8049c5a52a897f83a2cb463444e1f12d5c6d4a37b69a712a1bc5428a12d42eddb823c4a02732264fc5a1c1c";
+      sha512 = "238047229050a38375a05d9d16514c88c5312d56857b179d7818be4421e3fb6450558f378c18035707d2abbbbb878656f1aeff461fb9f6b0f7a1b9e7e9863b96";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/hy-AM/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/hy-AM/thunderbird-68.9.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "5df858d448b72d5a6f320048df9ec3cfb8c08914d7c7b63006eb01b1dc6c77e9b7487a951be7e89bc41922e9c3bb9087298a55ae9da146291ea1d284967bdc6d";
+      sha512 = "871c444b878cdc2c63d96d389ff0ece2773862e825bf00bb4534475130f4b0b684dcad1002bc1d183f6c81b730bb3af1098d29b81dd7d07a5321e01fff3c39c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/id/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/id/thunderbird-68.9.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "3ac1a1acd6b85404594caa11da1be1e55a980179a027b23fb323fb735c4d3bcf1ad12d25608d0f1ac3a89c30cd73a81fbb031112822fccb10e93d0c911504451";
+      sha512 = "518ce09cb9cedf086549873f6cc868235afa24fd04be3e2af00d92dcce8c1f08c7855c7af9c4cc21d2329187f2a28ddcbcdd46fb5a7f26f2993261e0f2cf7afc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/is/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/is/thunderbird-68.9.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "fb9569aa59fb4a084fa1c578c4d1ac49765e2e1a5f8a2445081797999d6c877b2e4aa13879d03b54b3f885d5d1054647cd891cc38f7e54db58b5c58b7e906486";
+      sha512 = "855c8d301067538bdd1494fb9a6b57e0182e94deab34a9aadc65dbe6a5829023145d88d4233f10702947fbbc7361812fea94b6a1352f687bc006988618781816";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/it/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/it/thunderbird-68.9.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "0c3063e9deebdb4ef1bd08f0d7c0208fe16363fb87c7de0bae772987fa5a3800baf723482506c5957ed0b641cc04cdfa9a80e3e200cacf0eafd9b5fc1870a3b3";
+      sha512 = "d447dcae327ceab2edc4302235d9055d1b11ff0407dc3a05cb1f16f8a53c6bd71dbaf5c33766f5c343ec357cbf8a8702c637c0748f658aa2083d244de9fff968";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/ja/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ja/thunderbird-68.9.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "bd12eb6ba2ac0c2c7caab313b726909ba35b2eaf21d70c7df98bd970a18e943042c69b7269a038f7edb852d0036cd2e34273aae77a2a4e31dbc05b3c61ec251e";
+      sha512 = "1ad5d5c0c7cb04fe7f471ea85557f8c4aac62eb9b7276b53fcc3111d3e37a7eed56e2e4521c1e978acc32c973618d84c05792b4100fbf9175d2a5db0c74eac1c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/ka/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ka/thunderbird-68.9.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "1ba48f3544e179b75c972c376a2dad256b7657124af9b4037cdef8a87bc0a3e237be79be8a53cf5286f6f5bfd048ecfa6f09624d4559bf5eb38432b4864995ab";
+      sha512 = "0d0f376c9a13165978e1b5d77e6b098f17ec552baa9e8e64d32b5d33c5b2d52f78c6e45ff92901f6c94cf9efc1d0349025c3dd7baff9693c9e5ce9f62e0a7c4f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/kab/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/kab/thunderbird-68.9.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "5f598ae0de491cf253860c87eb80fa15e1fbbd06f17667f0a78747f412ad8fee9b4a472c1a89f096c9e765ad289ad8d80f86aed50b538e52c68188c41caffa3b";
+      sha512 = "76927cd9f2630d8aa4b501a8ff49ebdabeaf75ecf5dc166aaccc254d38493a94df7dc6d432bb68511b78b5e31b483859503bf846b4c2e7fee2ea4d40e4506db9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/kk/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/kk/thunderbird-68.9.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "7e9d7cb00122945a2b74650b71712d1c761cc6df93de74c11812f0d39d25666c911beba60eba97376d9c1212ad0604577cfb46053052be420da1d2f6d53ad445";
+      sha512 = "1a0d0a328341a7efffb6fa5ebb7bdced15f8202d37520b1e2972a3f82f37053669d52e0a8a815a8a9f2cb439227fba2c6f25a5967f459b1d2d7140e16315cac1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/ko/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ko/thunderbird-68.9.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "5c4406cb82a5dc18235d158fc756eeeaa51bb2e791663ef00d315a56a595fa6290f030f0cad726a9ef98706a80146fe63a3cd5d3edea6869f7ceb4aeb1b7676e";
+      sha512 = "d4b654cfc6f0f8be641d844a52eb332c2218b419c7a699852ad693b90958d185ef29c2c1bba5b7b9e397e05fe1572b80b0f0df01e83b65edede368e0c6ad9ead";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/lt/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/lt/thunderbird-68.9.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "3bb3655934068fcb965fb73dd8ff455e48ea4cfe578e0f33a0c442f1f001731aef9fd3d426cf720b9decf610192d1d7722f408e9b8362e25932c3715e396ae27";
+      sha512 = "fdedc91f7bffbc4f464682f3a020ab161592015fe5c50180899eecf951e9f775cf5ef3cc6b5baf7faa58221f00e19fe99074f60d292ca258cf44dad2db0d0d69";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/ms/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ms/thunderbird-68.9.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "0c6635d9e366a85b29549ba3329861d7912f9e1493bc7becb8cfa0225980c0c67b8e671f4f841a5aebb17e123ac4d38aa90ce9cc0bf72525918557a474262931";
+      sha512 = "1ecb61c99626dfbc8386364b747e94de7080facd6434813c8afeca60373d3cf07d2259ba90ed6de01c68a65e8b8408e58647d4e72b62f150f82da4a81e78f861";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/nb-NO/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/nb-NO/thunderbird-68.9.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "2c9cca7bd403a0a20ad1911d924555612e8eba7b572d4ac3cc3d1fecf3ff294c729147e77675be1f1026702b41000e43b0930815cf08ea03f7fde757266bc15e";
+      sha512 = "45ec1f8def3d2b57e29a3fd22bc38f08a9c7b1ebf44e6dfb736ee13d09cb1bcfcd632c2f8594e3c531d35aa7b696d45ffa1bf5c4cad7e1304fa92763f923df43";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/nl/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/nl/thunderbird-68.9.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "a16f58d19f6ec59e9dd557a3b1cf8cc22326596d5505289b93bcd04e801e551608a286df03832e4711b91887c9a408bf36364e9a47be4840a828ce53e0f96f49";
+      sha512 = "20dd4c7e946e0fca871fddc3481f2f44b72939de3a7f5064ab8f062981ea717d47f2a3c09af32c9913556e2f5fc01fe1dd78c2d35b5fd44a7f35cdef1e4252d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/nn-NO/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/nn-NO/thunderbird-68.9.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "10a0ce11cf64713079143cf8f357f8abc5001e9d285eb56b4c7e9f4f560d660de7e3bce544b7099e588f599a4a4b1c73241ea5e542d149d41dc8a4ccf21b332e";
+      sha512 = "c366bdbd0cda3143c7684c1cfd948965c2b80bd5076878cf3e98b9b5fb82baa6df419445ab0da134209a969baa0e36d759297bfda701d2ea4cd8c6720b61f123";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/pl/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/pl/thunderbird-68.9.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "8a6fec22b065d43ba320508992dca6d21f0782d4c4c28dbc6721852029f74c45b1451002c03f5deac70f09f3e9d07fcb161dd1a3943239231d10da4b2972f7ff";
+      sha512 = "163130f55ed9e0cbc68b48c41541748aa320d7a8fdb954c38fc25ca7e2dac6fea98b30b2653b6e8b31230ebd8364ca12281551e00375e4dd64b87515f08e6bec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/pt-BR/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/pt-BR/thunderbird-68.9.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "d57e6e42fef8a13bbe515089d2ee761509f464cc0a97a984e369bd96022dba7cd15dd40aaa9715b63531a161d708e06ec809bcda56c92968da1f11f5e66e62ac";
+      sha512 = "5e362e0c53f898d1d156c53415469fe965162047bf5ab55798ece681a33322d677a874b80f9f934067a847da9f2c45a62d63753b866e368585ac5f0844e410df";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/pt-PT/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/pt-PT/thunderbird-68.9.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "064d2b04a60bceb7e300ec5f71e13fd1dd427bb89ae471760dc1933c574a36427581bd0d671335e9f52cdfc33f6b9addafcc703a093e2223d58e96e90982c491";
+      sha512 = "b322096fd6fb0778fc26146b69fa9a63f249e927de6d2ae3fd6093e3e24b4825ed29a1d09cb68de274aebeb06effdec78e6445fa5282dd6a733b2181ead21248";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/rm/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/rm/thunderbird-68.9.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "4a3025096ce81672a45de762c2ec2fa43d302310206fe04331fb6bd12d73e49427c3a9b9576f39fcfedceaedfa4d44f044b26245b15a8c2ef2fd8e127befe70a";
+      sha512 = "715075dabca54e27001f68b11e6c3c99fc5e20f1fcba637e7613584d84a97520e06fd73761bc6c780ae8abbec3121504fb1b51b615a35c0d8660381d71f94eb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/ro/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ro/thunderbird-68.9.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "7b28416c0e2cbf248a7ab9cb6d72b5280f7e60f7bf8925a45575afb9a549dbed39f38a9d9984864d7c9dd246546b7597fa51ef7dc14597330fc4cd80cfebe95b";
+      sha512 = "fc279090426b3baef609f23228ac11d4665fd805d6118a4ecc2bfd1dd7b36d37004033db4be1095275c677a092026a083199e699b553c6eb82192db0190d844d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/ru/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ru/thunderbird-68.9.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "da97be95512ca48f688ff04c701bc7a0e351ad979f9c3ecf2c493aec79f694ecb09cb5399613262b90132934d6600852213d26a3281b48f1598aa692d2e13bd9";
+      sha512 = "8c575c2749cd719878ffba2c8158597222d1d494f2c3749c6b5253a8d75607f42a45799a288f85042d8390225f74ac55d7497abc76a8fc870f89f8f7b7a3c699";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/si/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/si/thunderbird-68.9.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "d97a111b90bea06760ea58dcafdfb279de340ea1cdecde008e47f9eb101e77e39466890e70f874bcb7f6061de96ce32807476da7aa97c867bf8d9ac4c4d022ac";
+      sha512 = "b2edb098eea69332528f24a352e2cd318161ab3383cf13f878c7fdbca14f923f74a769fd494b435d0ef2fd760d4b7cfead063c91112fd44dfd3d4a47d4597549";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/sk/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/sk/thunderbird-68.9.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "f35670ec66342aa95c50d5cff47a9eff9faf3123174bbf5cf4156bbb1fd3ba98f47972328c0c33513cb92767e0a5dc67550a4a3259981c84b1bca035731544d9";
+      sha512 = "2dde57c16b15b823a698f7c17d98eadd5528ea29cbc50d22a586c3ad7357289f2c4719edf8ba47c59c3419383c64b8ff948582a58356719990340f5db0be84c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/sl/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/sl/thunderbird-68.9.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "49a9f388c696c1708b0bf76dbe3fb7a2836c128f6d40055c585f83c0b62b84b5efa3cc4e2c26889846045340ed8bf95fead053e79b8d7064b1488c3d306d9c94";
+      sha512 = "0014d8985ee139ec3ffae5ff18bcb8ac6f0921930853bab3ddcdcd6d21b9453aaa0af058068770dacb04bd1521b555945f9bfa7d9f47ba4a2adfd667fb067d78";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/sq/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/sq/thunderbird-68.9.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "77e9090243b04cc1f0e3dbd074f55f40949556f0284962d5a4cdac53f7c31ca2740fc71602d6eb7b391f0ad71c9a8e81e699ea94871f209c5771745241783698";
+      sha512 = "5aa41dfc73adbad839452077b436ff302d0e611fb342998a7f6bffe98fd634d7995a30f49f8640645052b9f68c149c71a6bcdf0fd2df7e3c67783bca3c4ef511";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/sr/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/sr/thunderbird-68.9.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "9fb67b03585edba5b1d25d4d5667f1cde44e53b7b9c32730fa294e2118698c63527c0abaecc90b2778943490f9167d8bc2cd4bba2aca7054a592fe653a11c759";
+      sha512 = "266d0030c7d018dd68d5cd8496eeba061453e1d5a37e99c1645aa9c677492d0da397b2a9e70aed5d927c2e955449ff5b75efbad74d60fea4bb4ef90c36d765ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/sv-SE/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/sv-SE/thunderbird-68.9.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "d8aa3a745266ab30aa8c32c7ef034576ec293a02f214f8ce96beefecba877e2de3b7944aeca9a218dc587ab77b95f327a619bab5c192857327810c6e81e1b05f";
+      sha512 = "6ce755bf48a29522e1f0805d6fb37bdbf145f75a4b6fa176c06562bd1b6b272d752a3d638ab66bf66dd6dc67fd817d76e70cc31fdf9b201f56c6bacd058e49df";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/tr/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/tr/thunderbird-68.9.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "56ac7582ffd7fb8c0c8bc02216c2d0a5d4405e356385406c7fd6ae545d128c8c18488e75ea8d8d63de9313aa48f2fc93f3e5e1947298b2b32937af8d40c0fa51";
+      sha512 = "302b03ab2e23f6c0cac0fff85cfeacfcebabea838fef824b7d1733054fd9a3cb766dcff1dad333b199ea876a16ab7a059fe4e01289aef4ed481126c27011b4c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/uk/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/uk/thunderbird-68.9.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "d783440bdf153ee044204f1b1739f1fa771bfac6d8ed4c5e6fa2b72d406e3c50b3e76b5f9b644fcf5b5e0183584a51336670d5788a949070994206db7187c8e2";
+      sha512 = "b3d59d62dd3d3e6e9ce8be3c4c746c41a0a0962d1327d1187b0b2034d0c1691970d181405cc7ab7e2f1fcafec6caaa26863020f5edae4479e453718619b7d02e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/uz/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/uz/thunderbird-68.9.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "7aa40bf1d31cc59d42f90f821b75a75610ca2a66a37003d103f1aaa83d5897388599d41a61346f614db7005bf14fbe0c45cfabbe3dc304c9a2704d2c5466362f";
+      sha512 = "73d36534f000d00a52988825c0145288d8d1eb944065d11231501f6e2906e97b0beb89d59b796d3f2828054ed9393e8f65866cfcaed6eb7f939cf657b6f3d740";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/vi/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/vi/thunderbird-68.9.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "ebe1eb9914f489e679d7b4935681b3c5c266e5cb3868507f662e1b4c6a5f791f8a653f3d1cf788758b9aed13fc436a76b20b80fd293563f25543af41372e2f7b";
+      sha512 = "b3ec66f92f5d023933e8dae18f0827f0fc8c5880890f9986b339f06b4e565cbe228bc2b0843924bd2a524a77ded7667e63c2747d2ff6c3789d57c8a68e440714";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/zh-CN/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/zh-CN/thunderbird-68.9.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "b15026fffffba21ef50c98a8fe391a3f949a300b104d9d238c07d154d4279b70228e261083a00aca529f69739d3e79a36da3919bbb3cc19043faf182c25464c0";
+      sha512 = "e61e72c3dcd376d74e732d76c5a49203b47e2ea31c86bcdcaad673583795f5c01549fa2c5526205857e565f2a72b8abf8b2aa4e7ede45a94b218428607662a1e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-x86_64/zh-TW/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/zh-TW/thunderbird-68.9.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "d5f654661851b4079e7fab3f71e4135f8928d59b822d87e8fa6cc8388fcd5aecc067a88790c27fa8bc4e7d95ff9fa123b8841efaa0e3eaa7bb9e97a50e2c7076";
+      sha512 = "f47bfe43ec5b570863ed1fc81828a23beb250db24fb77d2df2dfb5ec60a9c750f188cbda1a0f2927688865219f6a36695d87e4a8eb1fd642c4c9650dcf2e9063";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/ar/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ar/thunderbird-68.9.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "9608a6b9e2ad0fa3853f413ae644d5a1c9cf56432b3fe546ad9fb60cd6fda2f42cd8e1a4eff5ac4acc6b95817d03107d248cd6971f049f7f1d95419a3125b0cf";
+      sha512 = "83a77d9f39196a8a3ec72469c038c835fb6b50872a2dd611519b178f5e46ef40293bfbdd908b3ce236681205b9b3ed133c845e357abb70285f9920401ad90cd2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/ast/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ast/thunderbird-68.9.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "1e06d68a8a7999005eee84e3da15c23c2bfc5b4fd03fd1c5ff9e8100f64f974bf894bd62e974d52db4ecf8030dc41de6446f797d83a62529679730b0f24861cd";
+      sha512 = "83084855cf03e66968d20d2caca749a9ff9d47b0cfdecdcedf0320b4bc7e628ff5f3a971ae1f6472c5a44facfcaee419250f55ebb254bff9f344c64772f54791";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/be/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/be/thunderbird-68.9.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "82122ff9a1b1327bd3164f1d7c8d18e47d63dbb2981765f7fa7499ebf26f2937f714cddf7882c6c47a6b4f4a480e5a43c44c35eb7a4769988461945ff657e48f";
+      sha512 = "722bcaa29137994e36f70a438fddb5be55355cd85d414fcf70cb8bbaf66a9ab0fc21408cf282272dbe977f46b5aa63575c7504bef8292adbd8d4c6e308655411";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/bg/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/bg/thunderbird-68.9.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "1d95aa7716f43591943be6f2f5eedf502cdcb5f08d262e359e3560da7198e9108052d0c5bc5b5d594fd2d8a2560f9332acd661f518c1e3f534843d65dffd02a7";
+      sha512 = "95464ffd5256fb181599ad795fbfe5d9cfe8ef0c02a7830174ee4732761cd94a2cca75b6a686559e07d996640f5e973a660fc857f0839d6bea5594e61f2f7e4e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/br/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/br/thunderbird-68.9.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "6ee97fb0942474747676c191c25c27fffd91810b3ce3d4ae24bac25c3dd90b99192210c242192d533d6e85497f3d4638b0c8d2e939bae93f4dc1648c6b5c9dee";
+      sha512 = "fe09bb21248975aa60ffd74a970c9dcfbef578c1188bc1c3704c7411c2e94f88976ac7ac5e52a69ac6235723332f2fc76757ef9118092833fe64bf0a05e3ecf3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/ca/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ca/thunderbird-68.9.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "6b7a0e8b8e42b62585ccb333c16ffb19337afd2d68c673bb364f92248248a814ca57d6409a49959d2b8fa7bed1f9031bad1296e24ee7091e62b78a81c059a0bb";
+      sha512 = "01ac3c0090448f1ffc7c97623df8576a7a3c184a2bc1a2761f0e3451a18dee6d4f6bc37b305dcaea89930a1750a9541116bdf03f613b333ddc47d5f257b3bfc0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/cak/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/cak/thunderbird-68.9.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "faf8b1a06ffc96cbc6a16e09290652f7a9c270d8dae4aba0d5685d250f8686957341b68459affc8215522cdd6166d1b5e7c498713e9ad8c981d07a97156ca4ab";
+      sha512 = "27dad086126a268f2c6700a5f01006c40e911ecbc95dc994da7cd2dadc3f2bd3bc94d5da15a297b2e72e8b20254d40c757456c308b70bae2c1d451ec6ad7d1d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/cs/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/cs/thunderbird-68.9.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "5aaa310e3e67b174114b6c440cc1ceb2b7d0d934b10685ca89e3b7a1cc859bd026ca8fdb8607d70da16c039c853a9f1f11ef94701c90172220d988da03e902d2";
+      sha512 = "b99dc13bf43a9aebd08f13fb113186e6e4a72c68d609895afc8a52c4909a0506f646ba394c705004272d1b91db4efc81a5518bbd06e359a8a24c85f4fbb30102";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/cy/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/cy/thunderbird-68.9.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "7523a32ca26e46cd388142850c96ae256fa2e7774f5552771b3ea13a2b632feab637a2552b762b1f4bc56b81f92bed3b8139e994b46b515e98070115dd3624e5";
+      sha512 = "36c1557a9955e461128929b7be0f679a02592b65e4b401b052ecf1f467a231ba725c92eb96b8118bb75d49ae45f8287bb5fbeb22d94ba11dcf311cdb87170ee0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/da/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/da/thunderbird-68.9.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "0b528d5b0b4838fdb62e49c136f1d997ecfac946154a8c5515ac22a542e7c4e00c1a44dd8aefb4e20528301001d79c88e3fc97b60a10674ec4a3562c0807b508";
+      sha512 = "e81b41e38b322f2eddfd68c07f326ec9d716bdbdf31c3a02d22d9377002fd21b58a68a8ac952fed2ed164a02f8b20e9f6678c52fbaca741a4bcde1079ecbe38a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/de/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/de/thunderbird-68.9.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "792545f3fcbad3cb303bb5d91a90788374db1d41962180225f7d1ffaced19dd8b4352d36645df06926347dc31d6ff00eb0fee32efad27a15260115896e7cbcb0";
+      sha512 = "da6a44a2a6545b10bbe12644e433932c4410471f5948278b919baca1c6eb0181366114c1a6f611b897c71bf4091a6734393fd36f997c118f49466faa8dd2264d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/dsb/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/dsb/thunderbird-68.9.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "105c814511f32d85ede8c1991074bcde6ce72eb67280a883de13b69de4f74c4f97828dc3e5c170b1346ad22b4ad8b51329c3600979ca468bdbc444cc49b880bd";
+      sha512 = "6d19a0010553d1b08bc47a22c0c7f23bf4c86ca79ef3ca26c970cd502e6db003ccf045488f88d68a5b1b0ece4436de55d65592b314126b9b5792be30c9def553";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/el/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/el/thunderbird-68.9.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "e7000a3e243b77cdaf6b46cff8380dfd1ecad3d07f69566f5d34f8e1ae15c582ef56eca8227fc75a8983bbb78736e935fe94dd1e7814e9b95158c9620985da4c";
+      sha512 = "67e6382474356c4ff25e6f49a7ee3859eba5bb29a4e795668e1ec52131dbaf0d87b9cfb8ffe1fa855bf8f34e841b8fac90c356545f47a711b533e3593219e957";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/en-GB/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/en-GB/thunderbird-68.9.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "87446eebfdc281eac83e7ad67900d06a2088b67d809f6f5ba1551a069a75d4ec4e642a241954671800ed4900b2930a11c4b8080fff06888c78acc0521d50e39e";
+      sha512 = "f4e1d9b10ffc96aa7ef4202e73445d98a06082abcb87fb60d951ce491ead7cee4bad5c1009270004540d03aaf383eb5b8203845f84335b523d92bb586ed5932c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/en-US/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/en-US/thunderbird-68.9.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "644a6d2b6df53d624dbc26301640d4b5f601f60fafafbd4a1ed07583d9258f89a4276655686187e09268c25dd9ecf1d8400ba3bc7e6c55d21dbd19a034614bca";
+      sha512 = "a8fcf918c869e8064c2dd39a03bb768616b1a5e4e1c6121aa544d72626bfb790625e2cc48dc973443b947c6e619f9481cb20239d544b10bdf287b7fa4e05128c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/es-AR/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/es-AR/thunderbird-68.9.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "227ddddf7bbf47527f8911b122d74f9c718639a3028ba56a22b2c93dd665521d82b543b0b0814b5bf1923fbc6ef2b39d52fa60616c1c5e5474de067b762c5af4";
+      sha512 = "6b98ed36080e8eba879e305aa34ccc77e1735700d104f592095cf9810545bdf25665dd36a527e19cf12ec4cf782a6387e30f7b4406b76230c08a350f4cfd5fcc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/es-ES/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/es-ES/thunderbird-68.9.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "746cc55bfab6a7c71282ebf63738bd7f8c8cab67a01329a3d125a84bdc5a7c210958a52881734315612845a0d386baa75373cc26ce9c5f51c7ccbddbbd752db2";
+      sha512 = "0cf479d98ce943e20871e7073188db3c9162dec8cf2b0abaedbaabfac9b29411dad39fdf44c038680956c42f7f7e303d5e2bf8d7ef9225fa093821ce760e9974";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/et/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/et/thunderbird-68.9.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "655bf1fe4942388f357d89c2e7cdeacc4c09f95e3c7a6e25d3991aebd571c6270d45fc52e4b80884c87705232d8113b50f28d657abe49f907878187e03f6b752";
+      sha512 = "51584ee5c76710a9b805d4da528d5463f1e51e3efa6ca3b9cf3fc6bb6b953cac6b7919f908975905f619d9be75e4b9ea32980bd5f198f77dae0f75795465fc23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/eu/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/eu/thunderbird-68.9.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "4581e53d1202bd5fbca9b20979a71d51752e8f1883855510722f499489fa40d77070bc71834d371843e6d5a601e0bde8a6c86a5c1c9857a1150a792ca9aeebb7";
+      sha512 = "bbcbd4a91856ebb9418c00feed41f00c93ffc5eed4af7c1c27585c707aa8dbfe4e48b0204cbb236a8205a219f0044811dc43f4cc94b6610f30d38120e3ab4b21";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/fi/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/fi/thunderbird-68.9.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "4109ca4d181485ead1ed865b101787c6d12879764fd5c399f73eeb23b157f09ad12f237d8b9460634441601d51e5cd4a3365657e3269aef614b6306339a3682f";
+      sha512 = "f03014cd7a28b4d85c2d896e8e2a5a1db959c7290c98cfd0c12839170956e98e0087685ab4304fbbdae42b06a8ff7b5563e70c9bbe0a787d2d9b4103019cf31a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/fr/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/fr/thunderbird-68.9.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "53437450a3d67c79c4e44a223e846ac59eb2c534121e923649e0c44891437d5c180d15b43a00955706ada271ecfe651f1a9ca1c1e28830b200bbd6689411a536";
+      sha512 = "ce7b187a572da6bee677cc7849bd5123545bf437005b16a855d9e4bfcd58a10f3b095a3b0a767d5a67aa113c0a9e0d437827c37fe1c8bf84a3fc8c8d2c702a8d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/fy-NL/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/fy-NL/thunderbird-68.9.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "5c9cecc67893973aafad3b2eba78e82fe459b70a5b467fbeb9839ddad93371b6f6d77f96dad6f7a757821645d680f561f1cda45a360e556229e6202d60f2a75f";
+      sha512 = "2062090196c7b07ce148a2937027637469e7593ac092db0bf7139286faac51d350c786c0bfed6e32903bcb7f2ddc4e3df6e993f8637fc68c1aae1be89ceddc98";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/ga-IE/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ga-IE/thunderbird-68.9.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "2e23ae199d505493dff47191c599d116749d7d4d362906ab9022e1cf3b06d41694247167c96a3c92d58fc7e6c39e850773b7a2dfc2e1a8dbc63385e20a4ffa87";
+      sha512 = "fb11eadd35e46081a16116843a4a134b8197c4e8e1d1a52981a085f02bbda7ca49dbf1d9a88f4a7fe2542a99ff24f6d35fc661414cef1fb50edecb98c6693f4f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/gd/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/gd/thunderbird-68.9.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "1d703587272271a8787c0ea6020888b202f5f07f529e8f5e448b57adab781946625511941d37d6527e52d027d02be121ef8e5b0d6ff05494a2aad775bfa467e8";
+      sha512 = "e9b985732d6619555c24ababbbe38303998750986395c647aadebb0c209467fcdfe5f9dca99ecef0e0b747aa8598f887ef2218140ad1d97e7e3d73b430dad1d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/gl/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/gl/thunderbird-68.9.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "7f07e56433349000859c8dfa420160d9388c4fe70494f0b614b9740aed4cc00f17f3be475303a74a5ef58c16bd334dc8fa8e7d73d989202841a171afca4388bf";
+      sha512 = "3b8eff0004db222eff3b4f42be4eff168310fd0e17e676ae92fddd9c11e3a6d4826c63a35f9de37095a7fa88f7f4931e36bc17ace548e36f91bd8334fa53799f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/he/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/he/thunderbird-68.9.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "2ca1b2f949af32e3af1fa80de361c2d35bed79e7e832dc4d7dfa3b3ac3866ae0a5d7c1fe22fe2a49f4d92f4136abb06cdccb44daa4fbce41596a8cf3f30f3711";
+      sha512 = "e3dcd319e08ddb5aef2bc576f136eae7838e3aca3c9160aabdaecc32332f0c250201a80f31724233a77f4dd2857684f2bcd9b194df5ec965d69cc04a9e9b7da9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/hr/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/hr/thunderbird-68.9.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "cc01c61ef5c2fd136283b035b3baa282b57643afdc4feb82e014475c6afc7aae73f41b607e16a19367b010fb551f39cccf48250bae6650cfc2882a40e8d59d00";
+      sha512 = "84164d00d087e507ab79aa4db6567311bd0cecbde1cb1be7337f4ffc42abc8c7cd0f4fe9a3aae2e35b01683f96e1bfbc816fa96e6fb872157cb473128679e19f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/hsb/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/hsb/thunderbird-68.9.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "abd12a6378f51ef7ec3e5f3cfc4b5f5774a7386887bd39f0d4cf715483810436f258e80753eccc204eaec61f602e90525d63f027a3ac264127eaec3261c30cdc";
+      sha512 = "a3fac91f5e2fbf739d2f2c164c6d58ea89026c1e8250a41c51ee11640bd7831c73a4c3148cd80ae2b40a2e1a369d47d3832f96a276dae2c80ba2d90d6990d062";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/hu/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/hu/thunderbird-68.9.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "d4ce5b41a15b40539bf123dbf4f075b00da495007eca83c9c49c5ba5578a0744fd3e38ee71d6746432eb8ef79490ea9b5991497946ed6246537ac4d592a85b62";
+      sha512 = "002c42f700616d2ddcf1753d37de064959965e4504112e96507a8aaf2398fa25f650e1fcb50189aebf3bc3d0c3de795b496d1f8e1550fc0186d74ef312a11d74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/hy-AM/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/hy-AM/thunderbird-68.9.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "caea7744d3e7d5e76ab5bfb98d18ce27b869f8f3c8e8be206ef4ca8b34819ba8a552dbcbb409d53cb45ba709288fab550f2f46607dd8f67908272be3b64d55ce";
+      sha512 = "41fe16657886ccde1c6410e3e62ade72d8890a50e77526994e82cb929c8296110d0aa32d8d02dd7d1482d594322325d28cfa54afe113dc69e2520dcfd56516f1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/id/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/id/thunderbird-68.9.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "a4e7862dbc71b7af2eb2f348de8632ea7865408c72b8ae6a3f78aaf97746662020b61757072d49639293b529395359e35f459ee11c4f37cabbb848fc363fa16f";
+      sha512 = "8fb8703220a801bb2d29e436d28325a3310b61f6a22d3d8964b98bd9cea9e74f9e53cd41c8c9a501057d1915a6c71f6f5d27fea267b802082488d2690a0ee088";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/is/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/is/thunderbird-68.9.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "cca9db1eba2143dc567ca454d33b7c6dbc7d1d3d3daa858bfe2e2db1910b8260c74af0a5b5cbe53d94487d42cd12e7bab143deec5dab33c2bd14f889f2ceeaa5";
+      sha512 = "09c59bca1a0282416aff4043b7d64e5f8ce308792efd35e197b2d91125715453769b482e5815c9f33cd0d9d3809bbe898c40e767c13786868673bc7f041f1c17";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/it/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/it/thunderbird-68.9.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "185e5c4246f73bb5fc46187bfcb73ea1bf8749f67558bb162f4557e35e8657ffb19b61a04fe425b7bad32c20bcbde67894848422c350ba38a27c32624ab0829b";
+      sha512 = "c3f09f2681d0aa197084b0935855dba98517d6f5595595385d93dd7a998ff5b0c98f35141091f41ea8e91ea10b25f6464f242218cd7030351347f77f35396ca2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/ja/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ja/thunderbird-68.9.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "1ad054c656cb4d4ea906603aef9370014480f5bd4041d56027fb0f9602f5aacaee709e130fd29cf4a0b1fa638ea52085eb1b86e27e38731da9b22f5b69197e15";
+      sha512 = "4bdea34b50edfea5b3dd3bb80935e1148b3ad926c95d84a3d265268f783ff3c487527726b0151643c8f3eb5d061d441742da23f6cb03297894a8076a87275574";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/ka/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ka/thunderbird-68.9.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "366542d5b1ca00092fecc577d92111a2db6bc7e3fcc66753d91fc971b9536717494c13a256ccf43522fcdb9964f629870a327488e8201ef5185d6d6e2fe2a1af";
+      sha512 = "ec029d7a58aa502742160e131eab70f50f83851124297fef72214d58f1309f047b9881d824432a8bd3841dd158493ca2b41e41f4f9bf9dc043db9ec4df1a1d24";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/kab/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/kab/thunderbird-68.9.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "f19a99f2824cd65a10ee264ddc8d21516dcbe2c2d807e076e8d137b56375237307d3adedbaaaff5a3f88a1d4ed80faca292abb7941a349a42bad6207fd267ca2";
+      sha512 = "cf291b9d2924e72b9871a4eadf10118cd0299e2206151c67bf36fe0c766b75c9e67e9b11e8612ca5d95c50c6cd3d90e95210e9625ed8eb1c14ba5a8d45bb997b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/kk/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/kk/thunderbird-68.9.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "12903b5f1df5ec077c5ea7cd53a8cec4489613fa87862bdb594819b87d70be76997f9b9c825e1335a3a5e785a070b25f75cc2ac19dac726638aa454822bd2a4a";
+      sha512 = "1031db4a9f0716973fb1ddbc8e12b2252bdb8450617a6c642ad4001c119cd3eb3bad999b861e8204a85699b415fdc5d768b6aafa6fee2c5b9efb7e9a3558eda2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/ko/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ko/thunderbird-68.9.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "d246ac4a6f110075e7efa1da523e1a171d34415752536c8ecc40d296187d65e589e1a9a20e3da93813dbba058c6c3d820ce93f8473c207190d2b58bda6496326";
+      sha512 = "bde75ae38856970c4da871cdbd63d96f31021f707869be7517d4c719ecce3f505f886c65e9faad8bcc0ac26885777e070246576fd47f75669b77f0247689954f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/lt/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/lt/thunderbird-68.9.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "cce06ce9899dd9cd50bcd09f2699fe8fce1a08666240bd997cf03a813befe4c1e15823e4e3ff16148a301e3725210a2bdf2af2ec72b9c55c470519860454a14c";
+      sha512 = "9459b50e1fd01ce742bfe6f13ac26241958ad5307c08e3980ed5a84023a12be009dc6a83085ad52c68e162e6a45f4f430e79e21e4d19f67e470ab07151c40bc8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/ms/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ms/thunderbird-68.9.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "f9facdfbde7ba320c9d16ca41194fed7a0b7aec758b83c57c64fb2a778aef90ad9840f0b0dea838598d8786ce5318d7ea790048c877d492f1f6f77ea7ce5ad44";
+      sha512 = "0632af25fd5245ec2a15a09a075db24a64e3020ea6353e88f72fa74f929d8507cb868cc617da8e97f01efff19a9108c9b2b30adc8e58b0e7e6353332219e658d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/nb-NO/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/nb-NO/thunderbird-68.9.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "994d93d68806ec039ae59fb9ef5a27a940305ca7919ebc427267affc797e5b386cf96d67cbacff0f708b659d4aec8692271f376dc4eb56e510096387a83af0f6";
+      sha512 = "b16523b5a40dbe496537df487d72f8cb16ccf338c1a96e6ec3dc7e1a5d3073991c12ada23fc6b31f34d2fb712050334eae145a45420994c607a63799ed42d264";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/nl/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/nl/thunderbird-68.9.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "8ae07cb28e0f777b79c005e0c6848854ed40f072f63b98d68841c3aab4dacab04d90131e4c76c65943eeee05ec01bdf79c3872f0a0df1b10e02be1707e2709ce";
+      sha512 = "82f0ab2e4969323ea8294f732b13144ddd453a613a68b582ff398cb85aee88874a5fb5eb61627f142ce8124b476f49fa6cf68cdaa41fdaf3621519c53c4ac16b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/nn-NO/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/nn-NO/thunderbird-68.9.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "994e22db5edc1d1b6ec4f51dbbcdd200695e468aaf7cefa228f54c5ec4eca7aaf5faea8afeb1efcc1db5dd221e2022e666bbee65a685409790dd7614d0dc4b20";
+      sha512 = "815d0010de5f6d9144a182a2170c59a502b167f18eec65d23987e4b73e6d5bae46be18d7f55462a3ec8634466639aceca03ad9b772c7e8b232eb874998e6148c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/pl/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/pl/thunderbird-68.9.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "4efb0643491e7b469e277f98d16f106e046514a35a3f33d30ceb25809a037e521639c2c5c6304be6716fc9f7f39c216dd2ecc204d47f81bc9d1a3987808d8ac9";
+      sha512 = "5be434a54c91097d4f6477767af96f8b862828912783eee48577cc450a14eceee2e067e9c10697633a2833f473b9d10bea33b3c6c6377b898a18d3d7c6568f96";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/pt-BR/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/pt-BR/thunderbird-68.9.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "008c6291daae9eb05a981db2e5931fc5a2b72c55b349978dd3e76c8bc632ef95b78f94af8934e2e89600877899218acd1352e910ab128e8796a30eec4734dc91";
+      sha512 = "b7b3fd6bb8535f2328ceb9259d7517bfd695cc881130720d3857d5a27197deba4fe683e163f49613054ebec2827e805a31a62c9a9e578f4ffb760f421a4ea506";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/pt-PT/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/pt-PT/thunderbird-68.9.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "be53376fc3f29cdc6f7bd13fcc4de35292dee928d9c65016dde0910333c028fa85563a688dbd644459aac9bf81a5dc68e5cba528f495170193dbeb5024042b5d";
+      sha512 = "b9561a6f55c25cff2bec9bda78e46204dc85429c52bb42f33b6ae972c0bf16f3a99ccbe3f283ef08cca955d31e5eb6d91ff9d8b50e85bd75443998236d6e08b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/rm/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/rm/thunderbird-68.9.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "a66262a586bd1b79772fc791fb93bce764b9f0cd5d39c03b26b1b9743ceb83f54e64b30bfd1fc0e03236aef8f320b90017a4e4d997090910c7b8963e30f505e5";
+      sha512 = "7ff72dc448c9303a70403558ae46cd720e645c24681dabbf265db783ef872e92216f8ee9169e155904d3fcd3288f2ee0ad11ca22bbf041b380884d57b306876e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/ro/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ro/thunderbird-68.9.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "43fa63b41001e01ae7e0183841d6efa5bda0c2518949b6925d035690f507586e39fe9d1bde404f15f34d807e0fb02efa8f7816efd2b584680b43896c6cdb603f";
+      sha512 = "7f585b942076749269ca86161694ef1b9f4e68e75300d60ea4141b2404be0c79761a2658c123787d67e65992e4b3dd5b7406acfee6084846bdefdb0f82d9baea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/ru/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ru/thunderbird-68.9.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "2d5d700879d1c95bc7ba066ba336f3b9f5681d089c019279cf27c2a837b6a12527d92940378e1bdc794bdfd516deb09c97fd5fccc07571a9b9c92c7c24bed3ce";
+      sha512 = "e4ef9e081cfdb3567f1823866ffd0e3e5fbe8596fd3a7dbb94869a8d1ebd328938c490669c8f46bc6575d6b8c5c351e387faf8dd2a33db263cb2fb5ddb2974f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/si/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/si/thunderbird-68.9.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "b78fa143b483cd6499cb7c4cc71821b8dc7bce79059765650d09876a3ddfa1d62a676f3b3326cd3ecfb6aff9823a7f26c7b83a2c74ada5e7aa57b59238ecb350";
+      sha512 = "42db8e43c4bd722102778d4a9cdfb0ba54b0151882b7963e07c0b8cd653d7303eb22a541a8fc3a5b93c9db09c1a24db8f5c3365b5654e997c17d3b4b2c2a5f38";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/sk/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/sk/thunderbird-68.9.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "b6cd21b14fdb6334b03a6e780c6fe4815a3b6124973233e5c783ddf0db9e6e7505b0569eacfa0c2c65d0e740e4616f4ed3fa6f2b9a2461643abca1b437436cdd";
+      sha512 = "fb025203b739cd89169bc25b36e6d541ebaf8726720c0b51e58a33fd0e71c2a4ae46428fe16547ed5e639e81ce35253a5519a28de9a8baa952a1b1af184b77a3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/sl/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/sl/thunderbird-68.9.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "9c791c58cbcb91bd682d30feae3b85d8e30b016b9e64fe295b2c11dbae6f72464a2a2637858eb62815f76e83bf92c2ba1549e2e9d1b3a2c19b3720ad383a859b";
+      sha512 = "ba392d3748b697d323e63c7217ce3c3aa4eaf6b994d798655a1667644733a6f19b23b95df420b2235e9ee000a868485d4f32fbe5d737ef5c7296c085738168bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/sq/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/sq/thunderbird-68.9.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "735f2aa6020787f8119dc795af0e28d04f596a001d6ea0f1a2437b90658d571a9b2c96fe2f13e6ea919d8a12ff149e562bb1949d123f0573d8f53bcf0ad0f82c";
+      sha512 = "b795928265f2b50a1032ab8fcce954f6d0d35a6dab2b381f11ca1b6b204aa1ae91b0ceb221da5ccadcca303f20792715d0f770c215dc59654df1b325ccc3e42e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/sr/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/sr/thunderbird-68.9.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "456bc22b998665dfed7a8d87cf754d6d5cbda4e19074086c4a08176e8767244e8b16d90c25173c9f41c51dd27c8c2b83a400424e148dc266da46aed6e75b71a0";
+      sha512 = "274c3675cd3d5264c2ce74b101b7c87bfd1703645e4341f6499c25b4905781395f514ed8412b22289ad097994e748ee7b527f1d6081022429292a64155d2df74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/sv-SE/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/sv-SE/thunderbird-68.9.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "1ad151afb1bf9324c03fc78c98a49d9fe6fd765d245eac3e35f17edd6e96ba3c2503d8569f72e95d22982736e33c391e7f44a5141a9f850f26f9d3504a312c11";
+      sha512 = "318ccb06cf2c9f5fdbf25fe70a8c5e65c20e5d7ca375f52f64724410d2afa8a852f9e9e77b673c1f59e26bddd6fde74783a96f69f7bd73a1b7042633b624b310";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/tr/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/tr/thunderbird-68.9.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "ed539d023abf5adfcee314a3da0e1ebdf1a378720c87b75d059d072db65e5682338b58d4b9b0eb1b02920031fa253c2e237cce3635e4897ef618291df6b9a467";
+      sha512 = "a86a69a8c146a0765e9fb7c835c1cc774a0a7fc309fa7f6627f427bc2cb4bd1b3e18f4aa61288cb68483f267b0be02662250abcdcafcb6619f1b4e3437cbb908";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/uk/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/uk/thunderbird-68.9.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "7f044b3d8d44d3f5177cf7f7fdec7fe8b8fc183a5a231ae64cd403f9a459d2d4b808e0ee08591410163358bf7841e94ba6a14ab74d955dcdddff9240c2bccc6a";
+      sha512 = "86407123381e64df9f97190b0df253792582b0ba5296d6663bc0d8faf3004e3ec95cbc0140c9292928a7750cece1cc6887086a9e218f3169bee2246232643685";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/uz/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/uz/thunderbird-68.9.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "3dbb3a4bcf800621f191b11ca3e05e2acb114348dbab49695478fbc653ad154a92f0aa62cd6d86216e1447728d6d3ddd01da678f4a9feb2b7964794f5609f7e5";
+      sha512 = "2d31a86952df2f5b339479cc6dabd1cbcc000119514775b07ca086e01e8310fe0d0d2c63cc57cb936588c59a5f72a5d9dae0e0a6e2f9b7cdf6225e400c24bd31";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/vi/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/vi/thunderbird-68.9.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "8724cbf93d5d7ebf6fa67b85bf559bfe905cca6b76a4e386db99252d7460ce78d3b63f3c1e5a14782f72d1434906a2d7ad2497bb66ffa6cb66aaf44dc84d0a0e";
+      sha512 = "3c241242e918bb69d811289879323205c070620829e05488e224450e7edb2be32b0f2c36f3182fcab95a1673fd133635e89801feaf6a34fa1553d8fea3b57641";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/zh-CN/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/zh-CN/thunderbird-68.9.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "3cc8703dffdedc2de263c2ce10e2fc2f374c991ec7b34ab3d5530d3441ce8049577824cbeb0ec4ab233973e2d5c0120958360b1920e3f43ae9362132b4948cdd";
+      sha512 = "b4932b43158a5f8627ec951a3cb726863575a81b9d7b93ab35a9168224cd91480ecde55a1e7d4c01b9ed74f92440724475980010f1645db9b2ef0b6c42e92d93";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.8.1/linux-i686/zh-TW/thunderbird-68.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/zh-TW/thunderbird-68.9.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "bf37041bac13932ad283d49a2f4f552cd4422aaab7baec7a18e19ffd4101b155a8e864aa666eb85683a82668c393c7210631754a375d012e9c9e200c554776c3";
+      sha512 = "018fff050295932a492433992a97fd01acc36685f7d1f96bba2f41972fdd6cd592c117434d2de81d0d018595c8473427aefe5a7b66194bc18d127c2e7eab5a34";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -72,13 +72,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "68.8.1";
+  version = "68.9.0";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "2zq65qhrg8xsz75yywcijdjbkndn79w73v5vyahiyyibc8lfjphz0zaihk67ja82fpnxlnsfvy45s8x5l42kcbb0wibkjy7m55bd6h7";
+      "3q0dikgkfr72hhz39pxi2f0cljn09lw4940qcn9kzfwfid2h290j7pihx6gs0z6h82fl78f9fl1598d064lwl1i2434dzx6bg4p4549";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- High security fixes
- Other fixes

https://www.mozilla.org/en-US/security/advisories/mfsa2020-22/
https://www.thunderbird.net/en-US/thunderbird/68.9.0/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
