### PR TITLE
spigot: init at 20200101

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5099,6 +5099,12 @@
     githubId = 2971615;
     name = "Marius Bergmann";
   };
+  mcbeth = {
+    email = "mcbeth@broggs.org";
+    github = "mcbeth";
+    githubId = 683809;
+    name = "Jeffrey Brent McBeth";
+  };
   mcmtroffaes = {
     email = "matthias.troffaes@gmail.com";
     github = "mcmtroffaes";

--- a/pkgs/tools/misc/spigot/default.nix
+++ b/pkgs/tools/misc/spigot/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, buildPackages
+, fetchgit
+, autoreconfHook
+, gmp
+, ncurses
+, halibut
+, perl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "spigot";
+  version = "20200101";
+  src = fetchgit {
+    url = "https://git.tartarus.org/simon/spigot.git";
+    rev = "b1b0b202b3523b72f0638fb31fd49c47f4abb39c";
+    sha256 = "0lh5v42aia1hvhsqzs515q0anrjc6c2s9bjklfaap5gz0cg59wbv";
+  };
+
+  nativeBuildInputs = [ autoreconfHook halibut perl ];
+
+  configureFlags = [ "--with-gmp" ];
+
+  buildInputs = [ gmp ncurses ];
+
+  strictDeps = true;
+
+  meta = with lib; {
+    description = "A command-line exact real calculator";
+    homepage = "https://www.chiark.greenend.org.uk/~sgtatham/spigot/";
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = with maintainers; [ mcbeth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6838,6 +6838,8 @@ in
 
   spectre-meltdown-checker = callPackage ../tools/security/spectre-meltdown-checker { };
 
+  spigot = callPackage ../tools/misc/spigot { };
+
   spiped = callPackage ../tools/networking/spiped { };
 
   sqliteman = callPackage ../applications/misc/sqliteman { };


### PR DESCRIPTION
Spigot is a streaming command-line calculator by Simon Tatham

###### Motivation for this change

I had a need for this tool, I'm aspiring to move to NixOS, so I added the tool.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
