### PR TITLE
pythonPackages.flake8: 3.7.9 -> 3.8.3

### DIFF
--- a/pkgs/development/python-modules/flake8/default.nix
+++ b/pkgs/development/python-modules/flake8/default.nix
@@ -1,22 +1,23 @@
 { stdenv, buildPythonPackage, fetchPypi, pythonOlder
 , mock, pytest, pytestrunner
-, configparser, enum34, mccabe, pycodestyle, pyflakes, entrypoints, functools32, typing
+, configparser, enum34, mccabe, pycodestyle, pyflakes, functools32, typing, importlib-metadata
 }:
 
 buildPythonPackage rec {
   pname = "flake8";
-  version = "3.7.9";
+  version = "3.8.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb";
+    sha256 = "02527892hh0qjivxaiphzalj7q32qkna1cqaikjs7c03mk5ryjzh";
   };
 
   checkInputs = [ pytest mock pytestrunner ];
-  propagatedBuildInputs = [ entrypoints pyflakes pycodestyle mccabe ]
+  propagatedBuildInputs = [ pyflakes pycodestyle mccabe ]
     ++ stdenv.lib.optionals (pythonOlder "3.2") [ configparser functools32 ]
     ++ stdenv.lib.optionals (pythonOlder "3.4") [ enum34 ]
-    ++ stdenv.lib.optionals (pythonOlder "3.5") [ typing ];
+    ++ stdenv.lib.optionals (pythonOlder "3.5") [ typing ]
+    ++ stdenv.lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   checkPhase = ''
     py.test tests

--- a/pkgs/development/python-modules/pycodestyle/default.nix
+++ b/pkgs/development/python-modules/pycodestyle/default.nix
@@ -5,19 +5,19 @@
 
 buildPythonPackage rec {
   pname = "pycodestyle";
-  version = "2.5.0";
+  version = "2.6.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0v4prb05n21bm8650v0a01k1nyqjdmkrsm3zycfxh2j5k9n962p4";
+    sha256 = "0bhr6ia0hmgx3nhgibc9pmkzhlh1zcqk707i5fbxgs702ll7v2n5";
   };
 
-  # https://github.com/PyCQA/pycodestyle/blob/2.5.0/tox.ini#L14
+  # https://github.com/PyCQA/pycodestyle/blob/2.6.0/tox.ini#L13
   checkPhase = ''
-    python pycodestyle.py --max-doc-length=72 --testsuite testsuite
     python pycodestyle.py --statistics pycodestyle.py
+    python pycodestyle.py --max-doc-length=72 --testsuite testsuite
     python pycodestyle.py --max-doc-length=72 --doctest
-    python setup.py test
+    python -m unittest discover testsuite -vv
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pyflakes/default.nix
+++ b/pkgs/development/python-modules/pyflakes/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "pyflakes";
-  version = "2.1.1";
+  version = "2.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2";
+    sha256 = "1j3zqbiwkyicvww499bblq33x0bjpzdrxajhaysr7sk7x5gdgcim";
   };
 
   checkInputs = [ unittest2 ];


### PR DESCRIPTION
Also updated deps that didn't much flake8 requirements

###### Motivation for this change

https://gitlab.com/pycqa/flake8/-/blob/master/docs/source/release-notes/3.8.3.rst

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
