### PR TITLE
urjtag: 0.10 -> 2019.2

### DIFF
--- a/pkgs/tools/misc/urjtag/default.nix
+++ b/pkgs/tools/misc/urjtag/default.nix
@@ -1,5 +1,5 @@
 { stdenv, autoconf, automake, pkgconfig, gettext, libtool, bison
-, flex, which, subversion, fetchsvn, makeWrapper, libftdi, libusb-compat-0_1, readline
+, flex, which, subversion, fetchurl, makeWrapper, libftdi, libusb-compat-0_1, readline
 , python3
 , svfSupport ? true
 , bsdlSupport ? true
@@ -7,14 +7,13 @@
 , jedecSupport ? true
 }:
 
-stdenv.mkDerivation {
-  version = "0.10";
+stdenv.mkDerivation rec {
+  version = "2019.12";
   pname = "urjtag";
 
-  src = fetchsvn {
-    url = "svn://svn.code.sf.net/p/urjtag/svn/trunk/urjtag";
-    rev = "2051";
-    sha256 = "0pyl0y27136nr8mmjdml7zjnfnpbjmgqzkjk99j3hvj38k10wq7f";
+  src = fetchurl {
+    url = "https://downloads.sourceforge.net/project/urjtag/urjtag/${version}/urjtag-${version}.tar.xz";
+    sha256 = "1k2vmvvarik0q3llbfbk8ad35mcns7w1ln9gla1mn7z9c6x6x90r";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -27,8 +26,6 @@ stdenv.mkDerivation {
     (stdenv.lib.enableFeature staplSupport "stapl")
     (stdenv.lib.enableFeature jedecSupport "jedec-exp")
   ];
-
-  preConfigure = "./autogen.sh";
 
   meta = {
     description = "Enhanced, modern tool for communicating over JTAG with flash chips, CPUs,and many more";

--- a/pkgs/tools/misc/urjtag/default.nix
+++ b/pkgs/tools/misc/urjtag/default.nix
@@ -1,5 +1,5 @@
 { stdenv, autoconf, automake, pkgconfig, gettext, libtool, bison
-, flex, which, subversion, fetchurl, makeWrapper, libftdi, libusb-compat-0_1, readline
+, flex, which, subversion, fetchurl, makeWrapper, libftdi1, libusb-compat-0_1, readline
 , python3
 , svfSupport ? true
 , bsdlSupport ? true
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ gettext autoconf automake libtool bison flex which
-    subversion makeWrapper readline libftdi libusb-compat-0_1 python3 ];
+    subversion makeWrapper readline libftdi1 libusb-compat-0_1 python3 ];
 
   configureFlags = [
     (stdenv.lib.enableFeature svfSupport   "svf")


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

0.10 is too old.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
