### PR TITLE
coqPackages.simple-io: 1.2.0 → 1.3.0

### DIFF
--- a/pkgs/development/coq-modules/simple-io/default.nix
+++ b/pkgs/development/coq-modules/simple-io/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, coq, coq-ext-lib }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.0";
+  version = "1.3.0";
   name = "coq${coq.coq-version}-simple-io-${version}";
   src = fetchFromGitHub {
     owner = "Lysxia";
     repo = "coq-simple-io";
     rev = version;
-    sha256 = "1im1vwp7l7ha8swnhgbih0qjg187n8yx14i003nf6yy7p0ryxc9m";
+    sha256 = "1yp7ca36jyl9kz35ghxig45x6cd0bny2bpmy058359p94wc617ax";
   };
 
   buildInputs = [ coq ] ++ (with coq.ocamlPackages; [ ocaml ocamlbuild ]);
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.7" "8.8" "8.9" "8.10" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.7" "8.8" "8.9" "8.10" "8.11" ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Support for Coq 8.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
