### PR TITLE
input-utils: Fix cross-compilation

### DIFF
--- a/pkgs/os-specific/linux/input-utils/default.nix
+++ b/pkgs/os-specific/linux/input-utils/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "prefix=$(out)"
-    "STRIP=-s"
+    "STRIP="
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
We actually don't need to `strip` using `install`. Stripping is already
part of the fixup. This ends up being a fix we can apply universally,
but works around an issue where `install` doesn't know about the
prefixed `strip` binary.

###### Motivation for this change

I completely forgot that this trivial fix is needed for https://github.com/NixOS/mobile-nixos/pull/155 to compile successfully.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] Mobile NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
