### PR TITLE
Revert "lua*Packages.cqueues: fixup darwin build"

### DIFF
--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -40,11 +40,6 @@ with super;
       { name = "CRYPTO"; dep = pkgs.openssl; }
       { name = "OPENSSL"; dep = pkgs.openssl; }
     ];
-
-    # https://github.com/wahern/cqueues/issues/227
-    NIX_CFLAGS_COMPILE = with pkgs.stdenv; lib.optionalString hostPlatform.isDarwin
-      "-DCLOCK_MONOTONIC -DCLOCK_REALTIME";
-
     disabled = luaOlder "5.1" || luaAtLeast "5.4";
     # Upstream rockspec is pointlessly broken into separate rockspecs, per Lua
     # version, which doesn't work well for us, so modify it


### PR DESCRIPTION
This reverts commit 47ad7d313135f97815efa2eaacfd7fdb52cc689c.
The fix isn't needed after the update contained in PR #89632.