### PR TITLE
micropro: init at 0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8869,4 +8869,10 @@
     github = "cpcloud";
     githubId = 417981;
   };
+  kalium = {
+    name = "Martijn Becker";
+    email = "nixpkgs@kalium.xyz";
+    github = "kaliumxyz";
+    githubId = 25854553;
+  };
 }

--- a/pkgs/development/tools/minipro/default.nix
+++ b/pkgs/development/tools/minipro/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, installShellFiles, fetchFromGitLab, pkg-config, libusb1 }:
+stdenv.mkDerivation rec {
+  pname = "minipro";
+  version = "0.4";
+
+  src = fetchFromGitLab {
+    owner = "DavidGriffith";
+    repo = "minipro";
+    rev = version;
+    sha256 = "17k2vanz0xrmvl5sa12jr1n4x5m2s7292qs79mvj40bxbhrcmaci";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    libusb1
+  ];
+
+  preConfigure = ''
+    export PKG_CONFIG="${pkg-config}/bin/pkg-config";
+    substituteInPlace Makefile --replace '$(shell date "+%Y-%m-%d %H:%M:%S %z")' "1970-01-01 00:00:00 +0000"
+  '';
+
+  makeFlags = [ "-e minipro" ];
+
+  installPhase = ''
+    mkdir $out/bin $out/lib/udev/rules.d -pv
+    cp -rv ./minipro $out/bin/
+    mv udev/* $out/lib/udev/rules.d/ -v
+    installManPage ./man/minipro.1
+    installShellCompletion --bash ./bash_completion.d/minipro
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An open source program for controlling the MiniPRO TL866xx series of chip programmers";
+    homepage = "https://gitlab.com/DavidGriffith/minipro";
+    maintainers = with maintainers; [ kalium ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/tools/minipro/unstable.nix
+++ b/pkgs/development/tools/minipro/unstable.nix
@@ -1,0 +1,44 @@
+{ stdenv, installShellFiles, fetchFromGitLab, pkg-config, libusb1 }:
+stdenv.mkDerivation rec {
+  pname = "minipro";
+  version = "unstable-2020-04-18";
+
+  src = fetchFromGitLab {
+    owner = "DavidGriffith";
+    repo = "minipro";
+    rev = version;
+    sha256 = "0jv2nw2rx5di71fmzavhjw31iz5v1v7azkdlmqjwk4lzincrkxxv";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    libusb1
+  ];
+
+  preConfigure = ''
+    export PKG_CONFIG="${pkg-config}/bin/pkg-config";
+    substituteInPlace Makefile --replace '$(shell date "+%Y-%m-%d %H:%M:%S %z")' "1970-01-01 00:00:00 +0000"
+  '';
+
+  makeFlags = [ "-e minipro" ];
+
+  installPhase = ''
+    mkdir $out/bin $out/lib/udev/rules.d -pv
+    cp -rv ./minipro $out/bin/
+    mv udev/* $out/lib/udev/rules.d/ -v
+    installManPage ./man/minipro.1
+    installShellCompletion --bash ./bash_completion.d/minipro
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An open source program for controlling the MiniPRO TL866xx series of chip programmers";
+    homepage = "https://gitlab.com/DavidGriffith/minipro";
+    maintainers = with maintainers; [ kalium ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26679,6 +26679,9 @@ in
 
   omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { };
 
+  minipro = callPackage ../development/tools/minipro { };
+  minipro-unstable = callPackage ../development/tools/minipro/unstable.nix { };
+
   wasmtime = callPackage ../development/interpreters/wasmtime {};
 
   wfuzz = with python3Packages; toPythonApplication wfuzz;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
getting the Micropro TL866CS universal programmer utility in nixpkgs

###### Things done
Wrote nix file for micropro utility, added self as its maintainer.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
