### PR TITLE
lumina.lumina: make bsdtar available for lumina-archiver

### DIFF
--- a/pkgs/desktops/lumina/lumina/default.nix
+++ b/pkgs/desktops/lumina/lumina/default.nix
@@ -2,6 +2,7 @@
 , mkDerivation
 , fetchFromGitHub
 , fluxbox
+, libarchive
 , numlockx
 , qmake
 , qtbase
@@ -33,6 +34,7 @@ mkDerivation rec {
 
   buildInputs = [
     fluxbox # window manager for Lumina DE
+    libarchive # make `bsdtar` available for lumina-archiver
     numlockx # required for changing state of numlock at login
     qtbase
     qtmultimedia
@@ -66,9 +68,12 @@ mkDerivation rec {
     substituteInPlace src-qt5/core-utils/lumina-config/pages/page_fluxbox_settings.cpp \
       --replace 'LOS::AppPrefix()+"share/fluxbox' "\"${fluxbox}/share/fluxbox"
 
+    # Add full path of bsdtar to lumina-archiver
+    substituteInPlace src-qt5/desktop-utils/lumina-archiver/TarBackend.cpp \
+      --replace '"bsdtar"' '"${stdenv.lib.getBin libarchive}/bin/bsdtar"'
+
     # Fix desktop files
     for i in $(grep -lir 'OnlyShowIn=Lumina' src-qt5); do
-      echo ===== $i
       substituteInPlace $i --replace 'OnlyShowIn=Lumina' 'OnlyShowIn=X-Lumina'
     done
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`lumina-archiver` needs `bsdtar` to work properly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).