### PR TITLE
marp-cli: init at 0.18.1

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -3,6 +3,7 @@
 , "@antora/cli"
 , "@antora/site-generator-default"
 , "@bitwarden/cli"
+, "@marp-team/marp-cli"
 , "@vue/cli"
 , "@webassemblyjs/cli"
 , "@webassemblyjs/repl"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -22,31 +22,31 @@ let
         sha512 = "t4WmWoGV9gyzypwG3y3JlcK2t8fKLtvzBA7xEoFTj9SMPvOuLsf13uh4ikK0RRaaa9RPPWLgFUdOyIRaQvCpwQ==";
       };
     };
-    "@angular-devkit/architect-0.901.7" = {
+    "@angular-devkit/architect-0.901.8" = {
       name = "_at_angular-devkit_slash_architect";
       packageName = "@angular-devkit/architect";
-      version = "0.901.7";
+      version = "0.901.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.901.7.tgz";
-        sha512 = "yW/PUEqle55QihOFbmeNXaVTodhfeXkteoFDUpz+YpX3xiQDXDtNbIJSzKOQTojtBKdSMKMvZkQLr+RAa7/1EA==";
+        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.901.8.tgz";
+        sha512 = "tK9ZQlubH6n+q+c2J9Wvfcxg3RFuRiTfJriNoodo6GHvtF2KLdPY67w3Gen0Sp172A5Q8Y927NseddNI8RZ/0A==";
       };
     };
-    "@angular-devkit/core-9.1.7" = {
+    "@angular-devkit/core-9.1.8" = {
       name = "_at_angular-devkit_slash_core";
       packageName = "@angular-devkit/core";
-      version = "9.1.7";
+      version = "9.1.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-9.1.7.tgz";
-        sha512 = "guvolu9Cl+qYMTtedLZD9wCqustJjdqzJ2psD2C1Sr1LrX9T0mprmDldR/YnhsitThveJEb6sM/0EvqWxoSvKw==";
+        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-9.1.8.tgz";
+        sha512 = "4k1pZwje2oh5c/ULg7pnCBzTstx3l3uF7O5tQq/KXomDDsam97IhLm6cKUqQpaoyC1NUsBV6xJARJ0PyUP5TPQ==";
       };
     };
-    "@angular-devkit/schematics-9.1.7" = {
+    "@angular-devkit/schematics-9.1.8" = {
       name = "_at_angular-devkit_slash_schematics";
       packageName = "@angular-devkit/schematics";
-      version = "9.1.7";
+      version = "9.1.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-9.1.7.tgz";
-        sha512 = "oeHPJePBcPp/bd94jHQeFUnft93PGF5iJiKV9szxqS8WWC5OMZ5eK7icRY0PwvLyfenspAZxdZcNaqJqPMul5A==";
+        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-9.1.8.tgz";
+        sha512 = "/8L5J4X6SkcFMRmrSQHvJWOPilrMWTNlv1lD+1z06D3xGJEktVxXM3gCUXhDrbMvpoi+lYtR2Fuia0E6zvyjCQ==";
       };
     };
     "@antora/asciidoc-loader-2.3.3" = {
@@ -220,13 +220,13 @@ let
         sha512 = "fDj5rWlTi/czvUS5t7V7I45Ai6bOO3Z7JARYj21Y2xxfbRGtJi6h8FvLX0N/EbzQgo/fiZc/HAhtfwn+OCjD7A==";
       };
     };
-    "@apollographql/graphql-playground-html-1.6.24" = {
+    "@apollographql/graphql-playground-html-1.6.26" = {
       name = "_at_apollographql_slash_graphql-playground-html";
       packageName = "@apollographql/graphql-playground-html";
-      version = "1.6.24";
+      version = "1.6.26";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz";
-        sha512 = "8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ==";
+        url = "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.26.tgz";
+        sha512 = "XAwXOIab51QyhBxnxySdK3nuMEUohhDsHQ5Rbco/V1vjlP75zZ0ZLHD9dTpXTN8uxKxopb2lUvJTq+M4g2Q0HQ==";
       };
     };
     "@azu/format-text-1.0.1" = {
@@ -2236,6 +2236,33 @@ let
         sha512 = "RibeMnDPvlL8bFYW5C8cs4mbI3AHfQef73tnJCQ/SgrXZHehmHnsyWUiE7qDQCAo+B1RfTapvSyFF69iPj326A==";
       };
     };
+    "@marp-team/marp-core-1.2.0" = {
+      name = "_at_marp-team_slash_marp-core";
+      packageName = "@marp-team/marp-core";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@marp-team/marp-core/-/marp-core-1.2.0.tgz";
+        sha512 = "16oF4DXfjpIAr987jt62NYleO0Sj4Isb0PkrM8PEICA2iCikRU8kG1UmHUVP+oRrWb0faFyCs1tqOLA98WObEA==";
+      };
+    };
+    "@marp-team/marpit-1.6.2" = {
+      name = "_at_marp-team_slash_marpit";
+      packageName = "@marp-team/marpit";
+      version = "1.6.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@marp-team/marpit/-/marpit-1.6.2.tgz";
+        sha512 = "eT9VmIQe3gXECirLy1YZ2MK/8yUZmAfteuo/1pdydkEaPSkjz8U8s3adE8lWXlHSJJkHJmWqnMFODjN4G5PpvQ==";
+      };
+    };
+    "@marp-team/marpit-svg-polyfill-1.3.0" = {
+      name = "_at_marp-team_slash_marpit-svg-polyfill";
+      packageName = "@marp-team/marpit-svg-polyfill";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@marp-team/marpit-svg-polyfill/-/marpit-svg-polyfill-1.3.0.tgz";
+        sha512 = "KdmyocuqUW63ZLClFMbBbXz+ikYgF1La+EDOqCzwM6Sk1JZXzm1bh3JP5g6NKhPaMcuOJA2R+6/uyn6We5UjCw==";
+      };
+    };
     "@mrmlnc/readdir-enhanced-2.2.1" = {
       name = "_at_mrmlnc_slash_readdir-enhanced";
       packageName = "@mrmlnc/readdir-enhanced";
@@ -2524,22 +2551,22 @@ let
         sha512 = "60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==";
       };
     };
-    "@octokit/auth-token-2.4.1" = {
+    "@octokit/auth-token-2.4.2" = {
       name = "_at_octokit_slash_auth-token";
       packageName = "@octokit/auth-token";
-      version = "2.4.1";
+      version = "2.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.1.tgz";
-        sha512 = "NB81O5h39KfHYGtgfWr2booRxp2bWOJoqbWwbyUg2hw6h35ArWYlAST5B3XwAkbdcx13yt84hFXyFP5X0QToWA==";
+        url = "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz";
+        sha512 = "jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==";
       };
     };
-    "@octokit/endpoint-6.0.2" = {
+    "@octokit/endpoint-6.0.3" = {
       name = "_at_octokit_slash_endpoint";
       packageName = "@octokit/endpoint";
-      version = "6.0.2";
+      version = "6.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.2.tgz";
-        sha512 = "xs1mmCEZ2y4shXCpFjNq3UbmNR+bLzxtZim2L0zfEtj9R6O6kc4qLDvYw66hvO6lUsYzPTM5hMkltbuNAbRAcQ==";
+        url = "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.3.tgz";
+        sha512 = "Y900+r0gIz+cWp6ytnkibbD95ucEzDSKzlEnaWS52hbCDNcCJYO5mRmWW7HRAnDc7am+N/5Lnd8MppSaTYx1Yg==";
       };
     };
     "@octokit/plugin-enterprise-rest-6.0.1" = {
@@ -2578,13 +2605,13 @@ let
         sha512 = "EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==";
       };
     };
-    "@octokit/request-5.4.4" = {
+    "@octokit/request-5.4.5" = {
       name = "_at_octokit_slash_request";
       packageName = "@octokit/request";
-      version = "5.4.4";
+      version = "5.4.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/request/-/request-5.4.4.tgz";
-        sha512 = "vqv1lz41c6VTxUvF9nM+a6U+vvP3vGk7drDpr0DVQg4zyqlOiKVrY17DLD6de5okj+YLHKcoqaUZTBtlNZ1BtQ==";
+        url = "https://registry.npmjs.org/@octokit/request/-/request-5.4.5.tgz";
+        sha512 = "atAs5GAGbZedvJXXdjtKljin+e2SltEs48B3naJjqWupYl2IUBbB/CJisyjbNHcKpHzb3E+OYEZ46G8eakXgQg==";
       };
     };
     "@octokit/request-error-1.2.1" = {
@@ -2630,6 +2657,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@octokit/types/-/types-4.1.10.tgz";
         sha512 = "/wbFy1cUIE5eICcg0wTKGXMlKSbaAxEr00qaBXzscLXpqhcwgXeS6P8O0pkysBhRfyjkKjJaYrvR1ExMO5eOXQ==";
+      };
+    };
+    "@octokit/types-5.0.0" = {
+      name = "_at_octokit_slash_types";
+      packageName = "@octokit/types";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@octokit/types/-/types-5.0.0.tgz";
+        sha512 = "3LVS+MbeqwSd5G4KS8123cZz+hWomsiGeMnQ/QJIBFDwL/YHX8kkr0FZXrgWEMO7Fgi2/VOrhbiFnk9sZ+s4qA==";
       };
     };
     "@parcel/fs-1.11.0" = {
@@ -2821,22 +2857,22 @@ let
         sha512 = "MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==";
       };
     };
-    "@schematics/angular-9.1.7" = {
+    "@schematics/angular-9.1.8" = {
       name = "_at_schematics_slash_angular";
       packageName = "@schematics/angular";
-      version = "9.1.7";
+      version = "9.1.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/angular/-/angular-9.1.7.tgz";
-        sha512 = "ld3WcoMWvup04V3OWioQ+AFGQBzz7IDM4Fxc5+Qc3wILWkDJnNkrc4EmJAow96Ab4/T1+Wl1vof3tV4At0BTzA==";
+        url = "https://registry.npmjs.org/@schematics/angular/-/angular-9.1.8.tgz";
+        sha512 = "fjyAP9m4aF51OVdksRXCOF8BTyt96PqFmKK9G0kuwOzgfx2gPZNOO3wOZH6xFAMZ09y86VGzasZxZNeDdyN4sQ==";
       };
     };
-    "@schematics/update-0.901.7" = {
+    "@schematics/update-0.901.8" = {
       name = "_at_schematics_slash_update";
       packageName = "@schematics/update";
-      version = "0.901.7";
+      version = "0.901.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/update/-/update-0.901.7.tgz";
-        sha512 = "6IpQVFvbu47CrXfqqHAzv2vi7AOdfi1S+SiayXU6FWTeA2wV47H8R60VjxurL8JkDGoVhFgC4+lK6KG++g3dQw==";
+        url = "https://registry.npmjs.org/@schematics/update/-/update-0.901.8.tgz";
+        sha512 = "v1tEYX6yM5vuwXW7AG7OZ4OtjqRwTo3kd69LVJyOdF/d9HlqaAFU301RuEsAPwOrPqZEQdTwklH1fNJnqgpB/w==";
       };
     };
     "@serverless/cli-1.4.0" = {
@@ -2938,13 +2974,13 @@ let
         sha512 = "hcMiX523rkp6kHeKnM1x6/dXEY+d1UFSr901yVKeeCgpFy4u33UI9vlKaPweAZCF6Ahzqywf01IsFTuBVadCrQ==";
       };
     };
-    "@serverless/utils-china-0.1.13" = {
+    "@serverless/utils-china-0.1.14" = {
       name = "_at_serverless_slash_utils-china";
       packageName = "@serverless/utils-china";
-      version = "0.1.13";
+      version = "0.1.14";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-0.1.13.tgz";
-        sha512 = "NeWXaNDUs/8mUyq2OVtSyzTHEg4PabaEmz31tIkG5+AUuNdfg/mlE5RTzOmH0pW/WeKwFtmm3Wehs75WEpzYcQ==";
+        url = "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-0.1.14.tgz";
+        sha512 = "M1/bvs/ZhqPfj1yqdsyxu4yIWtCXHd+a5Av/ZXef1deTn1zJHO+ZJdOtvFzWHb0Sr7sX4p2ZHD/vGj0Rve/Pzg==";
       };
     };
     "@sindresorhus/is-0.14.0" = {
@@ -4009,6 +4045,15 @@ let
         sha512 = "FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==";
       };
     };
+    "@types/yauzl-2.9.1" = {
+      name = "_at_types_slash_yauzl";
+      packageName = "@types/yauzl";
+      version = "2.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz";
+        sha512 = "A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==";
+      };
+    };
     "@types/yoga-layout-1.9.2" = {
       name = "_at_types_slash_yoga-layout";
       packageName = "@types/yoga-layout";
@@ -4099,40 +4144,40 @@ let
         sha512 = "uh+Y2QO7dxNrdLw7mVnjUqkwO/InxEqwN0wF+Za6eo3coxls9aH9kQ/5rSvW2GcNanebRTmsT5w1/92lAOb1bA==";
       };
     };
-    "@vue/cli-shared-utils-4.4.1" = {
+    "@vue/cli-shared-utils-4.4.4" = {
       name = "_at_vue_slash_cli-shared-utils";
       packageName = "@vue/cli-shared-utils";
-      version = "4.4.1";
+      version = "4.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.4.1.tgz";
-        sha512 = "teevHgI7XUsKVMOncx3M+6iLjO28woGfRwgUG4hR83moVBHQe5x2OCr2i5t/58bwpv269RD5RYXBQCGtIXuxZw==";
+        url = "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.4.4.tgz";
+        sha512 = "ccMZtTMSutR35V5nrU/eyj+zRMomTRGBTLwJPmaJ2sRiW/93MTggQGXDWC8JRAA8yiU1N8xza8mjBxS0O2wIAA==";
       };
     };
-    "@vue/cli-ui-4.4.1" = {
+    "@vue/cli-ui-4.4.4" = {
       name = "_at_vue_slash_cli-ui";
       packageName = "@vue/cli-ui";
-      version = "4.4.1";
+      version = "4.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-4.4.1.tgz";
-        sha512 = "UPDvDdYvuacUuq39OQ/WfLsuIrzIJMdL2bkMecpcegDRPi6MEgkInXqSOMEl5v72FX8qStwXYCUSxifoYIIZ/g==";
+        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-4.4.4.tgz";
+        sha512 = "BKzDvUgy6fsZolrMLBvMLlue7s3dFeIJdxWWJtc8/CjD5VvLG+XawAePx8W+24QZwCZpvoZIz4zU38D341IT9A==";
       };
     };
-    "@vue/cli-ui-addon-webpack-4.4.1" = {
+    "@vue/cli-ui-addon-webpack-4.4.4" = {
       name = "_at_vue_slash_cli-ui-addon-webpack";
       packageName = "@vue/cli-ui-addon-webpack";
-      version = "4.4.1";
+      version = "4.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-4.4.1.tgz";
-        sha512 = "UJrv7bCSEJIq+nG3xKSOMjkUnQBbUr+vwk6PjBPsMcjOdbra7p8sQfDIXeRSviCgoDVcnODJDMyD0tqg6OI/sA==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-4.4.4.tgz";
+        sha512 = "qx3MnLxk4JeKpkGK2h5ZihuA8Asgu7sbLDagOOaEbF6GpnHSfkrYioE7es8AHm4QHBgn/MWqnkBts5XDN5r4LA==";
       };
     };
-    "@vue/cli-ui-addon-widgets-4.4.1" = {
+    "@vue/cli-ui-addon-widgets-4.4.4" = {
       name = "_at_vue_slash_cli-ui-addon-widgets";
       packageName = "@vue/cli-ui-addon-widgets";
-      version = "4.4.1";
+      version = "4.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-4.4.1.tgz";
-        sha512 = "VaAnCI1X2SEllLNf1TXNz0BARfdb+COMUMzc17PMb5xmdqDswPvVKG5pnFurKODWFgI7zcbk4kBnrYojdLnhNg==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-4.4.4.tgz";
+        sha512 = "nOe6LOwZsKCiaH+jrAO2/G90qAkzB1RYivcWGnXirQAH7nec1ZysDNQv1HMDIfWbhCkJMWhGICuWcrn+rtb/8Q==";
       };
     };
     "@webassemblyjs/ast-1.8.1" = {
@@ -4693,15 +4738,6 @@ let
         sha1 = "9a8eac8ff79866f3f9b4bb1443ca778f1598aeda";
       };
     };
-    "accepts-1.2.13" = {
-      name = "accepts";
-      packageName = "accepts";
-      version = "1.2.13";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz";
-        sha1 = "e5f1f3928c6d95fd96558c36ec3d9d0de4a6ecea";
-      };
-    };
     "accepts-1.3.7" = {
       name = "accepts";
       packageName = "accepts";
@@ -4774,13 +4810,13 @@ let
         sha512 = "ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==";
       };
     };
-    "acorn-7.2.0" = {
+    "acorn-7.3.1" = {
       name = "acorn";
       packageName = "acorn";
-      version = "7.2.0";
+      version = "7.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz";
-        sha512 = "apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==";
+        url = "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz";
+        sha512 = "tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==";
       };
     };
     "acorn-globals-1.0.9" = {
@@ -5593,13 +5629,13 @@ let
         sha512 = "sbLEIMQrkV7RkIruqTPXxeCMkAAycv4yzTkBzRgOR1BrR5UB7qZtupqxkersTJSf0HZ3sbaNRrNV80TnnM7cUw==";
       };
     };
