### PR TITLE
wxsqlite3/wxsqliteplus: use gtk2 variant

### DIFF
--- a/pkgs/development/libraries/wxsqlite3/default.nix
+++ b/pkgs/development/libraries/wxsqlite3/default.nix
@@ -1,13 +1,14 @@
 { stdenv
+, lib
 , fetchFromGitHub
 , autoreconfHook
-, wxGTK
 , sqlite
 , darwin
+, withGtk2 ? false, wxGTK30-gtk2 ? null, wxGTK30-gtk3 ? null
 }:
 
 stdenv.mkDerivation rec {
-  pname = "wxsqlite3";
+  pname = "wxsqlite3-gtk${toString (if withGtk2 then 2 else 3)}";
   version = "4.5.1";
 
   src = fetchFromGitHub {
@@ -19,12 +20,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  buildInputs = [ wxGTK sqlite ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Cocoa darwin.stubs.setfile darwin.stubs.rez darwin.stubs.derez ];
+  buildInputs = [ sqlite ]
+    ++ [ (if withGtk2 then wxGTK30-gtk2 else wxGTK30-gtk3) ]
+    ++ lib.optionals stdenv.isDarwin (with darwin; [ apple_sdk.frameworks.Cocoa ] ++ (with stubs; [ setfile rez derez ]));
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = "https://utelle.github.io/wxsqlite3/";
     description = "A C++ wrapper around the public domain SQLite 3.x for wxWidgets";
+    homepage = "https://utelle.github.io/wxsqlite3/";
     platforms = platforms.unix;
     maintainers = with maintainers; [ vrthra ];
     license = [ licenses.lgpl2 ];

--- a/pkgs/development/libraries/wxsqliteplus/default.nix
+++ b/pkgs/development/libraries/wxsqliteplus/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, wxGTK, wxsqlite3, sqlite }:
+{ stdenv, fetchFromGitHub, sqlite
+, wxGTK30-gtk2, wxsqlite3-gtk2 }:
 
 stdenv.mkDerivation rec {
   pname = "wxsqliteplus";
@@ -11,11 +12,13 @@ stdenv.mkDerivation rec {
     sha256 = "0mgfq813pli56mar7pdxlhwjf5k10j196rs3jd0nc8b6dkzkzlnf";
   };
 
-  buildInputs = [ wxGTK wxsqlite3 sqlite ];
+  buildInputs = [ wxGTK30-gtk2 wxsqlite3-gtk2 sqlite ];
 
   makeFlags = [
-    "LDFLAGS=-L${wxsqlite3}/lib"
+    "LDFLAGS=-L${wxsqlite3-gtk2}/lib"
   ];
+
+  enableParallelBuilding = true;
 
   preBuild = ''
     sed -ie 's|all: $(LIBPREFIX)wxsqlite$(LIBEXT)|all: |g' Makefile
@@ -24,14 +27,14 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    install -D wxsqliteplus $out/bin/wxsqliteplus
+    install -Dm555 -t $out/bin wxsqliteplus
   '';
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/guanlisheng/wxsqliteplus";
     description = "A simple SQLite database browser built with wxWidgets";
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ vrthra ];
     license = licenses.gpl2;
+    maintainers = with maintainers; [ vrthra ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/wxwidgets/3.0/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchurl, pkgconfig
-, libXinerama, libSM, libXxf86vm
+, libXinerama, libSM, libXxf86vm, libnotify
 , gtk2, GConf ? null, gtk3
 , xorgproto, gstreamer, gst-plugins-base, setfile
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
@@ -20,7 +20,7 @@ assert assertMsg (withGtk2 -> withWebKit == false) "wxGTK30: You cannot enable w
 
 stdenv.mkDerivation rec {
   version = "3.0.4";
-  pname = "wxwidgets";
+  pname = "wxwidgets-gtk${toString (if withGtk2 then 2 else 3)}";
 
   src = fetchFromGitHub {
     owner = "wxWidgets";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    libXinerama libSM libXxf86vm xorgproto gstreamer gst-plugins-base
+    libXinerama libSM libXxf86vm xorgproto gstreamer gst-plugins-base libnotify
   ] ++ optionals withGtk2 [ gtk2 GConf ]
     ++ optional (!withGtk2) gtk3
     ++ optional withMesa libGLU

--- a/pkgs/development/libraries/wxwidgets/3.1/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.1/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchurl, pkgconfig
-, libXinerama, libSM, libXxf86vm
+, libXinerama, libSM, libXxf86vm, libnotify
 , gtk2, GConf ? null, gtk3
 , xorgproto, gstreamer, gst-plugins-base, setfile
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
@@ -19,7 +19,7 @@ assert assertMsg (withGtk2 -> withWebKit == false) "wxGTK31: You cannot enable w
 
 stdenv.mkDerivation rec {
   version = "3.1.2";
-  pname = "wxwidgets";
+  pname = "wxwidgets-gtk${toString (if withGtk2 then 2 else 3)}";
 
   src = fetchFromGitHub {
     owner = "wxWidgets";
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    libXinerama libSM libXxf86vm xorgproto gstreamer gst-plugins-base
+    libXinerama libSM libXxf86vm xorgproto gstreamer gst-plugins-base libnotify
   ] ++ optionals withGtk2 [ gtk2 GConf ]
     ++ optional (!withGtk2) gtk3
     ++ optional withMesa libGLU

--- a/pkgs/tools/misc/woeusb/default.nix
+++ b/pkgs/tools/misc/woeusb/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, autoreconfHook, makeWrapper
 , coreutils, dosfstools, findutils, gawk, gnugrep, grub2_light, ncurses, ntfs3g, parted, p7zip, utillinux, wget
-, wxGTK30 }:
+, wxGTK30-gtk3, gsettings_desktop_schemas }:
 
 stdenv.mkDerivation rec {
   version = "3.3.1";
@@ -16,7 +16,10 @@ stdenv.mkDerivation rec {
   patches = [ ./remove-workaround.patch ];
 
   nativeBuildInputs = [ autoreconfHook makeWrapper ];
-  buildInputs = [ wxGTK30 ];
+
+  buildInputs = [ wxGTK30-gtk3 gsettings_desktop_schemas ];
+
+  enableParallelBuilding = true;
 
   postPatch = ''
     # Emulate version smudge filter (see .gitattributes, .gitconfig).

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15766,7 +15766,7 @@ in
 
   hiawatha = callPackage ../servers/http/hiawatha {};
 
-  home-assistant = callPackage ../servers/home-assistant { 
+  home-assistant = callPackage ../servers/home-assistant {
     python3 = python37;
   };
 
@@ -26454,13 +26454,17 @@ in
 
   wxmupen64plus = callPackage ../misc/emulators/wxmupen64plus { };
 
-  wxsqlite3 = callPackage ../development/libraries/wxsqlite3 {
-    wxGTK = wxGTK30;
+  wxsqlite3-gtk2 = callPackage ../development/libraries/wxsqlite3 {
+    withGtk2 = true;
   };
 
-  wxsqliteplus = callPackage ../development/libraries/wxsqliteplus {
-    wxGTK = wxGTK30;
+  wxsqlite3-gtk3 = callPackage ../development/libraries/wxsqlite3 {
+    withGtk2 = false;
   };
+
+  wxsqlite3 = wxsqlite3-gtk3;
+
+  wxsqliteplus = callPackage ../development/libraries/wxsqliteplus { };
 
   x11idle = callPackage ../tools/misc/x11idle {};
 


### PR DESCRIPTION
###### Motivation for this change

Also, we set the pname for wxGTK3 to include the gtk version. This makes
it a lot clearer when trying to figure out what pulls in a gtk2 dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).