### PR TITLE
python3Packages.shellingham: use pyproject format

### DIFF
--- a/pkgs/development/python-modules/shellingham/default.nix
+++ b/pkgs/development/python-modules/shellingham/default.nix
@@ -4,6 +4,7 @@
 buildPythonPackage rec {
   pname = "shellingham";
   version = "1.3.2";
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/toggl-cli/default.nix
+++ b/pkgs/development/python-modules/toggl-cli/default.nix
@@ -1,13 +1,26 @@
-{ stdenv, buildPythonPackage, fetchPypi, twine, pbr, click, click-completion, validate-email,
-pendulum, ptable, requests, inquirer, pythonOlder, pytest, pytestcov, pytest-mock, faker, factory_boy,
-setuptools }:
+{ stdenv, buildPythonPackage, fetchPypi, pythonAtLeast, pythonOlder
+, click
+, click-completion
+, factory_boy
+, faker
+, inquirer
+, pbr
+, pendulum
+, ptable
+, pytest
+, pytestcov
+, pytest-mock
+, requests
+, setuptools
+, twine
+, validate-email
+}:
 
 
 buildPythonPackage rec {
   pname = "toggl-cli";
   version = "2.1.0";
-
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.5" || pythonAtLeast "3.8";
 
   src = fetchPypi {
     pname = "togglCli";


### PR DESCRIPTION
###### Motivation for this change
closes #89475 #89448

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
