### PR TITLE
python3Packages.simpy: add missing dependency

### DIFF
--- a/pkgs/development/python-modules/simpy/default.nix
+++ b/pkgs/development/python-modules/simpy/default.nix
@@ -1,8 +1,11 @@
-{ buildPythonPackage, fetchPypi, lib, setuptools_scm, pytestCheckHook }:
+{ buildPythonPackage, fetchPypi, isPy27, lib, setuptools, setuptools_scm
+, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "simpy";
   version = "4.0.1";
+
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
@@ -10,12 +13,15 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ setuptools_scm ];
+
+  propagatedBuildInputs = [ setuptools ];
+
   checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
-    homepage = "https://simpy.readthedocs.io/en/latest/";
-    description = "A process-based discrete-event simulation framework based on standard Python.";
+    homepage = "https://simpy.readthedocs.io/en/${version}/";
+    description = "Process-based discrete-event simulation framework based on standard Python";
     license = [ licenses.mit ];
-    maintainers = with maintainers; [ shlevy ];
+    maintainers = with maintainers; [ dmrauh shlevy ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment d<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

simpy didn't build because of missing `setuptools` as `propagatedBuildInputs` which I added in this PR, thus this resolves #90494. I'm still not to sure about the circumstances which caused the error, but my change fixes it. I also made some smaller cosmetic changes to the derivation while I was at it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

