### PR TITLE
libgcc: fix Darwin cross compile

### DIFF
--- a/pkgs/development/libraries/gcc/libgcc/default.nix
+++ b/pkgs/development/libraries/gcc/libgcc/default.nix
@@ -63,7 +63,7 @@ stdenvNoLibs.mkDerivation rec {
       export CPP_FOR_TARGET=${stdenvNoLibs.cc}/bin/$CPP
       export LD_FOR_TARGET=${stdenvNoLibs.cc.bintools}/bin/$LD
 
-      export NIX_BUILD_CFLAGS_COMPILE+=' -DGENERATOR_FILE=1'
+      export NIX_CFLAGS_COMPILE_FOR_BUILD+=' -DGENERATOR_FILE=1'
 
       "$sourceRoot/../gcc/configure" $gccConfigureFlags
 


### PR DESCRIPTION
I guess this is a fallout from the build variables reorganisation in [`1ac5398`](https://github.com/NixOS/nixpkgs/commit/1ac5398589916a6a433e845342c9b85c4c52f5dc): the previous infix notation was changed to a suffix notation.

With this patch, Linux versions of `libgcc` can be cross compiled on Darwin hosts again. Compilation on Linux still works.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).