### PR TITLE
pg_ed25519: init at 0.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_ed25519.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_ed25519.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "pg_ed25519";
+  version = "0.2";
+
+  src = fetchurl {
+    url = "https://gitlab.com/dwagin/${pname}/-/archive/${version}/${pname}-${version}.tar.bz2";
+    sha256 = "0q46pvk1vq5w3al6i3inzlw6w7za3n7p1gd4wfbbxzvzh7qnynda";
+  };
+
+  buildInputs = [ postgresql ];
+
+  installPhase = ''
+    mkdir -p $out/bin    # For buildEnv to setup proper symlinks. See #22653
+    mkdir -p $out/{lib,share/postgresql/extension}
+
+    cp *.so      $out/lib
+    cp *.sql     $out/share/postgresql/extension
+    cp *.control $out/share/postgresql/extension
+  '';
+
+  meta = with stdenv.lib; {
+    description = "PostgreSQL extension for signing and verifying ed25519 signatures";
+    homepage = "https://gitlab.com/dwagin/pg_ed25519";
+    maintainers = [ maintainers.renzo ];
+    platforms = postgresql.meta.platforms;
+    license = licenses.mit;
+  };
+}
+

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -13,6 +13,8 @@ self: super: {
 
     pg_bigm = super.callPackage ./ext/pg_bigm.nix { };
 
+    pg_ed25519 = super.callPackage ./ext/pg_ed25519.nix { };
+
     pg_repack = super.callPackage ./ext/pg_repack.nix { };
 
     pg_similarity = super.callPackage ./ext/pg_similarity.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add PostgreSQL extension for signing and verifying ed25519 signatures.

###### Things done

The extension is packaged in the same way other PostgreSQL extensions are packaged.

I tested that everything works as expected with the following vectors (all queries result in `true`):

```sql
CREATE EXTENSION "pg_ed25519";

-- GOOD SIGNATURE
SELECT ed25519.verify
  ( '\x4284abc51bb67235' :: bytea
  , '\xd6addec5afb0528ac17bb178d3e7f2887f9adbb1ad16e110545ef3bc57f9de2314a5c8388f723b8907be0f3ac90c6259bbe885ecc17645df3db7d488f805fa08' :: bytea
  , '\xf81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863' :: bytea
  ) = true;

-- BAD SIGNATURE: BAD MESSAGE
SELECT ed25519.verify
  ( '\x0000000000000000' :: bytea
  , '\xd6addec5afb0528ac17bb178d3e7f2887f9adbb1ad16e110545ef3bc57f9de2314a5c8388f723b8907be0f3ac90c6259bbe885ecc17645df3db7d488f805fa08' :: bytea
  , '\xf81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863' :: bytea
  ) = false;

-- BAD SIGNATURE
SELECT ed25519.verify
  ( '\x4284abc51bb67235' :: bytea
  , '\x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' :: bytea
  , '\xf81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863' :: bytea
  ) = false;

-- BAD SIGNATURE: BAD PUBLIC KEY
SELECT ed25519.verify
  ( '\x4284abc51bb67235' :: bytea
  , '\xd6addec5afb0528ac17bb178d3e7f2887f9adbb1ad16e110545ef3bc57f9de2314a5c8388f723b8907be0f3ac90c6259bbe885ecc17645df3db7d488f805fa08' :: bytea
  , '\x0000000000000000000000000000000000000000000000000000000000000000' :: bytea
  ) = false;

-- EXPECTED SIGNATURE
SELECT ed25519.sign
  ( '\x4284abc51bb67235' :: bytea
  , '\xf81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863' :: bytea
  , '\x3b26516fb3dc88eb181b9ed73f0bcd52bcd6b4c788e4bcaf46057fd078bee073' :: bytea
  ) = '\xd6addec5afb0528ac17bb178d3e7f2887f9adbb1ad16e110545ef3bc57f9de2314a5c8388f723b8907be0f3ac90c6259bbe885ecc17645df3db7d488f805fa08' :: bytea;
```



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] ~Tested execution of all binary files (usually in `./result/bin/`)~
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
