### PR TITLE
ocamlPackages.dns(-client): 4.5.0 -> 4.6.0

### DIFF
--- a/pkgs/development/ocaml-modules/dns/client.nix
+++ b/pkgs/development/ocaml-modules/dns/client.nix
@@ -1,5 +1,6 @@
 { lib, buildDunePackage, dns, ocaml_lwt, mirage-clock, mirage-time
-, mirage-random, mirage-stack, mirage-crypto-rng, mtime, randomconv }:
+, mirage-random, mirage-stack, mirage-crypto-rng, mtime, randomconv
+, cstruct, fmt, logs, rresult, domain-name, ipaddr, alcotest }:
 
 buildDunePackage {
   pname = "dns-client";
@@ -7,8 +8,11 @@ buildDunePackage {
 
   useDune2 = true;
 
-  propagatedBuildInputs = [ dns mtime ocaml_lwt randomconv mirage-clock mirage-time
-                            mirage-random mirage-stack mirage-crypto-rng ];
+  propagatedBuildInputs = [ cstruct fmt logs dns rresult randomconv domain-name ipaddr
+                            ocaml_lwt mirage-stack mirage-random mirage-time mirage-clock
+                            mtime mirage-crypto-rng ];
+  checkInputs = [ alcotest ];
+  doCheck = true;
 
   meta = dns.meta // {
     description = "Pure DNS resolver API";

--- a/pkgs/development/ocaml-modules/dns/default.nix
+++ b/pkgs/development/ocaml-modules/dns/default.nix
@@ -1,19 +1,19 @@
 { lib, buildDunePackage, fetchurl, alcotest
-, cstruct, domain-name, duration, gmap, ipaddr, logs, lru, metrics, ptime, rresult
+, cstruct, domain-name, duration, gmap, ipaddr, logs, lru, metrics, ptime, rresult, astring, fmt
 }:
 
 buildDunePackage rec {
   pname = "dns";
-  version = "4.5.0";
+  version = "4.6.0";
 
   minimumOCamlVersion = "4.07";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-dns/releases/download/v${version}/dns-v${version}.tbz";
-    sha256 = "10jrnnxvp06rvzk285wibyi9hn15qhjnqjy9xsfbwl8yhmzzqnq0";
+    sha256 = "1gkswpc91j4ps60bp52ggg4qwj5g88f49x6p6d619p4x8vmhjylv";
   };
 
-  propagatedBuildInputs = [ cstruct domain-name duration gmap ipaddr logs lru metrics ptime rresult ];
+  propagatedBuildInputs = [ rresult astring fmt logs ptime domain-name gmap cstruct ipaddr lru duration metrics ];
 
   doCheck = true;
   checkInputs = lib.optional doCheck alcotest;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New Release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
