### PR TITLE
git-revise: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/git-revise/default.nix
+++ b/pkgs/development/python-modules/git-revise/default.nix
@@ -1,30 +1,26 @@
 { lib
 , buildPythonPackage
-, fetchPypi
 , pythonOlder
-, tox
-, pytest
-, pylint
-, mypy
-, black
+, git
+, fetchFromGitHub
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "git-revise";
-  version = "0.5.1";
+  version = "0.6.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0l3xhg00106p7ysg4gl9dna2zcrax58mzmm0ajjaxw58jfn8wsf1";
+  # Missing tests on PyPI
+  src = fetchFromGitHub {
+    owner = "mystor";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "03v791yhips9cxz9hr07rhsgxfhwyqq17rzi7ayjhwvy65s4hzs9";
   };
 
   disabled = pythonOlder "3.6";
 
-  checkInputs = [ tox pytest pylint mypy black ];
-
-  checkPhase = ''
-    tox
-  '';
+  checkInputs = [ git pytestCheckHook ];
 
   meta = with lib; {
     description = "Efficiently update, split, and rearrange git commits";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
