### PR TITLE
Add python packages for fake-useragent, scrapy-fake-useragent, scrapy-deltafetch, scrapy-splash

### DIFF
--- a/pkgs/development/python-modules/fake-useragent/default.nix
+++ b/pkgs/development/python-modules/fake-useragent/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchPypi, buildPythonPackage, six, pytest }:
+
+buildPythonPackage rec {
+  pname = "fake-useragent";
+  version = "0.1.11";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0dfz3bpmjmaxlhda6hfgsac7afb65pljibi8zkp9gc0ffn5rj161";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ pytest ];
+
+  meta = with stdenv.lib; {
+    description = "Up to date simple useragent faker with real world database";
+    homepage = "https://github.com/hellysmile/fake-useragent";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ evanjs ];
+  };
+}

--- a/pkgs/development/python-modules/scrapy-deltafetch/default.nix
+++ b/pkgs/development/python-modules/scrapy-deltafetch/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchPypi, buildPythonPackage, pytest, scrapy, bsddb3 }:
+
+buildPythonPackage rec {
+  pname = "scrapy-deltafetch";
+  version = "1.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1m511psddvlapg492ny36l8rzy7z4i39yx6a1agxzfz6s9b83fq8";
+  };
+
+  propagatedBuildInputs = [ bsddb3 scrapy ];
+
+  checkInputs = [ pytest ];
+
+  meta = with stdenv.lib; {
+    description = "Scrapy spider middleware to ignore requests to pages containing items seen in previous crawls";
+    homepage = "https://github.com/scrapy-plugins/scrapy-deltafetch";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ evanjs ];
+  };
+}

--- a/pkgs/development/python-modules/scrapy-fake-useragent/default.nix
+++ b/pkgs/development/python-modules/scrapy-fake-useragent/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchPypi, buildPythonPackage, pytest, fake-useragent, scrapy }:
+
+buildPythonPackage rec {
+  pname = "scrapy-fake-useragent";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "02mayk804vdl15wjpx7jcjkc4zgrra4izf6iv00mcxq4fd4ck03l";
+  };
+
+  propagatedBuildInputs = [ fake-useragent ];
+
+  checkInputs = [ pytest scrapy ];
+
+  meta = with stdenv.lib; {
+    description = "Random User-Agent middleware based on fake-useragent";
+    homepage = "https://github.com/alecxe/scrapy-fake-useragent";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/scrapy-splash/default.nix
+++ b/pkgs/development/python-modules/scrapy-splash/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchPypi, buildPythonPackage, pytest, hypothesis, scrapy }:
+
+buildPythonPackage rec {
+  pname = "scrapy-splash";
+  version = "0.7.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1dg7csdza2hzqskd9b9gx0v3saqsch4f0fwdp0a3p0822aqqi488";
+  };
+
+  checkInputs = [ pytest hypothesis scrapy ];
+
+  meta = with stdenv.lib; {
+    description = "Scrapy+Splash for JavaScript integration";
+    homepage = "https://github.com/scrapy-plugins/scrapy-splash";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ evanjs ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6904,6 +6904,8 @@ in {
 
   scrapy-fake-useragent = callPackage ../development/python-modules/scrapy-fake-useragent { };
 
+  scrapy-deltafetch = callPackage ../development/python-modules/scrapy-deltafetch { };
+
   pandocfilters = callPackage ../development/python-modules/pandocfilters { };
 
   pandoc-attributes = callPackage ../development/python-modules/pandoc-attributes { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6902,6 +6902,8 @@ in {
 
   scrapy = callPackage ../development/python-modules/scrapy { };
 
+  scrapy-fake-useragent = callPackage ../development/python-modules/scrapy-fake-useragent { };
+
   pandocfilters = callPackage ../development/python-modules/pandocfilters { };
 
   pandoc-attributes = callPackage ../development/python-modules/pandoc-attributes { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6906,6 +6906,8 @@ in {
 
   scrapy-deltafetch = callPackage ../development/python-modules/scrapy-deltafetch { };
 
+  scrapy-splash = callPackage ../development/python-modules/scrapy-splash { };
+
   pandocfilters = callPackage ../development/python-modules/pandocfilters { };
 
   pandoc-attributes = callPackage ../development/python-modules/pandoc-attributes { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2808,6 +2808,8 @@ in {
 
   fake_factory = callPackage ../development/python-modules/fake_factory { };
 
+  fake-useragent = callPackage ../development/python-modules/fake-useragent { };
+
   factory_boy = callPackage ../development/python-modules/factory_boy { };
 
   Fabric = callPackage ../development/python-modules/Fabric { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add several scrapy-related packages

###### Things done
- Add fake-useragent
- Add scrapy packages
  - Add scrapy-fake-useragent
  - Add scrapy-deltafetch
  - Add scrapy-splash

___

All of the above scrapy packages currently fail to compile on master with `python38Packages`, due to `testfixtures` failing to compile with such.

Everything seems to compile fine using `python37Packages` / `python3Packages`.