### PR TITLE
asio: 1.12 -> 1.16

### DIFF
--- a/pkgs/development/libraries/asio/1.12.nix
+++ b/pkgs/development/libraries/asio/1.12.nix
@@ -1,6 +1,0 @@
-{callPackage, ... } @ args:
-
-callPackage ./generic.nix (args // {
-  version = "1.12.1";
-  sha256 = "0nln45662kg799ykvqx5m9z9qcsmadmgg6r5najryls7x16in2d9";
-})

--- a/pkgs/development/libraries/asio/default.nix
+++ b/pkgs/development/libraries/asio/default.nix
@@ -1,0 +1,6 @@
+{callPackage, ... } @ args:
+
+callPackage ./generic.nix (args // {
+  version = "1.16.1";
+  sha256 = "1333ca6lnsdck4fsgjpbqf4lagxsnbg9970wxlsrinmwvdvdnwg2";
+})

--- a/pkgs/development/libraries/asio/generic.nix
+++ b/pkgs/development/libraries/asio/generic.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     homepage = "http://asio.sourceforge.net/";
     description = "Cross-platform C++ library for network and low-level I/O programming";
     license = licenses.boost;
-    broken = stdenv.isDarwin;  # test when updating to >=1.12.1
+    broken = stdenv.isDarwin && stdenv.lib.versionOlder version "1.16.1";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11285,9 +11285,8 @@ in
 
   assimp = callPackage ../development/libraries/assimp { };
 
-  asio = asio_1_12;
   asio_1_10 = callPackage ../development/libraries/asio/1.10.nix { };
-  asio_1_12 = callPackage ../development/libraries/asio/1.12.nix { };
+  asio = callPackage ../development/libraries/asio/default.nix { };
 
   aspell = callPackage ../development/libraries/aspell { };
 


### PR DESCRIPTION
1.16 will now build on Darwin, properly mark it as such.

Keep asio_1_10 and asio_1_12 for applications which cannot easily upgrade.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

###### Motivation for this change
Another package dependency on `asio` broken in Darwin (will not compile).
The latest version will compile: upgraded.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions (Ubuntu 18.04)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev 931cd746"`
- [n/a] Tested execution of all binary files (usually in `./result/bin/`)
- [n/a] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
