### PR TITLE
Generated factorio mods

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -13,38 +13,6 @@ assert releaseType == "alpha"
 
 let
 
-  helpMsg = ''
-
-    ===FETCH FAILED===
-    Please ensure you have set the username and token with config.nix, or
-    /etc/nix/nixpkgs-config.nix if on NixOS.
-
-    Your token can be seen at https://factorio.com/profile (after logging in). It is
-    not as sensitive as your password, but should still be safeguarded. There is a
-    link on that page to revoke/invalidate the token, if you believe it has been
-    leaked or wish to take precautions.
-
-    Example:
-    {
-      packageOverrides = pkgs: {
-        factorio = pkgs.factorio.override {
-          username = "FactorioPlayer1654";
-          token = "d5ad5a8971267c895c0da598688761";
-        };
-      };
-    }
-
-    Alternatively, instead of providing the username+token, you may manually
-    download the release through https://factorio.com/download , then add it to
-    the store using e.g.:
-
-      releaseType=alpha
-      version=0.17.74
-      nix-prefetch-url file://$HOME/Downloads/factorio_\''${releaseType}_x64_\''${version}.tar.xz --name factorio_\''${releaseType}_x64-\''${version}.tar.xz
-
-    Note the ultimate "_" is replaced with "-" in the --name arg!
-  '';
-
   branch = if experimental then "experimental" else "stable";
 
   # NB `experimental` directs us to take the latest build, regardless of its branch;
@@ -84,27 +52,7 @@ let
       inherit version arch;
       src =
         if withAuth then
-          (stdenv.lib.overrideDerivation
-            (fetchurl {
-              inherit name url sha256;
-              curlOpts = [
-                "--get"
-                "--data-urlencode" "username@username"
-                "--data-urlencode" "token@token"
-              ];
-            })
-            (_: { # This preHook hides the credentials from /proc
-                  preHook = ''
-                    echo -n "${username}" >username
-                    echo -n "${token}"    >token
-                  '';
-                  failureHook = ''
-                    cat <<EOF
-                    ${helpMsg}
-                    EOF
-                  '';
-            })
-          )
+          factorio-utils.fetchurlWithAuth { inherit name url sha256 username token; }
         else
           fetchurl { inherit name url sha256; };
     };

--- a/pkgs/games/factorio/mods.json
+++ b/pkgs/games/factorio/mods.json
@@ -1,0 +1,253 @@
+[
+  {
+    "name": "bobassembly",
+    "version": "0.18.5",
+    "src": {
+      "name": "bobassembly_0.18.5.zip",
+      "url": "https://mods.factorio.com//download/bobassembly/5ec96a30c15abe000ba19cdf",
+      "sha1": "py6papmqz360s871nvzv7d31adg6wy04"
+    },
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": [
+      "bobplates"
+    ]
+  },
+  {
+    "name": "bobconfig",
+    "version": "0.14.0",
+    "src": {
+      "name": "bobconfig_0.14.0.zip",
+      "url": "https://mods.factorio.com//download/bobconfig/5a5f1ae6adcc441024d73e06",
+      "sha1": "k2icavmwws5pw62gs9gh6a3v3an3gkqs"
+    },
+    "deps": [],
+    "optionalDeps": []
+  },
+  {
+    "name": "bobelectronics",
+    "version": "0.18.1",
+    "src": {
+      "name": "bobelectronics_0.18.1.zip",
+      "url": "https://mods.factorio.com//download/bobelectronics/5e6aa8f2d1a668000ef958cf",
+      "sha1": "5dslfxfflb9lrxy5w8nknn99vmvprzad"
+    },
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": [
+      "bobplates"
+    ]
+  },
+  {
+    "name": "bobenemies",
+    "version": "0.18.5",
+    "src": {
+      "name": "bobenemies_0.18.5.zip",
+      "url": "https://mods.factorio.com//download/bobenemies/5ec96a4f552ff2000d1b7027",
+      "sha1": "05v0lcgmy23q15djhs651g4q4m60yc5k"
+    },
+    "deps": [],
+    "optionalDeps": []
+  },
+  {
+    "name": "bobgreenhouse",
+    "version": "0.18.1",
+    "src": {
+      "name": "bobgreenhouse_0.18.1.zip",
+      "url": "https://mods.factorio.com//download/bobgreenhouse/5e98951a6bb914000bcc7c0c",
+      "sha1": "g3vsdr605hw2i2wrvzwb5lk9lrlynjrc"
+    },
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": [
+      "bobplates"
+    ]
+  },
+  {
+    "name": "bobinserters",
+    "version": "0.18.4",
+    "src": {
+      "name": "bobinserters_0.18.4.zip",
+      "url": "https://mods.factorio.com//download/bobinserters/5edd6b670c4233000c076243",
+      "sha1": "5al5j71cb2v0hyc7r8bldvqi8jbrkvzj"
+    },
+    "deps": [],
+    "optionalDeps": []
+  },
+  {
+    "name": "boblibrary",
+    "version": "0.18.9",
+    "src": {
+      "name": "boblibrary_0.18.9.zip",
+      "url": "https://mods.factorio.com//download/boblibrary/5e9daef69e85eb000cee2549",
+      "sha1": "sgzjq2kp96qckwmy26f4mh0zs884702f"
+    },
+    "deps": [],
+    "optionalDeps": []
+  },
+  {
+    "name": "boblogistics",
+    "version": "0.18.9",
+    "src": {
+      "name": "boblogistics_0.18.9.zip",
+      "url": "https://mods.factorio.com//download/boblogistics/5eaaf2fe89f712000c87bcdb",
+      "sha1": "9n2m6jmyjq2dhi6c3n12c59l4q1gcxj6"
+    },
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": [
+      "bobplates",
+      "bobinserters"
+    ]
+  },
+  {
+    "name": "bobmining",
+    "version": "0.18.1",
+    "src": {
+      "name": "bobmining_0.18.1.zip",
+      "url": "https://mods.factorio.com//download/bobmining/5e6aa97bd1a668000d4baea5",
+      "sha1": "nvafswxyzhllz2vhkd52d2gyg04nwi5r"
+    },
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": [
+      "bobores",
+      "bobplates"
+    ]
+  },
+  {
+    "name": "bobmodules",
+    "version": "0.18.3",
+    "src": {
+      "name": "bobmodules_0.18.3.zip",
+      "url": "https://mods.factorio.com//download/bobmodules/5ec96a713cf12a000e056513",
+      "sha1": "9dn8y3s9n03jgfjrw2nvqrflik89b1h4"
+    },
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": [
+      "bobplates",
+      "bobelectronics",
+      "DiscoScience"
+    ]
+  },
+  {
+    "name": "bobores",
+    "version": "0.18.3",
+    "src": {
+      "name": "bobores_0.18.3.zip",
+      "url": "https://mods.factorio.com//download/bobores/5ec96a823cf12a000b34fcb0",
+      "sha1": "dp8lsh6arkl7wysvkygwiycv2sajr4jc"
+    },
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": []
+  },
+  {
+    "name": "bobplates",
+    "version": "0.18.8",
+    "src": {
+      "name": "bobplates_0.18.8.zip",
+      "url": "https://mods.factorio.com//download/bobplates/5ec96a9bc15abe000c94659e",
+      "sha1": "vyh086cfp6igiiq8a5nx0jnmgc434j5p"
+    },
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": [
+      "bobores",
+      "bobenemies"
+    ]
+  },
+  {
+    "name": "bobpower",
+    "version": "0.18.6",
+    "src": {
+      "name": "bobpower_0.18.6.zip",
+      "url": "https://mods.factorio.com//download/bobpower/5ec96ab3552ff2000b2edbfc",
+      "sha1": "gh6sxlhl9d0l8iq867a44lbnga2blsix"
+    },
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": [
+      "bobplates"
+    ]
+  },
+  {
+    "name": "bobrevamp",
+    "version": "0.18.5",
+    "src": {
+      "name": "bobrevamp_0.18.5.zip",
+      "url": "https://mods.factorio.com//download/bobrevamp/5ec96ac7552ff2000e291dea",
+      "sha1": "yvkfxwqvcc2lfns9h4dzhmfdx3h5cycq"
+    },
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": [
+      "bobplates"
+    ]
+  },
+  {
+    "name": "bobtech",
+    "version": "0.18.3",
+    "src": {
+      "name": "bobtech_0.18.3.zip",
+      "url": "https://mods.factorio.com//download/bobtech/5e78fa88936116000e23eea5",
+      "sha1": "f64qsxcw4l97wyscv4xww1pmwga95l3y"
+    },
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": [
+      "bobenemies",
+      "DiscoScience"
+    ]
+  },
+  {
+    "name": "bobtechsave",
+    "version": "0.14.2",
+    "src": {
+      "name": "bobtechsave_0.14.2.zip",
+      "url": "https://mods.factorio.com//download/bobtechsave/5a5f1ae6adcc441024d746e2",
+      "sha1": "swqiz9ywllg6xsfm5h2x832a84glb6xf"
+    },
+    "deps": [],
+    "optionalDeps": []
+  },
+  {
+    "name": "bobwarfare",
+    "version": "0.18.6",
+    "src": {
+      "name": "bobwarfare_0.18.6.zip",
+      "url": "https://mods.factorio.com//download/bobwarfare/5ec96addc15abe000d64428c",
+      "sha1": "3f0xlni5y1hwmgxx2zinqzpg33h02wgx"
+    },
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": [
+      "bobplates",
+      "bobenemies"
+    ]
+  },
+  {
+    "name": "clock",
+    "version": "0.18.1",
+    "src": {
+      "name": "clock_0.18.1.zip",
+      "url": "https://mods.factorio.com//download/clock/5edd6b4c0c4233000b59f065",
+      "sha1": "c5granjd8sfx6f33a4wwzn7b13xqkd6s"
+    },
+    "deps": [],
+    "optionalDeps": []
+  }
+]

