### PR TITLE
python3Packages.prometheus_flask_exporter: init at 0.15.4 

### DIFF
--- a/pkgs/development/python-modules/prometheus_flask_exporter/default.nix
+++ b/pkgs/development/python-modules/prometheus_flask_exporter/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, flask, prometheus_client }:
+
+buildPythonPackage rec {
+  pname = "prometheus_flask_exporter";
+  version = "0.15.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c590656b45fa6dd23d81dec3d3dc1e31b17fcba48310f69d0ff31b5c865fc799";
+  };
+
+  propagatedBuildInputs = [
+    flask prometheus_client
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/rycus86/prometheus_flask_exporter";
+    description = "Prometheus exporter for Flask applications";
+    maintainers = with maintainers; [ nphilou ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4646,6 +4646,8 @@ in {
 
   prometheus_client = callPackage ../development/python-modules/prometheus_client { };
 
+  prometheus_flask_exporter = callPackage ../development/python-modules/prometheus_flask_exporter { };
+
   promise = callPackage ../development/python-modules/promise { };
 
   prompt_toolkit = let


### PR DESCRIPTION
Add prometheus-flask-exporter python package

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This package is required to update mlflow to last version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
