### PR TITLE
pythonPackages.swifter: 0.304

### DIFF
--- a/pkgs/development/python-modules/swifter/default.nix
+++ b/pkgs/development/python-modules/swifter/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, nose,
+  pandas, psutil, dask, tqdm, ipywidgets, numba, bleach, parso, distributed }:
+buildPythonPackage rec {
+  version = "0.304";
+  pname = "swifter";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5fe99d18e8716e82bce5a76322437d180c25ef1e29f1e4c5d5dd007928a316e9";
+  };
+
+  checkInputs = [ nose ];
+  propagatedBuildInputs = [ pandas psutil dask tqdm ipywidgets numba bleach parso distributed ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "swifter" ];
+  checkPhase = ''
+    nosetests
+  '';
+
+  # Tests require extra dependencies
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/jmcarpenter2/swifter";
+    description = "A package which efficiently applies any function to a pandas dataframe or series in the fastest available manner";
+    license = licenses.mit;
+    maintainers = [ maintainers.moritzs ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7418,6 +7418,8 @@ in {
 
   rxv     = callPackage ../development/python-modules/rxv     { };
 
+  swifter = callPackage ../development/python-modules/swifter { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

Python library was absent from nixpkgs

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Both pythonImportLibrary and checkPhase = "nosetests" pass.
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip" <- no dependencies
- [x] Tested execution of all binary files (usually in `./result/bin/`) <- no binaries
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md). 

I added myself as maintainer