### PR TITLE
Revert "python3Packages.shellingham: 1.3.1 -> 1.3.2"

### DIFF
--- a/pkgs/development/python-modules/shellingham/default.nix
+++ b/pkgs/development/python-modules/shellingham/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "shellingham";
-  version = "1.3.2";
+  version = "1.3.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "576c1982bea0ba82fb46c36feb951319d7f42214a82634233f58b40d858a751e";
+    sha256 = "1q7kws7w4x2hji3g7y0ni9ddk4sd676ylrb3db54gbpys6xj6nwq";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
This reverts commit e36caa13c6fb461ef2b6ba28942f2f45d8f91fcc.



###### Motivation for this change

As described in #89448, the automatic upgrade to shellingham broke the package. The pypi-tarball of version 1.3.2 does not contain setup.py, which is however required for building the package. 

###### Things done

- [x] checked presence (and absence) of setup.py in tarballs of version 1.3.1 and 1.3.2
- [x] run `nix-build -A python37Packages.shellingham`
- [x] using NixOS

After reverting, the package builds as expected.
