### PR TITLE
powershell: actually run the install check

### DIFF
--- a/pkgs/shells/powershell/default.nix
+++ b/pkgs/shells/powershell/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   doInstallCheck = true;
-  installCheck = ''
+  installCheckPhase = ''
     $out/bin/pwsh --help > /dev/null
   '';
 


### PR DESCRIPTION
###### Motivation for this change
i almost made this mistake, found it while grepping for the manual
(the manual keeps saying `the installCheck phase`, not sure if that should be changed...)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - +`0`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@jonringer who's line i changed
@yrashk and @SRGOM , the maintainers of this package