### PR TITLE
gitlab: 13.0.4 -> 13.0.6

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,13 +1,13 @@
 {
-  "version": "13.0.4",
-  "repo_hash": "15pfg3ss1diqsnlf0xpx4ixlpjnvzghzjfvs6y3bv21qnjfwkp0g",
+  "version": "13.0.6",
+  "repo_hash": "0iyzx5lnkwp6m8q5p60gzsjmpf6qflvzl0vzfw37hymnxwq646zy",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v13.0.4-ee",
+  "rev": "v13.0.6-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "13.0.4",
+    "GITALY_SERVER_VERSION": "13.0.6",
     "GITLAB_PAGES_VERSION": "1.18.0",
     "GITLAB_SHELL_VERSION": "13.2.0",
-    "GITLAB_WORKHORSE_VERSION": "8.31.1"
+    "GITLAB_WORKHORSE_VERSION": "8.31.2"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -19,14 +19,14 @@ let
       };
   };
 in buildGoPackage rec {
-  version = "13.0.4";
+  version = "13.0.6";
   pname = "gitaly";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "1hnjv2q98016srvjmyjpd5fkpg68mra6qk0asl1l83z2vin2xrkm";
+    sha256 = "14vp73z9f0p3m1bjykkfzrmw9miyjxiqm79rns477xbm2dbmwa4s";
   };
 
   # Fix a check which assumes that hook files are writeable by their

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -3,13 +3,13 @@
 buildGoPackage rec {
   pname = "gitlab-workhorse";
 
-  version = "8.31.1";
+  version = "8.31.2";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-workhorse";
     rev = "v${version}";
-    sha256 = "1c2y1icil98qay9d95q1rlpi0ffhll990grkkib9srsn55b2i86v";
+    sha256 = "0wvhhjfb490mjdrmc9xwr3qfh3941xn3b02c757ghrvzwv329wvg";
   };
 
   goPackagePath = "gitlab.com/gitlab-org/gitlab-workhorse";


### PR DESCRIPTION
CI Token Access Control

An authorization issue discovered in the mirroring logic allowed read access to private repositories. This issue is now mitigated in the latest release and is waiting for a CVE ID to be assigned.

https://about.gitlab.com/releases/2020/06/10/critical-security-release-13-0-6-released/

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
