### PR TITLE
diffoscope: 146 -> 147

### DIFF
--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, runCommand, makeWrapper, python3Packages, docutils, help2man
+{ lib, stdenv, fetchurl, fetchpatch, runCommand, makeWrapper, python3Packages, docutils, help2man
 , abootimg, acl, apktool, binutils-unwrapped, build-tools, bzip2, cbfstool, cdrkit, colord, colordiff, coreutils, cpio, db, diffutils, dtc
 , e2fsprogs, file, findutils, fontforge-fonttools, ffmpeg_4, fpc, gettext, ghc, ghostscriptX, giflib, gnumeric, gnupg, gnutar
 , gzip, hdf5, imagemagick, jdk, libarchive, libcaca, llvm, lz4, mono, openssh, openssl, pdftk, pgpdump, poppler_utils, qemu, R
@@ -16,11 +16,11 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "diffoscope";
-  version = "146";
+  version = "147";
 
   src = fetchurl {
     url    = "https://diffoscope.org/archive/diffoscope-${version}.tar.bz2";
-    sha256 = "1iy4f05ws7qsd5p7hadc1979l77543pwi2c5zx1yr5zc674kwb3y";
+    sha256 = "1pichn3l10401cqk08zrys2ya9b6cjznk7ra28awnmvlg6l1cypj";
   };
 
   outputs = [ "out" "man" ];
@@ -28,6 +28,12 @@ python3Packages.buildPythonApplication rec {
   patches = [
     ./ignore_links.patch
     ./skip-failing-test.patch
+
+    # Fix for CBFS comparator
+    (fetchpatch {
+      url = "https://salsa.debian.org/reproducible-builds/diffoscope/-/commit/39ec527371c469d61e4afc04b3ee6ae3563f7b4c.patch";
+      sha256 = "1mzdcbxg3ad5ynpf79phvif5hzckmhf7vzd82l1sffhlqxh0v4h3";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -88,7 +88,7 @@ python3Packages.buildPythonApplication rec {
     '';
     homepage    = "https://diffoscope.org/";
     license     = licenses.gpl3Plus;
-    maintainers = with maintainers; [ dezgeg ma27 ];
+    maintainers = with maintainers; [ dezgeg ma27 danielfullmer ];
     platforms   = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bump to latest version. Tested working with and without `enableBloat`. I also added a patch for a PR I have upstream to fix the CBFS comparator:
https://salsa.debian.org/reproducible-builds/diffoscope/-/merge_requests/50

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
