### PR TITLE
Agda: Fix haskell version 2.6.1

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2537,6 +2537,7 @@ default-package-overrides:
 
 extra-packages:
   - aeson < 0.8                         # newer versions don't work with GHC 7.6.x or earlier
+  - Agda == 2.6.1                       # allows the agdaPackage set to be fixed to this version so that it won't break when another agda version is released.
   - ansi-terminal == 0.10.3             # required by cabal-plan, and policeman in ghc-8.8.x
   - aeson-pretty < 0.8                  # required by elm compiler
   - apply-refact < 0.4                  # newer versions don't work with GHC 8.0.x


### PR DESCRIPTION
In the future, it would be good to maintain multiple `agdaPackages` sets along side different versions, like how `coq-packages` is set up. To do this we would need access to different versions of Agda. As a start I have tried to fix version `2.6.1` of `Agda` so that the current package set can be fixed to this version and won't break when another version comes out.

My understanding is that this will make an `Agda` package which follows the latest version, and an `Agda_2_6_1` package which is fixed on `2.6.1`. Apologies if what I have done in this PR does not do this or if there is a better way to achieve this.
