### PR TITLE
paraview: 5.6.3 -> 5.8.0

### DIFF
--- a/pkgs/applications/graphics/paraview/default.nix
+++ b/pkgs/applications/graphics/paraview/default.nix
@@ -1,26 +1,33 @@
-{ stdenv, fetchFromGitHub, cmake, makeWrapper, qtbase , qttools, python
-, libGLU, libGL , libXt, qtx11extras, qtxmlpatterns , mkDerivation }:
+{ boost, cmake, fetchFromGitHub, ffmpeg, qtbase, qtx11extras,
+  qttools, qtxmlpatterns, qtsvg, gdal, gfortran, libXt, makeWrapper,
+  mkDerivation, ninja, openmpi, python3, stdenv, tbb, libGLU, libGL }:
 
 mkDerivation rec {
   pname = "paraview";
-  version = "5.6.3";
+  version = "5.8.0";
 
-  # fetching from GitHub instead of taking an "official" source
-  # tarball because of missing submodules there
   src = fetchFromGitHub {
     owner = "Kitware";
     repo = "ParaView";
     rev = "v${version}";
-    sha256 = "0zcij59pg47c45gfddnpbin13w16smzhcbivzm1k4pg4366wxq1q";
+    sha256 = "1mka6wwg9mbkqi3phs29mvxq6qbc44sspbm4awwamqhilh4grhrj";
     fetchSubmodules = true;
   };
 
-  cmakeFlags = [
-    "-DPARAVIEW_ENABLE_PYTHON=ON"
-    "-DPARAVIEW_INSTALL_DEVELOPMENT_FILES=ON"
-    "-DPARAVIEW_ENABLE_EMBEDDED_DOCUMENTATION=OFF"
-    "-DOpenGL_GL_PREFERENCE=GLVND"
-  ];
+  # Avoid error: format not a string literal and
+  # no format arguments [-Werror=format-security]
+  preConfigure = ''
+    substituteInPlace VTK/Common/Core/vtkLogger.h \
+      --replace 'vtkLogScopeF(verbosity_name, __func__)' 'vtkLogScopeF(verbosity_name, "%s", __func__)'
+
+    substituteInPlace VTK/Common/Core/vtkLogger.h \
+      --replace 'vtkVLogScopeF(level, __func__)' 'vtkVLogScopeF(level, "%s", __func__)'
+  '';
+
+  # Find the Qt platform plugin "minimal"
+  patchPhase = ''
+    export QT_PLUGIN_PATH=${qtbase.bin}/${qtbase.qtPluginPrefix}
+  '';
 
   # During build, binaries are called that rely on freshly built
   # libraries.  These reside in build/lib, and are not found by
@@ -29,37 +36,50 @@ mkDerivation rec {
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD/lib:$PWD/VTK/ThirdParty/vtkm/vtk-m/lib
   '';
 
-  enableParallelBuilding = true;
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DPARAVIEW_ENABLE_FFMPEG=ON"
+    "-DPARAVIEW_ENABLE_GDAL=ON"
+    "-DPARAVIEW_ENABLE_MOTIONFX=ON"
+    "-DPARAVIEW_ENABLE_VISITBRIDGE=ON"
+    "-DPARAVIEW_ENABLE_XDMF3=ON"
+    "-DPARAVIEW_INSTALL_DEVELOPMENT_FILES=ON"
+    "-DPARAVIEW_USE_MPI=ON"
+    "-DPARAVIEW_USE_PYTHON=ON"
+    "-DVTK_SMP_IMPLEMENTATION_TYPE=TBB"
+    "-DVTKm_ENABLE_MPI=ON"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DOpenGL_GL_PREFERENCE=GLVND"
+    "-GNinja"
+  ];
 
   nativeBuildInputs = [
     cmake
     makeWrapper
+    ninja
+    gfortran
   ];
 
   buildInputs = [
-    python
-    python.pkgs.numpy
     libGLU libGL
     libXt
+    openmpi
+    (python3.withPackages (ps: with ps; [ numpy matplotlib mpi4py ]))
+    tbb
+    boost
+    ffmpeg
+    gdal
     qtbase
     qtx11extras
     qttools
     qtxmlpatterns
+    qtsvg
   ];
 
-  # Paraview links into the Python library, resolving symbolic links on the way,
-  # so we need to put the correct sitePackages (with numpy) back on the path
-  preFixup = ''
-    wrapQtApp $out/bin/paraview \
-      --prefix PYTHONPATH "${python.pkgs.numpy}/${python.sitePackages}"
-    wrapQtApp $out/bin/pvbatch \
-      --prefix PYTHONPATH "${python.pkgs.numpy}/${python.sitePackages}"
-    wrapQtApp $out/bin/pvpython \
-      --prefix PYTHONPATH "${python.pkgs.numpy}/${python.sitePackages}"
-  '';
-
   meta = with stdenv.lib; {
-    homepage = "http://www.paraview.org/";
+    homepage = "https://www.paraview.org/";
     description = "3D Data analysis and visualization application";
     license = licenses.free;
     maintainers = with maintainers; [ guibert ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update ParaView to latest release 5.8.0.
Closing my packaging request at https://github.com/NixOS/nixpkgs/issues/89167

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