--- a/pkgs/games/factorio/mods.json
+++ b/pkgs/games/factorio/mods.json
@@ -2,11 +2,9 @@
   {
     "name": "bobassembly",
     "version": "0.18.5",
-    "src": {
-      "name": "bobassembly_0.18.5.zip",
-      "url": "https://mods.factorio.com//download/bobassembly/5ec96a30c15abe000ba19cdf",
-      "sha1": "py6papmqz360s871nvzv7d31adg6wy04"
-    },
+    "file_name": "bobassembly_0.18.5.zip",
+    "download_url": "/download/bobassembly/5ec96a30c15abe000ba19cdf",
+    "sha1": "py6papmqz360s871nvzv7d31adg6wy04",
     "deps": [
       "boblibrary"
     ],
@@ -17,11 +15,9 @@
   {
     "name": "bobclasses",
     "version": "0.18.8",
-    "src": {
-      "name": "bobclasses_0.18.8.zip",
-      "url": "https://mods.factorio.com//download/bobclasses/5edd6b3cfd6b7c000dcec7af",
-      "sha1": "1fyk9idbz4psgf1z15j91b37zc37f7kk"
-    },
+    "file_name": "bobclasses_0.18.8.zip",
+    "download_url": "/download/bobclasses/5edd6b3cfd6b7c000dcec7af",
+    "sha1": "1fyk9idbz4psgf1z15j91b37zc37f7kk",
     "deps": [
       "boblibrary"
     ],
@@ -32,22 +28,18 @@
   {
     "name": "bobconfig",
     "version": "0.14.0",
-    "src": {
-      "name": "bobconfig_0.14.0.zip",
-      "url": "https://mods.factorio.com//download/bobconfig/5a5f1ae6adcc441024d73e06",
-      "sha1": "k2icavmwws5pw62gs9gh6a3v3an3gkqs"
-    },
+    "file_name": "bobconfig_0.14.0.zip",
+    "download_url": "/download/bobconfig/5a5f1ae6adcc441024d73e06",
+    "sha1": "k2icavmwws5pw62gs9gh6a3v3an3gkqs",
     "deps": [],
     "optionalDeps": []
   },
   {
     "name": "bobelectronics",
     "version": "0.18.1",
-    "src": {
-      "name": "bobelectronics_0.18.1.zip",
-      "url": "https://mods.factorio.com//download/bobelectronics/5e6aa8f2d1a668000ef958cf",
-      "sha1": "5dslfxfflb9lrxy5w8nknn99vmvprzad"
-    },
+    "file_name": "bobelectronics_0.18.1.zip",
+    "download_url": "/download/bobelectronics/5e6aa8f2d1a668000ef958cf",
+    "sha1": "5dslfxfflb9lrxy5w8nknn99vmvprzad",
     "deps": [
       "boblibrary"
     ],
@@ -58,22 +50,18 @@
   {
     "name": "bobenemies",
     "version": "0.18.5",
-    "src": {
-      "name": "bobenemies_0.18.5.zip",
-      "url": "https://mods.factorio.com//download/bobenemies/5ec96a4f552ff2000d1b7027",
-      "sha1": "05v0lcgmy23q15djhs651g4q4m60yc5k"
-    },
+    "file_name": "bobenemies_0.18.5.zip",
+    "download_url": "/download/bobenemies/5ec96a4f552ff2000d1b7027",
+    "sha1": "05v0lcgmy23q15djhs651g4q4m60yc5k",
     "deps": [],
     "optionalDeps": []
   },
   {
     "name": "bobequipment",
     "version": "0.18.1",
-    "src": {
-      "name": "bobequipment_0.18.1.zip",
-      "url": "https://mods.factorio.com//download/bobequipment/5e6aa917d1a668000ef959b7",
-      "sha1": "f1nz3j4z6p4i2sr0fjpq3h21ri9bx54j"
-    },
+    "file_name": "bobequipment_0.18.1.zip",
+    "download_url": "/download/bobequipment/5e6aa917d1a668000ef959b7",
+    "sha1": "f1nz3j4z6p4i2sr0fjpq3h21ri9bx54j",
     "deps": [
       "boblibrary"
     ],
@@ -82,11 +70,9 @@
   {
     "name": "bobgreenhouse",
     "version": "0.18.1",
-    "src": {
-      "name": "bobgreenhouse_0.18.1.zip",
-      "url": "https://mods.factorio.com//download/bobgreenhouse/5e98951a6bb914000bcc7c0c",
-      "sha1": "g3vsdr605hw2i2wrvzwb5lk9lrlynjrc"
-    },
+    "file_name": "bobgreenhouse_0.18.1.zip",
+    "download_url": "/download/bobgreenhouse/5e98951a6bb914000bcc7c0c",
+    "sha1": "g3vsdr605hw2i2wrvzwb5lk9lrlynjrc",
     "deps": [
       "boblibrary"
     ],
@@ -97,33 +83,27 @@
   {
     "name": "bobinserters",
     "version": "0.18.4",
-    "src": {
-      "name": "bobinserters_0.18.4.zip",
-      "url": "https://mods.factorio.com//download/bobinserters/5edd6b670c4233000c076243",
-      "sha1": "5al5j71cb2v0hyc7r8bldvqi8jbrkvzj"
-    },
+    "file_name": "bobinserters_0.18.4.zip",
+    "download_url": "/download/bobinserters/5edd6b670c4233000c076243",
+    "sha1": "5al5j71cb2v0hyc7r8bldvqi8jbrkvzj",
     "deps": [],
     "optionalDeps": []
   },
   {
     "name": "boblibrary",
     "version": "0.18.9",
-    "src": {
-      "name": "boblibrary_0.18.9.zip",
-      "url": "https://mods.factorio.com//download/boblibrary/5e9daef69e85eb000cee2549",
-      "sha1": "sgzjq2kp96qckwmy26f4mh0zs884702f"
-    },
+    "file_name": "boblibrary_0.18.9.zip",
+    "download_url": "/download/boblibrary/5e9daef69e85eb000cee2549",
+    "sha1": "sgzjq2kp96qckwmy26f4mh0zs884702f",
     "deps": [],
     "optionalDeps": []
   },
   {
     "name": "boblogistics",
     "version": "0.18.9",
-    "src": {
-      "name": "boblogistics_0.18.9.zip",
-      "url": "https://mods.factorio.com//download/boblogistics/5eaaf2fe89f712000c87bcdb",
-      "sha1": "9n2m6jmyjq2dhi6c3n12c59l4q1gcxj6"
-    },
+    "file_name": "boblogistics_0.18.9.zip",
+    "download_url": "/download/boblogistics/5eaaf2fe89f712000c87bcdb",
+    "sha1": "9n2m6jmyjq2dhi6c3n12c59l4q1gcxj6",
     "deps": [
       "boblibrary"
     ],
@@ -135,11 +115,9 @@
   {
     "name": "bobmining",
     "version": "0.18.1",
-    "src": {
-      "name": "bobmining_0.18.1.zip",
-      "url": "https://mods.factorio.com//download/bobmining/5e6aa97bd1a668000d4baea5",
-      "sha1": "nvafswxyzhllz2vhkd52d2gyg04nwi5r"
-    },
+    "file_name": "bobmining_0.18.1.zip",
+    "download_url": "/download/bobmining/5e6aa97bd1a668000d4baea5",
+    "sha1": "nvafswxyzhllz2vhkd52d2gyg04nwi5r",
     "deps": [
       "boblibrary"
     ],
@@ -151,11 +129,9 @@
   {
     "name": "bobmodules",
     "version": "0.18.3",
-    "src": {
-      "name": "bobmodules_0.18.3.zip",
-      "url": "https://mods.factorio.com//download/bobmodules/5ec96a713cf12a000e056513",
-      "sha1": "9dn8y3s9n03jgfjrw2nvqrflik89b1h4"
-    },
+    "file_name": "bobmodules_0.18.3.zip",
+    "download_url": "/download/bobmodules/5ec96a713cf12a000e056513",
+    "sha1": "9dn8y3s9n03jgfjrw2nvqrflik89b1h4",
     "deps": [
       "boblibrary"
     ],
@@ -168,11 +144,9 @@
   {
     "name": "bobores",
     "version": "0.18.3",
-    "src": {
-      "name": "bobores_0.18.3.zip",
-      "url": "https://mods.factorio.com//download/bobores/5ec96a823cf12a000b34fcb0",
-      "sha1": "dp8lsh6arkl7wysvkygwiycv2sajr4jc"
-    },
+    "file_name": "bobores_0.18.3.zip",
+    "download_url": "/download/bobores/5ec96a823cf12a000b34fcb0",
+    "sha1": "dp8lsh6arkl7wysvkygwiycv2sajr4jc",
     "deps": [
       "boblibrary"
     ],
@@ -181,11 +155,9 @@
   {
     "name": "bobplates",
     "version": "0.18.8",
-    "src": {
-      "name": "bobplates_0.18.8.zip",
-      "url": "https://mods.factorio.com//download/bobplates/5ec96a9bc15abe000c94659e",
-      "sha1": "vyh086cfp6igiiq8a5nx0jnmgc434j5p"
-    },
+    "file_name": "bobplates_0.18.8.zip",
+    "download_url": "/download/bobplates/5ec96a9bc15abe000c94659e",
+    "sha1": "vyh086cfp6igiiq8a5nx0jnmgc434j5p",
     "deps": [
       "boblibrary"
     ],
@@ -197,11 +169,9 @@
   {
     "name": "bobpower",
     "version": "0.18.6",
-    "src": {
-      "name": "bobpower_0.18.6.zip",
-      "url": "https://mods.factorio.com//download/bobpower/5ec96ab3552ff2000b2edbfc",
-      "sha1": "gh6sxlhl9d0l8iq867a44lbnga2blsix"
-    },
+    "file_name": "bobpower_0.18.6.zip",
+    "download_url": "/download/bobpower/5ec96ab3552ff2000b2edbfc",
+    "sha1": "gh6sxlhl9d0l8iq867a44lbnga2blsix",
     "deps": [
       "boblibrary"
     ],
@@ -212,11 +182,9 @@
   {
     "name": "bobrevamp",
     "version": "0.18.5",
-    "src": {
-      "name": "bobrevamp_0.18.5.zip",
-      "url": "https://mods.factorio.com//download/bobrevamp/5ec96ac7552ff2000e291dea",
-      "sha1": "yvkfxwqvcc2lfns9h4dzhmfdx3h5cycq"
-    },
+    "file_name": "bobrevamp_0.18.5.zip",
+    "download_url": "/download/bobrevamp/5ec96ac7552ff2000e291dea",
+    "sha1": "yvkfxwqvcc2lfns9h4dzhmfdx3h5cycq",
     "deps": [
       "boblibrary"
     ],
@@ -227,11 +195,9 @@
   {
     "name": "bobtech",
     "version": "0.18.3",
-    "src": {
-      "name": "bobtech_0.18.3.zip",
-      "url": "https://mods.factorio.com//download/bobtech/5e78fa88936116000e23eea5",
-      "sha1": "f64qsxcw4l97wyscv4xww1pmwga95l3y"
-    },
+    "file_name": "bobtech_0.18.3.zip",
+    "download_url": "/download/bobtech/5e78fa88936116000e23eea5",
+    "sha1": "f64qsxcw4l97wyscv4xww1pmwga95l3y",
     "deps": [
       "boblibrary"
     ],
@@ -243,11 +209,9 @@
   {
     "name": "bobvehicleequipment",
     "version": "0.18.1",
-    "src": {
-      "name": "bobvehicleequipment_0.18.1.zip",
-      "url": "https://mods.factorio.com//download/bobvehicleequipment/5e6aaa26d1a668000ef977d3",
-      "sha1": "5fv8135j2jrxv61m24akil2daxgqp7wj"
-    },
+    "file_name": "bobvehicleequipment_0.18.1.zip",
+    "download_url": "/download/bobvehicleequipment/5e6aaa26d1a668000ef977d3",
+    "sha1": "5fv8135j2jrxv61m24akil2daxgqp7wj",
     "deps": [
       "boblibrary"
     ],
@@ -259,11 +223,9 @@
   {
     "name": "bobwarfare",
     "version": "0.18.6",
-    "src": {
-      "name": "bobwarfare_0.18.6.zip",
-      "url": "https://mods.factorio.com//download/bobwarfare/5ec96addc15abe000d64428c",
-      "sha1": "3f0xlni5y1hwmgxx2zinqzpg33h02wgx"
-    },
+    "file_name": "bobwarfare_0.18.6.zip",
+    "download_url": "/download/bobwarfare/5ec96addc15abe000d64428c",
+    "sha1": "3f0xlni5y1hwmgxx2zinqzpg33h02wgx",
     "deps": [
       "boblibrary"
     ],
@@ -275,11 +237,9 @@
   {
     "name": "clock",
     "version": "0.18.2",
-    "src": {
-      "name": "clock_0.18.2.zip",
-      "url": "https://mods.factorio.com//download/clock/5ede20bca9868c003ce1c8a3",
-      "sha1": "gsxbn06ly8hfa9w29qbaxnc0ln48jlka"
-    },
+    "file_name": "clock_0.18.2.zip",
+    "download_url": "/download/clock/5ede20bca9868c003ce1c8a3",
+    "sha1": "gsxbn06ly8hfa9w29qbaxnc0ln48jlka",
     "deps": [],
     "optionalDeps": []
   }

--- a/pkgs/games/factorio/mods.json
+++ b/pkgs/games/factorio/mods.json
@@ -5,11 +5,10 @@
     "file_name": "bobassembly_0.18.5.zip",
     "download_url": "/download/bobassembly/5ec96a30c15abe000ba19cdf",
     "sha1": "04786e5e5361b4b3ffb6e1200dccf8b85e758dbf",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": [
-      "bobplates"
+    "dependencies": [
+      "base >= 0.18.0",
+      "boblibrary >= 0.18.0",
+      "? bobplates >= 0.18.0"
     ]
   },
   {
@@ -18,11 +17,10 @@
     "file_name": "bobclasses_0.18.8.zip",
     "download_url": "/download/bobclasses/5edd6b3cfd6b7c000dcec7af",
     "sha1": "731e7706fb67ac9064093fb8a72ff9abc534bd0b",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": [
-      "bobplates"
+    "dependencies": [
+      "base >= 0.18.27",
+      "boblibrary >= 0.18.0",
+      "? bobplates >= 0.18.0"
     ]
   },
   {
@@ -31,8 +29,9 @@
     "file_name": "bobconfig_0.14.0.zip",
     "download_url": "/download/bobconfig/5a5f1ae6adcc441024d73e06",
     "sha1": "1acf37ac1a7b28035fd24f187e8be6bc6ec5a298",
-    "deps": [],
-    "optionalDeps": []
+    "dependencies": [
+      "base >= 0.14.0"
+    ]
   },
   {
     "name": "bobelectronics",
@@ -40,11 +39,10 @@
     "file_name": "bobelectronics_0.18.1.zip",
     "download_url": "/download/bobelectronics/5e6aa8f2d1a668000ef958cf",
     "sha1": "4dfd7c77dd29593b2de2c5f74cd3a2ce7547752b",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": [
-      "bobplates"
+    "dependencies": [
+      "base >= 0.18.0",
+      "boblibrary >= 0.18.0",
+      "? bobplates >= 0.18.0"
     ]
   },
   {
@@ -53,8 +51,9 @@
     "file_name": "bobenemies_0.18.5.zip",
     "download_url": "/download/bobenemies/5ec96a4f552ff2000d1b7027",
     "sha1": "b3300f4c2598bc508c86b2958087f0f5310a7601",
-    "deps": [],
-    "optionalDeps": []
+    "dependencies": [
+      "base >= 0.18.2"
+    ]
   },
   {
     "name": "bobequipment",
@@ -62,10 +61,10 @@
     "file_name": "bobequipment_0.18.1.zip",
     "download_url": "/download/bobequipment/5e6aa917d1a668000ef959b7",
     "sha1": "9294be52cc41c081af74206b11c9359fc8f16d70",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": []
+    "dependencies": [
+      "base >= 0.18.0",
+      "boblibrary >= 0.18.0"
+    ]
   },
   {
     "name": "bobgreenhouse",
@@ -73,11 +72,10 @@
     "file_name": "bobgreenhouse_0.18.1.zip",
     "download_url": "/download/bobgreenhouse/5e98951a6bb914000bcc7c0c",
     "sha1": "2c4beb69a669d2b2f8df998b28382cc0e4a6f778",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": [
-      "bobplates"
+    "dependencies": [
+      "base >= 0.18.0",
+      "boblibrary >= 0.18.0",
+      "? bobplates >= 0.18.0"
     ]
   },
   {
@@ -86,8 +84,9 @@
     "file_name": "bobinserters_0.18.4.zip",
     "download_url": "/download/bobinserters/5edd6b670c4233000c076243",
     "sha1": "f2ef99974411ef4617ca877908b6582c1c59a82a",
-    "deps": [],
-    "optionalDeps": []
+    "dependencies": [
+      "base >= 0.18.27"
+    ]
   },
   {
     "name": "boblibrary",
@@ -95,8 +94,9 @@
     "file_name": "boblibrary_0.18.9.zip",
     "download_url": "/download/boblibrary/5e9daef69e85eb000cee2549",
     "sha1": "4e804310d21fc04a9c11bef2c9b049770a2cffd3",
-    "deps": [],
-    "optionalDeps": []
+    "dependencies": [
+      "base >= 0.18.0"
+    ]
   },
   {
     "name": "boblogistics",
@@ -104,12 +104,11 @@
     "file_name": "boblogistics_0.18.9.zip",
     "download_url": "/download/boblogistics/5eaaf2fe89f712000c87bcdb",
     "sha1": "4676f60226341526821dcc44d80496be4a53854d",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": [
-      "bobplates",
-      "bobinserters"
+    "dependencies": [
+      "base >= 0.18.13",
+      "boblibrary >= 0.18.0",
+      "? bobplates >= 0.18.0",
+      "? bobinserters >= 0.18.0"
     ]
   },
   {
@@ -118,12 +117,11 @@
     "file_name": "bobmining_0.18.1.zip",
     "download_url": "/download/bobmining/5e6aa97bd1a668000d4baea5",
     "sha1": "b9446e0978fe89264a9b708b4f29fcbe73edd4b6",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": [
-      "bobores",
-      "bobplates"
+    "dependencies": [
+      "base >= 0.18.0",
+      "boblibrary >= 0.18.0",
+      "? bobores >= 0.18.0",
+      "? bobplates >= 0.18.0"
     ]
   },
   {
@@ -132,13 +130,12 @@
     "file_name": "bobmodules_0.18.3.zip",
     "download_url": "/download/bobmodules/5ec96a713cf12a000e056513",
     "sha1": "048695d08cd465bcade059ba2707b0490f8f6c4b",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": [
-      "bobplates",
-      "bobelectronics",
-      "DiscoScience"
+    "dependencies": [
+      "base >= 0.18.0",
+      "boblibrary >= 0.18.0",
+      "? bobplates >= 0.18.0",
+      "? bobelectronics >= 0.18.0",
+      "? DiscoScience"
     ]
   },
   {
@@ -147,10 +144,10 @@
     "file_name": "bobores_0.18.3.zip",
     "download_url": "/download/bobores/5ec96a823cf12a000b34fcb0",
     "sha1": "4c922c95169bf9c89f9f5b7b7ee8ccca404dd16d",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": []
+    "dependencies": [
+      "base >= 0.18.0",
+      "boblibrary >= 0.18.0"
+    ]
   },
   {
     "name": "bobplates",
@@ -158,12 +155,11 @@
     "file_name": "bobplates_0.18.8.zip",
     "download_url": "/download/bobplates/5ec96a9bc15abe000c94659e",
     "sha1": "b74832087bd54ad06d5108c7f8a2b98e1904a0df",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": [
-      "bobores",
-      "bobenemies"
+    "dependencies": [
+      "base >= 0.18.0",
+      "boblibrary >= 0.18.4",
+      "? bobores >= 0.18.0",
+      "? bobenemies >= 0.18.0"
     ]
   },
   {
@@ -172,11 +168,10 @@
     "file_name": "bobpower_0.18.6.zip",
     "download_url": "/download/bobpower/5ec96ab3552ff2000b2edbfc",
     "sha1": "3d6aba847a765142d431084744414b14d2ae0d7c",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": [
-      "bobplates"
+    "dependencies": [
+      "base >= 0.18.0",
+      "boblibrary >= 0.18.0",
+      "? bobplates >= 0.18.0"
     ]
   },
   {
@@ -185,11 +180,10 @@
     "file_name": "bobrevamp_0.18.5.zip",
     "download_url": "/download/bobrevamp/5ec96ac7552ff2000e291dea",
     "sha1": "987956e0e8cd55f81b81495b4705631bf3eee6f6",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": [
-      "bobplates"
+    "dependencies": [
+      "base >= 0.18.0",
+      "boblibrary >= 0.18.0",
+      "? bobplates >= 0.18.0"
     ]
   },
   {
@@ -198,12 +192,11 @@
     "file_name": "bobtech_0.18.3.zip",
     "download_url": "/download/bobtech/5e78fa88936116000e23eea5",
     "sha1": "7ed092d4e3f506ce3bd94c7b7e12259c758d8971",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": [
-      "bobenemies",
-      "DiscoScience"
+    "dependencies": [
+      "base >= 0.18.13",
+      "boblibrary >= 0.18.0",
+      "? bobenemies >= 0.18.0",
+      "? DiscoScience"
     ]
   },
   {
@@ -212,12 +205,11 @@
     "file_name": "bobvehicleequipment_0.18.1.zip",
     "download_url": "/download/bobvehicleequipment/5e6aaa26d1a668000ef977d3",
     "sha1": "929f8b5f574dd03815113598ddb314b28c80b62b",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": [
-      "boblogistics",
-      "bobwarfare"
+    "dependencies": [
+      "base >= 0.18.0",
+      "boblibrary >= 0.18.0",
+      "? boblogistics >= 0.18.0",
+      "? bobwarfare >= 0.18.0"
     ]
   },
   {
@@ -226,12 +218,11 @@
     "file_name": "bobwarfare_0.18.6.zip",
     "download_url": "/download/bobwarfare/5ec96addc15abe000d64428c",
     "sha1": "fd7101e018ef7e6ce317bdbfca61f0255ada811b",
-    "deps": [
-      "boblibrary"
-    ],
-    "optionalDeps": [
-      "bobplates",
-      "bobenemies"
+    "dependencies": [
+      "base >= 0.18.16",
+      "boblibrary >= 0.18.0",
+      "? bobplates >= 0.18.0",
+      "? bobenemies >= 0.18.0"
     ]
   },
   {
@@ -240,7 +231,8 @@
     "file_name": "clock_0.18.2.zip",
     "download_url": "/download/clock/5ede20bca9868c003ce1c8a3",
     "sha1": "6a528988a580d9ae164e8227e520f2d400bbba7e",
-    "deps": [],
-    "optionalDeps": []
+    "dependencies": [
+      "base >= 0.18.0"
+    ]
   }
 ]

--- a/pkgs/games/factorio/mods.json
+++ b/pkgs/games/factorio/mods.json
@@ -15,6 +15,21 @@
     ]
   },
   {
+    "name": "bobclasses",
+    "version": "0.18.8",
+    "src": {
+      "name": "bobclasses_0.18.8.zip",
+      "url": "https://mods.factorio.com//download/bobclasses/5edd6b3cfd6b7c000dcec7af",
+      "sha1": "1fyk9idbz4psgf1z15j91b37zc37f7kk"
+    },
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": [
+      "bobplates"
+    ]
+  },
+  {
     "name": "bobconfig",
     "version": "0.14.0",
     "src": {
@@ -49,6 +64,19 @@
       "sha1": "05v0lcgmy23q15djhs651g4q4m60yc5k"
     },
     "deps": [],
+    "optionalDeps": []
+  },
+  {
+    "name": "bobequipment",
+    "version": "0.18.1",
+    "src": {
+      "name": "bobequipment_0.18.1.zip",
+      "url": "https://mods.factorio.com//download/bobequipment/5e6aa917d1a668000ef959b7",
+      "sha1": "f1nz3j4z6p4i2sr0fjpq3h21ri9bx54j"
+    },
+    "deps": [
+      "boblibrary"
+    ],
     "optionalDeps": []
   },
   {
@@ -213,15 +241,20 @@
     ]
   },
   {
-    "name": "bobtechsave",
-    "version": "0.14.2",
+    "name": "bobvehicleequipment",
+    "version": "0.18.1",
     "src": {
-      "name": "bobtechsave_0.14.2.zip",
-      "url": "https://mods.factorio.com//download/bobtechsave/5a5f1ae6adcc441024d746e2",
-      "sha1": "swqiz9ywllg6xsfm5h2x832a84glb6xf"
+      "name": "bobvehicleequipment_0.18.1.zip",
+      "url": "https://mods.factorio.com//download/bobvehicleequipment/5e6aaa26d1a668000ef977d3",
+      "sha1": "5fv8135j2jrxv61m24akil2daxgqp7wj"
     },
-    "deps": [],
-    "optionalDeps": []
+    "deps": [
+      "boblibrary"
+    ],
+    "optionalDeps": [
+      "boblogistics",
+      "bobwarfare"
+    ]
   },
   {
     "name": "bobwarfare",
@@ -241,11 +274,11 @@
   },
   {
     "name": "clock",
-    "version": "0.18.1",
+    "version": "0.18.2",
     "src": {
-      "name": "clock_0.18.1.zip",
-      "url": "https://mods.factorio.com//download/clock/5edd6b4c0c4233000b59f065",
-      "sha1": "c5granjd8sfx6f33a4wwzn7b13xqkd6s"
+      "name": "clock_0.18.2.zip",
+      "url": "https://mods.factorio.com//download/clock/5ede20bca9868c003ce1c8a3",
+      "sha1": "gsxbn06ly8hfa9w29qbaxnc0ln48jlka"
     },
     "deps": [],
     "optionalDeps": []

--- a/pkgs/games/factorio/mods.json
+++ b/pkgs/games/factorio/mods.json
@@ -4,7 +4,7 @@
     "version": "0.18.5",
     "file_name": "bobassembly_0.18.5.zip",
     "download_url": "/download/bobassembly/5ec96a30c15abe000ba19cdf",
-    "sha1": "py6papmqz360s871nvzv7d31adg6wy04",
+    "sha1": "04786e5e5361b4b3ffb6e1200dccf8b85e758dbf",
     "deps": [
       "boblibrary"
     ],
@@ -17,7 +17,7 @@
     "version": "0.18.8",
     "file_name": "bobclasses_0.18.8.zip",
     "download_url": "/download/bobclasses/5edd6b3cfd6b7c000dcec7af",
-    "sha1": "1fyk9idbz4psgf1z15j91b37zc37f7kk",
+    "sha1": "731e7706fb67ac9064093fb8a72ff9abc534bd0b",
     "deps": [
       "boblibrary"
     ],
@@ -30,7 +30,7 @@
     "version": "0.14.0",
     "file_name": "bobconfig_0.14.0.zip",
     "download_url": "/download/bobconfig/5a5f1ae6adcc441024d73e06",
-    "sha1": "k2icavmwws5pw62gs9gh6a3v3an3gkqs",
+    "sha1": "1acf37ac1a7b28035fd24f187e8be6bc6ec5a298",
     "deps": [],
     "optionalDeps": []
   },
@@ -39,7 +39,7 @@
     "version": "0.18.1",
     "file_name": "bobelectronics_0.18.1.zip",
     "download_url": "/download/bobelectronics/5e6aa8f2d1a668000ef958cf",
-    "sha1": "5dslfxfflb9lrxy5w8nknn99vmvprzad",
+    "sha1": "4dfd7c77dd29593b2de2c5f74cd3a2ce7547752b",
     "deps": [
       "boblibrary"
     ],
@@ -52,7 +52,7 @@
     "version": "0.18.5",
     "file_name": "bobenemies_0.18.5.zip",
     "download_url": "/download/bobenemies/5ec96a4f552ff2000d1b7027",
-    "sha1": "05v0lcgmy23q15djhs651g4q4m60yc5k",
+    "sha1": "b3300f4c2598bc508c86b2958087f0f5310a7601",
     "deps": [],
     "optionalDeps": []
   },
@@ -61,7 +61,7 @@
     "version": "0.18.1",
     "file_name": "bobequipment_0.18.1.zip",
     "download_url": "/download/bobequipment/5e6aa917d1a668000ef959b7",
-    "sha1": "f1nz3j4z6p4i2sr0fjpq3h21ri9bx54j",
+    "sha1": "9294be52cc41c081af74206b11c9359fc8f16d70",
     "deps": [
       "boblibrary"
     ],
@@ -72,7 +72,7 @@
     "version": "0.18.1",
     "file_name": "bobgreenhouse_0.18.1.zip",
     "download_url": "/download/bobgreenhouse/5e98951a6bb914000bcc7c0c",
-    "sha1": "g3vsdr605hw2i2wrvzwb5lk9lrlynjrc",
+    "sha1": "2c4beb69a669d2b2f8df998b28382cc0e4a6f778",
     "deps": [
       "boblibrary"
     ],
@@ -85,7 +85,7 @@
     "version": "0.18.4",
     "file_name": "bobinserters_0.18.4.zip",
     "download_url": "/download/bobinserters/5edd6b670c4233000c076243",
-    "sha1": "5al5j71cb2v0hyc7r8bldvqi8jbrkvzj",
+    "sha1": "f2ef99974411ef4617ca877908b6582c1c59a82a",
     "deps": [],
     "optionalDeps": []
   },
@@ -94,7 +94,7 @@
     "version": "0.18.9",
     "file_name": "boblibrary_0.18.9.zip",
     "download_url": "/download/boblibrary/5e9daef69e85eb000cee2549",
-    "sha1": "sgzjq2kp96qckwmy26f4mh0zs884702f",
+    "sha1": "4e804310d21fc04a9c11bef2c9b049770a2cffd3",
     "deps": [],
     "optionalDeps": []
   },
@@ -103,7 +103,7 @@
     "version": "0.18.9",
     "file_name": "boblogistics_0.18.9.zip",
     "download_url": "/download/boblogistics/5eaaf2fe89f712000c87bcdb",
-    "sha1": "9n2m6jmyjq2dhi6c3n12c59l4q1gcxj6",
+    "sha1": "4676f60226341526821dcc44d80496be4a53854d",
     "deps": [
       "boblibrary"
     ],
@@ -117,7 +117,7 @@
     "version": "0.18.1",
     "file_name": "bobmining_0.18.1.zip",
     "download_url": "/download/bobmining/5e6aa97bd1a668000d4baea5",
-    "sha1": "nvafswxyzhllz2vhkd52d2gyg04nwi5r",
+    "sha1": "b9446e0978fe89264a9b708b4f29fcbe73edd4b6",
     "deps": [
       "boblibrary"
     ],
@@ -131,7 +131,7 @@
     "version": "0.18.3",
     "file_name": "bobmodules_0.18.3.zip",
     "download_url": "/download/bobmodules/5ec96a713cf12a000e056513",
-    "sha1": "9dn8y3s9n03jgfjrw2nvqrflik89b1h4",
+    "sha1": "048695d08cd465bcade059ba2707b0490f8f6c4b",
     "deps": [
       "boblibrary"
     ],
@@ -146,7 +146,7 @@
     "version": "0.18.3",
     "file_name": "bobores_0.18.3.zip",
     "download_url": "/download/bobores/5ec96a823cf12a000b34fcb0",
-    "sha1": "dp8lsh6arkl7wysvkygwiycv2sajr4jc",
+    "sha1": "4c922c95169bf9c89f9f5b7b7ee8ccca404dd16d",
     "deps": [
       "boblibrary"
     ],
@@ -157,7 +157,7 @@
     "version": "0.18.8",
     "file_name": "bobplates_0.18.8.zip",
     "download_url": "/download/bobplates/5ec96a9bc15abe000c94659e",
-    "sha1": "vyh086cfp6igiiq8a5nx0jnmgc434j5p",
+    "sha1": "b74832087bd54ad06d5108c7f8a2b98e1904a0df",
     "deps": [
       "boblibrary"
     ],
@@ -171,7 +171,7 @@
     "version": "0.18.6",
     "file_name": "bobpower_0.18.6.zip",
     "download_url": "/download/bobpower/5ec96ab3552ff2000b2edbfc",
-    "sha1": "gh6sxlhl9d0l8iq867a44lbnga2blsix",
+    "sha1": "3d6aba847a765142d431084744414b14d2ae0d7c",
     "deps": [
       "boblibrary"
     ],
@@ -184,7 +184,7 @@
     "version": "0.18.5",
     "file_name": "bobrevamp_0.18.5.zip",
     "download_url": "/download/bobrevamp/5ec96ac7552ff2000e291dea",
-    "sha1": "yvkfxwqvcc2lfns9h4dzhmfdx3h5cycq",
+    "sha1": "987956e0e8cd55f81b81495b4705631bf3eee6f6",
     "deps": [
       "boblibrary"
     ],
@@ -197,7 +197,7 @@
     "version": "0.18.3",
     "file_name": "bobtech_0.18.3.zip",
     "download_url": "/download/bobtech/5e78fa88936116000e23eea5",
-    "sha1": "f64qsxcw4l97wyscv4xww1pmwga95l3y",
+    "sha1": "7ed092d4e3f506ce3bd94c7b7e12259c758d8971",
     "deps": [
       "boblibrary"
     ],
@@ -211,7 +211,7 @@
     "version": "0.18.1",
     "file_name": "bobvehicleequipment_0.18.1.zip",
     "download_url": "/download/bobvehicleequipment/5e6aaa26d1a668000ef977d3",
-    "sha1": "5fv8135j2jrxv61m24akil2daxgqp7wj",
+    "sha1": "929f8b5f574dd03815113598ddb314b28c80b62b",
     "deps": [
       "boblibrary"
     ],
@@ -225,7 +225,7 @@
     "version": "0.18.6",
     "file_name": "bobwarfare_0.18.6.zip",
     "download_url": "/download/bobwarfare/5ec96addc15abe000d64428c",
-    "sha1": "3f0xlni5y1hwmgxx2zinqzpg33h02wgx",
+    "sha1": "fd7101e018ef7e6ce317bdbfca61f0255ada811b",
     "deps": [
       "boblibrary"
     ],
@@ -239,7 +239,7 @@
     "version": "0.18.2",
     "file_name": "clock_0.18.2.zip",
     "download_url": "/download/clock/5ede20bca9868c003ce1c8a3",
-    "sha1": "gsxbn06ly8hfa9w29qbaxnc0ln48jlka",
+    "sha1": "6a528988a580d9ae164e8227e520f2d400bbba7e",
     "deps": [],
     "optionalDeps": []
   }

--- a/pkgs/games/factorio/mods.nix
+++ b/pkgs/games/factorio/mods.nix
@@ -31,8 +31,10 @@ let
       (
         v:
           let
-            deps = map (s: head (splitString " " s)) (filter isRequiredDependency v.dependencies);
-            optionalDeps = map (s: findFirst (e: e != "?") (split " " s)) (filter isOptionalDependency v.dependencies);
+            depNames = map (s: head (splitString " " s)) (filter isRequiredDependency v.dependencies);
+            deps = map (dep: mods."${dep}") depNames;
+            optionalDepNames = map (s: findFirst (e: e != "?") (split " " s)) (filter isOptionalDependency v.dependencies);
+            optionalDeps = map (dep: mods."${dep}") optionalDepNames;
           in
             {
               inherit (v) name;

--- a/pkgs/games/factorio/mods.nix
+++ b/pkgs/games/factorio/mods.nix
@@ -10,18 +10,29 @@ with stdenv.lib;
 let
   modDrv = factorio-utils.modDrv { inherit allRecommendedMods allOptionalMods; };
 
+  mkSrc = let
+    baseUrl = "https://mods.factorio.com/";
+  in
+    v: {
+      name = v.file_name;
+      url = baseUrl + v.download_url;
+      inherit (v) sha1;
+    };
+
   mods = listToAttrs (
     map
-      (v: {
-        inherit (v) name;
-        value = modDrv {
-          name = "${v.name}-${v.version}";
-          src = factorio-utils.fetchurlWithAuth (v.src // { inherit username token; });
-          deps = map (dep: mods."${dep}") v.deps;
-          optionalDeps = map (dep: mods."${dep}") v.optionalDeps;
-          # TODO: Add recommendedDeps
-        };
-      })
+      (
+        v: {
+          inherit (v) name;
+          value = modDrv {
+            name = "${v.name}-${v.version}";
+            src = factorio-utils.fetchurlWithAuth ({ inherit username token; } // mkSrc v);
+            deps = map (dep: mods."${dep}") v.deps;
+            optionalDeps = map (dep: mods."${dep}") v.optionalDeps;
+            # TODO: Add recommendedDeps
+          };
+        }
+      )
       (fromJSON (readFile ./mods.json))
   );
 

--- a/pkgs/games/factorio/mods.nix
+++ b/pkgs/games/factorio/mods.nix
@@ -1,213 +1,29 @@
-# This file is here for demo purposes only, populated with a small sampling of
-# mods. It will eventually be replaced by a nixos-channel that will provide
-# derivations for most or all of the mods tracked through the official mod
-# manager site.
-{ stdenv, fetchurl
+{ stdenv
 , factorio-utils
 , allRecommendedMods ? true
 , allOptionalMods ? false
+, username ? ""
+, token ? "" # get/reset token at https://factorio.com/profile
 }:
+with builtins;
 with stdenv.lib;
 let
   modDrv = factorio-utils.modDrv { inherit allRecommendedMods allOptionalMods; };
+
+  mods = listToAttrs (
+    map
+      (v: {
+        inherit (v) name;
+        value = modDrv {
+          name = "${v.name}-${v.version}";
+          src = factorio-utils.fetchurlWithAuth (v.src // { inherit username token; });
+          deps = map (dep: mods."${dep}") v.deps;
+          optionalDeps = map (dep: mods."${dep}") v.optionalDeps;
+          # TODO: Add recommendedDeps
+        };
+      })
+      (fromJSON (readFile ./mods.json))
+  );
+
 in
-rec {
-
-  bobassembly = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobassembly_0.13.0.zip"
-      ];
-      sha256 = "0c0m7sb45r37g882x0aq8mc82yhfh9j9h8g018d4s5pf93vzr6d1";
-    };
-    deps = [ boblibrary ];
-    optionalDeps = [ bobconfig ];
-    recommendedDeps = [ bobplates ];
-  };
-
-  bobconfig = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobconfig_0.13.1.zip"
-      ];
-      sha256 = "0z4kmggm1slbr3qiy5xahc9nhdffllp21n9nv5gh1zbzv72sb1rp";
-    };
-  };
-
-  bobelectronics = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobelectronics_0.13.1.zip"
-      ];
-      sha256 = "16sn5w33s0ckiwqxx7b2pcsqmhxbxjm2w4h4vd99hwpvdpjyav52";
-    };
-    deps = [ boblibrary ];
-    optionalDeps = [ bobconfig ];
-    recommendedDeps = [ bobplates ];
-  };
-
-  bobenemies = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobenemies_0.13.1.zip"
-      ];
-      sha256 = "1wnb5wsvh9aa3i9mj17f36ybbd13qima3iwshw60i6xkzzqfk44d";
-    };
-    optionalDeps = [ bobconfig ];
-  };
-
-  bobgreenhouse = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobgreenhouse_0.13.2.zip"
-      ];
-      sha256 = "1ql26875dvz2lqln289jg1w6yjzsd0x0pqmd570jffwi5m320rrw";
-    };
-    deps = [ boblibrary ];
-    optionalDeps = [ bobconfig ];
-    recommendedDeps = [ bobplates ];
-  };
-
-  bobinserters = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobinserters_0.13.3.zip"
-      ];
-      sha256 = "0nys9zhaw0v3w2xzrhawr8g2hcxkzdmyqd4s8xm5bnbrgrq86g9z";
-    };
-    deps = [ boblibrary ];
-    optionalDeps = [ bobconfig ];
-    recommendedDeps = [ ];
-  };
-
-  boblibrary = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/boblibrary_0.13.1.zip"
-      ];
-      sha256 = "04fybs626lzxf0p21jl8kakh2mddah7l9m57srk7a87jw5bj1zx8";
-    };
-  };
-
-  boblogistics = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/boblogistics_0.13.7.zip"
-      ];
-      sha256 = "0c91zmyxwsmyv6vm6gp498vb7flqlcyzkbp9s5q1651hpyd378hx";
-    };
-    deps = [ boblibrary ];
-    optionalDeps = [ bobconfig ];
-    recommendedDeps = [ bobplates ];
-  };
-
-  bobmining = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobmining_0.13.1.zip"
-      ];
-      sha256 = "1l7k3v4aizihppgi802fr5b8zbnq2h05c2bbsk5hds239qgxy80m";
-    };
-    deps = [ boblibrary ];
-    optionalDeps = [ bobconfig bobores bobplates ];
-  };
-
-  bobmodules = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobmodules_0.13.0.zip"
-      ];
-      sha256 = "0ggd2gc4s5sbld7gyncbzdgq8gc00mvxjcfv7i2dchcrdzrlr556";
-    };
-    deps = [ boblibrary ];
-    optionalDeps = [ bobconfig ];
-    recommendedDeps = [ bobplates bobassembly bobelectronics ];
-  };
-
-  bobores = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobores_0.13.1.zip"
-      ];
-      sha256 = "1rri70655kj77sdr3zgp56whmcl0gfjmw90jm7lj1jp8l1pdfzb9";
-    };
-    deps = [ boblibrary ];
-    optionalDeps = [ bobconfig ];
-  };
-
-  bobplates = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobplates_0.13.2.zip"
-      ];
-      sha256 = "0iczpa26hflj17k84p4n6wz0pwhbbrfk86dgac4bfz28kqg58nj1";
-    };
-    deps = [ boblibrary ];
-    optionalDeps = [ bobconfig bobenemies ];
-    recommendedDeps = [ bobores bobtech ];
-  };
-
-  bobpower = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobpower_0.13.1.zip"
-      ];
-      sha256 = "18sblnlvprrm2vzlczlki09yj9lr4y64808zrwmcasf7470skar3";
-    };
-    deps = [ boblibrary ];
-    optionalDeps = [ bobconfig ];
-    recommendedDeps = [ bobplates ];
-  };
-
-  bobrevamp = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobrevamp_0.13.0.zip"
-      ];
-      sha256 = "0rkyf61clh8fjg72z9i7r4skvdzgd49ky6s0486xxljhbil4nxb7";
-    };
-    deps = [ boblibrary ];
-  };
-
-  bobtech = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobtech_0.13.0.zip"
-      ];
-      sha256 = "0arc9kilxzdpapn3gh5h8269ssgsjxib4ny0qissq2sg95gxlsn0";
-    };
-    deps = [ boblibrary ];
-    optionalDeps = [ bobenemies ];
-  };
-
-  bobtechsave = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobtechsave_0.13.0.zip"
-      ];
-      sha256 = "1vlv4sgdfd9ldjm8y79n95ms5k6x2i7khjc422lp9080m03v1hcl";
-    };
-  };
-
-  bobwarfare = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/bobwarfare_0.13.4.zip"
-      ];
-      sha256 = "07wzn16i4r0qjm41wfyl17rrhry2vrph08a0kq8w5iy6qcbqqfd3";
-    };
-    deps = [ boblibrary ];
-    optionalDeps = [ boblibrary bobplates ];
-    recommendedDeps = [ bobtech ];
-  };
-
-  clock = modDrv {
-    src = fetchurl {
-      urls = [
-        "https://f.xor.us/factorio-mods/clock_0.13.0.zip"
-      ];
-      sha256 = "0nflywbj6p2kz2w9wff78vskzljrzaf32ib56k3z456d9y8mlxfd";
-    };
-  };
-
-}
+mods