-    "apollo-2.28.2" = {
+    "apollo-2.28.3" = {
       name = "apollo";
       packageName = "apollo";
-      version = "2.28.2";
+      version = "2.28.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo/-/apollo-2.28.2.tgz";
-        sha512 = "UcQIj6+MKcCSEH6la0G1SinIV8+Q3AM9x8Oryq9YXRcwjJqnOYdq1qPpmmTG+SlR9Lfxpo8Sv+e16QuSBFVQNg==";
+        url = "https://registry.npmjs.org/apollo/-/apollo-2.28.3.tgz";
+        sha512 = "+X1RqODYOz1VPO0a/6tZpZiFQr7K6z0ZSm7H9oT9PmuZ9TMC27mwOh2N0i1p+OP+6JORKh8lHmjMvle+doZ82A==";
       };
     };
     "apollo-cache-1.3.5" = {
@@ -5638,49 +5674,49 @@ let
         sha512 = "jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==";
       };
     };
-    "apollo-codegen-core-0.37.2" = {
+    "apollo-codegen-core-0.37.3" = {
       name = "apollo-codegen-core";
       packageName = "apollo-codegen-core";
-      version = "0.37.2";
+      version = "0.37.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.37.2.tgz";
-        sha512 = "Cf4+mWf92nd0PlruwoLrHpS1/eRF2M2qaq/NBGyJlLFhwALrMlM63cqMuJ/Q2dWwAB7ecQLKgZdUkv4jisyimQ==";
+        url = "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.37.3.tgz";
+        sha512 = "/DwAhOOFzl57GdBfRGNnqIAcfZAXpsgFIeWYqlu3I/eIucGBCFWo9CEW1TcNwkZzYGAmSE8tURwPgt7dtnhFpg==";
       };
     };
-    "apollo-codegen-flow-0.35.2" = {
+    "apollo-codegen-flow-0.35.3" = {
       name = "apollo-codegen-flow";
       packageName = "apollo-codegen-flow";
-      version = "0.35.2";
+      version = "0.35.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.35.2.tgz";
-        sha512 = "B8Vo0bViAENNNQ+2uAwxnLYsdU0URyQwEpTQDXfV07JLQrm3ebNQqoLeDz2Xacknuh11QtQNexOmM02Q/dfjvw==";
+        url = "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.35.3.tgz";
+        sha512 = "npDt9PEJiw/ygKUsKxaDGHCnjQUANPlg/F9piIbQ71jwBjNNoNSXrRaRiD5632MfcTvEuBvanElEX3AO2sA1gw==";
       };
     };
-    "apollo-codegen-scala-0.36.2" = {
+    "apollo-codegen-scala-0.36.3" = {
       name = "apollo-codegen-scala";
       packageName = "apollo-codegen-scala";
-      version = "0.36.2";
+      version = "0.36.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.36.2.tgz";
-        sha512 = "423HUZo3i1SHBIvH+lusi8fXCRvQWjo+UoRRzzIxiALKDhLAWxgdNADXn0B1jcWJNnyNhfaw58Bh3PtGtFbDnA==";
+        url = "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.36.3.tgz";
+        sha512 = "KOmcP/0RiqSGY03fXdF87IzQ1RSsApbno3/M8KRVF2yhf+4X3GQXQRpXejHMt4DxnnfPBOn7MqwtP/cDMJIiyw==";
       };
     };
-    "apollo-codegen-swift-0.37.2" = {
+    "apollo-codegen-swift-0.37.3" = {
       name = "apollo-codegen-swift";
       packageName = "apollo-codegen-swift";
-      version = "0.37.2";
+      version = "0.37.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.37.2.tgz";
-        sha512 = "sa4huF3fnjMwf93CsOc2vaIwQbolZzELq2o9F3uX6ZNJhiE1oywF64fI5jLuw4adQSe9vX5RI5CbQiKeFoh0xA==";
+        url = "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.37.3.tgz";
+        sha512 = "0BpwtSE+IP12C7OdoScsOWUgxbcuThgwVRsxybBNugUcmddF5sCdGiRbdm+oKvX1vErsG+XimwmIuZnBPWv6ew==";
       };
     };
-    "apollo-codegen-typescript-0.37.2" = {
+    "apollo-codegen-typescript-0.37.3" = {
       name = "apollo-codegen-typescript";
       packageName = "apollo-codegen-typescript";
-      version = "0.37.2";
+      version = "0.37.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.37.2.tgz";
-        sha512 = "Y837GfKEKVusLj+1DKjHaLcKKyLAGsddNqZRFhXDFAQ4G5Mmrrrn2BzNTYKLoeyDEiBW3dle32Pzyc8UpHbURQ==";
+        url = "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.37.3.tgz";
+        sha512 = "tuf/AQTFcNrngQrT4q4WKRdiuPbglyR1m3L58g/nNevoO0cRmF6koIix4NB5sO05LgF8XJmd2zHvInUI5v33Ig==";
       };
     };
     "apollo-datasource-0.7.1" = {
@@ -5692,13 +5728,13 @@ let
         sha512 = "h++/jQAY7GA+4TBM+7ezvctFmmGNLrAPf51KsagZj+NkT9qvxp585rdsuatynVbSl59toPK2EuVmc6ilmQHf+g==";
       };
     };
-    "apollo-engine-reporting-2.0.0" = {
+    "apollo-engine-reporting-2.0.1" = {
       name = "apollo-engine-reporting";
       packageName = "apollo-engine-reporting";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-2.0.0.tgz";
-        sha512 = "FvNwORsh3nxEfvQqd2xbd468a0q/R3kYar/Bk6YQdBX5qwqUhqmOcOSxLFk8Zb77HpwHij5CPpPWJb53TU1zcA==";
+        url = "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-2.0.1.tgz";
+        sha512 = "3OYYk7DqNuJ5xKYnyLy5O2n506jYSryim8WqzBTn9MRphRamwPFjHYQm+akPA60AubXrWnYa6A8euMAiQU0ttA==";
       };
     };
     "apollo-engine-reporting-protobuf-0.5.1" = {
@@ -5728,13 +5764,13 @@ let
         sha512 = "0qa7UOoq7E71kBYE7idi6mNQhHLVdMEDInWk6TNw3KsSWZE2/I68gARP84Mj+paFTO5NYuw1Dht66PVX76Cc2w==";
       };
     };
-    "apollo-language-server-1.22.2" = {
+    "apollo-language-server-1.22.3" = {
       name = "apollo-language-server";
       packageName = "apollo-language-server";
-      version = "1.22.2";
+      version = "1.22.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.22.2.tgz";
-        sha512 = "b+KgnjkJnXFRzaNHUb83+IVTw6H5V515DrALBCTlhxa1LmAnET1pm0vuWaFNl5O2fHYqgbtLNz/omipIkvd/5g==";
+        url = "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.22.3.tgz";
+        sha512 = "RurKlBUNE1RrvY4m93b5WS/DXInUEI47MlzuvholRqZSQovt2rQi81R0RvmS/l3d6y5TBfxbPFpT5RyHbdAntw==";
       };
     };
     "apollo-link-1.2.14" = {
@@ -5818,13 +5854,13 @@ let
         sha512 = "L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==";
       };
     };
-    "apollo-server-core-2.14.3" = {
+    "apollo-server-core-2.14.4" = {
       name = "apollo-server-core";
       packageName = "apollo-server-core";
-      version = "2.14.3";
+      version = "2.14.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.14.3.tgz";
-        sha512 = "A9RkWuHFZ04uEnXof5V02T7wfhUel7Hx9LpEN4N59mXTpb7ewW+cb0u+J+SP+Y4vDhVqaHCGoveRVKy6X2kLhw==";
+        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.14.4.tgz";
+        sha512 = "aAfsvbJ2YrqAXDBgcBQocOmQJ5DkeOnEYQ6ADdkkDNU68V5yBRkAHLTOzPfbUlGHVrnOH8PT1FIVWwu5mBgkVA==";
       };
     };
     "apollo-server-env-2.4.4" = {
@@ -5845,13 +5881,13 @@ let
         sha512 = "7oEd6pUxqyWYUbQ9TA8tM0NU/3aGtXSEibo6+txUkuHe7QaxfZ2wHRp+pfT1LC1K3RXYjKj61/C2xEO19s3Kdg==";
       };
     };
-    "apollo-server-express-2.14.3" = {
+    "apollo-server-express-2.14.4" = {
       name = "apollo-server-express";
       packageName = "apollo-server-express";
-      version = "2.14.3";
+      version = "2.14.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.14.3.tgz";
-        sha512 = "35PZXG6sQYB0YT+TBZ5KRxyWqknVnevuHyPG5XSAhMtWsVF2ySMzRPs6JdQTi0p2jlFTo5pt4P6FT3hRu0EFUw==";
+        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.14.4.tgz";
+        sha512 = "g0ml0NGmghvJhTiXMR0HqDD8eTz77zdgzDG2XoqNoRehtVIsZq8fmKTagVt9cUKCKKiBPUF+4tqAGD9lnprUdw==";
       };
     };
     "apollo-server-plugin-base-0.9.0" = {
@@ -6520,6 +6556,15 @@ let
         sha512 = "mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==";
       };
     };
+    "array.prototype.map-1.0.2" = {
+      name = "array.prototype.map";
+      packageName = "array.prototype.map";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz";
+        sha512 = "Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==";
+      };
+    };
     "arraybuffer.slice-0.0.6" = {
       name = "arraybuffer.slice";
       packageName = "arraybuffer.slice";
@@ -6907,6 +6952,15 @@ let
         sha1 = "125dd09de95d3ea30a378adbed021092179b03c9";
       };
     };
+    "async-write-2.1.0" = {
+      name = "async-write";
+      packageName = "async-write";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async-write/-/async-write-2.1.0.tgz";
+        sha1 = "1e762817d849ce44bfac07925a42036787061b15";
+      };
+    };
     "asynckit-0.4.0" = {
       name = "asynckit";
       packageName = "asynckit";
@@ -7069,13 +7123,13 @@ let
         sha1 = "00f35b2d27ac91b1f0d3ef2084c98cf1d1f0adc3";
       };
     };
-    "aws-sdk-2.693.0" = {
+    "aws-sdk-2.696.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.693.0";
+      version = "2.696.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.693.0.tgz";
-        sha512 = "/0zy5IlE8wHrTXCxPYMSJGaqTKN1ulBBOSuWYeGxHU8pnTT6ZHpDdHlS83DHrVbsXnO/zq9prEf1nXRWlwgARw==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.696.0.tgz";
+        sha512 = "LpEZf0ozwVOARKiqXzJ5njXt9eQswRDCwLNK+iTeADGv1up5g7pwU23itOrSLeer3FHV6iueEr+CxEpjQhrEQw==";
       };
     };
     "aws-sign2-0.6.0" = {
@@ -7879,15 +7933,6 @@ let
         sha1 = "40866b9e1b9e0b55b481894311e68faffaebc522";
       };
     };
-    "better-curry-1.6.0" = {
-      name = "better-curry";
-      packageName = "better-curry";
-      version = "1.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/better-curry/-/better-curry-1.6.0.tgz";
-        sha1 = "38f716b24c8cee07a262abc41c22c314e20e3869";
-      };
-    };
     "bezier-js-2.6.1" = {
       name = "bezier-js";
       packageName = "bezier-js";
@@ -7994,15 +8039,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz";
         sha512 = "nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==";
-      };
-    };
-    "binaryheap-0.0.3" = {
-      name = "binaryheap";
-      packageName = "binaryheap";
-      version = "0.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/binaryheap/-/binaryheap-0.0.3.tgz";
-        sha1 = "0d6136c84e9f1a5a90c0b97178c3e00df59820d6";
       };
     };
     "bindings-1.2.1" = {
@@ -8257,15 +8293,6 @@ let
         sha1 = "2f7b4ec80216328a9fddebdf69c8d4942feff7d8";
       };
     };
-    "bluebird-2.9.9" = {
-      name = "bluebird";
-      packageName = "bluebird";
-      version = "2.9.9";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bluebird/-/bluebird-2.9.9.tgz";
-        sha1 = "61a26904d43d7f6b19dff7ed917dbc92452ad6d3";
-      };
-    };
     "bluebird-3.4.7" = {
       name = "bluebird";
       packageName = "bluebird";
@@ -8408,15 +8435,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bops/-/bops-0.0.7.tgz";
         sha1 = "b4a0a5a839a406454af0fe05a8b91a7a766a54e2";
-      };
-    };
-    "bottleneck-1.5.3" = {
-      name = "bottleneck";
-      packageName = "bottleneck";
-      version = "1.5.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bottleneck/-/bottleneck-1.5.3.tgz";
-        sha1 = "55fa64920d9670087d44150404525d59f9511c20";
       };
     };
     "boundary-1.0.1" = {
@@ -8948,15 +8966,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz";
         sha1 = "26e61ed1422fb70dd42e6e36729ed51d855fe8d9";
-      };
-    };
-    "buffercursor-0.0.12" = {
-      name = "buffercursor";
-      packageName = "buffercursor";
-      version = "0.0.12";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/buffercursor/-/buffercursor-0.0.12.tgz";
-        sha1 = "78a9a7f4343ae7d820a8999acc80de591e25a779";
       };
     };
     "buffers-0.1.1" = {
@@ -9958,6 +9967,15 @@ let
         sha512 = "dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==";
       };
     };
+    "chokidar-3.3.1" = {
+      name = "chokidar";
+      packageName = "chokidar";
+      version = "3.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz";
+        sha512 = "4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==";
+      };
+    };
     "chokidar-3.4.0" = {
       name = "chokidar";
       packageName = "chokidar";
@@ -10028,6 +10046,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.13.1.tgz";
         sha512 = "q8UiCNAknw6kCUvCVBTAEw1BwT0vaxabCrSjN3B/NWohp12YBD9+DalymYElSoKRD4KpVSu4CCl0us4v/J81Sg==";
+      };
+    };
+    "chrome-launcher-0.13.3" = {
+      name = "chrome-launcher";
+      packageName = "chrome-launcher";
+      version = "0.13.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.13.3.tgz";
+        sha512 = "ovrDuFXgXS96lzeDqFPQRsczkxla+6QMvzsF+1u0mKlD1KE8EuhjdLwiDfIFedb0FSLz18RK3y6IbKu8oqA0qw==";
       };
     };
     "chrome-net-3.3.4" = {
@@ -11047,15 +11074,6 @@ let
         sha1 = "a58d0df042c186fcf822a8e8015f5450d2d79a8b";
       };
     };
-    "combined-stream-0.0.7" = {
-      name = "combined-stream";
-      packageName = "combined-stream";
-      version = "0.0.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz";
-        sha1 = "0137e657baa5a7541c57ac37ac5fc07d73b4dc1f";
-      };
-    };
     "combined-stream-1.0.6" = {
       name = "combined-stream";
       packageName = "combined-stream";
@@ -11695,15 +11713,6 @@ let
         sha1 = "6874f1e935fca99d048caeaaad9a0aeb020bcce0";
       };
     };
-    "content-disposition-0.5.0" = {
-      name = "content-disposition";
-      packageName = "content-disposition";
-      version = "0.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz";
-        sha1 = "4284fe6ae0630874639e44e80a418c2934135e9e";
-      };
-    };
     "content-disposition-0.5.2" = {
       name = "content-disposition";
       packageName = "content-disposition";
@@ -11921,15 +11930,6 @@ let
         sha1 = "90eb469ddce905c866de687efc43131d8801f9d0";
       };
     };
-    "cookie-0.1.2" = {
-      name = "cookie";
-      packageName = "cookie";
-      version = "0.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz";
-        sha1 = "72fec3d24e48a3432073d90c12642005061004b1";
-      };
-    };
     "cookie-0.3.1" = {
       name = "cookie";
       packageName = "cookie";
@@ -11975,15 +11975,6 @@ let
         sha1 = "44e072148af01e6e8e24afbf12690d68ae698ecb";
       };
     };
-    "cookie-signature-1.0.5" = {
-      name = "cookie-signature";
-      packageName = "cookie-signature";
-      version = "1.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz";
-        sha1 = "a122e3f1503eca0f5355795b0711bb2368d450f9";
-      };
-    };
     "cookie-signature-1.0.6" = {
       name = "cookie-signature";
       packageName = "cookie-signature";
@@ -11991,15 +11982,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz";
         sha1 = "e303a882b342cc3ee8ca513a79999734dab3ae2c";
-      };
-    };
-    "cookiejar-2.0.1" = {
-      name = "cookiejar";
-      packageName = "cookiejar";
-      version = "2.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz";
-        sha1 = "3d12752f6adf68a892f332433492bd5812bb668f";
       };
     };
     "cookiejar-2.0.6" = {
@@ -12270,15 +12252,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/crc/-/crc-0.2.0.tgz";
         sha1 = "f4486b9bf0a12df83c3fca14e31e030fdabd9454";
-      };
-    };
-    "crc-3.2.1" = {
-      name = "crc";
-      packageName = "crc";
-      version = "3.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz";
-        sha1 = "5d9c8fb77a245cd5eca291e5d2d005334bab0082";
       };
     };
     "crc-3.8.0" = {
@@ -12666,6 +12639,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz";
         sha512 = "/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==";
+      };
+    };
+    "cssfilter-0.0.10" = {
+      name = "cssfilter";
+      packageName = "cssfilter";
+      version = "0.0.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz";
+        sha1 = "c6d2672632a2e5c83e013e6864a42ce8defd20ae";
       };
     };
     "cssnano-4.1.10" = {
@@ -13280,24 +13262,6 @@ let
         sha1 = "06e1ea8082c2cb14e39806e22e2f6f757f92af39";
       };
     };
