### PR TITLE
wiimms-iso-tools: init at 3.02a

### DIFF
--- a/pkgs/tools/filesystems/wiimms-iso-tools/default.nix
+++ b/pkgs/tools/filesystems/wiimms-iso-tools/default.nix
@@ -1,0 +1,37 @@
+{stdenv, fetchurl, zlib, ncurses, fuse}:
+
+stdenv.mkDerivation rec {
+  name = "wiimms-iso-tools";
+  version = "3.02a";
+
+  src = fetchurl {
+    url = "https://download.wiimm.de/source/wiimms-iso-tools/wiimms-iso-tools.source-${version}.tar.bz2";
+    sha256 = "074cvcaqz23xyihslc6n64wwxwcnl6xp7l0750yb9pc0wrqxmj69";
+  };
+
+  buildInputs = [ zlib ncurses fuse ];
+
+  patches = [ ./fix-paths.diff ];
+  postPatch = ''
+    patchShebangs setup.sh
+    patchShebangs gen-template.sh
+    patchShebangs gen-text-file.sh
+  '';
+
+  NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
+  INSTALL_PATH = "$out";
+
+  installPhase = ''
+    mkdir "$out"
+    patchShebangs install.sh
+    ./install.sh --no-sudo
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://wit.wiimm.de";
+    description = "A set of command line tools to manipulate Wii and GameCube ISO images and WBFS containers";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ nilp0inter ];
+  };
+}

--- a/pkgs/tools/filesystems/wiimms-iso-tools/fix-paths.diff
+++ b/pkgs/tools/filesystems/wiimms-iso-tools/fix-paths.diff
@@ -1,0 +1,12 @@
+diff -r -u wiimms-iso-tools.source-3.02a.patched/setup.sh wiimms-iso-tools.source-3.02a/setup.sh
+--- wiimms-iso-tools.source-3.02a.patched/setup.sh	2020-06-02 23:48:18.651495869 +0200
++++ wiimms-iso-tools.source-3.02a/setup.sh	2020-06-02 23:48:29.758162513 +0200
+@@ -57,7 +57,7 @@
+ 
+ #--------------------------------------------------
+ 
+-INSTALL_PATH=/usr/local
++ INSTALL_PATH="$out"
+ 
+ if [[ -d $INSTALL_PATH/bin ]]
+ then

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1083,6 +1083,8 @@ in
 
   wiiload = callPackage ../development/tools/wiiload { };
 
+  wiimms-iso-tools = callPackage ../tools/filesystems/wiimms-iso-tools { };
+
   xcodeenv = callPackage ../development/mobile/xcodeenv { };
 
   ssh-agents = callPackage ../tools/networking/ssh-agents { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I'd like to use WIT to manage my Wii and GameCube backups from my NixOS box.

###### Things done
Packaged using `mkDerivation`. I had to patch the sources because is not using standard autotools configure and is trying to install to hard-coded paths.

I tested it under Linux only but it should build well under MacOs given that the author have binaries available for that platform in their website.

Please note that although the version seems to be marked as *alpha*, it is the latest stable version that has been available for more than a year.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
