### PR TITLE
systemd: 245.5 -> 245.6

### DIFF
--- a/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
+++ b/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
@@ -1,4 +1,4 @@
-From b873e4c0de3e24f2ec9370e5a217247217e90587 Mon Sep 17 00:00:00 2001
+From 22f46f55c81d84e83a4614856d84e63c8400165c Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Tue, 8 Jan 2013 15:46:30 +0100
 Subject: [PATCH 01/18] Start device units for uninitialised encrypted devices

--- a/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
+++ b/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
@@ -1,4 +1,4 @@
-From bdd3ff777dd8253ff5732118dd6de0fa9a9b95fe Mon Sep 17 00:00:00 2001
+From e5b2b1e90d055068936336f6f01639bcde251b96 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Fri, 12 Apr 2013 13:16:57 +0200
 Subject: [PATCH 02/18] Don't try to unmount /nix or /nix/store
@@ -7,18 +7,18 @@ They'll still be remounted read-only.
 
 https://github.com/NixOS/nixos/issues/126
 ---
- src/core/mount.c      | 2 ++
- src/shutdown/umount.c | 2 ++
+ src/shared/fstab-util.c | 2 ++
+ src/shutdown/umount.c   | 2 ++
  2 files changed, 4 insertions(+)
 
-diff --git a/src/core/mount.c b/src/core/mount.c
-index 1c4aefd734..a5553226f8 100644
---- a/src/core/mount.c
-+++ b/src/core/mount.c
-@@ -412,6 +412,8 @@ static bool mount_is_extrinsic(Mount *m) {
- 
-         if (PATH_IN_SET(m->where,  /* Don't bother with the OS data itself */
-                         "/",       /* (strictly speaking redundant: should already be covered by the perpetual flag check above) */
+diff --git a/src/shared/fstab-util.c b/src/shared/fstab-util.c
+index b19127be09..f9adca1100 100644
+--- a/src/shared/fstab-util.c
++++ b/src/shared/fstab-util.c
+@@ -40,6 +40,8 @@ bool fstab_is_extrinsic(const char *mount, const char *opts) {
+         /* Don't bother with the OS data itself */
+         if (PATH_IN_SET(mount,
+                         "/",
 +                        "/nix",
 +                        "/nix/store",
                          "/usr",

--- a/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
+++ b/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
@@ -1,4 +1,4 @@
-From c28b3b2e254433e93549ee6fe8c93b43ce455776 Mon Sep 17 00:00:00 2001
+From ca7f6286c518d7ef3877458bbdf8e01f5518ab0e Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Wed, 16 Apr 2014 10:59:28 +0200
 Subject: [PATCH 03/18] Fix NixOS containers
@@ -10,10 +10,10 @@ container, so checking early whether it exists will fail.
  1 file changed, 2 insertions(+)
 
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 734dee1130..a97b1a4bc9 100644
+index 51d0c2a75b..4d3451ff3b 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -5018,6 +5018,7 @@ static int run(int argc, char *argv[]) {
+@@ -5017,6 +5017,7 @@ static int run(int argc, char *argv[]) {
                                  goto finish;
                          }
                  } else {
@@ -21,7 +21,7 @@ index 734dee1130..a97b1a4bc9 100644
                          const char *p, *q;
  
                          if (arg_pivot_root_new)
-@@ -5032,6 +5033,7 @@ static int run(int argc, char *argv[]) {
+@@ -5031,6 +5032,7 @@ static int run(int argc, char *argv[]) {
                                  r = -EINVAL;
                                  goto finish;
                          }

--- a/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
+++ b/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
@@ -1,4 +1,4 @@
-From baf52609ad18785aa1d2cd043185ae9438d59411 Mon Sep 17 00:00:00 2001
+From c87cc5b1cf9c37f195e6b362352279e14289554e Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Thu, 1 May 2014 14:10:10 +0200
 Subject: [PATCH 04/18] Look for fsck in the right place

--- a/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
+++ b/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
@@ -1,4 +1,4 @@
-From 45f80155b7c2edb1e73c233283f1ab1582e1cfbe Mon Sep 17 00:00:00 2001
+From 450c133c1815b473136b2a5540f9213fef5506ee Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Fri, 19 Dec 2014 14:46:17 +0100
 Subject: [PATCH 05/18] Add some NixOS-specific unit directories

--- a/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
+++ b/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
@@ -1,4 +1,4 @@
-From d52058070c0c12bb05f82460f0b4b55678b724e9 Mon Sep 17 00:00:00 2001
+From f88a9bb1e6080b539ed0116caa9781e7f6755f54 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Mon, 11 May 2015 15:39:38 +0200
 Subject: [PATCH 06/18] Get rid of a useless message in user sessions
@@ -13,7 +13,7 @@ in containers.
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/src/core/unit.c b/src/core/unit.c
-index 97e1b0004c..d3cc2ba9ec 100644
+index c306183555..3db39fa435 100644
 --- a/src/core/unit.c
 +++ b/src/core/unit.c
 @@ -2043,7 +2043,8 @@ static void unit_check_binds_to(Unit *u) {

--- a/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
+++ b/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
@@ -1,4 +1,4 @@
-From 409fc808794942ad1736c2cc74853d9792e4ad02 Mon Sep 17 00:00:00 2001
+From e2b25ce3606d05ff8a387185c41ab32fb2a36161 Mon Sep 17 00:00:00 2001
 From: Gabriel Ebner <gebner@gebner.org>
 Date: Sun, 6 Dec 2015 14:26:36 +0100
 Subject: [PATCH 07/18] hostnamed, localed, timedated: disable methods that

--- a/pkgs/os-specific/linux/systemd/0008-Fix-hwdb-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0008-Fix-hwdb-paths.patch
@@ -1,4 +1,4 @@
-From b56fc7b6ae8014eb2f71924c89498f395a1a81bd Mon Sep 17 00:00:00 2001
+From 5a6aad633a7ceffd62b009ce0c4ab6673129f7ff Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 7 Jul 2016 02:47:13 +0300
 Subject: [PATCH 08/18] Fix hwdb paths

--- a/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
+++ b/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
@@ -1,4 +1,4 @@
-From 4d304a321796db4de827aa39a149bea23d039214 Mon Sep 17 00:00:00 2001
+From b509dbd302a7933ae0002f44b99aac6a1fd5775b Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Tue, 11 Oct 2016 13:12:08 +0300
 Subject: [PATCH 09/18] Change /usr/share/zoneinfo to /etc/zoneinfo
@@ -79,7 +79,7 @@ index 901fbf0815..b57bdd8fbe 100644
          (void) mkdir_parents(etc_localtime, 0755);
          if (symlink(e, etc_localtime) < 0)
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index a97b1a4bc9..aed60439e3 100644
+index 4d3451ff3b..1adb91335c 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
 @@ -1657,8 +1657,8 @@ static int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t u

--- a/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
+++ b/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
@@ -1,4 +1,4 @@
-From cb3f1ec1793cbf74c4b5663e038bd49ff4576192 Mon Sep 17 00:00:00 2001
+From b5665ef8b9266c662c3a137df1ef1721cdff346e Mon Sep 17 00:00:00 2001
 From: Imuli <i@imu.li>
 Date: Wed, 19 Oct 2016 08:46:47 -0400
 Subject: [PATCH 10/18] localectl: use /etc/X11/xkb for list-x11-*

--- a/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
+++ b/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
@@ -1,4 +1,4 @@
-From 0ffb786d0e12a61899af448b1e4dd32a53ea5a8e Mon Sep 17 00:00:00 2001
+From be6b5c37779302384079b22b7fd767daad878fa9 Mon Sep 17 00:00:00 2001
 From: Franz Pletz <fpletz@fnordicwalking.de>
 Date: Sun, 11 Feb 2018 04:37:44 +0100
 Subject: [PATCH 11/18] build: don't create statedir and don't touch prefixdir
@@ -8,10 +8,10 @@ Subject: [PATCH 11/18] build: don't create statedir and don't touch prefixdir
  1 file changed, 3 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index fc216d22da..078db3bb5d 100644
+index c09115e06a..62eba4186c 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -3176,9 +3176,6 @@ install_data('LICENSE.GPL2',
+@@ -3184,9 +3184,6 @@ install_data('LICENSE.GPL2',
               'src/libsystemd/sd-bus/GVARIANT-SERIALIZATION',
               install_dir : docdir)
  

--- a/pkgs/os-specific/linux/systemd/0012-Install-default-configuration-into-out-share-factory.patch
+++ b/pkgs/os-specific/linux/systemd/0012-Install-default-configuration-into-out-share-factory.patch
@@ -1,4 +1,4 @@
-From 3dbcdab1ba22c4eeca6d61718c09bcb9b5551764 Mon Sep 17 00:00:00 2001
+From 9262f52b0e30cf8c39d9f7684a8c0e8fd4887cd5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
 Date: Mon, 26 Feb 2018 14:25:57 +0000
 Subject: [PATCH 12/18] Install default configuration into $out/share/factory
@@ -44,7 +44,7 @@ index 4df6dabf89..02d8d69095 100644
          meson.add_install_script('sh', '-c',
                                   'test -n "$DESTDIR" || @0@/systemd-hwdb update'
 diff --git a/meson.build b/meson.build
-index 078db3bb5d..6e1a6483fc 100644
+index 62eba4186c..b0b2edbb5a 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -154,6 +154,9 @@ udevhwdbdir = join_paths(udevlibexecdir, 'hwdb.d')
@@ -57,7 +57,7 @@ index 078db3bb5d..6e1a6483fc 100644
  bootlibdir = join_paths(prefixdir, 'lib/systemd/boot/efi')
  testsdir = join_paths(prefixdir, 'lib/systemd/tests')
  systemdstatedir = join_paths(localstatedir, 'lib/systemd')
-@@ -2503,7 +2506,7 @@ if conf.get('ENABLE_BINFMT') == 1
+@@ -2511,7 +2514,7 @@ if conf.get('ENABLE_BINFMT') == 1
          meson.add_install_script('sh', '-c',
                                   mkdir_p.format(binfmtdir))
          meson.add_install_script('sh', '-c',
@@ -66,7 +66,7 @@ index 078db3bb5d..6e1a6483fc 100644
  endif
  
  if conf.get('ENABLE_REPART') == 1
-@@ -2604,7 +2607,7 @@ executable('systemd-sleep',
+@@ -2612,7 +2615,7 @@ executable('systemd-sleep',
             install_dir : rootlibexecdir)
  
  install_data('src/sleep/sleep.conf',
@@ -75,7 +75,7 @@ index 078db3bb5d..6e1a6483fc 100644
  
  exe = executable('systemd-sysctl',
                   'src/sysctl/sysctl.c',
-@@ -2916,7 +2919,7 @@ if conf.get('HAVE_KMOD') == 1
+@@ -2924,7 +2927,7 @@ if conf.get('HAVE_KMOD') == 1
          meson.add_install_script('sh', '-c',
                                   mkdir_p.format(modulesloaddir))
          meson.add_install_script('sh', '-c',
@@ -84,7 +84,7 @@ index 078db3bb5d..6e1a6483fc 100644
  endif
  
  exe = executable('systemd-nspawn',
-@@ -3159,7 +3162,7 @@ install_subdir('factory/etc',
+@@ -3167,7 +3170,7 @@ install_subdir('factory/etc',
                 install_dir : factorydir)
  
  install_data('xorg/50-systemd-user.sh',

--- a/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
+++ b/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
@@ -1,4 +1,4 @@
-From 0b0510aa72cf8026f34f300efa3f150f45971404 Mon Sep 17 00:00:00 2001
+From 05c2761f6a981c8576fc47a3dd8beb5a2af3ef09 Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Fri, 2 Nov 2018 21:15:42 +0100
 Subject: [PATCH 13/18] inherit systemd environment when calling generators.
@@ -16,10 +16,10 @@ executables that are being called from managers.
  1 file changed, 8 insertions(+), 3 deletions(-)
 
 diff --git a/src/core/manager.c b/src/core/manager.c
-index 25afdbea04..7afd5e5a37 100644
+index 4412e7a849..b799eeca95 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
-@@ -3896,9 +3896,14 @@ static int manager_run_generators(Manager *m) {
+@@ -3901,9 +3901,14 @@ static int manager_run_generators(Manager *m) {
          argv[4] = NULL;
  
          RUN_WITH_UMASK(0022)

--- a/pkgs/os-specific/linux/systemd/0014-add-rootprefix-to-lookup-dir-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0014-add-rootprefix-to-lookup-dir-paths.patch
@@ -1,4 +1,4 @@
-From 4bd20cf0450455e2f9831b09ba91811ba3d58961 Mon Sep 17 00:00:00 2001
+From c70029539d0aec5df0c1e4203359335a3841a1e5 Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Thu, 9 May 2019 11:15:22 +0200
 Subject: [PATCH 14/18] add rootprefix to lookup dir paths

--- a/pkgs/os-specific/linux/systemd/0015-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
+++ b/pkgs/os-specific/linux/systemd/0015-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
@@ -1,4 +1,4 @@
-From f23a1e00de028048a2a21d322493039cce7ee214 Mon Sep 17 00:00:00 2001
+From 98580b4aa34f3d2e7401f54d6561c5af27ea3437 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 25 Jul 2019 20:45:55 +0300
 Subject: [PATCH 15/18] systemd-shutdown: execute scripts in
@@ -10,10 +10,10 @@ This is needed for NixOS to use such scripts as systemd directory is immutable.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/shutdown/shutdown.c b/src/shutdown/shutdown.c
-index 15e6c1799e..412bdefe74 100644
+index 523040b57c..561d91c94c 100644
 --- a/src/shutdown/shutdown.c
 +++ b/src/shutdown/shutdown.c
-@@ -298,7 +298,7 @@ int main(int argc, char *argv[]) {
+@@ -299,7 +299,7 @@ int main(int argc, char *argv[]) {
          _cleanup_free_ char *cgroup = NULL;
          char *arguments[3], *watchdog_device;
          int cmd, r, umount_log_level = LOG_INFO;

--- a/pkgs/os-specific/linux/systemd/0016-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
+++ b/pkgs/os-specific/linux/systemd/0016-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
@@ -1,4 +1,4 @@
-From 758b8211e6e76524d62a2e0ffcf37dcf55e3be87 Mon Sep 17 00:00:00 2001
+From 3821e20966ee20f74986041f33c4934ad20385b2 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 25 Jul 2019 20:46:58 +0300
 Subject: [PATCH 16/18] systemd-sleep: execute scripts in

--- a/pkgs/os-specific/linux/systemd/0017-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
+++ b/pkgs/os-specific/linux/systemd/0017-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
@@ -1,4 +1,4 @@
-From ce9fe2249c91fdfb224eaffce63e3dbdb4a5c25d Mon Sep 17 00:00:00 2001
+From b07defe819e0f66d08563690b3a5abea5da08620 Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sat, 7 Mar 2020 22:40:27 +0100
 Subject: [PATCH 17/18] kmod-static-nodes.service: Update ConditionFileNotEmpty

--- a/pkgs/os-specific/linux/systemd/0018-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
+++ b/pkgs/os-specific/linux/systemd/0018-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
@@ -1,4 +1,4 @@
-From 55b69fc1b5441e3aff8f1ab684ba8eed3718a32d Mon Sep 17 00:00:00 2001
+From 9c1ac48a7d95c09bef5a924bb5db6908596403b4 Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sun, 8 Mar 2020 01:05:54 +0100
 Subject: [PATCH 18/18] path-util.h: add placeholder for DEFAULT_PATH_NORMAL

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -31,7 +31,7 @@ let gnupg-minimal = gnupg.override {
   bzip2 = null;
 };
 in stdenv.mkDerivation {
-  version = "245.5";
+  version = "245.6";
   pname = "systemd";
 
   # When updating, use https://github.com/systemd/systemd-stable tree, not the development one!
@@ -39,8 +39,8 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "systemd";
     repo = "systemd-stable";
-    rev = "9a506b7e9291d997a920af9ac299e7b834368119";
-    sha256 = "19qd92hjlsljr6x5mbw1l2vdzz5y9hy7y7g0dwgpfifb0lwkxqbr";
+    rev = "aa0cb635f1f6a4d9b50ed2cca7782f3f751be933";
+    sha256 = "191f0r1g946bsqxky00z78wygsxi9pld11y2q4374bshnpsff2ll";
   };
 
   patches = [


### PR DESCRIPTION
This bumps systemd to their latest minor release.

 - aa0cb635f1 (tag: v245.6) network: L2TP fix crash
 - 9774347b57 Fix typo.
 - 2cac801f0f stat-util: trivial empty_or_null() tweaks
 - b054e69bf9 Check ambient set against bounding set prior to applying ambient set
 - bed695375a udev: when the BSD lock on a block device is taken, don't complain
 - 66fcfdfde7 core: add forgotten return in error path
 - 05dd19fad3 shared/efi-loader: remove check that uses absolute tick value
 - 753a71ad1d gpt: include homed GPT partition type in well-known partition table
 - 3668722049 units: don't set PrivateNetwork= in systemd-homed.service
 - 2bca2d77d3 resolved-dns-query: remove dns_query_candidate_is_routable
 - a3f6020432 sd-network: fix inverted error message
 - a7a9fe3c93 network: allow empty assignment to PreferredLifetime=
 - 8df6fc1241 Update resolvectl zsh completion
 - c1a83277d0 shared: treat generator units as vendor units
 - 1f382d818d tree-wide: fix bad errno checks
 - 667c207683 bus-message: immediately reject messages with invalid type
 - 116a8eadb6 bus-message: fix negative offset with ~empty message
 - 4d5779d886 load-fragment: fix a typo
 - c8b6de003a NEWS: retroactively document Family=
 - cf6b8e6ec5 man: fix dir name in sysctl.d(5)
 - 6d009b7a25 journalctl,elsewhere: make sure --file=foo fails with sane error msg if foo is not readable
 - cf786ef164 makefs: log about OOM condition
 - 0b1839822f blockdev: propagate one more unexpected error
 - d78ce949d0 repart: don't insist on coming up on partition label ourselves
 - 9e1363fcc6 journal: fix dropping first record during upload to remote journal
 - 50cb4e418d meson: initialize time-epoch to reproducible builds compatible value
 - 76abe079b7 limit-util: quieten a very common debug message that is misleading
 - b3e484a3b1 shared: fix integer overflow in calendarspec
 - 0c29eea969 repart: suppress complaints about lack of BLKRRPART when operating on regular file
 - 3db52f5ed8 repart: explain when we exit early and don't do a thing
 - d99cba3aaa mount: introduce mount_is_nofail() helper
 - 7bc4bcea15 mount: default startup dependencies and default network ones are orthogonal
 - 7fe617fa53 mount: introduce mount_add_default_ordering_dependencies()
 - e1c091b6d4 automount: fix handling of default dependencies for automount units
 - ae05a137c9 mount: let pid1 alone handle the default dependencies for mount units
 - f1fb197176 mount: mount unit activated by automount unit should be only ordered against the automount unit
 - c9bcc69703 generator: don't generate device dependencies for extrinsic mounts
 - ebac09ea0a fstab-util: introduce fstab_is_extrinsic()
 - a20e4ea0ed device: drop refuse_after
 - 2799fffac1 man: drop some left-over mentions of StandardOutput=syslog
 - 144aff9c3b sd-netlink: remove unused RTNL_WQUEUE_MAX define
 - 34ca8df8e1 test: Add return 0 to main() function (even it is not strictly necessary)
 - 6e03f328a9 network: 'cur' variable cannot be null, so simplify code
 - 8d0c97f6ca tree-wide: Initialize _cleanup_ variables if needed
 - 4f174e49ae netlink: Fix assert condition on n_containers
 - 3905ce532c journald: Increase stdout buffer size sooner, when almost full
 - 5a37eb7c61 core: don't bind varlink socket if running in test mode
 - 33fff72ce6 pam_systemd: also print debug lines when ending a session
 - ba9af79ccb pam_systemd_home: use correct macro for converting ptr to fd
 - 6199235489 Fix misuse of PAM_PROMPT_ECHO_OFF in systemd-homed
 - c180a2c452 shared/ethtool-util: hush gcc warnings about array bounds
 - 1addba4aac core: fix compilation with gcc -O3
 - 9c46b97161 random-util: use ERRNO_IS_NOT_SUPPORTED() macro
 - d85f9093d2 tmpfiles: clarify that "!" lines are filtered before collisions are checked
 - 2fac966a5c man: mention the exclamation mark and minus sign literally, to make things searchable
 - 4f61be3373 man: clarify that exit status name mappings are unaffected by SuccessExitStatus=
 - b747d74a41 seccomp-util: add new syscalls from kernel 5.6 to syscall filter table
 - c30d8caf8b tree-wide: Replace assert() by assert_se() when there is side effect
 - b6e8e3be7e networkctl: use uint64_t for link speed throughout
 - be66ce6089 tree-wide: use CMSG_SPACE() (and not CMSG_LEN()) to allocate control buffers
 - 1cb197798a man: suffix pam options with "=" where arg is required too
 - a5fe01d3da test: Use assert_se() where variables are only checked by assert
 - 6960efd198 tree-wide: Fix, replace assert() by assert_se() when there is side effect
 - 93c1b03074 tree-wide: Mark as _unused_ variables that are only used in assert()
 - c7679d7a9f tree-wide: Workaround -Wnonnull GCC bug
 - 073b257fd7 man: bring example PAM snippet of pam_systemd and pam_systemd_home back in sync
 - 855291a81c man: highlight relevant lines in pam_systemd_home.so example PAM snippet
 - f89ad7c0fd login: include pam_systemd_home.so in the default PAM snippet we ship for user@.service
 - 9357f9466f test: Skip test-boot-timestamps on permission denied
 - cad4ebe14e sysusers: be extra careful when locking accounts
 - 551e6f233a shared/install: print name of offending file in error
 - c6a2e51232 systemctl: fix --root support in querying presets
 - 6f1eedbfdd systemctl: fix hint when 'systemctl help' is given
 - 925521df7c shared/unit-file: fix resolution of absoulute symlinks with --root
 - 756ba362e8 man: mention that ProtectSystem= also takes care of /efi
 - 4f77cf43b5 man: systemd.service: systemd-analyze exit-codes -> exit-status
 - 7c6ea7a053 man: expand on the star…end/repetition time expressions
 - e06b940792 calendarspec: be more graceful with two kinds of calendar expressions
 - f3dd0b476d calendarspec: minor simplification
 - 3581c16d56 shutdown: fix spacing in shutdown error message
 - 9556255349 nspawn: mount custom paths before writing to /etc
 - 37447b7e78 repart: fix partition maximum size segfault
 - 7f231ba503 link: Add units and fix typo in (Rx|Tx)BufferSize= manpage. Clean up the implementation slightly
 - e75d2cdb0b main: bump RLIMIT_MEMLOCK by physical RAM size
 - e16b9a1e31 nspawn: be more careful with creating/chowning directories to overmount
 - 765d184a69 homectl: say "home area" in more places
 - c11bff4fa7 userdbctl: make --help fit in 80 columns
 - 0e56c2ef3f shell-completion/zsh: update systemd-analyze completions
 - 2bb580f994 zsh: fix disable/enable completion
 - 607a19a309 cgroup-util: check for SYSFS_MAGIC when detecting cgroup format
 - ddb3c38efc stat-util: no need to open a file to check fs type
 - bd8842304c sysusers,tmpfiles: always mention error when failing to replace specifiers
 - bdea9b65d2 sysusers: add accidentally forgotten 'return'
 - 17b059774d man: document binfmt's new --unregister switch
 - 560380d8ec binfmt: also unregister binfmt entries from unit
 - 80835d9c51 binfmt: modernize code a bit
 - a1745741b8 shutdown: unregister all binfmt_misc entries before entering shutdown loop
 - b637445950 shared: add common helper for unregistering all binfmt entries
 - 0215625e99 home: fix strv NUL termination
 - 038988baa1 networkd: don't do lldp rx nor tx on bond devices
 - 9512d576d9 sd-bus: Fix typo in sd_bus_message_append_array docs
 - 63cef71dd0 shared: add NULL callback check in one more place
 - 6b91ca22a2 core: fix unused variable warning when !HAVE_SECCOMP
 - f7c1c79c57 udev: prepare memory for extra NUL termination for NULSTR
 - 69e0ef0d99 tree-wide: use recvmsg_safe() at various places
 - cd0a84d4e9 socket-util: add recvmsg_safe() wrapper that handles MSG_CTRUNC
 - 2bb48c704b sd-bus: work around ubsan warning
 - c147bba1fb shared: Don't try calling NULL callback in bus_wait_for_units_clear
 - f907491463 run: don't wait for start job to complete when running interactively anyway
 - d3d1550a5d man: Fix typo "multiplied with" -> "multiplied by"
 - ae5a9f27c5 core: make sure we don't get confused when setting TERM for a tty fd
 - a07d3eaf76 man: document that VirtualEthernetExtra= has nothing to do with Bridge=
 - 35fe81078e core: add debug log when a job in the activation queue is not runnable
 - a0cd882be8 core: add log_get_max_level check optimization in log_unit_full
 - 2a6ad1093c util: return the correct correct wd from inotify helpers
 - 9ec244c5c1 core: minor error code handling fixes
 - a799283c91 man: document how to get the boot menu with zero time-out
 - 7263e86c8d resolved: return org.freedesktop.resolve1.DnsError.NXDOMAIN on LLMNR resolution failure
 - 6eab4c2b3e man: use manpages.ubuntu.com for resolvconf(8) link
 - 75ccec5cde man: add a note that resolvconf updates /etc/resolv.conf in specific circumstances
 - 3e3a31743a resolvectl: fix indentation of hexdump'ed packets
 - 6576058fab journald: add configuration option for enabling/disabling audit during journald startup
 - 52c5909f15 man/systemd-service: clarify env variable expansion
 - ac08df59c0 resolved: fix typo in an unused function and add comment

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
