### PR TITLE
sympa: 6.2.54 -> 6.2.56

### DIFF
--- a/pkgs/servers/mail/sympa/default.nix
+++ b/pkgs/servers/mail/sympa/default.nix
@@ -63,13 +63,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "sympa";
-  version = "6.2.54";
+  version = "6.2.56";
 
   src = fetchFromGitHub {
     owner = "sympa-community";
     repo = pname;
     rev = version;
-    sha256 = "07wfvr8rrg7pwkl2zglrdri7n42rl9gwrjbaffb8m37wq67s7fca";
+    sha256 = "13cs2azpskmp2hkfy5zqf4qb6sb9r8d4wwzc8mw74mg2kdjnvfpy";
   };
 
   configureFlags = [


### PR DESCRIPTION
ChangeLog: https://github.com/sympa-community/sympa/blob/6.2.56/NEWS.md

Even though the advisory says that *Attacker can execute arbitrary code with root privileges*, the package nor NixOS module have any setuid wrapper so I believe we're not affected.

###### Motivation for this change

* https://nvd.nist.gov/vuln/detail/CVE-2020-10936
* https://sympa-community.github.io/security/2020-002.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