-    "debug-1.0.5" = {
-      name = "debug";
-      packageName = "debug";
-      version = "1.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-1.0.5.tgz";
-        sha1 = "f7241217430f99dec4c2b473eab92228e874c2ac";
-      };
-    };
-    "debug-2.1.3" = {
-      name = "debug";
-      packageName = "debug";
-      version = "2.1.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz";
-        sha1 = "ce8ab1b5ee8fbee2bfa3b633cab93d366b63418e";
-      };
-    };
     "debug-2.2.0" = {
       name = "debug";
       packageName = "debug";
@@ -13865,15 +13829,6 @@ let
         sha512 = "Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA==";
       };
     };
-    "delayed-stream-0.0.5" = {
-      name = "delayed-stream";
-      packageName = "delayed-stream";
-      version = "0.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz";
-        sha1 = "d4b1f43a93e8296dfe02694f4680bc37a313c73f";
-      };
-    };
     "delayed-stream-1.0.0" = {
       name = "delayed-stream";
       packageName = "delayed-stream";
@@ -14025,15 +13980,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz";
         sha512 = "Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==";
-      };
-    };
-    "destroy-1.0.3" = {
-      name = "destroy";
-      packageName = "destroy";
-      version = "1.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz";
-        sha1 = "b433b4724e71fd8551d9885174851c5fc377e2c9";
       };
     };
     "destroy-1.0.4" = {
@@ -15251,13 +15197,13 @@ let
         sha512 = "7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==";
       };
     };
-    "electron-to-chromium-1.3.466" = {
+    "electron-to-chromium-1.3.472" = {
       name = "electron-to-chromium";
       packageName = "electron-to-chromium";
-      version = "1.3.466";
+      version = "1.3.472";
       src = fetchurl {
-        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.466.tgz";
-        sha512 = "eieqkoM2hCkZZRhETKyCouMziDV3l4XEKHRLuzcHG+HV+P7PeODU/z9HAmBgMQkzvHg2DoyQhfIDmmeguLZT/Q==";
+        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.472.tgz";
+        sha512 = "mDk+Q3dWiZo/v6x+1/vU/RdbPI5pMuylg9b1Y2qs+DAomAudcSBlAVZsNm6JuEh9JKIR2rg/eWYmxUVBKIbiOg==";
       };
     };
     "elegant-spinner-1.0.1" = {
@@ -15358,6 +15304,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz";
         sha512 = "MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==";
+      };
+    };
+    "emoji-regex-9.0.0" = {
+      name = "emoji-regex";
+      packageName = "emoji-regex";
+      version = "9.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz";
+        sha512 = "6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==";
       };
     };
     "emoji-server-1.0.0" = {
@@ -15783,6 +15738,15 @@ let
         sha512 = "BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==";
       };
     };
+    "es-array-method-boxes-properly-1.0.0" = {
+      name = "es-array-method-boxes-properly";
+      packageName = "es-array-method-boxes-properly";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz";
+        sha512 = "wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==";
+      };
+    };
     "es-get-iterator-1.1.0" = {
       name = "es-get-iterator";
       packageName = "es-get-iterator";
@@ -15817,15 +15781,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz";
         sha1 = "aba8d9e1943a895ac96837a62a39b3f55ecd94ab";
-      };
-    };
-    "es5class-2.3.1" = {
-      name = "es5class";
-      packageName = "es5class";
-      version = "2.3.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/es5class/-/es5class-2.3.1.tgz";
-        sha1 = "42c5c18a9016bcb0db28a4d340ebb831f55d1b66";
       };
     };
     "es6-error-4.1.1" = {
@@ -15979,15 +15934,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz";
         sha512 = "8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==";
-      };
-    };
-    "escape-html-1.0.1" = {
-      name = "escape-html";
-      packageName = "escape-html";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz";
-        sha1 = "181a286ead397a39a92857cfb1d43052e356bff0";
       };
     };
     "escape-html-1.0.3" = {
@@ -16449,15 +16395,6 @@ let
         sha512 = "kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==";
       };
     };
-    "etag-1.5.1" = {
-      name = "etag";
-      packageName = "etag";
-      version = "1.5.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz";
-        sha1 = "54c50de04ee42695562925ac566588291be7e9ea";
-      };
-    };
     "etag-1.8.1" = {
       name = "etag";
       packageName = "etag";
@@ -16548,15 +16485,6 @@ let
         sha1 = "b4c540012d0fe1498420f3d8946008db6393c37a";
       };
     };
-    "event-stream-3.2.2" = {
-      name = "event-stream";
-      packageName = "event-stream";
-      version = "3.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/event-stream/-/event-stream-3.2.2.tgz";
-        sha1 = "f79f9984c07ee3fd9b44ffb3cd0422b13e24084d";
-      };
-    };
     "event-stream-3.3.4" = {
       name = "event-stream";
       packageName = "event-stream";
@@ -16591,15 +16519,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz";
         sha1 = "8f61b75cde012b2e9eb284d4545583b5643b61ab";
-      };
-    };
-    "eventemitter3-0.1.6" = {
-      name = "eventemitter3";
-      packageName = "eventemitter3";
-      version = "0.1.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz";
-        sha1 = "8c7ac44b87baab55cd50c828dc38778eac052ea5";
       };
     };
     "eventemitter3-1.2.0" = {
@@ -16908,15 +16827,6 @@ let
         sha1 = "0b63ae626c96b71b78d13dfce079c10351635a86";
       };
     };
-    "express-4.11.2" = {
-      name = "express";
-      packageName = "express";
-      version = "4.11.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/express/-/express-4.11.2.tgz";
-        sha1 = "8df3d5a9ac848585f00a0777601823faecd3b148";
-      };
-    };
     "express-4.17.1" = {
       name = "express";
       packageName = "express";
@@ -17014,15 +16924,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz";
         sha512 = "yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==";
-      };
-    };
-    "extend-1.2.1" = {
-      name = "extend";
-      packageName = "extend";
-      version = "1.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz";
-        sha1 = "a0f5fd6cfc83a5fe49ef698d60ec8a624dd4576c";
       };
     };
     "extend-3.0.0" = {
@@ -17158,6 +17059,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz";
         sha512 = "xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==";
+      };
+    };
+    "extract-zip-2.0.1" = {
+      name = "extract-zip";
+      packageName = "extract-zip";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz";
+        sha512 = "GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==";
       };
     };
     "extsprintf-1.0.0" = {
@@ -17745,15 +17655,6 @@ let
         sha512 = "yDEp513p7+iLdFHWBVdZFnRiOYwg8ZqmpaAiZCMjzqsbo7tCS4Qm4ulXOht337NGzkukKa9u3W4wqQ9tQPm3Ug==";
       };
     };
-    "finalhandler-0.3.3" = {
-      name = "finalhandler";
-      packageName = "finalhandler";
-      version = "0.3.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz";
-        sha1 = "b1a09aa1e6a607b3541669b09bcb727f460cd426";
-      };
-    };
     "finalhandler-1.1.2" = {
       name = "finalhandler";
       packageName = "finalhandler";
@@ -18087,13 +17988,13 @@ let
         sha512 = "jlbUu0XkbpXeXhan5xyTqVK1jmEKNxE8hpzznI3TThHTr76GiFwK0iRzhDo4KNy+S9h/KxHaqVhTP86vA6wHCg==";
       };
     };
-    "flow-parser-0.126.1" = {
+    "flow-parser-0.127.0" = {
       name = "flow-parser";
       packageName = "flow-parser";
-      version = "0.126.1";
+      version = "0.127.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.126.1.tgz";
-        sha512 = "HDQAPl2F8vuGgyVm/Zx4vmT9Ja/ACAVIWVA3FRIcNoklkWsWDv+2vv2oVLk/2n+jAzESmvA5nFc2ElayVFZN1A==";
+        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.127.0.tgz";
+        sha512 = "T4T92hVeVtrkYYvU01L2KFANsA0TJQrgy46efIU/JBxDhVjxIdS7KzaBEsPJu7RPOM44FCR7wcFQg6rWtGGrLQ==";
       };
     };
     "fluent-ffmpeg-2.1.2" = {
@@ -18132,6 +18033,15 @@ let
         sha1 = "ae049a714386bb83e342657a82924b70364a90d6";
       };
     };
+    "flumedb-2.1.4" = {
+      name = "flumedb";
+      packageName = "flumedb";
+      version = "2.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/flumedb/-/flumedb-2.1.4.tgz";
+        sha512 = "jqbUXWsIPxHFmDOTN5/I5khgHzGtEl8cSL3kC13CC/FudT57tfzg+jvCWeXtSty15X1w6QD86lw8RW7cERuqsg==";
+      };
+    };
     "flumelog-offset-3.4.4" = {
       name = "flumelog-offset";
       packageName = "flumelog-offset";
@@ -18159,6 +18069,15 @@ let
         sha512 = "Nl0gJOgrDGpJGZDkP6gvo6s1Q9WmRynbHUvI/JY3eQ81YgzUUa2FKLlfu6OHV5ho5NeXP+00F+0K1yBVaEgJOQ==";
       };
     };
+    "flumeview-level-4.0.3" = {
+      name = "flumeview-level";
+      packageName = "flumeview-level";
+      version = "4.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/flumeview-level/-/flumeview-level-4.0.3.tgz";
+        sha512 = "lmSiImD7vNJ9pC9hB2j9hgx5WhleUZM5n69e2qUTGU4LCyvCbVuzn85pKfqdrKEAMuVjbb+jEPEErPJFNRj0SQ==";
+      };
+    };
     "flumeview-links-1.0.1" = {
       name = "flumeview-links";
       packageName = "flumeview-links";
@@ -18177,13 +18096,13 @@ let
         sha512 = "zDwy3WIbF5pKhwyK0wVtGdedU+1Xh2Dnrg06fJ0dIkAcQs8+u+CaoSBcnyp80i6XmzfzGCRkN0Fdve2b6f5XAA==";
       };
     };
-    "flumeview-reduce-1.3.16" = {
+    "flumeview-reduce-1.3.17" = {
       name = "flumeview-reduce";
       packageName = "flumeview-reduce";
-      version = "1.3.16";
+      version = "1.3.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.16.tgz";
-        sha512 = "4ATidV3QARML74eNdi+HPzGa4JtSZfnQpW6QQArlKZ6NRkjax3EFLt42hK2VJyADxnVnsVInt/ItqJL/4G1/5g==";
+        url = "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.17.tgz";
+        sha512 = "Li09TntlRpN51GtFKllIh5nDdBcyDazvi5a/yvbdUCS9xAFb8OA6H6uu32W9gG+4GyvfUi9AsOyN8RQ8OcREQA==";
       };
     };
     "flush-write-stream-1.1.1" = {
@@ -18321,15 +18240,6 @@ let
         sha512 = "F3E8C9CTPK+uRGdVTMBHGo7mHX+KRtClLzkegR6ux1yy+ByxOziumpTzxajzfhICHfYdnGWY4Bokl8dirYsDeA==";
       };
     };
-    "form-data-0.1.3" = {
-      name = "form-data";
-      packageName = "form-data";
-      version = "0.1.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz";
-        sha1 = "4ee4346e6eb5362e8344a02075bd8dbd8c7373ea";
-      };
-    };
     "form-data-1.0.0-rc3" = {
       name = "form-data";
       packageName = "form-data";
@@ -18411,15 +18321,6 @@ let
         sha1 = "68f63325a035e644b6f7bb3d11243b9761de1b30";
       };
     };
-    "formidable-1.0.14" = {
-      name = "formidable";
-      packageName = "formidable";
-      version = "1.0.14";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz";
-        sha1 = "2b3f4c411cbb5fdd695c44843e2a23514a43231a";
-      };
-    };
     "formidable-1.0.17" = {
       name = "formidable";
       packageName = "formidable";
@@ -18499,15 +18400,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz";
         sha1 = "bfd9402cf3df12c4a4c310c79f99a3dde13d34a7";
-      };
-    };
-    "fresh-0.2.4" = {
-      name = "fresh";
-      packageName = "fresh";
-      version = "0.2.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz";
-        sha1 = "3582499206c9723714190edd74b4604feb4a614c";
       };
     };
     "fresh-0.5.2" = {
@@ -20113,13 +20005,13 @@ let
         sha512 = "efoimZ4F2wF2OwZJzPq2KdPjQs1K+UgJSfsHoHBBA0TwveGyQ/0kS3lUphhJg/JXIrZociuRkfjrk8JC4iPPJQ==";
       };
     };
-    "graphql-extensions-0.12.2" = {
+    "graphql-extensions-0.12.3" = {
       name = "graphql-extensions";
       packageName = "graphql-extensions";
-      version = "0.12.2";
+      version = "0.12.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.2.tgz";
-        sha512 = "vFaZua5aLiCOOzxfY5qzHZ6S52BCqW7VVOwzvV52Wb5edRm3dn6u+1MR9yYyEqUHSf8LvdhEojYlOkKiaQ4ghA==";
+        url = "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.3.tgz";
+        sha512 = "W7iT0kzlwTiZU7fXfw9IgWnsqVj7EFLd0/wVcZZRAbR8L3f4+YsGls0oxKdsrvYBnbG347BXKQmIyo6GTEk4XA==";
       };
     };
     "graphql-subscriptions-1.1.0" = {
@@ -20878,6 +20770,15 @@ let
         sha1 = "b86ce808598e8a9d1892c571f3cedd86fc9f0653";
       };
     };
+    "highlight.js-10.1.0" = {
+      name = "highlight.js";
+      packageName = "highlight.js";
+      version = "10.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.0.tgz";
+        sha512 = "e8aO/LUHDoxW4ntyKQf0/T3OtIZPhsfTr8XRuOq+FW5VdWEg/UDAeArzKF/22BaNZp6hPi/Zu/XQlTLOGLix3Q==";
+      };
+    };
     "highlight.js-8.2.0" = {
       name = "highlight.js";
       packageName = "highlight.js";
@@ -20912,15 +20813,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/hipchatter/-/hipchatter-0.3.2.tgz";
         sha1 = "7f529cb676884032b0756750556ce77123bec406";
-      };
-    };
-    "hiredis-0.4.1" = {
-      name = "hiredis";
-      packageName = "hiredis";
-      version = "0.4.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/hiredis/-/hiredis-0.4.1.tgz";
-        sha1 = "aab4dcfd0fc4cbdb219d268005f2335a3c639e8f";
       };
     };
     "historic-readline-1.0.8" = {
@@ -21365,6 +21257,15 @@ let
         sha512 = "CbG3io8gUSIxNNSgq+XMjgpTMzAeVRipxVXjuGrDhH5M1a2kZ03w20s8FCLR1NjnnJj10KbvabvckmtQcYNb9g==";
       };
     };
+    "http-status-1.4.2" = {
+      name = "http-status";
+      packageName = "http-status";
+      version = "1.4.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/http-status/-/http-status-1.4.2.tgz";
+        sha512 = "mBnIohUwRw9NyXMEMMv8/GANnzEYUj0Y8d3uL01zDWFkxUjYyZ6rgCaAI2zZ1Wb34Oqtbx/nFZolPRDc8Xlm5A==";
+      };
+    };
     "http2-client-1.3.3" = {
       name = "http2-client";
       packageName = "http2-client";
@@ -21381,6 +21282,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/http_ece/-/http_ece-1.1.0.tgz";
         sha512 = "bptAfCDdPJxOs5zYSe7Y3lpr772s1G346R4Td5LgRUeCwIGpCGDUTJxRrhTNcAXbx37spge0kWEIH7QAYWNTlA==";
+      };
+    };
+    "https-1.0.0" = {
+      name = "https";
+      packageName = "https";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/https/-/https-1.0.0.tgz";
+        sha1 = "3c37c7ae1a8eeb966904a2ad1e975a194b7ed3a4";
       };
     };
     "https-browserify-1.0.0" = {
@@ -21696,6 +21606,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz";
         sha1 = "09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c";
+      };
+    };
+    "image-size-0.8.3" = {
+      name = "image-size";
+      packageName = "image-size";
+      version = "0.8.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/image-size/-/image-size-0.8.3.tgz";
+        sha512 = "SMtq1AJ+aqHB45c3FsB4ERK0UCiA2d3H1uq8s+8T0Pf8A3W4teyBQyaFaktH6xvZqh+npwlKU7i4fJo0r7TYTg==";
       };
     };
     "image-type-3.1.0" = {
@@ -22425,15 +22344,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.3.tgz";
         sha1 = "27a9ca37f148d2102b0ef191ccbf2c51a8f025c6";
-      };
-    };
-    "ipaddr.js-1.0.5" = {
-      name = "ipaddr.js";
-      packageName = "ipaddr.js";
-      version = "1.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz";
-        sha1 = "5fa78cf301b825c78abc3042d812723049ea23c7";
       };
     };
     "ipaddr.js-1.4.0" = {
@@ -23966,6 +23876,24 @@ let
         sha512 = "RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==";
       };
     };
