### PR TITLE
impy,evilpixie: init

### DIFF
--- a/pkgs/applications/graphics/evilpixie/default.nix
+++ b/pkgs/applications/graphics/evilpixie/default.nix
@@ -1,0 +1,59 @@
+{ mkDerivation
+, lib
+, fetchFromGitHub
+, makeDesktopItem
+, qmake
+, qtbase
+, libpng
+, giflib
+, impy
+}:
+
+let
+  desktopItem = makeDesktopItem {
+    name = "EvilPixie";
+    desktopName = "EvilPixie";
+    exec = "evilpixie %F";
+    icon = "evilpixie";
+    genericName = "Image Editor";
+    categories = "Graphics;2DGraphics;RasterGraphics;";
+    mimeType = "image/bmp;image/gif;image/jpeg;image/jpg;image/png;image/x-pcx;image/x-targa;image/x-tga;";
+  };
+
+in mkDerivation rec {
+  pname = "evilpixie";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "bcampbell";
+    repo = "evilpixie";
+    rev = "v${version}";
+    sha256 = "1yg4ic3kcxqmr7k5bbvrv5iavlnhpdx6510z5wha9k9k5q9c4dvh";
+  };
+
+  nativeBuildInputs = [
+    qmake
+  ];
+
+  buildInputs = [
+    qtbase
+    libpng
+    giflib
+    impy
+  ];
+
+  postInstall = ''
+    ln -s ${desktopItem}/share/applications $out/share
+    install -Dm 444 icon_128x128.png $out/share/icons/hicolor/128x128/apps/evilpixie.png
+  '';
+
+  meta = with lib; {
+    description = "Pixel-oriented paint program, modelled on Deluxe Paint";
+    homepage = "http://evilpixie.scumways.com/";
+    downloadPage = "https://github.com/bcampbell/evilpixie/releases";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/development/libraries/impy/default.nix
+++ b/pkgs/development/libraries/impy/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libpng
+, zlib
+, giflib
+, libjpeg
+, SDL2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "impy";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "bcampbell";
+    repo = "impy";
+    rev = "v${version}";
+    sha256 = "1h45xjms56radhknspyx17a12dpnm7xgqm1x1chy42aw5ic8b5qf";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libpng
+    zlib
+    giflib
+    libjpeg
+    SDL2
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A simple library for loading/saving images and animations, written in C";
+    homepage = "https://github.com/bcampbell/impy";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12416,6 +12416,8 @@ in
 
   imlibsetroot = callPackage ../applications/graphics/imlibsetroot { libXinerama = xorg.libXinerama; } ;
 
+  impy = callPackage ../development/libraries/impy { };
+
   ineffassign = callPackage ../development/tools/ineffassign { };
 
   ijs = callPackage ../development/libraries/ijs { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19413,6 +19413,8 @@ in
 
   evilvte = callPackage ../applications/misc/evilvte (config.evilvte or {});
 
+  evilpixie = libsForQt5.callPackage ../applications/graphics/evilpixie { };
+
   exercism = callPackage ../applications/misc/exercism { };
 
   go-motion = callPackage ../development/tools/go-motion { };


### PR DESCRIPTION
##### Motivation for this change

Cool pixel-oriented image editor. We're missing those.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
