### PR TITLE
steam: switch to correct runtime tarball

### DIFF
--- a/pkgs/games/steam/runtime.nix
+++ b/pkgs/games/steam/runtime.nix
@@ -1,4 +1,4 @@
-{ stdenv, steamArch, fetchurl, }:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
 
@@ -6,20 +6,15 @@ stdenv.mkDerivation rec {
   # from https://repo.steampowered.com/steamrt-images-scout/snapshots/
   version = "0.20200417.0";
 
-  src =
-    if steamArch == "amd64" then fetchurl {
-      url = "https://repo.steampowered.com/steamrt-images-scout/snapshots/${version}/com.valvesoftware.SteamRuntime.Platform-amd64,i386-scout-runtime.tar.gz";
-      sha256 = "0kps8i5v23sycqm69xz389n8k831jd7ncsmlrkky7nib2q91rbvj";
-      name = "scout-runtime-${version}.tar.gz";
-    } else fetchurl {
-      url = "https://repo.steampowered.com/steamrt-images-scout/snapshots/${version}/com.valvesoftware.SteamRuntime.Platform-i386-scout-runtime.tar.gz";
-      sha256 = "03fhac1r25xf7ia2pd35wjw360v5pa9h4870yrhhygp9h7v4klzf";
-      name = "scout-runtime-i386-${version}.tar.gz";
-    };
+  src = fetchurl {
+    url = "https://repo.steampowered.com/steamrt-images-scout/snapshots/${version}/steam-runtime.tar.xz";
+    sha256 = "0d4dfl6i31i8187wj8rr9yvmrg32bx96bsgs2ya21b00czf070sy";
+    name = "scout-runtime-${version}.tar.gz";
+  };
 
   buildCommand = ''
     mkdir -p $out
-    tar -C $out -x --strip=1 -f $src files/
+    tar -C $out --strip=1 -x -f $src
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
In my previous PR (#87243) I used the wrong upstream artifact for
the runtime. After reading the documentation in the
ValveSoftware/steam-runtime repo, I now know that the steam-runtime
tarball is what I actually wanted.

I also used 'diff' to compare the various artifacts with the old runtime
this package used before, and the steam-runtime one is certainly the
closest.

Most importantly, switching to the right steam-runtime package
reportedly fixes issues for other users (fixes #90229).

This also entirely removes the amd64/i386 split from runtime.nix because
the upstream package bundles both together, and if that's how upstream
wants to distribute this, it seems best to follow their lead.

###### Motivation for this change

Fixes an issue reported in #90229

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @hrdinka since you helped with the last PR. Apologies for my mistake here :sweat_smile: 