### PR TITLE
go-swagger: init at 0.24.0

### DIFF
--- a/pkgs/development/tools/go-swagger/default.nix
+++ b/pkgs/development/tools/go-swagger/default.nix
@@ -1,0 +1,24 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "go-swagger";
+  version = "0.24.0";
+
+  src = fetchFromGitHub {
+    owner = "go-swagger";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "051av25vnrcpvj9w6mqalwk7byw52m2dlh1m56y30xvm0ybbnayn";
+  };
+
+  vendorSha256 = "020z4izc8i4yhbbr8h2fn8bqbis9q9yfcrjnixd6rsiayw1brh4p";
+
+  subPackages = ["cmd/swagger"];
+
+  meta = with lib; {
+    description = "Golang implementation of Swagger 2.0, representation of your RESTful API.";
+    homepage = "https://github.com/go-swagger/go-swagger";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ kalbasit ];
+  };
+}

--- a/pkgs/development/tools/go-swagger/default.nix
+++ b/pkgs/development/tools/go-swagger/default.nix
@@ -13,10 +13,10 @@ buildGoModule rec {
 
   vendorSha256 = "020z4izc8i4yhbbr8h2fn8bqbis9q9yfcrjnixd6rsiayw1brh4p";
 
-  subPackages = ["cmd/swagger"];
+  subPackages = [ "cmd/swagger" ];
 
   meta = with lib; {
-    description = "Golang implementation of Swagger 2.0, representation of your RESTful API.";
+    description = "Golang implementation of Swagger 2.0, representation of your RESTful API";
     homepage = "https://github.com/go-swagger/go-swagger";
     license = licenses.asl20;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26278,6 +26278,8 @@ in
 
   sqsh = callPackage ../development/tools/sqsh { };
 
+  go-swagger = callPackage ../development/tools/go-swagger { };
+
   jx = callPackage ../applications/networking/cluster/jx {};
 
   prow = callPackage ../applications/networking/cluster/prow { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/go-swagger/go-swagger/releases/tag/v0.24.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
