### PR TITLE
ruby: Make it possible for it to not reference cc at all

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -90,6 +90,18 @@
     </para>
    </listitem>
    <listitem>
+     <para>
+       <literal>rubyMinimal</literal> was removed due to being unused and
+       unusable. The default ruby interpreter includes JIT support, which makes
+       it reference it's compiler. Since JIT support is probably needed by some
+       Gems, it was decided to enable this feature with all cc references by
+       default, and allow to build a Ruby derivation without references to cc,
+       by setting <literal>jitSupport = false;</literal> in an overlay. See
+       <link xlink:href="https://github.com/NixOS/nixpkgs/pull/90151">#90151</link>
+       for more info.
+     </para>
+   </listitem>
+   <listitem>
     <para>
      The option <option>fonts.enableFontDir</option> has been renamed to
      <xref linkend="opt-fonts.fontDir.enable"/>. The path of font directory

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -57,9 +57,8 @@ let
       # Since some Gems require JIT support, there's probably no
       # escape from this reference. Hence, it was decided to enable this
       # feature by default, as it's enabled by default by ruby's ./configure
-      # script. We do disable this feature though for the other cc references
-      # in all of the locations given above for the `rubyMinimal` build defined
-      # in all-packages.nix.
+      # script. If you'd like to have a ruby without reference to cc, setting
+      # jitSupport to false should remove all known references mentioned above.
       , removeReferencesTo, jitSupport ? true
       , autoreconfHook, bison, autoconf
       , buildEnv, bundler, bundix

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -501,6 +501,7 @@ mapAliases ({
   ruby_2_5_0 = throw "ruby_2_5_0 was deprecated on 2018-02-13: use a newer version of ruby";
   rubyPackages_2_4 = throw "rubyPackages_2_4 was deprecated in 2019-12: use a newer version of rubyPackages instead";
   rubygems = throw "rubygems was deprecated on 2016-03-02: rubygems is now bundled with ruby";
+  rubyMinimal = throw "rubyMinimal was removed due to being unused";
   rxvt_unicode-with-plugins = rxvt-unicode; # added 2020-02-02
   rxvt_unicode = rxvt-unicode-unwrapped; # added 2020-02-02
   urxvt_autocomplete_all_the_things = rxvt-unicode-plugins.autocomplete-all-the-things; # added 2020-02-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10548,6 +10548,7 @@ in
   rubyMinimal = ruby.override {
     # gem support is minimal overhead
     rubygemsSupport = true;
+    jitSupport = false;
     useRailsExpress = false;
     zlibSupport = false;
     opensslSupport = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10545,20 +10545,6 @@ in
     ruby_2_6
     ruby_2_7;
 
-  rubyMinimal = ruby.override {
-    # gem support is minimal overhead
-    rubygemsSupport = true;
-    jitSupport = false;
-    useRailsExpress = false;
-    zlibSupport = false;
-    opensslSupport = false;
-    gdbmSupport = false;
-    cursesSupport = false;
-    docSupport = false;
-    yamlSupport = false;
-    fiddleSupport = false;
-  };
-
   ruby = ruby_2_6;
   rubyPackages = rubyPackages_2_6;
 


### PR DESCRIPTION
###### Motivation for this change

Fix #89445.

Ruby's build flag called `removeReferencesToCC` doesn't do it's job completely - The file `rbconfig.rb` still retained the reference to CC. It seems that's unavoidable if JIT support is enabled. JIT support is enabled by default and it's probable that some Gems require this feature. Since the normal `ruby` we are shipping ever since a while always retained this cc reference, I think it should be best to make it possible to build a ruby flavor such as `rubyMinimal` without cc reference and let that derivation alone while leaving all of the regular `ruby`'s cc references as are (After @peterhoeg 's [comment](https://github.com/NixOS/nixpkgs/issues/89445#issuecomment-643081163)).

This for example allows for someone to add an override such as (tested):

```nix
self: super:

{
  ruby = super.ruby.override {
    # rubyMinimal disables too much features required by asciidoctor
    rubygemsSupport = true;
    jitSupport = false;
    useRailsExpress = false;
    zlibSupport = true;
    opensslSupport = true;
    gdbmSupport = false;
    cursesSupport = false;
    docSupport = false;
    yamlSupport = false;
    fiddleSupport = false;
  };
}
```

And this will allow them to not need GCC on their system for their usage of Ruby. For example, run with this PR and that overlay applied:

```sh
$ nix why-depends -f. asciidoctor gcc
```

And you should get:

```
'asciidoctor' does not depend on 'gcc'
```

But without this PR, (and the overlay would fail without the PR) you should get:

```
/nix/store/nyb3ry2yvhskrlni9dphfmj3w1ylakaw-asciidoctor-2.0.10
╚═══bin/asciidoctor -> /nix/store/06rmj52zhnb7kkp3dzvicaiddj9a8zmx-asciidoctor-2.0.10/bin/asciidoctor
    => /nix/store/06rmj52zhnb7kkp3dzvicaiddj9a8zmx-asciidoctor-2.0.10
    ╚═══bin/.asciidoctor-epub3-wrapped: …#!/nix/store/ighz4wp6bmpsm8x1lrsvwjz4m81r6a6d-ruby-2.6.6/bin/ruby.#.# This fi…
        => /nix/store/ighz4wp6bmpsm8x1lrsvwjz4m81r6a6d-ruby-2.6.6
        ╚═══lib/ruby/2.6.0/x86_64-linux/rbconfig.rb: …CONFIG["MJIT_CC"] = "/nix/store/r4l53b461b2lyclxn1pdj0n4hvbxl2l6-gcc-wrapper-9.3.0/bin/gcc".  CO…
            => /nix/store/r4l53b461b2lyclxn1pdj0n4hvbxl2l6-gcc-wrapper-9.3.0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).