### PR TITLE
buildbot: 2.7.0 -> 2.8.0

### DIFF
--- a/pkgs/development/python-modules/buildbot/default.nix
+++ b/pkgs/development/python-modules/buildbot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, fetchpatch, makeWrapper, isPy3k,
+{ stdenv, lib, buildPythonPackage, fetchFromGitHub, fetchpatch, makeWrapper, isPy3k,
   python, twisted, jinja2, zope_interface, future, sqlalchemy,
   sqlalchemy_migrate, dateutil, txaio, autobahn, pyjwt, pyyaml, treq,
   txrequests, pyjade, boto3, moto, mock, python-lz4, setuptoolsTrial,
@@ -25,12 +25,17 @@ let
 
   package = buildPythonPackage rec {
     pname = "buildbot";
-    version = "2.7.0";
+    version = "2.8.0";
 
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "0jj8fh611n7xc3vsfbgpqsllp38cfj3spkr2kz3ara2x7jvh3406";
+    # tests fail with the 2.8.0 sdist, so fetchFromGitHub instead
+    # https://github.com/buildbot/buildbot/pull/5322
+    src = fetchFromGitHub {
+      owner = "buildbot";
+      repo = "buildbot";
+      rev = "v${version}";
+      sha256 = "0akd61mgjp53c3vyf2yyzd0xf0cjwpvsi7g8pz72xrvnil1s4w7k";
     };
+    sourceRoot = "./source/master";
 
     propagatedBuildInputs = [
       # core

--- a/pkgs/development/python-modules/buildbot/pkg.nix
+++ b/pkgs/development/python-modules/buildbot/pkg.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "buildbot-pkg";
-  version = "2.7.0";
+  version = "2.8.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "03zb09r8w8dvd9qas7h6gdwlqc7q482ikph6h3708lpnkn72xdkb";
+    sha256 = "09sf36h8q8wrp0n57nb9915k86qdjyjj4xpdzy8q4s9z121iw0xz";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/buildbot/plugins.nix
+++ b/pkgs/development/python-modules/buildbot/plugins.nix
@@ -7,7 +7,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "1d8xdk4rq4p3fw03cvz7d1pmpjjbyrnzzjifzv46q88vk7jakgxi";
+      sha256 = "1xq7pqvvsvgd2n38yzk0bqx943ldxsldrdcldwjshazq831rbdbn";
     };
 
     # Remove unneccessary circular dependency on buildbot
@@ -34,7 +34,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "03pl75avi6cmmhjvfn0a0b4drn35yv37kvgn04zjdwa3m6p3haa8";
+      sha256 = "0ixq8x845glnykpab2z0vhwp69nbw98mg0df34kf32wjvm8j6kjh";
     };
 
     buildInputs = [ buildbot-pkg ];
@@ -56,7 +56,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "0rzjk3qmlvid8qag3r00zaszchncl1nl8l2yapvc1zqh2dqlln58";
+      sha256 = "1gn0amv8l0n0ny1x78g8x4rpfsnhcs9gkws2zw3nx78y4pbs6lw5";
     };
 
     buildInputs = [ buildbot-pkg ];
@@ -78,7 +78,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "1n4j73y9kwfqk7dz1fh1bpan68vlpnbz7idxpmsphyay8w8y9dd4";
+      sha256 = "04c0m4liyl4aaksq9x8wncasacfv0vgl0igafnhf440cf9lhkkwy";
     };
 
     buildInputs = [ buildbot-pkg ];
@@ -100,7 +100,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "1babkcgxczs6zfk2b6jmsy2vwbrgdydrp2px1mfwa3wmv8fwlssg";
+      sha256 = "0c7lr4q3dvz3zhbnsvs2chsc6yn2jh10dnh1y66axdxk8hpqs3nc";
     };
 
     buildInputs = [ buildbot-pkg ];

--- a/pkgs/development/python-modules/buildbot/worker.nix
+++ b/pkgs/development/python-modules/buildbot/worker.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage (rec {
   pname = "buildbot-worker";
-  version = "2.7.0";
+  version = "2.8.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1vwy46acvczgk1hhpsqdwpcw55j4hm5pkw6j01f92axiga8r5jk6";
+    sha256 = "19pabha9jh3jnz9micfn5y4khnx4q6g1zc27wvfw6663mw6spykx";
   };
 
   propagatedBuildInputs = [ twisted future ];


### PR DESCRIPTION
```
Bug fixes

    Fix GitHubEventHandler to include files in Change that comes from a github PR (issue # 5294)
    Updated the Docker container buildbot-master to Alpine 3.11 to fix segmentation faults caused by an old version of musl
    Base64 encoding logs and attachments sent via email so emails conform to RFC 5322 2.1.1
    Handling the case where the BitbucketStatusPush return code is not 200
    When cancelling a buildrequest, the reason field is now correctly transmitted all the way to the cancelled step.
    Fix Cache-control header to be compliant with RFC 7234 (issue # 5220)
    Fix GerritEventLogPoller class to be declared as entry_point (can be used in master.cfg file)
    Git poller: add –ignore-missing argument to git log call to avoid fatal: bad object errors
    Log watcher looks for the “tail” utility in the right location on Haiku OS.
    Add limit and filtering support for the changes data API as described in issue # 5207

Improved Documentation

    Make docs build with the latest sphinx and improve rendering of the example HTML file for custom dashboard
    Make docs build with Sphinx 3 and fix some typos and incorrect Python module declarations

Features

    Property and Interpolate objects can now be compared. This will generate a renderable that will be evaluated at runtime. see Renderable Comparison.
    Added argument count to lock access to allow a lock to consume a variable amount of units
    Added arguments pollRandomDelayMin and pollRandomDelayMax to HgPoller, GitPoller, P4Poller, SvnPoller to spread the polling load
```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
