### PR TITLE
ocamlPackages.piqi: 0.6.14 → 0.6.15

### DIFF
--- a/pkgs/development/ocaml-modules/piqi/default.nix
+++ b/pkgs/development/ocaml-modules/piqi/default.nix
@@ -1,16 +1,19 @@
-{ stdenv, fetchurl, ocaml, findlib, which, ulex, easy-format, ocaml_optcomp, xmlm, base64 }:
+{ stdenv, fetchFromGitHub, ocaml, findlib, which, sedlex_2, easy-format, xmlm, base64 }:
 
 stdenv.mkDerivation rec {
-  version = "0.6.14";
+  version = "0.6.15";
   pname = "piqi";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
  
-  src = fetchurl {
-    url = "https://github.com/alavrik/piqi/archive/v${version}.tar.gz";
-    sha256 = "1ssccnwqzfyf7syfq2fv4zyhwayxwd75rhq9y28mvq1w6qbww4l7";
+  src = fetchFromGitHub {
+    owner = "alavrik";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0v04hs85xv6d4ysqxyv1dik34dx49yab9shpi4x7iv19qlzl7csb";
   };
 
-  buildInputs = [ ocaml findlib which ocaml_optcomp ];
-  propagatedBuildInputs = [ulex xmlm easy-format base64];
+  buildInputs = [ ocaml findlib which ];
+  propagatedBuildInputs = [ sedlex_2 xmlm easy-format base64 ];
 
   patches = [ ./no-ocamlpath-override.patch ];
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -720,9 +720,7 @@ let
 
     phylogenetics = callPackage ../development/ocaml-modules/phylogenetics { };
 
-    piqi = callPackage ../development/ocaml-modules/piqi {
-      base64 = base64_2;
-    };
+    piqi = callPackage ../development/ocaml-modules/piqi { };
 
     piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };
 


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml ≥ 4.09

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
