### PR TITLE
clamav: enable build on darwin

### DIFF
--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig
 , zlib, bzip2, libiconv, libxml2, openssl, ncurses, curl, libmilter, pcre2
-, libmspack, systemd
+, libmspack, systemd, Foundation
 }:
 
 stdenv.mkDerivation rec {
@@ -20,13 +20,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     zlib bzip2 libxml2 openssl ncurses curl libiconv libmilter pcre2 libmspack
-    systemd
-  ];
+  ] ++ stdenv.lib.optional stdenv.isLinux systemd
+    ++ stdenv.lib.optional stdenv.isDarwin Foundation;
 
   configureFlags = [
     "--libdir=$(out)/lib"
     "--sysconfdir=/etc/clamav"
-    "--with-systemdsystemunitdir=$(out)/lib/systemd"
     "--disable-llvm" # enabling breaks the build at the moment
     "--with-zlib=${zlib.dev}"
     "--with-xml=${libxml2.dev}"
@@ -34,7 +33,8 @@ stdenv.mkDerivation rec {
     "--with-libcurl=${curl.dev}"
     "--with-system-libmspack"
     "--enable-milter"
-  ];
+  ] ++ stdenv.lib.optional stdenv.isLinux
+    "--with-systemdsystemunitdir=$(out)/lib/systemd";
 
   postInstall = ''
     mkdir $out/etc
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
     description = "Antivirus engine designed for detecting Trojans, viruses, malware and other malicious threats";
     license = licenses.gpl2;
     maintainers = with maintainers; [ phreedom robberer qknight fpletz globin ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2712,7 +2712,9 @@ in
 
   ckb-next = libsForQt5.callPackage ../tools/misc/ckb-next { };
 
-  clamav = callPackage ../tools/security/clamav { };
+  clamav = callPackage ../tools/security/clamav {
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  };
 
   clex = callPackage ../tools/misc/clex { };
 


### PR DESCRIPTION
This rather simple change allows to build ClamAV on Darwin. I made tests on Darwin with the on-demand scanner and things appear to be working.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
