### PR TITLE
facetimehd: 2019-12-10 -> 2020-04-16

### DIFF
--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -16,9 +16,9 @@ let
   #       still works.
   srcParams = if (stdenv.lib.versionAtLeast kernel.version "4.8") then
     { # Use mainline branch
-      version = "unstable-2019-12-10";
-      rev = "ea832ac486afb6dac9ef59aa37e90f332ab7f05a";
-      sha256 = "1dg2i558hjnjnyk53xyg0ayykqaial9bm420v22s9a3khzzjnwq3";
+      version = "unstable-2020-04-16";
+      rev = "82626d4892eeb9eb704538bf0dc49a00725ff451";
+      sha256 = "118z6vjvhhcwvs4n3sgwwdagys9w718b8nkh6l9ic93732vv7cqx";
     }
   else
     { # Use master branch (broken on 4.8)


### PR DESCRIPTION
###### Motivation for this change

Version bump which fixes build on `linux` >= `5.7.x`

Tested and runs on `5.7.1` :+1:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
