### PR TITLE
[r20.03] fwupd: 1.3.7 -> 1.3.9

### DIFF
--- a/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
@@ -1,8 +1,8 @@
 diff --git a/data/meson.build b/data/meson.build
-index d59bdc88..4a4cfc35 100644
+index 0667bd78..92d6c7b9 100644
 --- a/data/meson.build
 +++ b/data/meson.build
-@@ -16,7 +16,7 @@
+@@ -17,7 +17,7 @@ endif
  
  if build_standalone
    install_data(['daemon.conf'],
@@ -15,7 +15,7 @@ diff --git a/data/pki/meson.build b/data/pki/meson.build
 index eefcc914..dc801fa1 100644
 --- a/data/pki/meson.build
 +++ b/data/pki/meson.build
-@@ -4,14 +4,14 @@
+@@ -4,14 +4,14 @@ if get_option('gpg')
        'GPG-KEY-Linux-Foundation-Firmware',
        'GPG-KEY-Linux-Vendor-Firmware-Service',
      ],
@@ -32,7 +32,7 @@ index eefcc914..dc801fa1 100644
    )
  endif
  
-@@ -19,12 +19,12 @@
+@@ -19,12 +19,12 @@ if get_option('pkcs7')
    install_data([
        'LVFS-CA.pem',
      ],
@@ -51,7 +51,7 @@ diff --git a/data/remotes.d/meson.build b/data/remotes.d/meson.build
 index 826a3c1d..b78db663 100644
 --- a/data/remotes.d/meson.build
 +++ b/data/remotes.d/meson.build
-@@ -3,7 +3,7 @@
+@@ -3,7 +3,7 @@ if build_daemon and get_option('lvfs')
        'lvfs.conf',
        'lvfs-testing.conf',
      ],
