### PR TITLE
treewide: central.maven.org -> repo1.maven.org

### DIFF
--- a/pkgs/applications/editors/jedit/default.nix
+++ b/pkgs/applications/editors/jedit/default.nix
@@ -3,11 +3,11 @@
 let
   version = "5.2.0";
   bcpg = fetchurl {
-    url = "http://central.maven.org/maven2/org/bouncycastle/bcpg-jdk16/1.46/bcpg-jdk16-1.46.jar";
+    url = "mirror://maven/org/bouncycastle/bcpg-jdk16/1.46/bcpg-jdk16-1.46.jar";
     sha256 = "16xhmwks4l65m5x150nd23y5lyppha9sa5fj65rzhxw66gbli82d";
   };
   jsr305 = fetchurl {
-    url = "http://central.maven.org/maven2/com/google/code/findbugs/jsr305/2.0.0/jsr305-2.0.0.jar";
+    url = "mirror://maven/com/google/code/findbugs/jsr305/2.0.0/jsr305-2.0.0.jar";
     sha256 = "0s74pv8qjc42c7q8nbc0c3b1hgx0bmk3b8vbk1z80p4bbgx56zqy";
   };
 in

--- a/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
@@ -3,7 +3,7 @@
 let
   version = "1.13.0";
   jarName = "bfg-${version}.jar";
-  mavenUrl = "http://central.maven.org/maven2/com/madgag/bfg/${version}/${jarName}";
+  mavenUrl = "mirror://maven/com/madgag/bfg/${version}/${jarName}";
 in
   stdenv.mkDerivation {
     inherit version jarName;

--- a/pkgs/build-support/fetchmavenartifact/default.nix
+++ b/pkgs/build-support/fetchmavenartifact/default.nix
@@ -3,7 +3,7 @@
 { fetchurl, stdenv }:
 let
   defaultRepos = [
-    "http://central.maven.org/maven2"
+    "http://repo1.maven.org/maven2"
     "http://oss.sonatype.org/content/repositories/releases"
     "http://oss.sonatype.org/content/repositories/public"
     "http://repo.typesafe.com/typesafe/releases"

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -426,7 +426,6 @@
   # Maven Central
   maven = [
     "https://repo1.maven.org/maven2/"
-    "https://central.maven.org/maven2/"
   ];
 
   # Alsa Project

--- a/pkgs/servers/monitoring/prometheus/jmx-httpserver.nix
+++ b/pkgs/servers/monitoring/prometheus/jmx-httpserver.nix
@@ -3,7 +3,7 @@
 let
   version = "0.10";
   jarName = "jmx_prometheus_httpserver-${version}-jar-with-dependencies.jar";
-  mavenUrl = "http://central.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_httpserver/${version}/${jarName}";
+  mavenUrl = "mirror://maven/io/prometheus/jmx/jmx_prometheus_httpserver/${version}/${jarName}";
 in stdenv.mkDerivation {
   inherit version jarName;
 

--- a/pkgs/tools/networking/openapi-generator-cli/default.nix
+++ b/pkgs/tools/networking/openapi-generator-cli/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "http://central.maven.org/maven2/org/openapitools/${pname}/${version}/${jarfilename}";
+    url = "mirror://maven/org/openapitools/${pname}/${version}/${jarfilename}";
     sha256 = "1pafv432ll3pp52580pbnk0gnrm6byl5fkrf1rarhxfkpkr82yif";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Domain `central.maven.org` does not exist

```
# dig central.maven.org @8.8.8.8

; <<>> DiG 9.14.11 <<>> central.maven.org @8.8.8.8
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 50804
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;central.maven.org.		IN	A

;; AUTHORITY SECTION:
maven.org.		853	IN	SOA	ns-1965.awsdns-53.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400

;; Query time: 5 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Fri Jun 12 14:27:41 UTC 2020
;; MSG SIZE  rcvd: 133

```
