### PR TITLE
haskell: Make haskellPackages.callPackage overridable

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1450,6 +1450,10 @@ self: super: {
   # binary-instances needs the latest version.
   time-compat = self.time-compat_1_9_4;
 
+  optparse-generic_1_4_4 = super.optparse-generic_1_4_4.override {
+    optparse-applicative = self.optparse-applicative_0_16_0_0;
+  };
+
   # INSERT NEW OVERRIDES ABOVE THIS LINE
 } // (let
   inherit (self) hls-ghcide hls-brittany;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1442,6 +1442,9 @@ self: super: {
 
   autoapply = super.autoapply.override { th-desugar = self.th-desugar_1_11; };
 
+  # binary-instances needs the latest version.
+  time-compat = self.time-compat_1_9_4;
+
   # INSERT NEW OVERRIDES ABOVE THIS LINE
 } // (let
   inherit (self) hls-ghcide hls-brittany;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1471,6 +1471,10 @@ self: super: {
     optparse-applicative = self.optparse-applicative_0_16_0_0;
   };
 
+  # Our quickcheck-instances is too old for the newer binary-instances, but
+  # quickcheck-instances is only used in the tests of binary-instances.
+  binary-instances = dontCheck super.binary-instances;
+
   # INSERT NEW OVERRIDES ABOVE THIS LINE
 } // (let
   inherit (self) hls-ghcide hls-brittany;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -85,6 +85,11 @@ self: super: {
     url = "https://github.com/hercules-ci/optparse-applicative/compare/0.15.1...hercules-ci:0.15.1-nixpkgs-compgen.diff";
     sha256 = "1bcp6b7gvc8pqbn1n1ybhizkkl5if7hk9ipgl746vk08v0d3xxql";
   });
