### PR TITLE
python2Packages: default to dontUsePythonRecompileBytecode = true;

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -165,6 +165,11 @@ let
   # Python packages built through cross-compilation are always for the host platform.
   disallowedReferences = lib.optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [ python.pythonForBuild ];
 
+  # many packages that support python2, may include code
+  # which python2 is not able to compile
+  # mkDerivation hash will not change when passed null attrs
+  dontUsePythonRecompileBytecode = attrs.dontUsePythonRecompileBytecode or (if python.isPy27 then true else null);
+
   meta = {
     # default to python's platforms
     platforms = python.meta.platforms;

--- a/pkgs/development/python-modules/JPype1/default.nix
+++ b/pkgs/development/python-modules/JPype1/default.nix
@@ -1,12 +1,14 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , pytest
 }:
 
 buildPythonPackage rec {
   pname = "JPype1";
   version = "0.7.5";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/astral/default.nix
+++ b/pkgs/development/python-modules/astral/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytz, requests, pytest }:
+{ stdenv, buildPythonPackage, fetchPypi, isPy27, pytz, requests, pytest }:
 
 buildPythonPackage rec {
   pname = "astral";
   version = "2.2";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/auth0-python/default.nix
+++ b/pkgs/development/python-modules/auth0-python/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , requests
 , mock
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -20,6 +21,17 @@ buildPythonPackage rec {
 
   checkInputs = [
     mock
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    # jwt package is not available in nixpkgs
+    "--ignore=auth0/v3/test/authentication/test_token_verifier.py"
+  ];
+
+  # tries to ping websites (e.g. google.com)
+  disabledTests = [
+    "can_timeout"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/av/default.nix
+++ b/pkgs/development/python-modules/av/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , numpy
 , ffmpeg_4
 , pkgconfig
@@ -9,6 +10,7 @@
 buildPythonPackage rec {
   pname = "av";
   version = "8.0.2";
+  disabled = isPy27; # setup.py no longer compatible
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/avro/default.nix
+++ b/pkgs/development/python-modules/avro/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy3k }:
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, pycodestyle, isort }:
 
 buildPythonPackage rec {
   pname = "avro";
@@ -9,6 +9,9 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "4487f0e91d0d44142bd08b3c6da57073b720c3effb02eeb4e2e822804964c56b";
   };
+
+  nativeBuildInputs = [ pycodestyle ];
+  propagatedBuildInputs = [ isort ];
 
   meta = with stdenv.lib; {
     description = "A serialization and RPC framework";

--- a/pkgs/development/python-modules/base58/default.nix
+++ b/pkgs/development/python-modules/base58/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, fetchPypi, buildPythonPackage, pytest, pyhamcrest }:
+{ stdenv, fetchPypi, buildPythonPackage, isPy27, pytest, pyhamcrest }:
 
 buildPythonPackage rec {
   pname = "base58";
   version = "2.0.0";
+  disabled = isPy27; # python 2 abandoned upstream
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/cfgv/default.nix
+++ b/pkgs/development/python-modules/cfgv/default.nix
@@ -1,8 +1,9 @@
-{ lib, buildPythonPackage, fetchPypi, six }:
+{ lib, buildPythonPackage, fetchPypi, isPy27, six }:
 
 buildPythonPackage rec {
   pname = "cfgv";
   version = "3.1.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/cloudpickle/default.nix
+++ b/pkgs/development/python-modules/cloudpickle/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest, mock }:
+{ stdenv, buildPythonPackage, fetchPypi, isPy27, pytest, mock }:
 
 buildPythonPackage rec {
   pname = "cloudpickle";
   version = "1.4.1";
+  disabled = isPy27; # abandoned upstream
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/coveralls/default.nix
+++ b/pkgs/development/python-modules/coveralls/default.nix
@@ -1,6 +1,7 @@
 { buildPythonPackage
 , lib
 , fetchPypi
+, isPy27
 , mock
 , pytest
 , pytestrunner
@@ -15,8 +16,8 @@
 
 buildPythonPackage rec {
   pname = "coveralls";
-  name = "${pname}-python-${version}";
   version = "2.0.0";
+  disabled = isPy27;
 
   # wanted by tests
   src = fetchPypi {

--- a/pkgs/development/python-modules/dpath/default.nix
+++ b/pkgs/development/python-modules/dpath/default.nix
@@ -1,10 +1,11 @@
-{ stdenv, fetchPypi, buildPythonPackage
+{ stdenv, fetchPypi, buildPythonPackage, isPy27
 , mock, pytestCheckHook, nose, hypothesis
 }:
 
 buildPythonPackage rec {
   pname = "dpath";
   version = "2.0.1";
+  disabled = isPy27; # uses python3 imports
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/etelemetry/default.nix
+++ b/pkgs/development/python-modules/etelemetry/default.nix
@@ -1,8 +1,9 @@
-{ lib, buildPythonPackage, fetchPypi, requests, pytest }:
+{ lib, buildPythonPackage, fetchPypi, isPy27, requests, pytest }:
 
 buildPythonPackage rec {
   version = "0.2.1";
   pname = "etelemetry";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/filemagic/default.nix
+++ b/pkgs/development/python-modules/filemagic/default.nix
@@ -4,6 +4,7 @@
 buildPythonPackage {
   pname = "filemagic";
   version = "1.6";
+  disabled = !isPy3k; # asserts on ResourceWarning
 
   # Don't use the PyPI source because it's missing files required for testing
   src = fetchFromGitHub {
@@ -18,7 +19,7 @@ buildPythonPackage {
       "'${file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}'"
   '';
 
-  checkInputs = [ (if isPy3k then mock else unittest2) ];
+  checkInputs = [ mock ] ++ lib.optionals (!isPy3k) [ unittest2 ];
 
   meta = with lib; {
     description = "File type identification using libmagic";

--- a/pkgs/development/python-modules/flake8-debugger/default.nix
+++ b/pkgs/development/python-modules/flake8-debugger/default.nix
@@ -1,4 +1,10 @@
-{ lib, fetchPypi, buildPythonPackage, flake8, pycodestyle, pytestrunner, pytest }:
+{ lib, fetchPypi, buildPythonPackage, pythonOlder
+, flake8
+, importlib-metadata
+, pycodestyle
+, pytestrunner
+, pytest
+}:
 
 buildPythonPackage rec {
   pname = "flake8-debugger";
@@ -11,7 +17,8 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ pytestrunner ];
 
-  propagatedBuildInputs = [ flake8 pycodestyle ];
+  propagatedBuildInputs = [ flake8 pycodestyle ]
+    ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   checkInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/freezegun/default.nix
+++ b/pkgs/development/python-modules/freezegun/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , dateutil
 , six
 , mock
@@ -19,6 +20,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ dateutil six ];
   checkInputs = [ mock nose pytest ];
+  # contains python3 specific code
+  doCheck = !isPy27;
 
   meta = with stdenv.lib; {
     description = "FreezeGun: Let your Python tests travel through time";

--- a/pkgs/development/python-modules/http-ece/default.nix
+++ b/pkgs/development/python-modules/http-ece/default.nix
@@ -1,5 +1,5 @@
-{ lib, fetchPypi, buildPythonPackage
-, coverage, flake8, mock, nose
+{ lib, fetchPypi, buildPythonPackage, pythonOlder
+, coverage, flake8, mock, nose, importlib-metadata
 , cryptography }:
 
 buildPythonPackage rec {
@@ -11,7 +11,8 @@ buildPythonPackage rec {
     sha256 = "1y5ln09ji4dwpzhxr77cggk02kghq7lql60a6969a5n2lwpvqblk";
   };
 
-  propagatedBuildInputs = [ cryptography ];
+  propagatedBuildInputs = [ cryptography ]
+    ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   checkInputs = [ coverage flake8 mock nose ];
 

--- a/pkgs/development/python-modules/httptools/default.nix
+++ b/pkgs/development/python-modules/httptools/default.nix
@@ -1,11 +1,13 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "httptools";
   version = "0.1.1";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/humanize/default.nix
+++ b/pkgs/development/python-modules/humanize/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , mock
 , setuptools_scm
 }:
@@ -8,6 +9,7 @@
 buildPythonPackage rec {
   version = "2.4.0";
   pname = "humanize";
+  disabled = isPy27; # setup.py no longer compatible
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/inflection/default.nix
+++ b/pkgs/development/python-modules/inflection/default.nix
@@ -1,8 +1,9 @@
-{ lib, fetchPypi, buildPythonPackage, pytest } :
+{ lib, fetchPypi, buildPythonPackage, isPy27, pytest } :
 
 buildPythonPackage rec {
   pname = "inflection";
   version = "0.4.0";
+  disabled = isPy27;
 
   src = fetchPypi {
    inherit pname version;

--- a/pkgs/development/python-modules/limnoria/default.nix
+++ b/pkgs/development/python-modules/limnoria/default.nix
@@ -1,12 +1,14 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , pkgs
 }:
 
 buildPythonPackage rec {
   pname = "limnoria";
   version = "2020.04.11";
+  disabled = isPy27; # abandoned upstream
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/mutagen/1.43.nix
+++ b/pkgs/development/python-modules/mutagen/1.43.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fetchpatch
+, hypothesis
+, pycodestyle
+, pyflakes
+, pytest
+, setuptools
+, pkgs
+}:
+
+buildPythonPackage rec {
+  pname = "mutagen";
+  version = "1.43.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "125m0pkiw5lsffc0236xdlxfhwpr8csvxpmg6855405qy4wjv61s";
+  };
+
+  propagatedBuildInputs = [ setuptools ];
+  checkInputs = [
+    pkgs.faad2 pkgs.flac pkgs.vorbis-tools pkgs.liboggz
+    pkgs.glibcLocales pycodestyle pyflakes pytest hypothesis
+  ];
+  LC_ALL = "en_US.UTF-8";
+
+  meta = with lib; {
+    description = "Python multimedia tagging library";
+    homepage = "https://mutagen.readthedocs.io";
+    license = licenses.lgpl2Plus;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/mutagen/default.nix
+++ b/pkgs/development/python-modules/mutagen/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , fetchpatch
 , hypothesis
 , pycodestyle
@@ -13,6 +14,7 @@
 buildPythonPackage rec {
   pname = "mutagen";
   version = "1.44.0";
+  disabled = isPy27; # abandoned
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/ordered-set/default.nix
+++ b/pkgs/development/python-modules/ordered-set/default.nix
@@ -1,8 +1,9 @@
-{ buildPythonPackage, fetchPypi, lib, pytest }:
+{ buildPythonPackage, fetchPypi, lib, isPy27, pytest }:
 
 buildPythonPackage rec {
   pname = "ordered-set";
   version = "4.0.1";
+  disabled = isPy27;
 
   checkInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/pipdate/default.nix
+++ b/pkgs/development/python-modules/pipdate/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , appdirs
 , requests
 , pytest
@@ -9,6 +10,7 @@
 buildPythonPackage rec {
   pname = "pipdate";
   version = "0.5.1";
+  disabled = isPy27; # abandoned
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pytest-isort/default.nix
+++ b/pkgs/development/python-modules/pytest-isort/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pytest, isort }:
+{ lib, buildPythonPackage, fetchPypi, isPy27, mock, pytest, isort }:
 
 buildPythonPackage rec {
   pname = "pytest-isort";
@@ -11,7 +11,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ isort ];
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytest ]
+    ++ lib.optionals isPy27 [ mock ];
 
   checkPhase = ''
     py.test -vs --cache-clear

--- a/pkgs/development/python-modules/pytest-openfiles/default.nix
+++ b/pkgs/development/python-modules/pytest-openfiles/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , pytest
 , pytestCheckHook
 , psutil
@@ -10,6 +11,7 @@
 buildPythonPackage rec {
   pname = "pytest-openfiles";
   version = "0.5.0";
+  disabled = isPy27; # abandoned
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/traits/default.nix
+++ b/pkgs/development/python-modules/traits/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , python
 , pytest
 , numpy
@@ -9,6 +10,7 @@
 buildPythonPackage rec {
   pname = "traits";
   version = "6.1.0";
+  disabled = isPy27; # setup.py no longer py3 compat
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4655,7 +4655,10 @@ in {
 
   mutag = callPackage ../development/python-modules/mutag { };
 
-  mutagen = callPackage ../development/python-modules/mutagen { };
+  mutagen = if isPy27 then
+      callPackage ../development/python-modules/mutagen/1.43.nix { }
+    else
+      callPackage ../development/python-modules/mutagen { };
 
   muttils = callPackage ../development/python-modules/muttils { };
 


### PR DESCRIPTION
###### Motivation for this change
Help alleviate some of the pain around python2, just disable recompiling the bytecode, as many packages either contain python3-only test or sample code.

related: #90447

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
