### PR TITLE
onedrive: 2.3.13 -> 2.4.2

### DIFF
--- a/pkgs/applications/networking/sync/onedrive/default.nix
+++ b/pkgs/applications/networking/sync/onedrive/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, dmd, installShellFiles, pkgconfig
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, ldc, installShellFiles, pkgconfig
 , curl, sqlite, libnotify
 , withSystemd ? stdenv.isLinux, systemd ? null }:
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "10s33p1xzq9c5n1bxv9n7n31afxgx9i6c17w0xgxdrma75micm3a";
   };
 
-  nativeBuildInputs = [ autoreconfHook dmd installShellFiles pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook ldc installShellFiles pkgconfig ];
 
   buildInputs = [
     curl sqlite libnotify

--- a/pkgs/applications/networking/sync/onedrive/default.nix
+++ b/pkgs/applications/networking/sync/onedrive/default.nix
@@ -1,21 +1,37 @@
-{ stdenv, fetchFromGitHub, dmd, pkgconfig, curl, sqlite, libnotify }:
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, dmd, installShellFiles, pkgconfig
+, curl, sqlite, libnotify
+, withSystemd ? stdenv.isLinux, systemd ? null }:
 
 stdenv.mkDerivation rec {
   pname = "onedrive";
-  version = "2.3.13";
+  version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "abraunegg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0bcsrfh1g7bdlcp0zjn6np88qzpn5frv61lzxz9b2ayxf7wyybvi";
+    sha256 = "10s33p1xzq9c5n1bxv9n7n31afxgx9i6c17w0xgxdrma75micm3a";
   };
 
-  nativeBuildInputs = [ dmd pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook dmd installShellFiles pkgconfig ];
 
-  buildInputs = [ curl sqlite libnotify ];
+  buildInputs = [
+    curl sqlite libnotify
+  ] ++ lib.optional withSystemd systemd;
 
-  configureFlags = [ "--enable-notifications" ];
+  configureFlags = [
+    "--enable-notifications"
+  ] ++ lib.optionals withSystemd [
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+    "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user"
+  ];
+
+  # we could also pass --enable-completions to configure but we would then have to
+  # figure out the paths manually and pass those along.
+  postInstall = ''
+    installShellCompletion --bash --name ${pname}  contrib/completions/complete.bash
+    installShellCompletion --zsh  --name _${pname} contrib/completions/complete.zsh
+  '';
 
   meta = with stdenv.lib; {
     description = "A complete tool to interact with OneDrive on Linux";


### PR DESCRIPTION
###### Motivation for this change

Regular update. Also add shell completion and systemd units.

Works well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).