### PR TITLE
pythonPackages.pytorch: 1.4.1 -> 1.5.0

### DIFF
--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -104,7 +104,7 @@ let
     "LD_LIBRARY_PATH=${cudaStub}\${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH ";
 
 in buildPythonPackage rec {
-  version = "1.4.1";
+  version = "1.5.0";
   pname = "pytorch";
   disabled = !isPy3k;
 
@@ -118,7 +118,7 @@ in buildPythonPackage rec {
     repo   = "pytorch";
     rev    = "v${version}";
     fetchSubmodules = true;
-    sha256 = "1aa1il4f98pswfj20cv27yfb91l1jcq4515i7mvq7sh5647yzwms";
+    sha256 = "19qyrjd72mc0llcfn50av8ym05f2iwa38gv068wykji4ph7qjlv2";
   };
 
   preConfigure = lib.optionalString cudaSupport ''
@@ -127,24 +127,6 @@ in buildPythonPackage rec {
   '' + lib.optionalString (cudaSupport && cudnn != null) ''
     export CUDNN_INCLUDE_DIR=${cudnn}/include
   '';
-
-  patches = [
-    # Prevents a race condition which would be introduced by pull 30333.
-    # See https://github.com/pytorch/pytorch/issues/32277
-    # Can be removed >1.5.0.
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/30332.patch";
-      sha256 = "1v9dwbhz3rdxcx6sz8y8j9n3bj6nqs78b1r8yg89yc15n6l4cqx2";
-    })
-
-    # Fixes errors with gcc-9 compilation. Cherry-picked on advice from ezyang.
-    # See https://github.com/pytorch/pytorch/issues/32277
-    # Can be removed >1.5.0.
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/30333.patch";
-      sha256 = "139413fl37h2fnil0cv99a67mqqnsh02k74b92by1qyr6pcfyg3q";
-    })
-  ];
 
   # Use pytorch's custom configurations
   dontUseCmakeConfigure = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update pytorch to 1.5.0

The 1.4.1 version is broken for CUDA builds, see https://github.com/NixOS/nixpkgs/issues/89403
Also, the Nix package of pytorch on nixpkgs required some patches, but those were fixed in 1.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Testing

```
$ NIX_PATH="nixpkgs=/home/arsleust/nixpkgs" nix-shell -p python3Packages.pytorch

[nix-shell:~/nixpkgs]$ python
Python 3.7.7 (default, Mar 10 2020, 06:34:06) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> torch.__version__
'1.5.0'
>>> torch.cuda.is_available()
True
```