+    "iterate-iterator-1.0.1" = {
+      name = "iterate-iterator";
+      packageName = "iterate-iterator";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz";
+        sha512 = "3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==";
+      };
+    };
+    "iterate-value-1.0.2" = {
+      name = "iterate-value";
+      packageName = "iterate-value";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz";
+        sha512 = "A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==";
+      };
+    };
     "iterators-0.1.0" = {
       name = "iterators";
       packageName = "iterators";
@@ -24173,13 +24101,13 @@ let
         sha1 = "bcb4045c8dd0539c134bc1488cdd3e768a7a9e51";
       };
     };
-    "jquery.terminal-2.17.1" = {
+    "jquery.terminal-2.17.2" = {
       name = "jquery.terminal";
       packageName = "jquery.terminal";
-      version = "2.17.1";
+      version = "2.17.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jquery.terminal/-/jquery.terminal-2.17.1.tgz";
-        sha512 = "f+fqKLf0y6ZEhOLGlGCjlDdALPcf0APPd7pDAtDdUZ12Y6fWh0st1Y7RnygJRHpYkEYC3mRC+oogA03XqMH7YQ==";
+        url = "https://registry.npmjs.org/jquery.terminal/-/jquery.terminal-2.17.2.tgz";
+        sha512 = "FHs9cS0phsXFXI1waqK/kY9TnyiWmQp65NFu/vMZky1Tef4zIYD3D5qZcBhBkXhAbIFA+fPfmMUUgGKBQWtKlQ==";
       };
     };
     "js-base64-2.5.2" = {
@@ -24479,15 +24407,6 @@ let
         sha512 = "0vOQd9eLNBL18EGl5yYaO44GhixmImes2wiYn9Z3sag3QnehWrYWlB9AFtMxCL2Bj3fyxgDYkxGFEU/chlYssw==";
       };
     };
-    "json-rpc2-0.8.1" = {
-      name = "json-rpc2";
-      packageName = "json-rpc2";
-      version = "0.8.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/json-rpc2/-/json-rpc2-0.8.1.tgz";
-        sha1 = "efe8c9834605b556c488d1ed7bcf24ee381eeeb2";
-      };
-    };
     "json-schema-0.2.2" = {
       name = "json-schema";
       packageName = "json-schema";
@@ -24695,6 +24614,15 @@ let
         sha1 = "8771aae0799b64076b76640fca058f9c10e33ecb";
       };
     };
+    "jsonfile-5.0.0" = {
+      name = "jsonfile";
+      packageName = "jsonfile";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz";
+        sha512 = "NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==";
+      };
+    };
     "jsonfile-6.0.1" = {
       name = "jsonfile";
       packageName = "jsonfile";
@@ -24729,15 +24657,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz";
         sha1 = "330542ad3f0a654665b778f3eb2d9a9fa507ac64";
-      };
-    };
-    "jsonparse-0.0.6" = {
-      name = "jsonparse";
-      packageName = "jsonparse";
-      version = "0.0.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.6.tgz";
-        sha1 = "ab599f19324d4ae178fa21a930192ab11ab61a4e";
       };
     };
     "jsonparse-1.3.1" = {
@@ -25506,6 +25425,15 @@ let
         sha512 = "wcak5OQeA4rURGacqS62R/xNHjCYnJSQDBOlm4KNUGJVE9bWv2B04TclqReYejN+oD65PzD4FsqeWoI5wNC5Lg==";
       };
     };
+    "level-6.0.1" = {
+      name = "level";
+      packageName = "level";
+      version = "6.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level/-/level-6.0.1.tgz";
+        sha512 = "psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==";
+      };
+    };
     "level-codec-6.2.0" = {
       name = "level-codec";
       packageName = "level-codec";
@@ -25558,6 +25486,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/level-js/-/level-js-4.0.2.tgz";
         sha512 = "PeGjZsyMG4O89KHiez1zoMJxStnkM+oBIqgACjoo5PJqFiSUUm3GNod/KcbqN5ktyZa8jkG7I1T0P2u6HN9lIg==";
+      };
+    };
+    "level-js-5.0.2" = {
+      name = "level-js";
+      packageName = "level-js";
+      version = "5.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-js/-/level-js-5.0.2.tgz";
+        sha512 = "SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==";
       };
     };
     "level-packager-5.1.1" = {
@@ -25830,6 +25767,15 @@ let
         sha512 = "GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==";
       };
     };
+    "linkify-it-3.0.2" = {
+      name = "linkify-it";
+      packageName = "linkify-it";
+      version = "3.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz";
+        sha512 = "gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==";
+      };
+    };
     "listr-0.14.3" = {
       name = "listr";
       packageName = "listr";
@@ -26026,15 +25972,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz";
         sha1 = "fadd834b9683073da179b3eae6d9c0d15053f73e";
-      };
-    };
-    "lodash-3.1.0" = {
-      name = "lodash";
-      packageName = "lodash";
-      version = "3.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash/-/lodash-3.1.0.tgz";
-        sha1 = "d41b8b33530cb3be088853208ad30092d2c27961";
       };
     };
     "lodash-3.10.1" = {
@@ -26737,6 +26674,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.iteratee/-/lodash.iteratee-4.7.0.tgz";
         sha1 = "be4177db289a8ccc3c0990f1db26b5b22fc1554c";
+      };
+    };
+    "lodash.kebabcase-4.1.1" = {
+      name = "lodash.kebabcase";
+      packageName = "lodash.kebabcase";
+      version = "4.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz";
+        sha1 = "8489b1cb0d29ff88195cceca448ff6d6cc295c36";
       };
     };
     "lodash.keys-2.4.1" = {
@@ -27801,6 +27747,15 @@ let
         sha512 = "YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==";
       };
     };
+    "markdown-it-11.0.0" = {
+      name = "markdown-it";
+      packageName = "markdown-it";
+      version = "11.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/markdown-it/-/markdown-it-11.0.0.tgz";
+        sha512 = "+CvOnmbSubmQFSA9dKz1BRiaSMV7rhexl3sngKqFyXSagoA3fBdJQ8oZWtRy2knXdpDXaBw44euz37DeJQ9asg==";
+      };
+    };
     "markdown-it-8.4.2" = {
       name = "markdown-it";
       packageName = "markdown-it";
@@ -27862,6 +27817,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.2.tgz";
         sha512 = "JVW6fCmZWjvMdDQSbOT3nnOQtd9iAXmw7hTSh26+v42BnvXeVyGMDBm5b/EZocMed2MbCAHiTX632vY0FyGB8A==";
+      };
+    };
+    "markdown-it-front-matter-0.2.1" = {
+      name = "markdown-it-front-matter";
+      packageName = "markdown-it-front-matter";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/markdown-it-front-matter/-/markdown-it-front-matter-0.2.1.tgz";
+        sha512 = "ydUIqlKfDscRpRUTRcA3maeeUKn3Cl5EaKZSA+I/f0KOGCBurW7e+bbz59sxqkC3FA9Q2S2+t4mpkH9T0BCM6A==";
       };
     };
     "markdown-it-github-headings-1.1.2" = {
@@ -28078,6 +28042,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz";
         sha512 = "rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==";
+      };
+    };
+    "mathjax-full-3.0.5" = {
+      name = "mathjax-full";
+      packageName = "mathjax-full";
+      version = "3.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.0.5.tgz";
+        sha512 = "RzZ03DDMOgqeHPl3dkqDVS3bmXU+lfZZimj7+k3VA+s93LbZcOAKa2hlILF3rgBXgzGLR3YOR8Z8R/B3uAeAeA==";
       };
     };
     "mathjs-5.10.3" = {
@@ -28485,15 +28458,6 @@ let
         sha512 = "VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==";
       };
     };
-    "merge-descriptors-0.0.2" = {
-      name = "merge-descriptors";
-      packageName = "merge-descriptors";
-      version = "0.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz";
-        sha1 = "c36a52a781437513c57275f39dd9d317514ac8c7";
-      };
-    };
     "merge-descriptors-1.0.1" = {
       name = "merge-descriptors";
       packageName = "merge-descriptors";
@@ -28591,15 +28555,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz";
         sha1 = "335d429eefd21b7bacf2e9c922a8d2bd14a30e4f";
-      };
-    };
-    "methods-1.0.1" = {
-      name = "methods";
-      packageName = "methods";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz";
-        sha1 = "75bc91943dffd7da037cf3eeb0ed73a0037cd14b";
       };
     };
     "methods-1.1.2" = {
@@ -28737,15 +28692,6 @@ let
         sha512 = "RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==";
       };
     };
-    "mime-db-1.12.0" = {
-      name = "mime-db";
-      packageName = "mime-db";
-      version = "1.12.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz";
-        sha1 = "3d0c63180f458eb10d325aaa37d7c58ae312e9d7";
-      };
-    };
     "mime-db-1.33.0" = {
       name = "mime-db";
       packageName = "mime-db";
@@ -28771,15 +28717,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz";
         sha512 = "/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==";
-      };
-    };
-    "mime-types-2.0.14" = {
-      name = "mime-types";
-      packageName = "mime-types";
-      version = "2.0.14";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz";
-        sha1 = "310e159db23e077f8bb22b748dabfa4957140aa6";
       };
     };
     "mime-types-2.1.18" = {
@@ -29160,6 +29097,15 @@ let
         sha512 = "WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==";
       };
     };
+    "mj-context-menu-0.2.2" = {
+      name = "mj-context-menu";
+      packageName = "mj-context-menu";
+      version = "0.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.2.2.tgz";
+        sha512 = "OHlnKQqfFPEYZGdz2JWL0obrr82vVilha0WCUZslYfN+v+oz4VpmERnoHdTUWvOUVHNYjFkpOYnLEeHnt1BdsQ==";
+      };
+    };
     "mkdirp-0.3.0" = {
       name = "mkdirp";
       packageName = "mkdirp";
@@ -29367,6 +29313,15 @@ let
         sha512 = "+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==";
       };
     };
+    "monotonic-timestamp-0.0.9" = {
+      name = "monotonic-timestamp";
+      packageName = "monotonic-timestamp";
+      version = "0.0.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.9.tgz";
+        sha1 = "5ba5adc7aac85e1d7ce77be847161ed246b39603";
+      };
+    };
     "moo-0.5.1" = {
       name = "moo";
       packageName = "moo";
@@ -29455,15 +29410,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-5.6.1.tgz";
         sha512 = "eaF9rO2uFrIYEHomJxziuKTDkbWW5psLBaIGCazQSKqYsTaB3n4SpvJ1PexKaDBiPnMLPIFWBIiTYT3IfEJfww==";
-      };
-    };
-    "ms-0.7.0" = {
-      name = "ms";
-      packageName = "ms";
-      version = "0.7.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz";
-        sha1 = "865be94c2e7397ad8a57da6a633a6e2f30798b83";
       };
     };
     "ms-0.7.1" = {
@@ -30015,55 +29961,6 @@ let
         sha512 = "A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==";
       };
     };
-    "native-dns-cache-git+https://github.com/okTurtles/native-dns-cache.git#8714196bb9223cc9a4064a4fddf9e82ec50b7d4d" = {
-      name = "native-dns-cache";
-      packageName = "native-dns-cache";
-      version = "0.0.2";
-      src = fetchgit {
-        url = "https://github.com/okTurtles/native-dns-cache.git";
-        rev = "8714196bb9223cc9a4064a4fddf9e82ec50b7d4d";
-        sha256 = "3f06b2577afc3c1e428533baae3c51bad44a2e1e02fca147a1303943c214f841";
-      };
-    };
-    "native-dns-git+https://github.com/okTurtles/node-dns.git#08433ec98f517eed3c6d5e47bdf62603539cd402" = {
-      name = "native-dns";
-      packageName = "native-dns";
-      version = "0.6.1";
-      src = fetchgit {
-        url = "https://github.com/okTurtles/node-dns.git";
-        rev = "08433ec98f517eed3c6d5e47bdf62603539cd402";
-        sha256 = "a7342bfd4e952490a8a25a68efcb1d16ecc2391f1044109ebeace89ad284f7a2";
-      };
-    };
-    "native-dns-packet-0.1.1" = {
-      name = "native-dns-packet";
-      packageName = "native-dns-packet";
-      version = "0.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/native-dns-packet/-/native-dns-packet-0.1.1.tgz";
-        sha1 = "97da90570b8438a00194701ce24d011fd3cc109a";
-      };
-    };
-    "native-dns-packet-git+https://github.com/okTurtles/native-dns-packet.git#307e77a47ebba57a5ae9118a284e916e5ebb305a" = {
-      name = "native-dns-packet";
-      packageName = "native-dns-packet";
-      version = "0.0.3";
-      src = fetchgit {
-        url = "https://github.com/okTurtles/native-dns-packet.git";
-        rev = "307e77a47ebba57a5ae9118a284e916e5ebb305a";
-        sha256 = "f8aaa7bb3b2a652e52bfe5c13a6531c71d690f621ef4d86d0787838708a50358";
-      };
-    };
-    "native-dns-packet-git+https://github.com/okTurtles/native-dns-packet.git#8bf2714c318cfe7d31bca2006385882ccbf503e4" = {
-      name = "native-dns-packet";
-      packageName = "native-dns-packet";
-      version = "0.0.4";
-      src = fetchgit {
-        url = "https://github.com/okTurtles/native-dns-packet.git";
-        rev = "8bf2714c318cfe7d31bca2006385882ccbf503e4";
-        sha256 = "1f39a4bd88978a0b51d45c32c777fb7f75b12e220cf7d206aa5a12d1e4e80f9d";
-      };
-    };
     "native-promise-only-0.8.1" = {
       name = "native-promise-only";
       packageName = "native-promise-only";
@@ -30134,15 +30031,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/nconf/-/nconf-0.6.9.tgz";
         sha1 = "9570ef15ed6f9ae6b2b3c8d5e71b66d3193cd661";
-      };
-    };
-    "nconf-0.7.1" = {
-      name = "nconf";
-      packageName = "nconf";
-      version = "0.7.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/nconf/-/nconf-0.7.1.tgz";
-        sha1 = "ee4b561dd979a3c58db122e38f196d49d61aeb5b";
       };
     };
     "ncp-0.4.2" = {
@@ -33586,15 +33474,6 @@ let
         sha1 = "473e6a3a292a9d13fbae3edccee72d3baba8c619";
       };
     };
-    "path-to-regexp-0.1.3" = {
-      name = "path-to-regexp";
-      packageName = "path-to-regexp";
-      version = "0.1.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz";
-        sha1 = "21b9ab82274279de25b156ea08fd12ca51b8aecb";
-      };
-    };
     "path-to-regexp-0.1.7" = {
       name = "path-to-regexp";
       packageName = "path-to-regexp";
@@ -34784,6 +34663,15 @@ let
         sha512 = "MbIXTWwAfJ9qET6Zl29UNwJcDJEEz9Zkr5oDhiujitJa7YBJwEpbkX2cmuklCDxubTMoRWpid3q8DrSyGnUUzQ==";
       };
     };
+    "pptxgenjs-3.2.1" = {
+      name = "pptxgenjs";
+      packageName = "pptxgenjs";
+      version = "3.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pptxgenjs/-/pptxgenjs-3.2.1.tgz";
+        sha512 = "dWbDho64IKmfeB/pNYJf/8CLFtQZ/Sq7nHMrWsUR1E5HSV8yEgwgES72fNvT1oOiPPXTTVPdXm2iMRD13q7/Lw==";
+      };
+    };
     "prebuild-install-5.3.4" = {
       name = "prebuild-install";
       packageName = "prebuild-install";
@@ -35225,6 +35113,15 @@ let
         sha1 = "6739e968e3051da20ce6497fb2b50f6911df3d6d";
       };
     };
+    "promise.allsettled-1.0.2" = {
+      name = "promise.allsettled";
+      packageName = "promise.allsettled";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz";
+        sha512 = "UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==";
+      };
+    };
     "promised-temp-0.1.0" = {
       name = "promised-temp";
       packageName = "promised-temp";
@@ -35306,15 +35203,6 @@ let
         sha1 = "159fb06193d32003f4b3691dd2ec1a634aa80d1d";
       };
     };
-    "properties-1.2.1" = {
-      name = "properties";
-      packageName = "properties";
-      version = "1.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/properties/-/properties-1.2.1.tgz";
-        sha1 = "0ee97a7fc020b1a2a55b8659eda4aa8d869094bd";
-      };
-    };
     "property-information-5.5.0" = {
       name = "property-information";
       packageName = "property-information";
@@ -35376,15 +35264,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz";
         sha512 = "WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==";
-      };
-    };
-    "proxy-addr-1.0.10" = {
-      name = "proxy-addr";
-      packageName = "proxy-addr";
-      version = "1.0.10";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz";
-        sha1 = "0d40a82f801fc355567d2ecb65efe3f077f121c5";
       };
     };
     "proxy-addr-1.1.5" = {
@@ -36215,6 +36094,15 @@ let
         sha512 = "hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==";
       };
     };
