### PR TITLE
mesa: 19.3.3 -> 19.3.5

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -27,7 +27,7 @@
 with stdenv.lib;
 
 let
-  version = "19.3.3";
+  version = "19.3.5";
   branch  = versions.major version;
 in
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
       "https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
     ];
-    sha256 = "02czqdqf64i3az5p1allnxycyjad3x35cj0hz0017mi5pc84ikl1";
+    sha256 = "1dn6975sj25kx6a6x5054ql27lqlshkp5m8cg8nwhwdranq9b600";
   };
 
   prePatch = "patchShebangs .";


### PR DESCRIPTION
###### Motivation for this change
Bug-fix-only updates to mesa since freeze for 20.03. 
https://www.mesa3d.org/relnotes/19.3.4.html
https://www.mesa3d.org/relnotes/19.3.5.html

I am personally affected by a bug with amd-gpu in 19.3.3 that makes the computer unusable[1]. That particular issue was resolved in 19.3.4, but it seems to me that if it should be changed that we might as well also get the fixes provided by 19.3.5. 

I don't have the hardware to test compilation of _everything_ that depends on this change in a reasonable amount of time, but I did build and test KDE on top of it.

[1] https://gitlab.freedesktop.org/mesa/mesa/-/issues/1426

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@vcunat, maintainer.