### PR TITLE
thelounge: re-apply 'write out default path'

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -160,6 +160,9 @@ let
 
     thelounge = super.thelounge.override {
       buildInputs = [ self.node-pre-gyp ];
+      postInstall = ''
+        echo /var/lib/thelounge > $out/lib/node_modules/thelounge/.thelounge_home
+      '';
     };
   };
 in self


### PR DESCRIPTION
Re-apply
https://github.com/NixOS/nixpkgs/pull/70318/commits/df2f8d915051d3d494ba7cb572c66c84bef84dcf#diff-55e70513e1cc0032a186d6b7b367679aR128-R130

(cc https://github.com/NixOS/nixpkgs/pull/70318)

It seems like this got lost in #89184:

https://github.com/NixOS/nixpkgs/commit/6602f87384eb0e6f8caf0a23eca48f896fedb8b7#diff-55e70513e1cc0032a186d6b7b367679aL126-L131

https://github.com/NixOS/nixpkgs/commit/6602f87384eb0e6f8caf0a23eca48f896fedb8b7#diff-f7e3726c9a96ebbbffbb4e2ac12ba6d7R126-R128

With nice inline previews:

Before:
https://github.com/NixOS/nixpkgs/blob/33f1160930b30c239aed2be796ee79f59c594a92/pkgs/development/node-packages/default-v10.nix#L126-L131

After:
https://github.com/NixOS/nixpkgs/blob/6602f87384eb0e6f8caf0a23eca48f896fedb8b7/pkgs/development/node-packages/default-v12.nix#L126-L128

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

My `thelounge`-instance died after upgrading to the latest `nixos-unstable`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
