### PR TITLE
ctzpos-cups: init at 1.2.4

### DIFF
--- a/pkgs/misc/cups/drivers/ctzpos-cups/default.nix
+++ b/pkgs/misc/cups/drivers/ctzpos-cups/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, fetchurl, cups, gcc, rpmextract }:
+
+stdenv.mkDerivation rec {
+  pname = "ctzpos-cups";
+  version = "1.2.4";
+
+  src = fetchurl {
+    url = "https://www.citizen-systems.co.jp/english/support/download/printer/driver/cups/data_cups/${version}.0/ctzpos-cups-${version}-0.src.rpm";
+    sha256 = "0lpligmhvvr0j39f5lc8f7y44zjry95d681wm65jw76alavfn1wa";
+  };
+
+  nativeBuildInputs = [ rpmextract ];
+  buildInputs = [ cups gcc ];
+
+  unpackCmd = "rpmextract $src; tar xf *.tar.bz2";
+  sourceRoot = "ctzpos-cups-${version}";
+
+  patchPhase = ''
+    for SRC in *.c; do
+      sed -i 's/inline /static inline /g' $SRC
+    done   
+  '';
+
+  buildPhase = ''
+    for SRC in *.c; do
+      OBJ=`echo $SRC | sed "s/\.c//"`
+      gcc -Wall -fPIC -O2 -o $OBJ $SRC -lcupsimage -lcups
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/cups/model
+    mkdir -p $out/lib/cups/filter
+
+    # install ppds 
+    cp -r *.ppd $out/share/cups/model/
+    chmod 0644 $out/share/cups/model/*.ppd
+
+    # install binaries
+    for SRC in *.c; do
+      OBJ=`echo $SRC | sed "s/\.c//"`
+      cp $OBJ $out/lib/cups/filter
+      chmod 0755 $OBJ
+    done
+  '';
+
+  preFixup = ''
+    for OUT in $out/lib/cups/filter/*; do
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+               --set-rpath ${stdenv.lib.getLib cups}/lib:${stdenv.lib.getLib gcc}/lib $OUT;
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "CUPS drivers for CITIZEN POS printers";
+    homepage = https://www.citizen-systems.co.jp/english/;
+    downloadPage = https://www.citizen-systems.co.jp/english/support/download/printer/driver/cups/index.html;
+    license = licenses.unfree;
+    maintainers = [ maintainers.noneucat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26092,6 +26092,8 @@ in
 
   canon-cups-ufr2 = callPackage ../misc/cups/drivers/canon { };
 
+  ctzpos-cups = callPackage ../misc/cups/drivers/ctzpos-cups { };
+
   hll2390dw-cups = callPackage ../misc/cups/drivers/hll2390dw-cups { };
 
   mfcj470dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj470dwcupswrapper { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This pull request adds the package `ctzpos-cups`, which provides CUPS PPDs and filters compiled from source for CITIZEN-brand POS printers. Tested with a CITIZEN CT-S310II.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
