### PR TITLE
setzer: init at 0.2.8

### DIFF
--- a/pkgs/applications/editors/setzer/default.nix
+++ b/pkgs/applications/editors/setzer/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, python3
+, fetchFromGitHub
+, meson
+, ninja
+, gettext
+, appstream
+, appstream-glib
+, wrapGAppsHook
+, gobject-introspection
+, gtksourceview4
+, gspell
+, poppler_gi
+, webkitgtk
+, librsvg
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "setzer";
+  version = "0.2.8";
+
+  src = fetchFromGitHub {
+    owner = "cvfosammmm";
+    repo = "Setzer";
+    rev = "v${version}";
+    sha256 = "1llxxjj038nd2p857bjdyyhzskn56826qi259v47vaqlv9hkifil";
+  };
+
+  format = "other";
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    gettext
+    appstream # for appstreamcli
+    appstream-glib
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gobject-introspection
+    gtksourceview4
+    gspell
+    poppler_gi
+    webkitgtk
+    librsvg
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pygobject3
+    pyxdg
+  ];
+
+  meta = with lib; {
+    description = "LaTeX editor written in Python with Gtk";
+    homepage = src.meta.homepage;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6551,6 +6551,8 @@ in
 
   setserial = callPackage ../tools/system/setserial { };
 
+  setzer = callPackage ../applications/editors/setzer { };
+
   seqdiag = with python3Packages; toPythonApplication seqdiag;
 
   sequoia = callPackage ../tools/security/sequoia {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
A LaTeX editor that fits the looks of the Gnome desktop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
