### PR TITLE
python2Packages.pillow: freeze at 6.2.2

### DIFF
--- a/pkgs/development/python-modules/pillow/6.nix
+++ b/pkgs/development/python-modules/pillow/6.nix
@@ -1,0 +1,82 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPyPy
+, olefile
+, freetype, libjpeg, zlib, libtiff, libwebp, tcl, lcms2, tk, libX11
+, openjpeg, libimagequant
+, pytest, pytestrunner, pyroma, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "Pillow";
+  version = "6.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0l5rv8jkdrb5q846v60v03mcq64yrhklidjkgwv6s1pda71g17yv";
+  };
+
+  # Disable imagefont tests, because they don't work well with infinality:
+  # https://github.com/python-pillow/Pillow/issues/1259
+  postPatch = ''
+    rm Tests/test_imagefont.py
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    python -m pytest -v -x -W always
+    runHook postCheck
+  '';
+
+  propagatedBuildInputs = [ olefile ];
+
+  checkInputs = [ pytest pytestrunner pyroma numpy ];
+
+  buildInputs = [
+    freetype libjpeg openjpeg libimagequant zlib libtiff libwebp tcl lcms2 ]
+    ++ stdenv.lib.optionals (isPyPy) [ tk libX11 ];
+
+  # NOTE: we use LCMS_ROOT as WEBP root since there is not other setting for webp.
+  # NOTE: The Pillow install script will, by default, add paths like /usr/lib
+  # and /usr/include to the search paths. This can break things when building
+  # on a non-NixOS system that has some libraries installed that are not
+  # installed in Nix (for example, Arch Linux has jpeg2000 but Nix doesn't
+  # build Pillow with this support). We patch the `disable_platform_guessing`
+  # setting here, instead of passing the `--disable-platform-guessing`
+  # command-line option, since the command-line option doesn't work when we run
+  # tests.
+  preConfigure = let
+    libinclude' = pkg: ''"${pkg.out}/lib", "${pkg.out}/include"'';
+    libinclude = pkg: ''"${pkg.out}/lib", "${pkg.dev}/include"'';
+  in ''
+    sed -i "setup.py" \
+        -e 's|^FREETYPE_ROOT =.*$|FREETYPE_ROOT = ${libinclude freetype}|g ;
+            s|^JPEG_ROOT =.*$|JPEG_ROOT = ${libinclude libjpeg}|g ;
+            s|^JPEG2K_ROOT =.*$|JPEG2K_ROOT = ${libinclude openjpeg}|g ;
+            s|^IMAGEQUANT_ROOT =.*$|IMAGEQUANT_ROOT = ${libinclude' libimagequant}|g ;
+            s|^ZLIB_ROOT =.*$|ZLIB_ROOT = ${libinclude zlib}|g ;
+            s|^LCMS_ROOT =.*$|LCMS_ROOT = ${libinclude lcms2}|g ;
+            s|^TIFF_ROOT =.*$|TIFF_ROOT = ${libinclude libtiff}|g ;
+            s|^TCL_ROOT=.*$|TCL_ROOT = ${libinclude' tcl}|g ;
+            s|self\.disable_platform_guessing = None|self.disable_platform_guessing = True|g ;'
+    export LDFLAGS="-L${libwebp}/lib"
+    export CFLAGS="-I${libwebp}/include"
+  ''
+  # Remove impurities
+  + stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace setup.py \
+      --replace '"/Library/Frameworks",' "" \
+      --replace '"/System/Library/Frameworks"' ""
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://python-pillow.github.io/";
+    description = "Fork of The Python Imaging Library (PIL)";
+    longDescription = ''
+      The Python Imaging Library (PIL) adds image processing
+      capabilities to your Python interpreter.  This library
+      supports many file formats, and provides powerful image
+      processing and graphics capabilities.
+    '';
+    license = "http://www.pythonware.com/products/pil/license.htm";
+    maintainers = with maintainers; [ goibhniu prikhi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5086,9 +5086,14 @@ in {
 
   pyviz-comms = callPackage ../development/python-modules/pyviz-comms { };
 
-  pillow = callPackage ../development/python-modules/pillow {
-    inherit (pkgs) freetype libjpeg zlib libtiff libwebp tcl lcms2 tk;
-    inherit (pkgs.xorg) libX11;
+  pillow = if isPy27 then
+    callPackage ../development/python-modules/pillow/6.nix {
+      inherit (pkgs) freetype libjpeg zlib libtiff libwebp tcl lcms2 tk;
+      inherit (pkgs.xorg) libX11;
+    } else
+    callPackage ../development/python-modules/pillow {
+      inherit (pkgs) freetype libjpeg zlib libtiff libwebp tcl lcms2 tk;
+      inherit (pkgs.xorg) libX11;
   };
 
   pkgconfig = callPackage ../development/python-modules/pkgconfig {


### PR DESCRIPTION
###### Motivation for this change
fixes calibre

addresses https://github.com/NixOS/nixpkgs/commit/0e5e6b08aad464744ed5ad8e2fe79d28a4438748#commitcomment-39708178

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
