### PR TITLE
manual: Update commit message format

### DIFF
--- a/doc/contributing/submitting-changes.xml
+++ b/doc/contributing/submitting-changes.xml
@@ -59,7 +59,7 @@
      Format the commit in a following way:
     </para>
 <programlisting>
-(pkg-name | nixos/&lt;module>): (from -> to | init at version | refactor | etc)
+	(pkg-name | nixos/&lt;module>): (from -> to | from ->! breaking_update_to | init at version | refactor | etc)
 Additional information.
 </programlisting>
     <itemizedlist>
@@ -75,6 +75,11 @@ Additional information.
         <listitem>
          <para>
           <command>firefox: 54.0.1 -> 55.0</command>
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <command>onedrive: 2.3.13 ->! 2.4.2 (Notice the exclamation mark to be used when an update requires user intervention</command>
          </para>
         </listitem>
         <listitem>


### PR DESCRIPTION
###### Motivation for this change
As suggested by @danbst in https://github.com/NixOS/nixpkgs/pull/83280#issuecomment-603337347, start a convention for commit message format for breaking commits. Implemented here- https://github.com/NixOS/nixpkgs/pull/89198 

