### PR TITLE
sed-opal-unlocker: init at 1.0.0

### DIFF
--- a/pkgs/tools/security/sed-opal-unlocker/default.nix
+++ b/pkgs/tools/security/sed-opal-unlocker/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchFromGitHub, runCommand, python3, libargon2 }:
+
+let
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "dex6";
+    repo = "sed-opal-unlocker";
+    rev = "v${version}";
+    sha256 = "0gr94jlw8d01a1bz2x6jhwim2hh4rijlj94x2fqxxhk22lbk61n2";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/dex6/sed-opal-unlocker";
+    description = "Micro-utility for unlocking TCG-OPAL encrypted disks";
+    license = licenses.asl20;
+    maintainers = [ maintainers.tadfisher ];
+    platforms = platforms.linux;
+  };
+
+  # Keep this separate as it's not needed to unlock a disk, just to
+  # generate a password hash. This keeps python3 out of the main closure,
+  # in case someone wants to embed this in an initramfs or PBA image.
+  sedutil-passhasher = stdenv.mkDerivation {
+    inherit version src;
+    name = "sedutil-passhasher";
+
+    buildInputs = [ libargon2 python3 ];
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp sedutil-passhasher.py $out/bin/sedutil-passhasher
+    '';
+  };
+
+  sed-opal-unlocker = stdenv.mkDerivation {
+    inherit version src;
+    name = "sed-opal-unlocker";
+
+    buildInputs = [ libargon2 ];
+
+    passthru = {
+      inherit sedutil-passhasher;
+    };
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp sed-opal-unlocker $out/bin
+    '';
+  };
+
+in sed-opal-unlocker

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -914,6 +914,8 @@ in
 
   ecdsautils = callPackage ../tools/security/ecdsautils { };
 
+  sed-opal-unlocker = callPackage ../tools/security/sed-opal-unlocker { };
+
   sedutil = callPackage ../tools/security/sedutil { };
 
   elvish = callPackage ../shells/elvish { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [sed-opal-unlocker](https://github.com/dex6/sed-opal-unlocker), a tiny utility program to unlock self-encrypting drives using the TGC OPAL standard.

I have been using this for around a year now to unlock my laptop drive when resuming from hibernation, using `powerManagement.powerUpCommands`, and it's solid.

I split out the `sedutil-passhasher` script to a passthru derivation as it's only needed once to generate the password hash, and python doesn't need to be in the closure just to unlock a drive.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
