### PR TITLE
nixos/gnome3: nixos-artwork -> pkgs.nixos-artwork

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -320,8 +320,8 @@ in
         gnome-shell
         gnome-shell-extensions
         gnome-themes-extra
-        nixos-artwork.wallpapers.simple-dark-gray
-        nixos-artwork.wallpapers.simple-dark-gray-bottom
+        pkgs.nixos-artwork.wallpapers.simple-dark-gray
+        pkgs.nixos-artwork.wallpapers.simple-dark-gray-bottom
         pkgs.gnome-user-docs
         pkgs.orca
         pkgs.glib # for gsettings


### PR DESCRIPTION
cc @worldofpeace

```
$ sudo nixos-rebuild -I nixpkgs=. dry-build --show-trace
building the system configuration...
error: while evaluating the attribute 'activationScript' of the derivation 'nixos-system-laptop-nixos-20.09.git.944a86ed1a5M' at /home/zowoq/src/nixpkgs/nixos/modules/system/activation/top-level.nix:95:5:
while evaluating the attribute 'system.activationScripts.script' at /home/zowoq/src/nixpkgs/nixos/modules/system/activation/activation-script.nix:68:9:
while evaluating 'textClosureMap' at /home/zowoq/src/nixpkgs/lib/strings-with-deps.nix:70:35, called from /home/zowoq/src/nixpkgs/nixos/modules/system/activation/activation-script.nix:89:18:
while evaluating 'id' at /home/zowoq/src/nixpkgs/lib/trivial.nix:14:5, called from undefined position:
while evaluating the attribute 'text' at /home/zowoq/src/nixpkgs/nixos/modules/system/activation/activation-script.nix:9:5:
while evaluating the attribute 'text' at /home/zowoq/src/nixpkgs/lib/strings-with-deps.nix:77:38:
while evaluating the attribute 'sources' of the derivation 'etc' at /home/zowoq/src/nixpkgs/nixos/modules/system/etc/etc.nix:12:5:
while evaluating anonymous function at /home/zowoq/src/nixpkgs/nixos/modules/system/etc/etc.nix:20:20, called from undefined position:
while evaluating the attribute 'source' at undefined position:
while evaluating anonymous function at /home/zowoq/src/nixpkgs/lib/modules.nix:84:45, called from undefined position:
while evaluating the attribute 'value' at /home/zowoq/src/nixpkgs/lib/modules.nix:383:9:
while evaluating the option `environment.etc.dbus-1.source':
while evaluating the attribute 'mergedValue' at /home/zowoq/src/nixpkgs/lib/modules.nix:415:5:
while evaluating anonymous function at /home/zowoq/src/nixpkgs/lib/modules.nix:417:17, called from /home/zowoq/src/nixpkgs/lib/modules.nix:417:12:
while evaluating 'check' at /home/zowoq/src/nixpkgs/lib/types.nix:251:15, called from /home/zowoq/src/nixpkgs/lib/modules.nix:417:22:
while evaluating the attribute 'serviceDirectories' of the derivation 'dbus-1' at /home/zowoq/src/nixpkgs/pkgs/build-support/trivial-builders.nix:7:7:
while evaluating anonymous function at /home/zowoq/src/nixpkgs/lib/types.nix:263:14, called from undefined position:
while evaluating the attribute 'value' at /home/zowoq/src/nixpkgs/lib/modules.nix:428:27:
while evaluating anonymous function at /home/zowoq/src/nixpkgs/lib/modules.nix:417:17, called from /home/zowoq/src/nixpkgs/lib/modules.nix:417:12:
while evaluating 'check' at /home/zowoq/src/nixpkgs/lib/types.nix:251:15, called from /home/zowoq/src/nixpkgs/lib/modules.nix:417:22:
while evaluating the attribute 'passAsFile' of the derivation 'system-path' at /home/zowoq/src/nixpkgs/pkgs/build-support/trivial-builders.nix:7:7:
while evaluating the attribute 'environment.systemPackages' at undefined position:
while evaluating anonymous function at /home/zowoq/src/nixpkgs/lib/modules.nix:84:45, called from undefined position:
while evaluating the attribute 'value' at /home/zowoq/src/nixpkgs/lib/modules.nix:383:9:
while evaluating the option `environment.systemPackages':
while evaluating the attribute 'mergedValue' at /home/zowoq/src/nixpkgs/lib/modules.nix:415:5:
while evaluating 'merge' at /home/zowoq/src/nixpkgs/lib/types.nix:262:20, called from /home/zowoq/src/nixpkgs/lib/modules.nix:417:59:
while evaluating anonymous function at /home/zowoq/src/nixpkgs/lib/types.nix:263:35, called from undefined position:
while evaluating anonymous function at /home/zowoq/src/nixpkgs/lib/lists.nix:116:29, called from undefined position:
while evaluating anonymous function at /home/zowoq/src/nixpkgs/lib/types.nix:265:23, called from /home/zowoq/src/nixpkgs/lib/lists.nix:116:32:
while evaluating the attribute 'optionalValue' at /home/zowoq/src/nixpkgs/lib/modules.nix:427:5:
while evaluating the attribute 'values' at /home/zowoq/src/nixpkgs/lib/modules.nix:409:9:
while evaluating the attribute 'values' at /home/zowoq/src/nixpkgs/lib/modules.nix:508:7:
while evaluating anonymous function at /home/zowoq/src/nixpkgs/lib/modules.nix:395:28, called from /home/zowoq/src/nixpkgs/lib/modules.nix:395:17:
while evaluating definitions from `/home/zowoq/src/nixpkgs/nixos/modules/services/x11/desktop-managers/gnome3.nix':
while evaluating 'dischargeProperties' at /home/zowoq/src/nixpkgs/lib/modules.nix:467:25, called from /home/zowoq/src/nixpkgs/lib/modules.nix:396:137:
while evaluating the attribute 'value' at /home/zowoq/src/nixpkgs/lib/types.nix:269:40:
undefined variable 'nixos-artwork' at /home/zowoq/src/nixpkgs/nixos/modules/services/x11/desktop-managers/gnome3.nix:323:9
```