### PR TITLE
vlc: 3.0.10 -> 3.0.11

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -25,11 +25,11 @@ assert (withQt5 -> qtbase != null && qtsvg != null && qtx11extras != null && wra
 
 stdenv.mkDerivation rec {
   pname = "vlc";
-  version = "3.0.10";
+  version = "3.0.11";
 
   src = fetchurl {
     url = "http://get.videolan.org/vlc/${version}/${pname}-${version}.tar.xz";
-    sha256 = "0cackl1084hcmg4myf3kvjvd6sjxmzn0c0qkmanz6brvgzyanrm9";
+    sha256 = "06a9hfl60f6l0fs5c9ma5s8np8kscm4ala6m2pdfji9lyfna351y";
   };
 
   # VLC uses a *ton* of libraries for various pieces of functionality, many of


### PR DESCRIPTION
Release notes: http://git.videolan.org/?p=vlc/vlc-3.0.git;a=tag;h=1519d3219a8d151bca792f40003051fa8b967734

###### Motivation for this change

Includes a security fix for [CVE-2020-13428](https://nvd.nist.gov/vuln/detail/CVE-2020-13428).
Also available at: http://git.videolan.org/?p=vlc/vlc-3.0.git;a=blobdiff;f=modules/packetizer/hxxx_nal.c;h=6bdfd5a2a58ab9397d5758726ef16dfb27fec2a0;hp=73450606e382329a301e04d37c5ac259951448e8;hb=d5c43c21c747ff30ed19fcca745dea3481c733e0;hpb=441907f4352107737523bf9cfb56eabe3563edb4

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): no change in dependencies
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
