### PR TITLE
nixos/pam: ability to calls an external command

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -307,6 +307,48 @@ let
         '';
       };
 
+      externalCommand = mkOption {
+        default = null;
+        type = types.nullOr (types.submodule {
+          options = {
+
+            type = mkOption {
+              type = types.enum [ "account" "auth" "password" "session" ];
+              example = "session";
+              description = ''
+                The type is the management group that the rule corresponds to.
+              '';
+            };
+
+            control = mkOption {
+              type = types.enum [ "required" "requisite" "sufficient" "optional" "include" "substack" ];
+              example = "required";
+              description = ''
+                The behavior of the PAM-API should the module fail to succeed in its authentication task.
+              '';
+            };
+
+            command = mkOption {
+              type = types.path;
+              description = ''
+                Command to call
+              '';
+            };
+
+          };
+        });
+        example = literalExample ''
+          {
+            type = "session";
+            control = "required";
+            command = /path/to/command
+          }
+        '';
+        description = ''
+          External command to call with pam_exec.
+        '';
+      };
+
       text = mkOption {
         type = types.nullOr types.lines;
         description = "Contents of the PAM service file.";
@@ -463,6 +505,9 @@ let
               "session optional ${pkgs.gnome3.gnome-keyring}/lib/security/pam_gnome_keyring.so auto_start"}
           ${optionalString (config.virtualisation.lxc.lxcfs.enable)
                "session optional ${pkgs.lxc}/lib/security/pam_cgfs.so -c all"}
+
+          ${optionalString (cfg.externalCommand != null)
+              "${cfg.externalCommand.type} ${cfg.externalCommand.control} pam_exec.so ${cfg.externalCommand.command}"}
         '');
     };
 


### PR DESCRIPTION
As indicated in #90488, I would appreciate feedback on this.

###### Motivation for this change
See #90488


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using NixOps
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
