### PR TITLE
test-driver.py: randomize VM tmp state dir name

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -223,8 +223,8 @@ class Machine:
             os.makedirs(path, mode=0o700, exist_ok=True)
             return path
 
-        self.state_dir = create_dir("vm-state-{}".format(self.name))
         self.shared_dir = create_dir("shared-xchg")
+        self.state_dir = tempfile.mkdtemp(prefix="vm-state-{}-".format(self.name))
 
         self.booted = False
         self.connected = False


### PR DESCRIPTION
###### Motivation for this change
The NixOS test VMs state directory is currently hardcoded to
/tmp/vm-state-$machineName.

While this is perfectly fine when building the test from a sandboxed
environment, we can run into some stray state problem across various
runs when we use the test interactively. These stray state-induced
errors can be pretty subtle to spot and debug.

We fix this problem by using a randomized and unique state dir name
for each run. This should prevent any stray state across several runs
while keeping the state of the previous ones for a potential post-run
analysis.

After a run:
```
~/Code/nixpkgs(nin-randomize-VM-state*) » ll -t /tmp | head -n 5                                                                                                
total 1324
drwx------ 2 ninjatrappeur users    4096 17 juin  11:29 nixos-test-vde-8qvseqbo-vde1.ctl
drwx------ 3 ninjatrappeur users    4096 17 juin  11:28 vm-state-server-o7qiv1q7
drwx------ 3 ninjatrappeur users    4096 17 juin  11:28 vm-state-client-gwl7rtaa
drwx------ 2 ninjatrappeur users    4096 17 juin  11:27 nixos-test-vde-sq094o70-vde1.ctl
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
