### PR TITLE
fontforge: 20190801 -> 20200314

### DIFF
--- a/pkgs/tools/misc/fontforge/default.nix
+++ b/pkgs/tools/misc/fontforge/default.nix
@@ -4,10 +4,13 @@
 , readline, woff2, zeromq, libuninameslist
 , withSpiro ? false, libspiro
 , withGTK ? false, gtk3
+, withGUI ? withGTK
 , withPython ? true
 , withExtras ? true
 , Carbon ? null, Cocoa ? null
 }:
+
+assert withGTK -> withGUI;
 
 stdenv.mkDerivation rec {
   pname = "fontforge";
@@ -36,12 +39,13 @@ stdenv.mkDerivation rec {
     python freetype zlib glib libungif libpng libjpeg libtiff libxml2
   ]
     ++ lib.optionals withSpiro [libspiro]
-    ++ lib.optionals withGTK [ gtk3 cairo pango ]
+    ++ lib.optionals withGUI [ gtk3 cairo pango ]
     ++ lib.optionals stdenv.isDarwin [ Carbon Cocoa ];
 
   cmakeFlags = [ "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" ]
     ++ lib.optional (!withSpiro) "-DENABLE_LIBSPIRO=OFF"
-    ++ lib.optional (!withGTK) "-DENABLE_GUI=OFF"
+    ++ lib.optional (!withGUI) "-DENABLE_GUI=OFF"
+    ++ lib.optional (!withGTK) "-DENABLE_X11=ON"
     ++ lib.optional withExtras "-DENABLE_FONTFORGE_EXTRAS=ON";
 
   # work-around: git isn't really used, but configuration fails without it

--- a/pkgs/tools/misc/fontforge/default.nix
+++ b/pkgs/tools/misc/fontforge/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchurl, lib
-, autoconf, automake, gnum4, libtool, perl, uthash, pkgconfig, gettext
+, cmake, perl, uthash, pkgconfig, gettext
 , python, freetype, zlib, glib, libungif, libpng, libjpeg, libtiff, libxml2, cairo, pango
 , readline, woff2, zeromq, libuninameslist
 , withSpiro ? false, libspiro
-, withGTK ? false, gtk2
+, withGTK ? false, gtk3
 , withPython ? true
 , withExtras ? true
 , Carbon ? null, Cocoa ? null
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "fontforge";
-  version = "20190801";
+  version = "20200314";
 
   src = fetchurl {
-    url = "https://github.com/${pname}/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "0lh8yx01asbzxm6car5cfi64njh5p4lxc7iv8dldr5rwg357a86r";
+    url = "https://github.com/${pname}/${pname}/releases/download/${version}/${pname}-${version}.tar.xz";
+    sha256 = "0qf88wd6riycq56d24brybyc93ns74s0nyyavm43zp2kfcihn6fd";
   };
 
   # use $SOURCE_DATE_EPOCH instead of non-deterministic timestamps
@@ -30,40 +30,31 @@ stdenv.mkDerivation rec {
   # do not use x87's 80-bit arithmetic, rouding errors result in very different font binaries
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isi686 "-msse2 -mfpmath=sse";
 
-  nativeBuildInputs = [ pkgconfig autoconf automake gnum4 libtool perl gettext ];
+  nativeBuildInputs = [ pkgconfig cmake ];
   buildInputs = [
     readline uthash woff2 zeromq libuninameslist
     python freetype zlib glib libungif libpng libjpeg libtiff libxml2
   ]
     ++ lib.optionals withSpiro [libspiro]
-    ++ lib.optionals withGTK [ gtk2 cairo pango ]
+    ++ lib.optionals withGTK [ gtk3 cairo pango ]
     ++ lib.optionals stdenv.isDarwin [ Carbon Cocoa ];
 
-    configureFlags = [ "--enable-woff2" ]
-    ++ lib.optionals (!withPython) [ "--disable-python-scripting" "--disable-python-extension" ]
-    ++ lib.optional withGTK "--enable-gtk2-use"
-    ++ lib.optional (!withGTK) "--without-x"
-    ++ lib.optional withExtras "--enable-fontforge-extras";
+  cmakeFlags = [ "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" ]
+    ++ lib.optional (!withSpiro) "-DENABLE_LIBSPIRO=OFF"
+    ++ lib.optional (!withGTK) "-DENABLE_GUI=OFF"
+    ++ lib.optional withExtras "-DENABLE_FONTFORGE_EXTRAS=ON";
 
   # work-around: git isn't really used, but configuration fails without it
   preConfigure = ''
     # The way $version propagates to $version of .pe-scripts (https://github.com/dejavu-fonts/dejavu-fonts/blob/358190f/scripts/generate.pe#L19)
     export SOURCE_DATE_EPOCH=$(date -d ${version} +%s)
-
-    export GIT="$(type -P true)"
-    ./bootstrap --skip-git --force
   '';
-
-  doCheck = false; # tries to wget some fonts
-  doInstallCheck = doCheck;
 
   postInstall =
     # get rid of the runtime dependency on python
     lib.optionalString (!withPython) ''
       rm -r "$out/share/fontforge/python"
     '';
-
-  enableParallelBuilding = true;
 
   meta = {
     description = "A font editor";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3527,7 +3527,7 @@ in
   fontforge-gtk = fontforge.override {
     withSpiro = true;
     withGTK = true;
-    gtk2 = gtk2-x11;
+    gtk3 = gtk3-x11;
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fontforge is currently broken on staging. This upgrade seems to fix it. It’s needed by lots of GUI programs because it’s needed to build DejaVu.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
