### PR TITLE
[20.03] gitlab: 12.10.9 -> 12.10.11

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,13 +1,13 @@
 {
-  "version": "12.10.9",
-  "repo_hash": "0mhvw09rvvq4iq18s6xfnl17irg305pxkwjgrsn7k06k0zf4dx5l",
+  "version": "12.10.11",
+  "repo_hash": "058xnmmz4fnan85x0mw0s2i2lr9y7yx2hqxfcil1frj2rz7ralds",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v12.10.9-ee",
+  "rev": "v12.10.11-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "12.10.9",
+    "GITALY_SERVER_VERSION": "12.10.11",
     "GITLAB_PAGES_VERSION": "1.17.0",
     "GITLAB_SHELL_VERSION": "12.2.0",
-    "GITLAB_WORKHORSE_VERSION": "8.30.2"
+    "GITLAB_WORKHORSE_VERSION": "8.30.3"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -19,14 +19,14 @@ let
       };
   };
 in buildGoPackage rec {
-  version = "12.10.9";
+  version = "12.10.11";
   pname = "gitaly";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "0rcds6shwmqv2acjdj1i0jhjcp3ww8b1aysqqsyvsgfaa160n9s9";
+    sha256 = "1qzrfnihcx8ysy40z2sq5rgdgpp2gy5db8snlx7si2l9h6pjg7hz";
   };
 
   # Fix a check which assumes that hook files are writeable by their

--- a/pkgs/applications/version-management/gitlab/gitaly/deps.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/deps.nix
@@ -10,15 +10,6 @@
     };
   }
   {
-    goPackagePath = "dmitri.shuralyov.com/gpu/mtl";
-    fetch = {
-      type = "git";
-      url = "https://dmitri.shuralyov.com/gpu/mtl";
-      rev = "666a987793e9";
-      sha256 = "1isd03hgiwcf2ld1rlp0plrnfz7r4i7c5q4kb6hkcd22axnmrv0z";
-    };
-  }
-  {
     goPackagePath = "github.com/BurntSushi/toml";
     fetch = {
       type = "git";
@@ -1436,8 +1427,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/ugorji/go";
-      rev = "d75b2dcb6bc8";
-      sha256 = "0di1k35gpq9bp958ywranpbskx2vdwlb38s22vl9rybm3wa5g3ps";
+      rev = "v1.1.4";
+      sha256 = "0ma2qvn5wqvjidpdz74x832a813qnr1cxbx6n6n125ak9b3wbn5w";
     };
   }
   {

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -3,13 +3,13 @@
 buildGoPackage rec {
   pname = "gitlab-workhorse";
 
-  version = "8.30.2";
+  version = "8.30.3";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-workhorse";
     rev = "v${version}";
-    sha256 = "1ws59ry16kx4nqp92xcqw3fri570pvpdgvy822ndi7rybw5xij7p";
+    sha256 = "13xnx04j8p31l1lslcixf3ihagz9brih9zvypwnjb76ipgcg431z";
   };
 
   goPackagePath = "gitlab.com/gitlab-org/gitlab-workhorse";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/deps.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/deps.nix
@@ -10,15 +10,6 @@
     };
   }
   {
-    goPackagePath = "dmitri.shuralyov.com/gpu/mtl";
-    fetch = {
-      type = "git";
-      url = "https://dmitri.shuralyov.com/gpu/mtl";
-      rev = "666a987793e9";
-      sha256 = "1isd03hgiwcf2ld1rlp0plrnfz7r4i7c5q4kb6hkcd22axnmrv0z";
-    };
-  }
-  {
     goPackagePath = "github.com/BurntSushi/toml";
     fetch = {
       type = "git";


### PR DESCRIPTION
CI Token Access Control

An authorization issue discovered in the mirroring logic allowed read access to private repositories. This issue is now mitigated in the latest release and is waiting for a CVE ID to be assigned.

https://about.gitlab.com/releases/2020/06/10/critical-security-release-13-0-6-released/

PR for master (13.x): https://github.com/NixOS/nixpkgs/pull/90101


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
