### PR TITLE
formatting: fix missing leading whitespace

### DIFF
--- a/pkgs/applications/audio/sound-juicer/default.nix
+++ b/pkgs/applications/audio/sound-juicer/default.nix
@@ -5,7 +5,7 @@
 let
   pname = "sound-juicer";
   version = "3.24.0";
-in stdenv.mkDerivation rec{
+in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {

--- a/pkgs/applications/blockchains/btc1.nix
+++ b/pkgs/applications/blockchains/btc1.nix
@@ -5,7 +5,7 @@
 }:
 
 with stdenv.lib;
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   name = "bit1" + (toString (optional (!withGui) "d")) + "-" + version;
   version = "1.15.1";
 

--- a/pkgs/applications/misc/fme/default.nix
+++ b/pkgs/applications/misc/fme/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, autoconf, automake, gettext
 , fluxbox, bc, gtkmm2, glibmm, libglademm, libsigcxx }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
 
   pname = "fme";
   version = "1.1.3";

--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -36,7 +36,7 @@
 , zlib
 }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   pname = "wpsoffice";
   version = "11.1.0.9505";
 

--- a/pkgs/applications/video/dvdauthor/default.nix
+++ b/pkgs/applications/video/dvdauthor/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, imagemagick, libdvdread, libxml2, freetype, fribidi, libpng, zlib, pkgconfig
 , flex, bison }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   name = "dvdauthor-0.7.1";
 
   src = fetchurl {

--- a/pkgs/applications/window-managers/notion/default.nix
+++ b/pkgs/applications/window-managers/notion/default.nix
@@ -5,7 +5,7 @@
 , xlibsWrapper, makeWrapper
 }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   pname = "notion";
   version = "4.0.0";
 

--- a/pkgs/development/libraries/grib-api/default.nix
+++ b/pkgs/development/libraries/grib-api/default.nix
@@ -2,7 +2,7 @@
   cmake, netcdf, gfortran, libpng, openjpeg,
   enablePython ? false, pythonPackages }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   pname = "grib-api";
   version = "1.28.0";
 

--- a/pkgs/development/libraries/libchewing/default.nix
+++ b/pkgs/development/libraries/libchewing/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, sqlite }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   pname = "libchewing";
   version = "0.5.1";
 

--- a/pkgs/development/libraries/libqb/default.nix
+++ b/pkgs/development/libraries/libqb/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   name = "libqb-0.17.2";
 
   src = fetchurl {

--- a/pkgs/development/libraries/libtap/default.nix
+++ b/pkgs/development/libraries/libtap/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, cmake, perl }:
 
 with stdenv.lib;
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
 
   pname = "libtap";
   version = "1.14.0";

--- a/pkgs/development/libraries/libwnck/3.x.nix
+++ b/pkgs/development/libraries/libwnck/3.x.nix
@@ -19,7 +19,7 @@
 , gnome3
 }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   pname = "libwnck";
   version = "3.36.0";
 

--- a/pkgs/development/libraries/rapidcheck/default.nix
+++ b/pkgs/development/libraries/rapidcheck/default.nix
@@ -1,6 +1,6 @@
 { stdenv, cmake, fetchFromGitHub }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   pname = "rapidcheck";
   version = "unstable-2018-09-27";
 

--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, graalvm8, fetchurl }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   pname = "clj-kondo";
   version = "2020.04.05";
 

--- a/pkgs/development/tools/literate-programming/eweb/default.nix
+++ b/pkgs/development/tools/literate-programming/eweb/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, python3, asciidoc }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
 
   name = "eweb-${meta.version}";
 

--- a/pkgs/development/tools/literate-programming/nuweb/default.nix
+++ b/pkgs/development/tools/literate-programming/nuweb/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchurl, tex}:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
 
   pname = "nuweb";
   version = "1.60";

--- a/pkgs/development/web/cypress/default.nix
+++ b/pkgs/development/web/cypress/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchzip, autoPatchelfHook, xorg, gtk2, gnome2, gtk3, nss, alsaLib, udev, unzip, wrapGAppsHook }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   pname = "cypress";
   version = "4.5.0";
 

--- a/pkgs/games/freecell-solver/default.nix
+++ b/pkgs/games/freecell-solver/default.nix
@@ -3,7 +3,7 @@
 , perlPackages, python3 }:
 
 with stdenv.lib;
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
 
   pname = "freecell-solver";
   version = "4.18.0";

--- a/pkgs/games/galaxis/default.nix
+++ b/pkgs/games/galaxis/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, ncurses, xmlto }:
 
 with stdenv.lib;
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
 
   pname = "galaxis";
   version = "1.10";

--- a/pkgs/games/ninvaders/default.nix
+++ b/pkgs/games/ninvaders/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, ncurses }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   pname = "ninvaders";
   version = "0.1.2";
 

--- a/pkgs/games/vms-empire/default.nix
+++ b/pkgs/games/vms-empire/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, ncurses, xmlto }:
 
 with stdenv.lib;
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
 
   pname = "vms-empire";
   version = "1.15";

--- a/pkgs/misc/emulators/atari++/default.nix
+++ b/pkgs/misc/emulators/atari++/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, libSM, libX11, libICE, SDL, alsaLib, gcc-unwrapped, libXext }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   pname = "atari++";
   version = "1.83";
 

--- a/pkgs/misc/emulators/atari800/default.nix
+++ b/pkgs/misc/emulators/atari800/default.nix
@@ -2,7 +2,7 @@
 , unzip, zlib, SDL, readline, libGLU, libGL, libX11 }:
 
 with stdenv.lib;
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   pname = "atari800";
   version = "4.2.0";
 

--- a/pkgs/misc/mxt-app/default.nix
+++ b/pkgs/misc/mxt-app/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, autoreconfHook, libtool }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   version="1.28";
   pname = "mxt-app";
 

--- a/pkgs/tools/filesystems/netatalk/default.nix
+++ b/pkgs/tools/filesystems/netatalk/default.nix
@@ -3,7 +3,7 @@
 , ed, glibc, libevent
 }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   name = "netatalk-3.1.12";
 
   src = fetchurl {

--- a/pkgs/tools/misc/chafa/default.nix
+++ b/pkgs/tools/misc/chafa/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libtool, pkgconfig, which, libxslt, libxml2, docbook_xml_dtd_412, docbook_xsl, glib, imagemagick, darwin }:
 
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   version = "1.4.1";
   pname = "chafa";
 

--- a/pkgs/tools/misc/cowsay/default.nix
+++ b/pkgs/tools/misc/cowsay/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, perl }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   version = "3.03+dfsg2";
   pname = "cowsay";
 

--- a/pkgs/tools/networking/privoxy/default.nix
+++ b/pkgs/tools/networking/privoxy/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, autoreconfHook, zlib, pcre, w3m, man }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
 
   pname = "privoxy";
   version = "3.0.28";

--- a/pkgs/tools/networking/tinyproxy/default.nix
+++ b/pkgs/tools/networking/tinyproxy/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, autoreconfHook, asciidoc, libxml2,
   libxslt, docbook_xsl }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   pname = "tinyproxy";
   version = "1.10.0";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix formatting (missing leading whitespace in `rec  {`) so that all packages will use the same format (28 vs 6289).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
