### PR TITLE
virtual-ans: init at 3.0.2c

### DIFF
--- a/pkgs/applications/audio/virtual-ans/default.nix
+++ b/pkgs/applications/audio/virtual-ans/default.nix
@@ -1,0 +1,89 @@
+{ stdenv
+, fetchzip
+, libX11
+, libXi
+, libGL
+, alsaLib
+, SDL2
+, autoPatchelfHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "virtual-ans";
+  version = "3.0.2c";
+
+  src = fetchzip {
+    url = "https://warmplace.ru/soft/ans/virtual_ans-${version}.zip";
+    sha256 = "03r1v3l7rd59dakr7ndvgsqchv00ppkvi6sslgf1ng07r3rsvb1n";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    libX11
+    libXi
+    libGL
+    alsaLib
+    SDL2
+  ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R ./* $out/
+
+    # Remove all executables except for current architecture
+    ls -1d $out/START*              | grep -v ${startScript}     | xargs rm -rf
+    ls -1d $out/bin/pixilang_linux* | grep -v ${linuxExecutable} | xargs rm -rf
+
+    # Start script performs relative search for resources, so it cannot be moved
+    # to bin directory
+    ln -s $out/${startScript} $out/bin/virtual-ans
+  '';
+
+  startScript = if stdenv.isx86_32 then "START_LINUX_X86"
+    else        if stdenv.isx86_64 then "START_LINUX_X86_64"
+    #else        if stdenv.isDarwin then "START_MACOS.app" # disabled because I cannot test on Darwin
+    else abort "Unsupported platform: ${stdenv.platform.kernelArch}.";
+
+  linuxExecutable = if stdenv.isx86_32 then "pixilang_linux_x86"
+    else            if stdenv.isx86_64 then "pixilang_linux_x86_64"
+    else                                    "";
+
+  meta = with stdenv.lib; {
+    description = "Photoelectronic microtonal/spectral musical instrument";
+    longDescription = ''
+      Virtual ANS is a software simulator of the unique Russian synthesizer ANS
+      - photoelectronic musical instrument created by Evgeny Murzin from 1938 to
+      1958. The ANS made it possible to draw music in the form of a spectrogram
+      (sonogram), without live instruments and performers. It was used by
+      Stanislav Kreichi, Alfred Schnittke, Edward Artemiev and other Soviet
+      composers in their experimental works. You can also hear the sound of the
+      ANS in Andrei Tarkovsky's movies Solaris, The Mirror, Stalker.
+
+      The simulator extends the capabilities of the original instrument. Now
+      it's a full-featured graphics editor where you can convert sound into an
+      image, load and play pictures, draw microtonal/spectral music and create
+      some unusual deep atmospheric sounds. This app is for everyone who loves
+      experiments and is looking for something new.
+
+      Key features:
+
+      + unlimited number of pure tone generators;
+      + powerful sonogram editor - you can draw the spectrum and play it at the same time;
+      + any sound (from a WAV file or a Microphone/Line-in) can be converted to image (sonogram) and vice versa;
+      + support for MIDI devices;
+      + polyphonic synth mode with MIDI mapping;
+      + supported file formats: WAV, AIFF, PNG, JPEG, GIF;
+      + supported sound systems: ASIO, DirectSound, MME, ALSA, OSS, JACK, Audiobus, IAA.
+      '';
+    homepage = "https://warmplace.ru/soft/ans/";
+    license = licenses.free;
+    # I cannot test the Darwin version, so I'll leave it disabled
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = with maintainers; [ jacg ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23377,6 +23377,8 @@ in
 
   virtscreen = callPackage ../tools/admin/virtscreen {};
 
+  virtual-ans = callPackage ../applications/audio/virtual-ans {};
+
   virtualbox = libsForQt5.callPackage ../applications/virtualization/virtualbox {
     stdenv = stdenv_32bit;
     inherit (gnome2) libIDL;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

No Nix package for virtual-ans exists yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

