### PR TITLE
cpplint: 1.3.0 -> 1.5.1

### DIFF
--- a/pkgs/development/tools/analysis/cpplint/default.nix
+++ b/pkgs/development/tools/analysis/cpplint/default.nix
@@ -2,20 +2,21 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cpplint";
-  version = "1.3.0";
+  version = "1.5.1";
 
   # Fetch from github instead of pypi, since the test cases are not in the pypi archive
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "107v7bp35kxbv9v7wl79h7115z1m4b48rhasp0cnivql1grd277i";
+    sha256 = "0k927mycj1k4l3fbxrk597bhcjl2nrpaas1imbjgk64cyq8dv7lh";
   };
 
   postPatch = ''
     patchShebangs cpplint_unittest.py
   '';
 
+  checkInputs = with python3Packages; [ pytest pytestrunner ];
   checkPhase = ''
     ./cpplint_unittest.py
   '';


### PR DESCRIPTION
###### Motivation for this change
fixes build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/90556
1 package built:
cpplint
```