### PR TITLE
python38.pkgs.gst-python: Fix build

### DIFF
--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -45,6 +45,13 @@ buildPythonPackage rec {
       url = "https://github.com/GStreamer/gst-python/commit/f98c206bdf01529f8ea395a719b10baf2bdf717f.patch";
       sha256 = "04n4zrnfivgr7iaqw4sjlbd882s8halc2bbbhfxqf0sg2lqwmrxg";
     })
+  ] ++ [
+    # Fix linking against Python 3.8
+    # https://gitlab.freedesktop.org/gstreamer/gst-python/merge_requests/30
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/gstreamer/gst-python/commit/22f28155d86e27c4134de4ed2861264003fcfd23.patch";
+      sha256 = "Y70qVguHUBmmRVMFBKAP0d6anBQw5W0TKyu2bAwxbQg=";
+    })
   ];
 
   mesonFlags = [


### PR DESCRIPTION
###### Motivation for this change
Closes: https://github.com/NixOS/nixpkgs/issues/82974

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
