### PR TITLE
tpm2-abrmd: 2.2.0 -> 2.3.2

### DIFF
--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    autoreconfHook autoconf-archive pkg-config doxygen perl libgcrypt.dev
+    autoreconfHook autoconf-archive pkg-config doxygen perl
   ];
   buildInputs = [ openssl json_c curl libgcrypt ];
   checkInputs = [

--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -14,13 +14,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     doxygen perl pkgconfig
-    # For unit tests and integration tests.
-    ibm-sw-tpm2 iproute procps which
   ];
   buildInputs = [
     openssl json_c curl
-    # For unit tests and integration tests.
-    cmocka uthash
+  ];
+  checkInputs = [
+    cmocka uthash ibm-sw-tpm2 iproute procps which
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -1,24 +1,16 @@
 { stdenv, lib, fetchurl, fetchpatch
-, cmocka, doxygen, ibm-sw-tpm2, iproute, openssl, perl, pkgconfig, procps
+, cmocka, doxygen, ibm-sw-tpm2, iproute, openssl, perl, pkgconfig, procps, json_c, curl
 , uthash, which
 }:
 
 stdenv.mkDerivation rec {
   pname = "tpm2-tss";
-  version = "2.3.2";
+  version = "2.4.1";
 
   src = fetchurl {
     url = "https://github.com/tpm2-software/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "19jg09sxy3aj4dc1yv32jjv0m62cnmhjlw02jbh4d4pk2439m4l2";
+    sha256 = "03g6l64nzkpadjyabmbhnhs8648iqb95fviinnpslggzp75azmsq";
   };
-
-  patches = [
-    # Fix test failure. see https://github.com/tpm2-software/tpm2-tss/pull/1585
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/tpm2-software/tpm2-tss/pull/1585.patch";
-      sha256 = "0ak3l588ahzv3yx1gfa4sa6p74lsffxzkr23ppznm34wvlcci86n";
-    })
-  ];
 
   nativeBuildInputs = [
     doxygen perl pkgconfig
@@ -26,7 +18,7 @@ stdenv.mkDerivation rec {
     ibm-sw-tpm2 iproute procps which
   ];
   buildInputs = [
-    openssl
+    openssl json_c curl
     # For unit tests and integration tests.
     cmocka uthash
   ];

--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -1,26 +1,29 @@
-{ stdenv, lib, fetchurl, fetchpatch
-, cmocka, doxygen, ibm-sw-tpm2, iproute, openssl, perl, pkgconfig, procps, json_c, curl
-, uthash, which
+{ stdenv, lib, fetchFromGitHub
+, autoreconfHook, autoconf-archive, pkg-config, doxygen, perl
+, openssl, json_c, curl, libgcrypt
+, cmocka, uthash, ibm-sw-tpm2, iproute, procps, which
 }:
 
 stdenv.mkDerivation rec {
   pname = "tpm2-tss";
   version = "2.4.1";
 
-  src = fetchurl {
-    url = "https://github.com/tpm2-software/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "03g6l64nzkpadjyabmbhnhs8648iqb95fviinnpslggzp75azmsq";
+  src = fetchFromGitHub {
+    owner = "tpm2-software";
+    repo = pname;
+    rev = version;
+    sha256 = "09x5czaj4a8cyf8cxavcasx3yy1kik1s45a90c7zvxb7y1kfp9zs";
   };
 
   nativeBuildInputs = [
-    doxygen perl pkgconfig
+    autoreconfHook autoconf-archive pkg-config doxygen perl libgcrypt.dev
   ];
-  buildInputs = [
-    openssl json_c curl
-  ];
+  buildInputs = [ openssl json_c curl libgcrypt ];
   checkInputs = [
     cmocka uthash ibm-sw-tpm2 iproute procps which
   ];
+
+  preAutoreconf = "./bootstrap";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     cmocka uthash
   ];
 
+  enableParallelBuilding = true;
+
   postPatch = "patchShebangs script";
 
   configureFlags = [

--- a/pkgs/tools/security/tpm2-abrmd/default.nix
+++ b/pkgs/tools/security/tpm2-abrmd/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     tpm2-tss glib which dbus cmocka
   ];
 
+  enableParallelBuilding = true;
+
   # Unit tests are currently broken as the check phase attempts to start a dbus daemon etc.
   #configureFlags = [ "--enable-unit" ];
   doCheck = false;

--- a/pkgs/tools/security/tpm2-abrmd/default.nix
+++ b/pkgs/tools/security/tpm2-abrmd/default.nix
@@ -15,7 +15,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config makeWrapper autoreconfHook autoconf-archive which ];
-  buildInputs = [ tpm2-tss glib dbus cmocka ];
+  buildInputs = [ tpm2-tss glib dbus ];
+  checkInputs = [ cmocka ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/security/tpm2-abrmd/default.nix
+++ b/pkgs/tools/security/tpm2-abrmd/default.nix
@@ -1,21 +1,29 @@
-{ stdenv, fetchurl, lib
-, makeWrapper, tpm2-tss, pkgconfig, glib, which, dbus, cmocka }:
+{ stdenv, lib, fetchFromGitHub
+, autoreconfHook, pkg-config, autoconf-archive, makeWrapper, which
+, tpm2-tss, glib, dbus
+, cmocka}:
 
 stdenv.mkDerivation rec {
   pname = "tpm2-abrmd";
   version = "2.3.2";
 
-  src = fetchurl {
-    url = "https://github.com/tpm2-software/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "040d01pdzkj0nc1c0vsf6gfqf28cgil03ix8dasijvhiha4c20nz";
+  src = fetchFromGitHub {
+    owner = "tpm2-software";
+    repo = pname;
+    rev = version;
+    sha256 = "0jzglnlb700clcq6mjhhgvcq29a6893h888wsn9fbrh4f255sw8q";
   };
 
-  nativeBuildInputs = [ pkgconfig makeWrapper ];
-  buildInputs = [
-    tpm2-tss glib which dbus cmocka
-  ];
+  nativeBuildInputs = [ pkg-config makeWrapper autoreconfHook autoconf-archive which ];
+  buildInputs = [ tpm2-tss glib dbus cmocka ];
 
   enableParallelBuilding = true;
+
+  # Emulate the required behavior of ./bootstrap in the original
+  # package
+  preAutoreconf = ''
+    echo "${version}" > VERSION
+  '';
 
   # Unit tests are currently broken as the check phase attempts to start a dbus daemon etc.
   #configureFlags = [ "--enable-unit" ];

--- a/pkgs/tools/security/tpm2-abrmd/default.nix
+++ b/pkgs/tools/security/tpm2-abrmd/default.nix
@@ -34,10 +34,9 @@ stdenv.mkDerivation rec {
   # seems to require the path to the device TCTI (used for accessing
   # /dev/tpm0) in it's LD_LIBRARY_PATH
   postFixup = ''
-    wrapProgram $out/bin/tpm2-abrmd \
-      --suffix LD_LIBRARY_PATH : "${
-        lib.makeLibraryPath [ tpm2-tss ]
-      }"
+    wrapProgram $out/bin/tpm2-abrmd --suffix LD_LIBRARY_PATH : "${
+      lib.makeLibraryPath [ tpm2-tss ]
+    }"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Update of the TPM2 userspace resource manager (`abrmd`). This was originally professionally delayed(TM) by me in #74665. This is a later version and actually works, hence fixes #74665.

It turns out that the upgrade from 2.2.0 indeed breaks the resource manager, as it fails to load the `device` TCTI from tpm2-tss.

In a debugging effort, tpm2-tss was also upgraded to the latest version. As this was only tested using this specific version of tpm2-tss (and incompatibilities have traditionally been an issue with the TPM2 software stack for me) I'd kindly request to wait for #90595 to be merged first. Accordingly, this PR is based on the commits of #90595.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### nixpkgs-review pr 90599

Result of `nixpkgs-review pr 90599` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>8 packages built:</summary>
<br>- discover
<br>- fwupd
<br>- gnome-firmware-updater
<br>- gnome3.gnome-software
<br>- tpm2-abrmd
<br>- tpm2-pkcs11
<br>- tpm2-tools
<br>- tpm2-tss
</details>

@JohnAZoidberg 