### PR TITLE
pgloader: Use OpenSSL 1.0.2 (incompatible with OpenSSL 1.1)

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4044,7 +4044,9 @@ in
 
   pgformatter = callPackage ../development/tools/pgformatter { };
 
-  pgloader = callPackage ../development/tools/pgloader { };
+  pgloader = callPackage ../development/tools/pgloader {
+    openssl = openssl_1_0_2;
+  };
 
   pigz = callPackage ../tools/compression/pigz { };
 


### PR DESCRIPTION
See https://github.com/dimitri/pgloader/issues/1081 and https://github.com/dimitri/pgloader/issues/794

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This commit fixes an issue with logging into a local postgresql installation via user based authentication.  The following error occurs when using OpenSSL 1.1:

```
KABOOM!
FATAL error: Failed to connect to pgsql at "myserver.address" (port 5432) as user "user": The alien function "CRYPTO_num_locks" is undefined.
An unhandled error condition has been signalled:
   Failed to connect to pgsql at "myserver.address" (port 5432) as user "user": The alien function "CRYPTO_num_locks" is undefined.
```

Using OpenSSL 1.0.2 works fine as a workaround.  I do not know of any tracking issue where they are seeking to fix this behavior upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
