### PR TITLE
zstd: install static libraries to dev

### DIFF
--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -28,6 +28,12 @@ stdenv.mkDerivation rec {
     # work fine, and I'm not sure how to write the condition.
     ++ stdenv.lib.optional stdenv.hostPlatform.isWindows ./mcfgthreads-no-pthread.patch;
 
+  postPatch = ''
+    substituteInPlace build/cmake/lib/CMakeLists.txt \
+      --replace 'ARCHIVE DESTINATION "''${CMAKE_INSTALL_LIBDIR}"' \
+                "ARCHIVE DESTINATION \"''${!outputDev}/lib\""
+  '';
+
   cmakeFlags = [
     "-DZSTD_BUILD_SHARED:BOOL=${if enableShared then "ON" else "OFF"}"
     # They require STATIC for bin/zstd and tests.
@@ -56,8 +62,6 @@ stdenv.mkDerivation rec {
     substituteInPlace ../programs/zstdless \
       --replace "zstdcat" "$bin/bin/zstdcat"
   '';
-  # Don't duplicate the library code in runtime closures.
-  postInstall = stdenv.lib.optionalString enableShared ''rm "$out"/lib/libzstd.a'';
 
   outputs = [ "bin" "dev" "man" "out" ];
 


### PR DESCRIPTION
Achieved by patching cmake "install()" directive to ensure that
$dev/lib/cmake is generated with correct paths.

If we don't want to build static libraries we should be setting
ZSTD_BUILD_STATIC to OFF instead.

Fixes: 7f76daac ('zstd: get rid of static libs if enableShared')

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes some of the fallout from #78910

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
