### PR TITLE
lnd: 0.10.0 -> 0.10.3, enable same features as upstream

### DIFF
--- a/pkgs/applications/blockchains/lnd.nix
+++ b/pkgs/applications/blockchains/lnd.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "lnd";
-  version = "0.10.0-beta";
+  version = "0.10.3-beta";
 
   src = fetchFromGitHub {
     owner = "lightningnetwork";
     repo = "lnd";
     rev = "v${version}";
-    sha256 = "1amciz924s2h6qhy7w34jpv1jc25p5ayfxzvjph6hhx0bccrm88w";
+    sha256 = "129vi8z2sk4hagk7axa675nba6sbj9km88zlq8a1g8di7v2k9z6a";
   };
 
-  vendorSha256 = "1iyghg11cxvbzi0gl40fvv8pl3d3k52j179w3x5m1f09r5ji223y";
+  vendorSha256 = "0a4bk2qry0isnrvl0adwikqn6imxwzlaq5j3nglb5rmwwq2cdz0r";
 
   subPackages = ["cmd/lncli" "cmd/lnd"];
 

--- a/pkgs/applications/blockchains/lnd.nix
+++ b/pkgs/applications/blockchains/lnd.nix
@@ -1,4 +1,6 @@
-{ buildGoModule, fetchFromGitHub, lib }:
+{ buildGoModule, fetchFromGitHub, lib
+, tags ? [ "autopilotrpc" "signrpc" "walletrpc" "chainrpc" "invoicesrpc" "watchtowerrpc" ]
+}:
 
 buildGoModule rec {
   pname = "lnd";
@@ -14,6 +16,18 @@ buildGoModule rec {
   vendorSha256 = "0a4bk2qry0isnrvl0adwikqn6imxwzlaq5j3nglb5rmwwq2cdz0r";
 
   subPackages = ["cmd/lncli" "cmd/lnd"];
+
+  preBuild = let
+    buildVars = {
+      RawTags = lib.concatStringsSep "," tags;
+      GoVersion = "$(go version | egrep -o 'go[0-9]+[.][^ ]*')";
+    };
+    buildVarsFlags = lib.concatStringsSep " " (lib.mapAttrsToList (k: v: "-X github.com/lightningnetwork/lnd/build.${k}=${v}") buildVars);
+  in
+  lib.optionalString (tags != []) ''
+    buildFlagsArray+=("-tags=${lib.concatStringsSep " " tags}")
+    buildFlagsArray+=("-ldflags=${buildVarsFlags}")
+  '';
 
   meta = with lib; {
     description = "Lightning Network Daemon";


### PR DESCRIPTION
###### Motivation for this change

* 0.10.1 release: https://github.com/lightningnetwork/lnd/releases/tag/v0.10.1-beta
* was confused by missing `lncli` subcommands: https://github.com/lightningnetwork/lnd/blob/v0.10.1-beta/make/release_flags.mk#L36

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @jonasnick @cpunk2140 