### PR TITLE
tpm2-tss: 2.3.2 -> 2.4.1

### DIFF
--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    autoreconfHook autoconf-archive pkg-config doxygen perl libgcrypt.dev
+    autoreconfHook autoconf-archive pkg-config doxygen perl
   ];
   buildInputs = [ openssl json_c curl libgcrypt ];
   checkInputs = [

--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -14,13 +14,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     doxygen perl pkgconfig
-    # For unit tests and integration tests.
-    ibm-sw-tpm2 iproute procps which
   ];
   buildInputs = [
     openssl json_c curl
-    # For unit tests and integration tests.
-    cmocka uthash
+  ];
+  checkInputs = [
+    cmocka uthash ibm-sw-tpm2 iproute procps which
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -1,24 +1,16 @@
 { stdenv, lib, fetchurl, fetchpatch
-, cmocka, doxygen, ibm-sw-tpm2, iproute, openssl, perl, pkgconfig, procps
+, cmocka, doxygen, ibm-sw-tpm2, iproute, openssl, perl, pkgconfig, procps, json_c, curl
 , uthash, which
 }:
 
 stdenv.mkDerivation rec {
   pname = "tpm2-tss";
-  version = "2.3.2";
+  version = "2.4.1";
 
   src = fetchurl {
     url = "https://github.com/tpm2-software/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "19jg09sxy3aj4dc1yv32jjv0m62cnmhjlw02jbh4d4pk2439m4l2";
+    sha256 = "03g6l64nzkpadjyabmbhnhs8648iqb95fviinnpslggzp75azmsq";
   };
-
-  patches = [
-    # Fix test failure. see https://github.com/tpm2-software/tpm2-tss/pull/1585
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/tpm2-software/tpm2-tss/pull/1585.patch";
-      sha256 = "0ak3l588ahzv3yx1gfa4sa6p74lsffxzkr23ppznm34wvlcci86n";
-    })
-  ];
 
   nativeBuildInputs = [
     doxygen perl pkgconfig
@@ -26,7 +18,7 @@ stdenv.mkDerivation rec {
     ibm-sw-tpm2 iproute procps which
   ];
   buildInputs = [
-    openssl
+    openssl json_c curl
     # For unit tests and integration tests.
     cmocka uthash
   ];

--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -1,26 +1,29 @@
-{ stdenv, lib, fetchurl, fetchpatch
-, cmocka, doxygen, ibm-sw-tpm2, iproute, openssl, perl, pkgconfig, procps, json_c, curl
-, uthash, which
+{ stdenv, lib, fetchFromGitHub
+, autoreconfHook, autoconf-archive, pkg-config, doxygen, perl
+, openssl, json_c, curl, libgcrypt
+, cmocka, uthash, ibm-sw-tpm2, iproute, procps, which
 }:
 
 stdenv.mkDerivation rec {
   pname = "tpm2-tss";
   version = "2.4.1";
 
-  src = fetchurl {
-    url = "https://github.com/tpm2-software/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "03g6l64nzkpadjyabmbhnhs8648iqb95fviinnpslggzp75azmsq";
+  src = fetchFromGitHub {
+    owner = "tpm2-software";
+    repo = pname;
+    rev = version;
+    sha256 = "09x5czaj4a8cyf8cxavcasx3yy1kik1s45a90c7zvxb7y1kfp9zs";
   };
 
   nativeBuildInputs = [
-    doxygen perl pkgconfig
+    autoreconfHook autoconf-archive pkg-config doxygen perl libgcrypt.dev
   ];
-  buildInputs = [
-    openssl json_c curl
-  ];
+  buildInputs = [ openssl json_c curl libgcrypt ];
   checkInputs = [
     cmocka uthash ibm-sw-tpm2 iproute procps which
   ];
+
+  preAutoreconf = "./bootstrap";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     cmocka uthash
   ];
 
+  enableParallelBuilding = true;
+
   postPatch = "patchShebangs script";
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change
Update of the TPM2 software stack.
Originally done as part of investigating the errors in #74665.

This has been both tested to work with the latest version of the abrmd userspace resource manager (2.3.2) as well as the current nixpkgs master version of tpm-tools with the device TCTI.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@JohnAZoidberg 