### PR TITLE
ytalk: init at 3.3.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/ytalk/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ytalk/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "ytalk";
+  version = "3.3.0";
+
+  src = fetchurl {
+    url = "ftp://ftp.ourproject.org/pub/ytalk/${pname}-${version}.tar.gz";
+    sha256 = "1d3jhnj8rgzxyxjwfa22vh45qwzjvxw1qh8fz6b7nfkj3zvk9jvf";
+  };
+
+  buildInputs = [ ncurses ];
+
+  meta = {
+    homepage    = "http://ytalk.ourproject.org";
+    description = "A terminal based talk client";
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ taeer ];
+    license     = stdenv.lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23381,6 +23381,8 @@ in
 
   youtube-viewer = perlPackages.WWWYoutubeViewer;
 
+  ytalk = callPackage ../applications/networking/instant-messengers/ytalk { };
+
   ytcc = callPackage ../tools/networking/ytcc { };
 
   zam-plugins = callPackage ../applications/audio/zam-plugins { };


### PR DESCRIPTION
###### Motivation for this change
I wanted to be able to use ytalk

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [N/A] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