+    "puppeteer-core-3.3.0" = {
+      name = "puppeteer-core";
+      packageName = "puppeteer-core";
+      version = "3.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.3.0.tgz";
+        sha512 = "hynQ3r0J/lkGrKeBCqu160jrj0WhthYLIzDQPkBxLzxPokjw4elk1sn6mXAian/kfD2NRzpdh9FSykxZyL56uA==";
+      };
+    };
     "purgecss-1.4.2" = {
       name = "purgecss";
       packageName = "purgecss";
@@ -36303,15 +36191,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz";
         sha1 = "294b268e4b0d4250f6dde19b3b8b34935dff14ef";
-      };
-    };
-    "qs-1.2.0" = {
-      name = "qs";
-      packageName = "qs";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz";
-        sha1 = "ed079be28682147e6fd9a34cc2b0c1e0ec6453ee";
       };
     };
     "qs-2.3.3" = {
@@ -36456,6 +36335,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz";
         sha512 = "AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==";
+      };
+    };
+    "queue-6.0.1" = {
+      name = "queue";
+      packageName = "queue";
+      version = "6.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/queue/-/queue-6.0.1.tgz";
+        sha512 = "AJBQabRCCNr9ANq8v77RJEv73DPbn55cdTb+Giq4X0AVnNVZvMHlYp7XlQiN+1npCZj1DuSmaA2hYVUUDgxFDg==";
       };
     };
     "queue-microtask-1.1.3" = {
@@ -36654,15 +36542,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz";
         sha1 = "c0427ffef51c10acba0782a46c9602e744ff620b";
-      };
-    };
-    "range-parser-1.0.3" = {
-      name = "range-parser";
-      packageName = "range-parser";
-      version = "1.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz";
-        sha1 = "6872823535c692e2c2a0103826afd82c2e0ff175";
       };
     };
     "range-parser-1.2.0" = {
@@ -37088,6 +36967,15 @@ let
         sha512 = "crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==";
       };
     };
+    "readdirp-3.3.0" = {
+      name = "readdirp";
+      packageName = "readdirp";
+      version = "3.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz";
+        sha512 = "zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==";
+      };
+    };
     "readdirp-3.4.0" = {
       name = "readdirp";
       packageName = "readdirp";
@@ -37221,15 +37109,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz";
         sha1 = "8984b5815d99cb220469c99eeeffe38913e6cc0b";
-      };
-    };
-    "redis-0.12.1" = {
-      name = "redis";
-      packageName = "redis";
-      version = "0.12.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/redis/-/redis-0.12.1.tgz";
-        sha1 = "64df76ad0fc8acebaebd2a0645e8a48fac49185e";
       };
     };
     "reduce-component-1.0.1" = {
@@ -38438,13 +38317,13 @@ let
         sha512 = "/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==";
       };
     };
-    "rollup-2.15.0" = {
+    "rollup-2.16.0" = {
       name = "rollup";
       packageName = "rollup";
-      version = "2.15.0";
+      version = "2.16.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/rollup/-/rollup-2.15.0.tgz";
-        sha512 = "HAk4kyXiV5sdNDnbKWk5zBPnkX/DAgx09Kbp8rRIRDVsTUVN3vnSowR7ZHkV6/lAiE6c2TQ8HtYb72aCPGW4Jw==";
+        url = "https://registry.npmjs.org/rollup/-/rollup-2.16.0.tgz";
+        sha512 = "95NglykUQAhl+mTFZqVvGUWDoGHV4/XanOZBbR7LOwTKODde5yFNHfVDZEnERBMuQViDuYaxOlFW87i1GQMihA==";
       };
     };
     "rollup-plugin-babel-4.4.0" = {
@@ -39293,15 +39172,6 @@ let
         sha1 = "be70d8d1be01de61821af13780b50345a4f71abd";
       };
     };
-    "send-0.11.1" = {
-      name = "send";
-      packageName = "send";
-      version = "0.11.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/send/-/send-0.11.1.tgz";
-        sha1 = "1beabfd42f9e2709f99028af3078ac12b47092d5";
-      };
-    };
     "send-0.17.1" = {
       name = "send";
       packageName = "send";
@@ -39365,6 +39235,15 @@ let
         sha512 = "8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==";
       };
     };
+    "serialize-javascript-3.0.0" = {
+      name = "serialize-javascript";
+      packageName = "serialize-javascript";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.0.0.tgz";
+        sha512 = "skZcHYw2vEX4bw90nAr2iTTsz6x2SrHEnfxgKYmZlvJYBEZrvbKtobJWlQ20zczKb3bsHHXXTYt48zBA7ni9cw==";
+      };
+    };
     "serialize-javascript-3.1.0" = {
       name = "serialize-javascript";
       packageName = "serialize-javascript";
@@ -39417,15 +39296,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz";
         sha512 = "JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==";
-      };
-    };
-    "serve-static-1.8.1" = {
-      name = "serve-static";
-      packageName = "serve-static";
-      version = "1.8.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/serve-static/-/serve-static-1.8.1.tgz";
-        sha1 = "08fabd39999f050fc311443f46d5888a77ecfc7c";
       };
     };
     "server-destroy-1.0.1" = {
@@ -40229,13 +40099,13 @@ let
         sha512 = "3UlyogA67/9WOssJ7s4d7gqWQRWyO/LbgdBBNMhhmFDKa7eTUSW+A782CVHgyDSJZ2kNANcMWwMiOL+h3p6zQg==";
       };
     };
-    "snyk-docker-plugin-3.10.0" = {
+    "snyk-docker-plugin-3.12.0" = {
       name = "snyk-docker-plugin";
       packageName = "snyk-docker-plugin";
-      version = "3.10.0";
+      version = "3.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-3.10.0.tgz";
-        sha512 = "0OIIqBOq76wBZ/09oB+L+5CdyNXEeDAgLH92TRydEj5iuJwjddAfzWtoqeCIeh3d09DidsHBRP8mMhXKAht7Sg==";
+        url = "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-3.12.0.tgz";
+        sha512 = "Nv8ez1bykJFtM1OEkNPh6dRg11xHQg4ybTW8A6OC9IaLrWxkH/wrUfmRqhDnrJyzcDhF10CnyQX7KdUnsA7PwA==";
       };
     };
     "snyk-go-parser-1.4.1" = {
@@ -40985,6 +40855,15 @@ let
         sha512 = "1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==";
       };
     };
+    "speech-rule-engine-3.0.1" = {
+      name = "speech-rule-engine";
+      packageName = "speech-rule-engine";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-3.0.1.tgz";
+        sha512 = "07B/V6eKZQfoKHdw8QaRu3ENKwbE8XcgCFNJAGeKnz751TixF6xUmxqLnsAN4zIj0qUCUKxCy4/LHybBMBmNfQ==";
+      };
+    };
     "speedometer-0.1.4" = {
       name = "speedometer";
       packageName = "speedometer";
@@ -41237,6 +41116,15 @@ let
         sha512 = "J3fsWb5nS6PqObZLW2tclEz/bkRQ5pcF9goXanYGVsoH71F6W4f5sOnck9szeubI8srNaiL9pa0kPRv/lojHiw==";
       };
     };
+    "ssb-db-20.1.0" = {
+      name = "ssb-db";
+      packageName = "ssb-db";
+      version = "20.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-db/-/ssb-db-20.1.0.tgz";
+        sha512 = "oN5bBdnuOv6ZA6DRBeB5iH08VvGEHq5yfHNdtvaOv3IDj6RYSJMd0Z6qOwR9qlNgxtaD/fDo21nxaNcs5Hn/WQ==";
+      };
+    };
     "ssb-ebt-5.6.7" = {
       name = "ssb-ebt";
       packageName = "ssb-ebt";
@@ -41408,13 +41296,13 @@ let
         sha512 = "iRXjeI0sbRbgMwaKg+poqhHSH7GvUVgJ+8ysi8q7Hjj4wHkczLGAOyVjnyhjF+ErPDFn9kXN+46joneKqSgEDg==";
       };
     };
-    "ssb-ooo-1.3.2" = {
+    "ssb-ooo-1.3.3" = {
       name = "ssb-ooo";
       packageName = "ssb-ooo";
-      version = "1.3.2";
+      version = "1.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-ooo/-/ssb-ooo-1.3.2.tgz";
-        sha512 = "JBH0cDaqQ/WRZMfoyn/fNLDrbrs5w2xnSno/VUDWGhc+SX+3/h6zFK7VvCjdzEATlZ/D7VRkXMYrOedSIVIKwA==";
+        url = "https://registry.npmjs.org/ssb-ooo/-/ssb-ooo-1.3.3.tgz";
+        sha512 = "6yI5XBpBHkwFdAELpKwlf1C1V32Z0/AKEJYsoU7lk+Eh88blv8LKydo4a1DnjMiPy4ywn4lRU5oayQaPE5MRtQ==";
       };
     };
     "ssb-plugins-1.0.4" = {
@@ -41444,13 +41332,13 @@ let
         sha1 = "dfd30cd50eecd8546bd4aa7f06e7c8f501c08118";
       };
     };
-    "ssb-query-2.4.3" = {
+    "ssb-query-2.4.4" = {
       name = "ssb-query";
       packageName = "ssb-query";
-      version = "2.4.3";
+      version = "2.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-query/-/ssb-query-2.4.3.tgz";
-        sha512 = "Ktuk6Bl3s70gueDH7FBXzI8KHsf+h+n82J6Id33NTwP80u5iSDV5vXK2f7/He/cmP3uUVUI5ogJda7ShmrDIug==";
+        url = "https://registry.npmjs.org/ssb-query/-/ssb-query-2.4.4.tgz";
+        sha512 = "t81fskbvFzeXausdJ/TDGjqh8iyClhJy8B9JLgOAmt6D67IFDlkUPgVYF2ITqP4NIkqsLAj/jgX1KV32ntxaNg==";
       };
     };
     "ssb-ref-2.13.9" = {
@@ -41478,6 +41366,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ssb-unix-socket/-/ssb-unix-socket-1.0.0.tgz";
         sha512 = "Z4jBj917W+dKAiDglwxCpWm8vINOMtkpHQIgk50NQTb5jHqHI5Rcyiy7EO0uRcWwRWqXi1ZwOTEFVyLyyuittA==";
+      };
+    };
+    "ssb-validate-4.1.0" = {
+      name = "ssb-validate";
+      packageName = "ssb-validate";
+      version = "4.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-validate/-/ssb-validate-4.1.0.tgz";
+        sha512 = "GszJGLXZdnWSAP5f1evXwRct7qY0T/LFXR41eHIh/N63Z7kKBfBcIMd6mbQ5DgpU+sVHwdhXXloYXoMPZHiJDA==";
       };
     };
     "ssb-ws-6.2.3" = {
@@ -42047,15 +41944,6 @@ let
         sha1 = "eabe0956da7a8291c6de7486f7b35e58d031cd55";
       };
     };
-    "string-2.0.1" = {
-      name = "string";
-      packageName = "string";
-      version = "2.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/string/-/string-2.0.1.tgz";
-        sha1 = "ef1473b3e11cb8158671856556959b9aff5fd759";
-      };
-    };
     "string-3.3.3" = {
       name = "string";
       packageName = "string";
@@ -42596,13 +42484,13 @@ let
         sha1 = "0fdedc68e91addcfcb2e6be9c262581a6e8c28aa";
       };
     };
-    "strtok3-6.0.2" = {
+    "strtok3-6.0.3" = {
       name = "strtok3";
       packageName = "strtok3";
-      version = "6.0.2";
+      version = "6.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/strtok3/-/strtok3-6.0.2.tgz";
-        sha512 = "8/LNTW+SFsfUXbo0P/zNz5FqMVaKCZSZ3/aycaPw7l9RiNutj0XSLI9AcyJcLR+iIL/2FrpUHZxHfAzN7xisAA==";
+        url = "https://registry.npmjs.org/strtok3/-/strtok3-6.0.3.tgz";
+        sha512 = "/3RaYN9rW5WEYNHSvn081CgL4HziT027hfi5tsksbPfeWxi3BSLb8tolZDzpYU3I78/0ZqRiFpMDAqN2t4YShA==";
       };
     };
     "structured-source-3.0.2" = {
@@ -42783,15 +42671,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz";
         sha512 = "WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==";
-      };
-    };
-    "superagent-0.21.0" = {
-      name = "superagent";
-      packageName = "superagent";
-      version = "0.21.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/superagent/-/superagent-0.21.0.tgz";
-        sha1 = "fb15027984751ee7152200e6cd21cd6e19a5de87";
       };
     };
     "superagent-1.8.5" = {
@@ -44892,6 +44771,24 @@ let
         sha1 = "b75bc2df15649bb84e8b9aa3c0669c6c4bce0d25";
       };
     };
+    "twemoji-13.0.0" = {
+      name = "twemoji";
+      packageName = "twemoji";
+      version = "13.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/twemoji/-/twemoji-13.0.0.tgz";
+        sha512 = "JIkoLy0lL7ZlsiUKAOdXTp0o8C15O3CzDzAmnWdeDHpjeifmKDDKX4CyViUj+9g33pIqMr8Uhcy1WLwETr8oNg==";
+      };
+    };
+    "twemoji-parser-13.0.0" = {
+      name = "twemoji-parser";
+      packageName = "twemoji-parser";
+      version = "13.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-13.0.0.tgz";
+        sha512 = "zMaGdskpH8yKjT2RSE/HwE340R4Fm+fbie4AaqjDa4H/l07YUmAvxkSfNl6awVWNRRQ0zdzLQ8SAJZuY5MgstQ==";
+      };
+    };
     "twig-1.15.1" = {
       name = "twig";
       packageName = "twig";
@@ -45007,15 +44904,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz";
         sha512 = "4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==";
-      };
-    };
-    "type-is-1.5.7" = {
-      name = "type-is";
-      packageName = "type-is";
-      version = "1.5.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz";
-        sha1 = "b9368a593cc6ef7d0645e78b2f4c64cbecd05e90";
       };
     };
     "type-is-1.6.18" = {
@@ -46449,15 +46337,6 @@ let
         sha1 = "1352c340eb820e4d8ddba039a4fbfaa32ed4ef3a";
       };
     };
-    "utils-merge-1.0.0" = {
-      name = "utils-merge";
-      packageName = "utils-merge";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz";
-        sha1 = "0294fb922bb9375153541c4f7096231f287c8af8";
-      };
-    };
     "utils-merge-1.0.1" = {
       name = "utils-merge";
       packageName = "utils-merge";
@@ -46726,15 +46605,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz";
         sha1 = "d826b89f7490732fabc0c0ed693ed475dcb29ebf";
-      };
-    };
-    "vary-1.0.1" = {
-      name = "vary";
-      packageName = "vary";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz";
-        sha1 = "99e4981566a286118dfb2b817357df7993376d10";
       };
     };
     "vary-1.1.2" = {
@@ -48006,6 +47876,15 @@ let
         sha512 = "KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==";
       };
     };
+    "wicked-good-xpath-1.3.0" = {
+      name = "wicked-good-xpath";
+      packageName = "wicked-good-xpath";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz";
+        sha1 = "81b0e95e8650e49c94b22298fff8686b5553cf6c";
+      };
+    };
     "wide-align-1.1.3" = {
       name = "wide-align";
       packageName = "wide-align";
@@ -48274,6 +48153,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz";
         sha512 = "rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==";
+      };
+    };
+    "workerpool-6.0.0" = {
+      name = "workerpool";
+      packageName = "workerpool";
+      version = "6.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workerpool/-/workerpool-6.0.0.tgz";
+        sha512 = "fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==";
       };
     };
     "wrap-ansi-2.1.0" = {
@@ -48771,6 +48659,15 @@ let
         sha512 = "yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==";
       };
     };
