### PR TITLE
apk-tools, alpine-make-vm-image: init

### DIFF
--- a/pkgs/tools/package-management/apk-tools/default.nix
+++ b/pkgs/tools/package-management/apk-tools/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchurl, lua, openssl, pkg-config, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "apk-tools";
+  version = "2.10.5";
+
+  src = fetchurl {
+    url = "https://dev.alpinelinux.org/archive/apk-tools/apk-tools-${version}.tar.xz";
+    sha256 = "00z3fqnv8vk2czdm4p2q4sldq0n8sxyf2qfwppyk7wj59d2sq8dp";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ lua openssl zlib ];
+
+  makeFlags = [
+    "SBINDIR=$(out)/bin"
+    "LIBDIR=$(out)/lib"
+    "LUA_LIBDIR=$(out)/lib/lua/${lib.versions.majorMinor lua.version}"
+    "MANDIR=$(out)/share/man"
+    "DOCDIR=$(out)/share/doc/apk"
+    "INCLUDEDIR=$(out)/include"
+    "PKGCONFIGDIR=$(out)/lib/pkgconfig"
+  ];
+
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=unused-result" ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://gitlab.alpinelinux.org/alpine/apk-tools";
+    description = "Alpine Package Keeper";
+    maintainers = with maintainers; [ qyliss ];
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/virtualization/alpine-make-vm-image/default.nix
+++ b/pkgs/tools/virtualization/alpine-make-vm-image/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper
+, apk-tools, coreutils, e2fsprogs, findutils, gnugrep, gnused, kmod, qemu-utils
+, utillinux
+}:
+
+stdenv.mkDerivation rec {
+  pname = "alpine-make-vm-image";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "alpinelinux";
+    repo = "alpine-make-vm-image";
+    rev = "v${version}";
+    sha256 = "0955kd2ddqfynjwk2xfzys96l7abxp30hhrs2968hl78rhmkvpnq";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/alpine-make-vm-image --set PATH ${lib.makeBinPath [
+      apk-tools coreutils e2fsprogs findutils gnugrep gnused kmod qemu-utils
+      utillinux
+    ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/alpinelinux/alpine-make-vm-image";
+    description = "Make customized Alpine Linux disk image for virtual machines";
+    maintainers = with maintainers; [ qyliss ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -672,6 +672,10 @@ in
 
   apfs-fuse = callPackage ../tools/filesystems/apfs-fuse { };
 
+  apk-tools = callPackage ../tools/package-management/apk-tools {
+    lua = lua5_3;
+  };
+
   apktool = callPackage ../development/tools/apktool {
     inherit (androidenv.androidPkgs_9_0) build-tools;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -645,6 +645,8 @@ in
 
   almanah = callPackage ../applications/misc/almanah { };
 
+  alpine-make-vm-image = callPackage ../tools/virtualization/alpine-make-vm-image { };
+
   amazon-ecs-cli = callPackage ../tools/virtualization/amazon-ecs-cli { };
 
   amazon-glacier-cmd-interface = callPackage ../tools/backup/amazon-glacier-cmd-interface { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Wanted to run alpine-make-vm-image.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
