### PR TITLE
corerad: 0.2.5 -> 0.2.6

### DIFF
--- a/pkgs/tools/networking/corerad/default.nix
+++ b/pkgs/tools/networking/corerad/default.nix
@@ -2,20 +2,20 @@
 
 buildGoModule rec {
   pname = "corerad";
-  version = "0.2.5";
+  version = "0.2.6";
 
   src = fetchFromGitHub {
     owner = "mdlayher";
     repo = "corerad";
     rev = "v${version}";
-    sha256 = "0fi9wgv5aj3ds3r5qjyi4pxnd56psrpdy2sz84jd0sz2w48x4k4p";
+    sha256 = "16rwydvqkzi0jlgwpl3d4f8zd35y4lv4h5xa30ybqmwwp1k5ymf0";
   };
 
-  vendorSha256 = "11r3vpimhik7y09gwb3p6pl0yf53hpaw24ry4a833fw8060rqp3q";
+  vendorSha256 = "1431fvi9b0id3zhgkxhiampc5avvp998lncyd5l2gn5py3qz6sdl";
 
   buildFlagsArray = ''
     -ldflags=
-    -X github.com/mdlayher/corerad/internal/build.linkTimestamp=1590182656
+    -X github.com/mdlayher/corerad/internal/build.linkTimestamp=1591474872
     -X github.com/mdlayher/corerad/internal/build.linkVersion=v${version}
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New beta release of CoreRAD.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Built and tested on NixOS:

```
[matt@servnerr-3:~/src/nixpkgs]$ nix-build -A corerad                                          
these derivations will be built:                                                               
  /nix/store/718isyyijgs2awmk8m53jznw1x87w55s-corerad-0.2.6.drv                                
building '/nix/store/718isyyijgs2awmk8m53jznw1x87w55s-corerad-0.2.6.drv'...                    
unpacking sources                                                                              
unpacking source archive /nix/store/mw79f4c0cn1b196g359qblq4z26vy7qi-source
...
stripping (with command strip and flags -S) in /nix/store/d2rv2galqiiwj0phrsfvjp372js4m64l-core
rad-0.2.6/bin                                                                                  
patching script interpreter paths in /nix/store/d2rv2galqiiwj0phrsfvjp372js4m64l-corerad-0.2.6 
checking for references to /build/ in /nix/store/d2rv2galqiiwj0phrsfvjp372js4m64l-corerad-0.2.6
...                                                                                            
/nix/store/d2rv2galqiiwj0phrsfvjp372js4m64l-corerad-0.2.6                                      

[matt@servnerr-3:~/src/nixpkgs]$ ./result/bin/corerad -h
CoreRAD v0.2.6 BETA (2020-06-06)
flags:
  -c string
        path to configuration file (default "corerad.toml")
  -init
        write out a default configuration file to "corerad.toml" and exit
```

/cc @jonringer @marsam