### PR TITLE
unixODBCDrivers: fix sqlite driver to link with sqlite3

### DIFF
--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -108,7 +108,7 @@
 
     buildInputs = [ unixODBC sqlite zlib libxml2 ];
 
-    configureFlags = [ "--with-odbc=${unixODBC}" ];
+    configureFlags = [ "--with-odbc=${unixODBC}" "--with-sqlite3=${sqlite.dev}" ];
 
     installTargets = [ "install-3" ];
 


### PR DESCRIPTION
Without this change, it doesn't actually link to libsqlite3.so
correctly, and so the output driver has unresolved symbols.

###### Motivation for this change

Someone on IRC noticed the unixODBC sqlite3 driver was broken, and I dug into it and eventually found this to be the problem.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @vlstill as the maintainer