### PR TITLE
pythonPackages.coveralls: 1.9.2 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/coveralls/default.nix
+++ b/pkgs/development/python-modules/coveralls/default.nix
@@ -16,12 +16,13 @@
 buildPythonPackage rec {
   pname = "coveralls";
   name = "${pname}-python-${version}";
-  version = "1.9.2";
+  version = "2.0.0";
+  disabled = !isPy3k;
 
   # wanted by tests
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8e3315e8620bb6b3c6f3179a75f498e7179c93b3ddc440352404f941b1f70524";
+    sha256 = "1d82hs79vjpa6ydgqyhlb0kmywhpzsmwq5mk1lzx0lwhsknza4yj";
   };
 
   checkInputs = [
@@ -46,7 +47,7 @@ buildPythonPackage rec {
     coverage
     docopt
     requests
-  ] ++ lib.optional (!isPy3k) urllib3;
+  ];
 
   meta = {
     description = "Show coverage stats online via coveralls.io";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Something in my system depends on this and the new version is fine with the updated coverage (5.1) we have on master now.

```
ERROR: Could not find a version that satisfies the requirement coverage<5.0,>=3.6 (from coveralls==1.9.2) (from versions: none)
ERROR: No matching distribution found for coverage<5.0,>=3.6 (from coveralls==1.9.2)
```

This drops the python2 support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
