### PR TITLE
netcdf: prevent bogus runtime dependency on gcc

### DIFF
--- a/pkgs/development/libraries/netcdf/default.nix
+++ b/pkgs/development/libraries/netcdf/default.nix
@@ -3,6 +3,7 @@
 , hdf5
 , m4
 , curl # for DAP
+, removeReferencesTo
 }:
 
 let
@@ -26,7 +27,7 @@ in stdenv.mkDerivation rec {
     done
   '';
 
-  nativeBuildInputs = [ m4 ];
+  nativeBuildInputs = [ m4 removeReferencesTo ];
   buildInputs = [ hdf5 curl mpi ];
 
   passthru = {
@@ -41,6 +42,12 @@ in stdenv.mkDerivation rec {
       "--disable-dap-remote-tests"
   ]
   ++ (stdenv.lib.optionals mpiSupport [ "--enable-parallel-tests" "CC=${mpi}/bin/mpicc" ]);
+
+  disallowedReferences = [ stdenv.cc ];
+
+  postFixup = ''
+    remove-references-to -t ${stdenv.cc} "$(readlink -f $out/lib/libnetcdf.settings)"
+  '';
 
   doCheck = !mpiSupport;
 


### PR DESCRIPTION


###### Motivation for this change

Installation includes the the captured compilation settings in the outputs, and the full gcc path then leads to a bogus runtime dependency. To defeat this, we remove any occurrences of the compiler's store dir path from this file after installation.

An alternative fix might be to simply remove the settings file (it does not appear to be required for anything other than as a reference for repeating the compilation). I chose this more conservative change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
