### PR TITLE
coqPackages.mathcomp: 1.10.0 -> 1.11.0 [mistake]

### DIFF
--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -66,7 +66,8 @@ let
   #######################################################################
     # sha256 of released mathcomp versions
     sha256 = {
-      "1.11+beta1" = "12i3zznwajlihzpqsiqniv20rklj8d8401lhd241xy4s21fxkkjm";
+      "1.11.0"       = "06a71d196wd5k4wg7khwqb7j7ifr7garhwkd54s86i0j7d6nhl3c";
+      "1.11+beta1"   = "12i3zznwajlihzpqsiqniv20rklj8d8401lhd241xy4s21fxkkjm";
       "1.10.0"       = "1b9m6pwxxyivw7rgx82gn5kmgv2mfv3h3y0mmjcjfypi8ydkrlbv";
       "1.9.0"        = "0lid9zaazdi3d38l8042lczb02pw5m9wq0yysiilx891hgq2p81r";
       "1.8.0"        = "07l40is389ih8bi525gpqs3qp4yb2kl11r9c8ynk1ifpjzpnabwp";
@@ -75,7 +76,8 @@ let
     };
     # versions of coq compatible with released mathcomp versions
     coq-versions     = {
-      "1.11+beta1" = flip elem [ "8.7" "8.8" "8.9" "8.10" "8.11" ];
+      "1.11.0"       = flip elem [ "8.7" "8.8" "8.9" "8.10" "8.11" ];
+      "1.11+beta1"   = flip elem [ "8.7" "8.8" "8.9" "8.10" "8.11" ];
       "1.10.0"       = flip elem [ "8.7" "8.8" "8.9" "8.10" "8.11" ];
       "1.9.0"        = flip elem [ "8.7" "8.8" "8.9" "8.10" ];
       "1.8.0"        = flip elem [ "8.7" "8.8" "8.9" ];
@@ -94,7 +96,7 @@ let
     # mathcomp preferred versions by decreasing order
     # (the first version in the list will be tried first)
     version-preferences =
-      [ "1.10.0" "1.9.0" "1.11+beta1" "1.8.0" "1.7.0" "1.6.1" ];
+      [ "1.10.0" "1.11.0" "1.9.0" "1.11+beta1" "1.8.0" "1.7.0" "1.6.1" ];
 
     # list of core mathcomp packages sorted by dependency order
     packages = _version: # unused in current versions of mathcomp

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -66,7 +66,7 @@ let
   #######################################################################
     # sha256 of released mathcomp versions
     sha256 = {
-      "1.11.0+beta1" = "12i3zznwajlihzpqsiqniv20rklj8d8401lhd241xy4s21fxkkjm";
+      "1.11+beta1" = "12i3zznwajlihzpqsiqniv20rklj8d8401lhd241xy4s21fxkkjm";
       "1.10.0"       = "1b9m6pwxxyivw7rgx82gn5kmgv2mfv3h3y0mmjcjfypi8ydkrlbv";
       "1.9.0"        = "0lid9zaazdi3d38l8042lczb02pw5m9wq0yysiilx891hgq2p81r";
       "1.8.0"        = "07l40is389ih8bi525gpqs3qp4yb2kl11r9c8ynk1ifpjzpnabwp";
@@ -75,7 +75,7 @@ let
     };
     # versions of coq compatible with released mathcomp versions
     coq-versions     = {
-      "1.11.0+beta1" = flip elem [ "8.7" "8.8" "8.9" "8.10" "8.11" ];
+      "1.11+beta1" = flip elem [ "8.7" "8.8" "8.9" "8.10" "8.11" ];
       "1.10.0"       = flip elem [ "8.7" "8.8" "8.9" "8.10" "8.11" ];
       "1.9.0"        = flip elem [ "8.7" "8.8" "8.9" "8.10" ];
       "1.8.0"        = flip elem [ "8.7" "8.8" "8.9" ];
@@ -94,7 +94,7 @@ let
     # mathcomp preferred versions by decreasing order
     # (the first version in the list will be tried first)
     version-preferences =
-      [ "1.10.0" "1.9.0" "1.11.0+beta1" "1.8.0" "1.7.0" "1.6.1" ];
+      [ "1.10.0" "1.9.0" "1.11+beta1" "1.8.0" "1.7.0" "1.6.1" ];
 
     # list of core mathcomp packages sorted by dependency order
     packages = _version: # unused in current versions of mathcomp

--- a/pkgs/development/coq-modules/mathcomp/extra.nix
+++ b/pkgs/development/coq-modules/mathcomp/extra.nix
@@ -236,29 +236,29 @@ let
     in
       {
         "8.11" = {
-          "1.11.0+beta1" = v5;
+          "1.11+beta1" = v5;
           "1.10.0"       = v4 // {mathcomp-finmap = "1.4.0+coq-8.11";};
         };
         "8.10" = {
-          "1.11.0+beta1" = removeAttrs v5 ["coqeal"];
+          "1.11+beta1" = removeAttrs v5 ["coqeal"];
           "1.10.0"       = v4;
           "1.9.0"        = removeAttrs v3 ["coqeal"];
         };
         "8.9" = {
-          "1.11.0+beta1" = removeAttrs v5 ["mathcomp-analysis"];
+          "1.11+beta1" = removeAttrs v5 ["mathcomp-analysis"];
           "1.10.0"       = v4;
           "1.9.0"        = removeAttrs v3 ["coqeal"];
           "1.8.0"        = removeAttrs v2 ["coqeal"];
         };
         "8.8" = {
-          "1.11.0+beta1" = removeAttrs v5 ["mathcomp-analysis"];
+          "1.11+beta1" = removeAttrs v5 ["mathcomp-analysis"];
           "1.10.0"       = removeAttrs v4 ["mathcomp-analysis"];
           "1.9.0"        = removeAttrs v3 ["coqeal"];
           "1.8.0"        = removeAttrs v2 ["coqeal"];
           "1.7.0"        = removeAttrs v1 ["coqeal" "multinomials"];
         };
         "8.7" = {
-          "1.11.0+beta1" = removeAttrs v5 ["mathcomp-analysis"];
+          "1.11+beta1" = removeAttrs v5 ["mathcomp-analysis"];
           "1.10.0"       = removeAttrs v4 ["mathcomp-analysis"];
           "1.9.0"        = removeAttrs v3 ["coqeal" "mathcomp-analysis"];
           "1.8.0"        = removeAttrs v2 ["coqeal" "mathcomp-analysis"];

--- a/pkgs/development/coq-modules/mathcomp/extra.nix
+++ b/pkgs/development/coq-modules/mathcomp/extra.nix
@@ -112,7 +112,7 @@ let
 
       mathcomp-analysis = {version, coqPackages}: {
         propagatedBuildInputs = with coqPackages;
-          [ mathcomp.field mathcomp-finmap mathcomp-bigenough ];
+          [ mathcomp.field mathcomp-finmap mathcomp-bigenough mathcomp-real-closed ];
         meta = {
           description = "Analysis library compatible with Mathematical Components";
           homepage = "https://github.com/math-comp/analysis";
@@ -168,12 +168,15 @@ let
         "1.0.0" = "10g0gp3hk7wri7lijkrqna263346wwf6a3hbd4qr9gn8hmsx70wg";
       };
       mathcomp-analysis = {
+        "0.3.1" = "1iad288yvrjv8ahl9v18vfblgqb1l5z6ax644w49w9hwxs93f2k8";
+        "0.3.0" = "03klwi4fja0cqb4myp3kgycfbmdv00bznmxf8yg3zzzzw997hjqc";
         "0.2.3" = "0p9mr8g1qma6h10qf7014dv98ln90dfkwn76ynagpww7qap8s966";
         "0.2.2" = "1d5dwg9di2ppdzfg21zr0a691zigb5kz0lcw263jpyli1nrq7cvk";
         "0.2.0" = "1186xjxgns4ns1szyi931964bjm0mp126qzlv10mkqqgfw07nhrd";
         "0.1.0" = "0hwkr2wzy710pcyh274fcarzdx8sv8myp16pv0vq5978nmih46al";
       };
       multinomials = {
+        "1.5.2" = "15aspf3jfykp1xgsxf8knqkxv8aav2p39c2fyirw7pwsfbsv2c4s";
         "1.5.1" = "13nlfm2wqripaq671gakz5mn4r0xwm0646araxv0nh455p9ndjs3";
         "1.5"   = "064rvc0x5g7y1a0nip6ic91vzmq52alf6in2bc2dmss6dmzv90hw";
         "1.4"   = "0vnkirs8iqsv8s59yx1fvg1nkwnzydl42z3scya1xp1b48qkgn0p";
@@ -183,6 +186,8 @@ let
         "1.0"   = "1qmbxp1h81cy3imh627pznmng0kvv37k4hrwi2faa101s6bcx55m";
       };
       mathcomp-real-closed = {
+        "1.1.1" = "0ksjscrgq1i79vys4zrmgvzy2y4ylxa8wdsf4kih63apw6v5ws6b";
+        "1.1.0" = "0zgfmrlximw77bw5w6w0xg2nampp02pmrwnrzx8m1n5pqljnv8fh";
         "1.0.5" = "0q8nkxr9fba4naylr5xk7hfxsqzq2pvwlg1j0xxlhlgr3fmlavg2";
         "1.0.4" = "058v9dj973h9kfhqmvcy9a6xhhxzljr90cf99hdfcdx68fi2ha1b";
         "1.0.3" = "1xbzkzqgw5p42dx1liy6wy8lzdk39zwd6j14fwvv5735k660z7yb";
@@ -190,6 +195,7 @@ let
         "1.0.1" = "0j81gkjbza5vg89v4n9z598mfdbql416963rj4b8fzm7dp2r4rxg";
       };
       coqeal = {
+        "1.0.4" = "1g5m26lr2lwxh6ld2gykailhay4d0ayql4bfh0aiwqpmmczmxipk";
         "1.0.3" = "0hc63ny7phzbihy8l7wxjvn3haxx8jfnhi91iw8hkq8n29i23v24";
         "1.0.2" = "1brmf3gj03iky1bcl3g9vx8vknny7xfvs0y2rfr85am0296sxsfj";
         "1.0.1" = "19jhdrv2yp9ww0h8q73ihb2w1z3glz4waf2d2n45klafxckxi7bm";
@@ -201,13 +207,21 @@ let
     # CONSISTENT sets of packages. #
     ################################
     for-coq-and-mc = let
+      v6 = {
+        mathcomp-finmap       = "1.5.1";
+        mathcomp-bigenough    = "1.0.0";
+        mathcomp-analysis     = "0.3.1";
+        multinomials          = "1.5.2";
+        mathcomp-real-closed  = "1.0.5";
+        coqeal                = "1.0.4";
+      };
       v5 = {
         mathcomp-finmap       = "1.5.0";
         mathcomp-bigenough    = "1.0.0";
-        mathcomp-analysis     = "678d3cc37f5f3c71b1bd550836eb44e3ba2a5459";
-        multinomials           = "1.5.1";
+        mathcomp-analysis     = "0.3.0";
+        multinomials          = "1.5.1";
         mathcomp-real-closed  = "1.0.5";
-        coqeal                = "CohenCyril/bdfc96771644b082e41268edc43d61dc5fda2358";
+        coqeal                = "1.0.4";
       };
       v4 = v3 // { coqeal = "1.0.3"; };
       v3 = {
@@ -236,29 +250,34 @@ let
     in
       {
         "8.11" = {
+          "1.11.0"     = v5;
           "1.11+beta1" = v5;
           "1.10.0"       = v4 // {mathcomp-finmap = "1.4.0+coq-8.11";};
         };
         "8.10" = {
-          "1.11+beta1" = removeAttrs v5 ["coqeal"];
+          "1.11.0"       = removeAttrs v5 ["coqeal"];
+          "1.11+beta1"   = removeAttrs v5 ["coqeal"];
           "1.10.0"       = v4;
           "1.9.0"        = removeAttrs v3 ["coqeal"];
         };
         "8.9" = {
-          "1.11+beta1" = removeAttrs v5 ["mathcomp-analysis"];
+          "1.11.0"       = removeAttrs v5 ["mathcomp-analysis"];
+          "1.11+beta1"   = removeAttrs v5 ["mathcomp-analysis"];
           "1.10.0"       = v4;
           "1.9.0"        = removeAttrs v3 ["coqeal"];
           "1.8.0"        = removeAttrs v2 ["coqeal"];
         };
         "8.8" = {
-          "1.11+beta1" = removeAttrs v5 ["mathcomp-analysis"];
+          "1.11.0"       = removeAttrs v5 ["mathcomp-analysis"];
+          "1.11+beta1"   = removeAttrs v5 ["mathcomp-analysis"];
           "1.10.0"       = removeAttrs v4 ["mathcomp-analysis"];
           "1.9.0"        = removeAttrs v3 ["coqeal"];
           "1.8.0"        = removeAttrs v2 ["coqeal"];
           "1.7.0"        = removeAttrs v1 ["coqeal" "multinomials"];
         };
         "8.7" = {
-          "1.11+beta1" = removeAttrs v5 ["mathcomp-analysis"];
+          "1.11.0"       = removeAttrs v5 ["mathcomp-analysis"];
+          "1.11+beta1"   = removeAttrs v5 ["mathcomp-analysis"];
           "1.10.0"       = removeAttrs v4 ["mathcomp-analysis"];
           "1.9.0"        = removeAttrs v3 ["coqeal" "mathcomp-analysis"];
           "1.8.0"        = removeAttrs v2 ["coqeal" "mathcomp-analysis"];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).