### PR TITLE
devilutionx: fix build dependency on SDL2

### DIFF
--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -19,7 +19,11 @@ in stdenv.mkDerivation rec {
     "-I${SDL2_ttf}/include/SDL2"
     ''-DTTF_FONT_PATH="${placeholder "out"}/share/fonts/truetype/CharisSILB.ttf"''
   ];
-
+  
+  cmakeFlags = [ 
+    "-DBINARY_RELEASE=ON" 
+  ];
+  
   nativeBuildInputs = [ pkg-config cmake ];
   buildInputs = [ libsodium SDL2' SDL2_mixer SDL2_ttf ];
 

--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -1,5 +1,10 @@
 { stdenv, fetchFromGitHub, cmake, SDL2, SDL2_mixer, SDL2_ttf, libsodium, pkg-config }:
-stdenv.mkDerivation rec {
+
+let
+  # Cmake needs static SDL2
+  SDL2' = SDL2.override { withStatic = true; };
+
+in stdenv.mkDerivation rec {
   version = "1.0.1";
   pname = "devilutionx";
 
@@ -16,7 +21,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ pkg-config cmake ];
-  buildInputs = [ libsodium SDL2 SDL2_mixer SDL2_ttf ];
+  buildInputs = [ libsodium SDL2' SDL2_mixer SDL2_ttf ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
###### Motivation for this change

This fixes broken build of `devilutionx`, which was caused by removing static build of SDL2. Explanation can be found [here](https://github.com/NixOS/nixpkgs/pull/88519).

Also, I've added the flag `BINARY_RELEASE=ON"`to CMake build, which among other things greatly reduces the size of the  executable.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
