### PR TITLE
pythonPackages.pytest-check: 0.3.5 -> 0.3.9

### DIFF
--- a/pkgs/development/python-modules/pytest-check/default.nix
+++ b/pkgs/development/python-modules/pytest-check/default.nix
@@ -1,24 +1,20 @@
 { stdenv
 , buildPythonPackage
-, fetchFromGitHub
-, pytest
+, fetchPypi
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pytest-check";
-  version = "0.3.5";
+  version = "0.3.9";
 
-  src = fetchFromGitHub {
-    owner = "okken";
-    repo = "pytest-check";
-    rev = version;
-    sha256 = "11wb4f4sp4cr5mzqdakrbycwgfr2p1sx1l91fa6525wnfvgc0qy3";
+  src = fetchPypi {
+    inherit version;
+    pname = "pytest_check";
+    sha256 = "0asrrz0fgk6wqffsz1ffd6z9xyw314fwh5bwjzcq75w8w1g4ass9";
   };
 
-  buildInputs = [ pytest ];
-
-  checkInputs = [ pytest pytestCheckHook ];
+  checkInputs = [ pytestCheckHook ];
 
   meta = with stdenv.lib; {
     description = "pytest plugin allowing multiple failures per test";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Update to latest version available. 
- Also, the current v0.3.5 seems to be broken at least on macOS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
