### PR TITLE
python3Packages.jsonrpc{client,server}: init at {3.3.6,4.1.3}

### DIFF
--- a/pkgs/development/python-modules/apply_defaults/default.nix
+++ b/pkgs/development/python-modules/apply_defaults/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "apply_defaults";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "bcb";
+    repo = pname;
+    rev = version;
+    sha256 = "1nn2mch5spq8mhk741ia7zkb2bgjfn7bzxpavb476jzs38pb39d5";
+  };
+
+  checkInputs = [ pytest ];
+  checkPhase = "pytest";
+
+  meta = with stdenv.lib; {
+    description = "Apply values to optional params";
+    homepage = "https://github.com/bcb/apply_defaults";
+    license = licenses.mit;
+    maintainers = with maintainers; [ prusnak ];
+  };
+
+}

--- a/pkgs/development/python-modules/jsonrpcclient/default.nix
+++ b/pkgs/development/python-modules/jsonrpcclient/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, apply_defaults
+, click
+, jsonschema
+, mock
+, pytest
+, pytest-asyncio
+, aiohttp
+, requests
+, responses
+, pyzmq
+, testfixtures
+, tornado
+, websockets
+}:
+
+buildPythonPackage rec {
+  pname = "jsonrpcclient";
+  version = "3.3.6";
+
+  src = fetchFromGitHub {
+    owner = "bcb";
+    repo = pname;
+    rev = version;
+    sha256 = "1cy0y8pwi1dvz1hgbsnys2ck0v5rxmfkgn9qajd8h62cwv2wwjja";
+  };
+
+  propagatedBuildInputs = [ apply_defaults click jsonschema ];
+
+  checkInputs = [ mock pytest pytest-asyncio aiohttp requests responses pyzmq testfixtures tornado websockets ];
+  checkPhase = "pytest";
+
+  meta = with stdenv.lib; {
+    description = "Send JSON-RPC requests";
+    homepage = "https://github.com/bcb/jsonrpcclient";
+    license = licenses.mit;
+    maintainers = with maintainers; [ prusnak ];
+  };
+
+}

--- a/pkgs/development/python-modules/jsonrpcserver/default.nix
+++ b/pkgs/development/python-modules/jsonrpcserver/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, apply_defaults
+, jsonschema
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "jsonrpcserver";
+  version = "4.1.3";
+
+  src = fetchFromGitHub {
+    owner = "bcb";
+    repo = pname;
+    rev = version;
+    sha256 = "0s1v0q2wrfrds5gj7myy3sk5x7xhjlghc8dia2a8ncb9a6cyx84v";
+  };
+
+  propagatedBuildInputs = [ apply_defaults jsonschema ];
+
+  checkInputs = [ pytest ];
+  checkPhase = "pytest";
+
+  meta = with stdenv.lib; {
+    description = "Send JSON-RPC requests";
+    homepage = "https://github.com/bcb/jsonrpcclient";
+    license = licenses.mit;
+    maintainers = with maintainers; [ prusnak ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -867,6 +867,8 @@ in {
 
   jsonrpcclient = callPackage ../development/python-modules/jsonrpcclient { };
 
+  jsonrpcserver = callPackage ../development/python-modules/jsonrpcserver { };
+
   junit-xml = callPackage ../development/python-modules/junit-xml { };
 
   junitparser = callPackage ../development/python-modules/junitparser { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -865,6 +865,8 @@ in {
 
   jsonpath = callPackage ../development/python-modules/jsonpath { };
 
+  jsonrpcclient = callPackage ../development/python-modules/jsonrpcclient { };
+
   junit-xml = callPackage ../development/python-modules/junit-xml { };
 
   junitparser = callPackage ../development/python-modules/junitparser { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -197,6 +197,8 @@ in {
 
   aplpy = callPackage ../development/python-modules/aplpy { };
 
+  apply_defaults = callPackage ../development/python-modules/apply_defaults { };
+
   apprise = callPackage ../development/python-modules/apprise { };
 
   arrayqueues = callPackage ../development/python-modules/arrayqueues { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add new Python packages which are dependencies of the upcoming Electrum 4.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
