### PR TITLE
mooSpace: init at unstable-2020-06-10

### DIFF
--- a/pkgs/applications/audio/mooSpace/default.nix
+++ b/pkgs/applications/audio/mooSpace/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
+stdenv.mkDerivation rec {
+  pname = "mooSpace";
+  version = "unstable-2020-06-10";
+
+  src = fetchFromGitHub {
+    owner = "modularev";
+    repo = pname;
+    rev = "e5440407ea6ef9f7fcca838383b2b9a388c22874";
+    sha256 = "10vsbddf6d7i06040850v8xkmqh3bqawczs29kfgakair809wqxl";
+  };
+
+  buildInputs = [ faust2jaqt faust2lv2 ];
+
+  patchPhase = "mv ${pname}_faust.dsp ${pname}.dsp";
+
+  buildPhase = ''
+    faust2jaqt -time -vec -t 0 ${pname}.dsp
+    faust2lv2  -time -vec -t 0 -gui ${pname}.dsp
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${pname} $out/bin/
+      mkdir -p $out/lib/lv2
+      cp -r ${pname}.lv2 $out/lib/lv2
+  '';
+
+  meta = {
+    description = "Variable reverb audio effect, jack and lv2";
+    homepage = "https://github.com/modularev/mooSpace";
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.magnetophon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20899,6 +20899,8 @@ in
 
   moonlight-embedded = callPackage ../applications/misc/moonlight-embedded { };
 
+  mooSpace = callPackage ../applications/audio/mooSpace { };
+
   mop = callPackage ../applications/misc/mop { };
 
   mopidyPackages = callPackages ../applications/audio/mopidy/default.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
