### PR TITLE
apmplanner2: 2.0.27-rc1 -> 2.0.28-rc1

### DIFF
--- a/pkgs/applications/science/robotics/apmplanner2/default.nix
+++ b/pkgs/applications/science/robotics/apmplanner2/default.nix
@@ -5,22 +5,14 @@
 
 mkDerivation rec {
   pname = "apmplanner2";
-  version = "2.0.27-rc1";
+  version = "2.0.28-rc1";
 
   src = fetchFromGitHub {
     owner = "ArduPilot";
     repo = "apm_planner";
     rev = version;
-    sha256 = "1k0786mjzi49nb6yw4chh9l4dmkf9gybpxg9zqkr5yg019nyzcvd";
+    sha256 = "18yn8bdz5hmgb0m5hlk8bibz4cj4g25w75pm1rvc4ds0mr1qgyjd";
   };
-
-  patches = [
-    # can be dropped after 2.0.27-rc1
-    (fetchpatch {
-      url = "https://github.com/ArduPilot/apm_planner/commit/299ff23b5e9910de04edfc06b6893bb06b47a57b.patch";
-      sha256 = "16rc81iwqp2i46g6bm9lbvcjfsk83999r9h8w1pz0mys7rsilvqy";
-    })
-  ];
 
   buildInputs = [
     alsaLib libsndfile flite openssl udev SDL2
@@ -35,7 +27,7 @@ mkDerivation rec {
   preFixup = ''
     ln --relative --symbolic $out/share/APMPlanner2/* $out/bin/
     substituteInPlace $out/share/applications/apmplanner2.desktop \
-                      --replace /usr $out
+      --replace /usr $out
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
