### PR TITLE
nix-universal-prefetch: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/tools/package-management/nix-universal-prefetch/default.nix
+++ b/pkgs/tools/package-management/nix-universal-prefetch/default.nix
@@ -6,13 +6,13 @@
 # No gems used, so mkDerivation is fine.
 stdenv.mkDerivation rec {
   pname = "nix-universal-prefetch";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "samueldr";
     repo = "nix-universal-prefetch";
     rev = "v${version}";
-    sha256 = "1id9iaibrm2d3fa9dkcxnb3sd0j1vh502181gdd199a1cfsmzh1i";
+    sha256 = "1nmxp6846ip2x3mibys3ymgi0813g18p9szqnsciiib3dbis4kwf";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

The `fetchFromGithub` alias broke the tool. The update fixes it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
