### PR TITLE
idris2: fix build on MacOS

### DIFF
--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
     patchShebangs --build tests
   '';
 
-  makeFlags =
+  makeFlags = [ "PREFIX=$(out)" ]
+    ++ stdenv.lib.optional stdenv.isDarwin "OS=";
     if builtins.currentSystem == "x86_64-darwin"
     then [ "PREFIX=$(out)" "OS=" ]
     else [ "PREFIX=$(out)" ];
@@ -45,4 +46,3 @@ stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
   };
 }
-

--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -24,9 +24,6 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ]
     ++ stdenv.lib.optional stdenv.isDarwin "OS=";
-    if builtins.currentSystem == "x86_64-darwin"
-    then [ "PREFIX=$(out)" "OS=" ]
-    else [ "PREFIX=$(out)" ];
 
   # The name of the main executable of pkgs.chez is `scheme`
   buildFlags = [ "bootstrap-build" "SCHEME=scheme" ];

--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     patchShebangs --build tests
   '';
 
-  makeFlags = [ "PREFIX=$(out)" ];
+  makeFlags = [ "PREFIX=$(out) OS=" ];
 
   # The name of the main executable of pkgs.chez is `scheme`
   buildFlags = [ "bootstrap-build" "SCHEME=scheme" ];

--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A purely functional programming language with first class types";
-    homepage = https://github.com/idris-lang/Idris2;
+    homepage = "https://github.com/idris-lang/Idris2";
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ wchresta ];
     platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];

--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -22,7 +22,10 @@ stdenv.mkDerivation rec {
     patchShebangs --build tests
   '';
 
-  makeFlags = [ "PREFIX=$(out) OS=" ];
+  makeFlags =
+    if builtins.currentSystem == "x86_64-darwin"
+    then [ "PREFIX=$(out)" "OS=" ]
+    else [ "PREFIX=$(out)" ];
 
   # The name of the main executable of pkgs.chez is `scheme`
   buildFlags = [ "bootstrap-build" "SCHEME=scheme" ];
@@ -39,6 +42,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/idris-lang/Idris2;
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ wchresta ];
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
   };
 }
 

--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -43,6 +43,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/idris-lang/Idris2";
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ wchresta ];
-    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
+    inherit (chez.meta) platforms;
   };
 }


### PR DESCRIPTION
The idris2 Makefile tries to use different versions of sed depending on
the OS, but nix always uses the same version. Because the version of
sed that is expected on MacOS doesn't exist in the nix environment, the
build fails. Setting the OS to empty string resolves the issue.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix Idris2 install on MacOS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
