### PR TITLE
atom: 1.42.0 -> 1.48.0

### DIFF
--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -3,14 +3,14 @@
 let
   versions = {
     atom = {
-      version = "1.42.0";
-      sha256 = "1ira528nwxi30jfwyivlac3wkkqb9d2z4jhxwq5m7mnpm5yli6jy";
+      version = "1.48.0";
+      sha256 = "1693bxbylf6jhld9bdcr5pigk36wqlbj89praldpz9s96yxig9s1";
     };
 
     atom-beta = {
-      version = "1.43.0";
+      version = "1.49.0";
       beta = 0;
-      sha256 = "06if3w5hx7njmyal0012zawn8f5af1z4bjcbzj2c0gd15nlsgm95";
+      sha256 = "1fr6m4a7shdj3wpn6g4n95cqpkkg2x9srwjf7bqxv9f3d5jb1y33";
     };
   };
 

--- a/pkgs/applications/editors/atom/env.nix
+++ b/pkgs/applications/editors/atom/env.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, zlib, glib, alsaLib, dbus, gtk3, atk, pango, freetype, fontconfig
 , libgnome-keyring3, gdk-pixbuf, cairo, cups, expat, libgpgerror, nspr
 , gconf, nss, xorg, libcap, systemd, libnotify, libsecret, libuuid, at-spi2-atk
+, at-spi2-core
 }:
 
 let
@@ -10,7 +11,7 @@ let
     xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
     xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
     xorg.libXcursor xorg.libxkbfile xorg.libXScrnSaver libcap systemd libnotify
-    xorg.libxcb libsecret libuuid at-spi2-atk
+    xorg.libxcb libsecret libuuid at-spi2-atk at-spi2-core
   ];
 
   libPathNative = lib.makeLibraryPath packages;


### PR DESCRIPTION
And atom-beta: 1.43.0-beta0 -> 1.49.0-beta0

This version bump includes an important python2 -> python3 update:
node-gyp 3.7.0 -> 5.1.0 in Atom's apm/package-lock.json, which, per
https://github.com/nodejs/node-gyp/issues/1687, finally allows python3
to be used instead of EOL'd python2 for atom-package installation.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Be able to install atom packages without installing python2, which is 5 months past EOL.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
    `typora` and `termius-app` debs could not be fetched.  I didn't look into this further because these only build with allowUnfree.
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    1301740784 -> 1308167848 ( +0.5% )
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Maintainers: @offlinehacker @NeQuissimus @ysndr

Note that there is another open Atom version bump PR: #83340 1.42.0 -> 1.45.0.
(Atom needs to get to 1.48 to fix the python2 problem.)