### PR TITLE
pulumi: 2.1.0 -> 2.2.1, add kubernetes and postgresql providers

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,50 +1,42 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "2.1.0";
+  version = "2.2.1";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.1.0-linux-x64.tar.gz";
-        sha256 = "0d9bmljgf62dhj1z8h71c2pj2cbvf4ghhlbbbh2jcg55i33ks8ih";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.2.1-linux-x64.tar.gz";
+        sha256 = "0bvwkvsinnhlh1yhh5llffh89w07f412q6z03ypzl19p6fvik1k1";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.1.0-linux-amd64.tar.gz";
-        sha256 = "1kf43j1b4wp39sny92dnsy1myn6wb2msli1ydds3yza81srgcfnh";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.1.1-linux-amd64.tar.gz";
+        sha256 = "0ggi1c4lg6pip6d4bh2cji25hcwv3ii870bjwd35ax668z0dc28d";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.3.0-linux-amd64.tar.gz";
-        sha256 = "17anj9pc90hhiknyf2yab7dzvcfbjn1803bl6ld26r701w3h1jqx";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.6.0-linux-amd64.tar.gz";
+        sha256 = "0l4vv7vkzsphvk9r28l253ds8ny0wh0fahqjjnz31jqzfbvzyxm8";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.0.0-linux-amd64.tar.gz";
-        sha256 = "0526a4ll1q9v566i313223pnx2pa3qkcjp01l49h5jmgn8qpw1fn";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.2.0-linux-amd64.tar.gz";
-        sha256 = "14ya2sax2yyza3zbxp5a638y81pcbi26hv8k9y8agnjn82bgx8dy";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.5.0-linux-amd64.tar.gz";
+        sha256 = "02xjwx2rfh3k9zk8aw39n4k6jnp8chcfc5f1zac7x4xfkqyjlpcy";
       }
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.1.0-darwin-x64.tar.gz";
-        sha256 = "1d7w32wac2sc0z5i893h66fgyivf4x3mqki649vxkxc3081kpzi9";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.2.1-darwin-x64.tar.gz";
+        sha256 = "1fizddk1hxazn33xliankps3fv0casx4r8rvwkdzqx1piqq18xy4";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.1.0-darwin-amd64.tar.gz";
-        sha256 = "1smy1y2pnxnvw8zcs31q9xs80hyqhzawfzcwkkfnyamdrgasxqsi";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.1.1-darwin-amd64.tar.gz";
+        sha256 = "1mdchvibk989xq5zfjb7cdzgh9m769cvj2l5dfxmkava7zhmj2bj";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.3.0-darwin-amd64.tar.gz";
-        sha256 = "03idn1livy9w3izi7qrdgnigx3ayrp8qp2q3m5ik9ffvv2g11962";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.6.0-darwin-amd64.tar.gz";
+        sha256 = "013c13ypvz75x9qppzmlvwg4bnjryw9q16j6v987ibrrfxblan5b";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.0.0-darwin-amd64.tar.gz";
-        sha256 = "06m6ldqa82w82kjz7pxi0pbk9x02pzsy4x0in8fcq9gsh1p0gka9";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.2.0-darwin-amd64.tar.gz";
-        sha256 = "0mymvn2355bq9ykvnww0si0imikzxp7mp1yh2scn8kjn2gs4nhgk";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.5.0-darwin-amd64.tar.gz";
+        sha256 = "0kc4il1ixh7ricl4n3vadvjy0rjj0bps7n8lbqgrq8lm5m419izv";
       }
     ];
   };

--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -9,12 +9,20 @@
         sha256 = "0bvwkvsinnhlh1yhh5llffh89w07f412q6z03ypzl19p6fvik1k1";
       }
       {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.1.1-linux-amd64.tar.gz";
+        sha256 = "0bj9nlxsb77ycwvmba1vsh1vydyrszq3jxlf9d1qsv71h4s88a90";
+      }
+      {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.1.1-linux-amd64.tar.gz";
         sha256 = "0ggi1c4lg6pip6d4bh2cji25hcwv3ii870bjwd35ax668z0dc28d";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.6.0-linux-amd64.tar.gz";
         sha256 = "0l4vv7vkzsphvk9r28l253ds8ny0wh0fahqjjnz31jqzfbvzyxm8";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.2.0-linux-amd64.tar.gz";
+        sha256 = "1maiy1i43p0gl2w12hfk9zgfz418innzi7nkv68qlyxd4hi5v6mf";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.5.0-linux-amd64.tar.gz";
@@ -27,12 +35,20 @@
         sha256 = "1fizddk1hxazn33xliankps3fv0casx4r8rvwkdzqx1piqq18xy4";
       }
       {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.1.1-darwin-amd64.tar.gz";
+        sha256 = "17iqzv06s4xhnway3j534lsj8gzxld67kfn7awn4ymwh2zn8l3z0";
+      }
+      {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.1.1-darwin-amd64.tar.gz";
         sha256 = "1mdchvibk989xq5zfjb7cdzgh9m769cvj2l5dfxmkava7zhmj2bj";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.6.0-darwin-amd64.tar.gz";
         sha256 = "013c13ypvz75x9qppzmlvwg4bnjryw9q16j6v987ibrrfxblan5b";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.2.0-darwin-amd64.tar.gz";
+        sha256 = "0maca137agmig8njz0fd0yhxahdra7pqaw23mxfxa8m5j44p787a";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.5.0-darwin-amd64.tar.gz";

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
-VERSION="2.1.0"
+VERSION="2.2.1"
 
 declare -A plugins
 plugins=(
-    ["aws"]="2.2.0"
-    ["gcp"]="3.3.0"
-    ["random"]="2.1.0"
-    ["kubernetes"]="2.0.0"
+    ["aws"]="2.5.0"
+    ["gcp"]="3.6.0"
+    ["random"]="2.1.1"
+    ["kubernetes"]="2.2.0"
+    ["postgresql"]="2.1.1"
 )
 
 function genMainSrc() {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update pulumi, add kubernetes and postgresql providers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