+    "xmldom-sre-0.1.31" = {
+      name = "xmldom-sre";
+      packageName = "xmldom-sre";
+      version = "0.1.31";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz";
+        sha512 = "f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==";
+      };
+    };
     "xmlhttprequest-1.8.0" = {
       name = "xmlhttprequest";
       packageName = "xmlhttprequest";
@@ -48860,6 +48757,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/xspfr/-/xspfr-0.3.1.tgz";
         sha1 = "f164263325ae671f53836fb210c7ddbcfda46598";
+      };
+    };
+    "xss-1.0.7" = {
+      name = "xss";
+      packageName = "xss";
+      version = "1.0.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xss/-/xss-1.0.7.tgz";
+        sha512 = "A9v7tblGvxu8TWXQC9rlpW96a+LN1lyw6wyhpTmmGW+FwRMactchBR3ROKSi33UPCUcUHSu8s9YP6F+K3Mw//w==";
       };
     };
     "xstream-11.12.0" = {
@@ -49462,17 +49368,17 @@ in
   "@angular/cli" = nodeEnv.buildNodePackage {
     name = "_at_angular_slash_cli";
     packageName = "@angular/cli";
-    version = "9.1.7";
+    version = "9.1.8";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@angular/cli/-/cli-9.1.7.tgz";
-      sha512 = "NhsIa725S/U/n7nDxp6ForusdYHEXF4aSIvsFRdoK6vbQ889c5e1Rdj+T5EWXLmpQZxeprSKhLI2alNX0nVhhQ==";
+      url = "https://registry.npmjs.org/@angular/cli/-/cli-9.1.8.tgz";
+      sha512 = "yfF7glPo3Xm7fTJVln1bFZVXqHu8wkIGZRZGb6lsJa+QH4ePxHgn+dNYXho0MYpGUnhY7xOBW4MJzjS7E+1y5Q==";
     };
     dependencies = [
-      sources."@angular-devkit/architect-0.901.7"
-      sources."@angular-devkit/core-9.1.7"
-      sources."@angular-devkit/schematics-9.1.7"
-      sources."@schematics/angular-9.1.7"
-      sources."@schematics/update-0.901.7"
+      sources."@angular-devkit/architect-0.901.8"
+      sources."@angular-devkit/core-9.1.8"
+      sources."@angular-devkit/schematics-9.1.8"
+      sources."@schematics/angular-9.1.8"
+      sources."@schematics/update-0.901.8"
       sources."@types/color-name-1.1.1"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."JSONStream-1.3.5"
@@ -50311,13 +50217,347 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
+  "@marp-team/marp-cli" = nodeEnv.buildNodePackage {
+    name = "_at_marp-team_slash_marp-cli";
+    packageName = "@marp-team/marp-cli";
+    version = "0.18.1";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-0.18.1.tgz";
+      sha512 = "q3htajlomw4p/Yw45XhWBl4pj7QClr3l2LDX6X4FrHWf3oKpRpo3fJLlXS7k4hKZqufNamD4yQQAJQx7a/l7OA==";
+    };
+    dependencies = [
+      sources."@babel/code-frame-7.10.1"
+      sources."@babel/helper-validator-identifier-7.10.1"
+      sources."@babel/highlight-7.10.1"
+      sources."@marp-team/marp-core-1.2.0"
+      sources."@marp-team/marpit-1.6.2"
+      sources."@marp-team/marpit-svg-polyfill-1.3.0"
+      sources."@nodelib/fs.scandir-2.1.3"
+      sources."@nodelib/fs.stat-2.0.3"
+      sources."@nodelib/fs.walk-1.2.4"
+      sources."@types/color-name-1.1.1"
+      sources."@types/node-14.0.13"
+      sources."@types/parse-json-4.0.0"
+      sources."@types/yauzl-2.9.1"
+      sources."accepts-1.3.7"
+      sources."agent-base-5.1.1"
+      sources."alphanum-sort-1.0.2"
+      sources."ansi-regex-5.0.0"
+      sources."ansi-styles-3.2.1"
+      sources."anymatch-3.1.1"
+      sources."argparse-1.0.10"
+      sources."array-flatten-1.1.1"
+      sources."array-union-2.1.0"
+      sources."balanced-match-1.0.0"
+      sources."base64-js-1.3.1"
+      sources."batch-0.6.1"
+      sources."binary-extensions-2.0.0"
+      (sources."bl-4.0.2" // {
+        dependencies = [
+          sources."readable-stream-3.6.0"
+        ];
+      })
+      sources."body-parser-1.19.0"
+      sources."brace-expansion-1.1.11"
+      sources."braces-3.0.2"
+      sources."browserslist-4.12.0"
+      sources."buffer-5.6.0"
+      sources."buffer-crc32-0.2.13"
+      sources."bytes-3.1.0"
+      sources."callsites-3.1.0"
+      sources."camelcase-5.3.1"
+      sources."caniuse-lite-1.0.30001081"
+      (sources."chalk-2.4.2" // {
+        dependencies = [
+          sources."supports-color-5.5.0"
+        ];
+      })
+      sources."chokidar-3.4.0"
+      sources."chownr-1.1.4"
+      sources."chrome-launcher-0.13.3"
+      sources."cliui-6.0.0"
+      sources."color-convert-1.9.3"
+      sources."color-name-1.1.3"
+      sources."color-string-1.5.3"
+      sources."commander-2.20.3"
+      sources."concat-map-0.0.1"
+      sources."content-disposition-0.5.3"
+      sources."content-type-1.0.4"
+      sources."cookie-0.4.0"
+      sources."cookie-signature-1.0.6"
+      sources."core-util-is-1.0.2"
+      sources."cosmiconfig-6.0.0"
+      sources."cssfilter-0.0.10"
+      sources."cssnano-util-get-arguments-4.0.0"
+      sources."debug-2.6.9"
+      sources."decamelize-1.2.0"
+      sources."depd-1.1.2"
+      sources."destroy-1.0.4"
+      sources."dir-glob-3.0.1"
+      sources."dot-prop-5.2.0"
+      sources."ee-first-1.1.1"
+      sources."electron-to-chromium-1.3.472"
+      sources."emoji-regex-9.0.0"
+      sources."encodeurl-1.0.2"
+      sources."end-of-stream-1.4.4"
+      sources."entities-2.0.3"
+      (sources."error-ex-1.3.2" // {
+        dependencies = [
+          sources."is-arrayish-0.2.1"
+        ];
+      })
+      sources."escape-html-1.0.3"
+      sources."escape-string-regexp-1.0.5"
+      sources."esm-3.2.25"
+      sources."esprima-4.0.1"
+      sources."etag-1.8.1"
+      sources."express-4.17.1"
+      (sources."extract-zip-2.0.1" // {
+        dependencies = [
+          sources."debug-4.2.0"
+          sources."ms-2.1.2"
+        ];
+      })
+      sources."fast-glob-3.2.2"
+      sources."fastq-1.8.0"
+      sources."fd-slicer-1.1.0"
+      sources."fill-range-7.0.1"
+      sources."finalhandler-1.1.2"
+      sources."find-up-2.1.0"
+      sources."forwarded-0.1.2"
+      sources."fresh-0.5.2"
+      sources."fs-constants-1.0.0"
+      (sources."fs-extra-8.1.0" // {
+        dependencies = [
+          sources."jsonfile-4.0.0"
+        ];
+      })
+      sources."fs.realpath-1.0.0"
+      sources."fsevents-2.1.3"
+      sources."function-bind-1.1.1"
+      sources."get-caller-file-2.0.5"
+      sources."get-stream-5.1.0"
+      sources."glob-7.1.6"
+      sources."glob-parent-5.1.1"
+      sources."globby-11.0.1"
+      sources."graceful-fs-4.2.4"
+      sources."has-1.0.3"
+      sources."has-flag-3.0.0"
+      sources."highlight.js-10.1.0"
+      (sources."http-errors-1.7.2" // {
+        dependencies = [
+          sources."inherits-2.0.3"
+        ];
+      })
+      sources."https-1.0.0"
+      (sources."https-proxy-agent-4.0.0" // {
+        dependencies = [
+          sources."debug-4.2.0"
+          sources."ms-2.1.2"
+        ];
+      })
+      sources."iconv-lite-0.4.24"
+      sources."ieee754-1.1.13"
+      sources."ignore-5.1.8"
+      sources."image-size-0.8.3"
+      sources."immediate-3.0.6"
+      sources."import-fresh-3.2.1"
+      sources."indexes-of-1.0.1"
+      sources."inflight-1.0.6"
+      sources."inherits-2.0.4"
+      sources."ipaddr.js-1.9.1"
+      sources."is-arrayish-0.3.2"
+      sources."is-binary-path-2.1.0"
+      sources."is-docker-2.0.0"
+      sources."is-extglob-2.1.1"
+      sources."is-fullwidth-code-point-3.0.0"
+      sources."is-glob-4.0.1"
+      sources."is-number-7.0.0"
+      sources."is-obj-2.0.0"
+      sources."is-wsl-2.2.0"
+      sources."isarray-1.0.0"
+      sources."js-tokens-4.0.0"
+      sources."js-yaml-3.14.0"
+      sources."json-parse-better-errors-1.0.2"
+      sources."jsonfile-5.0.0"
+      sources."jszip-3.4.0"
+      sources."katex-0.11.1"
+      sources."lie-3.3.0"
+      sources."lighthouse-logger-1.2.0"
+      sources."lines-and-columns-1.1.6"
+      sources."linkify-it-3.0.2"
+      sources."locate-path-2.0.0"
+      sources."lodash.kebabcase-4.1.1"
+      sources."markdown-it-11.0.0"
+      sources."markdown-it-emoji-1.4.0"
+      sources."markdown-it-front-matter-0.2.1"
+      sources."marky-1.2.1"
+      sources."mathjax-full-3.0.5"
+      sources."mdurl-1.0.1"
+      sources."media-typer-0.3.0"
+      sources."merge-descriptors-1.0.1"
+      sources."merge2-1.4.1"
+      sources."methods-1.1.2"
+      sources."micromatch-4.0.2"
+      sources."mime-1.6.0"
+      sources."mime-db-1.44.0"
+      sources."mime-types-2.1.27"
+      sources."minimatch-3.0.4"
+      sources."minimist-1.2.5"
+      sources."mj-context-menu-0.2.2"
+      sources."mkdirp-0.5.5"
+      sources."mkdirp-classic-0.5.3"
+      sources."ms-2.0.0"
+      sources."negotiator-0.6.2"
+      sources."node-releases-1.1.58"
+      sources."normalize-path-3.0.0"
+      sources."on-finished-2.3.0"
+      sources."once-1.4.0"
+      sources."p-limit-1.3.0"
+      sources."p-locate-2.0.0"
+      sources."p-try-1.0.0"
+      sources."pako-1.0.11"
+      sources."parent-module-1.0.1"
+      sources."parse-json-5.0.0"
+      sources."parseurl-1.3.3"
+      sources."path-exists-3.0.0"
+      sources."path-is-absolute-1.0.1"
+      sources."path-to-regexp-0.1.7"
+      sources."path-type-4.0.0"
+      sources."pend-1.2.0"
+      sources."picomatch-2.2.2"
+      sources."pkg-up-2.0.0"
+      sources."postcss-7.0.32"
+      sources."postcss-minify-params-4.0.2"
+      sources."postcss-minify-selectors-4.0.2"
+      sources."postcss-normalize-whitespace-4.0.2"
+      sources."postcss-selector-parser-3.1.2"
+      sources."postcss-value-parser-3.3.1"
+      sources."pptxgenjs-3.2.1"
+      sources."process-nextick-args-2.0.1"
+      sources."progress-2.0.3"
+      sources."proxy-addr-2.0.6"
+      sources."proxy-from-env-1.1.0"
+      sources."pump-3.0.0"
+      (sources."puppeteer-core-3.3.0" // {
+        dependencies = [
+          sources."debug-4.2.0"
+          sources."mime-2.4.6"
+          sources."ms-2.1.2"
+        ];
+      })
+      sources."qs-6.7.0"
+      sources."queue-6.0.1"
+      sources."range-parser-1.2.1"
+      sources."raw-body-2.4.0"
+      sources."readable-stream-2.3.7"
+      sources."readdirp-3.4.0"
+      sources."require-directory-2.1.1"
+      sources."require-main-filename-2.0.0"
+      sources."resolve-from-4.0.0"
+      sources."reusify-1.0.4"
+      sources."rimraf-3.0.2"
+      sources."run-parallel-1.1.9"
+      sources."safe-buffer-5.1.2"
+      sources."safer-buffer-2.1.2"
+      (sources."send-0.17.1" // {
+        dependencies = [
+          sources."ms-2.1.1"
+        ];
+      })
+      (sources."serve-index-1.9.1" // {
+        dependencies = [
+          sources."http-errors-1.6.3"
+          sources."inherits-2.0.3"
+          sources."setprototypeof-1.1.0"
+        ];
+      })
+      sources."serve-static-1.14.1"
+      sources."set-blocking-2.0.0"
+      sources."set-immediate-shim-1.0.1"
+      sources."setprototypeof-1.1.1"
+      sources."simple-swizzle-0.2.2"
+      sources."slash-3.0.0"
+      sources."source-map-0.6.1"
+      sources."speech-rule-engine-3.0.1"
+      sources."sprintf-js-1.0.3"
+      sources."statuses-1.5.0"
+      (sources."string-width-4.2.0" // {
+        dependencies = [
+          sources."emoji-regex-8.0.0"
+        ];
+      })
+      sources."string_decoder-1.1.1"
+      sources."strip-ansi-6.0.0"
+      sources."supports-color-6.1.0"
+      sources."tar-fs-2.1.0"
+      (sources."tar-stream-2.1.2" // {
+        dependencies = [
+          sources."readable-stream-3.6.0"
+        ];
+      })
+      sources."through-2.3.8"
+      sources."tmp-0.2.1"
+      sources."to-regex-range-5.0.1"
+      sources."toidentifier-1.0.0"
+      sources."twemoji-13.0.0"
+      sources."twemoji-parser-13.0.0"
+      sources."type-is-1.6.18"
+      sources."uc.micro-1.0.6"
+      sources."unbzip2-stream-1.4.3"
+      sources."uniq-1.0.1"
+      sources."uniqs-2.0.0"
+      sources."universalify-0.1.2"
+      sources."unpipe-1.0.0"
+      sources."util-deprecate-1.0.2"
+      sources."utils-merge-1.0.1"
+      sources."v8-compile-cache-2.1.1"
+      sources."vary-1.1.2"
+      sources."which-module-2.0.0"
+      sources."wicked-good-xpath-1.3.0"
+      (sources."wrap-ansi-6.2.0" // {
+        dependencies = [
+          sources."ansi-styles-4.2.1"
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
+        ];
+      })
+      sources."wrappy-1.0.2"
+      sources."ws-7.3.0"
+      sources."xmldom-sre-0.1.31"
+      sources."xss-1.0.7"
+      sources."y18n-4.0.0"
+      sources."yaml-1.10.0"
+      (sources."yargs-15.3.1" // {
+        dependencies = [
+          sources."find-up-4.1.0"
+          sources."locate-path-5.0.0"
+          sources."p-limit-2.3.0"
+          sources."p-locate-4.1.0"
+          sources."p-try-2.2.0"
+          sources."path-exists-4.0.0"
+        ];
+      })
+      sources."yargs-parser-18.1.3"
+      sources."yauzl-2.10.0"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "A CLI interface for Marp and Marpit based converters";
+      homepage = "https://github.com/marp-team/marp-cli#readme";
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
   "@vue/cli" = nodeEnv.buildNodePackage {
     name = "_at_vue_slash_cli";
     packageName = "@vue/cli";
-    version = "4.4.1";
+    version = "4.4.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@vue/cli/-/cli-4.4.1.tgz";
-      sha512 = "X9K0EZFipqnckuzaUa2MzCtxPzazy4CwCJN0OTeXwc6I3q8f0M3H/5BuJM7cGPBn9CHDQTsiR1x7b2t3IKw7Vg==";
+      url = "https://registry.npmjs.org/@vue/cli/-/cli-4.4.4.tgz";
+      sha512 = "52pXlikVdBiPlZqEBx+vFQCrTmPrP3aLLxE0Wue00yJacPXt8ph6cb1PhCwYQAY1N9ROQstVJlsrm3GOXpCfyw==";
     };
     dependencies = [
       sources."@akryum/winattr-3.0.0"
@@ -50332,7 +50572,7 @@ in
       sources."@apollographql/graphql-language-service-parser-2.0.2"
       sources."@apollographql/graphql-language-service-types-2.0.2"
       sources."@apollographql/graphql-language-service-utils-2.0.2"
-      sources."@apollographql/graphql-playground-html-1.6.24"
+      sources."@apollographql/graphql-playground-html-1.6.26"
       sources."@babel/code-frame-7.10.1"
       (sources."@babel/core-7.10.2" // {
         dependencies = [
@@ -50488,14 +50728,14 @@ in
       sources."@types/serve-static-1.13.4"
       sources."@types/ws-7.2.5"
       sources."@types/zen-observable-0.8.0"
-      sources."@vue/cli-shared-utils-4.4.1"
-      (sources."@vue/cli-ui-4.4.1" // {
+      sources."@vue/cli-shared-utils-4.4.4"
+      (sources."@vue/cli-ui-4.4.4" // {
         dependencies = [
           sources."clone-2.1.2"
         ];
       })
-      sources."@vue/cli-ui-addon-webpack-4.4.1"
-      sources."@vue/cli-ui-addon-widgets-4.4.1"
+      sources."@vue/cli-ui-addon-webpack-4.4.4"
+      sources."@vue/cli-ui-addon-widgets-4.4.4"
       sources."@wry/context-0.4.4"
       sources."@wry/equality-0.1.11"
       sources."abbrev-1.1.1"
@@ -50519,7 +50759,7 @@ in
           sources."normalize-path-2.1.1"
         ];
       })
