### PR TITLE
hostapd: apply patches for CVE-2020-12695

### DIFF
--- a/pkgs/os-specific/linux/hostapd/default.nix
+++ b/pkgs/os-specific/linux/hostapd/default.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
     repositories.git = "git://w1.fi/hostap.git";
     description = "A user space daemon for access point and authentication servers";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ phreedom ninjatrappeur ];
+    maintainers = with maintainers; [ phreedom ninjatrappeur hexa ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/hostapd/default.nix
+++ b/pkgs/os-specific/linux/hostapd/default.nix
@@ -19,10 +19,29 @@ stdenv.mkDerivation rec {
       url = "https://raw.githubusercontent.com/openwrt/openwrt/master/package/network/services/hostapd/patches/300-noscan.patch";
       sha256 = "04wg4yjc19wmwk6gia067z99gzzk9jacnwxh5wyia7k5wg71yj5k";
     })
+    # AP mode PMF disconnection protection bypass (CVE.2019-16275), can be removed >= 2.10
+    # https://w1.fi/security/2019-7/
     (fetchurl {
       name = "CVE-2019-16275.patch";
       url = "https://w1.fi/security/2019-7/0001-AP-Silently-ignore-management-frame-from-unexpected-.patch";
       sha256 = "15xjyy7crb557wxpx898b5lnyblxghlij0xby5lmj9hpwwss34dz";
+    })
+    # Fixes for UPnP SUBSCRIBE misbehavior in hostapd WPS AP (CVE-2020-12695), can be removed >= 2.10
+    # https://w1.fi/security/2020-1/
+    (fetchurl {
+      name = "CVE-2020-12695_0001-WPS-UPnP-Do-not-allow-event-subscriptions-with-URLs-.patch";
+      url = "https://w1.fi/security/2020-1/0001-WPS-UPnP-Do-not-allow-event-subscriptions-with-URLs-.patch";
+      sha256 = "1mrbhicqb34jlw1nid5hk2vnjbvfhvp7r5iblaj4l6vgc6fmp6id";
+    })
+    (fetchurl {
+      name = "CVE-2020-12695_0002-WPS-UPnP-Fix-event-message-generation-using-a-long-U.patch";
+      url = "https://w1.fi/security/2020-1/0002-WPS-UPnP-Fix-event-message-generation-using-a-long-U.patch";
+      sha256 = "1pk08b06b24is50bis3rr56xjd3b5kxdcdk8bx39n9vna9db7zj9";
+    })
+    (fetchurl {
+      name = "CVE-2020-12695_0003-WPS-UPnP-Handle-HTTP-initiation-failures-for-events-.patch";
+      url = "https://w1.fi/security/2020-1/0003-WPS-UPnP-Handle-HTTP-initiation-failures-for-events-.patch";
+      sha256 = "12npqp2skgrj934wwkqicgqksma0fxz09di29n1b5fm5i4njl8d8";
     })
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://w1.fi/security/2020-1/upnp-subscribe-misbehavior-wps-ap.txt

Fixes: CVE-2020-12695

> Vulnerable versions/configurations
> 
> All hostapd versions with WPS AP support with UPnP enabled in the build
> parameters (CONFIG_WPS_UPNP=y) and in the runtime configuration
> (upnp_iface).
> 

We don't enable `CONFIG_WPS_UPNP` and it's not enabled in hostapds `defconfig`, so an enduser would need to overwrite `extraConfig` to enable it for exposure first.

> Possible mitigation steps
> 
> - Disable WPS UPnP support in the hostapd runtime configuration by
>   removing the upnp_iface parameter.
> 
> - Merge the following commits to hostapd and rebuild:
> 
>   For CVE-2020-12695:
>   WPS UPnP: Do not allow event subscriptions with URLs to other networks
>   For the other issues:
>   WPS UPnP: Fix event message generation using a long URL path
>   WPS UPnP: Handle HTTP initiation failures for events more properly
> 
>   These patches are available from https://w1.fi/security/2020-1/
> 
> - Update to hostapd v2.10 or newer, once available
> 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@phreedom @ninjatrappeur