### PR TITLE
freeswitch: Add support for mod_opusfile

### DIFF
--- a/pkgs/servers/sip/freeswitch/default.nix
+++ b/pkgs/servers/sip/freeswitch/default.nix
@@ -3,7 +3,7 @@
 , openssl, perl, sqlite, libjpeg, speex, pcre
 , ldns, libedit, yasm, which, libsndfile, libtiff
 
-, curl, lua, libmysqlclient, postgresql, libopus, libctb, gsmlib
+, callPackage
 
 , SystemConfiguration
 
@@ -13,9 +13,7 @@
 
 let
 
-availableModules = import ./modules.nix {
-  inherit curl lua libmysqlclient postgresql libopus libctb gsmlib;
-};
+availableModules = callPackage ./modules.nix { };
 
 # the default list from v1.8.7, except with applications/mod_signalwire also disabled
 defaultModules = mods: with mods; [

--- a/pkgs/servers/sip/freeswitch/modules.nix
+++ b/pkgs/servers/sip/freeswitch/modules.nix
@@ -1,8 +1,12 @@
 { libopus
+, opusfile
+, libopusenc
+, libogg
 , libctb
 , gsmlib
 , lua
 , curl
+, ffmpeg
 , libmysqlclient
 , postgresql
 }:
@@ -17,7 +21,7 @@ in
 {
   applications = {
     abstraction = mk "applications/mod_abstraction" [];
-    av = mk "applications/mod_av" [];
+    av = mk "applications/mod_av" [ ffmpeg ];
     avmd = mk "applications/mod_avmd" [];
     bert = mk "applications/mod_bert" [];
     blacklist = mk "applications/mod_blacklist" [];
@@ -161,6 +165,7 @@ in
     imagick = mk "formats/mod_imagick" [];
     local_stream = mk "formats/mod_local_stream" [];
     native_file = mk "formats/mod_native_file" [];
+    opusfile = mk "formats/mod_opusfile" [ libopus opusfile libopusenc libogg ];
     png = mk "formats/mod_png" [];
     portaudio_stream = mk "formats/mod_portaudio_stream" [];
     shell_stream = mk "formats/mod_shell_stream" [];
@@ -169,6 +174,7 @@ in
     ssml = mk "formats/mod_ssml" [];
     tone_stream = mk "formats/mod_tone_stream" [];
     vlc = mk "formats/mod_vlc" [];
+    webm = mk "formats/mod_webm" [];
   };
 
   languages = {


### PR DESCRIPTION
Also switch to callPackage, add the webm module (untested), fix the
include path to libopus, and fix the av module.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
