### PR TITLE
coqPackages.coq-elpi: 1.4.0 -> 1.4.1

### DIFF
--- a/pkgs/development/coq-modules/coq-elpi/default.nix
+++ b/pkgs/development/coq-modules/coq-elpi/default.nix
@@ -2,9 +2,9 @@
 
 let params = {
   "8.11" = rec {
-    version = "1.4.0";
+    version = "1.4.1";
     rev = "v${version}";
-    sha256 = "1pzmjgvvdwki59rfsha3c1ik4gii39j44ijyb9m9as1cyfpxx906";
+    sha256 = "12jwldcianai62y9jnghsjfya5dj6fvc6ilf37c7w037kylx45sd";
   };
 };
   param = params.${coq.coq-version};


### PR DESCRIPTION
###### Motivation for this change

Updating coq-elpi.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).