### PR TITLE
handbrake: fix Darwin build

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -1,6 +1,6 @@
-# Upstream distributes HandBrake with bundle of according versions of libraries and patches to them.
-#
-# Derivation patches HandBrake to use Nix closure dependencies.
+# Upstream distributes HandBrake with bundle of according versions of libraries
+# and patches to them. This derivation patches HandBrake to use Nix closure
+# dependencies.
 #
 # NOTE: 2019-07-19: This derivation does not currently support the native macOS
 # GUI--it produces the "HandbrakeCLI" CLI version only. In the future it would
@@ -44,11 +44,6 @@
   useFdk ? false, fdk_aac ? null
 }:
 
-assert stdenv.isDarwin -> AudioToolbox != null
-       && Foundation != null
-       && libobjc != null
-       && VideoToolbox != null;
-
 stdenv.mkDerivation rec {
   pname = "handbrake";
   version = "1.3.3";
@@ -76,15 +71,26 @@ _EOF
 
     patchShebangs scripts
 
-    substituteInPlace libhb/module.defs \
-      --replace /usr/include/libxml2 ${libxml2.dev}/include/libxml2
-
     # Force using nixpkgs dependencies
     sed -i '/MODULES += contrib/d' make/include/main.defs
     sed -e 's/^[[:space:]]*\(meson\|ninja\|nasm\)[[:space:]]*= ToolProbe.*$//g' \
         -e '/    ## Additional library and tool checks/,/    ## MinGW specific library and tool checks/d' \
         -i make/configure.py
-  '';
+  '' + (lib.optionalString stdenv.isDarwin ''
+    # Use the Nix-provided libxml2 instead of the patched version available on
+    # the Handbrake website.
+    substituteInPlace libhb/module.defs \
+      --replace '$(CONTRIB.build/)include/libxml2' ${libxml2.dev}/include/libxml2
+
+    # Prevent the configure script from failing if xcodebuild isn't available,
+    # which it isn't in the Nix context. (The actual build goes fine without
+    # xcodebuild.)
+    sed -e '/xcodebuild = ToolProbe/s/abort=.\+)/abort=False)/' -i make/configure.py
+  '') + (lib.optionalString stdenv.isLinux ''
+    # Use the Nix-provided libxml2 instead of the system-provided one.
+    substituteInPlace libhb/module.defs \
+      --replace /usr/include/libxml2 ${libxml2.dev}/include/libxml2
+  '');
 
   nativeBuildInputs = [
     pkgconfig autoconf automake libtool m4 python3
@@ -94,8 +100,9 @@ _EOF
     ffmpeg-full libogg libtheora x264 x265 libvpx dav1d
     libopus lame libvorbis a52dec speex libsamplerate
     libiconv fribidi fontconfig freetype libass jansson libxml2 harfbuzz
-    libdvdread libdvdnav libdvdcss libbluray lzma numactl
-  ] ++ lib.optionals useGtk [
+    libdvdread libdvdnav libdvdcss libbluray lzma
+  ] ++ lib.optional (!stdenv.isDarwin) numactl
+  ++ lib.optionals useGtk [
     glib gtk3 libappindicator-gtk3 libnotify
     gst_all_1.gstreamer gst_all_1.gst-plugins-base dbus-glib udev
     libgudev hicolor-icon-theme


### PR DESCRIPTION
###### Motivation for this change

The handbrake build had broken under Darwin. This PR fixes it by

- Omitting the numactl dependency under Darwin.
- Preventing the configure script from checking for xcodebuild. This check always failed (because xcodebuild isn't available in the build context) but xcodebuild isn't actually needed for the build, which uses `--disable-xcode`.
- Using the Nix-provided libxml2 under Darwin like we already do under Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Anton-Latukha @wmertens 