### PR TITLE
EFI improvements for qemu-vm.nix

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -210,6 +210,10 @@ let
           mkdir /boot
           mount /dev/vda2 /boot
 
+          ${optionalString config.boot.loader.efi.canTouchEfiVariables ''
+            mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+          ''}
+
           # This is needed for GRUB 0.97, which doesn't know about virtio devices.
           mkdir /boot/grub
           echo '(hd0) /dev/vda' > /boot/grub/device.map

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -323,7 +323,7 @@ in
   systemd = handleTest ./systemd.nix {};
   systemd-analyze = handleTest ./systemd-analyze.nix {};
   systemd-binfmt = handleTestOn ["x86_64-linux"] ./systemd-binfmt.nix {};
-  systemd-boot = handleTestOn ["x86_64-linux"] ./systemd-boot.nix {};
+  systemd-boot = handleTest ./systemd-boot.nix {};
   systemd-confinement = handleTest ./systemd-confinement.nix {};
   systemd-timesyncd = handleTest ./systemd-timesyncd.nix {};
   systemd-networkd-vrf = handleTest ./systemd-networkd-vrf.nix {};

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -38,13 +38,17 @@ edk2.mkDerivation projectDscPath {
 
   postFixup = if stdenv.isAarch64 then ''
     mkdir -vp $fd/FV
+    mkdir -vp $fd/AAVMF
     mv -v $out/FV/QEMU_{EFI,VARS}.fd $fd/FV
 
     # Use Debian dir layout: https://salsa.debian.org/qemu-team/edk2/blob/debian/debian/rules
-    # Note that Fedora dir layout is different: https://src.fedoraproject.org/cgit/rpms/edk2.git/tree/edk2.spec
     dd of=$fd/FV/AAVMF_CODE.fd  if=/dev/zero bs=1M    count=64
     dd of=$fd/FV/AAVMF_CODE.fd  if=$fd/FV/QEMU_EFI.fd conv=notrunc
     dd of=$fd/FV/AAVMF_VARS.fd  if=/dev/zero bs=1M    count=64
+
+    # Also add symlinks for Fedora dir layout: https://src.fedoraproject.org/cgit/rpms/edk2.git/tree/edk2.spec
+    ln -s $fd/FV/AAVMF_CODE.fd $fd/AAVMF/QEMU_EFI-pflash.raw
+    ln -s $fd/FV/AAVMF_VARS.fd $fd/AAVMF/vars-template-pflash.raw
   '' else ''
     mkdir -vp $fd/FV
     mv -v $out/FV/OVMF{,_CODE,_VARS}.fd $fd/FV

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -38,14 +38,13 @@ edk2.mkDerivation projectDscPath {
 
   postFixup = if stdenv.isAarch64 then ''
     mkdir -vp $fd/FV
-    mkdir -vp $fd/AAVMF
     mv -v $out/FV/QEMU_{EFI,VARS}.fd $fd/FV
 
-    # Uses Fedora dir layout: https://src.fedoraproject.org/cgit/rpms/edk2.git/tree/edk2.spec
-    # FIXME: why is it different from Debian dir layout? https://salsa.debian.org/qemu-team/edk2/blob/debian/debian/rules
-    dd of=$fd/AAVMF/QEMU_EFI-pflash.raw       if=/dev/zero bs=1M    count=64
-    dd of=$fd/AAVMF/QEMU_EFI-pflash.raw       if=$fd/FV/QEMU_EFI.fd conv=notrunc
-    dd of=$fd/AAVMF/vars-template-pflash.raw if=/dev/zero bs=1M    count=64
+    # Use Debian dir layout: https://salsa.debian.org/qemu-team/edk2/blob/debian/debian/rules
+    # Note that Fedora dir layout is different: https://src.fedoraproject.org/cgit/rpms/edk2.git/tree/edk2.spec
+    dd of=$fd/FV/AAVMF_CODE.fd  if=/dev/zero bs=1M    count=64
+    dd of=$fd/FV/AAVMF_CODE.fd  if=$fd/FV/QEMU_EFI.fd conv=notrunc
+    dd of=$fd/FV/AAVMF_VARS.fd  if=/dev/zero bs=1M    count=64
   '' else ''
     mkdir -vp $fd/FV
     mv -v $out/FV/OVMF{,_CODE,_VARS}.fd $fd/FV


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The most user-visible change is that this adds support for `nixos-rebuild build-vm-with-bootloader` on `aarch64-linux`.

Take a look at these commits in order so they make more sense. They were unfortunately not  independently separable into multiple PRs, as the later commits depend on the earlier ones.

These changes also help set the foundation for testing secure boot with systemd-boot properly: https://github.com/NixOS/nixpkgs/pull/53901#issuecomment-612722455

I've done the following to test, both on `x86_64-linux` and `aarch64-linux`:
```console
$ nix-build ./nixos/tests/systemd-boot.nix
```
as well as:
```console
$ nix-build ./nixos -A vmWithBootLoader -I nixos-config=./test.nix
$ ./result/bin/run-nixos-vm -nographic -serial stdio -monitor none
```
where `test.nix` is:
```nix
{
  boot.loader.systemd-boot.enable = true;
  boot.loader.efi.canTouchEfiVariables = true;
  virtualisation.useEFIBoot = true;
}
```

CC @samueldr @lheckemann @flokli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
