### PR TITLE
pythonPackages.canopen: 0.5.1 -> 1.1.0

### DIFF
--- a/pkgs/development/python-modules/canopen/default.nix
+++ b/pkgs/development/python-modules/canopen/default.nix
@@ -1,32 +1,18 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , nose
 , can
 , canmatrix }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "canopen";
-  version = "0.5.1";
+  version = "1.1.0";
 
-  # use fetchFromGitHub until version containing test/sample.eds
-  # is available on PyPi
-  # https://github.com/christiansandberg/canopen/pull/57
-
-  src = fetchFromGitHub {
-    owner = "christiansandberg";
-    repo = "canopen";
-    rev = "b20575d84c3aef790fe7c38c5fc77601bade0ea4";
-    sha256 = "1qg47qrkyvyxiwi13sickrkk89jp9s91sly2y90bz0jhws2bxh64";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fqa4p3qg7800fykib1x264gizhhmb6dz2hajgwr0hxf5xa19wdl";
   };
-
-  #src = fetchPypi {
-  #  inherit pname version;
-  #  sha256 = "0806cykarpjb9ili3mf82hsd9gdydbks8532nxgz93qzg4zdbv2g";
-  #};
-
-  # test_pdo failure https://github.com/christiansandberg/canopen/issues/58
-  doCheck = false;
 
   propagatedBuildInputs =
     [ can


### PR DESCRIPTION
###### Motivation for this change
Much newer version available, re-enable tests and use fetchPypi.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
