### PR TITLE
nixos/gnupg: add pinentry to systemPackages

### DIFF
--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -123,7 +123,7 @@ in
 
     services.dbus.packages = mkIf (cfg.agent.pinentryFlavor == "gnome3") [ pkgs.gcr ];
 
-    environment.systemPackages = with pkgs; [ cfg.package ];
+    environment.systemPackages = with pkgs; [ cfg.package pinentry.${cfg.agent.pinentryFlavor} ];
     systemd.packages = [ cfg.package ];
 
     environment.interactiveShellInit = ''


### PR DESCRIPTION
###### Motivation for this change
This is needed at runtime:
```
gpg: agent_genkey failed: No pinentry
Key generation failed: No pinentry
```
```
gpgconf --check-programs
gpgconf: error running '/nix/store/dxf4w1gdp2x87d2q326a0064qnbvcl19-gnupg-2.2.20/bin/pinentry': probably not installed
gpg:OpenPGP:/nix/store/dxf4w1gdp2x87d2q326a0064qnbvcl19-gnupg-2.2.20/bin/gpg:1:1:
gpg-agent:Private Keys:/nix/store/dxf4w1gdp2x87d2q326a0064qnbvcl19-gnupg-2.2.20/bin/gpg-agent:1:1:
scdaemon:Smartcards:/nix/store/dxf4w1gdp2x87d2q326a0064qnbvcl19-gnupg-2.2.20/libexec/scdaemon:1:1:
gpgsm:S/MIME:/nix/store/dxf4w1gdp2x87d2q326a0064qnbvcl19-gnupg-2.2.20/bin/gpgsm:1:1:
dirmngr:Network:/nix/store/dxf4w1gdp2x87d2q326a0064qnbvcl19-gnupg-2.2.20/bin/dirmngr:1:1:
pinentry:Passphrase Entry:/nix/store/dxf4w1gdp2x87d2q326a0064qnbvcl19-gnupg-2.2.20/bin/pinentry:0:0:
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
