### PR TITLE
faad2: 2.8.8 -> 2.9.2

### DIFF
--- a/pkgs/development/libraries/faad2/default.nix
+++ b/pkgs/development/libraries/faad2/default.nix
@@ -1,43 +1,23 @@
-{stdenv, fetchurl
+{stdenv, fetchFromGitHub, autoreconfHook
 , drmSupport ? false # Digital Radio Mondiale
 }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "faad2";
-  version = "2.8.8";
+  version = "2.9.2";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/faac/${pname}-${version}.tar.gz";
-    sha256 = "1db37ydb6mxhshbayvirm5vz6j361bjim4nkpwjyhmy4ddfinmhl";
+  src = fetchFromGitHub {
+    owner = "knik0";
+    repo = "faad2";
+    rev = builtins.replaceStrings [ "." ] [ "_" ] version;
+    sha256 = "0rdi6bmyryhkwf4mpprrsp78m6lv1nppav2f0lf1ywifm92ng59c";
   };
-
-  patches = let
-    fp = { ver ? "2.8.8-3", pname, name ? (pname + ".patch"), sha256 }: fetchurl {
-      url = "https://salsa.debian.org/multimedia-team/faad2/raw/debian/${ver}"
-          + "/debian/patches/${pname}.patch?inline=false";
-      inherit name sha256;
-    };
-  in [
-    (fp {
-      # critical bug addressed in vlc 3.0.7 (but we use system-provided faad)
-      pname = "0004-Fix-a-couple-buffer-overflows";
-      sha256 = "1mwycdfagz6wpda9j3cp7lf93crgacpa8rwr58p3x0i5cirnnmwq";
-    })
-    (fp {
-      name = "CVE-2018-20362.patch";
-      pname = "0009-syntax.c-check-for-syntax-element-inconsistencies";
-      sha256 = "1z849l5qyvhyn5pvm6r07fa50nrn8nsqnrka2nnzgkhxlhvzpa81";
-    })
-    (fp {
-      name = "CVE-2018-20194.patch";
-      pname = "0010-sbr_hfadj-sanitize-frequency-band-borders";
-      sha256 = "1b1kbz4mv0zhpq8h3djnvqafh1gn12nikk9v3jrxyryywacirah4";
-    })
-  ];
 
   configureFlags = []
     ++ optional drmSupport "--with-drm";
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   meta = {
     description = "An open source MPEG-4 and MPEG-2 AAC decoder";


### PR DESCRIPTION
Changelog: https://github.com/knik0/faad2/blob/2_9_2/ChangeLog

Switch upstream to GitHub. It's unclear to me whether the repo is "official":
- [webpage](https://www.audiocoding.com/downloads.html) still offers 2.8.8 tarball for download
- the main repo seems to be located on [sourceforge](https://sourceforge.net/projects/faac/) but appears inactive
- sourceforge page links to the github repo
- [Debian](https://packages.debian.org/source/bullseye/faad2) ships the 2.9.2 version from github repo

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes: https://nvd.nist.gov/vuln/detail/CVE-2019-6956 (at least)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @codyopel 
