### PR TITLE
lua.pkgs.pulseaudio: Move from generated to lua-packages.nix

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -77,5 +77,4 @@ say,,,,,
 std__debug,std._debug,,,,
 std_normalize,std.normalize,,,,
 stdlib,,,,,vyp
-pulseaudio,,,,,doronbehar
 vstruct,,,,,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1455,24 +1455,6 @@ stdlib = buildLuarocksPackage {
     license.fullName = "MIT/X11";
   };
 };
-pulseaudio = buildLuarocksPackage {
-  pname = "pulseaudio";
-  version = "0.2-1";
-
-  src = fetchurl {
-    url    = "mirror://luarocks/pulseaudio-0.2-1.src.rock";
-    sha256 = "06w8fmwddrpm02yam818yi30gghw4ckb18zljjncy3x0zfijyhz7";
-  };
-  disabled = (luaOlder "5.1");
-  propagatedBuildInputs = [ lua ];
-
-  meta = with stdenv.lib; {
-    homepage = "https://github.com/doronbehar/lua-pulseaudio";
-    description = "Bindings to libpulse";
-    maintainers = with maintainers; [ doronbehar ];
-    license.fullName = "Apache v2.0";
-  };
-};
 vstruct = buildLuarocksPackage {
   pname = "vstruct";
   version = "2.0.2-1";

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -316,13 +316,4 @@ with super;
       sed -i '/set(CMAKE_C_FLAGS/d' CMakeLists.txt
     '';
   });
-
-  pulseaudio = super.pulseaudio.override({
-    buildInputs = [
-      pkgs.libpulseaudio
-    ];
-    nativeBuildInputs = [
-      pkgs.pulseaudio pkgs.pkgconfig
-    ];
-  });
 }

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -160,5 +160,37 @@ with self; {
     };
   });
 
+  pulseaudio = buildLuaPackage rec {
+    name = "pulseaudio-${version}";
+    version = "0.2-1";
+
+    src = fetchFromGitHub {
+      owner = "doronbehar";
+      repo = "lua-pulseaudio";
+      rev = "v${version}";
+      sha256 = "140y1m6k798c4w7xfl0zb0a4ffjz6i1722bgkdcdg8g76hr5r8ys";
+    };
+    disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+    buildInputs = [ pkgs.libpulseaudio ];
+    propagatedBuildInputs = [ lua ];
+    nativeBuildInputs = [ pkgs.pulseaudio pkgconfig ];
+
+    makeFlags = [
+      "INST_LIBDIR=${placeholder "out"}/lib/lua/${lua.luaversion}"
+      "INST_LUADIR=${placeholder "out"}/share/lua/${lua.luaversion}"
+      "LUA_BINDIR=${placeholder "out"}/bin"
+    ];
+    preBuild = ''
+      mkdir -p ${placeholder "out"}/lib/lua/${lua.luaversion}
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = "https://github.com/doronbehar/lua-pulseaudio";
+      description = "Bindings to libpulse";
+      maintainers = with maintainers; [ doronbehar ];
+      license = licenses.lgpl21;
+    };
+  };
+
 });
 in packages


### PR DESCRIPTION
From some reason, the package is not usable if it's built with `buildLuarocksPackage`. Adding `extraVariables` as in `makeFlags` doesn't work. See:
https://github.com/NixOS/nixpkgs/pull/89632#issuecomment-640094842

Now it uses `buildLuaPackage` as it used to.

cc @teto. I really don't know why is that. If you could find something wrong with "upstream's" rockspec file or my Makefile, please tell me:

- https://github.com/doronbehar/lua-pulseaudio/blob/v0.2/Makefile
- https://github.com/doronbehar/lua-pulseaudio/blob/v0.2/pulseaudio-0.2-1.rockspec

I only followed Luarocks' Wiki when I wrote these - https://github.com/luarocks/luarocks/wiki/Rockspec-format .

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