-      (sources."apollo-2.28.2" // {
+      (sources."apollo-2.28.3" // {
         dependencies = [
           sources."strip-ansi-5.2.0"
         ];
@@ -50528,18 +50768,18 @@ in
       sources."apollo-cache-control-0.11.0"
       sources."apollo-cache-inmemory-1.6.6"
       sources."apollo-client-2.6.10"
-      (sources."apollo-codegen-core-0.37.2" // {
+      (sources."apollo-codegen-core-0.37.3" // {
         dependencies = [
           sources."recast-0.19.1"
           sources."source-map-0.6.1"
         ];
       })
-      sources."apollo-codegen-flow-0.35.2"
-      sources."apollo-codegen-scala-0.36.2"
-      sources."apollo-codegen-swift-0.37.2"
-      sources."apollo-codegen-typescript-0.37.2"
+      sources."apollo-codegen-flow-0.35.3"
+      sources."apollo-codegen-scala-0.36.3"
+      sources."apollo-codegen-swift-0.37.3"
+      sources."apollo-codegen-typescript-0.37.3"
       sources."apollo-datasource-0.7.1"
-      (sources."apollo-engine-reporting-2.0.0" // {
+      (sources."apollo-engine-reporting-2.0.1" // {
         dependencies = [
           sources."uuid-8.1.0"
         ];
@@ -50547,7 +50787,7 @@ in
       sources."apollo-engine-reporting-protobuf-0.5.1"
       sources."apollo-env-0.6.5"
       sources."apollo-graphql-0.4.5"
-      sources."apollo-language-server-1.22.2"
+      sources."apollo-language-server-1.22.3"
       sources."apollo-link-1.2.14"
       sources."apollo-link-context-1.0.20"
       sources."apollo-link-error-1.1.13"
@@ -50557,10 +50797,10 @@ in
       sources."apollo-link-state-0.4.2"
       sources."apollo-link-ws-1.0.20"
       sources."apollo-server-caching-0.5.1"
-      sources."apollo-server-core-2.14.3"
+      sources."apollo-server-core-2.14.4"
       sources."apollo-server-env-2.4.4"
       sources."apollo-server-errors-2.4.1"
-      sources."apollo-server-express-2.14.3"
+      sources."apollo-server-express-2.14.4"
       sources."apollo-server-plugin-base-0.9.0"
       sources."apollo-server-types-0.5.0"
       sources."apollo-tracing-0.11.0"
@@ -50782,6 +51022,7 @@ in
       sources."crypto-random-string-1.0.0"
       sources."css-select-1.2.0"
       sources."css-what-2.1.3"
+      sources."cssfilter-0.0.10"
       sources."csv-parser-1.12.1"
       sources."dashdash-1.14.1"
       sources."date-fns-1.30.1"
@@ -50940,7 +51181,7 @@ in
       })
       sources."find-up-3.0.0"
       sources."fkill-6.2.0"
-      sources."flow-parser-0.126.1"
+      sources."flow-parser-0.127.0"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -51004,7 +51245,7 @@ in
           sources."ts-invariant-0.3.3"
         ];
       })
-      sources."graphql-extensions-0.12.2"
+      sources."graphql-extensions-0.12.3"
       sources."graphql-subscriptions-1.1.0"
       sources."graphql-tag-2.10.3"
       sources."graphql-tools-4.0.8"
@@ -51775,6 +52016,7 @@ in
       sources."xdg-basedir-3.0.0"
       sources."xml2js-0.4.23"
       sources."xmlbuilder-11.0.1"
+      sources."xss-1.0.7"
       sources."xtend-4.0.2"
       sources."yallist-2.1.2"
       (sources."yaml-front-matter-3.4.1" // {
@@ -52457,7 +52699,7 @@ in
     };
     dependencies = [
       sources."JSONStream-1.3.5"
-      sources."acorn-7.2.0"
+      sources."acorn-7.3.1"
       sources."acorn-node-1.8.2"
       sources."acorn-walk-7.1.1"
       (sources."asn1.js-4.10.1" // {
@@ -53165,10 +53407,10 @@ in
   coc-git = nodeEnv.buildNodePackage {
     name = "coc-git";
     packageName = "coc-git";
-    version = "1.7.14";
+    version = "1.7.15";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-git/-/coc-git-1.7.14.tgz";
-      sha512 = "LOq7zTp2mb2omi1Pc0r1PEK2N+bwuPYpSfszm78Rsvvht9cU+o/YuC0HagG4VZ7iwuiy9VRvpNz218sMZJqm7Q==";
+      url = "https://registry.npmjs.org/coc-git/-/coc-git-1.7.15.tgz";
+      sha512 = "R2h5x0j9FLlGZLEMlEnvoIors0b10yC2eBYkyYlwEFavWZn9DXwpnL3r2p6VUKNY02pwEyTGY0L5ffnPFZsUWA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -53183,14 +53425,15 @@ in
   coc-go = nodeEnv.buildNodePackage {
     name = "coc-go";
     packageName = "coc-go";
-    version = "0.7.0";
+    version = "0.8.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-go/-/coc-go-0.7.0.tgz";
-      sha512 = "ntDgRtLshBtxUuUXkkxH2S+xUWZW86ptrLO0pe74MzeS6m/Z744QvwSor+abHUTHO370nrUEUtGaQDUEh9p2BA==";
+      url = "https://registry.npmjs.org/coc-go/-/coc-go-0.8.0.tgz";
+      sha512 = "PMMybjPvAT+gGZDRaTmq1rIe59JsG9WRWWzVlT3gRo/Zp5Xwg2ho424m65ubGgre/UU23D9LVH9FLZDU4NH2Gg==";
     };
     dependencies = [
       sources."isexe-2.0.0"
-      sources."tslib-1.13.0"
+      sources."node-fetch-2.6.0"
+      sources."tslib-2.0.0"
       sources."which-2.0.2"
     ];
     buildInputs = globalBuildInputs;
@@ -53482,7 +53725,7 @@ in
       sources."@typescript-eslint/experimental-utils-3.2.0"
       sources."@typescript-eslint/parser-3.2.0"
       sources."@typescript-eslint/typescript-estree-3.2.0"
-      sources."acorn-7.2.0"
+      sources."acorn-7.3.1"
       sources."acorn-jsx-5.2.0"
       sources."ajv-6.12.2"
       sources."ajv-keywords-3.4.1"
@@ -53640,7 +53883,7 @@ in
       sources."domutils-1.7.0"
       sources."dot-prop-5.2.0"
       sources."duplexer3-0.1.4"
-      sources."electron-to-chromium-1.3.466"
+      sources."electron-to-chromium-1.3.472"
       sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
       sources."entities-1.1.2"
@@ -54679,7 +54922,7 @@ in
       sources."domhandler-2.4.2"
       sources."domutils-1.7.0"
       sources."dot-prop-5.2.0"
-      sources."electron-to-chromium-1.3.466"
+      sources."electron-to-chromium-1.3.472"
       sources."emoji-regex-8.0.0"
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
@@ -55299,7 +55542,7 @@ in
         ];
       })
       sources."abbrev-1.1.1"
-      sources."acorn-7.2.0"
+      sources."acorn-7.3.1"
       sources."acorn-jsx-5.2.0"
       (sources."aggregate-error-3.0.1" // {
         dependencies = [
@@ -58486,151 +58729,6 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
-  dnschain = nodeEnv.buildNodePackage {
-    name = "dnschain";
-    packageName = "dnschain";
-    version = "0.5.3";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/dnschain/-/dnschain-0.5.3.tgz";
-      sha1 = "9b21d9ac5e203295f372ac37df470e9f0854c470";
-    };
-    dependencies = [
-      sources."accepts-1.2.13"
-      sources."assert-plus-1.0.0"
-      sources."async-0.9.2"
-      sources."better-curry-1.6.0"
-      sources."binaryheap-0.0.3"
-      sources."bindings-1.5.0"
-      sources."bluebird-2.9.9"
-      sources."bottleneck-1.5.3"
-      sources."buffercursor-0.0.12"
-      sources."colors-0.6.2"
-      sources."combined-stream-0.0.7"
-      sources."component-emitter-1.1.2"
-      sources."content-disposition-0.5.0"
-      sources."cookie-0.1.2"
-      sources."cookie-signature-1.0.5"
-      sources."cookiejar-2.0.1"
-      sources."core-util-is-1.0.2"
-      sources."crc-3.2.1"
-      sources."cycle-1.0.3"
-      sources."debug-2.1.3"
-      sources."delayed-stream-0.0.5"
-      sources."depd-1.0.1"
-      sources."destroy-1.0.3"
-      sources."duplexer-0.1.1"
-      sources."ee-first-1.1.0"
-      sources."es5class-2.3.1"
-      sources."escape-html-1.0.1"
-      sources."etag-1.5.1"
-      sources."event-stream-3.2.2"
-      sources."eventemitter3-0.1.6"
-      sources."express-4.11.2"
-      sources."extend-1.2.1"
-      sources."extsprintf-1.4.0"
-      sources."eyes-0.1.8"
-      sources."faye-websocket-0.11.3"
-      sources."file-uri-to-path-1.0.0"
-      sources."finalhandler-0.3.3"
-      sources."form-data-0.1.3"
-      sources."formidable-1.0.14"
-      sources."forwarded-0.1.2"
-      sources."fresh-0.2.4"
-      sources."from-0.1.7"
-      sources."hiredis-0.4.1"
-      sources."http-parser-js-0.5.2"
-      sources."inherits-2.0.4"
-      sources."ini-1.3.5"
-      sources."ipaddr.js-1.0.5"
-      sources."isarray-0.0.1"
-      (sources."json-rpc2-0.8.1" // {
-        dependencies = [
-          sources."debug-1.0.5"
-          sources."lodash-2.4.2"
-          sources."ms-2.0.0"
-        ];
-      })
-      sources."jsonparse-0.0.6"
-      sources."lodash-3.1.0"
-      sources."map-stream-0.1.0"
-      sources."media-typer-0.3.0"
-      sources."merge-descriptors-0.0.2"
-      sources."methods-1.1.2"
-      sources."mime-1.2.11"
-      sources."mime-db-1.44.0"
-      sources."mime-types-2.1.27"
-      sources."minimist-0.0.10"
-      sources."ms-0.7.0"
-      sources."nan-2.14.1"
-      (sources."native-dns-git+https://github.com/okTurtles/node-dns.git#08433ec98f517eed3c6d5e47bdf62603539cd402" // {
-        dependencies = [
-          sources."native-dns-packet-git+https://github.com/okTurtles/native-dns-packet.git#8bf2714c318cfe7d31bca2006385882ccbf503e4"
-        ];
-      })
-      (sources."native-dns-cache-git+https://github.com/okTurtles/native-dns-cache.git#8714196bb9223cc9a4064a4fddf9e82ec50b7d4d" // {
-        dependencies = [
-          sources."native-dns-packet-git+https://github.com/okTurtles/native-dns-packet.git#307e77a47ebba57a5ae9118a284e916e5ebb305a"
-        ];
-      })
-      sources."native-dns-packet-0.1.1"
-      sources."nconf-0.7.1"
-      sources."negotiator-0.5.3"
-      sources."on-finished-2.2.1"
-      sources."optimist-0.6.1"
-      sources."parseurl-1.3.3"
-      sources."path-to-regexp-0.1.3"
-      sources."pause-stream-0.0.11"
-      sources."pkginfo-0.3.1"
-      sources."properties-1.2.1"
-      sources."proxy-addr-1.0.10"
-      sources."qs-2.3.3"
-      sources."range-parser-1.0.3"
-      sources."readable-stream-1.0.27-1"
-      sources."redis-0.12.1"
-      sources."reduce-component-1.0.1"
-      sources."safe-buffer-5.2.1"
-      sources."send-0.11.1"
-      sources."serve-static-1.8.1"
-      sources."split-0.3.3"
-      sources."stack-trace-0.0.10"
-      sources."stream-combiner-0.0.4"
-      sources."string-2.0.1"
-      sources."string_decoder-0.10.31"
-      (sources."superagent-0.21.0" // {
-        dependencies = [
-          sources."methods-1.0.1"
-          sources."qs-1.2.0"
-        ];
-      })
-      sources."through-2.3.8"
-      (sources."type-is-1.5.7" // {
-        dependencies = [
-          sources."mime-db-1.12.0"
-          sources."mime-types-2.0.14"
-        ];
-      })
-      sources."utils-merge-1.0.0"
-      sources."vary-1.0.1"
-      sources."verror-1.10.0"
-      sources."websocket-driver-0.7.4"
-      sources."websocket-extensions-0.1.4"
-      (sources."winston-0.8.0" // {
-        dependencies = [
-          sources."async-0.2.10"
-        ];
-      })
-      sources."wordwrap-0.0.3"
-    ];
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "A blockchain-based DNS + HTTPS server that fixes HTTPS security, and more!";
-      homepage = https://github.com/okTurtles/dnschain;
-      license = "MPL-2.0";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
   dockerfile-language-server-nodejs = nodeEnv.buildNodePackage {
     name = "dockerfile-language-server-nodejs";
     packageName = "dockerfile-language-server-nodejs";
@@ -58674,10 +58772,10 @@ in
   elasticdump = nodeEnv.buildNodePackage {
     name = "elasticdump";
     packageName = "elasticdump";
-    version = "6.28.4";
+    version = "6.29.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-6.28.4.tgz";
-      sha512 = "KgKHW1PDfOOMzbldVhySG4sLFrllEFLvqNO/Is0F15sSho11lOjAb2MoKOB/bypJQ7DgrxR/O9zMVFxvEI6Vdg==";
+      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-6.29.1.tgz";
+      sha512 = "p/4ZAjzx0C6wVPnqHBqFZXwa2HI40mg3pchl3kW8utLg3G0ILA5H1ypXB62S1uyPuuNXgq3GdiEj8C12aa15nQ==";
     };
     dependencies = [
       sources."JSONStream-1.3.5"
@@ -58686,7 +58784,7 @@ in
       sources."assert-plus-1.0.0"
       sources."async-2.6.3"
       sources."asynckit-0.4.0"
-      sources."aws-sdk-2.693.0"
+      sources."aws-sdk-2.696.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.10.0"
       sources."base64-js-1.3.1"
@@ -58715,6 +58813,7 @@ in
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
+      sources."http-status-1.4.2"
       sources."ieee754-1.1.13"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
@@ -59200,7 +59299,7 @@ in
         ];
       })
       sources."@types/color-name-1.1.1"
-      sources."acorn-7.2.0"
+      sources."acorn-7.3.1"
       sources."acorn-jsx-5.2.0"
       sources."ajv-6.12.2"
       (sources."ansi-escapes-4.3.1" // {
@@ -59376,7 +59475,7 @@ in
         ];
       })
       sources."@types/color-name-1.1.1"
