### PR TITLE
go-migrate: init at 4.11.0

### DIFF
--- a/pkgs/development/tools/go-migrate/default.nix
+++ b/pkgs/development/tools/go-migrate/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-migrate";
+  version = "4.11.0";
+
+  src = fetchFromGitHub {
+    owner = "golang-migrate";
+    repo = "migrate";
+    rev = "v${version}";
+    sha256 = "Dw+TiuksgOfFBCzNc9rsxyQCoXES+fpr4wTrZfqohGM=";
+  };
+
+  vendorSha256 = "CezVFRZ/cknvK4t/MjyP46zJACGkzj4CZ5JVQ502Ihw=";
+
+  subPackages = [ "cmd/migrate" ];
+
+  meta = with stdenv.lib; {
+    homepage    = "https://github.com/golang-migrate/migrate";
+    description = "Database migrations. CLI and Golang library.";
+    maintainers = with maintainers; [ offline ];
+    license     = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17389,6 +17389,8 @@ in
 
   gotop = callPackage ../tools/system/gotop { };
 
+  go-migrate = callPackage ../development/tools/go-migrate { };
+
   gomodifytags = callPackage ../development/tools/gomodifytags { };
 
   go-langserver = callPackage ../development/tools/go-langserver { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Package cli tool for `go-migrate`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
