### PR TITLE
nixos/undervolt: misc cleanups / fixes

### DIFF
--- a/nixos/modules/services/hardware/undervolt.nix
+++ b/nixos/modules/services/hardware/undervolt.nix
@@ -30,7 +30,7 @@ in
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The amount of voltage to offset the CPU cores by. Accepts a floating point number.
+        The amount of voltage in mV to offset the CPU cores by.
       '';
     };
 
@@ -38,7 +38,7 @@ in
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The amount of voltage to offset the GPU by. Accepts a floating point number.
+        The amount of voltage in mV to offset the GPU by.
       '';
     };
 
@@ -46,7 +46,7 @@ in
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The amount of voltage to offset uncore by. Accepts a floating point number.
+        The amount of voltage in mV to offset uncore by.
       '';
     };
 
@@ -54,7 +54,7 @@ in
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The amount of voltage to offset analogio by. Accepts a floating point number.
+        The amount of voltage in mV to offset analogio by.
       '';
     };
 
@@ -62,7 +62,7 @@ in
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The temperature target. Accepts a floating point number.
+        The temperature target in Celsius degrees.
       '';
     };
 
@@ -70,7 +70,7 @@ in
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The temperature target on AC power. Accepts a floating point number.
+        The temperature target on AC power in Celsius degrees.
       '';
     };
 
@@ -78,7 +78,7 @@ in
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The temperature target on battery power. Accepts a floating point number.
+        The temperature target on battery power in Celsius degrees.
       '';
     };
   };

--- a/nixos/modules/services/hardware/undervolt.nix
+++ b/nixos/modules/services/hardware/undervolt.nix
@@ -27,7 +27,7 @@ in
     };
 
     coreOffset = mkOption {
-      type = types.nullOr types.str;
+      type = types.nullOr types.int;
       default = null;
       description = ''
         The amount of voltage in mV to offset the CPU cores by.
@@ -35,7 +35,7 @@ in
     };
 
     gpuOffset = mkOption {
-      type = types.nullOr types.str;
+      type = types.nullOr types.int;
       default = null;
       description = ''
         The amount of voltage in mV to offset the GPU by.
@@ -43,7 +43,7 @@ in
     };
 
     uncoreOffset = mkOption {
-      type = types.nullOr types.str;
+      type = types.nullOr types.int;
       default = null;
       description = ''
         The amount of voltage in mV to offset uncore by.
@@ -51,7 +51,7 @@ in
     };
 
     analogioOffset = mkOption {
-      type = types.nullOr types.str;
+      type = types.nullOr types.int;
       default = null;
       description = ''
         The amount of voltage in mV to offset analogio by.
@@ -59,7 +59,7 @@ in
     };
 
     temp = mkOption {
-      type = types.nullOr types.str;
+      type = types.nullOr types.int;
       default = null;
       description = ''
         The temperature target in Celsius degrees.
@@ -67,7 +67,7 @@ in
     };
 
     tempAc = mkOption {
-      type = types.nullOr types.str;
+      type = types.nullOr types.int;
       default = null;
       description = ''
         The temperature target on AC power in Celsius degrees.
@@ -75,7 +75,7 @@ in
     };
 
     tempBat = mkOption {
-      type = types.nullOr types.str;
+      type = types.nullOr types.int;
       default = null;
       description = ''
         The temperature target on battery power in Celsius degrees.
@@ -104,14 +104,14 @@ in
         ExecStart = ''
           ${pkgs.undervolt}/bin/undervolt \
             ${optionalString cfg.verbose "--verbose"} \
-            ${optionalString (cfg.coreOffset != null) "--core ${cfg.coreOffset}"} \
-            ${optionalString (cfg.coreOffset != null) "--cache ${cfg.coreOffset}"} \
-            ${optionalString (cfg.gpuOffset != null) "--gpu ${cfg.gpuOffset}"} \
-            ${optionalString (cfg.uncoreOffset != null) "--uncore ${cfg.uncoreOffset}"} \
-            ${optionalString (cfg.analogioOffset != null) "--analogio ${cfg.analogioOffset}"} \
-            ${optionalString (cfg.temp != null) "--temp ${cfg.temp}"} \
-            ${optionalString (cfg.tempAc != null) "--temp-ac ${cfg.tempAc}"} \
-            ${optionalString (cfg.tempBat != null) "--temp-bat ${cfg.tempBat}"}
+            ${optionalString (cfg.coreOffset != null) "--core ${toString cfg.coreOffset}"} \
+            ${optionalString (cfg.coreOffset != null) "--cache ${toString cfg.coreOffset}"} \
+            ${optionalString (cfg.gpuOffset != null) "--gpu ${toString cfg.gpuOffset}"} \
+            ${optionalString (cfg.uncoreOffset != null) "--uncore ${toString cfg.uncoreOffset}"} \
+            ${optionalString (cfg.analogioOffset != null) "--analogio ${toString cfg.analogioOffset}"} \
+            ${optionalString (cfg.temp != null) "--temp ${toString cfg.temp}"} \
+            ${optionalString (cfg.tempAc != null) "--temp-ac ${toString cfg.tempAc}"} \
+            ${optionalString (cfg.tempBat != null) "--temp-bat ${toString cfg.tempBat}"}
         '';
       };
     };

--- a/nixos/modules/services/hardware/undervolt.nix
+++ b/nixos/modules/services/hardware/undervolt.nix
@@ -1,18 +1,13 @@
 { config, pkgs, lib, ... }:
 
 with lib;
-
 let
   cfg = config.services.undervolt;
-in {
+in
+{
   options.services.undervolt = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to undervolt intel cpus.
-      '';
-    };
+    enable = mkEnableOption
+      "Intel CPU undervolting service (WARNING: may permanently damage your hardware!)";
 
     verbose = mkOption {
       type = types.bool;


### PR DESCRIPTION
###### Motivation for this change

Closes #74029.

Apart from adding a warning I also tried to improve the options' descriptions and their types to more closely match what the `undervolt` package expects.

/cc @Vodurden @adisbladis 

###### Things done

Tested on my system with:

```nix
services = {
  undervolt = {
    enable = true;
    coreOffset = -110;
    analogioOffset = -110;
    gpuOffset = -70;
  };
};
```

and verified the values are still correctly applied.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
