### PR TITLE
Fix some pitfalls from the Raspberry Pi 4 specific sd image

### DIFF
--- a/nixos/modules/installer/cd-dvd/sd-image-raspberrypi4.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-raspberrypi4.nix
@@ -18,11 +18,18 @@
 
   sdImage = {
     firmwareSize = 128;
+    firmwarePartitionName = "NIXOS_BOOT";
     # This is a hack to avoid replicating config.txt from boot.loader.raspberryPi
     populateFirmwareCommands =
       "${config.system.build.installBootLoader} ${config.system.build.toplevel} -d ./firmware";
     # As the boot process is done entirely in the firmware partition.
     populateRootCommands = "";
+  };
+
+  fileSystems."/boot/firmware" = {
+    # This effectively "renames" the loaOf entry set in sd-image.nix
+    mountPoint = "/boot";
+    neededForBoot = true;
   };
 
   # the installation media is also the installation target,

--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -63,6 +63,14 @@ in
       '';
     };
 
+    firmwarePartitionName = mkOption {
+      type = types.str;
+      default = "FIRMWARE";
+      description = ''
+        Name of the filesystem which holds the boot firmware.
+      '';
+    };
+
     rootPartitionUUID = mkOption {
       type = types.nullOr types.str;
       default = null;
@@ -114,7 +122,7 @@ in
   config = {
     fileSystems = {
       "/boot/firmware" = {
-        device = "/dev/disk/by-label/FIRMWARE";
+        device = "/dev/disk/by-label/${config.sdImage.firmwarePartitionName}";
         fsType = "vfat";
         # Alternatively, this could be removed from the configuration.
         # The filesystem is not needed at runtime, it could be treated
@@ -178,7 +186,7 @@ in
         # Create a FAT32 /boot/firmware partition of suitable size into firmware_part.img
         eval $(partx $img -o START,SECTORS --nr 1 --pairs)
         truncate -s $((SECTORS * 512)) firmware_part.img
-        faketime "1970-01-01 00:00:00" mkfs.vfat -i ${config.sdImage.firmwarePartitionID} -n FIRMWARE firmware_part.img
+        faketime "1970-01-01 00:00:00" mkfs.vfat -i ${config.sdImage.firmwarePartitionID} -n ${config.sdImage.firmwarePartitionName} firmware_part.img
 
         # Populate the files intended for /boot/firmware
         mkdir firmware

--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi-builder.sh
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi-builder.sh
@@ -1,4 +1,7 @@
-#! @bash@/bin/sh -e
+#! @bash@/bin/sh
+
+# This can end up being called disregarding the shebang.
+set -e
 
 shopt -s nullglob
 


### PR DESCRIPTION
###### Motivation for this change

The SD image is not exactly trivial to use if you are not intimately knowledgeable of the way our default generic aarch64 image is built. That is, we have only shoe-horned the rpi4 kernel, and rpi boot chain on top of that default image.

This change aims to square the circle, and make it less trivial to get things wrong.

The main change is that we are naming the FAT32 partition something more obvious *for this use case*, `NIXOS_BOOT`, and we are also mounting it by default so new generations will boot as expected.

This is needed since I haven't managed to get `u-boot` booting NixOS on the pi4 yet, and the mainline kernel is (supposedly) still not there yet.

###### What does this change??

Well, mainly, it makes the difference in this image, compared to the default, much more obvious. Hopefully fixing the issue where users ended up confused with boot "reverting" to an old generation.

The main thing to look out for, is that we're going to have to ask users to list from `/dev/disk/by-label` to know the label of the filesystem, and *then* validate it's properly mounted.

I had a "first boot" boot once, though could not reproduce with a fresh image, where the `neededForBoot` `/boot` partition didn't end up mounting, and the boot didn't fail. It was mounted after a reboot. I don't think that if it is an issue, that is an issue specific to the changes here, but I don't know what it could be.

###### Things done

This was tested using cross-compilation, and using #89717 commits.

Verified to boot on a raspberry pi 4.