### PR TITLE
gitAndTools.gh: add github-cli alias

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19815,6 +19815,8 @@ in
 
   git-review = callPackage ../applications/version-management/git-review { };
 
+  github-cli = gitAndTools.gh;
+
   gitolite = callPackage ../applications/version-management/gitolite { };
 
   inherit (gnome3) gitg;


### PR DESCRIPTION
This has been resubmitted as `github-cli` twice. 

https://github.com/NixOS/nixpkgs/pull/80110, https://github.com/NixOS/nixpkgs/pull/89661