### PR TITLE
openjdk: 11.0.6 -> 11.0.7

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -10,7 +10,7 @@
 
 let
   major = "11";
-  update = ".0.6";
+  update = ".0.7";
   build = "ga";
 
   openjdk = stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ let
 
     src = fetchurl {
       url = "http://hg.openjdk.java.net/jdk-updates/jdk${major}u/archive/jdk-${version}.tar.gz";
-      sha256 = "1w6n0cnz9izpjb3sc870q7a0jz85a6c7fiszymxin10cnsajkzir";
+      sha256 = "14daacng9ndxf4kmvsn7nracwfiwwmw5rha8rkk3723pfk9g8q7p";
     };
 
     nativeBuildInputs = [ pkgconfig autoconf ];

--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -135,7 +135,7 @@ let
       homepage = "http://openjdk.java.net/";
       license = licenses.gpl2;
       description = "The open-source Java Development Kit";
-      maintainers = with maintainers; [ edwtjo ];
+      maintainers = with maintainers; [ edwtjo asbachb ];
       platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
     };
 


### PR DESCRIPTION
###### Motivation for this change
Updated to latest release version.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
[root@nixos:~/nix/nixpkgs/pkgs/development/compilers/openjdk]# nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
these paths will be fetched (0.03 MiB download, 0.13 MiB unpacked):
  /nix/store/j2gsdfiimrywkj0p5ir5cfs4q6ax068s-nixpkgs-review-2.3.1
copying path '/nix/store/j2gsdfiimrywkj0p5ir5cfs4q6ax068s-nixpkgs-review-2.3.1' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 48, done.
remote: Counting objects: 100% (48/48), done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 60 (delta 42), reused 43 (delta 42), pack-reused 12
Unpacking objects: 100% (60/60), 19.57 KiB | 217.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
 * [new branch]              master     -> refs/nixpkgs-review/0
$ git worktree add /root/.cache/nixpkgs-review/rev-890485a2bd8ab4318048e24987d91986a4758ed3-dirty/nixpkgs 1d924f0354ffb255e79ec2274f8ab72640f93a60
Preparing worktree (detached HEAD 1d924f0354f)
Updating files: 100% (21856/21856), done.
HEAD is now at 1d924f0354f Merge pull request #89772 from rnhmjoj/dnschain
$ nix-env -f /root/.cache/nixpkgs-review/rev-890485a2bd8ab4318048e24987d91986a4758ed3-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
```
[nix-shell:~/nix/nixpkgs/pkgs/development/compilers/openjdk]# java -version
openjdk version "11.0.7-internal" 2020-04-14
OpenJDK Runtime Environment (build 11.0.7-internal+0-adhoc..jdk11u-jdk-11.0.7-ga)
OpenJDK 64-Bit Server VM (build 11.0.7-internal+0-adhoc..jdk11u-jdk-11.0.7-ga, mixed mode)
```
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
