### PR TITLE
mp3blaster: fix build on darwin

### DIFF
--- a/pkgs/applications/audio/mp3blaster/default.nix
+++ b/pkgs/applications/audio/mp3blaster/default.nix
@@ -1,13 +1,12 @@
 { stdenv, fetchFromGitHub, ncurses, libvorbis, SDL }:
+
 stdenv.mkDerivation rec {
-
-  version = "3.2.6";
-
   pname = "mp3blaster";
+  version = "3.2.6";
 
   src = fetchFromGitHub {
     owner = "stragulus";
-    repo = "mp3blaster";
+    repo = pname;
     rev = "v${version}";
     sha256 = "0pzwml3yhysn8vyffw9q9p9rs8gixqkmg4n715vm23ib6wxbliqs";
   };
@@ -17,14 +16,17 @@ stdenv.mkDerivation rec {
     libvorbis
   ] ++ stdenv.lib.optional stdenv.isDarwin SDL;
 
-  buildFlags = [ "CXXFLAGS=-Wno-narrowing" ];
+  NIX_CFLAGS_COMPILE = toString ([
+    "-Wno-narrowing"
+  ] ++ stdenv.lib.optionals stdenv.cc.isClang [
+    "-Wno-reserved-user-defined-literal"
+  ]);
 
   meta = with stdenv.lib; {
     description = "An audio player for the text console";
     homepage = "http://www.mp3blaster.org/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ earldouglas ];
-    platforms = platforms.all;
+    platforms = with platforms; linux ++ darwin;
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change
Fix build error on darwin:
```
In file included from nmixer.cc:1:
./nmixer.h:29:30: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
#define MYVERSION "<<NMixer "VERSION">>"
                             ^

1 error generated.
make[2]: *** [Makefile:424: nmixer.o] Error 1
```

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
