### PR TITLE
honggfuzz: init at 2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1592,6 +1592,16 @@
     githubId = 411324;
     name = "Carles Pagès";
   };
+  cpu = {
+    email = "daniel@binaryparadox.net";
+    github = "cpu";
+    githubId = 292650;
+    name = "Daniel McCarney";
+    keys = [{
+      longkeyid = "rsa2048/0x08FB2BFC470E75B4";
+      fingerprint = "8026 D24A A966 BF9C D3CD  CB3C 08FB 2BFC 470E 75B4";
+    }];
+  };
   craigem = {
     email = "craige@mcwhirter.io";
     github = "craigem";

--- a/pkgs/tools/security/honggfuzz/default.nix
+++ b/pkgs/tools/security/honggfuzz/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, callPackage, makeWrapper
+, clang, llvm, libbfd, libopcodes, libunwind, libblocksruntime
+}:
+
+let
+  honggfuzz = stdenv.mkDerivation rec {
+    pname = "honggfuzz";
+    version = "2.2";
+
+    src = fetchFromGitHub {
+      owner = "google";
+      repo = pname;
+      rev = "${version}";
+      sha256 = "0ycpx087mhv5s7w01chg2b6rfb3zgfpp9in0x73kpv7y4dcvg7gw";
+    };
+    enableParallelBuilding = true;
+
+    nativeBuildInputs = [ makeWrapper ];
+    buildInputs = [ llvm ];
+    propagatedBuildInputs = [ libbfd libopcodes libunwind libblocksruntime ];
+
+    makeFlags = [ "PREFIX=$(out)" ];
+
+    meta = {
+      description = "A security oriented, feedback-driven, evolutionary, easy-to-use fuzzer";
+      longDescription = ''
+        Honggfuzz is a security oriented, feedback-driven, evolutionary,
+        easy-to-use fuzzer with interesting analysis options. It is
+        multi-process and multi-threaded, blazingly fast when the persistent
+        fuzzing mode is used and has a solid track record of uncovered security
+        bugs.
+
+        Honggfuzz uses low-level interfaces to monitor processes and it will
+        discover and report hijacked/ignored signals from crashes. Feed it
+        a simple corpus directory (can even be empty for the feedback-driven
+        fuzzing), and it will work its way up, expanding it by utilizing
+        feedback-based coverage metrics.
+      '';
+      homepage    = "https://honggfuzz.dev/";
+      license     = stdenv.lib.licenses.asl20;
+      platforms   = ["x86_64-linux"];
+      maintainers = with stdenv.lib.maintainers; [ cpu ];
+    };
+  };
+in honggfuzz

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -599,6 +599,8 @@ in
     stdenv = clangStdenv;
   };
 
+  honggfuzz = callPackage ../tools/security/honggfuzz { };
+
   aflplusplus = callPackage ../tools/security/aflplusplus {
     clang = clang_9;
     llvm = llvm_9;


### PR DESCRIPTION
###### Motivation for this change

Adds `honggfuzz` v2.2 to Nixpkgs.

Honggfuzz is a security oriented, feedback-driven, evolutionary, easy-to-use fuzzer with interesting analysis options. It is multi-process and multi-threaded, blazingly fast when the persistent fuzzing mode is used and has a solid track record of uncovered security bugs.

See https://honggfuzz.dev for more information.

###### Things done

_Note to reviewers: This is my first Nixpkgs PR and I'm generally new to Nix & NixOS. Happy to iterate on anything problematic if given kind feedback :-)_

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
