### PR TITLE
python2Packages.nixpart0: fix build

### DIFF
--- a/pkgs/tools/filesystems/nixpart/0.4/cryptsetup.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/cryptsetup.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lvm2, libgcrypt, libuuid, pkgconfig, popt
+{ stdenv, fetchurl, fetchpatch, lvm2, libgcrypt, libuuid, pkgconfig, popt
 , enablePython ? true, python ? null
 }:
 
@@ -11,6 +11,15 @@ stdenv.mkDerivation rec {
     url = "http://cryptsetup.googlecode.com/files/${name}.tar.bz2";
     sha256 = "1n1qk5chyjspbiianrdb55fhb4wl0vfyqz2br05vfb24v4qlgbx2";
   };
+
+  patches = [
+    # Fix build with glibc >= 2.28
+    # https://github.com/NixOS/nixpkgs/issues/86403
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-fs/cryptsetup/files/cryptsetup-1.7.1-sysmacros.patch?id=d72316f97ebcc7fe622b21574442a9ac59b9115f";
+      sha256 = "0xbhazgl44bimqhcrhajk016w9wi7bkrgwyfq13xmrvyrllqvgdx";
+    })
+  ];
 
   configureFlags = [ "--enable-cryptsetup-reencrypt" ]
                 ++ stdenv.lib.optional enablePython "--enable-python";

