### PR TITLE
rust: fix rust cross-compile

### DIFF
--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -69,6 +69,11 @@ let
       "--with-gnu-ld"
       "--disable-debug"
       "--disable-win32-registry"
+      "--enable-hash-synchronization"
+      "--enable-libssp"
+      "--disable-nls"
+      # To keep ABI compatibility with upstream mingw-w64
+      "--enable-fully-dynamic-string"      
     ] ++ lib.optionals (crossMingw && targetPlatform.isx86_32) [
       # See Note [Windows Exception Handling]
       "--enable-sjlj-exceptions"
@@ -93,12 +98,6 @@ let
     ] ++ lib.optionals (targetPlatform.libc == "musl") [
       # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
       "--disable-libmpx"
-    ] ++ lib.optionals crossMingw [
-      "--enable-hash-synchronization"
-      "--enable-libssp"
-      "--disable-nls"
-      # To keep ABI compatibility with upstream mingw-w64
-      "--enable-fully-dynamic-string"
     ] ++ lib.optional (targetPlatform.libc == "newlib") "--with-newlib"
       ++ lib.optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
     );

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -58,8 +58,9 @@ let
       "--with-gnu-as"
       "--with-gnu-ld"
       "--disable-debug"
-      "--enable-sjlj-exceptions"
       "--disable-win32-registry"
+    ] ++ lib.optionals (crossMingw && targetPlatform.isx86_32) [
+      "--enable-sjlj-exceptions"
     ] else [
       (if crossDarwin then "--with-sysroot=${lib.getLib libcCross}/share/sysroot"
        else                "--with-headers=${lib.getDev libcCross}${libcCross.incdir or "/include"}")
@@ -81,13 +82,14 @@ let
       # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
       "--disable-libmpx"
     ] ++ lib.optionals crossMingw [
-      "--enable-sjlj-exceptions"
       "--enable-hash-synchronization"
       "--enable-libssp"
       "--disable-nls"
-      "--with-dwarf2"
       # To keep ABI compatibility with upstream mingw-w64
       "--enable-fully-dynamic-string"
+    ] ++ lib.optionals (crossMingw && targetPlatform.isx86_32) [
+      "--enable-sjlj-exceptions"
+      "--with-dwarf2"
     ] ++ lib.optional (targetPlatform.libc == "newlib") "--with-newlib"
       ++ lib.optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
     );


### PR DESCRIPTION
reasoning:
sjlj (short jump long jump) exception handling makes no sense on x86_64, it's forcably slowing programs down as it produces a constant overhead. On x86_64 we have SEH (Structured Exception Handling) and we should use that. On i686, we do not have SEH, and have to use sjlj with dwarf2. Hence it's now conditional on x86_32

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
