### PR TITLE
formatting: fix missing leading whitespace

### DIFF
--- a/pkgs/applications/science/misc/sasview/xhtml2pdf.nix
+++ b/pkgs/applications/science/misc/sasview/xhtml2pdf.nix
@@ -2,7 +2,7 @@
 
 let
   #xhtml2pdf specifically requires version "1.0b10" of html5lib
-  html5 = html5lib.overrideAttrs( oldAttrs: rec{
+  html5 = html5lib.overrideAttrs( oldAttrs: rec {
     name = "${oldAttrs.pname}-${version}";
     version = "1.0b10";
     src = oldAttrs.src.override {

--- a/pkgs/applications/virtualization/8086tiny/default.nix
+++ b/pkgs/applications/virtualization/8086tiny/default.nix
@@ -4,7 +4,7 @@
 
 assert sdlSupport -> (SDL != null);
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
 
   pname = "8086tiny";
   version = "1.25";

--- a/pkgs/development/libraries/celt/0.5.1.nix
+++ b/pkgs/development/libraries/celt/0.5.1.nix
@@ -1,6 +1,6 @@
 { callPackage, fetchurl, ... } @ args:
 
-callPackage ./generic.nix (args // rec{
+callPackage ./generic.nix (args // rec {
   version = "0.5.1.3";
 
   src = fetchurl {

--- a/pkgs/development/libraries/celt/0.7.nix
+++ b/pkgs/development/libraries/celt/0.7.nix
@@ -1,6 +1,6 @@
 { callPackage, fetchurl, ... } @ args:
 
-callPackage ./generic.nix (args // rec{
+callPackage ./generic.nix (args // rec {
   version = "0.7.1";
 
   src = fetchurl {

--- a/pkgs/development/libraries/celt/default.nix
+++ b/pkgs/development/libraries/celt/default.nix
@@ -1,6 +1,6 @@
 { callPackage, fetchurl, ... } @ args:
 
-callPackage ./generic.nix (args // rec{
+callPackage ./generic.nix (args // rec {
   version = "0.11.3";
 
   src = fetchurl {

--- a/pkgs/development/python-modules/pandocfilters/default.nix
+++ b/pkgs/development/python-modules/pandocfilters/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 }:
 
-buildPythonPackage rec{
+buildPythonPackage rec {
   version = "1.4.2";
   pname = "pandocfilters";
 

--- a/pkgs/development/python-modules/periodictable/default.nix
+++ b/pkgs/development/python-modules/periodictable/default.nix
@@ -1,6 +1,6 @@
 {lib, fetchPypi, buildPythonPackage, numpy, pyparsing}:
 
-buildPythonPackage rec{
+buildPythonPackage rec {
   pname = "periodictable";
   version = "1.5.2";
 

--- a/pkgs/development/python-modules/toolz/default.nix
+++ b/pkgs/development/python-modules/toolz/default.nix
@@ -4,7 +4,7 @@
 , nose
 }:
 
-buildPythonPackage rec{
+buildPythonPackage rec {
   pname = "toolz";
   version = "0.10.0";
 

--- a/pkgs/development/python-modules/trezor_agent/default.nix
+++ b/pkgs/development/python-modules/trezor_agent/default.nix
@@ -13,7 +13,7 @@
 , pinentry
 }:
 
-buildPythonPackage rec{
+buildPythonPackage rec {
   pname = "trezor_agent";
   version = "0.10.0";
 

--- a/pkgs/development/python-modules/x11_hash/default.nix
+++ b/pkgs/development/python-modules/x11_hash/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 }:
 
-buildPythonPackage rec{
+buildPythonPackage rec {
   version = "1.4";
   pname = "x11_hash";
 

--- a/pkgs/development/python-modules/yenc/default.nix
+++ b/pkgs/development/python-modules/yenc/default.nix
@@ -6,7 +6,7 @@
 , isPy3k
 }:
 
-buildPythonPackage rec{
+buildPythonPackage rec {
   pname = "yenc";
   version = "0.4.0";
   src = fetchurl {

--- a/pkgs/tools/admin/scaleway-cli/default.nix
+++ b/pkgs/tools/admin/scaleway-cli/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, buildGoPackage }:
 
-buildGoPackage rec{
+buildGoPackage rec {
   pname = "scaleway-cli";
   version = "1.20";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix formatting (missing leading whitespace in `rec {` in other cases than `stdenv.mkDerivation`) so that all packages will use the same format. Addition to https://github.com/NixOS/nixpkgs/pull/89770.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
