### PR TITLE
enlightenment.efl: add dependence mint-x-icons

### DIFF
--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -39,6 +39,7 @@
 , luajit
 , lz4
 , mesa
+, mint-x-icons
 , openjpeg
 , openssl
 , poppler
@@ -92,7 +93,7 @@ stdenv.mkDerivation rec {
     xorg.libXcursor
     xorg.xorgproto
     zlib
-    # still missing parent icon themes: Mint-X, RAVE-X, Faenza
+    # still missing parent icon themes: RAVE-X, Faenza
   ];
 
   propagatedBuildInputs = [
@@ -107,6 +108,7 @@ stdenv.mkDerivation rec {
     fribidi
     ghostscript
     harfbuzz
+    hicolor-icon-theme # for the icon theme
     jbig2dec
     libdrm
     libinput
@@ -117,6 +119,7 @@ stdenv.mkDerivation rec {
     libwebp
     libxkbcommon
     luajit
+    mint-x-icons # Mint-X is a parent icon theme of Enlightenment-X
     openjpeg
     poppler
     utillinux


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

It provides the Mint-X icon theme, which is a parent of the Enlightenment-X icon theme.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
