### PR TITLE
nixos/bitwarden_rs: add test

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3835,6 +3835,12 @@
     githubId = 51518420;
     name = "jitwit";
   };
+  jjjollyjim = {
+    email = "jamie@kwiius.com";
+    github = "JJJollyjim";
+    githubId = 691552;
+    name = "Jamie McClymont";
+  };
   jk = {
     email = "hello+nixpkgs@j-k.io";
     github = "06kellyjac";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -34,6 +34,7 @@ in
   bind = handleTest ./bind.nix {};
   bitcoind = handleTest ./bitcoind.nix {};
   bittorrent = handleTest ./bittorrent.nix {};
+  bitwarden = handleTest ./bitwarden.nix {};
   blockbook-frontend = handleTest ./blockbook-frontend.nix {};
   buildkite-agents = handleTest ./buildkite-agents.nix {};
   boot = handleTestOn ["x86_64-linux"] ./boot.nix {}; # syslinux is unsupported on aarch64

--- a/nixos/tests/bitwarden.nix
+++ b/nixos/tests/bitwarden.nix
@@ -1,0 +1,188 @@
+{ system ? builtins.currentSystem
+, config ? { }
+, pkgs ? import ../.. { inherit system config; }
+}:
+
+# These tests will:
+#  * Set up a bitwarden-rs server
+#  * Have Firefox use the web vault to create an account, log in, and save a password to the valut
+#  * Have the bw cli log in and read that password from the vault
+#
+# Note that Firefox must be on the same machine as the server for WebCrypto APIs to be available (or HTTPS must be configured)
+#
+# The same tests should work without modification on the official bitwarden server, if we ever package that.
+
+with import ../lib/testing-python.nix { inherit system pkgs; };
+with pkgs.lib;
+let
+  backends = [ "sqlite" "mysql" "postgresql" ];
+
+  dbPassword = "please_dont_hack";
+
+  userEmail = "meow@example.com";
+  userPassword = "also_super_secret_ZJWpBKZi668QGt"; # Must be complex to avoid interstitial warning on the signup page
+
+  storedPassword = "seeeecret";
+
+  makeBitwardenTest = backend: makeTest {
+    name = "bitwarden_rs-${backend}";
+    meta = {
+      maintainers = with pkgs.stdenv.lib.maintainers; [ jjjollyjim ];
+    };
+
+    nodes = {
+      server = { pkgs, ... }:
+        let backendConfig = {
+          mysql = {
+            services.mysql = {
+              enable = true;
+              initialScript = pkgs.writeText "mysql-init.sql" ''
+                CREATE DATABASE bitwarden;
+                CREATE USER 'bitwardenuser'@'localhost' IDENTIFIED BY '${dbPassword}';
+                GRANT ALL ON `bitwarden`.* TO 'bitwardenuser'@'localhost';
+                FLUSH PRIVILEGES;
+              '';
+              package = pkgs.mysql;
+            };
+
+            services.bitwarden_rs.config.databaseUrl = "mysql://bitwardenuser:${dbPassword}@localhost/bitwarden";
+
+            systemd.services.bitwarden_rs.after = [ "mysql.service" ];
+          };
+
+          postgresql = {
+            services.postgresql = {
+              enable = true;
+              initialScript = pkgs.writeText "postgresql-init.sql" ''
+                CREATE DATABASE bitwarden;
+                CREATE USER bitwardenuser WITH PASSWORD '${dbPassword}';
+                GRANT ALL PRIVILEGES ON DATABASE bitwarden TO bitwardenuser;
+              '';
+            };
+
+            services.bitwarden_rs.config.databaseUrl = "postgresql://bitwardenuser:${dbPassword}@localhost/bitwarden";
+
+            systemd.services.bitwarden_rs.after = [ "postgresql.service" ];
+          };
+
+          sqlite = { };
+        };
+        in
+        mkMerge [
+          backendConfig.${backend}
+          {
+            services.bitwarden_rs = {
+              enable = true;
+              dbBackend = backend;
+              config.rocketPort = 80;
+            };
+
+            networking.firewall.allowedTCPPorts = [ 80 ];
+
+            environment.systemPackages =
+              let
+                testRunner = pkgs.writers.writePython3Bin "test-runner"
+                  {
+                    libraries = [ pkgs.python3Packages.selenium ];
+                  } ''
+                  from selenium.webdriver import Firefox
+                  from selenium.webdriver.firefox.options import Options
+                  from selenium.webdriver.support.ui import WebDriverWait
+                  from selenium.webdriver.support import expected_conditions as EC
+
+                  options = Options()
+                  options.add_argument('--headless')
+                  driver = Firefox(options=options)
+
+                  driver.implicitly_wait(20)
+                  driver.get('http://localhost/#/register')
+
+                  wait = WebDriverWait(driver, 10)
+
+                  wait.until(EC.title_contains("Create Account"))
+
+                  driver.find_element_by_css_selector('input#email').send_keys(
+                    '${userEmail}'
+                  )
+                  driver.find_element_by_css_selector('input#name').send_keys(
+                    'A Cat'
+                  )
+                  driver.find_element_by_css_selector('input#masterPassword').send_keys(
+                    '${userPassword}'
+                  )
+                  driver.find_element_by_css_selector('input#masterPasswordRetype').send_keys(
+                    '${userPassword}'
+                  )
+
+                  driver.find_element_by_xpath("//button[contains(., 'Submit')]").click()
+
+                  wait.until_not(EC.title_contains("Create Account"))
+
+                  driver.find_element_by_css_selector('input#masterPassword').send_keys(
+                    '${userPassword}'
+                  )
+                  driver.find_element_by_xpath("//button[contains(., 'Log In')]").click()
+
+                  wait.until(EC.title_contains("My Vault"))
+
+                  driver.find_element_by_xpath("//button[contains(., 'Add Item')]").click()
+
+                  driver.find_element_by_css_selector('input#name').send_keys(
+                    'secrets'
+                  )
+                  driver.find_element_by_css_selector('input#loginPassword').send_keys(
+                    '${storedPassword}'
+                  )
+
+                  driver.find_element_by_xpath("//button[contains(., 'Save')]").click()
+                '';
+              in
+              [ pkgs.firefox-unwrapped pkgs.geckodriver testRunner ];
+
+            virtualisation.memorySize = 768;
+          }
+        ];
+
+      client = { pkgs, ... }:
+        {
+          environment.systemPackages = [ pkgs.bitwarden-cli ];
+        };
+    };
+
+    testScript = ''
+      start_all()
+      server.wait_for_unit("bitwarden_rs.service")
+      server.wait_for_open_port(80)
+
+      with subtest("configure the cli"):
+          client.succeed("bw --nointeraction config server http://server")
+
+      with subtest("can't login to nonexistant account"):
+          client.fail(
+              "bw --nointeraction --raw login ${userEmail} ${userPassword}"
+          )
+
+      with subtest("use the web interface to sign up, log in, and save a password"):
+          server.succeed("PYTHONUNBUFFERED=1 test-runner | systemd-cat -t test-runner")
+
+      with subtest("log in with the cli"):
+          key = client.succeed(
+              "bw --nointeraction --raw login ${userEmail} ${userPassword}"
+          ).strip()
+
+      with subtest("sync with the cli"):
+          client.succeed(f"bw --nointeraction --raw --session {key} sync -f")
+
+      with subtest("get the password with the cli"):
+          password = client.succeed(
+              f"bw --nointeraction --raw --session {key} list items | ${pkgs.jq}/bin/jq -r .[].login.password"
+          )
+          assert password.strip() == "${storedPassword}"
+    '';
+  };
+in
+builtins.listToAttrs (
+  map
+    (backend: { name = backend; value = makeBitwardenTest backend; })
+    backends
+)

--- a/pkgs/tools/security/bitwarden_rs/default.nix
+++ b/pkgs/tools/security/bitwarden_rs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, rustPlatform, fetchFromGitHub
+{ stdenv, rustPlatform, fetchFromGitHub, nixosTests
 , pkgconfig, openssl
 , Security, CoreServices
 , dbBackend ? "sqlite", libmysqlclient, postgresql }:
@@ -34,6 +34,8 @@ in rustPlatform.buildRustPackage rec {
     cargo test ${featuresFlag} -- ''${checkFlags} ''${checkFlagsArray+"''${checkFlagsArray[@]}"}
     runHook postCheck
   '';
+
+  passthru.tests = nixosTests.bitwarden;
 
   meta = with stdenv.lib; {
     description = "Unofficial Bitwarden compatible server written in Rust";

--- a/pkgs/tools/security/bitwarden_rs/vault.nix
+++ b/pkgs/tools/security/bitwarden_rs/vault.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "bitwarden_rs-vault";
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     tar xf $src
     mv web-vault vault
   '';
+
+  passthru.tests = nixosTests.bitwarden;
 
   meta = with stdenv.lib; {
     description = "Integrates the web vault into bitwarden_rs";


### PR DESCRIPTION
##### Motivation for this change

The bitwarden ecosystem is currently untested in NixOS, and the server (bitwarden-rs) is somewhat important for those that rely on it.

This test provides coverage for all three database backends of `bitwarden_rs`, as well as `bitwarden_rs-vault` under Firefox and `bitwarden-cli`. The electron client `bitwarden` remains untested.

My original goal was to just use the cli, but it does not support account creation, so I ended up using webdriver to interact with the web UI. This approach is borrowed from nixos/tests/nginx-etag.nix. I expect that this will break at some point if the web UI is heavily modified -- I have added myself as maintainer to signal my intention to fix breakages.

As I note in a comment, the same tests should work without modification on the official bitwarden server, if we ever package that. (#51212).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
