### PR TITLE
php < 7.4: Fix validation of PKG_CONFIG var

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -195,9 +195,10 @@ let
 
           hardeningDisable = [ "bindnow" ];
 
-          preConfigure = ''
-            # Don't record the configure flags since this causes unnecessary
-            # runtime dependencies
+          preConfigure =
+          # Don't record the configure flags since this causes unnecessary
+          # runtime dependencies
+          ''
             for i in main/build-defs.h.in scripts/php-config.in; do
               substituteInPlace $i \
                 --replace '@CONFIGURE_COMMAND@' '(omitted)' \
@@ -206,7 +207,14 @@ let
             done
 
             export EXTENSION_DIR=$out/lib/php/extensions
-
+          ''
+          # PKG_CONFIG need not be a relative path
+          + lib.optionalString (! lib.versionAtLeast version "7.4") ''
+            for i in $(find . -type f -name "*.m4"); do
+              substituteInPlace $i \
+                --replace 'test -x "$PKG_CONFIG"' 'type -P "$PKG_CONFIG" >/dev/null'
+            done
+          '' + ''
             ./buildconf --copy --force
 
             if test -f $src/genfiles; then


### PR DESCRIPTION
###### Motivation for this change

They were assuming it is an absolute path, but it (conventionally) can
be something to look up on the PATH too.

Fixes #90202

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
