### PR TITLE
pythonPackages.croniter: fix build

### DIFF
--- a/pkgs/development/python-modules/croniter/default.nix
+++ b/pkgs/development/python-modules/croniter/default.nix
@@ -1,9 +1,11 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, natsort
 , python-dateutil
 , pytest
 , pytz
+, tzlocal
 }:
 
 buildPythonPackage rec {
@@ -16,12 +18,14 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    natsort
     python-dateutil
   ];
 
   checkInputs = [
     pytest
     pytz
+    tzlocal
   ];
 
   checkPhase = ''


### PR DESCRIPTION
Has new dependencies after update:
https://github.com/taichino/croniter/blob/master/requirements/base.txt
https://github.com/taichino/croniter/blob/master/requirements/test.txt

CC @fridh @jonringer


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).