### PR TITLE
php: replace substituteInPlace to patch

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -211,14 +211,7 @@ let
             done
 
             export EXTENSION_DIR=$out/lib/php/extensions
-          ''
-          # PKG_CONFIG need not be a relative path
-          + lib.optionalString (! lib.versionAtLeast version "7.4") ''
-            for i in $(find . -type f -name "*.m4"); do
-              substituteInPlace $i \
-                --replace 'test -x "$PKG_CONFIG"' 'type -P "$PKG_CONFIG" >/dev/null'
-            done
-          '' + ''
+
             ./buildconf --copy --force
 
             if test -f $src/genfiles; then
@@ -271,16 +264,24 @@ let
     version = "7.2.31";
     sha256 = "0057x1s43f9jidmrl8daka6wpxclxc1b1pm5cjbz616p8nbmb9qv";
 
-    # https://bugs.php.net/bug.php?id=76826
-    extraPatches = lib.optional stdenv.isDarwin ./php72-darwin-isfinite.patch;
+    extraPatches = [
+      # PKG_CONFIG need not be a relative path
+      ./fix-paths-pkgconfig-php72.patch
+    ]
+      # https://bugs.php.net/bug.php?id=76826
+      ++ lib.optional stdenv.isDarwin ./php72-darwin-isfinite.patch;
   });
 
   php73base = callPackage generic (_args // {
     version = "7.3.19";
     sha256 = "199l1lr7ima92icic7b1bqlb036md78m305lc3v6zd4zw8qix70d";
 
-    # https://bugs.php.net/bug.php?id=76826
-    extraPatches = lib.optional stdenv.isDarwin ./php73-darwin-isfinite.patch;
+    extraPatches = [
+      # PKG_CONFIG need not be a relative path
+      ./fix-paths-pkgconfig-php73.patch
+    ]
+      # https://bugs.php.net/bug.php?id=76826
+      ++ lib.optional stdenv.isDarwin ./php73-darwin-isfinite.patch;
   });
 
   php74base = callPackage generic (_args // {

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -200,16 +200,7 @@ let
           hardeningDisable = [ "bindnow" ];
 
           preConfigure =
-          # Don't record the configure flags since this causes unnecessary
-          # runtime dependencies
           ''
-            for i in main/build-defs.h.in scripts/php-config.in; do
-              substituteInPlace $i \
-                --replace '@CONFIGURE_COMMAND@' '(omitted)' \
-                --replace '@CONFIGURE_OPTIONS@' "" \
-                --replace '@PHP_LDFLAGS@' ""
-            done
-
             export EXTENSION_DIR=$out/lib/php/extensions
 
             ./buildconf --copy --force
@@ -265,6 +256,8 @@ let
     sha256 = "0057x1s43f9jidmrl8daka6wpxclxc1b1pm5cjbz616p8nbmb9qv";
 
     extraPatches = [
+      # Don't record the configure flags since this causes unnecessary runtime dependencies
+      ./fix-runtime-deps-php72.patch
       # PKG_CONFIG need not be a relative path
       ./fix-paths-pkgconfig-php72.patch
     ]
@@ -277,6 +270,8 @@ let
     sha256 = "199l1lr7ima92icic7b1bqlb036md78m305lc3v6zd4zw8qix70d";
 
     extraPatches = [
+      # Don't record the configure flags since this causes unnecessary runtime dependencies
+      ./fix-runtime-deps-php73.patch
       # PKG_CONFIG need not be a relative path
       ./fix-paths-pkgconfig-php73.patch
     ]
@@ -287,6 +282,11 @@ let
   php74base = callPackage generic (_args // {
     version = "7.4.7";
     sha256 = "0ynq4fz54jpzh9nxvbgn3vrdad2clbac0989ai0yrj2ryc0hs3l0";
+
+    extraPatches = [
+      # Don't record the configure flags since this causes unnecessary runtime dependencies
+      ./fix-runtime-deps-php74.patch
+    ];
   });
 
   defaultPhpExtensions = { all, ... }: with all; ([

--- a/pkgs/development/interpreters/php/fix-paths-pkgconfig-php72.patch
+++ b/pkgs/development/interpreters/php/fix-paths-pkgconfig-php72.patch
@@ -1,0 +1,118 @@
+diff --git a/acinclude.m4 b/acinclude.m4
+index 0690ec7d..3eb8b7c9 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -2208,7 +2208,7 @@ AC_DEFUN([PHP_SETUP_ICU],[
+   fi
+ 
+   dnl If pkg-config is found try using it
+-  if test "$PHP_ICU_DIR" = "DEFAULT" && test -x "$PKG_CONFIG" && $PKG_CONFIG --exists icu-uc icu-io icu-i18n; then
++  if test "$PHP_ICU_DIR" = "DEFAULT" && type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists icu-uc icu-io icu-i18n; then
+     if $PKG_CONFIG --atleast-version=4.0 icu-uc; then
+       found_icu=yes
+       icu_version_full=`$PKG_CONFIG --modversion icu-uc`
+@@ -2361,7 +2361,7 @@ AC_DEFUN([PHP_SETUP_OPENSSL],[
+   fi
+ 
+   dnl If pkg-config is found try using it
+-  if test "$PHP_OPENSSL_DIR" = "yes" && test -x "$PKG_CONFIG" && $PKG_CONFIG --exists openssl; then
++  if test "$PHP_OPENSSL_DIR" = "yes" && type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists openssl; then
+     if $PKG_CONFIG --atleast-version=1.0.1 openssl; then
+       found_openssl=yes
+       OPENSSL_LIBS=`$PKG_CONFIG --libs openssl`
+@@ -2596,7 +2596,7 @@ AC_DEFUN([PHP_SETUP_LIBXML], [
+     fi
+ 
+     dnl If pkg-config is found try using it
+-    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libxml-2.0; then
++    if type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists libxml-2.0; then
+       if $PKG_CONFIG --atleast-version=2.6.11 libxml-2.0; then
+         found_libxml=yes
+         LIBXML_LIBS=`$PKG_CONFIG --libs libxml-2.0`
+diff --git a/ext/curl/config.m4 b/ext/curl/config.m4
+index 10055837..c13fc413 100644
+--- a/ext/curl/config.m4
++++ b/ext/curl/config.m4
+@@ -10,7 +10,7 @@ if test "$PHP_CURL" != "no"; then
+     AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+   fi
+ 
+-  if test -x "$PKG_CONFIG"; then
++  if type -P "$PKG_CONFIG" >/dev/null; then
+     dnl using pkg-config output
+ 
+     AC_MSG_CHECKING(for libcurl.pc)
+diff --git a/ext/odbc/config.m4 b/ext/odbc/config.m4
+index 21fd94c8..fb77ffe5 100644
+--- a/ext/odbc/config.m4
++++ b/ext/odbc/config.m4
+@@ -395,7 +395,7 @@ PHP_ARG_WITH(iodbc,,
+     if test -z "$PKG_CONFIG"; then
+       AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+     fi
+-    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libiodbc ; then
++    if type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists libiodbc ; then
+       PHP_ADD_LIBRARY_WITH_PATH(iodbc, $PHP_IODBC/$PHP_LIBDIR)
+       ODBC_TYPE=iodbc
+       ODBC_INCLUDE=`$PKG_CONFIG --cflags-only-I libiodbc`
+diff --git a/ext/pdo_pgsql/config.m4 b/ext/pdo_pgsql/config.m4
+index 1b6dd0e1..2c75063d 100644
+--- a/ext/pdo_pgsql/config.m4
++++ b/ext/pdo_pgsql/config.m4
+@@ -74,7 +74,7 @@ if test "$PHP_PDO_PGSQL" != "no"; then
+     AC_MSG_RESULT([yes])
+     dnl First try to find pkg-config
+     AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+-    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists openssl; then
++    if type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists openssl; then
+       PDO_PGSQL_CFLAGS=`$PKG_CONFIG openssl --cflags`
+     fi
+   else
+diff --git a/ext/sodium/config.m4 b/ext/sodium/config.m4
+index 9388fc21..225f7e2f 100644
+--- a/ext/sodium/config.m4
++++ b/ext/sodium/config.m4
+@@ -17,7 +17,7 @@ if test "$PHP_SODIUM" != "no"; then
+     AC_MSG_RESULT([found in $PHP_SODIUM])
+ 
+   dnl pkg-config output
+-  elif test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libsodium; then
++  elif type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists libsodium; then
+     LIBSODIUM_VERSION=`$PKG_CONFIG libsodium --modversion`
+     if $PKG_CONFIG libsodium --atleast-version=1.0.8; then
+       LIBSODIUM_CFLAGS=`$PKG_CONFIG libsodium --cflags`
+diff --git a/ext/zip/config.m4 b/ext/zip/config.m4
+index 58c78538..7f68011d 100644
+--- a/ext/zip/config.m4
++++ b/ext/zip/config.m4
+@@ -62,7 +62,7 @@ if test "$PHP_ZIP" != "no"; then
+       LIBZIP_LIBDIR="$PHP_LIBZIP/$PHP_LIBDIR"
+       AC_MSG_RESULT(from option: found in $PHP_LIBZIP)
+ 
+-    elif test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libzip; then
++    elif type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists libzip; then
+       if $PKG_CONFIG libzip --atleast-version 0.11; then
+         LIBZIP_CFLAGS=`$PKG_CONFIG libzip --cflags`
+         LIBZIP_LIBDIR=`$PKG_CONFIG libzip --variable=libdir`
+diff --git a/sapi/fpm/config.m4 b/sapi/fpm/config.m4
+index 4cf4ba49..864c707d 100644
+--- a/sapi/fpm/config.m4
++++ b/sapi/fpm/config.m4
+@@ -593,7 +593,7 @@ if test "$PHP_FPM" != "no"; then
+     unset SYSTEMD_LIBS
+     unset SYSTEMD_INCS
+ 
+-    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libsystemd; then
++    if type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists libsystemd; then
+       dnl systemd version >= 209 provides libsystemd
+       AC_MSG_CHECKING([for libsystemd])
+       SYSTEMD_LIBS=`$PKG_CONFIG --libs libsystemd`
+@@ -601,7 +601,7 @@ if test "$PHP_FPM" != "no"; then
+       SYSTEMD_VERS=`$PKG_CONFIG --modversion libsystemd`
+       AC_MSG_RESULT([version $SYSTEMD_VERS])
+ 
+-    elif test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libsystemd-daemon; then
++    elif type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists libsystemd-daemon; then
+       dnl systemd version < 209 provides libsystemd-daemon
+       AC_MSG_CHECKING([for libsystemd-daemon])
+       SYSTEMD_LIBS=`$PKG_CONFIG --libs libsystemd-daemon`

--- a/pkgs/development/interpreters/php/fix-paths-pkgconfig-php73.patch
+++ b/pkgs/development/interpreters/php/fix-paths-pkgconfig-php73.patch
@@ -1,0 +1,131 @@
+diff --git a/acinclude.m4 b/acinclude.m4
+index bf4c88d3..0c350bc9 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -2180,7 +2180,7 @@ AC_DEFUN([PHP_SETUP_ICU],[
+   fi
+ 
+   dnl If pkg-config is found try using it
+-  if test "$PHP_ICU_DIR" = "DEFAULT" && test -x "$PKG_CONFIG" && $PKG_CONFIG --exists icu-uc icu-io icu-i18n; then
++  if test "$PHP_ICU_DIR" = "DEFAULT" && type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists icu-uc icu-io icu-i18n; then
+     if $PKG_CONFIG --atleast-version=4.0 icu-uc; then
+       found_icu=yes
+       icu_version_full=`$PKG_CONFIG --modversion icu-uc`
+@@ -2339,7 +2339,7 @@ AC_DEFUN([PHP_SETUP_OPENSSL],[
+   fi
+ 
+   dnl If pkg-config is found try using it
+-  if test "$PHP_OPENSSL_DIR" = "yes" && test -x "$PKG_CONFIG" && $PKG_CONFIG --exists openssl; then
++  if test "$PHP_OPENSSL_DIR" = "yes" && type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists openssl; then
+     if $PKG_CONFIG --atleast-version=1.0.1 openssl; then
+       found_openssl=yes
+       OPENSSL_LIBS=`$PKG_CONFIG --libs openssl`
+@@ -2574,7 +2574,7 @@ AC_DEFUN([PHP_SETUP_LIBXML], [
+     fi
+ 
+     dnl If pkg-config is found try using it
+-    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libxml-2.0; then
++    if type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists libxml-2.0; then
+       if $PKG_CONFIG --atleast-version=2.6.11 libxml-2.0; then
+         found_libxml=yes
+         LIBXML_LIBS=`$PKG_CONFIG --libs libxml-2.0`
+diff --git a/ext/curl/config.m4 b/ext/curl/config.m4
+index 7d36458a..137e9f08 100644
+--- a/ext/curl/config.m4
++++ b/ext/curl/config.m4
+@@ -8,7 +8,7 @@ if test "$PHP_CURL" != "no"; then
+     AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+   fi
+ 
+-  if test -x "$PKG_CONFIG"; then
++  if type -P "$PKG_CONFIG" >/dev/null; then
+     dnl using pkg-config output
+ 
+     AC_MSG_CHECKING(for libcurl.pc)
+diff --git a/ext/odbc/config.m4 b/ext/odbc/config.m4
+index 5d5456e3..94d6e9c6 100644
+--- a/ext/odbc/config.m4
++++ b/ext/odbc/config.m4
+@@ -321,7 +321,7 @@ PHP_ARG_WITH(iodbc,,
+     if test -z "$PKG_CONFIG"; then
+       AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+     fi
+-    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libiodbc ; then
++    if type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists libiodbc ; then
+       PHP_ADD_LIBRARY_WITH_PATH(iodbc, $PHP_IODBC/$PHP_LIBDIR)
+       ODBC_TYPE=iodbc
+       ODBC_INCLUDE=`$PKG_CONFIG --cflags-only-I libiodbc`
+diff --git a/ext/pcre/config0.m4 b/ext/pcre/config0.m4
+index 3b043aec..a7d80d81 100644
+--- a/ext/pcre/config0.m4
++++ b/ext/pcre/config0.m4
+@@ -15,7 +15,7 @@ PHP_ARG_WITH(pcre-jit,,[  --with-pcre-jit         Enable PCRE JIT functionality
+       if test -z "$PKG_CONFIG"; then
+         AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+       fi
+-      if test -x "$PKG_CONFIG"; then
++      if type -P "$PKG_CONFIG" >/dev/null; then
+         AC_MSG_CHECKING(for PCRE2 10.30 or greater)
+         if $PKG_CONFIG --atleast-version 10.30 libpcre2-8; then
+           PCRE2_VER=`$PKG_CONFIG --modversion libpcre2-8`
+diff --git a/ext/pdo_pgsql/config.m4 b/ext/pdo_pgsql/config.m4
+index ca6320ef..fb82e1e4 100644
+--- a/ext/pdo_pgsql/config.m4
++++ b/ext/pdo_pgsql/config.m4
+@@ -73,7 +73,7 @@ if test "$PHP_PDO_PGSQL" != "no"; then
+     AC_MSG_RESULT([yes])
+     dnl First try to find pkg-config
+     AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+-    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists openssl; then
++    if type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists openssl; then
+       PDO_PGSQL_CFLAGS=`$PKG_CONFIG openssl --cflags`
+     fi
+   else
+diff --git a/ext/sodium/config.m4 b/ext/sodium/config.m4
+index d9061c53..d44f6a4b 100644
+--- a/ext/sodium/config.m4
++++ b/ext/sodium/config.m4
+@@ -16,7 +16,7 @@ if test "$PHP_SODIUM" != "no"; then
+     AC_MSG_RESULT([found in $PHP_SODIUM])
+ 
+   dnl pkg-config output
+-  elif test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libsodium; then
++  elif type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists libsodium; then
+     LIBSODIUM_VERSION=`$PKG_CONFIG libsodium --modversion`
+     if $PKG_CONFIG libsodium --atleast-version=1.0.8; then
+       LIBSODIUM_CFLAGS=`$PKG_CONFIG libsodium --cflags`
+diff --git a/ext/zip/config.m4 b/ext/zip/config.m4
+index c3370129..eb2392e3 100644
+--- a/ext/zip/config.m4
++++ b/ext/zip/config.m4
+@@ -60,7 +60,7 @@ if test "$PHP_ZIP" != "no"; then
+       LIBZIP_LIBDIR="$PHP_LIBZIP/$PHP_LIBDIR"
+       AC_MSG_RESULT(from option: found in $PHP_LIBZIP)
+ 
+-    elif test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libzip; then
++    elif type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists libzip; then
+       if $PKG_CONFIG libzip --atleast-version 0.11; then
+         LIBZIP_CFLAGS=`$PKG_CONFIG libzip --cflags`
+         LIBZIP_LIBDIR=`$PKG_CONFIG libzip --variable=libdir`
+diff --git a/sapi/fpm/config.m4 b/sapi/fpm/config.m4
+index 44d842b2..d8ef1f10 100644
+--- a/sapi/fpm/config.m4
++++ b/sapi/fpm/config.m4
+@@ -582,7 +582,7 @@ if test "$PHP_FPM" != "no"; then
+     unset SYSTEMD_LIBS
+     unset SYSTEMD_INCS
+ 
+-    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libsystemd; then
++    if type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists libsystemd; then
+       dnl systemd version >= 209 provides libsystemd
+       AC_MSG_CHECKING([for libsystemd])
+       SYSTEMD_LIBS=`$PKG_CONFIG --libs libsystemd`
+@@ -590,7 +590,7 @@ if test "$PHP_FPM" != "no"; then
+       SYSTEMD_VERS=`$PKG_CONFIG --modversion libsystemd`
+       AC_MSG_RESULT([version $SYSTEMD_VERS])
+ 
+-    elif test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libsystemd-daemon; then
++    elif type -P "$PKG_CONFIG" >/dev/null && $PKG_CONFIG --exists libsystemd-daemon; then
+       dnl systemd version < 209 provides libsystemd-daemon
+       AC_MSG_CHECKING([for libsystemd-daemon])
+       SYSTEMD_LIBS=`$PKG_CONFIG --libs libsystemd-daemon`

--- a/pkgs/development/interpreters/php/fix-runtime-deps-php72.patch
+++ b/pkgs/development/interpreters/php/fix-runtime-deps-php72.patch
@@ -1,0 +1,35 @@
+diff --git a/main/build-defs.h.in b/main/build-defs.h.in
+index 50849a11..74d6c79b 100644
+--- a/main/build-defs.h.in
++++ b/main/build-defs.h.in
+@@ -18,7 +18,7 @@
+ 
+ /* $Id$ */
+ 
+-#define CONFIGURE_COMMAND "@CONFIGURE_COMMAND@"
++#define CONFIGURE_COMMAND       ""
+ #define PHP_ADA_INCLUDE		""
+ #define PHP_ADA_LFLAGS		""
+ #define PHP_ADA_LIBS		""
+diff --git a/scripts/php-config.in b/scripts/php-config.in
+index d6c62ccf..489b4094 100644
+--- a/scripts/php-config.in
++++ b/scripts/php-config.in
+@@ -8,7 +8,7 @@ version="@PHP_VERSION@"
+ vernum="@PHP_VERSION_ID@"
+ include_dir="@includedir@/php"
+ includes="-I$include_dir -I$include_dir/main -I$include_dir/TSRM -I$include_dir/Zend -I$include_dir/ext -I$include_dir/ext/date/lib"
+-ldflags="@PHP_LDFLAGS@"
++ldflags=""
+ libs="@EXTRA_LIBS@"
+ extension_dir='@EXTENSION_DIR@'
+ man_dir=`eval echo @mandir@`
+@@ -17,7 +17,7 @@ program_suffix="@program_suffix@"
+ exe_extension="@EXEEXT@"
+ php_cli_binary=NONE
+ php_cgi_binary=NONE
+-configure_options="@CONFIGURE_OPTIONS@"
++configure_options=""
+ php_sapis="@PHP_INSTALLED_SAPIS@"
+ 
+ # Set php_cli_binary and php_cgi_binary if available

--- a/pkgs/development/interpreters/php/fix-runtime-deps-php73.patch
+++ b/pkgs/development/interpreters/php/fix-runtime-deps-php73.patch
@@ -1,0 +1,35 @@
+diff --git a/main/build-defs.h.in b/main/build-defs.h.in
+index 67712b7b..5ed7d47a 100644
+--- a/main/build-defs.h.in
++++ b/main/build-defs.h.in
+@@ -16,7 +16,7 @@
+    +----------------------------------------------------------------------+
+ */
+ 
+-#define CONFIGURE_COMMAND "@CONFIGURE_COMMAND@"
++#define CONFIGURE_COMMAND       ""
+ #define PHP_ADA_INCLUDE		""
+ #define PHP_ADA_LFLAGS		""
+ #define PHP_ADA_LIBS		""
+diff --git a/scripts/php-config.in b/scripts/php-config.in
+index d6c62ccf..489b4094 100644
+--- a/scripts/php-config.in
++++ b/scripts/php-config.in
+@@ -8,7 +8,7 @@ version="@PHP_VERSION@"
+ vernum="@PHP_VERSION_ID@"
+ include_dir="@includedir@/php"
+ includes="-I$include_dir -I$include_dir/main -I$include_dir/TSRM -I$include_dir/Zend -I$include_dir/ext -I$include_dir/ext/date/lib"
+-ldflags="@PHP_LDFLAGS@"
++ldflags=""
+ libs="@EXTRA_LIBS@"
+ extension_dir='@EXTENSION_DIR@'
+ man_dir=`eval echo @mandir@`
+@@ -17,7 +17,7 @@ program_suffix="@program_suffix@"
+ exe_extension="@EXEEXT@"
+ php_cli_binary=NONE
+ php_cgi_binary=NONE
+-configure_options="@CONFIGURE_OPTIONS@"
++configure_options=""
+ php_sapis="@PHP_INSTALLED_SAPIS@"
+ 
+ # Set php_cli_binary and php_cgi_binary if available

--- a/pkgs/development/interpreters/php/fix-runtime-deps-php74.patch
+++ b/pkgs/development/interpreters/php/fix-runtime-deps-php74.patch
@@ -1,0 +1,35 @@
+diff --git a/main/build-defs.h.in b/main/build-defs.h.in
+index f0075268..a41353d0 100644
+--- a/main/build-defs.h.in
++++ b/main/build-defs.h.in
+@@ -16,7 +16,7 @@
+    +----------------------------------------------------------------------+
+ */
+ 
+-#define CONFIGURE_COMMAND "@CONFIGURE_COMMAND@"
++#define CONFIGURE_COMMAND       ""
+ #define PHP_ODBC_CFLAGS	"@ODBC_CFLAGS@"
+ #define PHP_ODBC_LFLAGS		"@ODBC_LFLAGS@"
+ #define PHP_ODBC_LIBS		"@ODBC_LIBS@"
+diff --git a/scripts/php-config.in b/scripts/php-config.in
+index 9271e872..2a1052f1 100644
+--- a/scripts/php-config.in
++++ b/scripts/php-config.in
+@@ -8,7 +8,7 @@ version="@PHP_VERSION@"
+ vernum="@PHP_VERSION_ID@"
+ include_dir="@includedir@/php"
+ includes="-I$include_dir -I$include_dir/main -I$include_dir/TSRM -I$include_dir/Zend -I$include_dir/ext -I$include_dir/ext/date/lib"
+-ldflags="@PHP_LDFLAGS@"
++ldflags=""
+ libs="@EXTRA_LIBS@"
+ extension_dir='@EXTENSION_DIR@'
+ man_dir=`eval echo @mandir@`
+@@ -17,7 +17,7 @@ program_suffix="@program_suffix@"
+ exe_extension="@EXEEXT@"
+ php_cli_binary=NONE
+ php_cgi_binary=NONE
+-configure_options="@CONFIGURE_OPTIONS@"
++configure_options=""
+ php_sapis="@PHP_INSTALLED_SAPIS@"
+ ini_dir="@EXPANDED_PHP_CONFIG_FILE_SCAN_DIR@"
+ ini_path="@EXPANDED_PHP_CONFIG_FILE_PATH@"


### PR DESCRIPTION
###### Motivation for this change
Remove In the build log lot of warning mesages:
```
...
substituteStream(): WARNING: pattern '@CONFIGURE_OPTIONS@' doesn't match anything in file 'main/build-defs.h.in'
substituteStream(): WARNING: pattern '@PHP_LDFLAGS@' doesn't match anything in file 'main/build-defs.h.in'
substituteStream(): WARNING: pattern '@CONFIGURE_COMMAND@' doesn't match anything in file 'scripts/php-config.in'
substituteStream(): WARNING: pattern 'test -x "$PKG_CONFIG"' doesn't match anything in file './Zend/acinclude.m4'
substituteStream(): WARNING: pattern 'test -x "$PKG_CONFIG"' doesn't match anything in file './Zend/Zend.m4'
substituteStream(): WARNING: pattern 'test -x "$PKG_CONFIG"' doesn't match anything in file './ext/libxml/config0.m4'
substituteStream(): WARNING: pattern 'test -x "$PKG_CONFIG"' doesn't match anything in file './ext/dba/config.m4'
substituteStream(): WARNING: pattern 'test -x "$PKG_CONFIG"' doesn't match anything in file './ext/xml/config.m4'
substituteStream(): WARNING: pattern 'test -x "$PKG_CONFIG"' doesn't match anything in file './ext/tidy/config.m4'
substituteStream(): WARNING: pattern 'test -x "$PKG_CONFIG"' doesn't match anything in file './ext/date/config0.m4'
substituteStream(): WARNING: pattern 'test -x "$PKG_CONFIG"' doesn't match anything in file './ext/json/config.m4'
substituteStream(): WARNING: pattern 'test -x "$PKG_CONFIG"' doesn't match anything in file './ext/pdo_sqlite/config.m4'
substituteStream(): WARNING: pattern 'test -x "$PKG_CONFIG"' doesn't match anything in file './ext/xmlrpc/libxmlrpc/acinclude.m4'
substituteStream(): WARNING: pattern 'test -x "$PKG_CONFIG"' doesn't match anything in file './ext/xmlrpc/libxmlrpc/xmlrpc.m4'
...
```
and cleanup preConfigure phase.

cc @NixOS/php 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
