### PR TITLE
out-of-tree: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/development/tools/out-of-tree/default.nix
+++ b/pkgs/development/tools/out-of-tree/default.nix
@@ -2,17 +2,17 @@
 
 buildGoModule rec {
   pname = "out-of-tree";
-  version = "1.3.0";
+  version = "1.4.0";
 
   buildInputs = [ makeWrapper ];
 
   src = fetchgit {
     rev = "refs/tags/v${version}";
     url = "https://code.dumpstack.io/tools/${pname}.git";
-    sha256 = "02xh23nbwyyf087jqkm97jbnwpja1myaz190q5r166mpwcdpz2dn";
+    sha256 = "1rn824l3dzh3xjxsbzzj053qg1abhzjimc8l73r0n5qrl44k2qk2";
   };
 
-  vendorSha256 = "1dk0cipdgj2yyg1bc9l7nvy4y373pmqwy8xiyc0wg7pchb4h9p7s";
+  vendorSha256 = "0kg5c4h7xnwfcfshrh5n76xv98wzr73kxzr8q65iphsjimbxcpy3";
 
   postFixup = ''
     wrapProgram $out/bin/out-of-tree \


### PR DESCRIPTION
###### Motivation for this change

Update to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
