### PR TITLE
[20.03] palemoon: 28.9.3 -> 28.10.0

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -16,12 +16,12 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "28.9.3";
+  version = "28.10.0";
 
   src = fetchgit {
     url = "https://github.com/MoonchildProductions/Pale-Moon.git";
     rev = "${version}_Release";
-    sha256 = "1f8vfjyihlr2l79mkfgdcvwjnh261n6imkps310x9x3977jiq2wr";
+    sha256 = "0c64vmrp46sbl1dgl9dq2vkmpgz9gvgd59dk02jqwyhx4lln1g2l";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Backport of PR #89931.

> This is a development, bugfix and security update.

(Fixes CVE-2020-12399 & CVE-2020-12409, among general update things)

See http://www.palemoon.org/releasenotes.shtml.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
