### PR TITLE
wxGTK3: make gtk2 and gtk3 specific variants

### DIFF
--- a/pkgs/applications/audio/spek/default.nix
+++ b/pkgs/applications/audio/spek/default.nix
@@ -1,27 +1,28 @@
-{ stdenv, fetchzip, autoconf, automake, intltool, pkgconfig, ffmpeg, wxGTK }:
+{ stdenv, fetchFromGitHub, autoreconfHook, intltool, pkgconfig, ffmpeg, wxGTK30-gtk3, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "spek";
-  version = "0.8.3";
+  version = "unstable-2018-12-29";
 
-  src = fetchzip {
-    name = "${pname}-${version}-src";
-    url = "https://github.com/alexkay/spek/archive/v${version}.tar.gz";
-    sha256 = "0y4hlhswpqkqpsglrhg5xbfy1a6f9fvasgdf336vhwcjqsc3k2xv";
+  src = fetchFromGitHub {
+    owner = "alexkay";
+    repo = "spek";
+    rev = "f071c2956176ad53c7c8059e5c00e694ded31ded";
+    sha256 = "1l9gj9c1n92zlcjnyjyk211h83dk0idk644xnm5rs7q40p2zliy5";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ autoconf automake intltool ffmpeg wxGTK ];
+  # needed for autoreconfHook
+  AUTOPOINT="intltoolize --automake --copy";
 
-  preConfigure = ''
-    ./autogen.sh
-  '';
+  nativeBuildInputs = [ autoreconfHook intltool pkgconfig wrapGAppsHook ];
+
+  buildInputs = [ ffmpeg wxGTK30-gtk3 wxGTK30-gtk3.gtk ];
 
   meta = with stdenv.lib; {
     description = "Analyse your audio files by showing their spectrogram";
     homepage = "http://spek.cc/";
     license = licenses.gpl3;
+    maintainers = with maintainers; [ bjornfor ];
     platforms = platforms.all;
-    maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/applications/networking/ftp/filezilla/default.nix
+++ b/pkgs/applications/networking/ftp/filezilla/default.nix
@@ -10,16 +10,10 @@
 , pugixml
 , sqlite
 , tinyxml
-, wxGTK30
+, wxGTK30-gtk3
 , xdg_utils
 }:
 
-let
-  # we can drop this when wxgtk is built with gtk3 by default
-  # see: https://github.com/NixOS/nixpkgs/pull/73145
-  wxgtk' = wxGTK30.override { compat26 = false; withGtk2 = false; };
-
-in
 stdenv.mkDerivation rec {
   pname = "filezilla";
   version = "3.48.1";
@@ -52,8 +46,8 @@ stdenv.mkDerivation rec {
     pugixml
     sqlite
     tinyxml
-    wxgtk'
-    wxgtk'.gtk
+    wxGTK30-gtk3
+    wxGTK30-gtk3.gtk
     xdg_utils
   ];
 

--- a/pkgs/applications/radio/cubicsdr/default.nix
+++ b/pkgs/applications/radio/cubicsdr/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, fftw, hamlib, libpulseaudio, libGL, libX11, liquid-dsp,
-  pkgconfig, soapysdr-with-plugins, wxGTK, enableDigitalLab ? false }:
+  pkgconfig, soapysdr-with-plugins, wxGTK31-gtk3, enableDigitalLab ? false }:
 
 stdenv.mkDerivation rec {
   pname = "cubicsdr";
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ fftw hamlib libpulseaudio libGL libX11 liquid-dsp soapysdr-with-plugins wxGTK ];
+
+  buildInputs = [ fftw hamlib libpulseaudio libGL libX11 liquid-dsp soapysdr-with-plugins wxGTK31-gtk3 ];
 
   cmakeFlags = [ "-DUSE_HAMLIB=ON" ]
     ++ stdenv.lib.optional enableDigitalLab "-DENABLE_DIGITAL_LAB=ON";

--- a/pkgs/applications/radio/limesuite/default.nix
+++ b/pkgs/applications/radio/limesuite/default.nix
@@ -1,14 +1,11 @@
 { stdenv, fetchFromGitHub, cmake
-, sqlite, wxGTK30, libusb1, soapysdr
+, sqlite, wxGTK30-gtk3, libusb1, soapysdr
 , mesa_glu, libX11, gnuplot, fltk
 } :
 
-let
-  version = "20.01.0";
-
-in stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "limesuite";
-  inherit version;
+  version = "20.01.0";
 
   src = fetchFromGitHub {
     owner = "myriadrf";
@@ -17,14 +14,16 @@ in stdenv.mkDerivation {
     sha256 = "01z4idcby2lm34bbnpbp400ski7p61jjiir6sy6dalnvsl52m7vx";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DOpenGL_GL_PREFERENCE=GLVND"
+  ];
 
   buildInputs = [
     libusb1
     sqlite
-    wxGTK30
+    wxGTK30-gtk3
     fltk
     gnuplot
     libusb1
@@ -34,11 +33,8 @@ in stdenv.mkDerivation {
   ];
 
   postInstall = ''
-    mkdir -p $out/lib/udev/rules.d
-    cp ../udev-rules/64-limesuite.rules $out/lib/udev/rules.d
-
-    mkdir -p $out/share/limesuite
-    cp bin/Release/lms7suite_mcu/* $out/share/limesuite
+    install -Dm444 -t $out/lib/udev/rules.d ../udev-rules/64-limesuite.rules
+    install -Dm444 -t $out/share/limesuite bin/Release/lms7suite_mcu/*
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/wxwidgets/3.0/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/default.nix
@@ -1,8 +1,9 @@
 { stdenv, fetchFromGitHub, fetchurl, pkgconfig
-, gtk2, gtk3, libXinerama, libSM, libXxf86vm
-, xorgproto, gstreamer, gst-plugins-base, GConf, setfile
+, libXinerama, libSM, libXxf86vm
+, gtk2, GConf ? null, gtk3
+, xorgproto, gstreamer, gst-plugins-base, setfile
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
-, withMesa ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
+, withMesa ? libGLSupported
 , libGLU ? null, libGL ? null
 , compat24 ? false, compat26 ? true, unicode ? true
 , withGtk2 ? true
@@ -28,9 +29,10 @@ stdenv.mkDerivation rec {
     sha256 = "19mqglghjjqjgz4rbybn3qdgn2cz9xc511nq1pvvli9wx2k8syl1";
   };
 
-  buildInputs =
-    [ (if withGtk2 then gtk2 else gtk3) libXinerama libSM libXxf86vm xorgproto gstreamer
-      gst-plugins-base GConf ]
+  buildInputs = [
+    libXinerama libSM libXxf86vm xorgproto gstreamer gst-plugins-base
+  ] ++ optionals withGtk2 [ gtk2 GConf ]
+    ++ optional (!withGtk2) gtk3
     ++ optional withMesa libGLU
     ++ optional withWebKit webkitgtk
     ++ optionals stdenv.isDarwin [ setfile Carbon Cocoa Kernel QTKit ];

--- a/pkgs/development/libraries/wxwidgets/3.1/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.1/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchFromGitHub, fetchurl, pkgconfig
-, gtk2, gtk3, libXinerama, libSM, libXxf86vm
-, xorgproto, gstreamer, gst-plugins-base, GConf, setfile
+, libXinerama, libSM, libXxf86vm
+, gtk2, GConf ? null, gtk3
+, xorgproto, gstreamer, gst-plugins-base, setfile
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
 , withMesa ? libGLSupported, libGLU ? null, libGL ? null
 , compat28 ? false, compat30 ? true, unicode ? true
@@ -27,9 +28,10 @@ stdenv.mkDerivation rec {
     sha256 = "0gfdhb7xq5vzasm7s1di39nchv42zsp0dmn4v6knzb7mgsb107wb";
   };
 
-  buildInputs =
-    [ (if withGtk2 then gtk2 else gtk3) libXinerama libSM libXxf86vm xorgproto gstreamer
-      gst-plugins-base GConf ]
+  buildInputs = [
+    libXinerama libSM libXxf86vm xorgproto gstreamer gst-plugins-base
+  ] ++ optionals withGtk2 [ gtk2 GConf ]
+    ++ optional (!withGtk2) gtk3
     ++ optional withMesa libGLU
     ++ optional withWebKit webkitgtk
     ++ optionals stdenv.isDarwin [ setfile Carbon Cocoa Kernel QTKit ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15139,6 +15139,9 @@ in
 
   wxGTK = wxGTK28;
 
+  wxGTK30 = wxGTK30-gtk2;
+  wxGTK31 = wxGTK31-gtk2;
+
   wxGTK28 = callPackage ../development/libraries/wxwidgets/2.8 {
     inherit (gnome2) GConf;
   };
@@ -15149,14 +15152,28 @@ in
     inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QuickTime;
   };
 
-  wxGTK30 = callPackage ../development/libraries/wxwidgets/3.0 {
+  wxGTK30-gtk2 = callPackage ../development/libraries/wxwidgets/3.0 {
+    withGtk2 = true;
     inherit (gnome2) GConf;
     inherit (darwin.stubs) setfile;
     inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
   };
 
-  wxGTK31 = callPackage ../development/libraries/wxwidgets/3.1 {
+  wxGTK30-gtk3 = callPackage ../development/libraries/wxwidgets/3.0 {
+    withGtk2 = false;
+    inherit (darwin.stubs) setfile;
+    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
+  };
+
+  wxGTK31-gtk2 = callPackage ../development/libraries/wxwidgets/3.1 {
+    withGtk2 = true;
     inherit (gnome2) GConf;
+    inherit (darwin.stubs) setfile;
+    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
+  };
+
+  wxGTK31-gtk3 = callPackage ../development/libraries/wxwidgets/3.1 {
+    withGtk2 = false;
     inherit (darwin.stubs) setfile;
     inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19128,7 +19128,7 @@ in
 
   ctop = callPackage ../tools/system/ctop { };
 
-  cubicsdr = callPackage ../applications/radio/cubicsdr { wxGTK = wxGTK31; };
+  cubicsdr = callPackage ../applications/radio/cubicsdr { };
 
   cum = callPackage ../applications/misc/cum { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22194,9 +22194,7 @@ in
 
   soxr = callPackage ../applications/misc/audio/soxr { };
 
-  spek = callPackage ../applications/audio/spek {
-    ffmpeg = ffmpeg_2;
-  };
+  spek = callPackage ../applications/audio/spek { };
 
   spotify = callPackage ../applications/audio/spotify {
     libgcrypt = libgcrypt_1_5;


### PR DESCRIPTION
###### Motivation for this change

To ease the transition from gtk2 to gtk3 for wxwidgets applications,
introduce specific gtk2 and gtk3 versions.

Further to: https://github.com/NixOS/nixpkgs/pull/73145

This way we move things over step-by-step instead of doing big-bang migrations.

This PR includes 2 packages that move to wxGTK30-gtk3:

 - filezilla
 - spek

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).