### PR TITLE
caster-soundboard: init at unstable-2019-9-28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8869,4 +8869,10 @@
     github = "cpcloud";
     githubId = 417981;
   };
+  iqubic = {
+    name = "Avi Caspe";
+    email = "avi.caspe@gmail.com";
+    github = "iqubic";
+    githubId = 22628816;
+  };
 }

--- a/pkgs/applications/audio/caster-soundboard/default.nix
+++ b/pkgs/applications/audio/caster-soundboard/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, mkDerivation
+, qmake, qtmultimedia, gst_all_1 }:
+
+mkDerivation {
+  name = "caster-soundboard";
+  version = "unstable-2019-9-28";
+  src = fetchFromGitHub {
+    owner = "JupiterBroadcasting";
+    repo = "CasterSoundboard";
+    rev = "1a84315b3a3d4bdca1a4b784bd19460637f44438";
+    sha256 = "1npjcxw304hv8ihwv13cslbn2rcd6iqnknyqz94rdi496d1kfwv1";
+  };
+  sourceRoot = "source/CasterSoundboard";
+
+  buildInputs = [
+    qtmultimedia
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+  ];
+  nativeBuildInputs = [ qmake ];
+
+  enableParallelBuilding = true;
+
+  qtWrapperArgs = [
+    ''--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"''
+  ];
+
+  meta = {
+    description = "A soundboard for hot-keying and playing back sounds.";
+    homepage = "https://github.com/JupiterBroadcasting/CasterSoundboard";
+    maintainers = [ stdenv.lib.maintainers.iqubic ];
+    license = stdenv.lib.licenses.lgpl3;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/audio/caster-soundboard/default.nix
+++ b/pkgs/applications/audio/caster-soundboard/default.nix
@@ -2,14 +2,16 @@
 , qmake, qtmultimedia, gst_all_1 }:
 
 mkDerivation {
-  name = "caster-soundboard";
+  pname = "caster-soundboard";
   version = "unstable-2019-9-28";
-  src = fetchFromGitHub {
+
+   src = fetchFromGitHub {
     owner = "JupiterBroadcasting";
     repo = "CasterSoundboard";
     rev = "1a84315b3a3d4bdca1a4b784bd19460637f44438";
     sha256 = "1npjcxw304hv8ihwv13cslbn2rcd6iqnknyqz94rdi496d1kfwv1";
   };
+
   sourceRoot = "source/CasterSoundboard";
 
   buildInputs = [
@@ -27,11 +29,11 @@ mkDerivation {
     ''--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"''
   ];
 
-  meta = {
-    description = "A soundboard for hot-keying and playing back sounds.";
+  meta = with stdenv.lib; {
+    description = "A soundboard for hot-keying and playing back sounds";
     homepage = "https://github.com/JupiterBroadcasting/CasterSoundboard";
-    maintainers = [ stdenv.lib.maintainers.iqubic ];
-    license = stdenv.lib.licenses.lgpl3;
-    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ maintainers.iqubic ];
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18908,6 +18908,8 @@ in
 
   carla = qt5.callPackage ../applications/audio/carla { };
 
+  caster-soundboard = libsForQt5.callPackage ../applications/audio/caster-soundboard { };
+
   catimg = callPackage ../tools/misc/catimg { };
 
   catt = python3Packages.callPackage ../applications/video/catt { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
caster-soundboard is a great application, and I noticed it wasn't in nixpkgs, so I packaged it up.

###### Things done
Added a derivation for caster-soundboard in pkg/audio
Added caster-soundboard to all-packages.nix
Added iqubic to the maintainers

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
