### PR TITLE
autoPatchelfHook: add autoPatchelfIgnoreMissing

### DIFF
--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -2019,6 +2019,9 @@ addEnvHooks "$hostOffset" myBashFunction
        In certain situations you may want to run the main command (<command>autoPatchelf</command>) of the setup hook on a file or a set of directories instead of unconditionally patching all outputs. This can be done by setting the <varname>dontAutoPatchelf</varname> environment variable to a non-empty value.
       </para>
       <para>
+       By default <command>autoPatchelf</command> will fail as soon as any ELF file requires a dependency which cannot be resolved via the given build inputs. In some situations you might prefer to just leave missing dependencies unpatched and continue to patch the rest. This can be achieved by setting the <envar>autoPatchelfIgnoreMissingDeps</envar> environment variable to a non-empty value.
+      </para>
+      <para>
        The <command>autoPatchelf</command> command also recognizes a <parameter class="command">--no-recurse</parameter> command line flag, which prevents it from recursing into subdirectories.
       </para>
      </listitem>

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -141,7 +141,7 @@ autoPatchelfFile() {
     # This makes sure the builder fails if we didn't find a dependency, because
     # the stdenv setup script is run with set -e. The actual error is emitted
     # earlier in the previous loop.
-    [ $depNotFound -eq 0 ]
+    [ $depNotFound -eq 0 -o -n "$autoPatchelfIgnoreMissingDeps" ]
 
     if [ -n "$rpath" ]; then
         echo "setting RPATH to: $rpath" >&2


### PR DESCRIPTION
###### Motivation for this change
Currently autoPatchelfHook fails as soon as any dependency cannot be satisfied. But in some cases it is favorable to continue patching and ignore the missing dependencies. Some binary distributions contain optional features with their own dependencies. The current autoPatchelfHook forces you to patch all dependencies even if you know you will never use those features.
A specific example would be the python wheel distribution of Pytorch which contains files which depend on cuda, but in practice this dependency doesn't need to be satisfied if you don't plan to use cuda. (https://github.com/pytorch/pytorch/issues/38624)

To solve this problem, I added the possibility to ignore missing dependencies by setting the environment variable `autoPatchelfIgnoreMissing`.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
