### PR TITLE
python3Packages.duecredit: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/citeproc-py/default.nix
+++ b/pkgs/development/python-modules/citeproc-py/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nose
+, git
+, lxml
+, rnc2rng
+}:
+
+buildPythonPackage rec {
+  pname = "citeproc-py";
+  version = "0.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "00aaff50jy4j0nakdzq9258z1gzrac9baarli2ymgspj88jg5968";
+  };
+
+  buildInputs = [ rnc2rng ];
+
+  propagatedBuildInputs = [ lxml ];
+
+  checkInputs = [ nose git ];
+  checkPhase = "nosetests tests";
+  doCheck = false;  # seems to want a Git repository, but fetchgit with leaveDotGit also fails
+  pythonImportsCheck = [ "citeproc" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/brechtm/citeproc-py";
+    description = "Citation Style Language (CSL) parser for Python";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/duecredit/default.nix
+++ b/pkgs/development/python-modules/duecredit/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, contextlib2
+, pytest
+, pytestCheckHook
+, vcrpy
+, citeproc-py
+, requests
+, setuptools
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "duecredit";
+  version = "0.8.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1yxd8579pakrfhq0hls0iy37nxllsm8y33na220g08znibrp7ix0";
+  };
+
+  # bin/duecredit requires setuptools at runtime
+  propagatedBuildInputs = [ citeproc-py requests setuptools six ];
+
+  checkInputs = [ contextlib2 pytest pytestCheckHook vcrpy ];
+  disabledTests = [ "test_io" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/duecredit/duecredit";
+    description = "Simple framework to embed references in code";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/rnc2rng/default.nix
+++ b/pkgs/development/python-modules/rnc2rng/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, rply
+}:
+
+buildPythonPackage rec {
+  pname = "rnc2rng";
+  version = "2.6.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kmp3iwxxyzjsd47j2sprd47ihhkwhb3yydih3af5bbfq0ibh1w8";
+  };
+
+  propagatedBuildInputs = [ rply ];
+
+  checkPhase = "${python.interpreter} test.py";
+
+  meta = with lib; {
+    homepage = "https://github.com/djc/rnc2rng";
+    description = "Compact to regular syntax conversion library for RELAX NG schemata";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1995,6 +1995,8 @@ in {
     pythonProtobuf = self.protobuf;
   };
 
+  citeproc-py = callPackage ../development/python-modules/citeproc-py { };
+
   colorcet = callPackage ../development/python-modules/colorcet { };
 
   coloredlogs = callPackage ../development/python-modules/coloredlogs { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2067,6 +2067,8 @@ in {
 
   dodgy = callPackage ../development/python-modules/dodgy { };
 
+  duecredit = callPackage ../development/python-modules/duecredit { };
+
   dugong = callPackage ../development/python-modules/dugong {};
 
   easysnmp = callPackage ../development/python-modules/easysnmp {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5676,6 +5676,8 @@ in {
 
   Pyro5 = callPackage ../development/python-modules/pyro5 { };
 
+  rnc2rng = callPackage ../development/python-modules/rnc2rng { };
+
   rope = callPackage ../development/python-modules/rope { };
 
   ropper = callPackage ../development/python-modules/ropper { };


### PR DESCRIPTION
python3Packages.citeproc-py: init at 0.5.1
python3Packages.rnc2rng: init at 2.6.4

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
 `bin/duecredit` with no arguments gives an error due to https://bugs.python.org/issue16308
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
