### PR TITLE
alacritty: link binary inside .app on darwin

### DIFF
--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -101,6 +101,8 @@ rustPlatform.buildRustPackage rec {
     if stdenv.isDarwin then ''
       mkdir $out/Applications
       cp -r $releaseDir/osx/Alacritty.app $out/Applications/Alacritty.app
+      # Overwrite binary inside .app with a link to the binary inside bin/
+      ln -sfn ../../../../bin/alacritty $out/Applications/Alacritty.app/Contents/MacOS/alacritty
     '' else ''
       install -D extra/linux/Alacritty.desktop -t $out/share/applications/
       install -D extra/logo/compat/alacritty-term.svg $out/share/icons/hicolor/scalable/apps/Alacritty.svg


### PR DESCRIPTION
Otherwise you end up with two binaries, only one of which is stripped.
This causes an extra 4.3MB, because 'make app' does another cargo build
and copies that binary into the .app.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Installing alacritty on darwin right now causes two binaries to be created, only one of which is stripped.

```
tree -h /n/s/zqyw2yx0j4w5b6syh0adf79xm5wdb18l-alacritty-0.4.3
.
├── [  96]  Applications
│   └── [  96]  Alacritty.app
│       └── [ 160]  Contents
│           ├── [2.4K]  Info.plist
│           ├── [  96]  MacOS
│           │   └── [4.3M]  alacritty
│           └── [  96]  Resources
│               └── [650K]  alacritty.icns
├── [  96]  bin
│   └── [3.7M]  alacritty
├── [  96]  nix-support
│   └── [  69]  propagated-user-env-packages
└── [ 192]  share
    ├── [  96]  bash-completion
    │   └── [  96]  completions
    │       └── [1.8K]  alacritty.bash
    ├── [  96]  fish
    │   └── [  96]  vendor_completions.d
    │       └── [1.9K]  alacritty.fish
    ├── [  96]  man
    │   └── [  96]  man1
    │       └── [1.3K]  alacritty.1.gz
    └── [  96]  zsh
        └── [  96]  site-functions
            └── [1.3K]  _alacritty

16 directories, 9 files
```

In this PR I'm overwriting the binary inside the .app with a link to the binary inside bin/. The build still compiles the binary twice, but preventing that would require a patch to the Makefile

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
