### PR TITLE
pythonPackages.wtforms: 2.1 -> 2.3.1

### DIFF
--- a/pkgs/development/python-modules/wtforms/default.nix
+++ b/pkgs/development/python-modules/wtforms/default.nix
@@ -1,29 +1,29 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
-, Babel
+, markupsafe
 }:
 
 buildPythonPackage rec {
-  version = "2.1";
-  pname = "wtforms";
+  version = "2.3.1";
+  pname = "WTForms";
 
   src = fetchPypi {
     inherit pname version;
-    extension = "zip";
-    sha256 = "0vyl26y9cg409cfyj8rhqxazsdnd0jipgjw06civhrd53yyi1pzz";
+    sha256 = "0whrd9cqhlibm31yqhvhp9illddxf0cpgcn3v806f7ajmsri66l6";
   };
 
+  propagatedBuildInputs = [ markupsafe ];
+
   # Django tests are broken "django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet."
-  # This is fixed in master I believe but not yet in 2.1;
   doCheck = false;
 
-  propagatedBuildInputs = [ Babel ];
-
   meta = with stdenv.lib; {
-    homepage = "https://github.com/wtforms/wtforms";
     description = "A flexible forms validation and rendering library for Python";
+    homepage = "https://github.com/wtforms/wtforms";
+    changelog = "https://github.com/wtforms/wtforms/blob/${version}/CHANGES.rst";
     license = licenses.bsd3;
+    maintainers = [ maintainers.bhipple ];
   };
 
 }


### PR DESCRIPTION
2.1 is from 2015!
https://github.com/wtforms/wtforms/blob/master/CHANGES.rst


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).