### PR TITLE
rubyMinimal: don't reference stdenv.cc

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -157,6 +157,9 @@ let
               ${removeReferencesTo}/bin/remove-references-to \
                 -t ${stdenv.cc} \
                 $out/lib/libruby*
+              ${removeReferencesTo}/bin/remove-references-to \
+                -t ${stdenv.cc} \
+                $out/lib/ruby/${version}/${stdenv.targetPlatform.system}/rbconfig.rb
             ''
           }
           # Bundler tries to create this directory

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -37,6 +37,7 @@ let
       , fetchurl, fetchpatch, fetchFromSavannah, fetchFromGitHub
       , useRailsExpress ? true
       , rubygemsSupport ? true
+      , JitSupport ? true
       , zlib, zlibSupport ? true
       , openssl, opensslSupport ? true
       , gdbm, gdbmSupport ? true
@@ -118,6 +119,7 @@ let
 
         configureFlags = ["--enable-shared" "--enable-pthread" "--with-soname=ruby_${tag}"]
           ++ op useRailsExpress "--with-baseruby=${baseruby}/bin/ruby"
+          ++ op (!JitSupport) "--disable-jit-support"
           ++ op (!docSupport) "--disable-install-doc"
           ++ ops stdenv.isDarwin [
             # on darwin, we have /usr/include/tk.h -- so the configure script detects

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -159,7 +159,7 @@ let
                 $out/lib/libruby*
               ${removeReferencesTo}/bin/remove-references-to \
                 -t ${stdenv.cc} \
-                $out/lib/ruby/${version}/${stdenv.targetPlatform.system}/rbconfig.rb
+                $out/${passthru.libPath}/${stdenv.targetPlatform.system}/rbconfig.rb
             ''
           }
           # Bundler tries to create this directory

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9777,6 +9777,8 @@ in
   rubyMinimal = ruby.override {
     # gem support is minimal overhead
     rubygemsSupport = true;
+    removeReferenceToCC = true;
+    JitSupport = false;
     useRailsExpress = false;
     zlibSupport = false;
     opensslSupport = false;


### PR DESCRIPTION
###### Motivation for this change

I noticed ruby's builder was already supporting removing stdenv.cc references but this was not complete.

- Fix https://github.com/NixOS/nixpkgs/issues/89445 .
- Make the build flag `removeReferenceToCC` remove all references, not only in `$out/lib/libruby`.

###### Things done

- [x] Added flag to disable JIT support in Ruby,
- [x] Made `removeReferenceToCC` remove also refs in `rbconfig.rb`.
- [x] Disabled JIT and enabled `removeReferenceToCC` in the build of `rubyMinimal`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Maintainers

cc @vrthra & @manveru 