### PR TITLE
python3Packages.invoke: don't recompile bytecode

### DIFF
--- a/pkgs/development/python-modules/invoke/default.nix
+++ b/pkgs/development/python-modules/invoke/default.nix
@@ -20,6 +20,9 @@ buildPythonPackage rec {
   # errors with vendored libs
   doCheck = false;
 
+  # has vendored python2 code
+  dontUsePythonRecompileBytecode = true;
+
   meta = {
     description = "Pythonic task execution";
     license = lib.licenses.bsd2;


### PR DESCRIPTION
###### Motivation for this change
Has vendored code across many python interpreters, a given .py might not be compatible with the python interpreter version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
