### PR TITLE
pipewire: apply patch providing absolute path to pipewire-media-session

### DIFF
--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitLab
+, fetchpatch
 , meson
 , ninja
 , pkgconfig
@@ -43,6 +44,13 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "0g149vyaigf4gzm764fcgxxci9niw19z0af9afs4diwq5xzr1qd3";
   };
+
+  patches = [ (fetchpatch {
+    # Brought by https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/263,
+    # should be part of > 0.3.6
+    url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/d1162f28efd502fcb973e172867970f5cc8d7a6b.patch";
+    sha256 = "0ng34yin5726cvv0nll1b2xigyq6mj6j516l3xi0ys1i2g2fyby9";
+  })];
 
   nativeBuildInputs = [
     doxygen


### PR DESCRIPTION
So pipewire-daemon is able to locate pipewire-media-session (which it's
executing).

Context: https://github.com/NixOS/nixpkgs/issues/89528#issuecomment-640013433

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
