### PR TITLE
aws-lambda-builders: 0.8.0 -> 0.9.0; aws-sam-cli: 0.44.0 -> 1.0.0rc1

### DIFF
--- a/pkgs/development/python-modules/aws-lambda-builders/default.nix
+++ b/pkgs/development/python-modules/aws-lambda-builders/default.nix
@@ -2,22 +2,24 @@
 , buildPythonPackage
 , fetchFromGitHub
 , six
+, pathlib
 , pytest
 , mock
 , parameterized
+, isPy27
 , isPy35
 }:
 
 buildPythonPackage rec {
   pname = "aws-lambda-builders";
-  version = "0.8.0";
+  version = "0.9.0";
 
   # No tests available in PyPI tarball
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-lambda-builders";
     rev = "v${version}";
-    sha256 = "1akiv92cd7ciky0aay94lh9azr73jajn0x0x6ywaf3qm5c4hyvys";
+    sha256 = "0cgb0hwf4xg5dmm32wwlxqy7a77jw6gpnj7v8rq5948hsy2sfrcp";
   };
 
   # Package is not compatible with Python 3.5
@@ -25,7 +27,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     six
-  ];
+  ] ++ lib.optionals isPy27 [ pathlib ];
 
   checkInputs = [
     pytest

--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ fetchFromGitHub
+, lib
 , python
 , enableTelemetry ? false
 }:
@@ -6,6 +7,14 @@
 let
   py = python.override {
     packageOverrides = self: super: {
+      aws-sam-translator = super.aws-sam-translator.overridePythonAttrs (oldAttrs: rec {
+        version = "1.25.0";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "08756yl5lpqgrpr80f2b6bdcgygr37l6q1yygklcg9hz4yfpccav";
+        };
+      });
+
       flask = super.flask.overridePythonAttrs (oldAttrs: rec {
         version = "1.0.2";
         src = oldAttrs.src.override {
@@ -30,11 +39,11 @@ with py.pkgs;
 
 buildPythonApplication rec {
   pname = "aws-sam-cli";
-  version = "0.44.0";
+  version = "1.0.0rc1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0r3m41xjmg8m2jwsqwc9kdkcs3xbz8dsl240ybwbnr7rp29pnirf";
+    sha256 = "011b334gdvd9lhqia8c952q3cmzj99vik680180nbp0qh2xw6zpf";
   };
 
   # Tests are not included in the PyPI package
@@ -66,9 +75,11 @@ buildPythonApplication rec {
   # fix over-restrictive version bounds
   postPatch = ''
     substituteInPlace requirements/base.txt \
+      --replace "boto3~=1.13.0, >=1.13.0" "boto3~=1.14.3" \
       --replace "serverlessrepo==0.1.9" "serverlessrepo~=0.1.9" \
       --replace "python-dateutil~=2.6, <2.8.1" "python-dateutil~=2.6" \
-      --replace "tomlkit==0.5.8" "tomlkit~=0.5.8" \
+      --replace "jmespath~=0.9.5" "jmespath~=0.10.0" \
+      --replace "tomlkit==0.5.8" "tomlkit~=0.6.0" \
       --replace "requests==2.22.0" "requests~=2.22"
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The version of aws-sam-cli currently in nixpkgs does not support building `runtime: provided` functions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Also tested by building the `template.yaml` I was working on before I hit this problem.