### PR TITLE
nimmm: init at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3652,6 +3652,12 @@
     githubId = 41977;
     name = "Joachim Fasting";
   };
+  joachimschmidt557 = {
+    email = "joachim.schmidt557@outlook.com";
+    github = "joachimschmidt557";
+    githubId = 28556218;
+    name = "Joachim Schmidt";
+  };
   joamaki = {
     email = "joamaki@gmail.com";
     github = "joamaki";

--- a/pkgs/applications/misc/nimmm/default.nix
+++ b/pkgs/applications/misc/nimmm/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchFromGitHub, nim, termbox, pcre }:
+
+let
+  noise = fetchFromGitHub {
+    owner = "jangko";
+    repo = "nim-noise";
+    rev = "db1e86e312413e4348fa82c02340784316a89cc1";
+    sha256 = "0n9l2dww5smrsl1xfqxjnxz3f1srb72lc1wl3pdvs6xfyf44qzlh";
+  };
+
+  nimbox = fetchFromGitHub {
+    owner = "dom96";
+    repo = "nimbox";
+    rev = "6a56e76c01481176f16ae29b7d7c526bd83f229b";
+    sha256 = "15x1sdfxa1xcqnr68705jfnlv83lm0xnp2z9iz3pgc4bz5vwn4x1";
+  };
+
+  lscolors = fetchFromGitHub {
+    owner = "joachimschmidt557";
+    repo = "nim-lscolors";
+    rev = "v0.3.3";
+    sha256 = "0526hqh46lcfsvymb67ldsc8xbfn24vicn3b8wrqnh6mag8wynf4";
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "nimmm";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "joachimschmidt557";
+    repo = "nimmm";
+    rev = "v${version}";
+    sha256 = "1zpq181iz6g7yfi298gjwv33b89l4fpnkjprimykah7py5cpw67w";
+  };
+
+  nativeBuildInputs = [ nim ];
+  buildInputs = [ termbox pcre ];
+
+  NIX_LDFLAGS = "-lpcre";
+
+  buildPhase = ''
+    export HOME=$TMPDIR;
+    nim -p:${noise} -p:${nimbox} -p:${lscolors}/src c -d:release src/nimmm.nim
+  '';
+
+  installPhase = ''
+    install -Dt $out/bin src/nimmm
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Terminal file manager written in nim";
+    homepage = "https://github.com/joachimschmidt557/nimmm";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.joachimschmidt557 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5514,6 +5514,8 @@ in
 
   nilfs-utils = callPackage ../tools/filesystems/nilfs-utils {};
 
+  nimmm = callPackage ../applications/misc/nimmm { };
+
   nitrogen = callPackage ../tools/X11/nitrogen {};
 
   nms = callPackage ../tools/misc/nms { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

nimmm is a terminal file manager written in nim.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
