### PR TITLE
tegola: 0.8.1 -> 0.11.2

### DIFF
--- a/pkgs/servers/tegola/default.nix
+++ b/pkgs/servers/tegola/default.nix
@@ -2,16 +2,15 @@
 
 buildGoPackage rec {
   pname = "tegola";
-  version = "0.8.1";
-  rev = "8b2675a63624ad1d69a8d2c84a6a3f3933e25ca1";
+  version = "0.11.2";
 
   goPackagePath = "github.com/go-spatial/tegola";
 
   src = fetchFromGitHub {
     owner = "go-spatial";
-    repo = "tegola";
-    inherit rev;
-    sha256 = "1f70vsrj3i1d0kg76a8s741nps71hrglgyyrz2xm6a8b31w833pi";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0xrjs0py08q9i31rl0cxi6idncrrgqwcspqks3c5vd9i65yqc6fv";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/go-spatial/tegola/releases)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
