### PR TITLE
fish: replace use of tr with string split

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -81,18 +81,15 @@ let
       # NIX_PROFILES variable (same as config.environment.profiles)
       set -l __nix_profile_paths (string split ' ' $NIX_PROFILES)[-1..1]
 
-      set __extra_completionsdir \
+      set -p __extra_completionsdir \
         $__nix_profile_paths"/etc/fish/completions" \
-        $__nix_profile_paths"/share/fish/vendor_completions.d" \
-        $__extra_completionsdir
-      set __extra_functionsdir \
+        $__nix_profile_paths"/share/fish/vendor_completions.d"
+      set -p __extra_functionsdir \
         $__nix_profile_paths"/etc/fish/functions" \
-        $__nix_profile_paths"/share/fish/vendor_functions.d" \
-        $__extra_functionsdir
-      set __extra_confdir \
+        $__nix_profile_paths"/share/fish/vendor_functions.d"
+      set -p __extra_confdir \
         $__nix_profile_paths"/etc/fish/conf.d" \
-        $__nix_profile_paths"/share/fish/vendor_conf.d" \
-        $__extra_confdir
+        $__nix_profile_paths"/share/fish/vendor_conf.d"
     end
   '';
 

--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -79,7 +79,7 @@ let
 
       # additional profiles are expected in order of precedence, which means the reverse of the
       # NIX_PROFILES variable (same as config.environment.profiles)
-      set -l __nix_profile_paths (echo $NIX_PROFILES | ${coreutils}/bin/tr ' ' '\n')[-1..1]
+      set -l __nix_profile_paths (string split ' ' $NIX_PROFILES)[-1..1]
 
       set __extra_completionsdir \
         $__nix_profile_paths"/etc/fish/completions" \


### PR DESCRIPTION
This shaves about 4ms off fish start time. It also makes it more clear what's happening.

Before (profiled with 'fish --profile prof.txt -c fish_prompt'):

```
225	4636	----> set -l __nix_profile_paths (echo $NIX_PROFILES | /nix/store/m5ajgnzp2512na31brwfmydwk3l1gawb-coreutils-8.31/bin/tr ' ' '\n')[-1..1]
4411	4411	-----> echo $NIX_PROFILES | /nix/store/m5ajgnzp2512na31brwfmydwk3l1gawb-coreutils-8.31/bin/tr ' ' '\n'
```

After:

```
190	248	----> set -l __nix_profile_paths (string split ' ' $NIX_PROFILES)[-1..1]
```

Also use -p when expanding the profile paths, to make it clear we are
prepending.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
