### PR TITLE
kmod: 26 -> 27

### DIFF
--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -8,11 +8,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "kmod";
-  version = "26";
+  version = "27";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/kernel/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "17dvrls70nr3b3x1wm8pwbqy4r8a5c20m0dhys8mjhsnpg425fsp";
+    sha256 = "035wzfzjx4nwidk747p8n085mgkvy531ppn16krrajx2dkqzply1";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig libxslt ];
@@ -38,8 +38,16 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = "https://www.kernel.org/pub/linux/utils/kernel/kmod/";
     description = "Tools for loading and managing Linux kernel modules";
+    longDescription = ''
+      kmod is a set of tools to handle common tasks with Linux kernel modules
+      like insert, remove, list, check properties, resolve dependencies and
+      aliases. These tools are designed on top of libkmod, a library that is
+      shipped with kmod.
+    '';
+    homepage = "https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/";
+    downloadPage = "https://www.kernel.org/pub/linux/utils/kernel/kmod/";
+    changelog = "https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/plain/NEWS?h=v${version}";
     license = licenses.lgpl21;
     platforms = platforms.unix;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
