### PR TITLE
gimp: 2.10.18 -> 2.10.20

### DIFF
--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -50,13 +50,13 @@ let
   inherit (python2Packages) pygtk wrapPython python;
 in stdenv.mkDerivation rec {
   pname = "gimp";
-  version = "2.10.18";
+  version = "2.10.20";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "http://download.gimp.org/pub/gimp/v${lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
-    sha256 = "05np26g61fyr72s7qjfrcck8v57r0yswq5ihvqyzvgzfx08y3gv5";
+    sha256 = "4S+fh0saAHxCd7YKqB4LZzML5+YVPldJ6tg5uQL8ezw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/babl/default.nix
+++ b/pkgs/development/libraries/babl/default.nix
@@ -5,17 +5,18 @@
 , pkgconfig
 , gobject-introspection
 , lcms2
+, vala
 }:
 
 stdenv.mkDerivation rec {
   pname = "babl";
-  version = "0.1.74";
+  version = "0.1.78";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://download.gimp.org/pub/babl/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "03nfcvy3453xkfvsfcnsfcjf2vg2pin09qnr9jlssdysa1lhnwcs";
+    sha256 = "F9VJNjO/9VhdnzdbxN9ZJRV80ccMzXwipjW+dcFyUjo=";
   };
 
   nativeBuildInputs = [
@@ -23,6 +24,7 @@ stdenv.mkDerivation rec {
     ninja
     pkgconfig
     gobject-introspection
+    vala
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/gegl/4.0.nix
+++ b/pkgs/development/libraries/gegl/4.0.nix
@@ -35,25 +35,15 @@
 
 stdenv.mkDerivation rec {
   pname = "gegl";
-  version = "0.4.22";
+  version = "0.4.24";
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";
 
   src = fetchurl {
     url = "https://download.gimp.org/pub/gegl/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0q9cckf90fb82qc5d496fjz459f1xw4j4p3rff1f57yivx0yr20q";
+    sha256 = "d2VJnyc0Gw0WAy5mUxnLwSh2SD/2qUT83ySpxY4+JUo=";
   };
-
-  patches = [
-    # Prevent deadlock making tests time-out
-    # https://gitlab.gnome.org/GNOME/gegl/issues/226
-    # https://gitlab.gnome.org/GNOME/glib/issues/1941
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gegl/commit/1d530816266b52c8788bbe1504c5b2d6eceba036.patch";
-      sha256 = "1d8nhrzvwq35c5ws00xy9y6bfd9wsj3dm0301hiwkfi4niq59ygh";
-    })
-  ];
 
   nativeBuildInputs = [
     pkgconfig


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
