### PR TITLE
nixos/dovecot2: turn `mailboxes`-option into an attr-set

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -614,6 +614,29 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
      queued on the kernel side of the netlink socket.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     Specifying <link linkend="opt-services.dovecot2.mailboxes">mailboxes</link> in the <package>dovecot2</package> module
+     as a list is deprecated and will break eval in 21.03. Instead, an attribute-set should be specified where the <literal>name</literal>
+     should be the key of the attribute.
+    </para>
+    <para>
+     This means that a configuration like this
+<programlisting>{
+  <link linkend="opt-services.dovecot2.mailboxes">services.dovecot2.mailboxes</link> = [
+    { name = "Junk";
+      auto = "create";
+    }
+  ];
+}</programlisting>
+    should now look like this:
+<programlisting>{
+  <link linkend="opt-services.dovecot2.mailboxes">services.dovecot2.mailboxes</link> = {
+    Junk.auto = "create";
+  };
+}</programlisting>
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -125,6 +125,8 @@ let
   mailboxConfig = mailbox: ''
     mailbox "${mailbox.name}" {
       auto = ${toString mailbox.auto}
+  '' + optionalString (mailbox.autoexpunge != null) ''
+    autoexpunge = ${mailbox.autoexpunge}
   '' + optionalString (mailbox.specialUse != null) ''
     special_use = \${toString mailbox.specialUse}
   '' + "}";
@@ -147,6 +149,15 @@ let
         default = null;
         example = "Junk";
         description = "Null if no special use flag is set. Other than that every use flag mentioned in the RFC is valid.";
+      };
+      autoexpunge = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "60d";
+        description = ''
+          To automatically remove all email from the mailbox which is older than the
+          specified time.
+        '';
       };
     };
   };


### PR DESCRIPTION

###### Motivation for this change

* 7922a78: add the `autoexpunge`-setting to `services.dovecot2.mailboxes`. With this option specified, email older than the specified time will be automatically removed.

  This is e.g. helpful for spam-folders.

* 907d046 : turned the `mailboxes`-option into an attr-set. This makes it easier to override the settings for a single mailbox.

  It's still possible to use a list for backwards-compatibility, but this will raise a deprecation warning.

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
