### PR TITLE
Gnome shell 3.36.3

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -17,11 +17,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "gnome-shell";
-  version = "3.36.2";
+  version = "3.36.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0lqpxhvn073bshnzarnisym3da3k3awsi3h906hm85hz3wm9n4iv";
+    sha256 = "1fs51lcaal4lnx6m5a3j8922yjbjk32khznx77cxb2db1zvspn46";
   };
 
   LANG = "en_US.UTF-8";

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -44,13 +44,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mutter";
-  version = "3.36.2";
+  version = "3.36.3";
 
   outputs = [ "out" "dev" "man" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1x6svmd1k6w6a2m6ssq4hi997nxyq6z64fjjaid97z2rn177dcvm";
+    sha256 = "1lpf7anlm073npmfqc5n005kyj12j0ym8y9dqg9q7448ilp79kka";
   };
 
   mesonFlags = [

--- a/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-gsconnect";
-  version = "35";
+  version = "38";
 
   src = fetchFromGitHub {
     owner = "andyholmes";
     repo = "gnome-shell-extension-gsconnect";
     rev = "v${version}";
-    sha256 = "10z8kkp5agf2bfn10ad0kbhbf6hhx6vjpdh2y0z7qf28s55kd8qs";
+    sha256 = "1z5wn3n1sqc2xdxiq0g3dkga7srz5ak41qdyjsh9pzb5x93dxzi5";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

gnome-shell and mutter 3.36.3. Also bumped gsconnect.

<details> 
<summary> News (links to gsconnect releases in commit)</summary>

> 	Mutter 3.36.3
> 	======
> 	* Broadcast clipboard/primary offers [Carlos; [!1262](https://gitlab.gnome.org/GNOME/mutter/merge_requests/1262)]
> 	* Fix monitor screen cast on X11 [Jonas Å.; [!1251](https://gitlab.gnome.org/GNOME/mutter/merge_requests/1251)]
> 	* Implement touch-mode detecation for the X11 backend [Carlos; [!1278](https://gitlab.gnome.org/GNOME/mutter/merge_requests/1278)]
> 	* Drop external keyboard detection from touch-mode heuristics [Carlos; [!1277](https://gitlab.gnome.org/GNOME/mutter/merge_requests/1277)]
> 	* Fix leaked DMA buffers in screencasts [Jonas; [!1283](https://gitlab.gnome.org/GNOME/mutter/merge_requests/1283)]
> 	* Fixed crashes [Daniel, Carlos, Jonas D.; [!1256](https://gitlab.gnome.org/GNOME/mutter/merge_requests/1256), [!1258](https://gitlab.gnome.org/GNOME/mutter/merge_requests/1258), [!1280](https://gitlab.gnome.org/GNOME/mutter/merge_requests/1280)]
> 	
> 	Contributors:
> 	  Carlos Garnacho, Daniel van Vugt, Jonas Ådahl
> 	
> 	
> 	Gnome-shell 3.36.3
> 	======
> 	* Add gnome-shell-extension-prefs wrapper for compatibility [Florian; [!1220](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1220)]
> 	* Fix distorted fallback icons in top bar [Florian; [#2578](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2578)]
> 	* Lower timeout for scrolling in overview [Alexander; [#2602](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2602)]
> 	* Only start systemd units when running under systemd
> 	  [Carlos, Florian; [#2755](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2755), [!1242](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1242), [!1252](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1252)]
> 	* Fix "ghost" media controls  [Bryan; [#2776](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2776)]
> 	* Fix zombie sockets from extensions downloader [Michael; [#2774](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2774)]
> 	* Update world clocks offsets when timezone changes [Bryan; [#2209](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2209)]
> 	* Fix "Do Not Disturb" setting getting reset on startup [Florian; [#2804](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2804)]
> 	* Fix pad OSD glitches [Carlos; [!1290](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1290)]
> 	* Fix matching notifications by PID [Florian; [#2592](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2592)]
> 	* Only allow updates for extensions that aren't cached [Florian; [!1248](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1248)]
> 	* Fixed crashes [Jonas, Florian; [#2709](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2709), [#2757](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2757)]
> 	* Misc. bug fixes and cleanups [Michael, Piotr, Philip, Florian, Amr,
> 	  AsciiWolf; [!1233](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1233), [!1205](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1205), [!1229](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1229), [#2751](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2751), [!1232](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1232), [#2796](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2796), [!1249](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1249), [!1263](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1263),
> 	  [!1277](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1277), [#2286](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2286), [!1288](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1288), [!1291](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1291)]
> 	
> 	Contributors:
> 	  AsciiWolf, Michael Catanzaro, Philip Chimento, Jonas Dreßler, Bryan Dunsmore,
> 	  Carlos Garnacho, Amr Ibrahim, Michael Lass, Alexander Mikhaylenko,
> 	  Florian Müllner
> 	
> 	Translators:
> 	  Fabio Tomat [fur], Cheng-Chia Tseng [zh_TW], Dušan Kazik [sk],
> 	  Piotr Drąg [pl], Daniel Mustieles [es], Nathan Follens [nl],
> 	  Bruce Cowan [en_GB], Florentina Mușat [ro], Yuri Chornoivan [uk],
> 	  Milo Casagrande [it], Anders Jonsson [sv], Charles Monzat [fr],
> 	  Daniel Șerbănescu [ro], sicklylife [ja], Kukuh Syafaat [id],
> 	  Emin Tufan Çetin [tr], Jiri Grönroos [fi], Марко Костић [sr],
> 	  Christian Kirbach [de], Changwoo Ryu [ko], Aurimas Černius [lt],
> 	  Matej Urbančič [sl]


</details>

###### Things done

Running this on my system at the moment.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
