### PR TITLE
sox: Add WavPack support

### DIFF
--- a/pkgs/applications/misc/audio/sox/default.nix
+++ b/pkgs/applications/misc/audio/sox/default.nix
@@ -8,6 +8,7 @@
 , enableFLAC ? true, flac ? null
 , enablePNG ? true, libpng ? null
 , enableLibsndfile ? true, libsndfile ? null
+, enableWavpack ? true, wavpack ? null
 # amrnb and amrwb are unfree, disabled by default
 , enableAMR ? false, amrnb ? null, amrwb ? null
 , enableLibpulseaudio ? true, libpulseaudio ? null
@@ -36,6 +37,7 @@ stdenv.mkDerivation rec {
     optional enableFLAC flac ++
     optional enablePNG libpng ++
     optional enableLibsndfile libsndfile ++
+    optional enableWavpack wavpack ++
     optionals enableAMR [ amrnb amrwb ] ++
     optional enableLibpulseaudio libpulseaudio ++
     optional (stdenv.isDarwin) CoreAudio;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

[r128gain](https://github.com/NixOS/nixpkgs/blob/dbdc5af9e8145dbc7ffe71cf1c7287d7497f1c16/pkgs/applications/audio/r128gain/default.nix)'s tests include processing some WavPack files with sox.  Allow opting into linking with wavpack so those tests can be run.

I don't know how prevalent usage of WavPack is nor if it should be linked by default, but went that way because all other free dependencies are enabled by default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