--- a/pkgs/games/factorio/update-mods.sh
+++ b/pkgs/games/factorio/update-mods.sh
@@ -15,7 +15,6 @@ cat mods.json | jq -r '.[].name' | sort -u | while read name; do
     echo "$name $version" 1>&2
 
     release_json="$(jq -r ".releases[] | select(.version == \"${version}\")" <<< "$mod_json")"
-    sha1="$(nix-hash --to-base32 --type sha1 "$(jq -r '.sha1' <<< "$release_json")")"
 
     dependencies="$(jq '.info_json' <<< "$release_json")"
     deps="$(jq '.dependencies | map(split(" ")[0] | select(. != "base" and (.|startswith("?")|not) and (.|startswith("(?)")|not) and (.|startswith("!")|not)))' <<< "$dependencies")"
@@ -26,7 +25,7 @@ cat mods.json | jq -r '.[].name' | sort -u | while read name; do
         version,
         file_name,
         download_url,
-        sha1: \"$sha1\",
+        sha1,
         deps: $deps,
         optionalDeps: $optionalDeps
     }" <<< "$release_json"

--- a/pkgs/games/factorio/update-mods.sh
+++ b/pkgs/games/factorio/update-mods.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p jq nix coreutils curl nix-prefetch-git
+#! nix-shell -i bash -p jq nix coreutils curl
 set -eu -o pipefail
 
 # TODO:
@@ -9,7 +9,7 @@ base_url="https://mods.factorio.com/"
 
 echo "Updating mods."
 
-cat mods.json | jq -r '.[].name' | sort | while read name; do
+cat mods.json | jq -r '.[].name' | sort -u | while read name; do
     mod_json="$(curl -s https://mods.factorio.com/api/mods/${name}/full)"
     version="$(jq -r '.releases[] | .version' <<< "$mod_json" | sort -V | tail -n1)"
     echo "$name $version" 1>&2
@@ -24,7 +24,9 @@ cat mods.json | jq -r '.[].name' | sort | while read name; do
     jq "{
         name: \"$name\",
         version,
-        src: ({name: .file_name, url: (\"$base_url\" + .download_url), sha1: \"$sha1\"}),
+        file_name,
+        download_url,
+        sha1: \"$sha1\",
         deps: $deps,
         optionalDeps: $optionalDeps
     }" <<< "$release_json"

--- a/pkgs/games/factorio/update-mods.sh
+++ b/pkgs/games/factorio/update-mods.sh
@@ -16,19 +16,10 @@ cat mods.json | jq -r '.[].name' | sort -u | while read name; do
 
     release_json="$(jq -r ".releases[] | select(.version == \"${version}\")" <<< "$mod_json")"
 
-    dependencies="$(jq '.info_json' <<< "$release_json")"
-    deps="$(jq '.dependencies | map(split(" ")[0] | select(. != "base" and (.|startswith("?")|not) and (.|startswith("(?)")|not) and (.|startswith("!")|not)))' <<< "$dependencies")"
-    optionalDeps="$(jq '.dependencies | map(select(.|startswith("? ")) | split(" ")[1])' <<< "$dependencies")"
+    info_json="$(jq '.info_json' <<< "$release_json")"
+    dependencies="$(jq '.dependencies' <<< "$info_json")"
 
-    jq "{
-        name: \"$name\",
-        version,
-        file_name,
-        download_url,
-        sha1,
-        deps: $deps,
-        optionalDeps: $optionalDeps
-    }" <<< "$release_json"
+    jq "{ name: \"$name\", version, file_name, download_url, sha1, dependencies: $dependencies}" <<< "$release_json"
 done | jq -s . > mods.new.json
 mv mods.new.json mods.json
 

--- a/pkgs/games/factorio/update-mods.sh
+++ b/pkgs/games/factorio/update-mods.sh
@@ -2,15 +2,15 @@
 #! nix-shell -i bash -p jq nix coreutils curl
 set -eu -o pipefail
 
+# Lint: shellcheck -s bash update-mods.sh
+
 # TODO:
 # - Filter for stable and experimental mods by factorio_version (in info_json) in releases.
 
-base_url="https://mods.factorio.com/"
-
 echo "Updating mods."
 
-cat mods.json | jq -r '.[].name' | sort -u | while read name; do
-    mod_json="$(curl -s https://mods.factorio.com/api/mods/${name}/full)"
+jq -r '.[].name' < mods.json | sort -u | while read -r name; do
+    mod_json="$(curl -s https://mods.factorio.com/api/mods/"${name}"/full)"
     version="$(jq -r '.releases[] | .version' <<< "$mod_json" | sort -V | tail -n1)"
     echo "$name $version" 1>&2
 

--- a/pkgs/games/factorio/update-mods.sh
+++ b/pkgs/games/factorio/update-mods.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p jq nix coreutils curl nix-prefetch-git
+set -eu -o pipefail
+
+# TODO:
+# - Filter for stable and experimental mods by factorio_version (in info_json) in releases.
+
+base_url="https://mods.factorio.com/"
+
+echo "Updating mods."
+
+cat mods.json | jq -r '.[].name' | sort | while read name; do
+    mod_json="$(curl -s https://mods.factorio.com/api/mods/${name}/full)"
+    version="$(jq -r '.releases[] | .version' <<< "$mod_json" | sort -V | tail -n1)"
+    echo "$name $version" 1>&2
+
+    release_json="$(jq -r ".releases[] | select(.version == \"${version}\")" <<< "$mod_json")"
+    sha1="$(nix-hash --to-base32 --type sha1 "$(jq -r '.sha1' <<< "$release_json")")"
+
+    dependencies="$(jq '.info_json' <<< "$release_json")"
+    deps="$(jq '.dependencies | map(split(" ")[0] | select(. != "base" and . != "?" and . != "(?)"))' <<< "$dependencies")"
+    optionalDeps="$(jq '.dependencies | map(select(.|startswith("? ")) | split(" ")[1])' <<< "$dependencies")"
+
+    jq "{
+        name: \"$name\",
+        version,
+        src: ({name: .file_name, url: (\"$base_url\" + .download_url), sha1: \"$sha1\"}),
+        deps: $deps,
+        optionalDeps: $optionalDeps
+    }" <<< "$release_json"
+done | jq -s . > mods.new.json
+mv mods.new.json mods.json
+
+echo "Update successful."

--- a/pkgs/games/factorio/update-mods.sh
+++ b/pkgs/games/factorio/update-mods.sh
@@ -18,7 +18,7 @@ cat mods.json | jq -r '.[].name' | sort | while read name; do
     sha1="$(nix-hash --to-base32 --type sha1 "$(jq -r '.sha1' <<< "$release_json")")"
 
     dependencies="$(jq '.info_json' <<< "$release_json")"
-    deps="$(jq '.dependencies | map(split(" ")[0] | select(. != "base" and . != "?" and . != "(?)"))' <<< "$dependencies")"
+    deps="$(jq '.dependencies | map(split(" ")[0] | select(. != "base" and (.|startswith("?")|not) and (.|startswith("(?)")|not) and (.|startswith("!")|not)))' <<< "$dependencies")"
     optionalDeps="$(jq '.dependencies | map(select(.|startswith("? ")) | split(" ")[1])' <<< "$dependencies")"
 
     jq "{

--- a/pkgs/games/factorio/utils.nix
+++ b/pkgs/games/factorio/utils.nix
@@ -36,10 +36,10 @@ let
   '';
 in
 {
-  fetchurlWithAuth = { name, url, sha256, username, token }:
+  fetchurlWithAuth = { name, url, sha1 ? "", sha256 ? "", username, token }:
     stdenv.lib.overrideDerivation
       (fetchurl {
-        inherit name url sha256;
+        inherit name url sha1 sha256;
         curlOpts = [
           "--get"
           "--data-urlencode"

--- a/pkgs/games/factorio/utils.nix
+++ b/pkgs/games/factorio/utils.nix
@@ -1,8 +1,66 @@
 # This file provides a top-level function that will be used by both nixpkgs and nixos
 # to generate mod directories for use at runtime by factorio.
-{ stdenv }:
+{ stdenv, fetchurl }:
 with stdenv.lib;
+let
+  helpMsg = ''
+
+    ===FETCH FAILED===
+    Please ensure you have set the username and token with config.nix, or
+    /etc/nix/nixpkgs-config.nix if on NixOS.
+
+    Your token can be seen at https://factorio.com/profile (after logging in). It is
+    not as sensitive as your password, but should still be safeguarded. There is a
+    link on that page to revoke/invalidate the token, if you believe it has been
+    leaked or wish to take precautions.
+
+    Example:
+    {
+      packageOverrides = pkgs: {
+        factorio = pkgs.factorio.override {
+          username = "FactorioPlayer1654";
+          token = "d5ad5a8971267c895c0da598688761";
+        };
+      };
+    }
+
+    Alternatively, instead of providing the username+token, you may manually
+    download the release through https://factorio.com/download , then add it to
+    the store using e.g.:
+
+      releaseType=alpha
+      version=0.17.74
+      nix-prefetch-url file://$HOME/Downloads/factorio_\''${releaseType}_x64_\''${version}.tar.xz --name factorio_\''${releaseType}_x64-\''${version}.tar.xz
+
+    Note the ultimate "_" is replaced with "-" in the --name arg!
+  '';
+in
 {
+  fetchurlWithAuth = { name, url, sha256, username, token }:
+    stdenv.lib.overrideDerivation
+      (fetchurl {
+        inherit name url sha256;
+        curlOpts = [
+          "--get"
+          "--data-urlencode"
+          "username@username"
+          "--data-urlencode"
+          "token@token"
+        ];
+      })
+      (_: {
+        # This preHook hides the credentials from /proc
+        preHook = ''
+          echo -n "${username}" >username
+          echo -n "${token}"    >token
+        '';
+        failureHook = ''
+          cat <<EOF
+          ${helpMsg}
+          EOF
+        '';
+      });
+
   mkModDirDrv = mods: # a list of mod derivations
     let
       recursiveDeps = modDrv: [modDrv] ++ map recursiveDeps modDrv.deps;


### PR DESCRIPTION
###### Motivation for this change

Simplify factorio mod management in NixOS.

Todos:
- [x] Handle incompatible dependencies (prefixed by "!").
- [ ] Handle missing optional dependencies, i.e. optional dependencies that are not in factorio-mods.
- [ ] Handle mods for stable (0.17) and experimental (0.18) factorio. Provide factorio-mods and factorio-mods-experimental, similar to factorio and factorio-experimental.
- [ ] Handle/mention the licenses of the mods.
- [ ] Squash (some) commits and submit PR.

Future improvements (not in this PR):
- Include some more mods. In addition to Bob's mods I'd like to have Angel's mods, the AAI mods and RSO since I currently use them and they have a pretty high rating.
- Get in touch with the factorio devs and ask them for sha256 checksums for the mods, so we can get rid of sha1.

Additional informaiton:
- I use sha1 for veriying the downloaded mods. This is nice, because we get the sha1 sum from the mod portal api and I don't need to download all mods for each update but it is also not nice, because it's sha1.
- I currently ignore hidden optional deps (prefixed with "(?)"). I'm not sure if it would make sense to handle them any other way than ignoring them.
- Some mods are available on github (e.g. Angel's mods). Does it make sense to build them from source instead of using this "general solution"? => I go for the uniform solution and take all mods from the mod portal.
- Recommended dependencies might make sense but AFAIK they are only a concept in texts (e.g. Bob's mods should be used together) and not available from the API. Should we remove them or manually add them to the json (and keep them when updating)? => I ignore them for now.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
