### PR TITLE
Add 'wasm32-unknown' to known targets

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -22,6 +22,8 @@ let
 
     "wasm64-wasi" "wasm32-wasi"
 
+    "wasm32-unknown"
+
     "powerpc64le-linux"
 
     "riscv32-linux" "riscv64-linux"
@@ -71,6 +73,7 @@ in {
   wasi    = filterDoubles predicates.isWasi;
   windows = filterDoubles predicates.isWindows;
   genode  = filterDoubles predicates.isGenode;
+  wasm    = filterDoubles predicates.isWasm;
 
   embedded = filterDoubles predicates.isNone;
 

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -280,6 +280,7 @@ rec {
     windows = { execFormat = pe;      families = { }; };
     ghcjs   = { execFormat = unknown; families = { }; };
     genode  = { execFormat = elf;     families = { }; };
+    unknown = { execFormat = unknown; families = { }; };
   } // { # aliases
     # 'darwin' is the kernel for all of them. We choose macOS by default.
     darwin = kernels.macos;
@@ -342,6 +343,7 @@ rec {
     uclibceabihf = { float = "soft"; };
     uclibceabi   = { float = "hard"; };
     uclibc       = {};
+    wasm = {};
 
     unknown = {};
   };

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -185,6 +185,7 @@ stdenv.mkDerivation {
       else if targetPlatform.isAvr then "avr"
       else if targetPlatform.isAlpha then "alpha"
       else if targetPlatform.isVc4 then "vc4"
+      else if targetPlatform.isWasm then "wasm"
       else throw "unknown emulation for platform: ${targetPlatform.config}";
     in if targetPlatform.useLLVM or false then ""
        else targetPlatform.platform.bfdEmulation or (fmt + sep + arch);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


#### This adds the support of  `wasm32-unknown` / `wasm32-unknown-unknown` like targets.

[WebGHC](https://github.com/WebGHC/wasm-cross) uses the `wasm32-unknown-unknown-wasm` target for the web-assembly cross compilation support for GHC/Haskell. But this can be used by any other tool chain doing web-assembly cross compilation.

**It is necessary to upstream this as it is not possible to make it work using overlays. (let me know if I am wrong)**

The `wasm` is meant to be different from the `wasi` / `wasm32-unknown-wasi`/ `wasm32-wasi` target (already present in nixpkgs), as it is a general web-assembly target, and is not tied to the [wasi](https://github.com/WebAssembly/WASI) specification.

`wasi` is an already supported cross-compilation target in nixpkgs. But for [WebGHC](https://github.com/WebGHC/wasm-cross) it cannot be used right now, as it is somewhat constrained interface. In future WebGHC might also move to using the `wasi` interface, but for the time being it uses a custom `musl` fork, and therefore chose to use a more general `wasm32-unknown` target for itself.

This is the first of the two PRs needed for upstreaming all the nixpkgs changes for wasm cross compilation support of WebGHC.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
