### PR TITLE
Pycurl issue 77304 backports 20.03

### DIFF
--- a/pkgs/development/python-modules/pycurl/default.nix
+++ b/pkgs/development/python-modules/pycurl/default.nix
@@ -47,7 +47,8 @@ buildPythonPackage rec {
                      and not test_libcurl_ssl_openssl" \
                  --ignore=tests/getinfo_test.py \
                  --ignore=tests/memory_mgmt_test.py \
-                 --ignore=tests/multi_memory_mgmt_test.py
+                 --ignore=tests/multi_memory_mgmt_test.py \
+                 --ignore=tests/multi_timer_test.py
   '';
 
   preConfigure = ''

--- a/pkgs/development/python-modules/pycurl/default.nix
+++ b/pkgs/development/python-modules/pycurl/default.nix
@@ -36,6 +36,8 @@ buildPythonPackage rec {
   ];
 
   # skip impure or flakey tests
+  # See also:
+  #   * https://github.com/NixOS/nixpkgs/issues/77304
   checkPhase = ''
     HOME=$TMPDIR pytest tests -k "not test_ssl_in_static_libs \
                      and not test_keyfunction \
@@ -44,7 +46,8 @@ buildPythonPackage rec {
                      and not test_libcurl_ssl_nss \
                      and not test_libcurl_ssl_openssl" \
                  --ignore=tests/getinfo_test.py \
-                 --ignore=tests/memory_mgmt_test.py
+                 --ignore=tests/memory_mgmt_test.py \
+                 --ignore=tests/multi_memory_mgmt_test.py
   '';
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

20.03 backports (to fix flaky `pycurl` tests) of

* #89544
* #90481

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
