### PR TITLE
[20.03] pyxdg: fix missing class field Type

### DIFF
--- a/pkgs/development/python-modules/pyxdg/default.nix
+++ b/pkgs/development/python-modules/pyxdg/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -14,6 +15,14 @@ buildPythonPackage rec {
 
   # error: invalid command 'test'
   doCheck = false;
+
+  patches = [ 
+    # see: https://gitlab.freedesktop.org/xdg/pyxdg/-/merge_requests/5 
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/xdg/pyxdg/-/commit/78405aaa34463db2c6f33ca28ae2293dd3bb1e91.patch";
+      sha256 = "17cjax546rkqv5kvwczjqjdd6vmlvcxjanz0296dlfq23j2wbx63";
+    })
+  ];
 
   meta = with stdenv.lib; {
     homepage = http://freedesktop.org/wiki/Software/pyxdg;


### PR DESCRIPTION
Fixes #88593 by replacing call to missing Type field with getType()

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Helps with Xpra

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
