### PR TITLE
birdtray: fix qttranslations path

### DIFF
--- a/pkgs/applications/misc/birdtray/default.nix
+++ b/pkgs/applications/misc/birdtray/default.nix
@@ -7,6 +7,7 @@
   , qtbase
   , qttools
   , qtx11extras
+  , qttranslations
 }:
 
 mkDerivation rec {
@@ -20,10 +21,20 @@ mkDerivation rec {
     sha256 = "15l8drdmamq1dpqpj0h9ajj2r5vcs23cx421drvhfgs6bqlzd1hl";
   };
 
+  patches = [
+    # See https://github.com/NixOS/nixpkgs/issues/86054
+    ./fix-qttranslations-path.diff
+  ];
+
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [
     qtbase qttools qtx11extras
   ];
+
+  postPatch = ''
+    substituteInPlace src/birdtrayapp.cpp \
+      --subst-var-by qttranslations ${qttranslations}
+  '';
 
   meta = with lib; {
     description = "Mail system tray notification icon for Thunderbird";

--- a/pkgs/applications/misc/birdtray/fix-qttranslations-path.diff
+++ b/pkgs/applications/misc/birdtray/fix-qttranslations-path.diff
@@ -1,0 +1,13 @@
+diff --git a/src/birdtrayapp.cpp b/src/birdtrayapp.cpp
+index 847b4d3..3a3709a 100644
+--- a/src/birdtrayapp.cpp
++++ b/src/birdtrayapp.cpp
+@@ -130,7 +130,7 @@ bool BirdtrayApp::loadTranslations() {
+             [](QString path) { return path.append("/translations"); });
+     QLocale locale = QLocale::system();
+     bool success = loadTranslation(
+-            qtTranslator, locale, "qt", {QLibraryInfo::location(QLibraryInfo::TranslationsPath)});
++            qtTranslator, locale, "qt", {QLatin1String("@qttranslations@/translations")});
+     success &= loadTranslation(dynamicTranslator, locale, "dynamic", locations);
+     success &= loadTranslation(mainTranslator, locale, "main", locations);
+     return success;


### PR DESCRIPTION
###### Motivation for this change

- fix qttranslations path (#86054)
- birdtray crashes not finding the translations without this fix.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
