### PR TITLE
[20.03] golang backports

### DIFF
--- a/pkgs/development/compilers/go/1.12.nix
+++ b/pkgs/development/compilers/go/1.12.nix
@@ -233,8 +233,6 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  setupHook = ./setup-hook.sh;
-
   disallowedReferences = [ goBootstrap ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/compilers/go/1.13.nix
+++ b/pkgs/development/compilers/go/1.13.nix
@@ -30,11 +30,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.13.11";
+  version = "1.13.12";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "0y86q2k00lh8c7wj3lha43g804iwr61nap8j3i907l2sway1mvc9";
+    sha256 = "0d5s5rqyzp6ykj4x1dz8infcsmj3gy8djnf63ji971ypwi6jrfhp";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.13.nix
+++ b/pkgs/development/compilers/go/1.13.nix
@@ -30,11 +30,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.13.8";
+  version = "1.13.11";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "0d7cxffk72568h46srzswrxd0bsdip7amgkf499wzn6l6d3g0fxi";
+    sha256 = "0y86q2k00lh8c7wj3lha43g804iwr61nap8j3i907l2sway1mvc9";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.13.nix
+++ b/pkgs/development/compilers/go/1.13.nix
@@ -230,8 +230,6 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  setupHook = ./setup-hook.sh;
-
   disallowedReferences = [ goBootstrap ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -30,11 +30,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.14.1";
+  version = "1.14.2";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "0xkna02clggcdgl5xxwani62krnf64x6p3hk9k5v9ldh2lhmglia";
+    sha256 = "0z3zxsnhmsxplnwfw1l9gr6jgglwp50sr3p5njknv9i6jzk89plq";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -30,11 +30,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.14.3";
+  version = "1.14.4";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "0mmgf74snprdiajgh99jjliwjl5im71qcgm5qrxpnyfisiw3f0lk";
+    sha256 = "1105qk2l4kfy1ki9n9gh8j4gfqrfgfwapa1fp38hih9aphxsy4bh";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -30,11 +30,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.14.2";
+  version = "1.14.3";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "0z3zxsnhmsxplnwfw1l9gr6jgglwp50sr3p5njknv9i6jzk89plq";
+    sha256 = "0mmgf74snprdiajgh99jjliwjl5im71qcgm5qrxpnyfisiw3f0lk";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -2,6 +2,7 @@
 , perl, which, pkgconfig, patch, procps, pcre, cacert, Security, Foundation
 , mailcap, runtimeShell
 , buildPackages, pkgsTargetTarget
+, fetchpatch
 }:
 
 let
@@ -138,6 +139,12 @@ stdenv.mkDerivation rec {
     ./go-1.9-skip-flaky-20072.patch
     ./skip-external-network-tests.patch
     ./skip-nohup-tests.patch
+
+    # fix rare TestDontCacheBrokenHTTP2Conn failure
+    (fetchpatch {
+      url = "https://github.com/golang/go/commit/ea1437a8cdf6bb3c2d2447833a5d06dbd75f7ae4.patch";
+      sha256 = "1lyzy4nf8c34a966vw45j3j7hzpvncq2gqspfxffzkyh17xd8sgy";
+    })
   ] ++ [
     # breaks under load: https://github.com/golang/go/issues/25628
     (if stdenv.isAarch32

--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -230,8 +230,6 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  setupHook = ./setup-hook.sh;
-
   disallowedReferences = [ goBootstrap ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/compilers/go/1.4.nix
+++ b/pkgs/development/compilers/go/1.4.nix
@@ -151,8 +151,6 @@ stdenv.mkDerivation rec {
     ./all.bash
   '';
 
-  setupHook = ./setup-hook.sh;
-
   meta = with stdenv.lib; {
     branch = "1.4";
     homepage = http://golang.org/;

--- a/pkgs/development/compilers/go/setup-hook.sh
+++ b/pkgs/development/compilers/go/setup-hook.sh
@@ -1,5 +1,0 @@
-addToGoPath() {
-    addToSearchPath GOPATH $1/share/go
-}
-
-addEnvHooks "$targetOffset" addToGoPath

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -13,12 +13,15 @@
 # path to go.mod and go.sum directory
 , modRoot ? "./"
 
-# modSha256 is the sha256 of the vendored dependencies
+# vendorSha256 is the sha256 of the vendored dependencies
 #
-# CAUTION: if `null` is used as a value, the derivation won't be a
-# fixed-output derivation but disable the build sandbox instead. Don't use
-# this in nixpkgs as Hydra won't build those packages.
-, modSha256
+# if vendorSha256 is null, then we won't fetch any dependencies and
+# rely on the vendor folder within the source.
+, vendorSha256 ? null
+# Whether to delete the vendor folder supplied with the source.
+, deleteVendor ? false
+
+, modSha256 ? null
 
 # We want parallel builds by default
 , enableParallelBuilding ? true
@@ -37,21 +40,26 @@
 with builtins;
 
 let
-  args = removeAttrs args' [ "overrideModAttrs" "modSha256" "disabled" ];
+  args = removeAttrs args' [ "overrideModAttrs" "vendorSha256" "disabled" ];
 
   removeReferences = [ ] ++ lib.optional (!allowGoReference) go;
 
   removeExpr = refs: ''remove-references-to ${lib.concatMapStrings (ref: " -t ${ref}") refs}'';
 
-  go-modules = go.stdenv.mkDerivation (let modArgs = {
+  deleteFlag = if deleteVendor then "true" else "false";
+
+  go-modules = if vendorSha256 != null then go.stdenv.mkDerivation (let modArgs = {
+
     name = "${name}-go-modules";
 
-    nativeBuildInputs = [ go git cacert ];
+    nativeBuildInputs = (args.nativeBuildInputs or []) ++ [ go git cacert ];
 
     inherit (args) src;
     inherit (go) GOOS GOARCH;
 
     patches = args.patches or [];
+    preBuild = args.preBuild or "";
+    sourceRoot = args.sourceRoot or "";
 
     GO111MODULE = "on";
 
@@ -64,7 +72,6 @@ let
 
       export GOCACHE=$TMPDIR/go-cache
       export GOPATH="$TMPDIR/go"
-      mkdir -p "''${GOPATH}/pkg/mod/cache/download"
       cd "${modRoot}"
       runHook postConfigure
     '';
@@ -72,7 +79,16 @@ let
     buildPhase = args.modBuildPhase or ''
       runHook preBuild
 
-      go mod download
+      if [ ${deleteFlag} == "true" ]; then
+        rm -rf vendor
+      fi
+
+      if [ -e vendor ]; then
+        echo "vendor folder exists, please set 'vendorSha256=null;' or 'deleteVendor=true;' in your expression"
+        exit 10
+      fi
+      go mod vendor
+      mkdir -p vendor
 
       runHook postBuild
     '';
@@ -81,23 +97,19 @@ let
       runHook preInstall
 
       # remove cached lookup results and tiles
-      rm -rf "''${GOPATH}/pkg/mod/cache/download/sumdb"
-      cp -r "''${GOPATH}/pkg/mod/cache/download" $out
+      cp -r --reflink=auto vendor $out
 
       runHook postInstall
     '';
 
     dontFixup = true;
   }; in modArgs // (
-    if modSha256 == null then
-      { __noChroot = true; }
-    else
       {
         outputHashMode = "recursive";
         outputHashAlgo = "sha256";
-        outputHash = modSha256;
+        outputHash = vendorSha256;
       }
-  ) // overrideModAttrs modArgs);
+  ) // overrideModAttrs modArgs) else "";
 
   package = go.stdenv.mkDerivation (args // {
     nativeBuildInputs = [ removeReferencesTo go ] ++ nativeBuildInputs;
@@ -105,6 +117,7 @@ let
     inherit (go) GOOS GOARCH;
 
     GO111MODULE = "on";
+    GOFLAGS = "-mod=vendor";
 
     configurePhase = args.configurePhase or ''
       runHook preConfigure
@@ -112,9 +125,12 @@ let
       export GOCACHE=$TMPDIR/go-cache
       export GOPATH="$TMPDIR/go"
       export GOSUMDB=off
-      export GOPROXY=file://${go-modules}
-
+      export GOPROXY=off
       cd "$modRoot"
+      if [ -n "${go-modules}" ]; then 
+          rm -rf vendor
+          ln -s ${go-modules} vendor
+      fi
 
       runHook postConfigure
     '';
@@ -210,7 +226,7 @@ let
 
     disallowedReferences = lib.optional (!allowGoReference) go;
 
-    passthru = passthru // { inherit go go-modules modSha256; };
+    passthru = passthru // { inherit go go-modules vendorSha256 ; };
 
     meta = {
       # Add default meta information
@@ -223,5 +239,7 @@ let
   });
 in if disabled then
   throw "${package.name} not supported for go ${go.meta.branch}"
+else if modSha256 != null then
+  throw "${package.name} should use vendorSha256 not modSha256"
 else
   package

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -210,7 +210,7 @@ let
 
     disallowedReferences = lib.optional (!allowGoReference) go;
 
-    passthru = passthru // { inherit go go-modules; };
+    passthru = passthru // { inherit go go-modules modSha256; };
 
     meta = {
       # Add default meta information


### PR DESCRIPTION
~~Can we backport the `buildGoModule` changes (without the warning) so that we can use `vendorSha256` on 20.03?~~

Updated to include `buildGoModule` `vendorSha256`.

~~The last two `go` (1.14.4 and test fix) commits are in ~~staging~~ staging-next, are they okay to backport or do they need to land in master first?~~