### PR TITLE
dgraph: 1.0.17 -> 20.03.03

### DIFF
--- a/pkgs/servers/dgraph/default.nix
+++ b/pkgs/servers/dgraph/default.nix
@@ -1,28 +1,25 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "dgraph";
-  version = "1.0.17";
-
-  goPackagePath = "github.com/dgraph-io/dgraph";
+  version = "20.03.3";
 
   src = fetchFromGitHub {
     owner = "dgraph-io";
     repo = "dgraph";
     rev = "v${version}";
-    sha256 = "05z1xwbd76q49zyqahh9krvq78dgkzr22qc6srr4djds0l7y6x5i";
+    sha256 = "0z2zc0mf7ndf3cpzi1js396s1yxpgfjaj9jacifsi8v6i6r0c6cz";
   };
 
   # see licensing
   buildFlags = [ "-tags oss" ];
+  buildFlagsArray = [ "-ldflags=" "-X github.com/dgraph-io/dgraph/x.dgraphVersion=${version}" ];
 
-  goDeps = ./deps.nix;
-  subPackages = [ "dgraph"];
+  vendorSha256 = "1nz4yr3y4dr9l09hcsp8x3zhbww9kz0av1ax4192f5zxpw1q275s";
 
-  preBuild = ''
-    export buildFlagsArray="-ldflags=\
-      -X github.com/dgraph-io/dgraph/x.dgraphVersion=${version}"
-  '';
+  subPackages = [ 
+    "dgraph" 
+  ];
 
   meta = {
     homepage = "https://dgraph.io/";


### PR DESCRIPTION
###### Motivation for this change

Upgrade to the latest dgraph release

Note that although the version numbers jumped by 19 versions, dgraph changed their version scheme to follow `<year>.<month>.<rev>`, similar to NixOS.

Also transitions dgraph to `buildGoModule`

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
