### PR TITLE
WIP pythonPackages.pypdftk: init at 0.4

### DIFF
--- a/pkgs/development/python-modules/pypdftk/default.nix
+++ b/pkgs/development/python-modules/pypdftk/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+#, glibcLocales
+, python
+, pdftk
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "pypdftk";
+  version = "0.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0kl1kyqi5d8lwzlbv8430qvzz4q2jg8nv5sakd1i1qmnkn61g5n5";
+  };
+
+  #LC_ALL = "en_US.UTF-8";
+  #buildInputs = [ glibcLocales ];
+
+  checkPhase = ''
+    ${python.interpreter} test.py
+  '';
+
+  # Tests broken on Python 3.x
+  doCheck = !(isPy3k);
+
+  meta = with stdenv.lib; {
+    description = "Python wrapper for PDFTK";
+    homepage = "https://github.com/revolunet/pypdftk";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ cap ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5446,6 +5446,10 @@ in {
 
   pypdf2 = callPackage ../development/python-modules/pypdf2 { };
 
+  pypdftk = callPackage ../development/python-modules/pypdftk {
+    inherit (pkgs) pdftk;
+  };
+
   pyopengl = callPackage ../development/python-modules/pyopengl { };
 
   pyopenssl = callPackage ../development/python-modules/pyopenssl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add a python wrapper for pdftk to fill out pdf forms easily. 

###### Thinks I need help with
As this is my first python package I based this one on a copy of pypdf.
It is important to me that someone oversees this package and helps me to make it ready to merge.

* I'm not sure if doCheck = !(isPy3k); is necessary
* pdftk was inherited because pypdftk depends on it. Did I include it the right way?
* the build time is quite long which confuses me

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
