### PR TITLE
aerc: unstable-2020-02-01 -> 0.4.0

### DIFF
--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -4,15 +4,13 @@
 , fetchFromGitHub
 }:
 
-let
-  rev = "ea0df7bee433fedae5716906ea56141f92b9ce53";
-in buildGoModule rec {
+buildGoModule rec {
   pname = "aerc";
-  version = "unstable-2020-02-01";
+  version = "0.4.0";
 
   src = fetchurl {
-    url = "https://git.sr.ht/~sircmpwn/aerc/archive/${rev}.tar.gz";
-    sha256 = "1bx2fypw053v3bzalfgyi6a0s5fvv040z8jy4i63s7p53m8gmzs9";
+    url = "https://git.sr.ht/~sircmpwn/aerc/archive/${version}.tar.gz";
+    sha256 = "05qy14k9wmyhsg1hiv4njfx1zn1m9lz4d1p50kc36v7pq0n4csfk";
   };
 
   libvterm = fetchFromGitHub {
@@ -22,7 +20,7 @@ in buildGoModule rec {
     sha256 = "06vv4pgx0i6hjdjcar4ch18hp9g6q6687mbgkvs8ymmbacyhp7s6";
   };
 
-  vendorSha256 = "0rnyjjlsxsi0y23m6ckyd52562m33qr35fvdcdzy31mbfpi8kl2k";
+  vendorSha256 = "1rqn36510m0yb7k4bvq2hgirr3z8a2h5xa7cq5mb84xsmhvf0g69";
 
   overrideModAttrs = (_: {
       postBuild = ''


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://git.sr.ht/~sircmpwn/aerc/refs)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
