### PR TITLE
execline: 2.6.0.0 -> 2.6.1.0

### DIFF
--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -7,8 +7,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "execline";
-  version = "2.6.0.0";
-  sha256 = "1m6pvawxqaqjr49456vyjyl8dnqwvr19v77sjj7dnglfijwza5al";
+  version = "2.6.1.0";
+  sha256 = "0mj565xml3hvw27finydms0s9abbbpgbr29vnr8gwi7zjzq7ck52";
 
   description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
 


### PR DESCRIPTION
 Hello,

 execline-2.6.1.0 is out.

 This version features a more expressive format for the envfile binary.
Most of the files that are suitable for a systemd EnvironmentFile=
directive are now parsable with envfile: double quotes are supported,
backslashed newlines are supported, a few C escape sequences are
supported (including octal and hexadecimal). So it is now possible to
read most existing /etc/default configuration files without spawning a
shell.

 Additionally, envfile now comes with a -I option that makes it ignore
a nonexistent file, instead of failing.

 git://git.skarnet.org/execline
 https://skarnet.org/software/execline/

 Enjoy,
 Bug-reports welcome.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
