### PR TITLE
godot-server, godot-headless: init at 3.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9138,6 +9138,16 @@
       fingerprint = "85F8 E850 F8F2 F823 F934  535B EC50 6589 9AEA AF4C";
     }];
   };
+  yusdacra = {
+    email = "y.bera003.06@protonmail.com";
+    github = "yusdacra";
+    githubId = 19897088;
+    name = "Yusuf Bera Ertan";
+    keys = [{
+      longkeyid = "rsa2048/0x61807181F60EFCB2";
+      fingerprint = "9270 66BD 8125 A45B 4AC4 0326 6180 7181 F60E FCB2";
+    }];
+  };
   yvesf = {
     email = "yvesf+nix@xapek.org";
     github = "yvesf";

--- a/pkgs/development/tools/godot/headless.nix
+++ b/pkgs/development/tools/godot/headless.nix
@@ -1,0 +1,18 @@
+{ godot, stdenv }:
+godot.overrideAttrs (oldAttrs: rec {
+  pname = "godot-headless";
+  sconsFlags = "target=release_debug platform=server tools=yes";
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp bin/godot_server.* $out/bin/godot-headless
+
+    mkdir "$dev"
+    cp -r modules/gdnative/include $dev
+
+    mkdir -p "$man/share/man/man6"
+    cp misc/dist/linux/godot.6 "$man/share/man/man6/"
+  '';
+  meta.description =
+    "Free and Open Source 2D and 3D game engine (headless build)";
+  meta.maintainers = with stdenv.lib.maintainers; [ twey yusdacra ];
+})

--- a/pkgs/development/tools/godot/server.nix
+++ b/pkgs/development/tools/godot/server.nix
@@ -1,0 +1,18 @@
+{ godot, stdenv }:
+godot.overrideAttrs (oldAttrs: rec {
+  pname = "godot-server";
+  sconsFlags = "target=release platform=server tools=no";
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp bin/godot_server.* $out/bin/godot-server
+
+    mkdir "$dev"
+    cp -r modules/gdnative/include $dev
+
+    mkdir -p "$man/share/man/man6"
+    cp misc/dist/linux/godot.6 "$man/share/man/man6/"
+  '';
+  meta.description =
+    "Free and Open Source 2D and 3D game engine (server build)";
+  meta.maintainers = with stdenv.lib.maintainers; [ twey yusdacra ];
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3969,6 +3969,8 @@ in
   gocryptfs = callPackage ../tools/filesystems/gocryptfs { };
 
   godot = callPackage ../development/tools/godot {};
+  
+  godot-headless = callPackage ../development/tools/godot/headless.nix { };
 
   goklp = callPackage ../tools/networking/goklp {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3972,6 +3972,8 @@ in
   
   godot-headless = callPackage ../development/tools/godot/headless.nix { };
 
+  godot-server = callPackage ../development/tools/godot/server.nix { };
+
   goklp = callPackage ../tools/networking/goklp {};
 
   go-mtpfs = callPackage ../tools/filesystems/go-mtpfs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add godot-server for running dedicated game servers and godot-headless to export projects in an automated manner.
<https://docs.godotengine.org/en/stable/development/compiling/compiling_for_x11.html#compiling-a-headless-server-build> 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
