### PR TITLE
fltk1{3,4}: refactor

### DIFF
--- a/pkgs/applications/window-managers/afterstep/default.nix
+++ b/pkgs/applications/window-managers/afterstep/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, pkg-config
-, libjpeg, libtiff, libpng, freetype
+, libtiff
 , fltk, gtk
-, libX11, libXext, libICE
+, libICE, libSM
 , dbus
 , fetchpatch
 }:
@@ -24,8 +24,16 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  postPatch = ''
+    # Causes fatal ldconfig cache generation attempt on non-NixOS Linux
+    for mkfile in autoconf/Makefile.common.lib.in libAfter{Base,Image}/Makefile.in; do
+      substituteInPlace $mkfile \
+        --replace 'test -w /etc' 'false'
+    done
+  '';
+
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libjpeg libtiff libpng freetype fltk gtk libX11 libXext libICE dbus dbus ];
+  buildInputs = [ libtiff fltk gtk libICE libSM dbus ];
 
   # A strange type of bug: dbus is not immediately found by pkg-config
   preConfigure = ''

--- a/pkgs/development/libraries/fltk/1.4.nix
+++ b/pkgs/development/libraries/fltk/1.4.nix
@@ -1,52 +1,5 @@
-{ lib, stdenv, fetchurl, pkg-config, xlibsWrapper, xorgproto, libXi
-, freeglut, libGLU, libGL, libjpeg, zlib, libXft, libpng
-, libtiff, freetype, Cocoa, AGL, GLUT
-}:
-
-let
-  version = "1.4.x-r13121";
-in
-
-stdenv.mkDerivation {
-  pname = "fltk";
-  inherit version;
-
-  src = fetchurl {
-    url = "https://www.fltk.org/pub/fltk/snapshots/fltk-${version}.tar.gz";
-    sha256 = "1v8wxvxcbk99i82x2v5fpqg5vj8n7g8a38g30ry7nzcjn5sf3r63";
-  };
-
-  patches = lib.optionals stdenv.isDarwin [ ./nsosv.patch ];
-
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libGLU libGL libjpeg zlib libpng libXft ]
-    ++ lib.optional stdenv.isDarwin [ AGL Cocoa GLUT ];
-
-  propagatedBuildInputs = [ xorgproto ]
-    ++ (if stdenv.isDarwin
-        then [ freetype libtiff ]
-        else [ xlibsWrapper libXi freeglut ]);
-
-  configureFlags = [
-    "--enable-gl"
-    "--enable-largefile"
-    "--enable-shared"
-    "--enable-threads"
-    "--enable-xft"
-  ];
-
-  preConfigure = ''
-    make clean
-    rm VERSION
-  '';
-
-  enableParallelBuilding = true;
-
-  meta = with lib; {
-    description = "A C++ cross-platform lightweight GUI library";
-    homepage = "https://www.fltk.org";
-    platforms = platforms.linux ++ platforms.darwin;
-    license = licenses.gpl2;
-  };
-
+import ./common.nix rec {
+  version = "1.4.x-2021-07-04";
+  rev = "1008cdfab27609a6f6a0e82dadad9fd9cbd8a66d";
+  sha256 = "1h057dyhd04b9bjci952b2l7brxv183l9jw9i50mn9qjfljmvqim";
 }

