### PR TITLE
Add CF Checker and its cfunits dependency

### DIFF
--- a/pkgs/development/python-modules/cfunits/default.nix
+++ b/pkgs/development/python-modules/cfunits/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi, python, cftime, numpy, udunits }:
+buildPythonPackage rec {
+  pname = "cfunits";
+  version = "3.2.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0b5bq0zzgkfh1ih2q439gfd95rh7mb3r6y7al7f3lv0cnalslbbm";
+  };
+
+  postPatch = ''
+    substituteInPlace cfunits/units.py \
+      --replace "_libpath = ctypes.util.find_library('udunits2')" "_libpath = '${udunits}/lib/libudunits2.so.0'"
+  '';
+
+  checkPhase = ''
+    cd cfunits
+    ${python.interpreter} test/run_tests.py
+  '';
+
+  propagatedBuildInputs = [ cftime numpy udunits ];
+
+  meta = with stdenv.lib; {
+    description = "Interface to UNIDATA's UDUNITS-2 library with CF extensions";
+    homepage = "https://ncas-cms.github.io/cfunits/";
+    license = licenses.mit;
+    maintainers = [ maintainers.jshholland ];
+  };
+}

--- a/pkgs/tools/misc/cfchecker/default.nix
+++ b/pkgs/tools/misc/cfchecker/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonApplication, fetchPypi, numpy, netcdf4, future, cfunits }:
+
+buildPythonApplication rec {
+  pname = "cfchecker";
+  version = "4.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0igbn46aahszzhlk4hbk45qkgf6jrly4wx8rwp5vwqb03z846d2c";
+  };
+
+  propagatedBuildInputs = [ cfunits numpy netcdf4 future ];
+
+  meta = with stdenv.lib; {
+    description = "Check a NetCDF file complies with the Climate and Forecasts (CF) Metadata Convention";
+    homepage = "https://github.com/cedadev/cf-checker";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.jshholland ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2251,6 +2251,8 @@ with pkgs;
 
   cconv = callPackage ../tools/text/cconv { };
 
+  cfchecker = python3Packages.callPackage ../tools/misc/cfchecker { };
+
   go-check = callPackage ../development/tools/check { };
 
   go-cve-search = callPackage ../tools/security/go-cve-search { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1632,6 +1632,8 @@ in {
 
   cftime = callPackage ../development/python-modules/cftime { };
 
+  cfunits = callPackage ../development/python-modules/cfunits { };
+
   cgen = callPackage ../development/python-modules/cgen { };
 
   cgroup-utils = callPackage ../development/python-modules/cgroup-utils { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add a package that I use and its dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I'm not 100% sure if I've gone about fixing the path to `libudunits.so` in cfunits the right way, or whether I have categorised properly. CF conventions are used in atmospheric modelling, but I feel like cfchecker is not "large" enough to fit into `applications/science` and is more of a "tool".

Also, this currently doesn't build on master due to coveralls being broken there (see e.g. https://hydra.nixos.org/build/121765313)
