### PR TITLE
fast-downward: 2019-05-13 -> 19.12, build on darwin, fix runtime issues

### DIFF
--- a/pkgs/applications/science/logic/fast-downward/default.nix
+++ b/pkgs/applications/science/logic/fast-downward/default.nix
@@ -1,12 +1,13 @@
 { stdenv, lib, fetchhg, cmake, which, python3, osi, cplex }:
 
 stdenv.mkDerivation {
-  name = "fast-downward-2019-05-13";
+  version = "19.12";
+  pname = "fast-downward";
 
   src = fetchhg {
     url = "http://hg.fast-downward.org/";
-    rev = "090f5df5d84a";
-    sha256 = "14pcjz0jfzx5269axg66iq8js7lm2w3cnqrrhhwmz833prjp945g";
+    rev = "41688a4f16b3";
+    sha256 = "08m4k1mkx4sz7c2ab7xh7ip6b67zxv7kl68xrvwa83xw1yigqkna";
   };
 
   nativeBuildInputs = [ cmake which ];
@@ -17,19 +18,22 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  configurePhase = ''
+    python build.py release
+  '';
+
   postPatch = ''
-    cd src
     # Needed because the package tries to be too smart.
     export CC="$(which $CC)"
     export CXX="$(which $CXX)"
   '';
 
   installPhase = ''
-    install -Dm755 bin/downward $out/libexec/fast-downward/downward
-    cp -r ../translate $out/libexec/fast-downward/
-    install -Dm755 ../../fast-downward.py $out/bin/fast-downward
+    install -Dm755 builds/release/bin/downward $out/libexec/fast-downward/downward
+    cp -r builds/release/bin/translate $out/libexec/fast-downward/
+    install -Dm755 fast-downward.py $out/bin/fast-downward
     mkdir -p $out/${python3.sitePackages}
-    cp -r ../../driver $out/${python3.sitePackages}
+    cp -r driver $out/${python3.sitePackages}
 
     wrapPythonProgramsIn $out/bin "$out $pythonPath"
     wrapPythonProgramsIn $out/libexec/fast-downward/translate "$out $pythonPath"
@@ -43,6 +47,9 @@ stdenv.mkDerivation {
       echo "Moving $i to $dest"
       mv "$i" "$dest"
     done
+
+    substituteInPlace $out/${python3.sitePackages}/driver/arguments.py \
+      --replace 'args.build = "release"' "args.build = \"$out/libexec/fast-downward\""
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/logic/fast-downward/default.nix
+++ b/pkgs/applications/science/logic/fast-downward/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
     description = "A domain-independent planning system";
     homepage = "http://www.fast-downward.org/";
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = with platforms; (linux ++ darwin);
     maintainers = with maintainers; [ abbradar ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This package also builds happily on Darwin.

Update:
- Fixed issue where `fast-downward` program in existing derivation failed on both platforms due to not finding the release directory. Freezing the libexec subdir as the default release dir in `arguments.py` resolves this.
- Updated to latest stable release
- Use upstream's standard "build.py" configuration mechanism instead of working around it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
