### PR TITLE
wireshark: compile with QT_NO_DEBUG to avoid depending on qt*-dev

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -30,6 +30,9 @@ in stdenv.mkDerivation {
     "-DCMAKE_INSTALL_LIBDIR=lib"
   ];
 
+  # Avoid referencing -dev paths because of debug assertions.
+  NIX_CFLAGS_COMPILE = [ "-DQT_NO_DEBUG" ];
+
   nativeBuildInputs = [
     bison cmake flex pkgconfig
   ] ++ optional withQt qt5.wrapQtAppsHook;


### PR DESCRIPTION
###### Motivation for this change

Before:
```
$ nix path-info -Sh /nix/store/arcw7029w14lrv9l8mpqib3sncza3nah-wireshark-qt-3.2.4
/nix/store/arcw7029w14lrv9l8mpqib3sncza3nah-wireshark-qt-3.2.4	   1.1G
```

After:
```
$ nix path-info -Sh /nix/store/c86nls44m73rcz5lq3jf4l2hr5sj9l10-wireshark-qt-3.2.4
/nix/store/c86nls44m73rcz5lq3jf4l2hr5sj9l10-wireshark-qt-3.2.4	 463.1M
```

Note that qt5's mkDerivation does the same thing automatically. However, wireshark is built as both a Qt and a non-Qt package in nixpkgs right now (wireshark-cli) and I couldn't find an easy way to refactor and use libsForQt5.callPackage. So instead I just cherry-picked the QT_NO_DEBUG part.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
