### PR TITLE
html5validator: init at 0.3.3

### DIFF
--- a/pkgs/applications/misc/html5validator/default.nix
+++ b/pkgs/applications/misc/html5validator/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonApplication, fetchFromGitHub, nose, openjdk, lib }:
+
+buildPythonApplication rec {
+  pname = "html5validator";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "svenkreiss";
+    repo = "html5validator";
+    rev = "v${version}";
+    sha256 = "130acqi0dsy3midg7hwslykzry6crr4ln6ia0f0avyywkz4bplsv";
+  };
+
+  propagatedBuildInputs = [ openjdk ];
+
+  checkInputs = [ nose ];
+  checkPhase = "PATH=$PATH:$out/bin nosetests";
+
+  meta = with lib; {
+    homepage = "https://github.com/svenkreiss/html5validator";
+    description = "Command line tool that tests files for HTML5 validity";
+    license = licenses.mit;
+    maintainers = [ maintainers.phunehehe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -187,6 +187,8 @@ in
 
   hobbes = callPackage ../development/tools/hobbes { };
 
+  html5validator = python36Packages.callPackage ../applications/misc/html5validator { };
+
   proto-contrib = callPackage ../development/tools/proto-contrib {};
 
   protoc-gen-doc = callPackage ../development/tools/protoc-gen-doc {};


### PR DESCRIPTION
###### Motivation for this change

Add new package

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).