### PR TITLE
Tremor location fix

### DIFF
--- a/pkgs/development/libraries/tremor/default.nix
+++ b/pkgs/development/libraries/tremor/default.nix
@@ -1,10 +1,12 @@
-{ stdenv, fetchgit, autoreconfHook, pkgconfig, libogg }:
+{ stdenv, fetchFromGitLab, autoreconfHook, pkgconfig, libogg }:
 
 stdenv.mkDerivation {
   name = "tremor-unstable-2018-03-16";
 
-  src = fetchgit {
-    url = "https://git.xiph.org/tremor.git";
+  src = fetchFromGitLab {
+    owner = "xiph";
+    repo = "tremor";
+    domain = "gitlab.xiph.org";
     rev = "562307a4a7082e24553f3d2c55dab397a17c4b4f";
     sha256 = "0m07gq4zfgigsiz8b518xyb19v7qqp76qmp7lb262825vkqzl3zq";
   };


### PR DESCRIPTION
Tremor is not available any longer via 'https://git.xiph.org/tremor.git'.

###### Motivation for this change
Tremor is not accessible via https://git.xiph.org/tremor.git

###### Things done
Outdated git location replaced with actual

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
