### PR TITLE
pythonPackages.apache-airflow: disable for python 3.8

### DIFF
--- a/pkgs/development/python-modules/apache-airflow/default.nix
+++ b/pkgs/development/python-modules/apache-airflow/default.nix
@@ -52,13 +52,16 @@
 , typing
 , nose
 , python
-, isPy3k
+, pythonOlder
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
   pname = "apache-airflow";
   version = "1.10.5";
-  disabled = (!isPy3k);
+  # Upstream does not yet support python 3.8
+  # https://github.com/apache/airflow/issues/8674
+  disabled = pythonOlder "3.5" || pythonAtLeast "3.8";
 
   src = fetchFromGitHub rec {
     owner = "apache";
@@ -189,6 +192,6 @@ buildPythonPackage rec {
     description = "Programmatically author, schedule and monitor data pipelines";
     homepage = "http://airflow.apache.org/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ costrouc ingenieroariel ];
+    maintainers = with maintainers; [ bhipple costrouc ingenieroariel ];
   };
 }


### PR DESCRIPTION
Currently broken everywhere, but in principle it's fixable for 3.7

Will try to fix the 3.7 build in a follow up if no one beats me to it.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).