### PR TITLE
snapcast: v0.15.0 -> v0.20.0

### DIFF
--- a/pkgs/applications/audio/snapcast/default.nix
+++ b/pkgs/applications/audio/snapcast/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkgconfig
-, alsaLib, asio, avahi, flac, libogg, libvorbis }:
+, alsaLib, asio, avahi, boost170, flac, libogg, libvorbis, soxr }:
 
 let
 
@@ -33,21 +33,21 @@ in
 
 stdenv.mkDerivation rec {
   pname = "snapcast";
-  version = "0.15.0";
+  version = "0.20.0";
 
   src = fetchFromGitHub {
     owner  = "badaix";
     repo   = "snapcast";
     rev    = "v${version}";
-    sha256 = "11rnpy6w3wm240qgmkp74k5w8wh5b7hzfx05qrnh6l7ng7m25ky2";
+    sha256 = "152ic8hlyawcmj9pykb33xc6yx7il6yb9ilmsy6m9nlh40m8yxls";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkgconfig boost170.dev ];
   # snapcast also supports building against tremor but as we have libogg, that's
   # not needed
   buildInputs = [
     alsaLib asio avahi flac libogg libvorbis
-    aixlog popl
+    aixlog popl soxr
   ];
 
   # Upstream systemd unit files are pretty awful, so we provide our own in a


### PR DESCRIPTION
###### Motivation for this change

New upstream releases. Want to move to opus for streaming.

Did a quick testrun against an existing deployment and playback worked fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@fpletz 