### PR TITLE
python3Packages.google_api_python_client: 1.9.1 -> 1.9.2

### DIFF
--- a/pkgs/development/python-modules/google-api-python-client/default.nix
+++ b/pkgs/development/python-modules/google-api-python-client/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "google-api-python-client";
-  version = "1.9.1";
+  version = "1.9.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0nfqf62g3l7ij779ind41p800ahdjijkhqx8nq6y029p98672c52";
+    sha256 = "1sdhnbwdaqb4zb47lcqdgj5hfc8imw4rs4kl78r1p2mkfln0493b";
   };
 
   # No tests included in archive

--- a/pkgs/development/python-modules/google_api_core/default.nix
+++ b/pkgs/development/python-modules/google_api_core/default.nix
@@ -5,12 +5,12 @@
 
 buildPythonPackage rec {
   pname = "google-api-core";
-  version = "1.17.0";
+  version = "1.18.0";
   disabled = isPy27; # google namespace no longer works on python2
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "12fn05x2fdhqmcaspjkkny2lh66hnnl0xf6pz3idxhlx8w5jl274";
+    sha256 = "08kdakab22j026nnrw9sirj3cc85aybp2zlh1qhh1741x3yn42ks";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`nixpkgs-review`:
```
90 packages updated:
beancount deja-dup duplicity duply dvc fava gcalcli kmymoney lieer lieer python3.7-beancount python3.7-cirq python3.7-goobook python37Packages.google_api_core (1.17.0 → 1.18.0) python37Packages.google_api_python_client (1.9.1 → 1.9.2) python3.7-google-cloud-asset python3.7-google-cloud-automl python3.7-google-cloud-bigquery python3.7-google-cloud-bigquery-datatransfer python3.7-google-cloud-bigtable python3.7-google-cloud-container python3.7-google-cloud-core python3.7-google-cloud-dataproc python3.7-google-cloud-datastore python3.7-google-cloud-dlp python3.7-google-cloud-dns python3.7-google-cloud-error-reporting python3.7-google-cloud-firestore python3.7-google-cloud-iot python3.7-google-cloud-kms python3.7-google-cloud-language python3.7-google-cloud-logging python3.7-google-cloud-monitoring python3.7-google-cloud-pubsub python3.7-google-cloud-redis python3.7-google-cloud-resource-manager python3.7-google-cloud-runtimeconfig python3.7-google-cloud-securitycenter python3.7-google-cloud-spanner python3.7-google-cloud-speech python3.7-google-cloud-storage python3.7-google-cloud-tasks python3.7-google-cloud-texttospeech python3.7-google-cloud-trace python3.7-google-cloud-translate python3.7-google-cloud-videointelligence python3.7-google-cloud-vision python3.7-google-cloud-websecurityscanner python3.7-pydrive python3.7-weboob python3.8-beancount python3.8-cirq python3.8-goobook python38Packages.google_api_core (1.17.0 → 1.18.0) python38Packages.google_api_python_client (1.9.1 → 1.9.2) python3.8-google-cloud-asset python3.8-google-cloud-automl python3.8-google-cloud-bigquery python3.8-google-cloud-bigquery-datatransfer python3.8-google-cloud-bigtable python3.8-google-cloud-container python3.8-google-cloud-core python3.8-google-cloud-dataproc python3.8-google-cloud-datastore python3.8-google-cloud-dlp python3.8-google-cloud-dns python3.8-google-cloud-error-reporting python3.8-google-cloud-firestore python3.8-google-cloud-iot python3.8-google-cloud-kms python3.8-google-cloud-language python3.8-google-cloud-logging python3.8-google-cloud-monitoring python3.8-google-cloud-pubsub python3.8-google-cloud-redis python3.8-google-cloud-resource-manager python3.8-google-cloud-runtimeconfig python3.8-google-cloud-securitycenter python3.8-google-cloud-spanner python3.8-google-cloud-speech python3.8-google-cloud-storage python3.8-google-cloud-tasks python3.8-google-cloud-texttospeech python3.8-google-cloud-trace python3.8-google-cloud-translate python3.8-google-cloud-videointelligence python3.8-google-cloud-vision python3.8-google-cloud-websecurityscanner python3.8-pydrive python3.8-weboob
```

-> all packages did build fine

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
