### PR TITLE
qsudo: init at 2020.03.27

### DIFF
--- a/pkgs/applications/misc/qsudo/default.nix
+++ b/pkgs/applications/misc/qsudo/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, mkDerivation
+, fetchFromGitHub
+, qmake
+, qtbase
+, sudo
+}:
+
+mkDerivation rec {
+  pname = "qsudo";
+  version = "2020.03.27";
+
+  src = fetchFromGitHub {
+    owner = "project-trident";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "06kg057vwkvafnk69m9rar4wih3vq4h36wbzwbfc2kndsnn47lfl";
+  };
+
+  sourceRoot = "source/src-qt5";
+
+  nativeBuildInputs = [
+    qmake
+  ];
+
+  buildInputs = [
+    qtbase
+    sudo
+  ];
+
+  postPatch = ''
+    substituteInPlace qsudo.pro --replace /usr/bin $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Graphical sudo utility from Project Trident";
+    homepage = "https://github.com/project-trident/qsudo";
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21694,6 +21694,8 @@ in
     };
   };
 
+  qsudo = libsForQt5.callPackage ../applications/misc/qsudo { };
+
   qsynth = libsForQt5.callPackage ../applications/audio/qsynth { };
 
   qtbitcointrader = libsForQt5.callPackage ../applications/misc/qtbitcointrader { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [qsudo](https://github.com/project-trident/qsudo), a graphical front-end to launching applications through `sudo`, and promoting for password as needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).