### PR TITLE
[20.03] opencv3, opencv4: use openblasCompat

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13655,6 +13655,7 @@ in
 
   opencv3 = callPackage ../development/libraries/opencv/3.x.nix {
     inherit (darwin.apple_sdk.frameworks) AVFoundation Cocoa VideoDecodeAcceleration;
+    openblas = openblasCompat;
   };
 
   opencv3WithoutCuda = opencv3.override {
@@ -13663,6 +13664,7 @@ in
 
   opencv4 = callPackage ../development/libraries/opencv/4.x.nix {
     inherit (darwin.apple_sdk.frameworks) AVFoundation Cocoa VideoDecodeAcceleration;
+    openblas = openblasCompat;
   };
 
   openexr = callPackage ../development/libraries/openexr { };


### PR DESCRIPTION
###### Motivation for this change
Without `master`'s fix in #83888, `opencv3` and `opencv4` end up with an 8-byte `openblas`, which it does work with. However this causes the python bindings to also end up with an 8-byte `openblas`, which `numpy` doesn't work with. Force 4-byte `openblas` for `opencv`.

This is quite a big rebuild (for me, given my current setup), so I've only checked some key reverse dependencies (`facedetect` `digikam` `gmic` `gimpPlugins.gmic` `python37Packages.vidstab` `gmic-qt`) on linux x86_64 and macos 10.14.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
