### PR TITLE
anki: more no-op exp cleanup

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -31,7 +31,7 @@
 
 let
   # when updating, also update rev-manual to a recent version of
-  # https://github.com/dae/ankidocs
+  # https://github.com/ankitects/anki-docs
   # The manual is distributed independently of the software.
   version = "2.1.15";
   sha256-pkg = "12dvyf3j9df4nrhhnqbzd9b21rpzkh4i6yhhangn2zf7ch0pclss";
@@ -42,8 +42,8 @@ let
     pname = "anki-manual";
     inherit version;
     src = fetchFromGitHub {
-      owner = "dae";
-      repo = "ankidocs";
+      owner = "ankitects";
+      repo = "anki-docs";
       rev = rev-manual;
       sha256 = sha256-manual;
     };

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -112,16 +112,10 @@ buildPythonApplication rec {
     ./no-version-check.patch
   ];
 
-  buildPhase = ''
-    # Dummy build phase
-    # Anki does not use setup.py
-  '';
+  # Anki does not use setup.py
+  dontBuild = true;
 
   postPatch = ''
-    # Remove unused starter. We'll create our own, minimalistic,
-    # starter.
-    # rm anki/anki
-
     # Remove QT translation files. We'll use the standard QT ones.
     rm "locale/"*.qm
 
@@ -134,10 +128,10 @@ buildPythonApplication rec {
   # UTF-8 locale needed for testing
   LC_ALL = "en_US.UTF-8";
 
+  # - Anki writes some files to $HOME during tests
+  # - Skip tests using network
   checkPhase = ''
-    # - Anki writes some files to $HOME during tests
-    # - Skip tests using network
-    env HOME=$TMP pytest --ignore tests/test_sync.py
+    HOME=$TMP pytest --ignore tests/test_sync.py
   '';
 
   installPhase = ''
@@ -170,6 +164,7 @@ buildPythonApplication rec {
     cp -r ${manual}/share/doc/anki/html $doc/share/doc/anki
   '';
 
+  # now wrapPythonPrograms from postFixup will add both python and qt env variables
   dontWrapQtApps = true;
 
   preFixup = ''
@@ -178,8 +173,6 @@ buildPythonApplication rec {
       --prefix PATH ':' "${lame}/bin:${mplayer}/bin"
     )
   '';
-
-  # now wrapPythonPrograms from postFixup will add both python and qt env variables
 
   passthru = {
     inherit manual;


### PR DESCRIPTION
Continued progress towards #89745; just simplifying a bit.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).