### PR TITLE
i3pystatus: 2019-06-10 -> 2020-07-14; fix desktop notifications

### DIFF
--- a/pkgs/applications/window-managers/i3/pystatus.nix
+++ b/pkgs/applications/window-managers/i3/pystatus.nix
@@ -1,26 +1,32 @@
 { stdenv, fetchFromGitHub, libpulseaudio, python3Packages, extraLibs ? [] }:
 
-python3Packages.buildPythonApplication rec {
+let
+  ldWrapperSuffix = "--suffix LD_LIBRARY_PATH : \"${stdenv.lib.makeLibraryPath [ libpulseaudio ]}\"";
+in python3Packages.buildPythonApplication rec {
   # i3pystatus moved to rolling release:
   # https://github.com/enkore/i3pystatus/issues/584
-  version = "unstable-2019-06-10";
+  version = "unstable-2020-06-12";
   pname = "i3pystatus";
 
-  src = fetchFromGitHub
-  {
+  src = fetchFromGitHub {
     owner = "enkore";
     repo = "i3pystatus";
-    rev = "56ce08d0ff8d5d64950d6b588ebede35a95e0ce2";
-    sha256 = "12938860jbcly1xwhd71jvy2dff28pwv9kqh6mab1859148bzmcg";
+    rev = "dad5eb0c5c8a2ecd20c37ade4732586c6e53f44b";
+    sha256 = "18ygvkl92yr69kxsym57k1mc90asdxpz4b943i61qr0s4fc5n4mq";
   };
 
   propagatedBuildInputs = with python3Packages; [ keyring colour netifaces psutil basiciw ] ++
     [ libpulseaudio ] ++ extraLibs;
 
-  libpulseaudioPath = stdenv.lib.makeLibraryPath [ libpulseaudio ];
-  ldWrapperSuffix = "--suffix LD_LIBRARY_PATH : \"${libpulseaudioPath}\"";
   # LC_TIME != C results in locale.Error: unsupported locale setting
-  makeWrapperArgs = [ "--set LC_TIME C" ldWrapperSuffix ]; # libpulseaudio.so is loaded manually
+  makeWrapperArgs = [
+    "--set" "LC_TIME" "C"
+    ldWrapperSuffix
+  ]; # libpulseaudio.so is loaded manually
+
+  postConfigure = ''
+    makeWrapperArgs+=("--set" "GI_TYPELIB_PATH" "$GI_TYPELIB_PATH")
+  '';
 
   postInstall = ''
     makeWrapper ${python3Packages.python.interpreter} $out/bin/${pname}-python-interpreter \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
