### PR TITLE
sublime-merge: askpass bug fix

### DIFF
--- a/pkgs/applications/version-management/sublime-merge/common.nix
+++ b/pkgs/applications/version-management/sublime-merge/common.nix
@@ -67,6 +67,16 @@ in let
         --set NIX_REDIRECTS ${builtins.concatStringsSep ":" redirects} \
         --set LOCALE_ARCHIVE "${glibcLocales.out}/lib/locale/locale-archive" \
         "''${gappsWrapperArgs[@]}"
+
+      # We need to replace the ssh-askpass-sublime executable because the default one
+      # will not function properly, in order to work it needs to pass an argv[0] to
+      # the sublime_merge binary, and the built-in version will will try to call the
+      # sublime_merge wrapper script which cannot pass through the original argv[0] to
+      # the sublime_merge binary. Thankfully the ssh-askpass-sublime functionality is
+      # very simple and can be replaced with a simple wrapper script.
+      rm $out/ssh-askpass-sublime
+      makeWrapper $out/.${primaryBinary}-wrapped $out/ssh-askpass-sublime \
+        --argv0 "/ssh-askpass-sublime"
     '';
   };
 in stdenv.mkDerivation (rec {

--- a/pkgs/applications/version-management/sublime-merge/default.nix
+++ b/pkgs/applications/version-management/sublime-merge/default.nix
@@ -9,8 +9,8 @@ in {
   } {};
 
   sublime-merge-dev = common {
-    buildVersion = "2011";
-    sha256 = "0r5qqappaiicc4srk08az2vx42m7b6a75yn2ji5pv4w4085hlrzp";
+    buildVersion = "2022";
+    sha256 = "0fhxz6nx24wbspn7vfli3pvfv6fdbd591m619pvivig3scpidj61";
     dev = true;
   } {};
 }


### PR DESCRIPTION
Replace ssh-askpass-sublime executable from sublime-merge that is incompatable with the nix package wrapper. Fixes NixOS/nixpkgs#88600

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Sublime merge has it's own askpass program that is used when pushing/pulling from a git repo using an ssh key with a passphrase and no ssh-agent. Currently the askpass program doesn't work (askpass dialog is never shown) due to it's custom functionality requiring it to pass a custom argv[0] argument to the sublime-merge binary which doesn't work because of the wrapper bash script added by the Nix build process to set various environment variables needed for it to run.

###### Things done
I've replaced the askpass program that is distributed with sublime-merge with a simple bash script that has equivalent functionality and works properly with the Nix package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
