### PR TITLE
wait-for-it: init at unstable-2020-02-05

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3292,6 +3292,12 @@
       fingerprint = "6C2B 55D4 4E04 8266 6B7D  DA1A 422E 9EDA E015 7170";
     }];
   };
+  silviogutierrez = {
+    email = "silviogutierrez@gmail.com";
+    github = "silviogutierrez";
+    githubId = 92824;
+    name = "Silvio Gutierrez";
+  };
   ingenieroariel = {
     email = "ariel@nunez.co";
     github = "ingenieroariel";

--- a/pkgs/tools/networking/wait-for-it/default.nix
+++ b/pkgs/tools/networking/wait-for-it/default.nix
@@ -1,0 +1,28 @@
+{ stdenvNoCC, lib, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "wait-for-it-unstable";
+  version = "unstable-2020-02-05";
+
+  src = fetchFromGitHub {
+    owner = "vishnubob";
+    repo = "wait-for-it";
+    rev = "c096cface5fbd9f2d6b037391dfecae6fde1362e";
+    sha256 = "1k1il4bk8l2jmfrrcklznc8nbm69qrjgxm20l02k01vhv2m2jc85";
+  };
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+  installPhase = ''
+    runHook preInstall
+
+    install -D ./wait-for-it.sh  $out/bin/wait-for-it
+
+    runHook postInstall
+  '';
+  meta = {
+    homepage = "https://github.com/vishnubob/wait-for-it";
+    description =
+      "Pure bash script to test and wait on the availability of a TCP host and port";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.silviogutierrez ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7386,6 +7386,8 @@ in
 
   wakatime = pythonPackages.callPackage ../tools/misc/wakatime { };
 
+  wait-for-it = callPackage ../tools/networking/wait-for-it {};
+
   weather = callPackage ../applications/misc/weather { };
 
   wego = callPackage ../applications/misc/wego { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add wait-for-it package, a zero dependency battle-tested wait to wait for a service to be available.

**Please note, the repo, while very popular, does not seem to use the concept of tags, versions, or releases. So I just pinned it to the latest build from master.**

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
