### PR TITLE
gdk-pixbuf-xlib: fix the pkg-config file

### DIFF
--- a/pkgs/development/libraries/gdk-pixbuf/xlib.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/xlib.nix
@@ -42,6 +42,10 @@ stdenv.mkDerivation rec {
     "-Dgtk_doc=true"
   ];
 
+  postInstall = ''
+    substituteInPlace $out/lib/pkgconfig/gdk-pixbuf-xlib-2.0.pc --replace gdk-pixbuf-xlib-2.0 gdk-pixbuf-2.0
+  '';
+
   meta = with stdenv.lib; {
     description = "Deprecated API for integrating GdkPixbuf with Xlib data types";
     homepage = "https://gitlab.gnome.org/Archive/gdk-pixbuf-xlib";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The pkg-config file `gdk-pixbuf-xlib-2.0.pc` contains the line:

```
Cflags:-I${includedir}/gdk-pixbuf-xlib-2.0
```

But the header files are installed at `include/gdk-pixbuf-2.0`. Notice the missing **`xlib`** in the directory name.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).