### PR TITLE
mono: don't propagate a dependency to glib-dev (15% closure size saving)

### DIFF
--- a/pkgs/development/compilers/mono/generic.nix
+++ b/pkgs/development/compilers/mono/generic.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
     ]
     ++ (stdenv.lib.optionals stdenv.isDarwin [ Foundation libobjc ]);
 
-  propagatedBuildInputs = [glib];
-
   configureFlags = [
     "--x-includes=${libX11.dev}/include"
     "--x-libraries=${libX11.out}/lib"

--- a/pkgs/development/libraries/gio-sharp/default.nix
+++ b/pkgs/development/libraries/gio-sharp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, which, pkgconfig, mono, gtk-sharp-2_0 }:
+{ stdenv, fetchFromGitHub, autoconf, automake, which, pkgconfig, mono, glib, gtk-sharp-2_0 }:
 
 stdenv.mkDerivation rec {
   pname = "gio-sharp";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig autoconf automake which ];
-  buildInputs = [ mono gtk-sharp-2_0 ];
+  buildInputs = [ mono glib gtk-sharp-2_0 ];
 
   dontStrip = true;
 

--- a/pkgs/development/python-modules/pythonnet/default.nix
+++ b/pkgs/development/python-modules/pythonnet/default.nix
@@ -9,6 +9,7 @@
 , pkgconfig
 , dotnetbuildhelpers
 , clang
+, glib
 , mono
 }:
 
@@ -63,6 +64,7 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [
+    glib
     mono
     psutil # needed for memory leak tests
   ];

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -4,6 +4,7 @@
 , fetchurl
 , fetchFromGitHub
 , fetchNuGet
+, glib
 , pkgconfig
 , mono
 , fsharp
@@ -544,6 +545,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
 
     buildInputs = [
       fsharp
+      glib
       dotnetPackages.FSharpCompilerService
       dotnetPackages.NewtonsoftJson
       dotnetPackages.NDeskOptions


### PR DESCRIPTION
###### Motivation for this change

This was added in 2005 back in 51ce4ea2. This was not commented or
explained anywhere, and it does not seem to be necessary anymore
according to some quick testing I did.

Reduces mono closure size by ~80M.

Before: `/nix/store/4i8r0k2lq5602v1yqcr83vl9shamxnah-mono-5.20.1.27	 516.8M`  
After: `/nix/store/pckw8yafi1hpgs0djxak04zjq7fcww9l-mono-5.20.1.27	 436.6M`

Testing done: ran `pinta` and `keepass`. Both still seem to work as expected. Also did a round of `nixpkgs-review` and didn't notice any new regressions, but it's hard to tell since half of the stuff that depends on mono is broken...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
