### PR TITLE
displaycal: 3.5 -> 3.8.9.3

### DIFF
--- a/pkgs/applications/graphics/displaycal/default.nix
+++ b/pkgs/applications/graphics/displaycal/default.nix
@@ -12,16 +12,16 @@
  }:
 
 let
-  inherit (python2.pkgs) buildPythonApplication wxPython numpy;
-in buildPythonApplication {
+  inherit (python2.pkgs) buildPythonApplication wxPython numpy dbus-python;
+in buildPythonApplication rec {
   pname = "displaycal";
-  version = "3.5.0.0";
+  version = "3.8.9.3";
 
   enableParallelBuilding = true;
 
   src = fetchurl {
-    url = mirror://sourceforge/project/dispcalgui/release/3.5.0.0/DisplayCAL-3.5.0.0.tar.gz;
-    sha256 = "1j496sv8pbhby5hkkbp07k6bs3f7mb1l3dijmn2iga3kmix0fn5q";
+    url = "mirror://sourceforge/project/dispcalgui/release/${version}/DisplayCAL-${version}.tar.gz";
+    sha256 = "1sivi4q7sqsrc95qg5gh37bsm2761md4mpl89hflzwk6kyyxyd3w";
   };
 
   propagatedBuildInputs = [
@@ -34,6 +34,7 @@ in buildPythonApplication {
     argyllcms
     wxPython
     numpy
+    dbus-python
   ];
 
   nativeBuildInputs = [
@@ -42,7 +43,8 @@ in buildPythonApplication {
 
   preConfigure = ''
     mkdir dist
-    cp {misc,dist}/DisplayCAL.appdata.xml
+    cp {misc,dist}/net.displaycal.DisplayCAL.appdata.xml
+    touch dist/copyright
     mkdir -p $out
     ln -s $out/share/DisplayCAL $out/Resources
   '';


### PR DESCRIPTION
displaycal verison 3.5 built correctly but could not perform a calibration. This update fixes that.

(cherry picked from commit 009284cd4cc1ee62b45d13f9c67e7a5549024102)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
