### PR TITLE
jool: 4.0.5 -> 4.0.9

### DIFF
--- a/pkgs/os-specific/linux/jool/source.nix
+++ b/pkgs/os-specific/linux/jool/source.nix
@@ -1,11 +1,11 @@
 { fetchFromGitHub }:
 
 rec {
-  version = "4.0.5";
+  version = "4.0.9";
   src = fetchFromGitHub {
     owner = "NICMx";
     repo = "Jool";
     rev = "v${version}";
-    sha256 = "0zfda8mbcg4mgg39shxdx5n2bq6zi9w3v8bcx03b3dp09lmq45y3";
+    sha256 = "0zhdpk1sbsv1iyr9rvj94wk853684avz3zzn4cv2k4254d7n25m7";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Version update. Fixes the build error:
```
building
make: Entering directory '/build/source/src/mod'
make -C siit
make[1]: Entering directory '/build/source/src/mod/siit'
make -C /nix/store/zkv2csjnlrx352hv9v5i7kflfamryhrr-linux-5.4.44-dev/lib/modules/5.4.44/build M=$PWD JOOL_FLAGS=""
make[2]: Entering directory '/nix/store/zkv2csjnlrx352hv9v5i7kflfamryhrr-linux-5.4.44-dev/lib/modules/5.4.44/build'
  AR      /build/source/src/mod/siit/built-in.a
  CC [M]  /build/source/src/mod/siit/../common/rfc7915/4to6.o
/build/source/src/mod/siit/../common/rfc7915/4to6.c: In function 'ttp46_alloc_skb':
/build/source/src/mod/siit/../common/rfc7915/4to6.c:68:2: error: implicit declaration of function 'nf_reset' [-Werror=implicit-function-declaration]
   68 |  nf_reset(out);
      |  ^~~~~~~~
created 4875 symlinks in user environment
cc1: some warnings being treated as errors
make[4]: *** [/nix/store/zkv2csjnlrx352hv9v5i7kflfamryhrr-linux-5.4.44-dev/lib/modules/5.4.44/source/scripts/Makefile.build:266: /build/source/src/mod/siit/../common/rfc7915/4to6.o] Error 1
make[3]: *** [/nix/store/zkv2csjnlrx352hv9v5i7kflfamryhrr-linux-5.4.44-dev/lib/modules/5.4.44/source/Makefile:1703: /build/source/src/mod/siit] Error 2
make[2]: *** [/nix/store/zkv2csjnlrx352hv9v5i7kflfamryhrr-linux-5.4.44-dev/lib/modules/5.4.44/source/Makefile:179: sub-make] Error 2
make[2]: Leaving directory '/nix/store/zkv2csjnlrx352hv9v5i7kflfamryhrr-linux-5.4.44-dev/lib/modules/5.4.44/build'
make[1]: *** [Makefile:5: all] Error 2
make[1]: Leaving directory '/build/source/src/mod/siit'
make: *** [Makefile:8: siit] Error 2
make: Leaving directory '/build/source/src/mod'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
     - tested with Kernel 5.4.44 and 5.6.16 (boot.kernelPackages = pkgs.linuxPackages_latest;)
     - Test environment is a nixos-container which did ping and mtr to 64:ff9b::8.8.8.8
     - Only the NAT64 mode was tested.
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
