### PR TITLE
searx: fix missing dependency version

### DIFF
--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -25,7 +25,8 @@ buildPythonApplication rec {
       --replace 'pygments==2.1.3' 'pygments>=2.1,<3.0' \
       --replace 'pyopenssl==19.0.0' 'pyopenssl' \
       --replace 'python-dateutil==2.8.0' 'python-dateutil==2.8.*' \
-      --replace 'pyyaml==5.1' 'pyyaml'
+      --replace 'pyyaml==5.1' 'pyyaml' \
+      --replace 'requests[socks]==2.22.0' 'requests[socks]'
     substituteInPlace requirements-dev.txt \
       --replace 'plone.testing==5.0.0' 'plone.testing' \
       --replace 'pep8==1.7.0' 'pep8==1.7.*' \


### PR DESCRIPTION
Fixes #90060

Tested working with my own searx instance.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
