### PR TITLE
kubectx: re-pack, switch from bash to go

### DIFF
--- a/pkgs/development/tools/kubectx/default.nix
+++ b/pkgs/development/tools/kubectx/default.nix
@@ -1,8 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, kubectl, makeWrapper }:
+{ stdenv, buildGoModule, fetchFromGitHub, installShellFiles }:
 
-with lib;
-
-stdenv.mkDerivation rec {
+buildGoModule rec {
   pname = "kubectx";
   version = "0.9.0";
 
@@ -13,41 +11,19 @@ stdenv.mkDerivation rec {
     sha256 = "1b22jk8zl944w5zn3s7ybkkbmzp9519x32pfqwd1malfly7dzf55";
   };
 
-  buildInputs = [ makeWrapper ];
+  vendorSha256 = "168hfdc2rfwpz2ls607bz5vsm1aw4brhwm8hmbiq1n1l2dn2dj0y";
 
-  dontBuild = true;
-  doCheck = false;
+  nativeBuildInputs = [ installShellFiles ];
 
-  installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/zsh/site-functions
-    mkdir -p $out/share/bash-completion/completions
-    mkdir -p $out/share/fish/vendor_completions.d
-
-    cp kubectx $out/bin
-    cp kubens $out/bin
-
-    # Provide ZSH completions
-    cp completion/kubectx.zsh $out/share/zsh/site-functions/_kubectx
-    cp completion/kubens.zsh $out/share/zsh/site-functions/_kubens
-
-    # Provide BASH completions
-    cp completion/kubectx.bash $out/share/bash-completion/completions/kubectx
-    cp completion/kubens.bash $out/share/bash-completion/completions/kubens
-
-    # Provide FISH completions
-    cp completion/*.fish $out/share/fish/vendor_completions.d/
-
-    for f in $out/bin/*; do
-      wrapProgram $f --prefix PATH : ${makeBinPath [ kubectl ]}
-    done
+  postInstall = ''
+    installShellCompletion completion/*
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Fast way to switch between clusters and namespaces in kubectl!";
     license = licenses.asl20;
     homepage = "https://github.com/ahmetb/kubectx";
-    maintainers = with maintainers; [ periklis ];
+    maintainers = with maintainers; [ jlesquembre ];
     platforms = with platforms; unix;
   };
 }


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
With release 0.9, kubectx was rewritten in go. For more info see
https://github.com/ahmetb/kubectx/releases/tag/v0.9.0

As said in https://github.com/NixOS/nixpkgs/pull/86584#issuecomment-623306501 @periklis don't use this tool anymore, that's why I'm setting myself as maintainer. 
@periklis Is it ok with you? If not I'll update the PR to keep you as maintainer. 
If the reason to not use kubectx anymore is because you found an alternative, can you let me know which one? 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
