### PR TITLE
go: add CoreFoundation and Security frameworks for cgo on darwin

### DIFF
--- a/pkgs/development/compilers/go/1.13.nix
+++ b/pkgs/development/compilers/go/1.13.nix
@@ -2,6 +2,7 @@
 , perl, which, pkgconfig, patch, procps, pcre, cacert, Security, Foundation
 , mailcap, runtimeShell
 , buildPackages, pkgsTargetTarget
+, makeWrapper, darwin, callPackage
 }:
 
 let
@@ -41,6 +42,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ perl which pkgconfig patch procps ];
   buildInputs = [ cacert pcre ]
     ++ optionals stdenv.isLinux [ stdenv.cc.libc.out ]
+    ++ optionals stdenv.isDarwin [ makeWrapper ]
     ++ optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
 
   depsTargetTargetPropagated = optionals stdenv.isDarwin [ Security Foundation ];
@@ -228,6 +230,17 @@ stdenv.mkDerivation rec {
     ln -s $GOROOT_FINAL/bin $out/bin
     runHook postInstall
   '';
+
+  # These flags are needed to ensure the standard library compiles correctly
+  postInstall = optionalString stdenv.isDarwin (with darwin.apple_sdk.frameworks; ''
+    wrapProgram $out/share/go/bin/go \
+      --suffix CGO_CFLAGS  ' ' '-iframework ${CoreFoundation}/Library/Frameworks -iframework ${Security}/Library/Frameworks' \
+      --suffix CGO_LDFLAGS ' ' '-F${CoreFoundation}/Library/Frameworks -F${Security}/Library/Frameworks'
+  '');
+
+  passthru.tests = {
+    compile-cgo = callPackage ./test-compile-cgo-stdlib { goPackage = "go_1_13"; };
+  };
 
   disallowedReferences = [ goBootstrap ];
 

--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -1,9 +1,8 @@
 { stdenv, fetchurl, tzdata, iana-etc, runCommand
 , perl, which, pkgconfig, patch, procps, pcre, cacert, Security, Foundation
 , mailcap, runtimeShell
-, makeWrapper, darwin
 , buildPackages, pkgsTargetTarget
-, callPackage
+, makeWrapper, darwin, callPackage
 }:
 
 let
@@ -240,7 +239,7 @@ stdenv.mkDerivation rec {
   '');
 
   passthru.tests = {
-    compile-cgo = callPackage ./test-compile-cgo {};
+    compile-cgo = callPackage ./test-compile-cgo-stdlib { goPackage = "go_1_14"; };
   };
 
   disallowedReferences = [ goBootstrap ];

--- a/pkgs/development/compilers/go/test-compile-cgo-stdlib/default.nix
+++ b/pkgs/development/compilers/go/test-compile-cgo-stdlib/default.nix
@@ -1,0 +1,13 @@
+{ stdenv, go, darwin }:
+
+stdenv.mkDerivation {
+  name = "compile-cgo-stdlib";
+  meta.timeout = 60;
+  buildCommand = ''
+    export GOCACHE=$TMPDIR/cache
+    ${go}/bin/go build -x -o $TMPDIR/prog ${./file.go}
+    $TMPDIR/prog | grep "hello"
+    touch $out
+  '';
+}
+

--- a/pkgs/development/compilers/go/test-compile-cgo-stdlib/default.nix
+++ b/pkgs/development/compilers/go/test-compile-cgo-stdlib/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, go, darwin }:
+{ stdenv, darwin, goPackage, pkgs }:
 
-stdenv.mkDerivation {
-  name = "compile-cgo-stdlib";
-  meta.timeout = 60;
-  buildCommand = ''
-    export GOCACHE=$TMPDIR/cache
-    ${go}/bin/go build -x -o $TMPDIR/prog ${./file.go}
-    $TMPDIR/prog | grep "hello"
-    touch $out
-  '';
-}
-
+let
+  go = pkgs.${goPackage};
+in
+  stdenv.mkDerivation {
+    name = "compile-cgo-stdlib";
+    meta.timeout = 60;
+    buildCommand = ''
+      export GOCACHE=$TMPDIR/cache
+      ${go}/bin/go build -x -o $TMPDIR/prog ${./file.go}
+      $TMPDIR/prog | grep "hello"
+      touch $out
+    '';
+  }

--- a/pkgs/development/compilers/go/test-compile-cgo-stdlib/file.go
+++ b/pkgs/development/compilers/go/test-compile-cgo-stdlib/file.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	// This stdlib package uses cgo with system frameworks on darwin
+	_ "crypto/x509"
+	"fmt"
+)
+
+func main() {
+	fmt.Println("hello")
+}


### PR DESCRIPTION
Here I'm adding some CGO flags to ensure the c compiler is able to find system frameworks on Darwin. These frameworks need to be always available, to ensure some parts of the standard library (notably `crypto/x509`) can be compiled.

I've also added a test that reproduces the issue.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

See https://github.com/NixOS/nixpkgs/issues/56348 for background

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
