### PR TITLE
pythonPackages.pyside2: don't fail import on missing `shiboken2`

### DIFF
--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -23,11 +23,12 @@ stdenv.mkDerivation rec {
     "-DPYTHON_EXECUTABLE=${python.interpreter}"
   ];
 
-  nativeBuildInputs = [ cmake ninja qt5.qmake shiboken2 python ];
+  nativeBuildInputs = [ cmake ninja qt5.qmake python ];
   buildInputs = with qt5; [
     qtbase qtxmlpatterns qtmultimedia qttools qtx11extras qtlocation qtscript
     qtwebsockets qtwebengine qtwebchannel qtcharts qtsensors qtsvg
   ];
+  propagatedBuildInputs = [ shiboken2 ];
 
   meta = with stdenv.lib; {
     description = "LGPL-licensed Python bindings for Qt";


### PR DESCRIPTION
###### Motivation for this change

Don't fail on
`nix-shell -p "python3.withPackages (p: with p; [ pyside2 ])" --run 'python -c "import pyside2"'`
 with a `ModuleNotFoundError: No module named 'shiboken2'`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
# before
/nix/store/w88qlmzijrqm68j8xx1xm1x8r9q6vlv7-pyside2-5.12.3       1419920272
# after
/nix/store/lyca0iilbgpj9izrdglm9zlvpc6hgznq-pyside2-5.12.3       1420060640
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