--- a/pkgs/tools/filesystems/nixpart/0.4/default.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/default.nix
@@ -27,7 +27,7 @@ let
 
   lvm2 = import ./lvm2.nix {
     inherit stdenv fetchurl;
-    inherit (pkgs) pkgconfig utillinux systemd coreutils;
+    inherit (pkgs) fetchpatch pkgconfig utillinux systemd coreutils;
   };
 
   multipath_tools = import ./multipath-tools.nix {

--- a/pkgs/tools/filesystems/nixpart/0.4/default.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/default.nix
@@ -18,7 +18,7 @@ let
 
   cryptsetup = import ./cryptsetup.nix {
     inherit stdenv fetchurl python;
-    inherit (pkgs) pkgconfig libgcrypt libuuid popt lvm2;
+    inherit (pkgs) fetchpatch pkgconfig libgcrypt libuuid popt lvm2;
   };
 
   dmraid = import ./dmraid.nix {

--- a/pkgs/tools/filesystems/nixpart/0.4/default.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/default.nix
@@ -32,7 +32,7 @@ let
 
   multipath_tools = import ./multipath-tools.nix {
     inherit stdenv fetchurl lvm2;
-    inherit (pkgs) readline systemd libaio gzip;
+    inherit (pkgs) fetchpatch readline systemd libaio gzip;
   };
 
   parted = import ./parted.nix {

--- a/pkgs/tools/filesystems/nixpart/0.4/default.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/default.nix
@@ -37,7 +37,7 @@ let
 
   parted = import ./parted.nix {
     inherit stdenv fetchurl;
-    inherit (pkgs) utillinux readline libuuid gettext check lvm2;
+    inherit (pkgs) fetchpatch utillinux readline libuuid gettext check lvm2;
   };
 
   pyblock = import ./pyblock.nix {

--- a/pkgs/tools/filesystems/nixpart/0.4/lvm2.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/lvm2.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, systemd, utillinux, coreutils }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, systemd, utillinux, coreutils }:
 
 let
   v = "2.02.106";
@@ -11,6 +11,18 @@ stdenv.mkDerivation {
     url = "ftp://sources.redhat.com/pub/lvm2/releases/LVM2.${v}.tgz";
     sha256 = "0nr833bl0q4zq52drjxmmpf7bs6kqxwa5kahwwxm9411khkxz0vc";
   };
+
+  patches = [
+    # Fix build with glibc >= 2.28
+    # https://github.com/NixOS/nixpkgs/issues/86403
+    (fetchpatch {
+      url = "https://github.com/lvmteam/lvm2/commit/92d5a8441007f578e000b492cecf67d6b8a87405.patch";
+      sha256 = "1yqd6jng0b370k53vks1shg57yhfyribhpmv19km5zsjqf0qqx2d";
+      excludes = [
+        "libdm/libdm-stats.c"
+      ];
+    })
+  ];
 
   configureFlags = [
     "--disable-readline"

--- a/pkgs/tools/filesystems/nixpart/0.4/multipath-tools.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/multipath-tools.nix
@@ -38,6 +38,11 @@ stdenv.mkDerivation rec {
 
       substituteInPlace libmultipath/defaults.h --replace /lib/udev/scsi_id ${systemd.lib}/lib/udev/scsi_id
       substituteInPlace libmultipath/hwtable.c --replace /lib/udev/scsi_id ${systemd.lib}/lib/udev/scsi_id
+
+      sed -i -re '
+         s,^( *#define +DEFAULT_MULTIPATHDIR\>).*,\1 "'"$out/lib/multipath"'",
+      ' libmultipath/defaults.h
+
     '';
 
   meta = {

--- a/pkgs/tools/filesystems/nixpart/0.4/multipath-tools.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/multipath-tools.nix
@@ -1,6 +1,6 @@
 # FIXME: unify with pkgs/os-specific/linux/multipath-tools/default.nix.
 
-{ stdenv, fetchurl, lvm2, libaio, gzip, readline, systemd }:
+{ stdenv, fetchurl, fetchpatch, lvm2, libaio, gzip, readline, systemd }:
 
 stdenv.mkDerivation rec {
   name = "multipath-tools-0.4.9";
@@ -9,6 +9,18 @@ stdenv.mkDerivation rec {
     url = "http://christophe.varoqui.free.fr/multipath-tools/${name}.tar.bz2";
     sha256 = "04n7kazp1zrlqfza32phmqla0xkcq4zwn176qff5ida4a60whi4d";
   };
+
+  patches = [
+    # Fix build with glibc >= 2.28
+    # https://github.com/NixOS/nixpkgs/issues/86403
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-fs/multipath-tools/files/multipath-tools-0.6.4-sysmacros.patch?id=eb22b954c177b5c1e2b6ed5c7cdd02f40f40d757";
+      sha256 = "1an0cgmz7g03c4qjimhpm9fcf2iswws18lwqxi688k87qm3xb5qd";
+      excludes = [
+        "libmultipath/util.c"
+      ];
+    })
+  ];
 
   sourceRoot = ".";
 

--- a/pkgs/tools/filesystems/nixpart/0.4/parted.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/parted.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lvm2, libuuid, gettext, readline
+{ stdenv, fetchurl, fetchpatch, lvm2, libuuid, gettext, readline
 , utillinux, check, enableStatic ? false }:
 
 stdenv.mkDerivation rec {
@@ -8,6 +8,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/parted/${name}.tar.xz";
     sha256 = "05fa4m1bky9d13hqv91jlnngzlyn7y4rnnyq6d86w0dg3vww372y";
   };
+
+  patches = [
+    # Fix build with glibc >= 2.28
+    # https://github.com/NixOS/nixpkgs/issues/86403
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-block/parted/files/parted-3.2-sysmacros.patch?id=8e2414f551c14166f259f9a25a594aec7a5b9ea0";
+      sha256 = "0fdgifjbri7n28hv74zksac05gw72p2czzvyar0jp62b9dnql3mp";
+    })
+  ];
 
   buildInputs = [ libuuid ]
     ++ stdenv.lib.optional (readline != null) readline

--- a/pkgs/tools/filesystems/nixpart/0.4/pyblock-sysmacros.h.patch
+++ b/pkgs/tools/filesystems/nixpart/0.4/pyblock-sysmacros.h.patch
@@ -1,0 +1,12 @@
+diff --git a/dm.c b/dm.c
+index 5daa0e5..d5b84c8 100644
+--- a/dm.c
++++ b/dm.c
+@@ -19,6 +19,7 @@
+ #define _GNU_SOURCE
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <stdarg.h>

--- a/pkgs/tools/filesystems/nixpart/0.4/pyblock.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/pyblock.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "f6cef88969300a6564498557eeea1d8da58acceae238077852ff261a2cb1d815";
   };
 
+  patches = [
+    # Fix build with glibc >= 2.28
+    # https://github.com/NixOS/nixpkgs/issues/86403
+    ./pyblock-sysmacros.h.patch
+  ];
+
   postPatch = ''
     sed -i -e 's|/usr/include/python|${python}/include/python|' \
            -e 's/-Werror *//' -e 's|/usr/|'"$out"'/|' Makefile


### PR DESCRIPTION
##### Motivation for this change

While AFAICT not used directly in nixpkgs the package is used for provisioning new servers in nixops' Hetzner module.

This PR contains a collection of fixes for the package's dependencies to unblock its build. Closes #86403.

This branch contains the same commits as in https://github.com/NixOS/nixpkgs/issues/86403#issuecomment-628891971 just rebased onto more recent master.

If accepted I will make a backport PR to 20.03 as well as per the discussion on the linked issue.

/cc @nh2 
/cc @kolloch @mkg20001 who might still be interested as well

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
