### PR TITLE
lyaml: init at 6.2.5-1, update almost all luarocks generated packages

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -65,6 +65,7 @@ luazip,,,,,
 lua-yajl,,,,,pstn
 luuid,,,,,
 luv,,,,,
+lyaml,,,,,lblasc
 markdown,,,,,
 mediator_lua,,,,,
 mpack,,,,,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -15,7 +15,7 @@ alt-getopt = buildLuarocksPackage {
   version = "0.8.0-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/alt-getopt-0.8.0-1.src.rock";
+    url    = "mirror://luarocks/alt-getopt-0.8.0-1.src.rock";
     sha256 = "1mi97dqb97sf47vb6wrk12yf1yxcaz0asr9gbgwyngr5n1adh5i3";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
@@ -25,9 +25,7 @@ alt-getopt = buildLuarocksPackage {
     homepage = "https://github.com/cheusov/lua-alt-getopt";
     description = "Process application arguments the same way as getopt_long";
     maintainers = with maintainers; [ arobyn ];
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 ansicolors = buildLuarocksPackage {
@@ -35,7 +33,7 @@ ansicolors = buildLuarocksPackage {
   version = "1.0.2-3";
 
   src = fetchurl {
-    url    = "https://luarocks.org/ansicolors-1.0.2-3.src.rock";
+    url    = "mirror://luarocks/ansicolors-1.0.2-3.src.rock";
     sha256 = "1mhmr090y5394x1j8p44ws17sdwixn5a0r4i052bkfgk3982cqfz";
   };
   disabled = (luaOlder "5.1");
@@ -44,28 +42,24 @@ ansicolors = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/kikito/ansicolors.lua";
     description = "Library for color Manipulation.";
-    license = {
-      fullName = "MIT <http://opensource.org/licenses/MIT>";
-    };
+    license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 };
 argparse = buildLuarocksPackage {
   pname = "argparse";
-  version = "0.6.0-1";
+  version = "0.7.0-1";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/argparse-0.6.0-1.src.rock";
-    sha256 = "10ic5wppyghd1lmgwgl0lb40pv8z9fi9i87080axxg8wsr19y0p4";
+    url    = "mirror://luarocks/argparse-0.7.0-1.src.rock";
+    sha256 = "1jvar543d21x7wq8rxxaaf7h1ricd7zvxc16xwjblwa9ffgcmcs7";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/mpeterv/argparse";
+    homepage = "https://github.com/luarocks/argparse";
     description = "A feature-rich command-line argument parser";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 basexx = buildLuarocksPackage {
@@ -73,7 +67,7 @@ basexx = buildLuarocksPackage {
   version = "0.4.1-1";
 
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/basexx-0.4.1-1.rockspec";
+    url    = "mirror://luarocks/basexx-0.4.1-1.rockspec";
     sha256 = "0kmydxm2wywl18cgj303apsx7hnfd68a9hx9yhq10fj7yfcxzv5f";
   }).outPath;
 
@@ -88,9 +82,7 @@ basexx = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/aiq/basexx";
     description = "A base2, base16, base32, base64 and base85 library for Lua";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 binaryheap = buildLuarocksPackage {
@@ -98,7 +90,7 @@ binaryheap = buildLuarocksPackage {
   version = "0.4-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/binaryheap-0.4-1.src.rock";
+    url    = "mirror://luarocks/binaryheap-0.4-1.src.rock";
     sha256 = "11rd8r3bpinfla2965jgjdv1hilqdc1q6g1qla5978d7vzg19kpc";
   };
   disabled = (luaOlder "5.1");
@@ -108,9 +100,7 @@ binaryheap = buildLuarocksPackage {
     homepage = "https://github.com/Tieske/binaryheap.lua";
     description = "Binary heap implementation in pure Lua";
     maintainers = with maintainers; [ vcunat ];
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 bit32 = buildLuarocksPackage {
@@ -118,7 +108,7 @@ bit32 = buildLuarocksPackage {
   version = "5.3.0-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/bit32-5.3.0-1.src.rock";
+    url    = "mirror://luarocks/bit32-5.3.0-1.src.rock";
     sha256 = "19i7kc2pfg9hc6qjq4kka43q6qk71bkl2rzvrjaks6283q6wfyzy";
   };
   disabled = (luaOlder "5.1");
@@ -128,23 +118,21 @@ bit32 = buildLuarocksPackage {
     homepage = "http://www.lua.org/manual/5.2/manual.html#6.7";
     description = "Lua 5.2 bit manipulation library";
     maintainers = with maintainers; [ lblasc ];
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 busted = buildLuarocksPackage {
   pname = "busted";
-  version = "2.0.rc13-0";
+  version = "2.0.0-1";
 
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/busted-2.0.rc13-0.rockspec";
-    sha256 = "0hrvhg1324q5ra6cpjh1y3by6lrzs0ljah4jl48l8xlgw1z9z1q5";
+    url    = "mirror://luarocks/busted-2.0.0-1.rockspec";
+    sha256 = "0cbw95bjxl667n9apcgng2kr5hq6bc7gp3vryw4dzixmfabxkcbw";
   }).outPath;
 
   src = fetchurl {
-    url    = "https://github.com/Olivine-Labs/busted/archive/v2.0.rc13-0.tar.gz";
-    sha256 = "0m72bldn1r6j94ahcfmpaq1mmysrshf9qi9fjas7hpal0jp8ivvl";
+    url    = "https://github.com/Olivine-Labs/busted/archive/v2.0.0.tar.gz";
+    sha256 = "1ps7b3f4diawfj637mibznaw4x08gn567pyni0m2s50hrnw4v8zx";
   };
 
   disabled = (luaOlder "5.1");
@@ -153,9 +141,7 @@ busted = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://olivinelabs.com/busted/";
     description = "Elegant Lua unit testing.";
-    license = {
-      fullName = "MIT <http://opensource.org/licenses/MIT>";
-    };
+    license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 };
 cassowary = buildLuarocksPackage {
@@ -180,18 +166,16 @@ cjson = buildLuarocksPackage {
   version = "2.1.0.6-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/lua-cjson-2.1.0.6-1.src.rock";
+    url    = "mirror://luarocks/lua-cjson-2.1.0.6-1.src.rock";
     sha256 = "0dqqkn0aygc780kiq2lbydb255r8is7raf7md0gxdjcagp8afps5";
   };
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
-    homepage = "https://www.kyne.com.au/~mark/software/lua-cjson.php";
+    homepage = "http://www.kyne.com.au/~mark/software/lua-cjson.php";
     description = "A fast JSON encoding/parsing module";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 compat53 = buildLuarocksPackage {
@@ -199,7 +183,7 @@ compat53 = buildLuarocksPackage {
   version = "0.7-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/compat53-0.7-1.src.rock";
+    url    = "mirror://luarocks/compat53-0.7-1.src.rock";
     sha256 = "0kpaxbpgrwjn4jjlb17fn29a09w6lw732d21bi0302kqcaixqpyb";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
@@ -209,9 +193,7 @@ compat53 = buildLuarocksPackage {
     homepage = "https://github.com/keplerproject/lua-compat-5.3";
     description = "Compatibility module providing Lua-5.3-style APIs for Lua 5.2 and 5.1";
     maintainers = with maintainers; [ vcunat ];
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 cosmo = buildLuarocksPackage {
@@ -236,25 +218,23 @@ coxpcall = buildLuarocksPackage {
   version = "1.17.0-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/coxpcall-1.17.0-1.src.rock";
+    url    = "mirror://luarocks/coxpcall-1.17.0-1.src.rock";
     sha256 = "0n1jmda4g7x06458596bamhzhcsly6x0p31yp6q3jz4j11zv1zhi";
   };
 
   meta = with stdenv.lib; {
     homepage = "http://keplerproject.github.io/coxpcall";
     description = "Coroutine safe xpcall and pcall";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 cqueues = buildLuarocksPackage {
   pname = "cqueues";
-  version = "20190731.52-0";
+  version = "20190813.52-0";
 
   src = fetchurl {
-    url    = "https://luarocks.org/cqueues-20190731.52-0.src.rock";
-    sha256 = "07rs34amsxf2bc5ccqdad0c63c70737r54316cbd9qh1a2wbvz8s";
+    url    = "mirror://luarocks/cqueues-20190813.52-0.src.rock";
+    sha256 = "1mfhana4xdfddzxmr7vkvm65679hx549f9k1rmsrz6is2gji5wvi";
   };
   disabled = (lua.luaversion != "5.2");
   propagatedBuildInputs = [ lua ];
@@ -263,9 +243,7 @@ cqueues = buildLuarocksPackage {
     homepage = "http://25thandclement.com/~william/projects/cqueues.html";
     description = "Continuation Queues: Embeddable asynchronous networking, threading, and notification framework for Lua on Unix.";
     maintainers = with maintainers; [ vcunat ];
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 cyrussasl = buildLuarocksPackage {
@@ -273,7 +251,7 @@ cyrussasl = buildLuarocksPackage {
   version = "1.1.0-1";
 
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/cyrussasl-1.1.0-1.rockspec";
+    url    = "mirror://luarocks/cyrussasl-1.1.0-1.rockspec";
     sha256 = "0zy9l00l7kr3sq8phdm52jqhlqy35vdv6rdmm8mhjihcbx1fsplc";
   }).outPath;
 
@@ -290,12 +268,10 @@ cyrussasl = buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/JorjBauer/lua-cyrussasl";
+    homepage = "http://github.com/JorjBauer/lua-cyrussasl";
     description = "Cyrus SASL library for Lua 5.1+";
     maintainers = with maintainers; [ vcunat ];
-    license = {
-      fullName = "BSD";
-    };
+    license.fullName = "BSD";
   };
 };
 digestif = buildLuarocksPackage {
@@ -312,9 +288,7 @@ digestif = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/astoff/digestif/";
     description = "A code analyzer for TeX";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 dkjson = buildLuarocksPackage {
@@ -322,7 +296,7 @@ dkjson = buildLuarocksPackage {
   version = "2.5-2";
 
   src = fetchurl {
-    url    = "https://luarocks.org/dkjson-2.5-2.src.rock";
+    url    = "mirror://luarocks/dkjson-2.5-2.src.rock";
     sha256 = "1qy9bzqnb9pf9d48hik4iq8h68aw3270kmax7mmpvvpw7kkyp483";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
@@ -331,9 +305,7 @@ dkjson = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://dkolf.de/src/dkjson-lua.fsl/";
     description = "David Kolf's JSON module for Lua";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 fifo = buildLuarocksPackage {
@@ -341,7 +313,7 @@ fifo = buildLuarocksPackage {
   version = "0.2-0";
 
   src = fetchurl {
-    url    = "https://luarocks.org/fifo-0.2-0.src.rock";
+    url    = "mirror://luarocks/fifo-0.2-0.src.rock";
     sha256 = "082c5g1m8brnsqj5gnjs65bm7z50l6b05cfwah14lqaqsr5a5pjk";
   };
   propagatedBuildInputs = [ lua ];
@@ -349,9 +321,7 @@ fifo = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/daurnimator/fifo.lua";
     description = "A lua library/'class' that implements a FIFO";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 http = buildLuarocksPackage {
@@ -359,7 +329,7 @@ http = buildLuarocksPackage {
   version = "0.3-0";
 
   src = fetchurl {
-    url    = "https://luarocks.org/http-0.3-0.src.rock";
+    url    = "mirror://luarocks/http-0.3-0.src.rock";
     sha256 = "0vvl687bh3cvjjwbyp9cphqqccm3slv4g7y3h03scp3vpq9q4ccq";
   };
   disabled = (luaOlder "5.1");
@@ -369,9 +339,7 @@ http = buildLuarocksPackage {
     homepage = "https://github.com/daurnimator/lua-http";
     description = "HTTP library for Lua";
     maintainers = with maintainers; [ vcunat ];
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 inspect = buildLuarocksPackage {
@@ -379,7 +347,7 @@ inspect = buildLuarocksPackage {
   version = "3.1.1-0";
 
   src = fetchurl {
-    url    = "https://luarocks.org/inspect-3.1.1-0.src.rock";
+    url    = "mirror://luarocks/inspect-3.1.1-0.src.rock";
     sha256 = "0k4g9ahql83l4r2bykfs6sacf9l1wdpisav2i0z55fyfcdv387za";
   };
   disabled = (luaOlder "5.1");
@@ -388,9 +356,7 @@ inspect = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/kikito/inspect.lua";
     description = "Lua table visualizer, ideal for debugging";
-    license = {
-      fullName = "MIT <http://opensource.org/licenses/MIT>";
-    };
+    license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 };
 ldoc = buildLuarocksPackage {
@@ -398,7 +364,7 @@ ldoc = buildLuarocksPackage {
   version = "1.4.6-2";
 
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/ldoc-1.4.6-2.rockspec";
+    url    = "mirror://luarocks/ldoc-1.4.6-2.rockspec";
     sha256 = "14yb0qihizby8ja0fa82vx72vk903mv6m7izn39mzfrgb8mha0pm";
   }).outPath;
 
@@ -412,9 +378,7 @@ ldoc = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://stevedonovan.github.com/ldoc";
     description = "A Lua Documentation Tool";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 lgi = buildLuarocksPackage {
@@ -422,18 +386,16 @@ lgi = buildLuarocksPackage {
   version = "0.9.2-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/lgi-0.9.2-1.src.rock";
+    url    = "mirror://luarocks/lgi-0.9.2-1.src.rock";
     sha256 = "07ajc5pdavp785mdyy82n0w6d592n96g95cvq025d6i0bcm2cypa";
   };
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/pavouk/lgi";
+    homepage = "http://github.com/pavouk/lgi";
     description = "Lua bindings to GObject libraries";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 linenoise = buildLuarocksPackage {
@@ -456,9 +418,7 @@ linenoise = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/hoelzro/lua-linenoise";
     description = "A binding for the linenoise command line library";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 ljsyscall = buildLuarocksPackage {
@@ -466,7 +426,7 @@ ljsyscall = buildLuarocksPackage {
   version = "0.12-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/ljsyscall-0.12-1.src.rock";
+    url    = "mirror://luarocks/ljsyscall-0.12-1.src.rock";
     sha256 = "12gs81lnzpxi5d409lbrvjfflld5l2xsdkfhkz93xg7v65sfhh2j";
   };
   disabled = (lua.luaversion != "5.1");
@@ -476,9 +436,7 @@ ljsyscall = buildLuarocksPackage {
     homepage = "http://www.myriabit.com/ljsyscall/";
     description = "LuaJIT Linux syscall FFI";
     maintainers = with maintainers; [ lblasc ];
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 lpeg = buildLuarocksPackage {
@@ -486,7 +444,7 @@ lpeg = buildLuarocksPackage {
   version = "1.0.2-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/lpeg-1.0.2-1.src.rock";
+    url    = "mirror://luarocks/lpeg-1.0.2-1.src.rock";
     sha256 = "1g5zmfh0x7drc6mg2n0vvlga2hdc08cyp3hnb22mh1kzi63xdl70";
   };
   disabled = (luaOlder "5.1");
@@ -496,9 +454,7 @@ lpeg = buildLuarocksPackage {
     homepage = "http://www.inf.puc-rio.br/~roberto/lpeg.html";
     description = "Parsing Expression Grammars For Lua";
     maintainers = with maintainers; [ vyp ];
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 lpeg_patterns = buildLuarocksPackage {
@@ -506,7 +462,7 @@ lpeg_patterns = buildLuarocksPackage {
   version = "0.5-0";
 
   src = fetchurl {
-    url    = "https://luarocks.org/lpeg_patterns-0.5-0.src.rock";
+    url    = "mirror://luarocks/lpeg_patterns-0.5-0.src.rock";
     sha256 = "0mlw4nayrsdxrh98i26avz5i4170a9brciybw88kks496ra36v8f";
   };
   propagatedBuildInputs = [ lua lpeg ];
@@ -514,18 +470,16 @@ lpeg_patterns = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/daurnimator/lpeg_patterns/archive/v0.5.zip";
     description = "a collection of LPEG patterns";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 lpeglabel = buildLuarocksPackage {
   pname = "lpeglabel";
-  version = "1.5.0-1";
+  version = "1.6.0-1";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/lpeglabel-1.5.0-1.src.rock";
-    sha256 = "068mwvwwn5n69pdm04qnk354391w9mk34jsczxql0xi5qgmz6w8j";
+    url    = "mirror://luarocks/lpeglabel-1.6.0-1.src.rock";
+    sha256 = "0mihrs0gcj40gsjbh4x9b5pm92w2vdwwd1f3fyibyd4a8r1h93r9";
   };
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -533,9 +487,7 @@ lpeglabel = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/sqmedeiros/lpeglabel/";
     description = "Parsing Expression Grammars For Lua with Labeled Failures";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 lpty = buildLuarocksPackage {
@@ -543,7 +495,7 @@ lpty = buildLuarocksPackage {
   version = "1.2.2-1";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/lpty-1.2.2-1.src.rock";
+    url    = "mirror://luarocks/lpty-1.2.2-1.src.rock";
     sha256 = "1vxvsjgjfirl6ranz6k4q4y2dnxqh72bndbk400if22x8lqbkxzm";
   };
   disabled = (luaOlder "5.1");
@@ -552,9 +504,7 @@ lpty = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://www.tset.de/lpty/";
     description = "A simple facility for lua to control other programs via PTYs.";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 lrexlib-gnu = buildLuarocksPackage {
@@ -562,18 +512,16 @@ lrexlib-gnu = buildLuarocksPackage {
   version = "2.9.0-1";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/lrexlib-gnu-2.9.0-1.src.rock";
+    url    = "mirror://luarocks/lrexlib-gnu-2.9.0-1.src.rock";
     sha256 = "036rda4rji1pbnbxk1nzjy5zmigdsiacqbzrbvciwq3lrxa2j5s2";
   };
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/rrthomas/lrexlib";
+    homepage = "http://github.com/rrthomas/lrexlib";
     description = "Regular expression library binding (GNU flavour).";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 lrexlib-pcre = buildLuarocksPackage {
@@ -581,19 +529,17 @@ lrexlib-pcre = buildLuarocksPackage {
   version = "2.9.0-1";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/lrexlib-pcre-2.9.0-1.src.rock";
+    url    = "mirror://luarocks/lrexlib-pcre-2.9.0-1.src.rock";
     sha256 = "1nqai27lbd85mcjf5cb05dbdfg460vmp8cr0lmb8dd63ivk8cbvx";
   };
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/rrthomas/lrexlib";
+    homepage = "http://github.com/rrthomas/lrexlib";
     description = "Regular expression library binding (PCRE flavour).";
     maintainers = with maintainers; [ vyp ];
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 lrexlib-posix = buildLuarocksPackage {
@@ -601,18 +547,16 @@ lrexlib-posix = buildLuarocksPackage {
   version = "2.9.0-1";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/lrexlib-posix-2.9.0-1.src.rock";
+    url    = "mirror://luarocks/lrexlib-posix-2.9.0-1.src.rock";
     sha256 = "0ifpybf4m94g1nk70l0f5m45gph0rbp5wrxrl1hnw8ibv3mc1b1r";
   };
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/rrthomas/lrexlib";
+    homepage = "http://github.com/rrthomas/lrexlib";
     description = "Regular expression library binding (POSIX flavour).";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 ltermbox = buildLuarocksPackage {
@@ -620,7 +564,7 @@ ltermbox = buildLuarocksPackage {
   version = "0.2-1";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/ltermbox-0.2-1.src.rock";
+    url    = "mirror://luarocks/ltermbox-0.2-1.src.rock";
     sha256 = "08jqlmmskbi1ml1i34dlmg6hxcs60nlm32dahpxhcrgjnfihmyn8";
   };
   disabled = (luaOlder "5.1");
@@ -629,9 +573,7 @@ ltermbox = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://code.google.com/p/termbox";
     description = "A termbox library package";
-    license = {
-      fullName = "New BSD License";
-    };
+    license.fullName = "New BSD License";
   };
 };
 lua-cmsgpack = buildLuarocksPackage {
@@ -639,7 +581,7 @@ lua-cmsgpack = buildLuarocksPackage {
   version = "0.4.0-0";
 
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/lua-cmsgpack-0.4.0-0.rockspec";
+    url    = "mirror://luarocks/lua-cmsgpack-0.4.0-0.rockspec";
     sha256 = "10cvr6knx3qvjcw1q9v05f2qy607mai7lbq321nx682aa0n1fzin";
   }).outPath;
 
@@ -656,11 +598,9 @@ lua-cmsgpack = buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/antirez/lua-cmsgpack";
+    homepage = "http://github.com/antirez/lua-cmsgpack";
     description = "MessagePack C implementation and bindings for Lua 5.1/5.2/5.3";
-    license = {
-      fullName = "Two-clause BSD";
-    };
+    license.fullName = "Two-clause BSD";
   };
 };
 lua-iconv = buildLuarocksPackage {
@@ -668,7 +608,7 @@ lua-iconv = buildLuarocksPackage {
   version = "7-3";
 
   src = fetchurl {
-    url    = "https://luarocks.org/lua-iconv-7-3.src.rock";
+    url    = "mirror://luarocks/lua-iconv-7-3.src.rock";
     sha256 = "03xibhcqwihyjhxnzv367q4bfmzmffxl49lmjsq77g0prw8v0q83";
   };
   disabled = (luaOlder "5.1");
@@ -677,9 +617,7 @@ lua-iconv = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://ittner.github.com/lua-iconv/";
     description = "Lua binding to the iconv";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 lua-lsp = buildLuarocksPackage {
@@ -687,15 +625,15 @@ lua-lsp = buildLuarocksPackage {
   version = "scm-2";
 
   knownRockspec = (fetchurl {
-    url    = "http://luarocks.org/dev/lua-lsp-scm-2.rockspec";
+    url    = "mirror://luarocks/lua-lsp-scm-2.rockspec";
     sha256 = "0qk3i6j0km4d1fs61fxhkmnbxmgpq24nygr8wknl6hbj2kya25rb";
   }).outPath;
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "git://github.com/Alloyed/lua-lsp",
-  "rev": "0de511803ed616214333210a2d003cf05a64dc18",
-  "date": "2018-09-08T10:11:54-04:00",
-  "sha256": "15dnsyh5664vi7qn73y2r114rhs5l9lfi84pwqkq5cafkiiy49qa",
+  "rev": "905e71f9a97ea6366deb386503f9d976c87d9bab",
+  "date": "2019-09-22T09:46:00-04:00",
+  "sha256": "1mlgb2dp1ah76hjkbkwz0dp2y5mn491v5wf81nm086rb2fa3rzcg",
   "fetchSubmodules": true
 }
  '') ["date"]) ;
@@ -706,28 +644,24 @@ lua-lsp = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/Alloyed/lua-lsp";
     description = "No summary";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 lua-messagepack = buildLuarocksPackage {
   pname = "lua-messagepack";
-  version = "0.5.1-2";
+  version = "0.5.2-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/lua-messagepack-0.5.1-2.src.rock";
-    sha256 = "0bsdzdd24p9z3j4z1avw7qaqx87baa1pm58v275pw4h6n72z492g";
+    url    = "mirror://luarocks/lua-messagepack-0.5.2-1.src.rock";
+    sha256 = "0hqahc84ncl8g4miif14sdkzyvnpqip48886sagz9drl52qvgcfb";
   };
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
-    homepage = "http://fperrad.frama.io/lua-MessagePack/";
+    homepage = "https://fperrad.frama.io/lua-MessagePack/";
     description = "a pure Lua implementation of the MessagePack serialization format";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 lua-term = buildLuarocksPackage {
@@ -735,7 +669,7 @@ lua-term = buildLuarocksPackage {
   version = "0.7-1";
 
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/lua-term-0.7-1.rockspec";
+    url    = "mirror://luarocks/lua-term-0.7-1.rockspec";
     sha256 = "0r9g5jw7pqr1dyj6w58dqlr7y7l0jp077n8nnji4phf10biyrvg2";
   }).outPath;
 
@@ -748,9 +682,7 @@ lua-term = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/hoelzro/lua-term";
     description = "Terminal functions for Lua";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 lua-toml = buildLuarocksPackage {
@@ -758,7 +690,7 @@ lua-toml = buildLuarocksPackage {
   version = "2.0-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/lua-toml-2.0-1.src.rock";
+    url    = "mirror://luarocks/lua-toml-2.0-1.src.rock";
     sha256 = "0lyqlnydqbplq82brw9ipqy9gijin6hj1wc46plz994pg4i2c74m";
   };
   disabled = (luaOlder "5.1");
@@ -767,9 +699,7 @@ lua-toml = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/jonstoler/lua-toml";
     description = "toml decoder/encoder for Lua";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 lua-zlib = buildLuarocksPackage {
@@ -777,7 +707,7 @@ lua-zlib = buildLuarocksPackage {
   version = "1.2-0";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/lua-zlib-1.2-0.src.rock";
+    url    = "mirror://luarocks/lua-zlib-1.2-0.src.rock";
     sha256 = "0qa0vnx45nxdj6fqag6fr627zsnd2bmrr9bdbm8jv6lcnyi6nhs2";
   };
   disabled = (luaOlder "5.1");
@@ -787,9 +717,7 @@ lua-zlib = buildLuarocksPackage {
     homepage = "https://github.com/brimworks/lua-zlib";
     description = "Simple streaming interface to zlib for Lua.";
     maintainers = with maintainers; [ koral ];
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 lua_cliargs = buildLuarocksPackage {
@@ -797,7 +725,7 @@ lua_cliargs = buildLuarocksPackage {
   version = "3.0-2";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/lua_cliargs-3.0-2.src.rock";
+    url    = "mirror://luarocks/lua_cliargs-3.0-2.src.rock";
     sha256 = "0qqdnw00r16xbyqn4w1xwwpg9i9ppc3c1dcypazjvdxaj899hy9w";
   };
   disabled = (luaOlder "5.1");
@@ -806,9 +734,7 @@ lua_cliargs = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/amireh/lua_cliargs";
     description = "A command-line argument parser.";
-    license = {
-      fullName = "MIT <http://opensource.org/licenses/MIT>";
-    };
+    license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 };
 luabitop = buildLuarocksPackage {
@@ -816,7 +742,7 @@ luabitop = buildLuarocksPackage {
   version = "1.0.2-3";
 
   knownRockspec = (fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/luabitop-1.0.2-3.rockspec";
+    url    = "mirror://luarocks/luabitop-1.0.2-3.rockspec";
     sha256 = "07y2h11hbxmby7kyhy3mda64w83p4a6p7y7rzrjqgc0r56yjxhcc";
   }).outPath;
 
@@ -835,9 +761,7 @@ luabitop = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://bitop.luajit.org/";
     description = "Lua Bit Operations Module";
-    license = {
-      fullName = "MIT/X license";
-    };
+    license.fullName = "MIT/X license";
   };
 };
 luacheck = buildLuarocksPackage {
@@ -845,7 +769,7 @@ luacheck = buildLuarocksPackage {
   version = "0.23.0-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/luacheck-0.23.0-1.src.rock";
+    url    = "mirror://luarocks/luacheck-0.23.0-1.src.rock";
     sha256 = "0akj61c7k1na2mggsckvfn9a3ljfp4agnmr9gp3mac4vin99a1cl";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
@@ -854,18 +778,16 @@ luacheck = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/mpeterv/luacheck";
     description = "A static analyzer and a linter for Lua";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 luacov = buildLuarocksPackage {
   pname = "luacov";
-  version = "0.13.0-1";
+  version = "0.14.0-1";
 
   src = fetchurl {
-    url    = "mirror://luarocks/luacov-0.13.0-1.src.rock";
-    sha256 = "16am0adzr4y64n94f64d4yrz65in8rwa8mmjz1p0k8afm5p5759i";
+    url    = "mirror://luarocks/luacov-0.14.0-1.src.rock";
+    sha256 = "18wj4l55wxwvaimvmkg3g5c6amzz9czdpl57z56wmdb284454kca";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
@@ -873,9 +795,7 @@ luacov = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://keplerproject.github.io/luacov/";
     description = "Coverage analysis tool for Lua scripts";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 luadbi = buildLuarocksPackage {
@@ -883,7 +803,7 @@ luadbi = buildLuarocksPackage {
   version = "0.7.2-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/luadbi-0.7.2-1.src.rock";
+    url    = "mirror://luarocks/luadbi-0.7.2-1.src.rock";
     sha256 = "0mj9ggyb05l03gs38ds508620mqaw4fkrzz9861n4j0zxbsbmfwy";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
@@ -892,9 +812,7 @@ luadbi = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/mwild1/luadbi";
     description = "Database abstraction layer";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 luadbi-mysql = buildLuarocksPackage {
@@ -902,7 +820,7 @@ luadbi-mysql = buildLuarocksPackage {
   version = "0.7.2-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/luadbi-mysql-0.7.2-1.src.rock";
+    url    = "mirror://luarocks/luadbi-mysql-0.7.2-1.src.rock";
     sha256 = "1f8i5p66halws8qsa7g09110hwzg7pv29yi22mkqd8sjgjv42iq4";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
@@ -911,9 +829,7 @@ luadbi-mysql = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/mwild1/luadbi";
     description = "Database abstraction layer";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 luadbi-postgresql = buildLuarocksPackage {
@@ -921,7 +837,7 @@ luadbi-postgresql = buildLuarocksPackage {
   version = "0.7.2-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/luadbi-postgresql-0.7.2-1.src.rock";
+    url    = "mirror://luarocks/luadbi-postgresql-0.7.2-1.src.rock";
     sha256 = "0nmm1hdzl77wk8p6r6al6mpkh2n332a8r3iqsdi6v4nxamykdh28";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
@@ -930,9 +846,7 @@ luadbi-postgresql = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/mwild1/luadbi";
     description = "Database abstraction layer";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 luadbi-sqlite3 = buildLuarocksPackage {
@@ -940,7 +854,7 @@ luadbi-sqlite3 = buildLuarocksPackage {
   version = "0.7.2-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/luadbi-sqlite3-0.7.2-1.src.rock";
+    url    = "mirror://luarocks/luadbi-sqlite3-0.7.2-1.src.rock";
     sha256 = "17wd2djzk5x4l4pv2k3c7b8dcvl46s96kqyk8dp3q6ll8gdl7c65";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
@@ -949,9 +863,7 @@ luadbi-sqlite3 = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/mwild1/luadbi";
     description = "Database abstraction layer";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 luadoc = buildLuarocksPackage {
@@ -992,7 +904,7 @@ luaevent = buildLuarocksPackage {
   version = "0.4.6-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/luaevent-0.4.6-1.src.rock";
+    url    = "mirror://luarocks/luaevent-0.4.6-1.src.rock";
     sha256 = "0chq09nawiz00lxd6pkdqcb8v426gdifjw6js3ql0lx5vqdkb6dz";
   };
   disabled = (luaOlder "5.1");
@@ -1001,9 +913,7 @@ luaevent = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/harningt/luaevent";
     description = "libevent binding for Lua";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 luaexpat = buildLuarocksPackage {
@@ -1011,7 +921,7 @@ luaexpat = buildLuarocksPackage {
   version = "1.3.0-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/luaexpat-1.3.0-1.src.rock";
+    url    = "mirror://luarocks/luaexpat-1.3.0-1.src.rock";
     sha256 = "15jqz5q12i9zvjyagzwz2lrpzya64mih8v1hxwr0wl2gsjh86y5a";
   };
   disabled = (luaOlder "5.1");
@@ -1021,9 +931,7 @@ luaexpat = buildLuarocksPackage {
     homepage = "http://www.keplerproject.org/luaexpat/";
     description = "XML Expat parsing";
     maintainers = with maintainers; [ arobyn flosse ];
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 luaffi = buildLuarocksPackage {
@@ -1031,7 +939,7 @@ luaffi = buildLuarocksPackage {
   version = "scm-1";
 
   src = fetchurl {
-    url    = "http://luarocks.org/dev/luaffi-scm-1.src.rock";
+    url    = "mirror://luarocks/luaffi-scm-1.src.rock";
     sha256 = "0dia66w8sgzw26bwy36gzyb2hyv7kh9n95lh5dl0158rqa6fsf26";
   };
   disabled = (luaOlder "5.1");
@@ -1040,9 +948,7 @@ luaffi = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/facebook/luaffifb";
     description = "FFI library for calling C functions from lua";
-    license = {
-      fullName = "BSD";
-    };
+    license.fullName = "BSD";
   };
 };
 luafilesystem = buildLuarocksPackage {
@@ -1050,7 +956,7 @@ luafilesystem = buildLuarocksPackage {
   version = "1.7.0-2";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/luafilesystem-1.7.0-2.src.rock";
+    url    = "mirror://luarocks/luafilesystem-1.7.0-2.src.rock";
     sha256 = "0xhmd08zklsgpnpjr9rjipah35fbs8jd4v4va36xd8bpwlvx9rk5";
   };
   disabled = (luaOlder "5.1");
@@ -1060,9 +966,7 @@ luafilesystem = buildLuarocksPackage {
     homepage = "git://github.com/keplerproject/luafilesystem";
     description = "File System Library for the Lua Programming Language";
     maintainers = with maintainers; [ flosse vcunat ];
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 lualogging = buildLuarocksPackage {
@@ -1078,9 +982,7 @@ lualogging = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/Neopallium/lualogging";
     description = "A simple API to use logging features";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 luaossl = buildLuarocksPackage {
@@ -1088,7 +990,7 @@ luaossl = buildLuarocksPackage {
   version = "20190731-0";
 
   src = fetchurl {
-    url    = "https://luarocks.org/luaossl-20190731-0.src.rock";
+    url    = "mirror://luarocks/luaossl-20190731-0.src.rock";
     sha256 = "0gardlh547hah5w4kfsdg05jmxzrxr21macqigcmp5hw1l67jn5m";
   };
   propagatedBuildInputs = [ lua ];
@@ -1097,24 +999,22 @@ luaossl = buildLuarocksPackage {
     homepage = "http://25thandclement.com/~william/projects/luaossl.html";
     description = "Most comprehensive OpenSSL module in the Lua universe.";
     maintainers = with maintainers; [ vcunat ];
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 luaposix = buildLuarocksPackage {
   pname = "luaposix";
-  version = "34.0.4-1";
+  version = "34.1.1-1";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/luaposix-34.0.4-1.src.rock";
-    sha256 = "0yrm5cn2iyd0zjd4liyj27srphvy0gjrjx572swar6zqr4dwjqp2";
+    url    = "mirror://luarocks/luaposix-34.1.1-1.src.rock";
+    sha256 = "1l9pkn3g0nzlbmmfj12rhfwvkqb06c21ydqxqgmnmd3w9z4ck53w";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
-  propagatedBuildInputs = [ bit32 lua std_normalize ];
+  propagatedBuildInputs = [ bit32 lua ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/luaposix/luaposix/";
+    homepage = "http://github.com/luaposix/luaposix/";
     description = "Lua bindings for POSIX";
     maintainers = with maintainers; [ vyp lblasc ];
     license.fullName = "MIT/X11";
@@ -1145,11 +1045,11 @@ luarepl = buildLuarocksPackage {
 };
 luasec = buildLuarocksPackage {
   pname = "luasec";
-  version = "0.8-1";
+  version = "0.9-1";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/luasec-0.8-1.src.rock";
-    sha256 = "063rgz0zdmaizirsm6jbcfijgkpdcrb8a2fvhvg3y2s8ixbaff13";
+    url    = "mirror://luarocks/luasec-0.9-1.src.rock";
+    sha256 = "00npxdwr3s4638i1jzmhyvss796rhbqk43zrzkb5lzzhqlxpsz5q";
   };
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua luasocket ];
@@ -1158,9 +1058,7 @@ luasec = buildLuarocksPackage {
     homepage = "https://github.com/brunoos/luasec/wiki";
     description = "A binding for OpenSSL library to provide TLS/SSL communication over LuaSocket.";
     maintainers = with maintainers; [ flosse ];
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 luasocket = buildLuarocksPackage {
@@ -1168,7 +1066,7 @@ luasocket = buildLuarocksPackage {
   version = "3.0rc1-2";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/luasocket-3.0rc1-2.src.rock";
+    url    = "mirror://luarocks/luasocket-3.0rc1-2.src.rock";
     sha256 = "1isin9m40ixpqng6ds47skwa4zxrc6w8blza8gmmq566w6hz50iq";
   };
   disabled = (luaOlder "5.1");
@@ -1177,19 +1075,27 @@ luasocket = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://luaforge.net/projects/luasocket/";
     description = "Network support for the Lua language";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 luasql-sqlite3 = buildLuarocksPackage {
   pname = "luasql-sqlite3";
-  version = "2.4.0-1";
+  version = "2.5.0-1";
 
-  src = fetchurl {
-    url    = "https://luarocks.org/luasql-sqlite3-2.4.0-1.src.rock";
-    sha256 = "0pdk8c9iw0625imf5wdrhq60484jn475b85rvp0xgh86bsyalbsh";
-  };
+  knownRockspec = (fetchurl {
+    url    = "mirror://luarocks/luasql-sqlite3-2.5.0-1.rockspec";
+    sha256 = "1r0x21i6n18x6915iaj9n309lqqqk1b30bg9h2a6y8jzk839hk09";
+  }).outPath;
+
+  src = fetchgit ( removeAttrs (builtins.fromJSON ''{
+  "url": "git://github.com/keplerproject/luasql.git",
+  "rev": "5496d60185db0c4578e8abe0c74343e99b799311",
+  "date": "2019-06-14T10:54:41-03:00",
+  "sha256": "1jdm1abj2ngklg7syq1ijj142ai9nmdl9370dk2bgamzlxc41pqm",
+  "fetchSubmodules": true
+}
+ '') ["date"]) ;
+
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
@@ -1197,23 +1103,21 @@ luasql-sqlite3 = buildLuarocksPackage {
     homepage = "http://www.keplerproject.org/luasql/";
     description = "Database connectivity for Lua (SQLite3 driver)";
     maintainers = with maintainers; [ vyp ];
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 luassert = buildLuarocksPackage {
   pname = "luassert";
-  version = "1.7.11-0";
+  version = "1.8.0-0";
 
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/luassert-1.7.11-0.rockspec";
-    sha256 = "12zgybcv8acjzvjdbxd1764s1vxbksxdv9fkvsymcsdmppxkbd0s";
+    url    = "mirror://luarocks/luassert-1.8.0-0.rockspec";
+    sha256 = "1194y81nlkq4qmrrgl7z82i6vgvhqvp1p673kq0arjix8mv3zyz1";
   }).outPath;
 
   src = fetchurl {
-    url    = "https://github.com/Olivine-Labs/luassert/archive/v1.7.11.tar.gz";
-    sha256 = "1vwq3wqj9cjyz9lnf1n38yhpcglr2h40v3n9096i8vcpmyvdb3ka";
+    url    = "https://github.com/Olivine-Labs/luassert/archive/v1.8.0.tar.gz";
+    sha256 = "0xlwlb32215524bg33svp1ci8mdvh9wykchl8dkhihpxcd526mar";
   };
 
   disabled = (luaOlder "5.1");
@@ -1222,9 +1126,7 @@ luassert = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://olivinelabs.com/busted/";
     description = "Lua Assertions Extension";
-    license = {
-      fullName = "MIT <http://opensource.org/licenses/MIT>";
-    };
+    license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 };
 luasystem = buildLuarocksPackage {
@@ -1232,7 +1134,7 @@ luasystem = buildLuarocksPackage {
   version = "0.2.1-0";
 
   src = fetchurl {
-    url    = "https://luarocks.org/luasystem-0.2.1-0.src.rock";
+    url    = "mirror://luarocks/luasystem-0.2.1-0.src.rock";
     sha256 = "091xmp8cijgj0yzfsjrn7vljwznjnjn278ay7z9pjwpwiva0diyi";
   };
   disabled = (luaOlder "5.1");
@@ -1241,29 +1143,25 @@ luasystem = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://olivinelabs.com/luasystem/";
     description = "Platform independent system calls for Lua.";
-    license = {
-      fullName = "MIT <http://opensource.org/licenses/MIT>";
-    };
+    license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 };
 luautf8 = buildLuarocksPackage {
   pname = "luautf8";
-  version = "0.1.1-1";
+  version = "0.1.2-2";
 
   src = fetchurl {
-    url    = "https://luarocks.org/luautf8-0.1.1-1.src.rock";
-    sha256 = "1832ilrlddh4h7ayx4l9j7z1p8c2hk5yr96cpxjjrmirkld23aji";
+    url    = "mirror://luarocks/luautf8-0.1.2-2.src.rock";
+    sha256 = "1q0qpr87alfzwwx5x0v9cggnz5fqi20jlqdh1a3i5cijjaj6xwdn";
   };
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/starwing/luautf8";
+    homepage = "http://github.com/starwing/luautf8";
     description = "A UTF-8 support module for Lua";
     maintainers = with maintainers; [ pstn ];
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 luazip = buildLuarocksPackage {
@@ -1271,7 +1169,7 @@ luazip = buildLuarocksPackage {
   version = "1.2.7-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/luazip-1.2.7-1.src.rock";
+    url    = "mirror://luarocks/luazip-1.2.7-1.src.rock";
     sha256 = "1yprlr1ap6bhshhy88qfphmmyg9zp1py2hj2158iw6vsva0fk03l";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
@@ -1280,9 +1178,7 @@ luazip = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/mpeterv/luazip";
     description = "Library for reading files inside zip files";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 lua-yajl = buildLuarocksPackage {
@@ -1290,19 +1186,17 @@ lua-yajl = buildLuarocksPackage {
   version = "2.0-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/lua-yajl-2.0-1.src.rock";
+    url    = "mirror://luarocks/lua-yajl-2.0-1.src.rock";
     sha256 = "0bsm519vs53rchcdf8g96ygzdx2bz6pa4vffqlvc7ap49bg5np4f";
   };
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/brimworks/lua-yajl";
+    homepage = "http://github.com/brimworks/lua-yajl";
     description = "Integrate the yajl JSON library with Lua.";
     maintainers = with maintainers; [ pstn ];
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 luuid = buildLuarocksPackage {
@@ -1310,7 +1204,7 @@ luuid = buildLuarocksPackage {
   version = "20120509-2";
 
   src = fetchurl {
-    url    = "https://luarocks.org/luuid-20120509-2.src.rock";
+    url    = "mirror://luarocks/luuid-20120509-2.src.rock";
     sha256 = "08q54x0m51w89np3n117h2a153wsgv3qayabd8cz6i55qm544hkg";
   };
   disabled = (luaOlder "5.2") || (luaAtLeast "5.4");
@@ -1319,9 +1213,7 @@ luuid = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://www.tecgraf.puc-rio.br/~lhf/ftp/lua/#luuid";
     description = "A library for UUID generation";
-    license = {
-      fullName = "Public domain";
-    };
+    license.fullName = "Public domain";
   };
 };
 luv = buildLuarocksPackage {
@@ -1338,9 +1230,25 @@ luv = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/luvit/luv";
     description = "Bare libuv bindings for lua";
-    license = {
-      fullName = "Apache 2.0";
-    };
+    license.fullName = "Apache 2.0";
+  };
+};
+lyaml = buildLuarocksPackage {
+  pname = "lyaml";
+  version = "6.2.5-1";
+
+  src = fetchurl {
+    url    = "mirror://luarocks/lyaml-6.2.5-1.src.rock";
+    sha256 = "00pnz27sqi84arwkzjabz9v7w37h7xvwb5njk690cfmaknb1dfz6";
+  };
+  disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+  propagatedBuildInputs = [ lua ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://github.com/gvvaughan/lyaml";
+    description = "libYAML binding for Lua";
+    maintainers = with maintainers; [ lblasc ];
+    license.fullName = "MIT/X11";
   };
 };
 markdown = buildLuarocksPackage {
@@ -1348,7 +1256,7 @@ markdown = buildLuarocksPackage {
   version = "0.33-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/markdown-0.33-1.src.rock";
+    url    = "mirror://luarocks/markdown-0.33-1.src.rock";
     sha256 = "01xw4b4jvmrv1hz2gya02g3nphsj3hc94hsbc672ycj8pcql5n5y";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
@@ -1357,9 +1265,7 @@ markdown = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/mpeterv/markdown";
     description = "Markdown text-to-html markup system.";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 mediator_lua = buildLuarocksPackage {
@@ -1367,7 +1273,7 @@ mediator_lua = buildLuarocksPackage {
   version = "1.1.2-0";
 
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/mediator_lua-1.1.2-0.rockspec";
+    url    = "mirror://luarocks/mediator_lua-1.1.2-0.rockspec";
     sha256 = "0frzvf7i256260a1s8xh92crwa2m42972qxfq29zl05aw3pyn7bm";
   }).outPath;
 
@@ -1382,32 +1288,28 @@ mediator_lua = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://olivinelabs.com/mediator_lua/";
     description = "Event handling through channels";
-    license = {
-      fullName = "MIT <http://opensource.org/licenses/MIT>";
-    };
+    license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 };
 mpack = buildLuarocksPackage {
   pname = "mpack";
-  version = "1.0.7-0";
+  version = "1.0.8-0";
 
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/mpack-1.0.7-0.rockspec";
-    sha256 = "1sdw8qsni3g3fx9jnc5g64nxfw6v3n1rrw1xa3bkwc9wk815lqnz";
+    url    = "mirror://luarocks/mpack-1.0.8-0.rockspec";
+    sha256 = "0hhpamw2bydnfrild274faaan6v48918nhslnw3kvi9y36b4i5ha";
   }).outPath;
 
   src = fetchurl {
-    url    = "https://github.com/libmpack/libmpack-lua/releases/download/1.0.7/libmpack-lua-1.0.7.tar.gz";
-    sha256 = "1s4712ig3l4ds65pmlyg3r5zids2snn1rv8vsmmk27a4lf258mk8";
+    url    = "https://github.com/libmpack/libmpack-lua/releases/download/1.0.8/libmpack-lua-1.0.8.tar.gz";
+    sha256 = "1sf93ffx7a3y1waknc4994l2yrxilrlf3hcp2cj2cvxmpm5inszd";
   };
 
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/libmpack/libmpack-lua/releases/download/1.0.7/libmpack-lua-1.0.7.tar.gz";
+    homepage = "https://github.com/libmpack/libmpack-lua/releases/download/1.0.8/libmpack-lua-1.0.8.tar.gz";
     description = "Lua binding to libmpack";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 moonscript = buildLuarocksPackage {
@@ -1415,7 +1317,7 @@ moonscript = buildLuarocksPackage {
   version = "0.5.0-1";
 
   src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/moonscript-0.5.0-1.src.rock";
+    url    = "mirror://luarocks/moonscript-0.5.0-1.src.rock";
     sha256 = "09vv3ayzg94bjnzv5fw50r683ma0x3lb7sym297145zig9aqb9q9";
   };
   disabled = (luaOlder "5.1");
@@ -1425,9 +1327,7 @@ moonscript = buildLuarocksPackage {
     homepage = "http://moonscript.org";
     description = "A programmer friendly language that compiles to Lua";
     maintainers = with maintainers; [ arobyn ];
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 nvim-client = buildLuarocksPackage {
@@ -1435,51 +1335,41 @@ nvim-client = buildLuarocksPackage {
   version = "0.2.2-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/nvim-client-0.2.2-1.src.rock";
+    url    = "mirror://luarocks/nvim-client-0.2.2-1.src.rock";
     sha256 = "0bgx94ziiq0004zw9lz2zb349xaqs5pminqd8bwdrfdnfjnbp8x0";
   };
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua mpack luv coxpcall ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/neovim/lua-client/archive/0.2.2-1.tar.gz";
+    homepage = "https://github.com/neovim/lua-client";
     description = "Lua client to Nvim";
-    license = {
-      fullName = "Apache";
-    };
+    license.fullName = "Apache";
   };
 };
 penlight = buildLuarocksPackage {
   pname = "penlight";
-  version = "1.5.4-1";
-
-  knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/penlight-1.5.4-1.rockspec";
-    sha256 = "07mhsk9kmdxg4i2w4mrnnd2zs34bgggi9gigfplakxin96sa6c0p";
-  }).outPath;
+  version = "1.7.0-1";
 
   src = fetchurl {
-    url    = "http://stevedonovan.github.io/files/penlight-1.5.4.zip";
-    sha256 = "138f921p6kdqkmf4pz115phhj0jsqf28g33avws80d2vq2ixqm8q";
+    url    = "mirror://luarocks/penlight-1.7.0-1.src.rock";
+    sha256 = "0rr56vc33b2knr5qmfdjrb1wk98lyp3zmlyzz6m15v2s1s5yxgah";
   };
-
   propagatedBuildInputs = [ luafilesystem ];
 
   meta = with stdenv.lib; {
-    homepage = "http://stevedonovan.github.com/Penlight";
+    homepage = "http://tieske.github.io/Penlight";
     description = "Lua utility libraries loosely based on the Python standard libraries";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 rapidjson = buildLuarocksPackage {
   pname = "rapidjson";
-  version = "0.5.2-1";
+  version = "0.6.1-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/rapidjson-0.5.2-1.src.rock";
-    sha256 = "17lgbzv9kairx49kwa0m8xwyly95mg6fw60jan2dpqwnnkf2m8y6";
+    url    = "mirror://luarocks/rapidjson-0.6.1-1.src.rock";
+    sha256 = "106zdkmqspwjw6ywzi7ya9zss52p9zggh53rg0i36sk19z0xmp6j";
   };
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
@@ -1487,9 +1377,7 @@ rapidjson = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/xpol/lua-rapidjson";
     description = "Json module based on the very fast RapidJSON.";
-    license = {
-      fullName = "MIT";
-    };
+    license.fullName = "MIT";
   };
 };
 say = buildLuarocksPackage {
@@ -1497,7 +1385,7 @@ say = buildLuarocksPackage {
   version = "1.3-1";
 
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/say-1.3-1.rockspec";
+    url    = "mirror://luarocks/say-1.3-1.rockspec";
     sha256 = "0bknglb0qwd6r703wp3hcb6z2xxd14kq4md3sg9al3b28fzxbhdv";
   }).outPath;
 
@@ -1512,9 +1400,7 @@ say = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://olivinelabs.com/busted/";
     description = "Lua String Hashing/Indexing Library";
-    license = {
-      fullName = "MIT <http://opensource.org/licenses/MIT>";
-    };
+    license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 };
 std__debug = buildLuarocksPackage {
@@ -1522,7 +1408,7 @@ std__debug = buildLuarocksPackage {
   version = "1.0.1-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/std._debug-1.0.1-1.src.rock";
+    url    = "mirror://luarocks/std._debug-1.0.1-1.src.rock";
     sha256 = "1qkcc5rph3ns9mzrfsa1671pb3hzbzfnaxvyw7zdly2b7ll88svz";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
@@ -1531,28 +1417,24 @@ std__debug = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://lua-stdlib.github.io/_debug";
     description = "Debug Hints Library";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 std_normalize = buildLuarocksPackage {
   pname = "std.normalize";
-  version = "2.0.2-1";
+  version = "2.0.3-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/std.normalize-2.0.2-1.src.rock";
-    sha256 = "0yn60zqnxflhhlv6xk6w0ifdfxk1qcg8gq1wnrrbwsxwpipsrfjh";
+    url    = "mirror://luarocks/std.normalize-2.0.3-1.src.rock";
+    sha256 = "00pq2y5w8i052gxmyhgri5ibijksnfmc24kya9y3d5rjlin0n11s";
   };
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua std__debug ];
 
   meta = with stdenv.lib; {
     homepage = "https://lua-stdlib.github.io/normalize";
     description = "Normalized Lua Functions";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
   };
 };
 stdlib = buildLuarocksPackage {
@@ -1560,7 +1442,7 @@ stdlib = buildLuarocksPackage {
   version = "41.2.2-1";
 
   src = fetchurl {
-    url    = "https://luarocks.org/stdlib-41.2.2-1.src.rock";
+    url    = "mirror://luarocks/stdlib-41.2.2-1.src.rock";
     sha256 = "1kricll40xy75j72lrbp2jpyxsj9v8b9d7qjf3m3fq1bpg6dmsk7";
   };
   disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
@@ -1571,6 +1453,24 @@ stdlib = buildLuarocksPackage {
     description = "General Lua Libraries";
     maintainers = with maintainers; [ vyp ];
     license.fullName = "MIT/X11";
+  };
+};
+pulseaudio = buildLuarocksPackage {
+  pname = "pulseaudio";
+  version = "0.2-1";
+
+  src = fetchurl {
+    url    = "mirror://luarocks/pulseaudio-0.2-1.src.rock";
+    sha256 = "06w8fmwddrpm02yam818yi30gghw4ckb18zljjncy3x0zfijyhz7";
+  };
+  disabled = (luaOlder "5.1");
+  propagatedBuildInputs = [ lua ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/doronbehar/lua-pulseaudio";
+    description = "Bindings to libpulse";
+    maintainers = with maintainers; [ doronbehar ];
+    license.fullName = "Apache v2.0";
   };
 };
 vstruct = buildLuarocksPackage {

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -145,6 +145,14 @@ with super;
     ];
   });
 
+  lua-lsp = super.lua-lsp.override({
+    # until Alloyed/lua-lsp#28
+    postConfigure = ''
+      substituteInPlace ''${rockspecFilename} \
+        --replace '"lpeglabel ~> 1.5",' '"lpeglabel >= 1.5",'
+    '';
+  });
+
   lua-zlib = super.lua-zlib.override({
     buildInputs = [
       pkgs.zlib.dev
@@ -294,6 +302,12 @@ with super;
     };
   });
 
+  lyaml = super.lyaml.override({
+    buildInputs = [
+      pkgs.libyaml
+    ];
+  });
+
   mpack = super.mpack.override({
     buildInputs = [ pkgs.libmpack ];
     # the rockspec doesn't use the makefile so you may need to export more flags
@@ -306,5 +320,14 @@ with super;
       sed -i '/set(CMAKE_CXX_FLAGS/d' CMakeLists.txt
       sed -i '/set(CMAKE_C_FLAGS/d' CMakeLists.txt
     '';
+  });
+
+  pulseaudio = super.pulseaudio.override({
+    buildInputs = [
+      pkgs.libpulseaudio
+    ];
+    nativeBuildInputs = [
+      pkgs.pulseaudio pkgs.pkgconfig
+    ];
   });
 }

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -132,39 +132,6 @@ with self; {
     };
   };
 
-  pulseaudio = buildLuaPackage rec {
-    pname = "pulseaudio";
-    version = "0.2";
-    name = "pulseaudio-${version}";
-
-    src = fetchFromGitHub {
-      owner = "doronbehar";
-      repo = "lua-pulseaudio";
-      rev = "v${version}";
-      sha256 = "140y1m6k798c4w7xfl0zb0a4ffjz6i1722bgkdcdg8g76hr5r8ys";
-    };
-    disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
-    buildInputs = [ pkgs.libpulseaudio ];
-    propagatedBuildInputs = [ lua ];
-    nativeBuildInputs = [ pkgs.pulseaudio pkgconfig ];
-
-    makeFlags = [
-      "INST_LIBDIR=${placeholder "out"}/lib/lua/${lua.luaversion}"
-      "INST_LUADIR=${placeholder "out"}/share/lua/${lua.luaversion}"
-      "LUA_BINDIR=${placeholder "out"}/bin"
-    ];
-    preBuild = ''
-      mkdir -p ${placeholder "out"}/lib/lua/${lua.luaversion}
-    '';
-
-    meta = with stdenv.lib; {
-      homepage = "https://github.com/doronbehar/lua-pulseaudio";
-      description = "Libpulse Lua bindings";
-      maintainers = with maintainers; [ doronbehar ];
-      license = licenses.lgpl21;
-    };
-  };
-
   vicious = toLuaModule(stdenv.mkDerivation rec {
     pname = "vicious";
     version = "2.3.1";


### PR DESCRIPTION
### Motivation for this change

Update luarocks generated packages and add lyaml - lua yaml parser. I've also found that lua pulseaduio package was missing from `generated-packages.nix`.

I've tested most of the updated packages.

cc @teto @vcunat 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
