### PR TITLE
sof-firmware: 1.4.2 -> 1.5.1

### DIFF
--- a/pkgs/os-specific/linux/firmware/sof-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/sof-firmware/default.nix
@@ -1,28 +1,33 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "sof-firmware";
-  version = "1.4.2";
+  version = "1.5.1";
 
-  src = fetchurl {
-    url = "https://www.alsa-project.org/files/pub/misc/sof/${pname}-${version}.tar.bz2";
-    sha256 = "1nkh020gjm45vxd6fvmz63hj16ilff2nl5avvsklajjs6xci1sf5";
+  src = fetchFromGitHub {
+    owner = "thesofproject";
+    repo = "sof-bin";
+    rev = "ae61d2778b0a0f47461a52da0d1f191f651e0763";
+    sha256 = "0j6bpwz49skvdvian46valjw4anwlrnkq703n0snkbngmq78prba";
   };
 
   phases = [ "unpackPhase" "installPhase" ];
 
   installPhase = ''
-    rm lib/firmware/intel/{sof/LICENCE,sof-tplg/LICENCE}
-    mkdir $out
-    cp -r lib $out/lib
+    mkdir -p $out/lib/firmware/intel
+
+    sed -i 's/ROOT=.*$/ROOT=$out/g' go.sh
+    sed -i 's/VERSION=.*$/VERSION=v${version}/g' go.sh
+
+    ./go.sh
   '';
 
   meta = with stdenv.lib; {
     description = "Sound Open Firmware";
     homepage = "https://www.sofproject.org/";
     license = with licenses; [ bsd3 isc ];
-    maintainers = with maintainers; [ lblasc ];
+    maintainers = with maintainers; [ lblasc evenbrenden ];
     platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update stable version and change source repo from https://www.alsa-project.org/files/pub/misc/sof/ to https://github.com/thesofproject/sof-bin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
