### PR TITLE
Submit/stagit gopher

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3076,6 +3076,12 @@
     githubId = 147689;
     name = "Hans-Christian Esperer";
   };
+  hcssmith = {
+    email = "nix@hcssmith.com";
+    github = "hcssmith";
+    githubId = 66956565;
+    name = "Hallam Smith";
+  };
   hectorj = {
     email = "hector.jusforgues+nixos@gmail.com";
     github = "hectorj";

--- a/pkgs/development/tools/stagit-gopher/default.nix
+++ b/pkgs/development/tools/stagit-gopher/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, libgit2, fetchgit }:
+
+stdenv.mkDerivation rec {
+  pname = "stagit-gopher";
+  version = "0.9.3";
+
+  src = fetchgit {
+    url = "git://git.codemadness.org/stagit-gopher";
+    rev = version;
+    sha256 = "0dcyi3k900jb8p5qhgfk91gvplblysgfz1vyn6pqrlk931hpac80";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  buildInputs = [ libgit2 ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://git.codemadness.org/stagit-gopher/file/README.html";
+    description = "Static git site generator for gopher";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ hcssmith ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2192,6 +2192,8 @@ in
 
   stagit = callPackage ../development/tools/stagit { };
 
+  stagit-gopher = callPackage ../development/tools/stagit-gopher { };
+
   statserial = callPackage ../tools/misc/statserial { };
 
   step-ca = callPackage ../tools/security/step-ca { };
@@ -15753,7 +15755,7 @@ in
 
   hiawatha = callPackage ../servers/http/hiawatha {};
 
-  home-assistant = callPackage ../servers/home-assistant { 
+  home-assistant = callPackage ../servers/home-assistant {
     python3 = python37;
   };
 


### PR DESCRIPTION
stagit-gopher init at version 0.9.3

###### Motivation for this change
So I can use stagit-gopher on Nixos

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
