### PR TITLE
dawPlugins: init

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6345,8 +6345,6 @@ in
 
   rkflashtool = callPackage ../tools/misc/rkflashtool { };
 
-  rkrlv2 = callPackage ../applications/audio/rkrlv2 {};
-
   rmlint = callPackage ../tools/misc/rmlint {
     inherit (pythonPackages) sphinx;
   };
@@ -6629,8 +6627,6 @@ in
   simplescreenrecorder = libsForQt5.callPackage ../applications/video/simplescreenrecorder { };
 
   sipsak = callPackage ../tools/networking/sipsak { };
-
-  sisco.lv2 = callPackage ../applications/audio/sisco.lv2 { };
 
   sit = callPackage ../applications/version-management/sit {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
@@ -14459,6 +14455,8 @@ in
 
   lv2 = callPackage ../development/libraries/audio/lv2 { };
 
+  dawPlugins = callPackage ./daw-plugins.nix { };
+
   lvtk = callPackage ../development/libraries/audio/lvtk { };
 
   qm-dsp = callPackage ../development/libraries/audio/qm-dsp { };
@@ -18625,8 +18623,6 @@ in
 
   AMB-plugins = callPackage ../applications/audio/AMB-plugins { };
 
-  ams-lv2 = callPackage ../applications/audio/ams-lv2 { };
-
   amsn = callPackage ../applications/networking/instant-messengers/amsn { };
 
   androidStudioPackages = recurseIntoAttrs
@@ -19388,8 +19384,6 @@ in
 
   eterm = callPackage ../applications/misc/eterm { };
 
-  eteroj.lv2 = libsForQt5.callPackage ../applications/audio/eteroj.lv2 { };
-
   etesync-dav = callPackage ../applications/misc/etesync-dav {};
 
   etherape = callPackage ../applications/networking/sniffers/etherape { };
@@ -19987,10 +19981,6 @@ in
 
   gxmessage = callPackage ../applications/misc/gxmessage { };
 
-  gxmatcheq-lv2 = callPackage ../applications/audio/gxmatcheq-lv2 { };
-
-  gxplugins-lv2 = callPackage ../applications/audio/gxplugins-lv2 { };
-
   hackrf = callPackage ../applications/radio/hackrf { };
 
   hakuneko = callPackage ../tools/misc/hakuneko { };
@@ -20306,8 +20296,6 @@ in
   irssi = callPackage ../applications/networking/irc/irssi { };
 
   irssi_fish = callPackage ../applications/networking/irc/irssi/fish { };
-
-  ir.lv2 = callPackage ../applications/audio/ir.lv2 { };
 
   bip = callPackage ../applications/networking/irc/bip { };
 
@@ -20714,19 +20702,6 @@ in
 
   mail-notification = callPackage ../desktops/gnome-2/desktop/mail-notification {};
 
-  magnetophonDSP = {
-    CharacterCompressor = callPackage ../applications/audio/magnetophonDSP/CharacterCompressor { };
-    CompBus = callPackage ../applications/audio/magnetophonDSP/CompBus { };
-    ConstantDetuneChorus  = callPackage ../applications/audio/magnetophonDSP/ConstantDetuneChorus { };
-    faustCompressors =  callPackage ../applications/audio/magnetophonDSP/faustCompressors { };
-    LazyLimiter = callPackage ../applications/audio/magnetophonDSP/LazyLimiter { };
-    MBdistortion = callPackage ../applications/audio/magnetophonDSP/MBdistortion { };
-    pluginUtils = callPackage ../applications/audio/magnetophonDSP/pluginUtils  { };
-    RhythmDelay = callPackage ../applications/audio/magnetophonDSP/RhythmDelay { };
-    VoiceOfFaust = callPackage ../applications/audio/magnetophonDSP/VoiceOfFaust { };
-    shelfMultiBand = callPackage ../applications/audio/magnetophonDSP/shelfMultiBand  { };
-  };
-
   makeself = callPackage ../applications/misc/makeself { };
 
   mako = callPackage ../applications/misc/mako { };
@@ -20760,8 +20735,6 @@ in
 
   mcpp = callPackage ../development/compilers/mcpp { };
 
-  mda_lv2 = callPackage ../applications/audio/mda-lv2 { };
-
   mediainfo = callPackage ../applications/misc/mediainfo { };
 
   mediainfo-gui = callPackage ../applications/misc/mediainfo-gui { };
@@ -20792,8 +20765,6 @@ in
   merkaartor = libsForQt5.callPackage ../applications/misc/merkaartor { };
 
   meshlab = libsForQt5.callPackage ../applications/graphics/meshlab { };
-
-  metersLv2 = callPackage ../applications/audio/meters_lv2 { };
 
   mhwaveedit = callPackage ../applications/audio/mhwaveedit {};
 
@@ -22192,8 +22163,6 @@ in
   surf-display = callPackage ../desktops/surf-display { };
 
   sunvox = callPackage ../applications/audio/sunvox { };
-
-  swh_lv2 = callPackage ../applications/audio/swh-lv2 { };
 
   swift-im = libsForQt5.callPackage ../applications/networking/instant-messengers/swift-im {
     inherit (gnome2) GConf;

--- a/pkgs/top-level/daw-plugins.nix
+++ b/pkgs/top-level/daw-plugins.nix
@@ -1,0 +1,48 @@
+# DAW plugins
+# ===========
+#
+# This file contains various DAW plugins, e.g. those for LV2.
+#
+
+{ lib, pkgs }:
+
+lib.makeExtensible (self: with self; let
+
+  callPackage = pkgs.newScope self;
+
+in {
+
+  inherit callPackage;
+
+  CharacterCompressor = callPackage ../applications/audio/magnetophonDSP/CharacterCompressor { };
+  CompBus = callPackage ../applications/audio/magnetophonDSP/CompBus { };
+  ConstantDetuneChorus  = callPackage ../applications/audio/magnetophonDSP/ConstantDetuneChorus { };
+  faustCompressors =  callPackage ../applications/audio/magnetophonDSP/faustCompressors { };
+  LazyLimiter = callPackage ../applications/audio/magnetophonDSP/LazyLimiter { };
+  MBdistortion = callPackage ../applications/audio/magnetophonDSP/MBdistortion { };
+  pluginUtils = callPackage ../applications/audio/magnetophonDSP/pluginUtils  { };
+  RhythmDelay = callPackage ../applications/audio/magnetophonDSP/RhythmDelay { };
+  VoiceOfFaust = callPackage ../applications/audio/magnetophonDSP/VoiceOfFaust { };
+  shelfMultiBand = callPackage ../applications/audio/magnetophonDSP/shelfMultiBand  { };
+
+  ams-lv2 = callPackage ../applications/audio/ams-lv2 { };
+
+  eteroj.lv2 = libsForQt5.callPackage ../applications/audio/eteroj.lv2 { };
+
+  gxmatcheq-lv2 = callPackage ../applications/audio/gxmatcheq-lv2 { };
+
+  gxplugins-lv2 = callPackage ../applications/audio/gxplugins-lv2 { };
+
+  ir.lv2 = callPackage ../applications/audio/ir.lv2 { };
+
+  mda_lv2 = callPackage ../applications/audio/mda-lv2 { };
+
+  metersLv2 = callPackage ../applications/audio/meters_lv2 { };
+
+  rkrlv2 = callPackage ../applications/audio/rkrlv2 {};
+
+  sisco.lv2 = callPackage ../applications/audio/sisco.lv2 { };
+
+  swh_lv2 = callPackage ../applications/audio/swh-lv2 { };
+
+})


### PR DESCRIPTION
A new package set for DAW plugins such as LV2 plugins.

We have quite a lot of plugins, but they're spread out. Some
time ago someone even noticed we had a plugin twice. Let's
put them all together in a set.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