--- a/pkgs/development/libraries/fltk/common.nix
+++ b/pkgs/development/libraries/fltk/common.nix
@@ -1,0 +1,205 @@
+{ version, rev, sha256 }:
+
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, zlib
+, libjpeg
+, libpng
+, fontconfig
+, freetype
+, libX11
+, libXext
+, libXinerama
+, libXfixes
+, libXcursor
+, libXft
+, libXrender
+, ApplicationServices
+, Carbon
+, Cocoa
+
+, withGL ? true
+, libGL
+, libGLU
+, glew
+, OpenGL
+
+, withCairo ? true
+, cairo
+
+, withPango ? (lib.strings.versionAtLeast version "1.4" && stdenv.hostPlatform.isLinux)
+, pango
+
+, withDocs ? true
+, doxygen
+, graphviz
+, texlive
+
+, withExamples ? true
+, withShared ? true
+}:
+
+let
+  onOff = value: if value then "ON" else "OFF";
+  tex = texlive.combine {
+    inherit (texlive)
+      scheme-medium varwidth multirow hanging adjustbox collectbox stackengine
+      sectsty tocloft newunicodechar etoc;
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "fltk";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "fltk";
+    repo = "fltk";
+    inherit rev sha256;
+  };
+
+  outputs = [ "out" ]
+    ++ lib.optional withExamples "bin"
+    ++ lib.optional withDocs "doc";
+
+  # Manually move example & test binaries to $bin to avoid cyclic dependencies on dev binaries
+  outputBin = lib.optionalString withExamples "out";
+
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [
+    ./nsosv.patch
+  ];
+
+  postPatch = ''
+    patchShebangs documentation/make_*
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ] ++ lib.optionals withDocs [
+    doxygen
+    graphviz
+    tex
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    ApplicationServices
+    Carbon
+  ] ++ lib.optionals (withGL && !stdenv.hostPlatform.isDarwin) [
+    libGL
+    libGLU
+  ] ++ lib.optionals (withExamples && withGL) [
+    glew
+  ];
+
+  propagatedBuildInputs = [
+    zlib
+    libjpeg
+    libpng
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    freetype
+    fontconfig
+    libX11
+    libXext
+    libXinerama
+    libXfixes
+    libXcursor
+    libXft
+    libXrender
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    Cocoa
+  ] ++ lib.optionals (withGL && stdenv.hostPlatform.isDarwin) [
+    OpenGL
+  ] ++ lib.optionals withCairo [
+    cairo
+  ] ++ lib.optionals withPango [
+    pango
+  ];
+
+  cmakeFlags = [
+    # Common
+    "-DOPTION_BUILD_SHARED_LIBS=${onOff withShared}"
+    "-DOPTION_USE_SYSTEM_ZLIB=ON"
+    "-DOPTION_USE_SYSTEM_LIBJPEG=ON"
+    "-DOPTION_USE_SYSTEM_LIBPNG=ON"
+
+    # X11
+    "-DOPTION_USE_XINERAMA=${onOff stdenv.hostPlatform.isLinux}"
+    "-DOPTION_USE_XFIXES=${onOff stdenv.hostPlatform.isLinux}"
+    "-DOPTION_USE_XCURSOR=${onOff stdenv.hostPlatform.isLinux}"
+    "-DOPTION_USE_XFT=${onOff stdenv.hostPlatform.isLinux}"
+    "-DOPTION_USE_XRENDER=${onOff stdenv.hostPlatform.isLinux}"
+    "-DOPTION_USE_XDBE=${onOff stdenv.hostPlatform.isLinux}"
+
+    # GL
+    "-DOPTION_USE_GL=${onOff withGL}"
+    "-DOpenGL_GL_PREFERENCE=GLVND"
+
+    # Cairo
+    "-DOPTION_CAIRO=${onOff withCairo}"
+    "-DOPTION_CAIROEXT=${onOff withCairo}"
+
+    # Pango
+    "-DOPTION_USE_PANGO=${onOff withPango}"
+
+    # Examples & Tests
+    "-DFLTK_BUILD_EXAMPLES=${onOff withExamples}"
+
+    # Docs
+    "-DOPTION_BUILD_HTML_DOCUMENTATION=${onOff withDocs}"
+    "-DOPTION_BUILD_PDF_DOCUMENTATION=${onOff withDocs}"
+    "-DOPTION_INSTALL_HTML_DOCUMENTATION=${onOff withDocs}"
+    "-DOPTION_INSTALL_PDF_DOCUMENTATION=${onOff withDocs}"
+    "-DOPTION_INCLUDE_DRIVER_DOCUMENTATION=${onOff withDocs}"
+  ];
+
+  preBuild = lib.optionalString (withCairo && withShared && stdenv.hostPlatform.isDarwin) ''
+    # unresolved symbols in cairo dylib without this: https://github.com/fltk/fltk/issues/250
+    export NIX_LDFLAGS="$NIX_LDFLAGS -undefined dynamic_lookup"
+  '';
+
+  postBuild = lib.optionalString withDocs ''
+    make docs
+  '';
+
+  postInstall = lib.optionalString withExamples ''
+    mkdir -p $bin/bin
+    mv bin/{test,examples}/* $bin/bin/
+  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/Library/Frameworks
+    mv $out{,/Library/Frameworks}/FLTK.framework
+
+    moveAppBundles() {
+      echo "Moving and symlinking $1"
+      appname="$(basename "$1")"
+      binname="$(basename "$(find "$1"/Contents/MacOS/ -type f -executable | head -n1)")"
+      curpath="$(dirname "$1")"
+
+      mkdir -p "$curpath"/../Applications/
+      mv "$1" "$curpath"/../Applications/
+      [ -f "$curpath"/"$binname" ] && rm "$curpath"/"$binname"
+      ln -s ../Applications/"$appname"/Contents/MacOS/"$binname" "$curpath"/"$binname"
+    }
+
+    rm $out/bin/fluid.icns
+    for app in $out/bin/*.app ${lib.optionalString withExamples "$bin/bin/*.app"}; do
+      moveAppBundles "$app"
+    done
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/bin/fltk-config \
+      --replace "/$out/" "/"
+  '';
+
+  meta = with lib; {
+    description = "A C++ cross-platform lightweight GUI library";
+    homepage = "https://www.fltk.org";
+    platforms = platforms.unix;
+    # LGPL2 with static linking exception
+    # https://www.fltk.org/COPYING.php
+    license = licenses.lgpl2Only;
+  };
+}

--- a/pkgs/development/libraries/fltk/default.nix
+++ b/pkgs/development/libraries/fltk/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  version = "1.3.5";
+  version = "1.3.6";
 in
 
 stdenv.mkDerivation {
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.fltk.org/pub/fltk/${version}/fltk-${version}-source.tar.gz";
-    sha256 = "00jp24z1818k9n6nn6lx7qflqf2k13g4kxr0p8v1d37kanhb4ac7";
+    sha256 = "1arp1niiz3qxm8iacpmilwpc5rinsm6hsk4a6fsxfywvkvppbb4s";
   };
 
   patches = lib.optionals stdenv.isDarwin [ ./nsosv.patch ];

--- a/pkgs/development/libraries/fltk/default.nix
+++ b/pkgs/development/libraries/fltk/default.nix
@@ -1,46 +1,5 @@
-{ lib, stdenv, fetchurl, pkg-config, xlibsWrapper, xorgproto, libXi
-, freeglut, libGL, libGLU, libjpeg, zlib, libXft, libpng
-, libtiff, freetype, Cocoa, AGL, GLUT
-}:
-
-let
+import ./common.nix rec {
   version = "1.3.6";
-in
-
-stdenv.mkDerivation {
-  pname = "fltk";
-  inherit version;
-
-  src = fetchurl {
-    url = "https://www.fltk.org/pub/fltk/${version}/fltk-${version}-source.tar.gz";
-    sha256 = "1arp1niiz3qxm8iacpmilwpc5rinsm6hsk4a6fsxfywvkvppbb4s";
-  };
-
-  patches = lib.optionals stdenv.isDarwin [ ./nsosv.patch ];
-
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libGLU libGL libjpeg zlib libpng libXft ]
-    ++ lib.optional stdenv.isDarwin [ AGL Cocoa GLUT ];
-
-  propagatedBuildInputs = [ xorgproto ]
-    ++ (if stdenv.isDarwin
-        then [ freetype libtiff ]
-        else [ xlibsWrapper libXi freeglut ]);
-
-  configureFlags = [
-    "--enable-gl"
-    "--enable-largefile"
-    "--enable-shared"
-    "--enable-threads"
-    "--enable-xft"
-  ];
-
-  enableParallelBuilding = true;
-
-  meta = with lib; {
-    description = "A C++ cross-platform lightweight GUI library";
-    homepage = "https://www.fltk.org";
-    platforms = platforms.linux ++ platforms.darwin;
-    license = licenses.gpl2;
-  };
+  rev = "release-${version}";
+  sha256 = "0vzk4d6j927v7dxywr5xlqlf70myal1xikkdfvd11p94rcdf9bsv";
 }

--- a/pkgs/tools/X11/virtualgl/lib.nix
+++ b/pkgs/tools/X11/virtualgl/lib.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, cmake
-, libGL, libGLU, libX11, libXv, libXtst, libjpeg_turbo, fltk
+, libGL, libGLU, libXv, libXtst, libXi, libjpeg_turbo, fltk
 , xorg
 , opencl-headers, opencl-clhpp, ocl-icd
 }:
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ libjpeg_turbo libGL libGLU fltk
-    libX11 libXv libXtst xorg.xcbutilkeysyms
+    libXv libXtst libXi xorg.xcbutilkeysyms
     opencl-headers opencl-clhpp ocl-icd
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15056,12 +15056,27 @@ in
   flite = callPackage ../development/libraries/flite { };
 
   fltk13 = callPackage ../development/libraries/fltk {
-    inherit (darwin.apple_sdk.frameworks) Cocoa AGL GLUT;
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices Carbon Cocoa OpenGL;
   };
   fltk14 = callPackage ../development/libraries/fltk/1.4.nix {
-    inherit (darwin.apple_sdk.frameworks) Cocoa AGL GLUT;
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices Carbon Cocoa OpenGL;
   };
-  fltk = res.fltk13;
+  fltk13-minimal = fltk13.override {
+    withGL = false;
+    withCairo = false;
+    withPango = false;
+    withExamples = false;
+    withDocs = false;
+  };
+  fltk14-minimal = fltk14.override {
+    withGL = false;
+    withCairo = false;
+    withPango = false;
+    withExamples = false;
+    withDocs = false;
+  };
+  fltk = fltk13;
+  fltk-minimal = fltk13-minimal;
 
   flyway = callPackage ../development/tools/flyway { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28739,7 +28739,9 @@ in
 
   exult = callPackage ../games/exult { };
 
-  fltrator = callPackage ../games/fltrator { };
+  fltrator = callPackage ../games/fltrator {
+    fltk = fltk-minimal;
+  };
 
   factorio = callPackage ../games/factorio { releaseType = "alpha"; };
 


### PR DESCRIPTION
Needs more comprehensive testing of packages depending on FLTK & which `propagatedBuildInputs` are actually needed. Feedback on whether to keep this attribute-per-option approach or switch to some dynamic attribute name -> CMake option conversion would be great.

###### Motivation for this change
- FLTK versions are split into duplicate derivations
- src uses an deprecated source location
- build is missing alot of the available options
- has no maintainer one could bother about this

###### Things done
- Main derivation logic combined into 1 generic.nix with versions calling it, inspired by `boost`
- moved to CMake
- ~~added all cmake options via attributes that versions can override as needed~~ not all, only some useful ones
- updated 1.4.x to master (no fixed release yet)
- formatted with `nixpkgs-fmt`

~~CMake generates shared libraries with an extra suffix by default, patches *-0001-*
as based on upstream PR https://github.com/fltk/fltk/pull/21 fix this.
CMake switch breaks fltk-config generation, partly addressed in *-0002-*
patches. Hard references to CC and CXX used at FLTK compile time remain,
needs more patching post-build.
Some of the propagatedBuildInputs might not be required, I tested some FLTK
applications with only xorgproto and encountered no problems.
PDF documentation errors, no clue how to fix (uses `texlive` and some more stuff)~~

See comment for in-between assessments.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
