### PR TITLE
ocrmypdf: 9.8.0 -> 9.8.2

### DIFF
--- a/pkgs/tools/text/ocrmypdf/default.nix
+++ b/pkgs/tools/text/ocrmypdf/default.nix
@@ -12,7 +12,6 @@
 , unpaper
 , substituteAll
 }:
-
 let
   inherit (python3Packages) buildPythonApplication;
 
@@ -27,16 +26,17 @@ let
     pillow
   ];
 
-in buildPythonApplication rec {
+in
+buildPythonApplication rec {
   pname = "ocrmypdf";
-  version = "9.8.0";
+  version = "9.8.2";
   disabled = ! python3Packages.isPy3k;
 
   src = fetchFromGitHub {
     owner = "jbarlow83";
     repo = "OCRmyPDF";
     rev = "v${version}";
-    sha256 = "1l4bwnbd3g0wmdx8yv8hi5wm2z2q67y9mwrvrc4xxmkdrb5y8jcd";
+    sha256 = "0zff9gsbfaf72p8zbjamn6513czpr7papyh1jy0fz1z2a9h7ya0g";
   };
 
   nativeBuildInputs = with python3Packages; [


### PR DESCRIPTION
version bump also fixes build after pikepdf update:
https://github.com/NixOS/nixpkgs/pull/88680

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
