### PR TITLE
linux: make sure all config options have the same value

### DIFF
--- a/nixos/modules/system/boot/kernel_config.nix
+++ b/nixos/modules/system/boot/kernel_config.nix
@@ -2,24 +2,6 @@
 
 with lib;
 let
-  findWinner = candidates: winner:
-    any (x: x == winner) candidates;
-
-  # winners is an ordered list where first item wins over 2nd etc
-  mergeAnswer = winners: locs: defs:
-    let
-      values = map (x: x.value) defs;
-      inter = intersectLists values winners;
-      winner = head winners;
-    in
-    if defs == [] then abort "This case should never happen."
-    else if winner == [] then abort "Give a valid list of winner"
-    else if inter == [] then mergeOneOption locs defs
-    else if findWinner values winner then
-      winner
-    else
-      mergeAnswer (tail winners) locs defs;
-
   mergeFalseByDefault = locs: defs:
     if defs == [] then abort "This case should never happen."
     else if any (x: x == false) (getValues defs) then false
@@ -28,9 +10,7 @@ let
   kernelItem = types.submodule {
     options = {
       tristate = mkOption {
-        type = types.enum [ "y" "m" "n" null ] // {
-          merge = mergeAnswer [ "y" "m" "n" ];
-        };
+        type = types.enum [ "y" "m" "n" null ];
         default = null;
         internal = true;
         visible = true;

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -193,16 +193,17 @@ let
       NET_DROP_MONITOR = yes;
 
       # needed for ss
-      INET_DIAG         = module;
-      INET_TCP_DIAG     = module;
-      INET_UDP_DIAG     = module;
-      INET_RAW_DIAG     = whenAtLeast "4.14" module;
-      INET_DIAG_DESTROY = whenAtLeast "4.9" yes;
+      # Use a lower priority to allow these options to be overridden in hardened/config.nix
+      INET_DIAG         = mkDefault module;
+      INET_TCP_DIAG     = mkDefault module;
+      INET_UDP_DIAG     = mkDefault module;
+      INET_RAW_DIAG     = whenAtLeast "4.14" (mkDefault module);
+      INET_DIAG_DESTROY = whenAtLeast "4.9" (mkDefault yes);
 
       # enable multipath-tcp
       MPTCP           = whenAtLeast "5.6" yes;
       MPTCP_IPV6      = whenAtLeast "5.6" yes;
-      INET_MPTCP_DIAG = whenAtLeast "5.9" module;
+      INET_MPTCP_DIAG = whenAtLeast "5.9" (mkDefault module);
     };
 
     wireless = {

--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -65,7 +65,7 @@ assert (versionAtLeast version "4.9");
   PANIC_TIMEOUT = freeform "-1";
 
   GCC_PLUGINS = yes; # Enable gcc plugin options
-  # Gather additional entropy at boot time for systems that may = no;ot have appropriate entropy sources.
+  # Gather additional entropy at boot time for systems that may not have appropriate entropy sources.
   GCC_PLUGIN_LATENT_ENTROPY = yes;
 
   GCC_PLUGIN_STRUCTLEAK = whenAtLeast "4.11" yes; # A port of the PaX structleak plugin
@@ -78,6 +78,14 @@ assert (versionAtLeast version "4.9");
   ACPI_CUSTOM_METHOD = no; # Allows writing directly to physical memory
   PROC_KCORE         = no; # Exposes kernel text image layout
   INET_DIAG          = no; # Has been used for heap based attacks in the past
+
+  # INET_DIAG=n causes the following options to not exist anymore, but since they are defined in common-config.nix,
+  # make them optional
+  INET_DIAG_DESTROY = option no;
+  INET_RAW_DIAG     = option no;
+  INET_TCP_DIAG     = option no;
+  INET_UDP_DIAG     = option no;
+  INET_MPTCP_DIAG   = option no;
 
   # Use -fstack-protector-strong (gcc 4.9+) for best stack canary coverage.
   CC_STACKPROTECTOR_REGULAR = whenOlder "4.18" no;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Currently, kernel config options whose value is `yes` always override
options whose value is `no`.

This is not always desired.

Generally speaking, if someone defines an option to have the value
`no`, presumably they are disabling the option for a reason, so it's
not always OK to silently enable it due to another, probably unrelated
reason.

For example, a user may want to reduce the kernel attack surface and
therefore may want to disable features that are being enabled in
`common-config.nix`.

In fact, `common-config.nix` was already silently enabling options that
were intended to be disabled in `hardened/config.nix` for security
reasons, such as `INET_DIAG`.

By eliminating the custom merge function, these config options will
now use the default module option merge functions which make sure
that all options with the highest priority have the same value.

A user that wishes to override an option defined in `common-config.nix`
can currently use `mkForce` or `mkOverride` to do so, e.g.:
```
BINFMT_MISC = mkForce (option no);
```
That said, this is not going to be necessary in the future, because
the plan is for kernel config options defined in nixpkgs to use a
lower priority by default, like it currently happens for other module
options.

I've also added a commit that (along with #90057, which fixes other unrelated problems) fixes the hardened kernel builds due to said conflicting definitions.

Note: this came about due to https://github.com/NixOS/nixpkgs/pull/88946#issuecomment-635959637 and the following comments.
I know @teto expressed his opinion that the current merge strategy is fine as long as it's documented, but I disagree for the above reasons, and would like to discuss this issue on its own.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I've tested building the following kernels:
- [x] linux_4_4
- [x] linux_4_14
- [x] linux_4_19
- [x] linux_5_4
- [x] linux_5_6
- [x] linux_5_7
- [x] linux_hardened
- [x] linux_latest_hardened

cc @teto @vcunat 