### PR TITLE
dovecot: Add autoexpunge option to dovecot

### DIFF
--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -127,6 +127,8 @@ let
       auto = ${toString mailbox.auto}
   '' + optionalString (mailbox.specialUse != null) ''
     special_use = \${toString mailbox.specialUse}
+  '' + optionalString (mailbox.autoexpunge != null) ''
+    autoexpunge = ${toString mailbox.autoexpunge}
   '' + "}";
 
   mailboxes = { ... }: {
@@ -141,6 +143,12 @@ let
         default = "no";
         example = "subscribe";
         description = "Whether to automatically create or create and subscribe to the mailbox or not.";
+      };
+      autoexpunge = mkOption {
+        type = types.nullOr (types.strMatching ''[0-9]+([wdhms]|weeks|days|hours|mins|secs)'');
+        default = null;
+        example = "30d";
+        description = "When to automatically expunge messages from this mailbox. Processed on disconnect.";
       };
       specialUse = mkOption {
         type = types.nullOr (types.enum [ "All" "Archive" "Drafts" "Flagged" "Junk" "Sent" "Trash" ]);


### PR DESCRIPTION
###### Motivation for this change

Autoexpunge can be a handy option for dovecot special mailboxes like Junk and Trash, and it isn't supported by the current service.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
