### PR TITLE
whatfiles: init at 2020-06-16

### DIFF
--- a/pkgs/tools/misc/whatfiles/default.nix
+++ b/pkgs/tools/misc/whatfiles/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, makeWrapper}:
+
+stdenv.mkDerivation {
+  pname = "whatfiles-unstable";
+  version = "2020-06-16";
+
+  src = fetchFromGitHub {
+    owner = "spieglt";
+    repo = "whatfiles";
+    rev  = "2e12e73fec9683d95397b032fc3220ee00377ccc";
+    sha256 = "1l326ra8x38f3v99b7izcg6rwrl6dxps9xbp6ca0r711fdgaf1lg";
+  };
+
+  installPhase = ''
+    install -Dm755 bin/whatfiles $out/bin/whatfiles
+  '';
+
+  meta = with lib; {
+    description = "Log what files are accessed by any Linux process";
+    homepage = "https://github.com/spieglt/whatfiles";
+    maintainers = [ maintainers.matthiasbeyer ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13067,6 +13067,8 @@ in
 
   vtable-dumper = callPackage ../development/tools/misc/vtable-dumper { };
 
+  whatfiles = callPackage ../tools/misc/whatfiles { };
+
   whatstyle = callPackage ../development/tools/misc/whatstyle {
     inherit (llvmPackages) clang-unwrapped;
   };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
