### PR TITLE
ocamlPackages.async_unix: 0.13.0 → 0.13.1

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.13.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.13.nix
@@ -357,7 +357,8 @@ rec {
 
   async_unix = janePackage {
     pname = "async_unix";
-    hash = "0n3jz3qjlphyhkqgnbjbwf2fqxaksws82dx1mk4m4wnw3275gdi5";
+    version = "0.13.1";
+    hash = "1sb8grbj4bv6ih3yfdihxhn5c9rqczr56b5bhl85wy2mi92m17xv";
     meta.description = "Monadic concurrency library";
     propagatedBuildInputs = [ async_kernel core ];
   };


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
