### PR TITLE
prometheus-keylight-exporter: init at 0.1.1

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -28,6 +28,7 @@ let
     "dovecot"
     "fritzbox"
     "json"
+    "keylight"
     "mail"
     "mikrotik"
     "minio"

--- a/nixos/modules/services/monitoring/prometheus/exporters/keylight.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/keylight.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, options }:
+
+with lib;
+
+let
+  cfg = config.services.prometheus.exporters.keylight;
+in
+{
+  port = 9288;
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.prometheus-keylight-exporter}/bin/keylight_exporter \
+          -metrics.addr ${cfg.listenAddress}:${toString cfg.port} \
+          ${concatStringsSep " \\\n  " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -202,6 +202,25 @@ let
       '';
     };
 
+    keylight = {
+      # A hardware device is required to properly test this exporter, so just
+      # perform a couple of basic sanity checks that the exporter is running
+      # and requires a target, but cannot reach a specified target.
+      exporterConfig = {
+        enable = true;
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-keylight-exporter.service")
+        wait_for_open_port(9288)
+        succeed(
+            "curl -sS --write-out '%{http_code}' -o /dev/null http://localhost:9288/metrics | grep -q '400'"
+        )
+        succeed(
+            "curl -sS --write-out '%{http_code}' -o /dev/null http://localhost:9288/metrics?target=nosuchdevice | grep -q '500'"
+        )
+      '';
+    };
+
     mail = {
       exporterConfig = {
         enable = true;

--- a/pkgs/servers/monitoring/prometheus/keylight-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/keylight-exporter.nix
@@ -4,8 +4,6 @@ buildGoModule rec {
   pname = "keylight-exporter";
   version = "0.1.1";
 
-  goPackagePath = "github.com/mdlayher/keylight_exporter";
-
   src = fetchFromGitHub {
     owner = "mdlayher";
     repo = "keylight_exporter";

--- a/pkgs/servers/monitoring/prometheus/keylight-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/keylight-exporter.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "keylight-exporter";
+  version = "0.1.1";
+
+  goPackagePath = "github.com/mdlayher/keylight_exporter";
+
+  src = fetchFromGitHub {
+    owner = "mdlayher";
+    repo = "keylight_exporter";
+    rev = "v${version}";
+    sha256 = "141npawcnxj3sz2xqsnyf06r4x1azk3g55941i8gjr7pwcla34r7";
+  };
+
+  vendorSha256 = "0w065ls8dp687jmps4xdffcarss1wyls14dngr43g58xjw6519gb";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mdlayher/keylight_exporter";
+    description = "Prometheus exporter for Elgato Key Light devices.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mdlayher ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16134,6 +16134,7 @@ in
   prometheus-gitlab-ci-pipelines-exporter = callPackage ../servers/monitoring/prometheus/gitlab-ci-pipelines-exporter.nix { };
   prometheus-haproxy-exporter = callPackage ../servers/monitoring/prometheus/haproxy-exporter.nix { };
   prometheus-json-exporter = callPackage ../servers/monitoring/prometheus/json-exporter.nix { };
+  prometheus-keylight-exporter = callPackage ../servers/monitoring/prometheus/keylight-exporter.nix { };
   prometheus-mail-exporter = callPackage ../servers/monitoring/prometheus/mail-exporter.nix { };
   prometheus-mesos-exporter = callPackage ../servers/monitoring/prometheus/mesos-exporter.nix { };
   prometheus-mikrotik-exporter = callPackage ../servers/monitoring/prometheus/mikrotik-exporter.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- New Prometheus exporter for Elgato Key Light devices
- Pushing my package upstream so I don't have to maintain an overlay locally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[matt@servnerr-3:~/src/nixpkgs]$ nix-build -A prometheus-keylight-exporter
these derivations will be built:                                                                 
  /nix/store/p7yr2jywg2jv3dyxqsb4wd5dyppi226s-keylight-exporter-0.1.1.drv                                                                                                                          
building '/nix/store/p7yr2jywg2jv3dyxqsb4wd5dyppi226s-keylight-exporter-0.1.1.drv'...
...
/nix/store/7i3ydp9rysjbscwp2czzp8qkgypxifqd-keylight-exporter-0.1.1
                                                                                                 
[matt@servnerr-3:~/src/nixpkgs]$ ./result/bin/keylight_exporter -h
Usage of ./result/bin/keylight_exporter:
  -metrics.addr string
        address for Elgato Key Light exporter (default ":9288")
  -metrics.path string
        URL path for surfacing collected metrics (default "/metrics")

[matt@servnerr-3:~/src/nixpkgs]$ ./result/bin/keylight_exporter
2020/06/08 10:19:51 starting Elgato Key Light exporter on ":9288"
```