### PR TITLE
terraform-ls: init at 0.3.2

### DIFF
--- a/pkgs/development/tools/misc/terraform-ls/default.nix
+++ b/pkgs/development/tools/misc/terraform-ls/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "terraform-ls";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "11776nq1ixrg791xlmryjxldsc8gn69j1fc0wd6cdywy8yp2lh4w";
+  };
+
+  goPackagePath = "github.com/hashicorp/terraform-ls";
+
+  buildFlagsArray = [ "-ldflags=-s -w -X main.version=${version}" ];
+
+  meta = with lib; {
+    description = "Terraform Language Server (official)";
+    homepage = "https://github.com/hashicorp/terraform-ls";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ mbaillie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11057,6 +11057,7 @@ in
   terracognita = callPackage ../development/tools/misc/terracognita { };
 
   terraform-lsp = callPackage ../development/tools/misc/terraform-lsp { };
+  terraform-ls = callPackage ../development/tools/misc/terraform-ls { };
 
   texinfo413 = callPackage ../development/tools/misc/texinfo/4.13a.nix { };
   texinfo4 = texinfo413;


### PR DESCRIPTION
###### Motivation for this change

This introduces the new official Terraform language server from HashiCorp. 

I am also not removing the existing community `terraform-lsp` in nixpkgs yet based on this comment from [HashiCorp](https://github.com/hashicorp/terraform-ls#terraform-ls-vs-terraform-lsp):
```
Both HashiCorp and the maintainer of terraform-lsp expressed interest in collaborating on a language server and are working towards a long-term goal of a single stable and feature-complete implementation.

For the time being both projects continue to exist, giving users the choice:
    terraform-ls providing
        overall stability (by relying only on public APIs)
        compatibility with any provider and any Terraform >=0.12.0
        currently less features
            due to project being younger and relying on public APIs which may not offer the same functionality yet
    terraform-lsp providing
        currently more features
        compatibility with a single particular Terraform (0.12.20 at time of writing)
            configs designed for other 0.12 versions may work, but interpretation may be inaccurate
        less stability (due to reliance on Terraform's own internal packages)
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
