### PR TITLE
maintainers: rename 1000101 to b1000101

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -51,7 +51,7 @@
       fingerprint = "F466 A548 AD3F C1F1 8C88  4576 8702 7528 B006 D66D";
     }];
   };
-  "1000101" = {
+  b1000101 = {
     email = "b1000101@pm.me";
     github = "1000101";
     githubId = 791309;

--- a/nixos/tests/dokuwiki.nix
+++ b/nixos/tests/dokuwiki.nix
@@ -32,7 +32,7 @@ let
 
 in {
   name = "dokuwiki";
-  meta.maintainers = with pkgs.lib.maintainers; [ "1000101" ];
+  meta.maintainers = with pkgs.lib.maintainers; [ b1000101 ];
 
   machine = { ... }: {
     services.dokuwiki."site1.local" = {

--- a/nixos/tests/trezord.nix
+++ b/nixos/tests/trezord.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "trezord";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ mmahut "1000101" ];
+    maintainers = [ mmahut b1000101 ];
   };
 
   nodes = {

--- a/nixos/tests/trickster.nix
+++ b/nixos/tests/trickster.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "trickster";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ "1000101" ];
+    maintainers = [ b1000101 ];
   };
 
   nodes = {

--- a/pkgs/applications/misc/pdfsam-basic/default.nix
+++ b/pkgs/applications/misc/pdfsam-basic/default.nix
@@ -44,6 +44,6 @@ stdenv.mkDerivation rec {
       description = "Multi-platform software designed to extract pages, split, merge, mix and rotate PDF files";
       license = licenses.agpl3;
       platforms = platforms.all;
-      maintainers = with maintainers; [ maintainers."1000101" ];
+      maintainers = with maintainers; [ b1000101 ];
   };
 }

--- a/pkgs/development/python-modules/shamir-mnemonic/default.nix
+++ b/pkgs/development/python-modules/shamir-mnemonic/default.nix
@@ -17,6 +17,6 @@ buildPythonPackage rec {
     description = "Reference implementation of SLIP-0039";
     homepage = "https://github.com/trezor/python-shamir-mnemonic";
     license = licenses.mit;
-    maintainers = [ maintainers."1000101" ];
+    maintainers = with maintainers; [ b1000101 ];
   };
 }

--- a/pkgs/development/python-modules/trezor/default.nix
+++ b/pkgs/development/python-modules/trezor/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     description = "Python library for communicating with TREZOR Bitcoin Hardware Wallet";
     homepage = "https://github.com/trezor/trezor-firmware/tree/master/python";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ np prusnak mmahut maintainers."1000101" ];
+    maintainers = with maintainers; [ np prusnak mmahut b1000101 ];
   };
 }

--- a/pkgs/development/web/shopify-themekit/default.nix
+++ b/pkgs/development/web/shopify-themekit/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
     description = "A command line tool for shopify themes";
     homepage = "https://shopify.github.io/themekit/";
     license = licenses.mit;
-    maintainers = with maintainers; [ maintainers."1000101" ];
+    maintainers = with maintainers; [ b1000101 ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/servers/blockbook/default.nix
+++ b/pkgs/servers/blockbook/default.nix
@@ -65,7 +65,7 @@ buildGoModule rec {
     description = "Trezor address/account balance backend";
     homepage = "https://github.com/trezor/blockbook";
     license = licenses.agpl3;
-    maintainers = with maintainers; [ mmahut maintainers."1000101" ];
+    maintainers = with maintainers; [ mmahut b1000101 ];
     platforms = remove "aarch64-linux" platforms.unix;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/apcupsd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/apcupsd-exporter.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
     description = "Provides a Prometheus exporter for the apcupsd Network Information Server (NIS)";
     homepage = "https://github.com/mdlayher/apcupsd_exporter";
     license = licenses.mit;
-    maintainers = with maintainers; [ maintainers."1000101" mdlayher ];
+    maintainers = with maintainers; [ b1000101 mdlayher ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/process-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/process-exporter.nix
@@ -25,7 +25,7 @@ buildGoPackage rec {
     description = "Prometheus exporter that mines /proc to report on selected processes";
     homepage = "https://github.com/ncabatoff/process-exporter";
     license = licenses.mit;
-    maintainers = with maintainers; [ maintainers."1000101" ];
+    maintainers = with maintainers; [ b1000101 ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/trezord/default.nix
+++ b/pkgs/servers/trezord/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
     description = "TREZOR Communication Daemon aka TREZOR Bridge";
     homepage = "https://trezor.io";
     license = licenses.lgpl3;
-    maintainers = with maintainers; [ canndrew jb55 prusnak mmahut maintainers."1000101" ];
+    maintainers = with maintainers; [ canndrew jb55 prusnak mmahut b1000101 ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/trickster/trickster.nix
+++ b/pkgs/servers/trickster/trickster.nix
@@ -21,7 +21,7 @@ buildGoPackage rec {
     description = "Reverse proxy cache for the Prometheus HTTP APIv1";
     homepage = "https://github.com/Comcast/trickster";
     license = licenses.asl20;
-    maintainers = with maintainers; [ maintainers."1000101" ];
+    maintainers = with maintainers; [ b1000101 ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/servers/web-apps/dokuwiki/default.nix
+++ b/pkgs/servers/web-apps/dokuwiki/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     homepage = "https://www.dokuwiki.org";
     platforms = platforms.all;
-    maintainers = [ maintainers."1000101" ];
+    maintainers = with maintainers; [ b1000101 ];
   };
 }


### PR DESCRIPTION
Having a name starting with numbers is a problem because
the common pattern:

with maintainers; [ 1000101 ];

does not work and there have been cases where people dripped over it
including fixes in this PR itself.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
