### PR TITLE
pythonPackages.pulsectl: 20.4.3 -> 20.5.1

### DIFF
--- a/pkgs/development/python-modules/pulsectl/default.nix
+++ b/pkgs/development/python-modules/pulsectl/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "pulsectl";
-  version = "20.4.3";
+  version = "20.5.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1m5fz740r4rk2i8qsnblsn16hai7givqxbx21swhpflan1yzvzzm";
+    sha256 = "1nr2xq4as74vz9xhsgw0qg4hmc3q5y13ia16v1l68zaajzks1c1r";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

New upstream release, sadly no change log and no git tag. *sigh*

Changelog:
> Only (unlikely) intentional breaking changes and new/added non-trivial functionality is listed here, no bugfixes or commit messages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
