### PR TITLE
Alegreya

### DIFF
--- a/pkgs/data/fonts/alegreya-sans/default.nix
+++ b/pkgs/data/fonts/alegreya-sans/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "alegreya-sans";
+  version = "2.008";
+
+  src = fetchFromGitHub {
+    owner = "huertatipografica";
+    repo = "Alegreya-Sans";
+    rev = "v${version}";
+    sha256 = "0xz5lq9fh0pj02ifazhddzh792qkxkz1z6ylj26d93wshc90jl5g";
+  };
+
+  installPhase = ''
+    install -D -m 444 fonts/otf/* -t $out/share/fonts/otf
+    install -D -m 444 fonts/ttf/* -t $out/share/fonts/ttf
+    install -D -m 444 fonts/webfonts/*.woff -t $out/share/fonts/woff
+    install -D -m 444 fonts/webfonts/*.woff2 -t $out/share/fonts/woff2
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Humanist sans serif family with a calligraphic feeling";
+    longDescription = ''
+Alegreya Sans is a humanist sans serif family with a calligraphic feeling that conveys a dynamic and varied rhythm. This gives a pleasant feeling to readers of long texts.
+
+The family follows humanist proportions and principles, just like the serif version of the family, Alegreya. It achieves a ludic and harmonious paragraph through elements carefully designed in an atmosphere of diversity. The italics bring a strong emphasis to the roman styles, and each have seven weights to bring you a wide typographic palette.
+
+Alegreya Sans supports expert latin, greek and cyrillic character sets and provides advanced typography OpenType features such as small caps, dynamic ligatures and fractions, four set of figures, super and subscript characters, ordinals, localized accent forms for spanish, catalan, guaraní, dutch, turkish, romanian, serbian among others.
+
+The Alegreya type system is a "super family", originally intended for literature, and includes sans and serif sister families.
+    '';
+    homepage = "https://www.huertatipografica.com/en/fonts/alegreya-sans-ht";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ Thra11 ];
+  };
+}

--- a/pkgs/data/fonts/alegreya/default.nix
+++ b/pkgs/data/fonts/alegreya/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "alegreya";
+  version = "2.008";
+
+  src = fetchFromGitHub {
+    owner = "huertatipografica";
+    repo = "Alegreya";
+    rev = "v${version}";
+    sha256 = "1m5xr95y6qxxv2ryvhfck39d6q5hxsr51f530fshg53x48l2mpwr";
+  };
+
+  installPhase = ''
+    install -D -m 444 fonts/otf/* -t $out/share/fonts/otf
+    install -D -m 444 fonts/ttf/* -t $out/share/fonts/ttf
+    install -D -m 444 fonts/webfonts/*.woff -t $out/share/fonts/woff
+    install -D -m 444 fonts/webfonts/*.woff2 -t $out/share/fonts/woff2
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An elegant and versatile font family for comfortable reading";
+    longDescription = ''
+Alegreya is a typeface originally intended for literature. Among its crowning characteristics, it conveys a dynamic and varied rhythm which facilitates the reading of long texts. Also, it provides freshness to the page while referring to the calligraphic letter, not as a literal interpretation, but rather in a contemporary typographic language.
+
+The italic has just as much care and attention to detail in the design as the roman. The bold weights are strong, and the Black weights are really experimental for the genre. There is also a Small Caps sister family.
+
+Not only does Alegreya provide great performance, but also achieves a strong and harmonious text by means of elements designed in an atmosphere of diversity.
+
+The Alegreya type system is a "super family", originally intended for literature, and includes serif and sans serif sister families.
+
+It supports expert latin, greek and cyrillic character sets and provides advanced typography OpenType features such as small caps, dynamic ligatures and fractions, four set of figures, super and subscript characters, ordinals, localized accent forms for spanish, catalan, guaraní, dutch, turkish, romanian, serbian among others.
+
+Alegreya was chosen at the ATypI Letter2 competition in September 2011, and one of the top 14 text type systems. It was also selected in the 2nd Bienal Iberoamericana de Diseño, competition held in Madrid in 2010 and Tipos Latinos.
+
+Designed by Juan Pablo del Peral for Huerta Tipográfica.
+    '';
+    homepage = "https://www.huertatipografica.com/en/fonts/alegreya-ht-pro";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ Thra11 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17818,6 +17818,8 @@ in
 
   albatross = callPackage ../data/themes/albatross { };
 
+  alegreya = callPackage ../data/fonts/alegreya { };
+
   amber-theme = callPackage ../data/themes/amber { };
 
   amiri = callPackage ../data/fonts/amiri { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17820,6 +17820,8 @@ in
 
   alegreya = callPackage ../data/fonts/alegreya { };
 
+  alegreya-sans = callPackage ../data/fonts/alegreya-sans { };
+
   amber-theme = callPackage ../data/themes/amber { };
 
   amiri = callPackage ../data/fonts/amiri { };


### PR DESCRIPTION
###### Motivation for this change
Package a couple of really nice fonts

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
