### PR TITLE
Clean-up for some packages in `haskell-modules/configuration-common.nix`.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -218,7 +218,7 @@ self: super: {
 
   # 2020-06-05: HACK: does not passes own build suite - `dontCheck`
   hnix = generateOptparseApplicativeCompletion "hnix" (
-    dontCheck (doJailbreak super.hnix)
+    dontCheck super.hnix
     );
 
   # Fails for non-obvious reasons while attempting to use doctest.

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -216,9 +216,6 @@ self: super: {
   # base bound
   digit = doJailbreak super.digit;
 
-  # Needs older version of QuickCheck.
-  these_0_7_6 = doJailbreak super.these_0_7_6;
-
   # 2020-06-05: HACK: does not passes own build suite - `dontCheck`
   hnix = generateOptparseApplicativeCompletion "hnix" (
     dontCheck (doJailbreak super.hnix)

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1047,7 +1047,6 @@ self: super: {
   hgettext = doJailbreak super.hgettext;
 
   # The test suite is broken. Break out of "base-compat >=0.9.3 && <0.10, hspec >=2.4.4 && <2.5".
-  haddock-library = doJailbreak (dontCheck super.haddock-library);
   haddock-library_1_9_0 = doJailbreak (dontCheck super.haddock-library_1_9_0);
 
   # Generate shell completion.

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1034,9 +1034,8 @@ self: super: {
   # Missing test files in source distribution, fixed once 1.4.0 is bumped
   # https://github.com/dhall-lang/dhall-haskell/pull/997
   dhall-json =
-    generateOptparseApplicativeCompletions ["dhall-to-json" "dhall-to-yaml"] (
-      dontCheck super.dhall-json
-  );
+    generateOptparseApplicativeCompletions ["dhall-to-json" "dhall-to-yaml"]
+      super.dhall-json;
 
   dhall-nix =
     generateOptparseApplicativeCompletion "dhall-to-nix" (

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1031,8 +1031,6 @@ self: super: {
   # Should be solved when: https://github.com/dhall-lang/dhall-haskell/issues/1837
   dhall = generateOptparseApplicativeCompletion "dhall" (dontCheck super.dhall);
 
-  # Missing test files in source distribution, fixed once 1.4.0 is bumped
-  # https://github.com/dhall-lang/dhall-haskell/pull/997
   dhall-json =
     generateOptparseApplicativeCompletions ["dhall-to-json" "dhall-to-yaml"]
       super.dhall-json;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1101,7 +1101,8 @@ self: super: {
     # Generate shell completions
     generateOptparseApplicativeCompletion "purs" dontHaddockPurescript;
 
-  # https://github.com/kcsongor/generic-lens/pull/65
+  # 2020-06-05: HACK: Package can not pass test suite,
+  # Upstream Report: https://github.com/kcsongor/generic-lens/issues/83
   generic-lens = dontCheck super.generic-lens;
 
   # https://github.com/danfran/cabal-macosx/issues/13

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1027,7 +1027,8 @@ self: super: {
   # Test has either build errors or fails anyway, depending on the compiler.
   vector-algorithms = dontCheck super.vector-algorithms;
 
-  # The test suite attempts to use the network.
+  # 2020-06-04: HACK: dontCheck - The test suite attempts to use the network.
+  # Should be solved when: https://github.com/dhall-lang/dhall-haskell/issues/1837
   dhall = generateOptparseApplicativeCompletion "dhall" (dontCheck super.dhall);
 
   # Missing test files in source distribution, fixed once 1.4.0 is bumped

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1046,8 +1046,6 @@ self: super: {
   # https://github.com/haskell-hvr/hgettext/issues/14
   hgettext = doJailbreak super.hgettext;
 
-  # The test suite is broken. Break out of "base-compat >=0.9.3 && <0.10, hspec >=2.4.4 && <2.5".
-
   # Generate shell completion.
   cabal2nix = generateOptparseApplicativeCompletion "cabal2nix" super.cabal2nix;
   stack = generateOptparseApplicativeCompletion "stack" (super.stack.overrideScope (self: super: { http-download = self.http-download_0_2_0_0; }));

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -219,9 +219,9 @@ self: super: {
   # Needs older version of QuickCheck.
   these_0_7_6 = doJailbreak super.these_0_7_6;
 
-  hnix =
-    generateOptparseApplicativeCompletion "hnix" (
-      dontCheck (doJailbreak (super.hnix.override { these = self.these_0_7_6; }))
+  # 2020-06-05: HACK: does not passes own build suite - `dontCheck`
+  hnix = generateOptparseApplicativeCompletion "hnix" (
+    dontCheck (doJailbreak (super.hnix.override { these = self.these_0_7_6; }))
     );
 
   # Fails for non-obvious reasons while attempting to use doctest.

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -219,12 +219,6 @@ self: super: {
   # Needs older version of QuickCheck.
   these_0_7_6 = doJailbreak super.these_0_7_6;
 
-  # dontCheck: Can be removed once https://github.com/haskell-nix/hnix/commit/471712f is in (5.2 probably)
-  #   This is due to GenList having been removed from generic-random in 1.2.0.0
-  # doJailbreak: Can be removed once https://github.com/haskell-nix/hnix/pull/329 is in (5.2 probably)
-  #   This is due to hnix currently having an upper bound of <0.5 on deriving-compat, works just fine with our current version 0.5.1 though
-  # Does not support recent versions of "these".
-  # https://github.com/haskell-nix/hnix/issues/514
   hnix =
     generateOptparseApplicativeCompletion "hnix" (
       dontCheck (doJailbreak (super.hnix.override { these = self.these_0_7_6; }))

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -221,7 +221,7 @@ self: super: {
 
   # 2020-06-05: HACK: does not passes own build suite - `dontCheck`
   hnix = generateOptparseApplicativeCompletion "hnix" (
-    dontCheck (doJailbreak (super.hnix.override { these = self.these_0_7_6; }))
+    dontCheck (doJailbreak super.hnix)
     );
 
   # Fails for non-obvious reasons while attempting to use doctest.

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1148,7 +1148,9 @@ self: super: {
     '';
   });
 
-  # test suite failure: https://github.com/jgm/pandoc/issues/5582
+  # 2020-06-05: HACK: In Nixpkgs currently this is
+  # old pandoc version 2.7.4 to current 2.9.2.1,
+  # test suite failures: https://github.com/jgm/pandoc/issues/5582
   pandoc = dontCheck super.pandoc;
 
   # Fix build with attr-2.4.48 (see #53716)

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1047,7 +1047,6 @@ self: super: {
   hgettext = doJailbreak super.hgettext;
 
   # The test suite is broken. Break out of "base-compat >=0.9.3 && <0.10, hspec >=2.4.4 && <2.5".
-  haddock-library_1_9_0 = doJailbreak (dontCheck super.haddock-library_1_9_0);
 
   # Generate shell completion.
   cabal2nix = generateOptparseApplicativeCompletion "cabal2nix" super.cabal2nix;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2435,7 +2435,6 @@ extra-packages:
   - seqid-streams < 0.2                 # newer versions depend on transformers 0.4.x which we cannot provide in GHC 7.8.x
   - split < 0.2                         # newer versions don't work with GHC 6.12.3
   - tar < 0.4.2.0                       # later versions don't work with GHC < 7.6.x
-  - these == 0.7.6                      # required by hnix 0.6.1
   - transformers == 0.4.3.*             # the latest version isn't supported by mtl yet
   - vector < 0.10.10                    # newer versions don't work with GHC 6.12.3
   - xml-conduit ^>= 1.7                 # pre-lts-11.x versions neeed by git-annex 6.20180227

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5993,7 +5993,6 @@ broken-packages:
   - hmt-diagrams
   - hmumps
   - hnetcdf
-  - hnix
   - hnix-store-remote
   - HNM
   - hnormalise


### PR DESCRIPTION
###### Motivation for this change

Clean-ups and more informative docs to: `{haddock-library, haddock-library_1_9_0, pandoc (1.2.7), hnix, generic-lens, dhall, dhall-json, dhall-nix}`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
