### PR TITLE
stm32cubemx: 5.3.0 -> 5.6.1

### DIFF
--- a/pkgs/development/tools/misc/stm32cubemx/default.nix
+++ b/pkgs/development/tools/misc/stm32cubemx/default.nix
@@ -1,7 +1,7 @@
 { stdenv, requireFile, makeDesktopItem, libicns, imagemagick, zstd, jre }:
 
 let
-  version = "5.3.0";
+  version = "5.6.1";
   desktopItem = makeDesktopItem {
     name = "stm32CubeMX";
     exec = "stm32cubemx";
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
       Notice: The setup will quit with an error about /bin/chmod
     '';
-    sha256 = "1r5k5wmsvw1w2nfs3nb4gc6pb3j0x6bqljn9jzc4r8y5bxc34rr8";
+    sha256 = "14m2nanywng1kp7q9ax413ml3zz0x5n33cnp9nd256j0jh0rc080";
   };
 
   nativeBuildInputs = [ libicns imagemagick zstd ];


### PR DESCRIPTION

###### Motivation for this change

Upgrade a package to latest release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
