### PR TITLE
swiften: unbreak package using Arch patch and scons flags

### DIFF
--- a/pkgs/development/libraries/swiften/build-fix.patch
+++ b/pkgs/development/libraries/swiften/build-fix.patch
@@ -1,0 +1,32 @@
+diff -wbBur swift-4.0.2/Swift/QtUI/UserSearch/QtUserSearchWindow.h swift-4.0.2.my/Swift/QtUI/UserSearch/QtUserSearchWindow.h
+--- swift-4.0.2/Swift/QtUI/UserSearch/QtUserSearchWindow.h	2018-04-06 13:06:46.000000000 +0300
++++ swift-4.0.2.my/Swift/QtUI/UserSearch/QtUserSearchWindow.h	2019-10-08 20:52:23.171475337 +0300
+@@ -9,6 +9,7 @@
+ #include <set>
+ 
+ #include <QWizard>
++#include <QAbstractItemModel>
+ 
+ #include <Swiften/Base/Override.h>
+ 
+diff -wbBur swift-4.0.2/Swiften/Network/PlatformNATTraversalWorker.cpp swift-4.0.2.my/Swiften/Network/PlatformNATTraversalWorker.cpp
+--- swift-4.0.2/Swiften/Network/PlatformNATTraversalWorker.cpp	2018-04-06 13:06:46.000000000 +0300
++++ swift-4.0.2.my/Swiften/Network/PlatformNATTraversalWorker.cpp	2019-10-08 21:12:25.284754131 +0300
+@@ -157,7 +157,7 @@
+         miniUPnPInterface = new MiniUPnPInterface();
+         miniUPnPSupported = miniUPnPInterface->isAvailable();
+     }
+-    SWIFT_LOG(debug) << "UPnP NAT traversal supported: " << miniUPnPSupported << std::endl;
++//    SWIFT_LOG(debug) << "UPnP NAT traversal supported: " << miniUPnPSupported << std::endl;
+     if (miniUPnPSupported) {
+         return miniUPnPInterface;
+     }
+@@ -168,7 +168,7 @@
+         natPMPInterface = new NATPMPInterface();
+         natPMPSupported = natPMPInterface->isAvailable();
+     }
+-    SWIFT_LOG(debug) << "NAT-PMP NAT traversal supported: " << natPMPSupported << std::endl;
++//    SWIFT_LOG(debug) << "NAT-PMP NAT traversal supported: " << natPMPSupported << std::endl;
+     if (natPMPSupported) {
+         return natPMPInterface;
+     }

--- a/pkgs/development/libraries/swiften/default.nix
+++ b/pkgs/development/libraries/swiften/default.nix
@@ -12,17 +12,21 @@ stdenv.mkDerivation rec {
     sha256 = "0w0aiszjd58ynxpacwcgf052zpmbpcym4dhci64vbfgch6wryz0w";
   };
 
-  patches = [ ./scons.patch ];
+  patches = [ ./scons.patch ./build-fix.patch ];
 
   sconsFlags = [
     "openssl=${openssl.dev}"
     "boost_includedir=${boost.dev}/include"
     "boost_libdir=${boost.out}/lib"
     "boost_bundled_enable=false"
+    "max_jobs=1"
+    "optimize=1"
+    "debug=0"
+    "swiften_dll=1"
   ];
   preInstall = ''
     installTargets="$out"
-    installFlags+=" SWIFT_INSTALLDIR=$out"
+    installFlags+=" SWIFTEN_INSTALLDIR=$out"
   '';
 
   enableParallelBuilding = true;
@@ -33,6 +37,5 @@ stdenv.mkDerivation rec {
     license     = licenses.gpl2Plus;
     platforms   = platforms.linux;
     maintainers = [ maintainers.twey ];
-    broken = true; # Broken since 2019-11-20 (https://hydra.nixos.org/build/114681755)
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The `swiften` XMPP library was broken as of 2019. This commit
fixes it, by copying a patch from the Arch Linux PKGBUILD
(https://git.archlinux.org/svntogit/community.git/tree/trunk?h=packages/swift)
and by using the same scons flags in that PKGBUILD.

Of note is the flag swiften_dll=1, which means that the library
is now built dynamically.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
