### PR TITLE
linux: fix kernel config options for linux_*hardened

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -40,11 +40,12 @@ assert (versionAtLeast version "4.9");
   # Perform additional validation of commonly targeted structures.
   DEBUG_CREDENTIALS     = yes;
   DEBUG_NOTIFIERS       = yes;
-  DEBUG_PI_LIST         = yes; # doesn't BUG()
+  DEBUG_PI_LIST         = whenOlder "5.2" yes; # doesn't BUG()
+  DEBUG_PLIST           = whenAtLeast "5.2" yes;
   DEBUG_SG              = yes;
   SCHED_STACK_END_CHECK = yes;
 
-  REFCOUNT_FULL = whenAtLeast "4.13" yes;
+  REFCOUNT_FULL = whenBetween "4.13" "5.5" yes;
 
   # Randomize page allocator when page_alloc.shuffle=1
   SHUFFLE_PAGE_ALLOCATOR = whenAtLeast "5.2" yes;


### PR DESCRIPTION
Fix config options for linux_hardened and linux_latest_hardened due to #84302.
This is a continuation of #88946.

cc @vcunat @teto 

Since I already had `staging-next` compiled locally and had some free time, I went ahead and fixed these kernel builds too.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
