### PR TITLE
python3Packages.pyspinel: fix build

### DIFF
--- a/pkgs/development/python-modules/pyspinel/default.nix
+++ b/pkgs/development/python-modules/pyspinel/default.nix
@@ -1,21 +1,32 @@
-{ buildPythonPackage, fetchPypi, lib, future, pyserial, ipaddress }:
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27
+, future, pyserial, ipaddress
+}:
 
 buildPythonPackage rec {
   pname = "pyspinel";
-  version = "1.0.1";
+  version = "unstable-2020-06-19";  # no versioned release since 2018
+  disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "5cbfd0f6e9ef3b5cd3a4e72a9a0cee1fe50d518b43746be07a1fd17e883328c2";
+  src = fetchFromGitHub {
+    owner = "openthread";
+    repo = pname;
+    rev = "e0bb3f8e6f49b593ab248a75de04a71626ae8101";
+    sha256 = "0nfmdkgbhmkl82dfxjpwiiarxngm6a3fvdrzpaqp60a4b17pipqg";
   };
 
-  propagatedBuildInputs = [ pyserial ipaddress future ];
+  propagatedBuildInputs = [
+    future
+    ipaddress
+    pyserial
+  ];
 
   doCheck = false;
+  pythonImportsCheck = [ "spinel" ];
 
-  meta = {
+  meta = with lib; {
     description = "Interface to the OpenThread Network Co-Processor (NCP)";
     homepage = "https://github.com/openthread/pyspinel";
-    maintainers = with lib.maintainers; [ gebner ];
+    license = licenses.asl20;
+    maintainers = with maintainers; [ gebner ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to reference an upstream fix to build on python >=3.3

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
