### PR TITLE
piccata 1.0.1 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/piccata/default.nix
+++ b/pkgs/development/python-modules/piccata/default.nix
@@ -1,16 +1,22 @@
-{ buildPythonPackage, fetchPypi, lib, ipaddress, isPy3k }:
+{ buildPythonPackage, isPy27, fetchFromGitHub, lib, ipaddress }:
 
 buildPythonPackage rec {
   pname = "piccata";
-  version = "1.0.1";
-  disabled = isPy3k;
+  version = "2.0.0";
+  disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "45f6c98c2ea809d445040888117f99bc3ee843490d86fecc5805ff5ea41508f7";
+  src = fetchFromGitHub {
+    owner = "NordicSemiconductor";
+    repo = pname;
+    rev = version;
+    sha256 = "0pn842jcf2czjks5dphivgp1s7wiifqiv93s0a89h0wxafd6pbsr";
   };
 
-  propagatedBuildInputs = [ ipaddress ];
+  propagatedBuildInputs = [
+    ipaddress
+  ];
+
+  pythonImportsCheck = [ "piccata" ];
 
   meta = {
     description = "Simple CoAP (RFC7252) toolkit";


### PR DESCRIPTION
###### Motivation for this change

Needed piccata working with Python3, upgraded to latest version.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

NOTE:

- piccata will no longer build on python2.7; but this is EOL so not considered a problem
- nrfutil will not build ... this has been fixed and will be introduced in a later patch because it depends on this and other pull requests. See https://github.com/siriobalmelli-foss/nixpkgs/tree/upgrade/nrfutil 