### PR TITLE
lmdb: 0.9.24 -> 0.9.25

### DIFF
--- a/pkgs/development/libraries/lmdb/default.nix
+++ b/pkgs/development/libraries/lmdb/default.nix
@@ -1,14 +1,13 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchgit }:
 
 stdenv.mkDerivation rec {
   pname = "lmdb";
-  version = "0.9.24";
+  version = "0.9.25";
 
-  src = fetchFromGitHub {
-    owner = "LMDB";
-    repo = "lmdb";
+  src = fetchgit {
+    url = "https://git.openldap.org/openldap/openldap.git";
     rev = "LMDB_${version}";
-    sha256 = "088q6m8fvr12w43s461h7cvpg5hj8csaqj6n9pci150dz7bk5lxm";
+    sha256 = "0i60zlca8r6fib23gdgl4c80gxpx24772ggpvz94yr7zaai4k11w";
   };
 
   postUnpack = "sourceRoot=\${sourceRoot}/libraries/liblmdb";


### PR DESCRIPTION
Change to official repo (according to https://www.openldap.org/software/repo.html) and the latest version. The Github read-only mirror is abandoned and has been outdated for months.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
