### PR TITLE
luaPackages.ldbus: init at scm-0

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -18,6 +18,7 @@ dkjson,,,,,
 fifo,,,,,
 http,,,,,vcunat
 inspect,,,,,
+ldbus,,http://luarocks.org/dev,,,
 ldoc,,,,,
 lgi,,,,,
 linenoise,,,,,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -359,6 +359,33 @@ inspect = buildLuarocksPackage {
     license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 };
+ldbus = buildLuarocksPackage {
+  pname = "ldbus";
+  version = "scm-0";
+
+  knownRockspec = (fetchurl {
+    url    = "https://luarocks.org/dev/ldbus-scm-0.rockspec";
+    sha256 = "1yhkw5y8h1qf44vx31934k042cmnc7zcv2k0pv0g27wsmlxrlznx";
+  }).outPath;
+
+  src = fetchgit ( removeAttrs (builtins.fromJSON ''{
+  "url": "git://github.com/daurnimator/ldbus.git",
+  "rev": "9e176fe851006037a643610e6d8f3a8e597d4073",
+  "date": "2019-08-16T14:26:05+10:00",
+  "sha256": "06wcz4i5b7kphqbry274q3ivnsh331rxiyf7n4qk3zx2kvarq08s",
+  "fetchSubmodules": true
+}
+ '') ["date"]) ;
+
+  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  propagatedBuildInputs = [ lua ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/daurnimator/ldbus";
+    description = "A Lua library to access dbus.";
+    license.fullName = "MIT/X11";
+  };
+};
 ldoc = buildLuarocksPackage {
   pname = "ldoc";
   version = "1.4.6-2";

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -76,6 +76,17 @@ with super;
     */
   });
 
+  ldbus = super.ldbus.override({
+    extraVariables = {
+      DBUS_DIR="${pkgs.dbus.lib}";
+      DBUS_ARCH_INCDIR="${pkgs.dbus.lib}/lib/dbus-1.0/include";
+      DBUS_INCDIR="${pkgs.dbus.dev}/include/dbus-1.0";
+    };
+    buildInputs = with pkgs; [
+      dbus
+    ];
+  });
+
   ljsyscall = super.ljsyscall.override(rec {
     version = "unstable-20180515";
     # package hasn't seen any release for a long time


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This adds `ldbus`, a Lua library to use dbus. Note that the last version is 3 years old, but it's used by some AwesomeWM widgets, so it might be useful to have.

I use it for a bluetooth widget on awesome and it works well.

Related issue: #90532 
cc @teto 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
