### PR TITLE
linuxPackages.rtl8821cu: init at 2020-05-16

### DIFF
--- a/pkgs/os-specific/linux/rtl8821cu/default.nix
+++ b/pkgs/os-specific/linux/rtl8821cu/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, kernel, bc }:
+stdenv.mkDerivation rec {
+  name = "rtl8821cu-${kernel.version}-${version}";
+  version = "unstable-2020-05-16";
+
+  src = fetchFromGitHub {
+    owner = "brektrou";
+    repo = "rtl8821cu";
+    rev = "5c510c9f14352fed4906a10921040b9e46b58346";
+    sha256 = "1n74h1m3l2dj35caswaghzcjwcv5qlv3gj6j1rqdddbyg5khl4ag";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = [ bc ];
+  buildInputs = kernel.moduleBuildDependencies;
+
+  prePatch = ''
+    substituteInPlace ./Makefile \
+      --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
+      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
+      --replace /sbin/depmod \# \
+      --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  preInstall = ''
+    mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Realtek rtl8821cu driver";
+    homepage = "https://github.com/brektrou/rtl8821CU";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.contrun ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17607,6 +17607,8 @@ in
 
     rtl88x2bu = callPackage ../os-specific/linux/rtl88x2bu { };
 
+    rtl8821cu = callPackage ../os-specific/linux/rtl8821cu { };
+
     rtlwifi_new = callPackage ../os-specific/linux/rtlwifi_new { };
 
     openafs = callPackage ../servers/openafs/1.6/module.nix { };


### PR DESCRIPTION
###### Motivation for this change
Add driver for realtek 8821cu/8811cu devices

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
