### PR TITLE
rmlint: fix running rmlint --gui

### DIFF
--- a/pkgs/tools/misc/rmlint/default.nix
+++ b/pkgs/tools/misc/rmlint/default.nix
@@ -1,6 +1,22 @@
-{ stdenv, fetchFromGitHub
-, gettext, pkgconfig, scons
-, glib, json-glib, libelf, sphinx, utillinux }:
+{ stdenv
+, cairo
+, fetchFromGitHub
+, gettext
+, glib
+, gobject-introspection
+, gtksourceview3
+, json-glib
+, libelf
+, makeWrapper
+, pango
+, pkgconfig
+, polkit
+, python3
+, scons
+, sphinx
+, utillinux
+, wrapGAppsHook
+, withGui ? false }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -17,14 +33,39 @@ stdenv.mkDerivation rec {
   CFLAGS="-I${stdenv.lib.getDev utillinux}/include";
 
   nativeBuildInputs = [
-    pkgconfig sphinx gettext scons
+    pkgconfig
+    sphinx
+    gettext
+    scons
+  ] ++ stdenv.lib.optionals withGui [
+    makeWrapper
+    wrapGAppsHook
   ];
 
   buildInputs = [
-    glib json-glib libelf utillinux
+    glib
+    json-glib
+    libelf
+    utillinux
+  ] ++ stdenv.lib.optionals withGui [
+    cairo
+    gobject-introspection
+    gtksourceview3
+    pango
+    polkit
+    python3
+    python3.pkgs.pygobject3
   ];
 
-  prefixKey = "--prefix=";
+  # this doesn't seem to support configureFlags, and appends $out afterwards,
+  # so add the --without-gui in front of it
+  prefixKey = stdenv.lib.optionalString (!withGui) " --without-gui " + "--prefix=";
+
+  # in GUI mode, this shells out to itself, and tries to import python modules
+  postInstall = stdenv.lib.optionalString withGui ''
+    gappsWrapperArgs+=(--prefix PATH : "$out/bin")
+    gappsWrapperArgs+=(--prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${python3.pkgs.pygobject3}):$(toPythonPath ${python3.pkgs.pycairo})")
+  '';
 
   meta = {
     description = "Extremely fast tool to remove duplicates and other lint from your filesystem";


### PR DESCRIPTION
rmlint has a `--gui` option which is writing a python "bootstrap" script
in `/tmp`.

It currently can't find its own python modules, as we don't prefix
`PYTHONPATH` to point to it. Also, there's some other runtime
dependencies, mostly due to using gtk from python(3), which also needs
to be preprended to `PYTHONPATH`.

`rmlint` also executes itself again with `--version` to determine some
features, for which we need to prefix `PATH` with `$out/bin`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @k0ral 