### PR TITLE
hamster: init at 3.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2540,6 +2540,16 @@
     githubId = 11909469;
     name = "Fabian Geiselhart";
   };
+  fabianhauser = {
+    email = "fabian.nixos@fh2.ch";
+    github = "fabianhauser";
+    githubId = 368799;
+    name = "Fabian Hauser";
+    keys = [{
+      longkeyid = "rsa4096/0x8A52A140BEBF7D2C";
+      fingerprint = "50B7 11F4 3DFD 2018 DCE6  E8D0 8A52 A140 BEBF 7D2C";
+    }];
+  };
   fadenb = {
     email = "tristan.helmich+nixos@gmail.com";
     github = "fadenb";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -126,6 +126,7 @@
   ./programs/gpaste.nix
   ./programs/gnupg.nix
   ./programs/gphoto2.nix
+  ./programs/hamster.nix
   ./programs/iftop.nix
   ./programs/iotop.nix
   ./programs/java.nix

--- a/nixos/modules/programs/hamster.nix
+++ b/nixos/modules/programs/hamster.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  meta.maintainers = maintainers.fabianhauser;
+
+  options.programs.hamster.enable =
+    mkEnableOption "Whether to enable hamster time tracking.";
+
+  config = lib.mkIf config.programs.hamster.enable {
+    environment.systemPackages = [ pkgs.hamster ];
+    services.dbus.packages = [ pkgs.hamster ];
+  };
+}

--- a/pkgs/applications/misc/hamster/default.nix
+++ b/pkgs/applications/misc/hamster/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, fetchFromGitHub, python3Packages, intltool, glib, itstool
+, wrapGAppsHook, gobject-introspection, pango, gdk-pixbuf, atk, wafHook }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "hamster";
+  version = "3.0.2";
+
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "projecthamster";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "09ikiwc2izjvwqbbyp8knn190x5y4anwslkmb9k2h3r3jwrg2vd2";
+  };
+
+  nativeBuildInputs = [
+    python3Packages.setuptools
+    wrapGAppsHook
+    intltool
+    itstool
+    wafHook
+    glib
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    pango
+    gdk-pixbuf
+    atk
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    pycairo
+    pyxdg
+    dbus-python
+  ];
+
+  # Setup hooks have trouble with strict deps.
+  # https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  dontWrapGApps = true;
+
+  # Arguments to be passed to `makeWrapper`, only used by buildPython*
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  postFixup = ''
+    wrapPythonProgramsIn $out/libexec "$out $pythonPath"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Time tracking application";
+    homepage = "http://projecthamster.org/";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = [ maintainers.fabianhauser ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -198,7 +198,6 @@ mapAliases ({
   gupnp_igd = gupnp-igd; # added 2018-02-25
   gupnptools = gupnp-tools;  # added 2015-12-19
   gutenberg = zola;  # added 2018-11-17
-  hamster-time-traker = throw "hamster-time-tracker has been removed from nixpkgs, as it was unmaintained."; # added 2019-12-10
   heimdalFull = heimdal; # added 2018-05-01
   hepmc = hepmc2; # added 2019-08-05
   hexen = throw "hexen (SDL port) has been removed: Abandoned by upstream."; # added 2019-12-11

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19996,6 +19996,8 @@ in
 
   hakuneko = callPackage ../tools/misc/hakuneko { };
 
+  hamster = callPackage ../applications/misc/hamster { };
+
   hashit = callPackage ../tools/misc/hashit { };
 
   hactool = callPackage ../tools/compression/hactool { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add the hamster time tracking application. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
