### PR TITLE
libinput: ensure that we only apply touchpad options to touchpads

### DIFF
--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -219,6 +219,7 @@ in {
         Section "InputClass"
           Identifier "libinputConfiguration"
           MatchDriver "libinput"
+          MatchTag "Touchpad"
           ${optionalString (cfg.dev != null) ''MatchDevicePath "${cfg.dev}"''}
           Option "AccelProfile" "${cfg.accelProfile}"
           ${optionalString (cfg.accelSpeed != null) ''Option "AccelSpeed" "${cfg.accelSpeed}"''}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
It seems that the default `libinputConfiguration` `InputClass` section generated by the libinput module is intended for touchpads, and include touchpad-specific options such as `TappingDragLock` and (by default) `ScrollMethod twofinger`.  These are fine when applied to touchpads, but if we wish to set them on something else they may fail, causing the option to be ignored entirely.  For example, I have a Kensington Expert Mouse, one of whose four buttons I like to dedicate to being a scroll button, to allow me to use the trackball for scrolling rather than the scrolling ring, so I have an entry in `services.xserver.inputClassSections` like this:

```
    services.xserver.inputClassSections =
    [ ''
        Identifier "Kensington Expert Mouse"
        MatchProduct "Expert Mouse"
        Driver "libinput"
        Option "ScrollMethod" "button"
        Option "ScrollButton" "8"
      '' ];
```

Unfortunately, when Xorg loads the generated configuration file, it will first attempt to apply the `libinputConfiguration` section to my trackball, which states amongst other things that `Option "ScrollMethod" "twofinger"`, generating an error like this:

```
Jun 16 09:59:13 ingwaz xserver-wrapper[1745]: (EE) libinput: Kensington      Kensington Expert Mouse: Failed to set scroll to twofinger
```

Then, my own `Option "ScrollMethod" "button"` is ignored.

This PR adds a condition to the `libinputConfiguration` block that causes it to only match trackpads (as identified and tagged by udev).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
