### PR TITLE
qgroundcontrol: 3.5.5 -> 4.0.8

### DIFF
--- a/pkgs/applications/science/robotics/qgroundcontrol/default.nix
+++ b/pkgs/applications/science/robotics/qgroundcontrol/default.nix
@@ -1,33 +1,30 @@
 { lib, mkDerivation, fetchgit, SDL2
 , qtbase, qtcharts, qtlocation, qtserialport, qtsvg, qtquickcontrols2
-, qtgraphicaleffects, qtspeech, qmake
-, makeWrapper
-, gst_all_1, pkgconfig
+, qtgraphicaleffects, qtspeech, qtx11extras, qmake, qttools
+, gst_all_1, wayland, pkgconfig
 }:
 
 mkDerivation rec {
   pname = "qgroundcontrol";
-  version = "3.5.5";
+  version = "4.0.8";
 
   qtInputs = [
     qtbase qtcharts qtlocation qtserialport qtsvg qtquickcontrols2
-    qtgraphicaleffects qtspeech
+    qtgraphicaleffects qtspeech qtx11extras
   ];
 
   gstInputs = with gst_all_1; [
-    gstreamer gst-plugins-base
+    gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad wayland
   ];
 
   enableParallelBuilding = true;
   buildInputs = [ SDL2 ] ++ gstInputs ++ qtInputs;
-  nativeBuildInputs = [ pkgconfig makeWrapper qmake ];
+  nativeBuildInputs = [ pkgconfig qmake qttools ];
 
   preConfigure = ''
     mkdir build
     cd build
   '';
-
-  NIX_CFLAGS_COMPILE = [ "-Wno-address-of-packed-member" ]; # Don't litter logs with these warnings
 
   qmakeFlags = [
     # Default install tries to copy Qt files into package
@@ -36,6 +33,8 @@ mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     cd ..
 
     mkdir -p $out/share/applications
@@ -50,18 +49,19 @@ mkDerivation rec {
 
     mkdir -p $out/share/pixmaps
     cp -v resources/icons/qgroundcontrol.png $out/share/pixmaps
+
+    runHook postInstall
   '';
 
   postInstall = ''
-    wrapProgram "$out/bin/qgroundcontrol" \
-      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"
+    qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
   '';
 
   # TODO: package mavlink so we can build from a normal source tarball
   src = fetchgit {
     url = "https://github.com/mavlink/qgroundcontrol.git";
     rev = "v${version}";
-    sha256 = "05zy6w9lwwh254wa8c6wysa67kk0flywcvipii9b1rmy47slflhs";
+    sha256 = "0jr9jpjqdwizsvh9zm0fdp8k2r4536m40dxrn30fbr3ba8vnzkgq";
     fetchSubmodules = true;
   };
 
@@ -70,6 +70,6 @@ mkDerivation rec {
     homepage = "http://qgroundcontrol.org/";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ lopsided98 ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Updates QGroundControl to the latest version. I added myself as maintainer.

I improved GStreamer video support, but I was only able to test a local webcam source. Other sources should work unless they need an ugly plugin.

`-Waddress-of-packed-member` is still reported a few times, but not nearly as many times as before and therefore shouldn't cause the Hydra log limit to be exceeded. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @knedlsepp @globin