### PR TITLE
ssmtp: adding debug option

### DIFF
--- a/nixos/modules/programs/ssmtp.nix
+++ b/nixos/modules/programs/ssmtp.nix
@@ -24,6 +24,7 @@ in
     (mkRenamedOptionModule [ "networking" "defaultMailServer" "authPass" ] [ "services" "ssmtp" "authPass" ])
     (mkRenamedOptionModule [ "networking" "defaultMailServer" "authPassFile" ] [ "services" "ssmtp" "authPassFile" ])
     (mkRenamedOptionModule [ "networking" "defaultMailServer" "setSendmail" ] [ "services" "ssmtp" "setSendmail" ])
+    (mkRenamedOptionModule [ "networking" "defaultMailServer" "debug£" ] [ "services" "ssmtp" "debug" ])
   ];
 
   options = {
@@ -135,6 +136,12 @@ in
         description = "Whether to set the system sendmail to ssmtp's.";
       };
 
+      debug = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Log the entire contents of emails sent via sSMTP, including headers, to syslog.";
+      };
+
     };
 
   };
@@ -157,7 +164,7 @@ in
         ${optionalString (cfg.domain != "") "rewriteDomain=${cfg.domain}"}
         UseTLS=${yesNo cfg.useTLS}
         UseSTARTTLS=${yesNo cfg.useSTARTTLS}
-        #Debug=YES
+        Debug=${yesNo cfg.debug}
         ${optionalString (cfg.authUser != "")       "AuthUser=${cfg.authUser}"}
         ${optionalString (cfg.authPassFile != null) "AuthPassFile=${cfg.authPassFile}"}
       '';


### PR DESCRIPTION
##### Motivation for this change

Adding the debug option to the ssmtp module.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
