### PR TITLE
tre-command: 0.2.3 -> 0.3.1

### DIFF
--- a/pkgs/tools/system/tre-command/default.nix
+++ b/pkgs/tools/system/tre-command/default.nix
@@ -1,17 +1,17 @@
 { rustPlatform, fetchFromGitHub, stdenv }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "tre";
-  version = "0.2.3";
+  pname = "tre-command";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "dduan";
     repo = "tre";
     rev = "v${version}";
-    sha256 = "1fazw2wn738iknbv54gv7qll7d4q2gy9bq1s3f3cv21cdv6bqral";
+    sha256 = "1fm3fszy7fd0dgf5dwm35nb0ym0waw92iyx128lr2vlbyzln6ija";
   };
 
-  cargoSha256 = "16bvnwgjf3kj99d77j1pkldbasxfwy55sj9sv9vf2z6llfmzfabd";
+  cargoSha256 = "0sk4dn5rrqhkaxm76y1d7rsjsw6pdjdhb2xv7qqrlivfk6y5k31x";
 
   meta = with stdenv.lib; {
     description = "Tree command, improved";


### PR DESCRIPTION
##### Motivation for this change

New `tre` release: https://github.com/dduan/tre/releases/tag/v0.3.1

Also, change `pname` to match the actual desired name. Avoid name
conflict with the other (older) package named `tre`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
