### PR TITLE
mesa: Set datadir so that the path to the DriConf defaults is correct

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -79,6 +79,12 @@ stdenv.mkDerivation {
     substituteInPlace meson.build --replace \
       "find_program('pkg-config')" \
       "find_program('${buildPackages.pkg-config.targetPrefix}pkg-config')"
+
+    # The drirc.d directory cannot be installed to $drivers as that would cause a cyclic dependency:
+    substituteInPlace src/util/xmlconfig.c --replace \
+      'DATADIR "/drirc.d"' '"${placeholder "out"}/drirc.d"'
+    substituteInPlace src/util/meson.build --replace \
+      "get_option('datadir')" "'${placeholder "out"}'"
   '';
 
   outputs = [ "out" "dev" "drivers" ] ++ lib.optional enableOSMesa "osmesa";
@@ -86,6 +92,7 @@ stdenv.mkDerivation {
   # TODO: Figure out how to enable opencl without having a runtime dependency on clang
   mesonFlags = [
     "--sysconfdir=/etc"
+    "--datadir=${placeholder "drivers"}/share" # Vendor files
 
     # Don't build in debug mode
     # https://gitlab.freedesktop.org/mesa/mesa/blob/master/docs/meson.html#L327
@@ -155,9 +162,6 @@ stdenv.mkDerivation {
       # Move other drivers to a separate output
       mv $out/lib/lib*_mesa* $drivers/lib
     fi
-
-    # move vendor files
-    mv $out/share/ $drivers/
 
     # Update search path used by glvnd
     for js in $drivers/share/glvnd/egl_vendor.d/*.json; do


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This should fix #89421. Unfortunately it results in a cyclic dependency:
`cycle detected in the references of '/nix/store/4mnbqgm2a4b055mpmdak2b17ccp1ah82-mesa-20.0.2' from '/nix/store/br6c6zm6n8h48qyrb9a4qvf3nyqkcvr6-mesa-20.0.2-drivers'`

The cycle probably comes from `src/util/xmlconfig.c` in which case we cannot just drop the dependency. The problem is:
```
$ grep -R /nix/store/br6c6zm6n8h48qyrb9a4qvf3nyqkcvr6-mesa-20.0.2-drivers /nix/store/4mnbqgm2a4b055mpmdak2b17ccp1ah82-mesa-20.0.2
Binary file /nix/store/4mnbqgm2a4b055mpmdak2b17ccp1ah82-mesa-20.0.2/lib/libgbm.so.1 matches
Binary file /nix/store/4mnbqgm2a4b055mpmdak2b17ccp1ah82-mesa-20.0.2/lib/libgbm.so.1.0.0 matches
Binary file /nix/store/4mnbqgm2a4b055mpmdak2b17ccp1ah82-mesa-20.0.2/lib/libgbm.so matches
$ tree -a /nix/store/4mnbqgm2a4b055mpmdak2b17ccp1ah82-mesa-20.0.2
/nix/store/4mnbqgm2a4b055mpmdak2b17ccp1ah82-mesa-20.0.2
└── lib
    ├── libgbm.so -> libgbm.so.1
    ├── libgbm.so.1 -> libgbm.so.1.0.0
    ├── libgbm.so.1.0.0
    ├── libglapi.so -> libglapi.so.0
    ├── libglapi.so.0 -> libglapi.so.0.0.0
    └── libglapi.so.0.0.0
```

On NixOS we could use `/run/opengl-driver/share/` but then this wouldn't work on non-NixOS systems.

@vcunat any ideas what to do here?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
