### PR TITLE
postfix: Replaced config key by recommendation and introduced usage of system trust store

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -119,6 +119,11 @@ systemd.services.mysql.serviceConfig.ReadWritePaths = [ "/var/data" ];
       feature is disabled by default.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <varname>services.postfix.sslCACert</varname> was replaced by <varname>services.postfix.tlsTrustedAuthorities</varname> which now defaults to system certifcate authorities.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -454,7 +454,7 @@ in
         '';
         example = {
           mail_owner = "postfix";
-          smtp_use_tls = true;
+          smtp_tls_security_level = "may";
         };
       };
 
@@ -776,13 +776,13 @@ in
         smtp_tls_cert_file = cfg.sslCert;
         smtp_tls_key_file = cfg.sslKey;
 
-        smtp_use_tls = true;
+        smtp_tls_security_level = "may";
 
         smtpd_tls_CAfile = cfg.sslCACert;
         smtpd_tls_cert_file = cfg.sslCert;
         smtpd_tls_key_file = cfg.sslKey;
 
-        smtpd_use_tls = true;
+        smtpd_tls_security_level = "may";
       };
 
       services.postfix.masterConfig = {

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -466,16 +466,18 @@ in
         ";
       };
 
+      tlsTrustedAuthorities = mkOption {
+        type = types.str;
+        default = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+        description = ''
+          File containing trusted certification authorities (CA) to verify certificates of mailservers contacted for mail delivery. This basically sets smtp_tls_CAfile and enables opportunistic tls. Defaults to NixOS trusted certification authorities.
+        '';
+      };
+
       sslCert = mkOption {
         type = types.str;
         default = "";
         description = "SSL certificate to use.";
-      };
-
-      sslCACert = mkOption {
-        type = types.str;
-        default = "";
-        description = "SSL certificate of CA.";
       };
 
       sslKey = mkOption {
@@ -771,14 +773,16 @@ in
         recipient_canonical_classes = [ "envelope_recipient" ];
       }
       // optionalAttrs cfg.enableHeaderChecks { header_checks = [ "regexp:/etc/postfix/header_checks" ]; }
+      // optionalAttrs (cfg.tlsTrustedAuthorities != "") {
+        smtp_tls_CAfile = cfg.tlsTrustedAuthorities;
+        smtp_tls_security_level = "may";
+      }
       // optionalAttrs (cfg.sslCert != "") {
-        smtp_tls_CAfile = cfg.sslCACert;
         smtp_tls_cert_file = cfg.sslCert;
         smtp_tls_key_file = cfg.sslKey;
 
         smtp_tls_security_level = "may";
 
-        smtpd_tls_CAfile = cfg.sslCACert;
         smtpd_tls_cert_file = cfg.sslCert;
         smtpd_tls_key_file = cfg.sslKey;
 
@@ -900,4 +904,9 @@ in
       services.postfix.mapFiles.client_access = checkClientAccessFile;
     })
   ]);
+
+  imports = [
+   (mkRemovedOptionModule [ "services" "postfix" "sslCACert" ]
+     "services.postfix.sslCACert was replaced by services.postfix.tlsTrustedAuthorities. In case you intend that your server should validate requested client certificates use services.postfix.extraConfig.")
+  ];
 }


### PR DESCRIPTION
###### Motivation for this change
* Follow postfix documentation documentation how to enable tls
* Adding system trust store to so outgoing connections can be verified

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
[root@nixos:~/src/nix/nixpkgs]# nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
these paths will be fetched (6.04 MiB download, 44.56 MiB unpacked):
  /nix/store/pbw1gdajhgw48wi8x7kr3c8mgvcl7asc-git-2.25.4
  /nix/store/pvzh7c4y6fqxs1p4swhb02l0qpsh4ayn-nixpkgs-review-2.3.1
copying path '/nix/store/pbw1gdajhgw48wi8x7kr3c8mgvcl7asc-git-2.25.4' from 'https://cache.nixos.org'...
copying path '/nix/store/pvzh7c4y6fqxs1p4swhb02l0qpsh4ayn-nixpkgs-review-2.3.1' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 78, done.
remote: Counting objects: 100% (70/70), done.
remote: Compressing objects: 100% (20/20), done.
remote: Total 46 (delta 36), reused 34 (delta 24), pack-reused 0
Unpacking objects: 100% (46/46), 10.47 KiB | 25.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
 * [new branch]              master     -> refs/nixpkgs-review/0
$ git worktree add /root/.cache/nixpkgs-review/rev-6dfa1c839a1caff48343a33c5366b38d1abacf75-dirty/nixpkgs 580a0e52b1323b4693e9edbed1490830163c3d32
Preparing worktree (detached HEAD 580a0e52b13)
Updating files: 100% (21835/21835), done.
HEAD is now at 580a0e52b13 Merge pull request #89934 from zowoq/gogetdoc
$ nix-env -f /root/.cache/nixpkgs-review/rev-6dfa1c839a1caff48343a33c5366b38d1abacf75-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
