### PR TITLE
dqlite: 1.4.1 -> 1.4.4, raft-canonical: 0.9.18 -> 0.9.23

### DIFF
--- a/pkgs/development/libraries/dqlite/default.nix
+++ b/pkgs/development/libraries/dqlite/default.nix
@@ -5,13 +5,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "dqlite";
-  version = "1.4.1";
+  version = "1.4.4";
 
   src = fetchFromGitHub {
     owner = "canonical";
     repo = pname;
     rev = "v${version}";
-    sha256 = "04h3wbfv6bkzzmcwaja33x2qkj3czn0p6fgbdgqd1xli8sx2c2k4";
+    sha256 = "0wm7vkapjg8hdjm6bi48hwsf4w4ppgn3r655gqms5ssjxm50m15d";
   };
 
   nativeBuildInputs = [ autoreconfHook file pkgconfig ];
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     sqlite-replication
   ];
 
-  # tests hang for ever on x86_64-linux
+  # tests fail
   doCheck = false;
 
   outputs = [ "dev" "out" ];

--- a/pkgs/development/libraries/raft-canonical/default.nix
+++ b/pkgs/development/libraries/raft-canonical/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "raft-canonical";
-  version = "0.9.18";
+  version = "0.9.23";
 
   src = fetchFromGitHub {
     owner = "canonical";
     repo = "raft";
     rev = "v${version}";
-    sha256 = "0f613aiyxqskz9d10f7r37ar9ngqsf9qsyk3jjf7s5l14wh6vl5k";
+    sha256 = "0swn95cf11fqczllmxr0nj3ig532rw4n3w6g3ckdnqka8520xjyr";
   };
 
   nativeBuildInputs = [ autoreconfHook file pkgconfig ];
@@ -18,13 +18,7 @@ stdenv.mkDerivation rec {
     substituteInPlace configure --replace /usr/bin/ " "
   '';
 
-  # test fails
-  #
-  #append/finalizeSegment                                      [ ERROR ]
-  #Error: test/integration/test_uv_append.c:264: assertion failed: test_dir_has_file(f->dir, "0000000000000001-0000000000000004") is not true
-  #Error: child killed by signal 6 (Aborted)
-
-  doCheck = false;
+  doCheck = true;
 
   outputs = [ "dev" "out" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
