### PR TITLE
lattice-diamond: add libusb-compat-0_1 dependency

### DIFF
--- a/pkgs/development/tools/lattice-diamond/default.nix
+++ b/pkgs/development/tools/lattice-diamond/default.nix
@@ -1,5 +1,5 @@
 { stdenv, rpmextract, patchelf, makeWrapper, file, requireFile, glib, zlib, 
-    freetype, fontconfig, xorg }:
+    freetype, fontconfig, xorg, libusb-compat-0_1 }:
 
 stdenv.mkDerivation {
   name = "diamond-3.10";
@@ -98,6 +98,7 @@ stdenv.mkDerivation {
   libPath = stdenv.lib.makeLibraryPath [
     glib zlib freetype fontconfig
     xorg.libSM xorg.libICE xorg.libXrender xorg.libXext xorg.libX11 xorg.libXt
+    libusb-compat-0_1
   ];
 
   meta = {


### PR DESCRIPTION
Lattice Diamond won't be able to produce a PROM file
without libusb 0.1 so one has to be supplied.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Can't use Lattice Diamond productively without this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
