### PR TITLE
gitAndTools.git-subset: init at 0.1.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -136,6 +136,10 @@ let
 
   git-subrepo = callPackage ./git-subrepo { };
 
+  git-subset = callPackage ./git-subset {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   git-subtrac = callPackage ./git-subtrac { };
 
   git-sync = callPackage ./git-sync { };

--- a/pkgs/applications/version-management/git-and-tools/git-subset/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-subset/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, rustPlatform, fetchFromGitHub, pkg-config, openssl, curl, libiconv, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "git-subset";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "jasonwhite";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "02z2r0kcd0nnn1zjslp6xxam5ddbhrmzn67qzxhlamsw0p9vvkbb";
+  };
+
+  cargoSha256 = "1ydrrq35h1h5s59mx8kwwf3bp7lsmla3jl53ccdlsq29x0rj2jhs";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ] ++ stdenv.lib.optionals stdenv.isDarwin [ curl libiconv Security ];
+
+  meta = with stdenv.lib; {
+    description = "Super fast Git tree filtering";
+    homepage = "https://github.com/jasonwhite/git-subset";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
init https://github.com/jasonwhite/git-subset

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
