### PR TITLE
winePackages.staging: mention staging patches in description

### DIFF
--- a/pkgs/misc/emulators/wine/staging.nix
+++ b/pkgs/misc/emulators/wine/staging.nix
@@ -7,7 +7,7 @@ let patch = (callPackage ./sources.nix {}).staging;
       (mkBuildInputs wineUnstable.pkgArches pkgNames) ++ extra;
 in assert stdenv.lib.getVersion wineUnstable == patch.version;
 
-stdenv.lib.overrideDerivation wineUnstable (self: {
+(stdenv.lib.overrideDerivation wineUnstable (self: {
   buildInputs = build-inputs [ "perl" "utillinux" "autoconf" ] self.buildInputs;
 
   name = "${self.name}-staging";
@@ -21,4 +21,8 @@ stdenv.lib.overrideDerivation wineUnstable (self: {
     ./patchinstall.sh DESTDIR="$PWD/.." --all
     cd ..
   '';
-})
+})) // {
+  meta = wineUnstable.meta // {
+    description = wineUnstable.meta.description + " (with staging patches)";
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Fixes #72914

Should be 0-rebuild

Will probably self-merge

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
