### PR TITLE
buildPythonPackage: recompile bytecode for reproducibility

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -1,5 +1,6 @@
 # Hooks for building Python packages.
 { python
+, lib
 , callPackage
 , makeSetupHook
 , disabledIf
@@ -96,6 +97,16 @@ in rec {
         inherit pythonSitePackages;
       };
     } ./python-namespaces-hook.sh) {};
+
+  pythonRecompileBytecodeHook = callPackage ({ }:
+    makeSetupHook {
+      name = "python-recompile-bytecode-hook";
+      substitutions = {
+        inherit pythonInterpreter pythonSitePackages;
+        compileArgs = lib.concatStringsSep " " (["-q" "-f" "-i -"] ++ lib.optionals isPy3k ["-j $NIX_BUILD_CORES"]);
+        bytecodeName = if isPy3k then "__pycache__" else "*.pyc";
+      };
+    } ./python-recompile-bytecode-hook.sh ) {};
 
   pythonRemoveBinBytecodeHook = callPackage ({ }:
     makeSetupHook {

--- a/pkgs/development/interpreters/python/hooks/python-recompile-bytecode-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-recompile-bytecode-hook.sh
@@ -1,0 +1,24 @@
+# Setup hook for recompiling bytecode.
+# https://github.com/NixOS/nixpkgs/issues/81441
+echo "Sourcing python-recompile-bytecode-hook.sh"
+
+# Remove all bytecode from the $out output. Then, recompile only site packages folder
+# Note this effectively duplicates `python-remove-bin-bytecode`, but long-term
+# this hook should be removed again.
+
+pythonRecompileBytecodePhase () {
+    # TODO: consider other outputs than $out
+
+    items="$(find "$out" -name "@bytecodeName@")"
+    if [[ -n $items ]]; then
+        for pycache in $items; do
+            rm -rf "$pycache"
+        done
+    fi
+
+    find "$out"/@pythonSitePackages@ -name "*.py" -exec @pythonInterpreter@ -OO -m compileall @compileArgs@ {} +
+}
+
+if [ -z "${dontUsePythonRecompileBytecode-}" ]; then
+    postPhases+=" pythonRecompileBytecodePhase"
+fi

--- a/pkgs/development/interpreters/python/hooks/python-remove-bin-bytecode-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-remove-bin-bytecode-hook.sh
@@ -1,9 +1,9 @@
-# Setup hook for detecting conflicts in Python packages
+# Setup hook for removing bytecode from the bin folder
 echo "Sourcing python-remove-bin-bytecode-hook.sh"
 
-# Check if we have two packages with the same name in the closure and fail.
-# If this happens, something went wrong with the dependencies specs.
-# Intentionally kept in a subdirectory, see catch_conflicts/README.md.
+# The bin folder is added to $PATH and should only contain executables.
+# It may happen there are executables with a .py extension for which
+# bytecode is generated. This hook removes that bytecode.
 
 pythonRemoveBinBytecodePhase () {
     if [ -d "$out/bin" ]; then

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -17,6 +17,7 @@
 , pythonCatchConflictsHook
 , pythonImportsCheckHook
 , pythonNamespacesHook
+, pythonRecompileBytecodeHook
 , pythonRemoveBinBytecodeHook
 , pythonRemoveTestsDirHook
 , setuptoolsBuildHook
@@ -110,6 +111,7 @@ let
     python
     wrapPython
     ensureNewerSourcesForZipFilesHook  # move to wheel installer (pip) or builder (setuptools, flit, ...)?
+    pythonRecompileBytecodeHook  # Remove when solved https://github.com/NixOS/nixpkgs/issues/81441
     pythonRemoveTestsDirHook
   ] ++ lib.optionals catchConflicts [
     setuptools pythonCatchConflictsHook

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -118,6 +118,7 @@ in {
     pythonCatchConflictsHook
     pythonImportsCheckHook
     pythonNamespacesHook
+    pythonRecompileBytecodeHook
     pythonRemoveBinBytecodeHook
     pythonRemoveTestsDirHook
     setuptoolsBuildHook


### PR DESCRIPTION
Due to a change in pip the unpacked wheels are no longer reproducible.
We recompile the bytecode to cleanup this error.
https://github.com/NixOS/nixpkgs/issues/81441

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
