### PR TITLE
kmail: add missing dependency (kdepim-addons)

### DIFF
--- a/pkgs/applications/kde/kmail.nix
+++ b/pkgs/applications/kde/kmail.nix
@@ -7,7 +7,7 @@
   kmail-account-wizard, kmailtransport, knotifications, knotifyconfig,
   kontactinterface, kparts, kpty, kservice, ktextwidgets, ktnef, kwallet,
   kwidgetsaddons, kwindowsystem, kxmlgui, libgravatar, libksieve, mailcommon,
-  messagelib, pim-sieve-editor, qtscript, qtwebengine, akonadi
+  messagelib, pim-sieve-editor, qtscript, qtwebengine, akonadi, kdepim-addons
 }:
 
 mkDerivation {
@@ -24,6 +24,7 @@ mkDerivation {
     knotifications knotifyconfig kontactinterface kparts kpty kservice
     ktextwidgets ktnef kwidgetsaddons kwindowsystem kxmlgui libgravatar
     libksieve mailcommon messagelib pim-sieve-editor qtscript qtwebengine
+    kdepim-addons
   ];
   propagatedUserEnvPkgs = [ kdepim-runtime kwallet akonadi ];
   patches = [ ./kmail.patch ];


### PR DESCRIPTION
###### Motivation for this change

The `kdepim-addons` dependency is needed in KMail to add many of the
standard plug-ins, including the "External Editor" plug-in.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