@@ -60,7 +60,7 @@ index 826a3c1d..b78db663 100644
    )
    i18n.merge_file(
      input: 'lvfs.metainfo.xml',
-@@ -37,12 +37,12 @@
+@@ -37,12 +37,12 @@ configure_file(
    output : 'vendor.conf',
    configuration : con2,
    install: true,
@@ -79,7 +79,7 @@ diff --git a/meson.build b/meson.build
 index b1a523d2..aacb8e0a 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -169,6 +169,12 @@
+@@ -169,6 +169,12 @@ endif
  mandir = join_paths(prefix, get_option('mandir'))
  localedir = join_paths(prefix, get_option('localedir'))
  
@@ -96,7 +96,7 @@ diff --git a/meson_options.txt b/meson_options.txt
 index be0adfef..73983333 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -26,6 +26,7 @@
+@@ -26,6 +26,7 @@ option('plugin_coreboot', type : 'boolean', value : true, description : 'enable
  option('systemd', type : 'boolean', value : true, description : 'enable systemd support')
  option('systemdunitdir', type: 'string', value: '', description: 'Directory for systemd units')
  option('elogind', type : 'boolean', value : false, description : 'enable elogind support')
@@ -108,7 +108,7 @@ diff --git a/plugins/dell-esrt/meson.build b/plugins/dell-esrt/meson.build
 index ed4eee70..76dbdb1d 100644
 --- a/plugins/dell-esrt/meson.build
 +++ b/plugins/dell-esrt/meson.build
-@@ -37,5 +37,5 @@
+@@ -37,5 +37,5 @@ configure_file(
    output : 'dell-esrt.conf',
    configuration : con2,
    install: true,
@@ -119,7 +119,7 @@ diff --git a/plugins/redfish/meson.build b/plugins/redfish/meson.build
 index 25fc5c7d..77eb9a83 100644
 --- a/plugins/redfish/meson.build
 +++ b/plugins/redfish/meson.build
-@@ -27,7 +27,7 @@
+@@ -27,7 +27,7 @@ shared_module('fu_plugin_redfish',
  )
  
  install_data(['redfish.conf'],
@@ -132,7 +132,7 @@ diff --git a/plugins/thunderbolt/meson.build b/plugins/thunderbolt/meson.build
 index 06ab34ee..297a9182 100644
 --- a/plugins/thunderbolt/meson.build
 +++ b/plugins/thunderbolt/meson.build
-@@ -46,7 +46,7 @@
+@@ -46,7 +46,7 @@ executable('tbtfwucli',
  )
  
  install_data(['thunderbolt.conf'],
@@ -142,11 +142,11 @@ index 06ab34ee..297a9182 100644
  # we use functions from 2.52 in the tests
  if get_option('tests') and umockdev.found() and gio.version().version_compare('>= 2.52')
 diff --git a/plugins/uefi/meson.build b/plugins/uefi/meson.build
-index 39b5f566..0f904a22 100644
+index 7252580d..7188d1c5 100644
 --- a/plugins/uefi/meson.build
 +++ b/plugins/uefi/meson.build
-@@ -87,7 +87,7 @@
- )
+@@ -104,7 +104,7 @@ if get_option('man')
+ endif
  
  install_data(['uefi.conf'],
 -  install_dir:  join_paths(sysconfdir, 'fwupd')
@@ -154,3 +154,14 @@ index 39b5f566..0f904a22 100644
  )
  
  if get_option('tests')
+diff --git a/plugins/upower/meson.build b/plugins/upower/meson.build
+index 290a3eb6..9ab2f452 100644
+--- a/plugins/upower/meson.build
++++ b/plugins/upower/meson.build
+@@ -23,5 +23,5 @@ shared_module('fu_plugin_upower',
+ )
+ 
+ install_data(['upower.conf'],
+-  install_dir:  join_paths(sysconfdir, 'fwupd')
++  install_dir:  join_paths(sysconfdir_install, 'fwupd')
+ )

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -2,7 +2,6 @@
 
 { stdenv
 , fetchurl
-, fetchpatch
 , substituteAll
 , gtk-doc
 , pkgconfig
@@ -88,11 +87,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "fwupd";
-  version = "1.3.8";
+  version = "1.3.9";
 
   src = fetchurl {
     url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-    sha256 = "14hbwp3263n4z61ws62vj50kh9a89fz2l29hyv7f1xlas4zz6j8x";
+    sha256 = "ZuRG+UN8ebXv5Z8fOYWT0eCtHykGXoB8Ysu3wAeqx0A=";
   };
 
   # libfwupd goes to lib
@@ -162,12 +161,6 @@ stdenv.mkDerivation rec {
       src = ./installed-tests-path.patch;
       # needs a different set of modules than po/make-images
       inherit installedTestsPython;
-    })
-
-    # Find the correct lds and crt name when specifying -Defi_ldsdir
-    (fetchpatch {
-      url = "https://github.com/fwupd/fwupd/commit/52cda3db9ca9ab4faf99310edf29df926a713b5c.patch";
-      sha256 = "0hsj79dzamys7ryz33iwxwd58kb1h7gaw637whm0nkvzkqq6rm16";
     })
   ];
 
@@ -271,6 +264,7 @@ stdenv.mkDerivation rec {
       "fwupd/remotes.d/vendor.conf"
       "fwupd/remotes.d/vendor-directory.conf"
       "fwupd/thunderbolt.conf"
+      "fwupd/upower.conf"
       # "fwupd/uefi.conf" # already created by the module
       "pki/fwupd/GPG-KEY-Hughski-Limited"
       "pki/fwupd/GPG-KEY-Linux-Foundation-Firmware"

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -2,6 +2,7 @@
 
 { stdenv
 , fetchurl
+, fetchpatch
 , substituteAll
 , gtk-doc
 , pkgconfig
@@ -87,11 +88,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "fwupd";
-  version = "1.3.7";
+  version = "1.3.8";
 
   src = fetchurl {
     url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-    sha256 = "02mzn3whk5mba4nxyrkypawr1gzjx79n4nrkhrp8vja6mxxgsf10";
+    sha256 = "14hbwp3263n4z61ws62vj50kh9a89fz2l29hyv7f1xlas4zz6j8x";
   };
 
   # libfwupd goes to lib
@@ -161,6 +162,12 @@ stdenv.mkDerivation rec {
       src = ./installed-tests-path.patch;
       # needs a different set of modules than po/make-images
       inherit installedTestsPython;
+    })
+
+    # Find the correct lds and crt name when specifying -Defi_ldsdir
+    (fetchpatch {
+      url = "https://github.com/fwupd/fwupd/commit/52cda3db9ca9ab4faf99310edf29df926a713b5c.patch";
+      sha256 = "0hsj79dzamys7ryz33iwxwd58kb1h7gaw637whm0nkvzkqq6rm16";
     })
   ];
 


### PR DESCRIPTION
Closes #87000

###### Motivation for this change

Fix an issue where UEFI based updates don't get applied. Closes #87000.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
