### PR TITLE
rebazel: init at 0.1.4

### DIFF
--- a/pkgs/development/tools/rebazel/default.nix
+++ b/pkgs/development/tools/rebazel/default.nix
@@ -1,0 +1,21 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+rustPlatform.buildRustPackage rec {
+  pname = "rebazel";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "meetup";
+    repo = "rebazel";
+    rev = "v${version}";
+    hash = "sha256-v84ZXhtJpejQmP61NmP06+qrtMu/0yb7UyD7U12xlME=";
+  };
+
+  cargoSha256 = "sha256-2FmtbvtNfNoocj3Ly553KBLfOgBAa/eAxOrfZ3NGzzw=";
+
+  meta = with lib; {
+    description = "tool for expediting bazel build workflows";
+    homepage = "https://github.com/meetup/rebazel";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zimbatm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10075,6 +10075,8 @@ in
 
   bazelisk = callPackage ../development/tools/bazelisk { };
 
+  rebazel = callPackage ../development/tools/rebazel { };
+
   buildBazelPackage = callPackage ../build-support/build-bazel-package { };
 
   bear = callPackage ../development/tools/build-managers/bear { };


### PR DESCRIPTION
using this on a project

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---