### PR TITLE
pythonPackages.pipBuildHook: do not build in an isolated environment

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pip-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-build-hook.sh
@@ -24,7 +24,8 @@ pipShellHook() {
       export PATH="$tmp_path/bin:$PATH"
       export PYTHONPATH="$tmp_path/@pythonSitePackages@:$PYTHONPATH"
       mkdir -p "$tmp_path/@pythonSitePackages@"
-      @pythonInterpreter@ -m pip install -e . --prefix "$tmp_path" >&2
+      @pythonInterpreter@ -m pip install -e . --prefix "$tmp_path" \
+         --no-build-isolation >&2
     fi
 
     runHook postShellHook

--- a/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
@@ -29,7 +29,8 @@ setuptoolsShellHook() {
         export PATH="$tmp_path/bin:$PATH"
         export PYTHONPATH="$tmp_path/@pythonSitePackages@:$PYTHONPATH"
         mkdir -p "$tmp_path/@pythonSitePackages@"
-        eval "@pythonInterpreter@ -m pip install -e . --prefix $tmp_path >&2"
+        eval "@pythonInterpreter@ -m pip install -e . --prefix $tmp_path \
+          --no-build-isolation >&2"
     fi
 
     runHook postShellHook


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

When a PEP 517 project file is present, pip will not install
prerequisites in `site-packages`:
    
https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
    
For the shell hook, this has the consequence that the generated
temporary directory that is added to PYTHONPATH does not contain
`site.py`. As a result, Python does not discover the Python
module. Thus when a user executes nix-shell in a project, they cannot
import the project's Python module.
    
This change adds the `--no-build-isolation` option to pip when
creating the editable environment, to correctly generate `site.py`,
even when a `pyproject.toml` is present.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