-      sources."acorn-7.2.0"
+      sources."acorn-7.3.1"
       sources."acorn-jsx-5.2.0"
       sources."ajv-6.12.2"
       (sources."ansi-escapes-4.3.1" // {
@@ -60556,10 +60655,10 @@ in
   gitmoji-cli = nodeEnv.buildNodePackage {
     name = "gitmoji-cli";
     packageName = "gitmoji-cli";
-    version = "3.2.4";
+    version = "3.2.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/gitmoji-cli/-/gitmoji-cli-3.2.4.tgz";
-      sha512 = "rf0NbwZobW2Kwwomf41Ooas7rm7yg1z68fyKgrKaUs/VaaNtwIYMp/J11iQxcFu5p6i73huCytzmmo/8v4usDA==";
+      url = "https://registry.npmjs.org/gitmoji-cli/-/gitmoji-cli-3.2.5.tgz";
+      sha512 = "BOdKZqwwAf4VsAiIynnDdPxTz0UwHESeSpl6x54jspJ7Y06NxhbXBe++kuov2XoGoGJcKFrDJtJgqKVCQ6Pg/A==";
     };
     dependencies = [
       sources."@babel/code-frame-7.10.1"
@@ -62904,7 +63003,7 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."jquery-3.5.1"
-      sources."jquery.terminal-2.17.1"
+      sources."jquery.terminal-2.17.2"
       sources."jsonfile-2.4.0"
       sources."keyboardevent-key-polyfill-1.1.0"
       sources."line-reader-0.4.0"
@@ -63795,7 +63894,7 @@ in
       sources."@yarnpkg/lockfile-1.1.0"
       sources."abab-2.0.3"
       sources."abbrev-1.1.1"
-      sources."acorn-7.2.0"
+      sources."acorn-7.3.1"
       (sources."acorn-globals-4.3.4" // {
         dependencies = [
           sources."acorn-6.4.1"
@@ -65159,10 +65258,10 @@ in
   karma = nodeEnv.buildNodePackage {
     name = "karma";
     packageName = "karma";
-    version = "5.0.9";
+    version = "5.1.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/karma/-/karma-5.0.9.tgz";
-      sha512 = "dUA5z7Lo7G4FRSe1ZAXqOINEEWxmCjDBbfRBmU/wYlSMwxUQJP/tEEP90yJt3Uqo03s9rCgVnxtlfq+uDhxSPg==";
+      url = "https://registry.npmjs.org/karma/-/karma-5.1.0.tgz";
+      sha512 = "I3aPbkuIbwuBo6wSog97P5WnnhCgUTsWTu/bEw1vZVQFbXmKO3PK+cfFhZioOgVtJAuQxoyauGNjnwXNHMCxbw==";
     };
     dependencies = [
       sources."@types/color-name-1.1.1"
@@ -65824,8 +65923,8 @@ in
       sources."@lerna/write-log-file-3.13.0"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
-      sources."@octokit/auth-token-2.4.1"
-      (sources."@octokit/endpoint-6.0.2" // {
+      sources."@octokit/auth-token-2.4.2"
+      (sources."@octokit/endpoint-6.0.3" // {
         dependencies = [
           sources."is-plain-object-3.0.0"
           sources."isobject-4.0.0"
@@ -65844,9 +65943,13 @@ in
           sources."@octokit/types-2.16.2"
         ];
       })
-      (sources."@octokit/request-5.4.4" // {
+      (sources."@octokit/request-5.4.5" // {
         dependencies = [
-          sources."@octokit/request-error-2.0.1"
+          (sources."@octokit/request-error-2.0.1" // {
+            dependencies = [
+              sources."@octokit/types-4.1.10"
+            ];
+          })
           sources."is-plain-object-3.0.0"
           sources."isobject-4.0.0"
           sources."universal-user-agent-5.0.0"
@@ -65858,7 +65961,7 @@ in
         ];
       })
       sources."@octokit/rest-16.43.1"
-      sources."@octokit/types-4.1.10"
+      sources."@octokit/types-5.0.0"
       sources."@types/glob-7.1.2"
       sources."@types/minimatch-3.0.3"
       sources."@types/minimist-1.2.0"
@@ -67852,7 +67955,7 @@ in
       sources."@xtuc/long-4.2.2"
       sources."JSONStream-1.3.5"
       sources."ace.improved-0.2.1"
-      sources."acorn-7.2.0"
+      sources."acorn-7.3.1"
       sources."acorn-node-1.8.2"
       sources."acorn-walk-7.1.1"
       sources."ajv-6.12.2"
@@ -68128,7 +68231,7 @@ in
       sources."duplexer2-0.1.4"
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
-      sources."electron-to-chromium-1.3.466"
+      sources."electron-to-chromium-1.3.472"
       (sources."elliptic-6.5.2" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -69753,17 +69856,18 @@ in
   mocha = nodeEnv.buildNodePackage {
     name = "mocha";
     packageName = "mocha";
-    version = "7.2.0";
+    version = "8.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz";
-      sha512 = "O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==";
+      url = "https://registry.npmjs.org/mocha/-/mocha-8.0.1.tgz";
+      sha512 = "vefaXfdYI8+Yo8nPZQQi0QO2o+5q9UIMX1jZ1XMmK3+4+CQjc7+B0hPdUeglXiTlr8IHMVRo63IhO9Mzt6fxOg==";
     };
     dependencies = [
-      sources."ansi-colors-3.2.3"
+      sources."ansi-colors-4.1.1"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
       sources."anymatch-3.1.1"
       sources."argparse-1.0.10"
+      sources."array.prototype.map-1.0.2"
       sources."balanced-match-1.0.0"
       sources."binary-extensions-2.0.0"
       sources."brace-expansion-1.1.11"
@@ -69775,7 +69879,7 @@ in
           sources."supports-color-5.5.0"
         ];
       })
-      sources."chokidar-3.3.0"
+      sources."chokidar-3.3.1"
       (sources."cliui-5.0.0" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
@@ -69789,20 +69893,22 @@ in
       sources."debug-3.2.6"
       sources."decamelize-1.2.0"
       sources."define-properties-1.1.3"
-      sources."diff-3.5.0"
+      sources."diff-4.0.2"
       sources."emoji-regex-7.0.3"
       sources."es-abstract-1.17.5"
+      sources."es-array-method-boxes-properly-1.0.0"
+      sources."es-get-iterator-1.1.0"
       sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
       sources."fill-range-7.0.1"
-      sources."find-up-3.0.0"
+      sources."find-up-4.1.0"
       sources."flat-4.1.0"
       sources."fs.realpath-1.0.0"
       sources."fsevents-2.1.3"
       sources."function-bind-1.1.1"
       sources."get-caller-file-2.0.5"
-      sources."glob-7.1.3"
+      sources."glob-7.1.6"
       sources."glob-parent-5.1.1"
       sources."growl-1.10.5"
       sources."has-1.0.3"
@@ -69811,6 +69917,7 @@ in
       sources."he-1.2.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
+      sources."is-arguments-1.0.4"
       sources."is-binary-path-2.1.0"
       sources."is-buffer-2.0.4"
       sources."is-callable-1.2.0"
@@ -69818,35 +69925,38 @@ in
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-4.0.1"
+      sources."is-map-2.0.1"
       sources."is-number-7.0.0"
       sources."is-regex-1.1.0"
+      sources."is-set-2.0.1"
+      sources."is-string-1.0.5"
       sources."is-symbol-1.0.3"
+      sources."isarray-2.0.5"
       sources."isexe-2.0.0"
+      sources."iterate-iterator-1.0.1"
+      sources."iterate-value-1.0.2"
       sources."js-yaml-3.13.1"
-      sources."locate-path-3.0.0"
+      sources."locate-path-5.0.0"
       sources."lodash-4.17.15"
       sources."log-symbols-3.0.0"
       sources."minimatch-3.0.4"
-      sources."minimist-1.2.5"
-      sources."mkdirp-0.5.5"
-      sources."ms-2.1.1"
-      sources."node-environment-flags-1.0.6"
+      sources."ms-2.1.2"
       sources."normalize-path-3.0.0"
       sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."object.assign-4.1.0"
-      sources."object.getownpropertydescriptors-2.1.0"
       sources."once-1.4.0"
       sources."p-limit-2.3.0"
-      sources."p-locate-3.0.0"
+      sources."p-locate-4.1.0"
       sources."p-try-2.2.0"
-      sources."path-exists-3.0.0"
+      sources."path-exists-4.0.0"
       sources."path-is-absolute-1.0.1"
       sources."picomatch-2.2.2"
-      sources."readdirp-3.2.0"
+      sources."promise.allsettled-1.0.2"
+      sources."readdirp-3.3.0"
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
-      sources."semver-5.7.1"
+      sources."serialize-javascript-3.0.0"
       sources."set-blocking-2.0.0"
       sources."sprintf-js-1.0.3"
       sources."string-width-2.1.1"
@@ -69855,12 +69965,17 @@ in
       sources."string.prototype.trimright-2.1.2"
       sources."string.prototype.trimstart-1.0.1"
       sources."strip-ansi-4.0.0"
-      sources."strip-json-comments-2.0.1"
-      sources."supports-color-6.0.0"
+      sources."strip-json-comments-3.0.1"
+      (sources."supports-color-7.1.0" // {
+        dependencies = [
+          sources."has-flag-4.0.0"
+        ];
+      })
       sources."to-regex-range-5.0.1"
-      sources."which-1.3.1"
+      sources."which-2.0.2"
       sources."which-module-2.0.0"
       sources."wide-align-1.1.3"
+      sources."workerpool-6.0.0"
       (sources."wrap-ansi-5.1.0" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
@@ -69873,6 +69988,10 @@ in
       (sources."yargs-13.3.2" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
+          sources."find-up-3.0.0"
+          sources."locate-path-3.0.0"
+          sources."p-locate-3.0.0"
+          sources."path-exists-3.0.0"
           sources."string-width-3.1.0"
           sources."strip-ansi-5.2.0"
         ];
@@ -72113,7 +72232,7 @@ in
       sources."@parcel/workers-1.11.0"
       sources."@types/q-1.5.4"
       sources."abab-2.0.3"
-      sources."acorn-7.2.0"
+      sources."acorn-7.3.1"
       (sources."acorn-globals-4.3.4" // {
         dependencies = [
           sources."acorn-6.4.1"
@@ -72362,7 +72481,7 @@ in
       sources."duplexer2-0.1.4"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.466"
+      sources."electron-to-chromium-1.3.472"
       (sources."elliptic-6.5.2" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -73969,10 +74088,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "5.1.6";
+    version = "5.1.8";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-5.1.6.tgz";
-      sha512 = "BMY+RH2ggxY27pSlO5RtGAtTUcUfFVetQZHJdZURWu9tankNO0iDuqSx4w9iBGdIm9+Gd5eQqNYylqTksu2ueA==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-5.1.8.tgz";
+      sha512 = "DsyoyFo60MByj8rZEFH6a/ZKz0NQbg5tdKCIgjMlvA2kyNKt0d+XW2eaYjqw6ILGuy2k857yRPZfgJgV0Xgpjg==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -74150,10 +74269,10 @@ in
   pscid = nodeEnv.buildNodePackage {
     name = "pscid";
     packageName = "pscid";
-    version = "2.9.1";
+    version = "2.9.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pscid/-/pscid-2.9.1.tgz";
-      sha512 = "K/v6B+pLyKi3PxthFbNwpWxVvIMIAFWgwo3SewjPnylBaSx9xGLxTrMneKHMf3whOMJlXMD/lrXdGJ0paYfRGQ==";
+      url = "https://registry.npmjs.org/pscid/-/pscid-2.9.2.tgz";
+      sha512 = "xK6xfd8AhzJIddcpwveQjFEH+7ODr4gVM84rsvXwP6/167quMbt4VB2pcMf051gew1iwFgK90L301CcW+UD7Cg==";
     };
     dependencies = [
       sources."balanced-match-1.0.0"
@@ -74194,7 +74313,7 @@ in
     };
     dependencies = [
       sources."JSONStream-1.3.5"
-      sources."acorn-7.2.0"
+      sources."acorn-7.3.1"
       sources."acorn-node-1.8.2"
       sources."acorn-walk-7.1.1"
       (sources."asn1.js-4.10.1" // {
@@ -74648,10 +74767,10 @@ in
   rollup = nodeEnv.buildNodePackage {
     name = "rollup";
     packageName = "rollup";
-    version = "2.15.0";
+    version = "2.16.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/rollup/-/rollup-2.15.0.tgz";
-      sha512 = "HAk4kyXiV5sdNDnbKWk5zBPnkX/DAgx09Kbp8rRIRDVsTUVN3vnSowR7ZHkV6/lAiE6c2TQ8HtYb72aCPGW4Jw==";
+      url = "https://registry.npmjs.org/rollup/-/rollup-2.16.0.tgz";
+      sha512 = "95NglykUQAhl+mTFZqVvGUWDoGHV4/XanOZBbR7LOwTKODde5yFNHfVDZEnERBMuQViDuYaxOlFW87i1GQMihA==";
     };
     dependencies = [
       sources."fsevents-2.1.3"
@@ -74705,7 +74824,7 @@ in
           sources."semver-7.3.2"
         ];
       })
-      sources."acorn-7.2.0"
+      sources."acorn-7.3.1"
       sources."acorn-jsx-5.2.0"
       sources."agent-base-4.3.0"
       sources."ajv-6.12.2"
@@ -74973,7 +75092,7 @@ in
       sources."resolve-from-4.0.0"
       sources."restore-cursor-3.1.0"
       sources."rimraf-2.6.3"
-      sources."rollup-2.15.0"
+      sources."rollup-2.16.0"
       sources."run-async-2.4.1"
       (sources."rxjs-6.5.5" // {
         dependencies = [
@@ -75404,7 +75523,7 @@ in
         ];
       })
       sources."@serverless/template-1.1.3"
-      sources."@serverless/utils-china-0.1.13"
+      sources."@serverless/utils-china-0.1.14"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       (sources."@tencent-sdk/capi-0.2.15-alpha.0" // {
@@ -75480,7 +75599,7 @@ in
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
-      (sources."aws-sdk-2.693.0" // {
+      (sources."aws-sdk-2.696.0" // {
         dependencies = [
           sources."buffer-4.9.2"
           sources."isarray-1.0.0"
@@ -77101,10 +77220,10 @@ in
   snyk = nodeEnv.buildNodePackage {
     name = "snyk";
     packageName = "snyk";
-    version = "1.338.0";
+    version = "1.339.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/snyk/-/snyk-1.338.0.tgz";
-      sha512 = "kygisp/bsNVLnATEdHeb3ASQS58b8DKOju9BcVNC3OpUi0Ajjiqy5o7RdfNPfCzp9lYglLT9grIM59zJuC2sFg==";
+      url = "https://registry.npmjs.org/snyk/-/snyk-1.339.2.tgz";
+      sha512 = "BpXMOZX/jj/4fHOq2gfSlAPE9+DNe/WEqNCbQ68uy1U9NA1tucGJf3B376NofsgXCYIrJ0tw5Mjf1yfq7F4Vxw==";
     };
     dependencies = [
       sources."@sindresorhus/is-0.14.0"
@@ -77451,7 +77570,7 @@ in
           sources."debug-4.2.0"
         ];
       })
-      (sources."snyk-docker-plugin-3.10.0" // {
+      (sources."snyk-docker-plugin-3.12.0" // {
         dependencies = [
           sources."debug-4.2.0"
         ];
@@ -77911,10 +78030,10 @@ in
   ssb-server = nodeEnv.buildNodePackage {
     name = "ssb-server";
     packageName = "ssb-server";
-    version = "16.0.0";
+    version = "16.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ssb-server/-/ssb-server-16.0.0.tgz";
-      sha512 = "pmAXsxC5OIzwciT1IcTNXI36qMWJJr7zLjq6Hft8fsijaw3NMh5eyGq72UMbeHIdaTPESmtg7Y2cuVuPhv3vrA==";
+      url = "https://registry.npmjs.org/ssb-server/-/ssb-server-16.0.1.tgz";
+      sha512 = "cast7wQRxqUSiRVyFoaTtymeukwSh5nlfDj5ShHmdnh0qmfi4uQnvPuBA5BBgC3WEtI/ozgNjAc1/vqJFgILig==";
     };
     dependencies = [
       sources."abstract-leveldown-6.0.3"
@@ -77935,6 +78054,7 @@ in
       sources."assign-symbols-1.0.0"
       sources."async-each-1.0.3"
       sources."async-single-1.0.5"
+      sources."async-write-2.1.0"
       sources."atob-2.1.2"
       (sources."atomic-file-2.0.1" // {
         dependencies = [
@@ -78093,26 +78213,36 @@ in
           sources."level-codec-6.2.0"
         ];
       })
+      sources."flumedb-2.1.4"
       sources."flumelog-offset-3.4.4"
       (sources."flumeview-hashtable-1.1.1" // {
         dependencies = [
           sources."atomic-file-1.1.5"
         ];
       })
-      sources."flumeview-level-3.0.14"
+      (sources."flumeview-level-4.0.3" // {
+        dependencies = [
+          sources."abstract-leveldown-6.2.3"
+          sources."level-6.0.1"
+          sources."level-js-5.0.2"
+          sources."mkdirp-1.0.4"
+        ];
+      })
       (sources."flumeview-links-1.0.1" // {
         dependencies = [
           sources."deep-equal-2.0.3"
+          sources."flumeview-level-3.0.14"
           sources."isarray-2.0.5"
           sources."map-filter-reduce-3.2.2"
         ];
       })
       (sources."flumeview-query-7.2.2" // {
         dependencies = [
+          sources."flumeview-level-3.0.14"
           sources."map-filter-reduce-3.2.2"
         ];
       })
-      sources."flumeview-reduce-1.3.16"
+      sources."flumeview-reduce-1.3.17"
       sources."for-each-0.3.3"
       sources."for-in-1.0.2"
       sources."for-own-0.1.5"
@@ -78288,6 +78418,7 @@ in
         ];
       })
       sources."mkdirp-0.5.5"
+      sources."monotonic-timestamp-0.0.9"
       sources."moo-0.5.1"
       sources."ms-2.1.2"
       sources."multiblob-1.13.7"
@@ -78590,6 +78721,12 @@ in
       sources."ssb-caps-1.1.0"
       sources."ssb-client-4.9.0"
       sources."ssb-config-3.4.4"
+      (sources."ssb-db-20.1.0" // {
+        dependencies = [
+          sources."glob-7.1.6"
+          sources."rimraf-3.0.2"
+        ];
+      })
       sources."ssb-ebt-5.6.7"
       sources."ssb-friends-4.1.4"
       (sources."ssb-gossip-1.1.1" // {
@@ -78606,7 +78743,7 @@ in
       sources."ssb-msgs-5.2.0"
       sources."ssb-no-auth-1.0.0"
       sources."ssb-onion-1.0.0"
-      (sources."ssb-ooo-1.3.2" // {
+      (sources."ssb-ooo-1.3.3" // {
         dependencies = [
           sources."flumecodec-0.0.1"
           sources."level-codec-6.2.0"
@@ -78614,10 +78751,11 @@ in
       })
       sources."ssb-plugins-1.0.4"
       sources."ssb-private1-1.0.1"
-      sources."ssb-query-2.4.3"
+      sources."ssb-query-2.4.4"
       sources."ssb-ref-2.13.9"
       sources."ssb-replicate-1.3.2"
       sources."ssb-unix-socket-1.0.0"
+      sources."ssb-validate-4.1.0"
       sources."ssb-ws-6.2.3"
       sources."stack-0.1.0"
       (sources."static-extend-0.1.2" // {
@@ -78820,7 +78958,7 @@ in
       sources."async-1.5.2"
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
-      (sources."aws-sdk-2.693.0" // {
+      (sources."aws-sdk-2.696.0" // {
         dependencies = [
           sources."uuid-3.3.2"
         ];
@@ -81822,7 +81960,7 @@ in
       sources."strip-ansi-3.0.1"
       sources."strip-json-comments-2.0.1"
       sources."strip-outer-1.0.1"
-      (sources."strtok3-6.0.2" // {
+      (sources."strtok3-6.0.3" // {
         dependencies = [
           sources."debug-4.2.0"
           sources."ms-2.1.2"
@@ -83286,7 +83424,7 @@ in
       })
       (sources."eslint-plugin-vue-6.2.2" // {
         dependencies = [
-          sources."acorn-7.2.0"
+          sources."acorn-7.3.1"
           sources."debug-4.2.0"
           sources."eslint-scope-5.1.0"
           sources."espree-6.2.1"
@@ -84384,7 +84522,7 @@ in
       sources."eslint-visitor-keys-1.1.0"
       (sources."espree-6.2.1" // {
         dependencies = [
-          sources."acorn-7.2.0"
+          sources."acorn-7.3.1"
         ];
       })
       sources."esprima-4.0.1"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The existing marp tool is being deprecated, and marp-cli is a component of the replacement

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
