### PR TITLE
electron: mark insecure versions (3,4,5) and require explicit version of electron in packages

### DIFF
--- a/pkgs/applications/blockchains/whirlpool-gui/default.nix
+++ b/pkgs/applications/blockchains/whirlpool-gui/default.nix
@@ -3,6 +3,7 @@
 
 let
   system = stdenv.hostPlatform.system;
+  electron = electron_7;
 
 in stdenv.mkDerivation rec {
   pname = "whirlpool-gui";
@@ -71,7 +72,7 @@ in stdenv.mkDerivation rec {
     ln -s "${desktopItem}/share/applications" "$out/share/applications"
 
     # wrap electron
-    makeWrapper '${electron_7}/bin/electron' "$out/bin/whirlpool-gui" \
+    makeWrapper '${electron}/bin/electron' "$out/bin/whirlpool-gui" \
       --add-flags "$out/libexec/whirlpool-gui" \
       --prefix PATH : "${jre8}/bin:${tor}/bin"
   '';

--- a/pkgs/applications/editors/typora/default.nix
+++ b/pkgs/applications/editors/typora/default.nix
@@ -12,6 +12,9 @@
 , pandoc
 }:
 
+let
+  electron = electron_8;
+in
 stdenv.mkDerivation rec {
   pname = "typora";
   version = "0.9.89";
@@ -52,7 +55,7 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    makeWrapper ${electron_8}/bin/electron $out/bin/typora \
+    makeWrapper ${electron}/bin/electron $out/bin/typora \
       --add-flags $out/share/typora \
       "''${gappsWrapperArgs[@]}" \
       ${lib.optionalString withPandoc ''--prefix PATH : "${lib.makeBinPath [ pandoc ]}"''} \

--- a/pkgs/applications/misc/obinskit/default.nix
+++ b/pkgs/applications/misc/obinskit/default.nix
@@ -16,7 +16,7 @@ let
     genericName = "Obinskit keyboard configurator";
     categories = "Utility";
   };
-
+  electron = electron_3;
 in
 stdenv.mkDerivation rec {
   pname = "obinskit";
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    makeWrapper ${electron_3}/bin/electron $out/bin/${pname} \
+    makeWrapper ${electron}/bin/electron $out/bin/${pname} \
       --add-flags $out/opt/obinskit/resources/app.asar \
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib libxkbcommon systemd.lib xorg.libXt ]}"
   '';

--- a/pkgs/applications/misc/stretchly/default.nix
+++ b/pkgs/applications/misc/stretchly/default.nix
@@ -1,8 +1,11 @@
-{ stdenv, lib, fetchurl, makeWrapper, wrapGAppsHook, electron
+{ stdenv, lib, fetchurl, makeWrapper, wrapGAppsHook, electron_7
 , common-updater-scripts
 , writeShellScript
 }:
 
+let
+  electron = electron_7;
+in
 stdenv.mkDerivation rec {
   pname = "stretchly";
   version = "0.21.1";

--- a/pkgs/applications/misc/teleprompter/default.nix
+++ b/pkgs/applications/misc/teleprompter/default.nix
@@ -1,5 +1,8 @@
-{ lib, stdenv, fetchurl, electron, makeDesktopItem, makeWrapper, nodePackages, autoPatchelfHook}:
+{ lib, stdenv, fetchurl, electron_4, makeDesktopItem, makeWrapper, nodePackages, autoPatchelfHook}:
 
+let
+  electron = electron_4;
+in
 stdenv.mkDerivation rec {
   pname = "teleprompter";
   version = "2.3.4";

--- a/pkgs/applications/networking/instant-messengers/rambox/pro.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/pro.nix
@@ -1,5 +1,8 @@
-{ autoPatchelfHook, electron, fetchurl, makeDesktopItem, makeWrapper, nodePackages, nss, stdenv, xdg_utils, xorg }:
+{ autoPatchelfHook, electron_4, fetchurl, makeDesktopItem, makeWrapper, nodePackages, nss, stdenv, xdg_utils, xorg }:
 
+let
+  electron = electron_4;
+in
 stdenv.mkDerivation rec {
   pname = "rambox-pro";
   version = "1.3.2";

--- a/pkgs/applications/networking/openbazaar/client.nix
+++ b/pkgs/applications/networking/openbazaar/client.nix
@@ -8,6 +8,9 @@
 , electron_6
 }:
 
+let
+  electron = electron_6;
+in
 stdenv.mkDerivation rec {
   pname = "openbazaar-client";
   version = "2.4.6";
@@ -42,7 +45,7 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    makeWrapper ${electron_6}/bin/electron $out/bin/${pname} \
+    makeWrapper ${electron}/bin/electron $out/bin/${pname} \
       --add-flags $out/share/${pname}/resources/app \
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ gcc-unwrapped.lib ]}"
   '';

--- a/pkgs/development/tools/electron/generic.nix
+++ b/pkgs/development/tools/electron/generic.nix
@@ -10,6 +10,7 @@ let
     license = licenses.mit;
     maintainers = with maintainers; [ travisbhartwell manveru prusnak ];
     platforms = [ "x86_64-darwin" "x86_64-linux" "i686-linux" "armv7l-linux" "aarch64-linux" ];
+    knownVulnerabilities = optional (version < "6") "Electron version ${version} is EOL";
   };
 
   fetcher = vers: tag: hash: fetchurl {

--- a/pkgs/development/tools/haskell/hyper-haskell/default.nix
+++ b/pkgs/development/tools/haskell/hyper-haskell/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchFromGitHub, jshon, electron
+{ stdenv, fetchFromGitHub, jshon, electron_3
 , runtimeShell, hyper-haskell-server, extra-packages ? [] }:
 
 let
   binPath = stdenv.lib.makeBinPath ([ hyper-haskell-server ] ++ extra-packages);
-
+  electron = electron_3;
 in stdenv.mkDerivation rec {
   pname = "hyper-haskell";
   version = "0.1.0.2";

--- a/pkgs/tools/misc/etcher/default.nix
+++ b/pkgs/tools/misc/etcher/default.nix
@@ -21,6 +21,8 @@ let
     "i686-linux" = "i386";
   }."${stdenv.system}";
 
+  electron = electron_7;
+
 in
 
 stdenv.mkDerivation rec {
@@ -69,7 +71,7 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    makeWrapper ${electron_7}/bin/electron $out/bin/${pname} \
+    makeWrapper ${electron}/bin/electron $out/bin/${pname} \
       --add-flags $out/share/${pname}/resources/app.asar \
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ gcc-unwrapped.lib ]}"
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10145,7 +10145,7 @@ in
 
   inherit (callPackages ../development/tools/electron { })
     electron_3 electron_4 electron_5 electron_6 electron_7 electron_8 electron_9;
-  electron = electron_4;
+  electron = electron_9;
 
   autobuild = callPackage ../development/tools/misc/autobuild { };
 
@@ -22530,10 +22530,7 @@ in
 
   stp = callPackage ../applications/science/logic/stp { };
 
-  stretchly = callPackage ../applications/misc/stretchly {
-    # Error on launch w/electron_8
-    electron = electron_7;
-  };
+  stretchly = callPackage ../applications/misc/stretchly { };
 
   stumpish = callPackage ../applications/window-managers/stumpish {};
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

1. require explicit version of electron in packages
2. point electron alias to the latest stable version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
