### PR TITLE
terraform-providers.ct: init at 0.5.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/data.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/data.nix
@@ -224,6 +224,14 @@
       version = "2.7.0";
       sha256  = "11c54waq7w34l79ak4kizjkmh8zjca5ygh9yib691hdmxsx2cifj";
     };
+  ct =
+    {
+      owner   = "poseidon";
+      repo    = "terraform-provider-ct";
+      rev     = "v0.5.0";
+      version = "0.5.0";
+      sha256  = "1zqfaxlyhr9vpqj2qqpfyh1f1nfpynb7c5ris6mdmy9zin55ppni";
+    };
   datadog =
     {
       owner   = "terraform-providers";

--- a/pkgs/applications/networking/cluster/terraform-providers/update-all
+++ b/pkgs/applications/networking/cluster/terraform-providers/update-all
@@ -118,6 +118,7 @@ slugs=(
   carlpett/terraform-provider-sops
   poseidon/terraform-provider-matchbox
   spaceapegames/terraform-provider-wavefront
+  poseidon/terraform-provider-ct
   tweag/terraform-provider-nixos
   tweag/terraform-provider-secret
 )


### PR DESCRIPTION
This is a Terraform provider that can validate and render Ignition files
for Container Linux and Fedora CoreOS.

###### Motivation for this change
Above distros don't accept the ignition config generated by `terraform-providers.ignition`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
