### PR TITLE
solargraph: 0.38.6 -> 0.39.8

### DIFF
--- a/pkgs/development/ruby-modules/solargraph/Gemfile.lock
+++ b/pkgs/development/ruby-modules/solargraph/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.0)
+    ast (2.4.1)
     backport (1.1.2)
     benchmark (0.1.0)
     e2mmap (0.1.0)
@@ -11,22 +11,26 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     parallel (1.19.1)
-    parser (2.7.0.5)
+    parser (2.7.1.3)
       ast (~> 2.4.0)
     rainbow (3.0.0)
-    reverse_markdown (1.4.0)
+    regexp_parser (1.7.1)
+    reverse_markdown (2.0.0)
       nokogiri
     rexml (3.2.4)
-    rubocop (0.80.1)
-      jaro_winkler (~> 1.5.1)
+    rubocop (0.85.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
       rexml
+      rubocop-ast (>= 0.0.3)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.0.3)
+      parser (>= 2.7.0.1)
     ruby-progressbar (1.10.1)
-    solargraph (0.38.6)
+    solargraph (0.39.8)
       backport (~> 1.1)
       benchmark
       bundler (>= 1.17.2)
@@ -35,15 +39,15 @@ GEM
       maruku (~> 0.7, >= 0.7.3)
       nokogiri (~> 1.9, >= 1.9.1)
       parser (~> 2.3)
-      reverse_markdown (~> 1.0, >= 1.0.5)
+      reverse_markdown (>= 1.0.5, < 3)
       rubocop (~> 0.52)
       thor (~> 1.0)
       tilt (~> 2.0)
-      yard (~> 0.9)
+      yard (~> 0.9, >= 0.9.24)
     thor (1.0.1)
     tilt (2.0.10)
-    unicode-display_width (1.6.1)
-    yard (0.9.24)
+    unicode-display_width (1.7.0)
+    yard (0.9.25)
 
 PLATFORMS
   ruby

--- a/pkgs/development/ruby-modules/solargraph/gemset.nix
+++ b/pkgs/development/ruby-modules/solargraph/gemset.nix
@@ -1,14 +1,13 @@
 {
   ast = {
-    dependencies = [];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "184ssy3w93nkajlz2c70ifm79jp3j737294kbc5fjw69v1w0n9x7";
+      sha256 = "1l3468czzjmxl93ap40hp7z94yxp4nbag0bxqs789bm30md90m2a";
       type = "gem";
     };
-    version = "2.4.0";
+    version = "2.4.1";
   };
   backport = {
     dependencies = [];
@@ -104,10 +103,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0iirjc36irgwpfb58jdf9gli382cj893y9caqhxas8anpzzlikgc";
+      sha256 = "162122h7vkg9crc9gsjwpy6bjrwg9r8ghhimwk952i5rrln3kird";
       type = "gem";
     };
-    version = "2.7.0.5";
+    version = "2.7.1.3";
   };
   rainbow = {
     dependencies = [];
@@ -120,16 +119,26 @@
     };
     version = "3.0.0";
   };
+  regexp_parser = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "106azpr2c280y2f8jnr6fd49q1abb43xh9hhgbxc4d4kvzpa8094";
+      type = "gem";
+    };
+    version = "1.7.1";
+  };
   reverse_markdown = {
     dependencies = ["nokogiri"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0w786j869fjhjf72waj0hc9i4ghi45b78a2am27kij4sa2hmsc53";
+      sha256 = "0w6fv779542vdliq2kmikfhymjv55z8mgzblkfjdy2agl07da9c6";
       type = "gem";
     };
-    version = "1.4.0";
+    version = "2.0.0";
   };
   rexml = {
     dependencies = [];
@@ -143,15 +152,26 @@
     version = "3.2.4";
   };
   rubocop = {
-    dependencies = ["jaro_winkler" "parallel" "parser" "rainbow" "rexml" "ruby-progressbar" "unicode-display_width"];
+    dependencies = ["parallel" "parser" "rainbow" "regexp_parser" "rexml" "rubocop-ast" "ruby-progressbar" "unicode-display_width"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1i8pw7p4dk11xpahs0j6vlvqlv3rgapaccj933g0i34hbx392lj8";
+      sha256 = "1ghvlbaxcvwqqpkikzdg125frf5i733lhnih79ghrvc4rykvi86h";
       type = "gem";
     };
-    version = "0.80.1";
+    version = "0.85.1";
+  };
+  rubocop-ast = {
+    dependencies = ["parser"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lbs9is1y85cmd6p3yq3v0nppq4rhpy8ynk2ln0y4rwrlb5088dh";
+      type = "gem";
+    };
+    version = "0.0.3";
   };
   ruby-progressbar = {
     dependencies = [];
@@ -170,10 +190,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "06kcqm032sq1y4pgg7cl32hv74573b1vsy79x81zglar80ybgzv4";
+      sha256 = "140zs7syf6l641p6459rg1byc2h9z2ldhmc0hbzmkgqp4lw18n7c";
       type = "gem";
     };
-    version = "0.38.6";
+    version = "0.39.8";
   };
   thor = {
     dependencies = [];
@@ -198,25 +218,23 @@
     version = "2.0.10";
   };
   unicode-display_width = {
-    dependencies = [];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1pppclzq4qb26g321553nm9xqca3zgllvpwb2kqxsdadwj51s09x";
+      sha256 = "06i3id27s60141x6fdnjn5rar1cywdwy64ilc59cz937303q3mna";
       type = "gem";
     };
-    version = "1.6.1";
+    version = "1.7.0";
   };
   yard = {
-    dependencies = [];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1g0bw2qcl48fxawrdf68l229508z53mrqisavji2lkxzv4w4j2pp";
+      sha256 = "126m49mvh4lbvlvrprq7xj2vjixbq3xqr8dwr089vadvs0rkn4rd";
       type = "gem";
     };
-    version = "0.9.24";
+    version = "0.9.25";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

To be able to use the latest version

##### [Changelogs](https://github.com/castwide/solargraph/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
