### PR TITLE
facetimehd: remove patch in nixpkgs, patched upstream

### DIFF
--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -47,11 +47,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  preBuild = lib.optionalString (stdenv.lib.versionAtLeast kernel.version "5.6")
-  ''
-    sed -i 's/ioremap_nocache/ioremap_cache/g' fthd_drv.c
-  '';
-
   makeFlags = [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];


### PR DESCRIPTION
###### Motivation for this change

We don't need to do this patching in `nixpkgs` anymore, as it has been [patched upstream recently](https://github.com/patjak/bcwc_pcie/commit/e989703071246a9d4e6d75e8de34b746b707ecde)

Tested on `5.6.17` and `5.7.1`, `facetimehd` builds and works :heavy_check_mark: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
