### PR TITLE
byobu: add screen backend

### DIFF
--- a/pkgs/development/libraries/newt/default.nix
+++ b/pkgs/development/libraries/newt/default.nix
@@ -1,5 +1,8 @@
-{ fetchurl, stdenv, slang, popt }:
+{ lib, fetchurl, stdenv, slang, popt, python }:
 
+let
+  pythonIncludePath = "${lib.getDev python}/include/python";
+in
 stdenv.mkDerivation rec {
   pname = "newt";
   version = "0.52.21";
@@ -11,9 +14,14 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     sed -i -e s,/usr/bin/install,install, -e s,-I/usr/include/slang,, Makefile.in po/Makefile
+
+    substituteInPlace configure \
+      --replace "/usr/include/python" "${pythonIncludePath}"
+    substituteInPlace configure.ac \
+      --replace "/usr/include/python" "${pythonIncludePath}"
   '';
 
-  buildInputs = [ slang popt ];
+  buildInputs = [ slang popt python ];
 
   NIX_LDFLAGS = "-lncurses";
 

--- a/pkgs/tools/misc/byobu/default.nix
+++ b/pkgs/tools/misc/byobu/default.nix
@@ -1,5 +1,11 @@
-{ stdenv, fetchurl, python3, perl, textual-window-manager }:
+{ stdenv, fetchurl, makeWrapper
+, ncurses, python3, perl, textual-window-manager
+, gettext, vim, bc, screen }:
 
+let
+  inherit (stdenv) lib;
+  pythonEnv = python3.withPackages (ps: with ps; [ snack ]);
+in
 stdenv.mkDerivation rec {
   version = "5.133";
   name = "byobu-" + version;
@@ -11,26 +17,59 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  buildInputs = [ python3 perl ];
-  propagatedBuildInputs = [ textual-window-manager ];
+  buildInputs = [ perl makeWrapper gettext ];
+  propagatedBuildInputs = [ textual-window-manager screen ];
 
-  meta = {
+  postPatch = ''
+    substituteInPlace usr/bin/byobu-export.in \
+      --replace "gettext" "${gettext}/bin/gettext"
+    substituteInPlace usr/lib/byobu/menu \
+      --replace "gettext" "${gettext}/bin/gettext"
+  '';
+
+  postInstall = ''
+    # Byobu does not compile its po files for some reason
+    for po in po/*.po; do
+      lang=''${po#po/}
+      lang=''${lang%.po}
+      # Path where byobu looks for translations as observed in the source code and strace
+      mkdir -p $out/share/byobu/po/$lang/LC_MESSAGES/
+      msgfmt $po -o $out/share/byobu/po/$lang/LC_MESSAGES/byobu.mo
+    done
+
+    # Override the symlinks otherwise they mess with the wrapping
+    cp --remove-destination $out/bin/byobu $out/bin/byobu-screen
+    cp --remove-destination $out/bin/byobu $out/bin/byobu-tmux
+
+    for i in $out/bin/byobu*; do
+      # We don't use the usual ".$package-wrapped" because arg0 within the shebang scripts
+      # points to the filename and byobu matches against this to know which backend
+      # to start with
+      file=".$(basename $i)"
+      mv $i $out/bin/$file
+      makeWrapper "$out/bin/$file" "$out/bin/$(basename $i)" --argv0 $(basename $i) \
+        --set BYOBU_PATH ${lib.escapeShellArg (lib.makeBinPath [ vim bc ])} \
+        --set BYOBU_PYTHON "${pythonEnv}/bin/python"
+    done
+  '';
+
+  meta = with stdenv.lib; {
     homepage = "https://launchpad.net/byobu/";
     description = "Text-based window manager and terminal multiplexer";
 
     longDescription =
-      ''Byobu is a GPLv3 open source text-based window manager and terminal multiplexer. 
-        It was originally designed to provide elegant enhancements to the otherwise functional, 
-        plain, practical GNU Screen, for the Ubuntu server distribution. 
-        Byobu now includes an enhanced profiles, convenient keybindings, 
-        configuration utilities, and toggle-able system status notifications for both 
-        the GNU Screen window manager and the more modern Tmux terminal multiplexer, 
+      ''Byobu is a GPLv3 open source text-based window manager and terminal multiplexer.
+        It was originally designed to provide elegant enhancements to the otherwise functional,
+        plain, practical GNU Screen, for the Ubuntu server distribution.
+        Byobu now includes an enhanced profiles, convenient keybindings,
+        configuration utilities, and toggle-able system status notifications for both
+        the GNU Screen window manager and the more modern Tmux terminal multiplexer,
         and works on most Linux, BSD, and Mac distributions.
       '';
 
-    license = stdenv.lib.licenses.gpl3;
+    license = licenses.gpl3;
 
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.qknight ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ qknight berbiche ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6610,6 +6610,8 @@ in {
 
   smugpy = callPackage ../development/python-modules/smugpy { };
 
+  snack = toPythonModule (pkgs.newt.override { inherit (self) python; });
+
   snakebite = callPackage ../development/python-modules/snakebite { };
 
   snakeviz = callPackage ../development/python-modules/snakeviz { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Screen backend was missing.

``` console
[nix-shell:~/dev/nixpkgs/result]$ byobu-screen - -v
Screen version 4.08.00 (GNU) 05-Feb-20
```

Closure size:
``` text
before: /nix/store/44rqjxl15zqlizgkwnxjxl8428asjm57-byobu-5.133	 156.1M
after:  /nix/store/a2lzmr53zvjbg9d5jdcxsj4v1nfvmc0f-byobu-5.133	 226.6M
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
