### PR TITLE
python3Packages.pytest-rerunfailures: 8.0 -> 9.0

### DIFF
--- a/pkgs/development/python-modules/pytest-rerunfailures/default.nix
+++ b/pkgs/development/python-modules/pytest-rerunfailures/default.nix
@@ -23,6 +23,6 @@ buildPythonPackage rec {
     description = "pytest plugin to re-run tests to eliminate flaky failures";
     homepage = "https://github.com/pytest-dev/pytest-rerunfailures";
     license = licenses.mpl20;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ das-g ];
   };
 }

--- a/pkgs/development/python-modules/pytest-rerunfailures/default.nix
+++ b/pkgs/development/python-modules/pytest-rerunfailures/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest, mock }:
+{ stdenv, buildPythonPackage, pythonOlder, fetchPypi, pytest, mock }:
 
 buildPythonPackage rec {
   pname = "pytest-rerunfailures";
-  version = "8.0";
+  version = "9.0";
+
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "04p8rfvv7yi3gsdm1dw1mfhjwg6507rhgj7nbm5gfqw4kxmj7h8p";
+    sha256 = "1r5qnkkhkfvx1jbi1wfyxpyggwyr32w6h5z3i93a03bc92kc4nl9";
   };
 
   checkInputs = [ mock pytest ];


### PR DESCRIPTION
fixes #89508

- bump `pytest-rerunfailures` to 9.0
- drop Python 2.7 support for `pytest-rerunfailures`, because upstream did
- drop Python &le;3.4 support for `pytest-rerunfailures`, because upstream did (in [8.0](https://github.com/pytest-dev/pytest-rerunfailures/blob/9.0/CHANGES.rst#80-2019-11-18) already)
- add myself (@das-g) as maintainer

###### Motivation for this change

- #89508
- upstream release 9.0
  - [release notes](https://github.com/pytest-dev/pytest-rerunfailures/blob/9.0/CHANGES.rst#90-2020-03-18)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
    - (there are none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
   - (`meta.description` is not capitalized. Should it really?)

---

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
<br>- python37Packages.pytest-rerunfailures
<br>- python38Packages.pytest-rerunfailures
<br>- xonsh
</details>