### PR TITLE
pythonPackages.spidev: init at 3.5

### DIFF
--- a/pkgs/development/python-modules/spidev/default.nix
+++ b/pkgs/development/python-modules/spidev/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "spidev";
+  version = "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03cicc9kpi5khhq0bl4dcy8cjcl2j488mylp8sna47hnkwl5qzwa";
+  };
+
+  # package does not include tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "spidev" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/doceme/py-spidev";
+    description = "Python bindings for Linux SPI access through spidev";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1567,6 +1567,8 @@ in {
 
   spglib = callPackage ../development/python-modules/spglib { };
 
+  spidev = callPackage ../development/python-modules/spidev { };
+
   srvlookup = callPackage ../development/python-modules/srvlookup { };
 
   sshpubkeys = callPackage ../development/python-modules/sshpubkeys { };


### PR DESCRIPTION
###### Motivation for this change

I need this library to control APA102 LEDs ✨ on my ReSpeaker Mic Array 🎤.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
