### PR TITLE
pythonPackages.py4j: fix extension zip to default of tar.gz

### DIFF
--- a/pkgs/development/python-modules/py4j/default.nix
+++ b/pkgs/development/python-modules/py4j/default.nix
@@ -7,7 +7,6 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    extension= "zip";
     sha256 = "36ec57f43ff8ced260a18aa9a4e46c3500a730cac8860e259cbaa546c2b9db2f";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
the py4j version of 0.10.9 has been changed extension name to `tar.gz`
fixes error output
```
 curl: (22) The requested URL returned error:             
 404                                                      
 error: cannot download py4j-0.10.9.zip from any mirror   
```
- [tar.gz] https://pypi.org/project/py4j/0.10.9/#files
- [zip] https://pypi.org/project/py4j/0.10.8.1/#files

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
