### PR TITLE
slstatus: unstable-2018-04-16 -> unstable-2019-02-16

### DIFF
--- a/pkgs/applications/misc/slstatus/default.nix
+++ b/pkgs/applications/misc/slstatus/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, fetchgit, pkgconfig, writeText, libX11, conf ? null }:
+{ stdenv, fetchgit, pkgconfig, writeText, libX11, conf ? null, patches ? [] }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "slstatus";
-  version = "unstable-2018-04-16";
+  version = "unstable-2019-02-16";
 
   src = fetchgit {
     url = "https://git.suckless.org/slstatus";
-    rev = "97ef7c2a1d67bb2c9c379e657fbc8e35acd6aafb";
-    sha256 = "1777hgl10imk0l2sgnqgbkfchv1mpxrd82ninzwp7f1rgwchz36v";
+    rev = "b14e039639ed28005fbb8bddeb5b5fa0c93475ac";
+    sha256 = "0kayyhpmppybhwndxgabw48wsk9v8x9xdb05xrly9szkw3jbvgw4";
   };
 
   configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
   preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
+
+  inherit patches;
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libX11 ];


### PR DESCRIPTION
#### Motivation for this change
Update slstatus to the most recent commit. Also add a patches attribute which the user can add to using overrides, as the other suckless utils have in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
 