### PR TITLE
overmind: 2.0.3 -> 2.1.1

### DIFF
--- a/pkgs/applications/misc/overmind/default.nix
+++ b/pkgs/applications/misc/overmind/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "overmind";
-  version = "2.0.3";
+  version = "2.1.1";
   goPackagePath = "github.com/DarthSim/overmind";
 
   nativeBuildInputs = [ makeWrapper ];
@@ -15,8 +15,10 @@ buildGoPackage rec {
     owner = "DarthSim";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0c551c240lqxdjg0jj01rh2fyhwls02k5lczlxacj05prp1plz9p";
+    sha256 = "0akqn8s1mgk5q00gzh3ymq7nrnkyi6avyaxxvbxnjyq9bxsqz327";
   };
+
+  goDeps = ./deps.nix;
 
   meta = with lib; {
     homepage = "https://github.com/DarthSim/overmind";

--- a/pkgs/applications/misc/overmind/deps.nix
+++ b/pkgs/applications/misc/overmind/deps.nix
@@ -1,0 +1,147 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev = "v0.3.1";
+      sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
+    };
+  }
+  {
+    goPackagePath = "github.com/DarthSim/godotenv";
+    fetch = {
+      type = "git";
+      url = "https://github.com/DarthSim/godotenv";
+      rev = "v1.3.1";
+      sha256 = "0fb9nl5qrnv7f9w0pgg00ak34afw9kjgcql0l38z22faz2bhgl1q";
+    };
+  }
+  {
+    goPackagePath = "github.com/cpuguy83/go-md2man";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cpuguy83/go-md2man";
+      rev = "f79a8a8ca69d";
+      sha256 = "0r1f7v475dxxgzqci1mxfliwadcrk86ippflx9n411325l4g3ghv";
+    };
+  }
+  {
+    goPackagePath = "github.com/kardianos/osext";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kardianos/osext";
+      rev = "2bc1f35cddc0";
+      sha256 = "1pvrbrvmrf4mx0fxbfaphbzgqgwn8v6lkfk2vyrs0znxrs1xyc5r";
+    };
+  }
+  {
+    goPackagePath = "github.com/matoous/go-nanoid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matoous/go-nanoid";
+      rev = "eab626deece6";
+      sha256 = "1a82lclk56y7c44jg7wn5vq733dmn0g20r5yqbchrxnpfl75dw89";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/term";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/term";
+      rev = "aa71e9d9e942";
+      sha256 = "1gyxnj4jq3z2k4gjwwlz8hn56c1ys8jvafdd61nd6qs8jwp6iqp3";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/russross/blackfriday";
+    fetch = {
+      type = "git";
+      url = "https://github.com/russross/blackfriday";
+      rev = "v2.0.1";
+      sha256 = "0nlz7isdd4rgnwzs68499hlwicxz34j2k2a0b8jy0y7ycd2bcr5j";
+    };
+  }
+  {
+    goPackagePath = "github.com/sevlyar/go-daemon";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sevlyar/go-daemon";
+      rev = "v0.1.5";
+      sha256 = "1y3gnxaifykcjcbzx91lz9bc93b95w3xj4rjxjbii26pm3j7gqyk";
+    };
+  }
+  {
+    goPackagePath = "github.com/shurcooL/sanitized_anchor_name";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shurcooL/sanitized_anchor_name";
+      rev = "v1.0.0";
+      sha256 = "1gv9p2nr46z80dnfjsklc6zxbgk96349sdsxjz05f3z6wb6m5l8f";
+    };
+  }
+  {
+    goPackagePath = "github.com/urfave/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/urfave/cli";
+      rev = "v1.22.2";
+      sha256 = "10mcnvi5qmn00vpyk6si8gjka7p654wr9hac4zc9w5h3ickhvbdc";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "88737f569e3a";
+      sha256 = "02vkqfd6kc28zm6lffagw8nr78sayv6jabfgk9dcifl7826vi3k7";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "81d4e9dc473e";
+      sha256 = "0074zjpkhclz5qbgjv0zmdwy6hmf5k2ri5yagnm6i12ahxaa48dr";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "20d25e280405";
+      sha256 = "0k1m83ji9l1a7ng8a7v40psbymxasmssbrrhpdv2wl4rhs0nc3np";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/urfave/cli.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/urfave/cli.v1";
+      rev = "v1.20.0";
+      sha256 = "0y6f4sbzkiiwrxbl15biivj8c7qwxnvm3zl2dd3mw4wzg4x10ygj";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.2.2";
+      sha256 = "01wj12jzsdqlnidpyjssmj0r4yavlqy7dwrg7adqd8dicjc4ncsa";
+    };
+  }
+]


### PR DESCRIPTION
###### Motivation for this change

https://github.com/DarthSim/overmind/releases/tag/v2.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
