### PR TITLE
nixos/krb5: allow lists in configuration

### DIFF
--- a/nixos/modules/config/krb5/default.nix
+++ b/nixos/modules/config/krb5/default.nix
@@ -41,31 +41,29 @@ let
         value)
     else value;
 
-  mkIndent = depth: concatStrings (builtins.genList (_:  " ") (2 * depth));
+  indent = "  ";
 
-  mkRelation = name: value: "${name} = ${mkVal { inherit value; }}";
+  mkRelation = name: value: "${name} = ${mkVal value}";
 
-  mkVal = { value, depth ? 0 }:
+  mkVal = value:
     if (value == true) then "true"
     else if (value == false) then "false"
     else if (isInt value) then (toString value)
     else if (isList value) then
-      concatMapStringsSep " " mkVal { inherit value depth; }
+      concatMapStringsSep " " mkVal value
     else if (isAttrs value) then
-      (concatStringsSep "\n${mkIndent (depth + 1)}"
-        ([ "{" ] ++ (mapAttrsToList
-          (attrName: attrValue: let
-            mappedAttrValue = mkVal {
-              value = attrValue;
-              depth = depth + 1;
-            };
-          in "${attrName} = ${mappedAttrValue}")
-        value))) + "\n${mkIndent depth}}"
+      let configLines = concatLists
+        (map (splitString "\n")
+          (mapAttrsToList mkRelation value));
+      in
+      (concatStringsSep "\n${indent}"
+        ([ "{" ] ++ configLines))
+      + "\n}"
     else value;
 
   mkMappedAttrsOrString = value: concatMapStringsSep "\n"
     (line: if builtins.stringLength line > 0
-      then "${mkIndent 1}${line}"
+      then "${indent}${line}"
       else line)
     (splitString "\n"
       (if isAttrs value then

--- a/nixos/modules/config/krb5/default.nix
+++ b/nixos/modules/config/krb5/default.nix
@@ -43,14 +43,15 @@ let
 
   indent = "  ";
 
-  mkRelation = name: value: "${name} = ${mkVal value}";
+  mkRelation = name: value:
+    if (isList value) then
+      concatMapStringsSep "\n" (mkRelation name) value
+    else "${name} = ${mkVal value}";
 
   mkVal = value:
     if (value == true) then "true"
     else if (value == false) then "false"
     else if (isInt value) then (toString value)
-    else if (isList value) then
-      concatMapStringsSep " " mkVal value
     else if (isAttrs value) then
       let configLines = concatLists
         (map (splitString "\n")

--- a/nixos/modules/config/krb5/default.nix
+++ b/nixos/modules/config/krb5/default.nix
@@ -113,7 +113,10 @@ in {
           {
             "ATHENA.MIT.EDU" = {
               admin_server = "athena.mit.edu";
-              kdc = "athena.mit.edu";
+              kdc = [
+                "athena01.mit.edu"
+                "athena02.mit.edu"
+              ];
             };
           };
         '';

--- a/nixos/tests/krb5/example-config.nix
+++ b/nixos/tests/krb5/example-config.nix
@@ -18,7 +18,10 @@ import ../make-test-python.nix ({ pkgs, ...} : {
         realms = {
           "ATHENA.MIT.EDU" = {
             admin_server = "athena.mit.edu";
-            kdc = "athena.mit.edu";
+            kdc = [
+              "athena01.mit.edu"
+              "athena02.mit.edu"
+            ];
           };
         };
         domain_realm = {
@@ -65,7 +68,8 @@ import ../make-test-python.nix ({ pkgs, ...} : {
       [realms]
         ATHENA.MIT.EDU = {
           admin_server = athena.mit.edu
-          kdc = athena.mit.edu
+          kdc = athena01.mit.edu
+          kdc = athena02.mit.edu
         }
 
       [domain_realm]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix #89626 

Kerberos allows multiple values for `kdc` to be specified, this should be possible by passing a list to `config.krb5.realms.<realm>.kdc`. In general, when specifying a list, it should  end up as multiple lines of `<attrName> = <list item>` in `krb5.conf`.

Although there has been code to accept lists, evaluating would lead to _attrs_ to be passed to `concatMapStringsSep` instead of a _list_ as the last parameter, causing the evaluation to fail. Because of this, removing it is not a breaking change.
https://github.com/NixOS/nixpkgs/blob/adc908a87371e9567950afb0ea55b929b870823c/nixos/modules/config/krb5/default.nix#L52-L53

###### Things done

Simplified indentation generation, allowing `mkRelation` to be more easily reused by `mkVal` (and vice versa). Added list handling to `mkRelation` and removed list handling from `mkVal`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date  
  There is no documentation beside the examples, changing the relevant example would be an option.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
