### PR TITLE
Add socket-based IPFS support

### DIFF
--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -249,12 +249,13 @@ in {
 
     # Note the upstream service assumes default host / port
     # we should override it when a custom is provided above.
-    systemd.sockets.ipfs-gateway = mkIf cfg.startWhenNeeded {
+    systemd.sockets.ipfs-gateway = {
       wantedBy = [ "sockets.target" ];
     };
 
-    systemd.sockets.ipfs-api = mkIf cfg.startWhenNeeded {
+    systemd.sockets.ipfs-api = {
       wantedBy = [ "sockets.target" ];
+      socketConfig.ListenStream = [ "%t/ipfs.sock" ];
     };
 
   };

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -1,7 +1,8 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, options, ... }:
 with lib;
 let
   cfg = config.services.ipfs;
+  opt = options.services.ipfs;
 
   ipfsFlags = toString ([
     (optionalString  cfg.autoMount                   "--mount")
@@ -247,15 +248,16 @@ in {
       wantedBy = [ "default.target" ];
     };
 
-    # Note the upstream service assumes default host / port
-    # we should override it when a custom is provided above.
     systemd.sockets.ipfs-gateway = {
       wantedBy = [ "sockets.target" ];
+      socketConfig.ListenStream = [ "" ]
+        ++ lib.optional (cfg.gatewayAddress == opt.gatewayAddress.default) [ "127.0.0.1:8080" "[::1]:8080" ];
     };
 
     systemd.sockets.ipfs-api = {
       wantedBy = [ "sockets.target" ];
-      socketConfig.ListenStream = [ "%t/ipfs.sock" ];
+      socketConfig.ListenStream = [ "" "%t/ipfs.sock" ]
+        ++ lib.optional (cfg.apiAddress == opt.apiAddress.default) [ "127.0.0.1:5001" "[::1]:5001" ];
     };
 
   };

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -7,7 +7,6 @@ let
 
   ipfsFlags = toString ([
     (optionalString  cfg.autoMount                   "--mount")
-    #(optionalString  cfg.autoMigrate                 "--migrate")
     (optionalString  cfg.enableGC                    "--enable-gc")
     (optionalString (cfg.serviceFdlimit != null)     "--manage-fdlimit=false")
     (optionalString (cfg.defaultMode == "offline")   "--offline")
@@ -36,7 +35,6 @@ let
 
   baseService = recursiveUpdate commonEnv {
     wants = [ "ipfs-init.service" ];
-    # NB: migration must be performed prior to pre-start, else we get the failure message!
     preStart = optionalString cfg.autoMount ''
       ipfs --local config Mounts.FuseAllowOther --json true
       ipfs --local config Mounts.IPFS ${cfg.ipfsMountDir}
@@ -97,18 +95,6 @@ in {
         default = "online";
         description = "systemd service that is enabled by default";
       };
-
-      /*
-      autoMigrate = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether IPFS should try to migrate the file system automatically.
-
-          The daemon will need to be able to download a binary from https://ipfs.io to perform the migration.
-        '';
-      };
-      */
 
       autoMount = mkOption {
         type = types.bool;

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -179,6 +179,8 @@ in {
       "d '${cfg.ipnsMountDir}' - ${cfg.user} ${cfg.group} - -"
     ];
 
+    systemd.packages = [ pkgs.ipfs ];
+
     systemd.services.ipfs-init = {
       description = "IPFS Initializer";
 
@@ -237,7 +239,7 @@ in {
               cfg.extraConfig))
           );
       serviceConfig = {
-        ExecStart = "${pkgs.ipfs}/bin/ipfs daemon ${ipfsFlags}";
+        ExecStart = ["" "${pkgs.ipfs}/bin/ipfs daemon ${ipfsFlags}"];
         User = cfg.user;
         Group = cfg.group;
       } // optionalAttrs (cfg.serviceFdlimit != null) { LimitNOFILE = cfg.serviceFdlimit; };

--- a/nixos/tests/ipfs.nix
+++ b/nixos/tests/ipfs.nix
@@ -21,5 +21,12 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     )
 
     machine.succeed(f"ipfs cat /ipfs/{ipfs_hash.strip()} | grep fnord")
+
+    ipfs_hash = machine.succeed(
+        "echo fnord2 | ipfs --api /unix/run/ipfs.sock add | awk '{ print $2 }'"
+    )
+    machine.succeed(
+        f"ipfs --api /unix/run/ipfs.sock cat /ipfs/{ipfs_hash.strip()} | grep fnord2"
+    )
   '';
 })

--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -26,6 +26,14 @@ buildGoModule rec {
 
   vendorSha256 = null;
 
+  postInstall = ''
+    install -D misc/systemd/ipfs.service $out/etc/systemd/system/ipfs.service
+    install -D misc/systemd/ipfs-api.socket $out/etc/systemd/system/ipfs-api.socket
+    install -D misc/systemd/ipfs-gateway.socket $out/etc/systemd/system/ipfs-gateway.socket
+    substituteInPlace $out/etc/systemd/system/ipfs.service \
+      --replace /usr/bin/ipfs $out/bin/ipfs
+  '';
+
   meta = with stdenv.lib; {
     description = "A global, versioned, peer-to-peer filesystem";
     homepage = "https://ipfs.io/";


### PR DESCRIPTION
Does a few things:

- Previously we had three services for different config flavors. This is
confusing because only one instance of IPFS can run on a host / port
combination at once. So move all into ipfs.service, which contains the
configuration specified in services.ipfs.

- Cleanup; Remove unused auto-migrate feature, remove wrapper usages

- Add startWhenNeeded for systemd-based socket/tcp activation.