### PR TITLE
crawl: 0.24.1 -> 0.25.0

### DIFF
--- a/pkgs/games/crawl/crawl_purify.patch
+++ b/pkgs/games/crawl/crawl_purify.patch
@@ -1,37 +1,22 @@
-diff -ru3 crawl-ref-0.23.2-src-old/crawl-ref/source/Makefile crawl-ref-0.23.2-src-new/crawl-ref/source/Makefile
---- crawl-ref-0.23.2-src-old/crawl-ref/source/Makefile	1970-01-01 03:00:01.000000000 +0300
-+++ crawl-ref-0.23.2-src-new/crawl-ref/source/Makefile	2017-07-27 14:45:34.611221571 +0300
-@@ -224,9 +224,9 @@
-	STRIP := strip -x
-	NEED_APPKIT = YesPlease
-	LIBNCURSES_IS_UNICODE = Yes
+diff --git a/crawl-ref/source/Makefile b/crawl-ref/source/Makefile
+--- a/crawl-ref/source/Makefile
++++ b/crawl-ref/source/Makefile
+@@ -248,9 +248,9 @@ ifeq ($(uname_S),Darwin)
+ 	STRIP := strip -x
+ 	NEED_APPKIT = YesPlease
+ 	LIBNCURSES_IS_UNICODE = Yes
 -	NO_PKGCONFIG = Yes
 -	BUILD_SQLITE = YesPlease
 -	BUILD_ZLIB = YesPlease
 +	#NO_PKGCONFIG = Yes
 +	#BUILD_SQLITE = YesPlease
 +	#BUILD_ZLIB = YesPlease
-	ifdef TILES
-		EXTRA_LIBS += -framework AppKit -framework AudioUnit -framework CoreAudio -framework ForceFeedback -framework Carbon -framework IOKit -framework OpenGL -framework AudioToolbox -framework CoreVideo contrib/install/$(ARCH)/lib/libSDL2main.a
-		BUILD_FREETYPE = YesPlease
-@@ -286,13 +286,7 @@
- LIBZ := contrib/install/$(ARCH)/lib/libz.a
- 
- ifndef CROSSHOST
--	# FreeBSD keeps all of its userland includes in /usr/local so
--	# look there
--	ifeq ($(uname_S),FreeBSD)
--		SQLITE_INCLUDE_DIR := /usr/local/include
--	else
--		SQLITE_INCLUDE_DIR := /usr/include
--	endif
-+	SQLITE_INCLUDE_DIR := ${sqlite}/include
- else
- 	# This is totally wrong, works only with some old-style setups, and
- 	# on some architectures of Debian/new FHS multiarch -- excluding, for
-diff -ru3 crawl-ref-0.23.2-src-old/crawl-ref/source/util/find_font crawl-ref-0.23.2-src-new/crawl-ref/source/util/find_font
---- crawl-ref-0.23.2-src-old/crawl-ref/source/util/find_font	1970-01-01 03:00:01.000000000 +0300
-+++ crawl-ref-0.23.2-src-new/crawl-ref/source/util/find_font	2017-07-27 14:44:29.784235540 +0300
+ 	ifdef TILES
+ 		EXTRA_LIBS += -framework AppKit -framework AudioUnit -framework CoreAudio -framework ForceFeedback -framework Carbon -framework IOKit -framework OpenGL -framework AudioToolbox -framework CoreVideo contrib/install/$(ARCH)/lib/libSDL2main.a
+ 		BUILD_FREETYPE = YesPlease
+diff --git a/crawl-ref/source/util/find_font b/crawl-ref/source/util/find_font
+--- a/crawl-ref/source/util/find_font
++++ b/crawl-ref/source/util/find_font
 @@ -1,6 +1,6 @@
  #! /bin/sh
  

--- a/pkgs/games/crawl/default.nix
+++ b/pkgs/games/crawl/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   name = "crawl-${version}${lib.optionalString tileMode "-tiles"}";
-  version = "0.24.1";
+  version = "0.25.0";
 
   src = fetchFromGitHub {
     owner = "crawl";
     repo = "crawl";
     rev = version;
-    sha256 = "1fiizkigmbrw0nb1l1m3syl2mw4a4r36l1y0n4z8z7slp79bsbv4";
+    sha256 = "0swcl8cxz64yw8dl9macz8ar1ccwrkwz89j7s1f60inb5jlxifqm";
   };
 
   # Patch hard-coded paths and remove force library builds


### PR DESCRIPTION
Thanks to @emilazy adding support for pkgconfig for SQLite upstream,
we can drop that part of the patch. The rest is still needed.

Tested crawl and crawlTiles, both get in-game fine.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