+  optparse-applicative_0_16_0_0 = appendPatch super.optparse-applicative_0_16_0_0 (pkgs.fetchpatch {
+    name = "optparse-applicative-0.15.1-hercules-ci-compgen.diff";
+    url = "https://github.com/hercules-ci/optparse-applicative/compare/0.15.1...hercules-ci:0.15.1-nixpkgs-compgen.diff";
+    sha256 = "1bcp6b7gvc8pqbn1n1ybhizkkl5if7hk9ipgl746vk08v0d3xxql";
+  });
 
   # Fix test trying to access /home directory
   shell-conduit = overrideCabal super.shell-conduit (drv: {

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -69,7 +69,6 @@ self: super: {
   integer-logarithms = doJailbreak super.integer-logarithms;
   lucid = doJailbreak super.lucid;
   parallel = doJailbreak super.parallel;
-  quickcheck-instances = doJailbreak super.quickcheck-instances;
   setlocale = doJailbreak super.setlocale;
   split = doJailbreak super.split;
   system-fileio = doJailbreak super.system-fileio;

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -232,6 +232,31 @@ rec {
     fixupPhase = ":";
   });
 
+  /* Create a documentation tarball suitable for uploading to Hackage instead
+     of building the package.
+   */
+  documentationTarball = pkg:
+    pkgs.lib.overrideDerivation pkg (drv: {
+      name = "${drv.name}-docs";
+      # Like sdistTarball, disable the "doc" output here.
+      outputs = [ "out" ];
+      buildPhase = ''
+        runHook preHaddock
+        ./Setup haddock --for-hackage
+        runHook postHaddock
+      '';
+      haddockPhase = ":";
+      checkPhase = ":";
+      installPhase = ''
+        runHook preInstall
+        mkdir -p "$out"
+        tar --format=ustar \
+          -czf "$out/${drv.name}-docs.tar.gz" \
+          -C dist/doc/html "${drv.name}-docs"
+        runHook postInstall
+      '';
+    });
+
   /* Use the gold linker. It is a linker for ELF that is designed
      "to run as fast as possible on modern systems"
    */

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -156,6 +156,9 @@ rec {
   addBuildDepend = drv: x: addBuildDepends drv [x];
   addBuildDepends = drv: xs: overrideCabal drv (drv: { buildDepends = (drv.buildDepends or []) ++ xs; });
 
+  addTestToolDepend = drv: x: addTestToolDepends drv [x];
+  addTestToolDepends = drv: xs: overrideCabal drv (drv: { testToolDepends = (drv.testToolDepends or []) ++ xs; });
+
   addPkgconfigDepend = drv: x: addPkgconfigDepends drv [x];
   addPkgconfigDepends = drv: xs: overrideCabal drv (drv: { pkgconfigDepends = (drv.pkgconfigDepends or []) ++ xs; });
 

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -86,11 +86,11 @@ rec {
      future.
 
      Instead of jailbreaking, you can patch the cabal file.
-     
+
      Note that jailbreaking at this time, doesn't lift bounds on
-     conditional branches. 
+     conditional branches.
      https://github.com/peti/jailbreak-cabal/issues/7 has further details.
-     
+
    */
   doJailbreak = drv: overrideCabal drv (drv: { jailbreak = true; });
 

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -169,7 +169,7 @@ let
       };
     });
 
-in package-set { inherit pkgs stdenv callPackage; } self // {
+in package-set { inherit pkgs stdenv; inherit (self) callPackage; } self // {
 
     inherit mkDerivation callPackage haskellSrc2nix hackage2nix buildHaskellPackages;
 
@@ -248,7 +248,7 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
     ghcWithHoogle = selectFrom:
       let
         packages = selectFrom self;
-        hoogle = callPackage ./hoogle.nix {
+        hoogle = self.callPackage ./hoogle.nix {
           inherit packages;
         };
       in withPackages (packages ++ [ hoogle ]);

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -23,6 +23,7 @@ with pkgs;
   stdenv-inputs = callPackage ./stdenv-inputs { };
 
   haskell-shellFor = callPackage ./haskell-shellFor { };
+  haskell-documentationTarball = callPackage ./haskell-documentationTarball { };
 
   cc-multilib-gcc = callPackage ./cc-wrapper/multilib.nix { stdenv = gccMultiStdenv; };
   cc-multilib-clang = callPackage ./cc-wrapper/multilib.nix { stdenv = clangMultiStdenv; };

--- a/pkgs/test/haskell-documentationTarball/default.nix
+++ b/pkgs/test/haskell-documentationTarball/default.nix
@@ -1,0 +1,17 @@
+{ pkgs, haskellPackages }:
+
+let
+  drv = haskellPackages.vector;
+  docs = pkgs.haskell.lib.documentationTarball drv;
+
+in pkgs.runCommand "test haskell.lib.documentationTarball" { } ''
+  tar xvzf "${docs}/${drv.name}-docs.tar.gz"
+
+  # Check for Haddock html
+  find "${drv.name}-docs" | grep -q "Data-Vector.html"
+
+  # Check for source html
+  find "${drv.name}-docs" | grep -q  "src/Data.Vector.html"
+
+  touch "$out"
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6180,6 +6180,8 @@ in
 
   update-dotdee = with python3Packages; toPythonApplication update-dotdee;
 
+  update-nix-fetchgit = haskell.lib.justStaticExecutables haskellPackages.update-nix-fetchgit;
+
   update-resolv-conf = callPackage ../tools/networking/openvpn/update-resolv-conf.nix { };
 
   update-systemd-resolved = callPackage ../tools/networking/openvpn/update-systemd-resolved.nix { };


### PR DESCRIPTION
#### Motivation for this change

Currently [nh2/static-haskell-nix](https://github.com/nh2/static-haskell-nix) overrides every executable package to add the required options for static compilation. This works, but it would be much nicer to just override `callPackage` to add these options, so that users can just use `callPackage`, `callCabal2nix` and `developPackage` from the resulting package set and have them work as expected (i.e. generate statically linked executables).

Previously `self.callPackage` was used in some places and `callPackage` in others. This patch makes it so that `self.callPackage` is used consistently, so we can override `callPackage` and have the overriden version be used everywhere.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).