### PR TITLE
docs: increase awareness of NIXPKGS_ALLOW_INSECURE=1

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -107,8 +107,13 @@ let
 
         You can install it anyway by whitelisting this package, using the
         following methods:
+        
+        a) To temporarily allow all insecure packages, you can use an environment variable 
+           for a single invocation of the nix tools:
+           
+           $ export NIXPKGS_ALLOW_INSECURE=1
 
-        a) for `nixos-rebuild` you can add ‘${getName attrs}’ to
+        b) for `nixos-rebuild` you can add ‘${getName attrs}’ to
            `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
            like so:
 
@@ -118,7 +123,7 @@ let
                ];
              }
 
-        b) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
+        c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         ‘${getName attrs}’ to `permittedInsecurePackages` in
         ~/.config/nixpkgs/config.nix, like so:
 


### PR DESCRIPTION
nb. I did this edit in the GitHub file editor and have not tested locally.

###### Motivation for this change

The option is documented at https://github.com/NixOS/nixpkgs/blob/496bc90c6c9b54e8200a069862e3c4fad21f9f58/doc/using/configuration.xml#L190 but is not documented in the error output from nix-tools.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
