### PR TITLE
crystal: 0.34 -> 0.35

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -192,6 +192,15 @@ in rec {
     };
   };
 
+  binaryCrystal_0_35 = genericBinary {
+    version = "0.35.0";
+    sha256s = {
+      x86_64-linux  = "1pcjzwsgdwfh0amn21kizf95psxw4zyxb5xrw925xgskxy4lp0ds";
+      i686-linux    = "01nfzx3vm2n5hdv219jajqyyhp7ym3hj5n4wjgcka6yqlsjr62b1";
+      x86_64-darwin = "17qi7lp3pz5fhnas8rwy3ss24k03lanznbf2a1k13c7yqp4zpz9p";
+    };
+  };
+
   crystal_0_31 = generic {
     version = "0.31.1";
     sha256  = "1dswxa32w16gnc6yjym12xj7ibg0g6zk3ngvl76lwdjqb1h6lwz8";
@@ -219,7 +228,15 @@ in rec {
     doCheck = false; # 4 checks are failing now
   };
 
-  crystal = crystal_0_34;
+  crystal_0_35 = generic {
+    version = "0.35.0";
+    sha256  = "168a6w3k5pgzzpxj2y7y092f3ai7c4dlh9li6dshdcdm72zg696f";
+    binary = binaryCrystal_0_35;
+    doCheck = false; # 4 checks are failing now
+    extraBuildInputs = [ git ];
+  };
+
+  crystal = crystal_0_35;
 
   crystal2nix = callPackage ./crystal2nix.nix {};
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8187,6 +8187,7 @@ in
     crystal_0_32
     crystal_0_33
     crystal_0_34
+    crystal_0_35
     crystal
     crystal2nix;
 


### PR DESCRIPTION
#### Motivation for this change

New Crystal Release: https://crystal-lang.org/2020/06/09/crystal-0.35.0-released.html

Before merging, we need to resolve https://github.com/NixOS/nixpkgs/pull/89863 first.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
