### PR TITLE
tuijam: init at unstable 2020-06-05

### DIFF
--- a/pkgs/applications/audio/tuijam/default.nix
+++ b/pkgs/applications/audio/tuijam/default.nix
@@ -1,0 +1,46 @@
+{ buildPythonApplication
+, fetchFromGitHub
+, lib
+, python3Packages
+, youtube-dl
+}:
+
+buildPythonApplication rec {
+  pname = "tuijam";
+  version = "unstable-2020-06-05";
+
+  src = fetchFromGitHub {
+    owner = "cfangmeier";
+    repo = pname;
+    rev = "7baec6f6e80ee90da0d0363b430dd7d5695ff03b";
+    sha256 = "1l0s88jvj99jkxnczw5nfj78m8vihh29g815n4mg9jblad23mgx5";
+  };
+
+  buildInputs = [ python3Packages.Babel ];
+
+  # the package has no tests
+  doCheck = false;
+
+  propagatedBuildInputs = with python3Packages; [
+    gmusicapi
+    google_api_python_client
+    mpv
+    pydbus
+    pygobject3
+    pyyaml
+    requests
+    rsa
+    urwid
+  ];
+
+  meta = with lib; {
+    description = "A fancy TUI client for Google Play Music";
+    longDescription = ''
+      TUIJam seeks to make a simple, attractive, terminal-based interface to
+      listening to music for Google Play Music All-Access subscribers.
+    '';
+    homepage    = "https://github.com/cfangmeier/tuijam";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -564,6 +564,8 @@ in
 
   adlplug = callPackage ../applications/audio/adlplug { };
 
+  tuijam = callPackage ../applications/audio/tuijam { inherit (python3Packages) buildPythonApplication; };
+
   opnplug = callPackage ../applications/audio/adlplug {
     adlplugChip = "-DADLplug_CHIP=OPN2";
     pname = "OPNplug";
@@ -15770,7 +15772,7 @@ in
 
   hiawatha = callPackage ../servers/http/hiawatha {};
 
-  home-assistant = callPackage ../servers/home-assistant { 
+  home-assistant = callPackage ../servers/home-assistant {
     python3 = python37;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

[TUIJam](https://github.com/cfangmeier/tuijam) is a console-based Google Play Music player.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
