### PR TITLE
martin: init at 0.5.0

### DIFF
--- a/pkgs/servers/martin/default.nix
+++ b/pkgs/servers/martin/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, rustPlatform, fetchFromGitHub, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "martin";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "urbica";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1i9zhmjkgid4s90n52wqmrl3lwswcaxd6d47ssycgjl1nv0jla4k";
+  };
+
+  cargoSha256 = "08rr783qvpm1q7s60k7mh3k5npf0lg5s1x74lnxcxdgrlgpn5gcf";
+
+  buildInputs = with stdenv; lib.optional isDarwin Security;
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Blazing fast and lightweight PostGIS vector tiles server";
+    homepage = "https://martin.urbica.co/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4708,6 +4708,10 @@ in
 
   makebootfat = callPackage ../tools/misc/makebootfat { };
 
+  martin = callPackage ../servers/martin {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   /* Python 3.8 is currently broken with matrix-synapse since `python38Packages.bleach` fails
     (https://github.com/NixOS/nixpkgs/issues/76093) */
   matrix-synapse = callPackage ../servers/matrix-synapse { /*python3 = python38;*/ };


### PR DESCRIPTION
###### Motivation for this change
[**Martin**](https://martin.urbica.co/) - blazing fast and lightweight PostGIS vector tiles server.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
