### PR TITLE
nixos/corerad: add settings option to supersede configFile

### DIFF
--- a/nixos/modules/services/networking/corerad.nix
+++ b/nixos/modules/services/networking/corerad.nix
@@ -4,13 +4,47 @@ with lib;
 
 let
   cfg = config.services.corerad;
+
+  writeTOML = name: x:
+    pkgs.runCommandNoCCLocal name { } ''
+      echo '${builtins.toJSON x}' | ${pkgs.go-toml}/bin/jsontoml > $out
+    '';
+
 in {
-  meta = {
-    maintainers = with maintainers; [ mdlayher ];
-  };
+  meta.maintainers = with maintainers; [ mdlayher ];
 
   options.services.corerad = {
     enable = mkEnableOption "CoreRAD IPv6 NDP RA daemon";
+
+    settings = mkOption {
+      type = types.uniq types.attrs;
+      example = literalExample ''
+        {
+          interfaces = [
+            # eth0 is an upstream interface monitoring for IPv6 router advertisements.
+            {
+              name = "eth0";
+              monitor = true;
+            }
+            # eth1 is a downstream interface advertising IPv6 prefixes for SLAAC.
+            {
+              name = "eth1";
+              advertise = true;
+              prefix = [{ prefix = "::/64"; }];
+            }
+          ];
+          # Optionally enable Prometheus metrics.
+          debug = {
+            address = "localhost:9430";
+            prometheus = true;
+          };
+        }
+      '';
+      description = ''
+        Configuration for CoreRAD, see <link xlink:href="https://github.com/mdlayher/corerad/blob/master/internal/config/default.toml"/>
+        for supported values. Ignored if configFile is set.
+      '';
+    };
 
     configFile = mkOption {
       type = types.path;
@@ -27,6 +61,9 @@ in {
   };
 
   config = mkIf cfg.enable {
+    # Prefer the config file over settings if both are set.
+    services.corerad.configFile = mkDefault (writeTOML "corerad.toml" cfg.settings);
+
     systemd.services.corerad = {
       description = "CoreRAD IPv6 NDP RA daemon";
       after = [ "network.target" ];

--- a/nixos/tests/corerad.nix
+++ b/nixos/tests/corerad.nix
@@ -3,7 +3,7 @@ import ./make-test-python.nix (
     nodes = {
       router = {config, pkgs, ...}: { 
         config = {
-          # This machines simulates a router with IPv6 forwarding and a static IPv6 address.
+          # This machine simulates a router with IPv6 forwarding and a static IPv6 address.
           boot.kernel.sysctl = {
             "net.ipv6.conf.all.forwarding" = true;
           };
@@ -14,13 +14,25 @@ import ./make-test-python.nix (
             enable = true;
             # Serve router advertisements to the client machine with prefix information matching
             # any IPv6 /64 prefixes configured on this interface.
-            configFile = pkgs.writeText "corerad.toml" ''
-              [[interfaces]]
-              name = "eth1"
-              advertise = true
-                [[interfaces.prefix]]
-                prefix = "::/64"
-            '';
+            #
+            # This configuration is identical to the example in the CoreRAD NixOS module.
+            settings = {
+              interfaces = [
+                {
+                  name = "eth0";
+                  monitor = true;
+                }
+                {
+                  name = "eth1";
+                  advertise = true;
+                  prefix = [{ prefix = "::/64"; }];
+                }
+              ];
+              debug = {
+                address = "localhost:9430";
+                prometheus = true;
+              };
+            };
           };
         };
       };
@@ -66,5 +78,12 @@ import ./make-test-python.nix (
           assert (
               "/64 scope global temporary" in addrs
           ), "SLAAC temporary address was not configured on client after router advertisement"
+
+      with subtest("Verify HTTP debug server is configured"):
+          out = router.succeed("curl localhost:9430/metrics")
+
+          assert (
+              "corerad_build_info" in out
+          ), "Build info metric was not found in Prometheus output"
     '';
   })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Compliance with https://github.com/NixOS/rfcs/pull/42 since @marsam added go-toml which made outputting TOML config trivial. I borrowed the pattern here from the Prometheus module:

https://github.com/NixOS/nixpkgs/blob/0e040d16e8af51f721623fe583236f14d972ef67/nixos/modules/services/monitoring/prometheus/default.nix#L20-L24

We also add a new test for HTTP metrics output and set up a monitoring interface which can't easily be tested, but does verify that the various config modes work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @aanderse @jonringer @Infinisil who discussed adding a settings option with me in my original PR: https://github.com/NixOS/nixpkgs/pull/77252