### PR TITLE
rq: fix build on darwin

### DIFF
--- a/pkgs/development/tools/rq/default.nix
+++ b/pkgs/development/tools/rq/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, rustPlatform, libiconv, llvmPackages, v8 }:
+{ stdenv, lib, fetchFromGitHub, rustPlatform, libiconv, llvmPackages, v8 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "rq";
@@ -13,7 +13,8 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "0c5vwy3c5ji602dj64z6jqvcpi2xff03zvjbnwihb3ydqwnb3v67";
 
-  buildInputs = [ llvmPackages.clang-unwrapped v8 ];
+  buildInputs = [ llvmPackages.clang-unwrapped v8 ] 
+  ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   configurePhase = ''
     export LIBCLANG_PATH="${llvmPackages.clang-unwrapped}/lib"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`rq` could be built on macOS Mojave. The build is failing with following error:

```
cargo:warning=libgit2/src/path.h:430:10: fatal error: 'iconv.h' file not found
...
warning: build failed, waiting for other jobs to finish...
error: build failed
builder for '/nix/store/akdda7ya5mysclcrjmgjyscysbx5dp0v-rq-1.0.2.drv' failed with exit code 101
error: build of '/nix/store/akdda7ya5mysclcrjmgjyscysbx5dp0v-rq-1.0.2.drv' failed
```

Just copied the fix from similar PR: https://github.com/NixOS/nixpkgs/pull/36179

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
