### PR TITLE
Bump minver.nix to 2.2

### DIFF
--- a/lib/minver.nix
+++ b/lib/minver.nix
@@ -1,2 +1,2 @@
 # Expose the minimum required version for evaluating Nixpkgs
-"2.0"
+"2.2"


### PR DESCRIPTION
This bumps the minimal Nix version required for Nixpkgs to 2.2 (which is what NixOS 19.03 used).