### PR TITLE
kapptemplate: init at 19.12.3

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -89,6 +89,7 @@ let
       kaddressbook = callPackage ./kaddressbook.nix {};
       kalarm = callPackage ./kalarm.nix {};
       kalarmcal = callPackage ./kalarmcal.nix {};
+      kapptemplate = callPackage ./kapptemplate.nix { };
       kate = callPackage ./kate.nix {};
       kbreakout = callPackage ./kbreakout.nix {};
       kcachegrind = callPackage ./kcachegrind.nix {};

--- a/pkgs/applications/kde/kapptemplate.nix
+++ b/pkgs/applications/kde/kapptemplate.nix
@@ -1,0 +1,24 @@
+{ lib
+, mkDerivation
+, fetchurl
+, cmake
+, extra-cmake-modules
+, qtbase
+, kactivities
+}:
+mkDerivation {
+
+  name = "kapptemplate";
+
+  nativeBuildInputs = [ extra-cmake-modules cmake  ];
+
+  buildInputs = [ kactivities qtbase ];
+
+  meta = with lib; {
+    description = "KDE App Code Template Generator";
+    license = licenses.gpl2;
+    homepage = "https://kde.org/applications/en/development/org.kde.kapptemplate";
+    maintainers = [ maintainers.shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20395,7 +20395,7 @@ in
 
   inherit (kdeApplications)
     akonadi akregator ark dolphin dragon elisa ffmpegthumbs filelight gwenview k3b
-    kaddressbook kate kcachegrind kcalc kcharselect kcolorchooser kdenlive kdf kdialog
+    kaddressbook kapptemplate kate kcachegrind kcalc kcharselect kcolorchooser kdenlive kdf kdialog
     keditbookmarks kfind kget kgpg khelpcenter kig kleopatra kmail kmix kmplot kolourpaint kompare konsole yakuake
     kpkpass kitinerary kontact korganizer krdc krfb ksystemlog ktouch kwalletmanager marble minuet okular spectacle;
 


### PR DESCRIPTION
###### Motivation for this change
Nice utility to quickly start the developpment of a new KDE app.

###### Things done
Packaged KAppTemplate 19.12.3 (in pkgs.kdeApplications) 

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
