### PR TITLE
tap-plugins: init at 1.0.1

### DIFF
--- a/pkgs/applications/audio/tap-plugins/default.nix
+++ b/pkgs/applications/audio/tap-plugins/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, ladspa-sdk, pkgs, ... }:
+
+stdenv.mkDerivation rec {
+  pname = "tap-plugins";
+  version = "1.0.1";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "tomszilagyi";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0c6qhyf8smlypc36vmpr42dm3mrzk6pg9cc9r0vx22qbrd5zfpjw";
+  };
+
+  buildInputs = [ ladspa-sdk ];
+
+  preInstall = ''
+    substituteInPlace Makefile --replace /usr/local "$out"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tom's Audio Processing plugins";
+    longDescription = ''
+      A number of LADSPA plugins including: TAP AutoPanner, TAP Chorus/Flanger, TAP DeEsser,
+      TAP Dynamics (Mono & Stereo), TAP Equalizer and TAP Equalizer/BW, TAP Fractal Doubler, TAP Pink/Fractal Noise,
+      TAP Pitch Shifter, TAP Reflector, TAP Reverberator, TAP Rotary Speaker, TAP Scaling Limiter,
+      TAP Sigmoid Booster, TAP Stereo Echo, TAP Tremolo, TAP TubeWarmth, TAP Vibrato.
+    '';
+    homepage = "http://tap-plugins.sourceforge.net/ladspa.html";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.fps ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24344,6 +24344,8 @@ in
 
   taskell = haskell.lib.justStaticExecutables haskellPackages.taskell;
 
+  tap-plugins = callPackage ../applications/audio/tap-plugins { };
+
   taskjuggler = callPackage ../applications/misc/taskjuggler { };
 
   tabula = callPackage ../applications/misc/tabula { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I needed tap-plugins for an experiment I ran. Once I had finished the expression I thought "Why not send a PR to nixpkgs?". So I did.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
