### PR TITLE
GZDoom 4.3.3 -> 4.4.2

### DIFF
--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gzdoom";
-  version = "4.3.3";
+  version = "4.4.2";
 
   src = fetchFromGitHub {
     owner = "coelckers";
     repo = "gzdoom";
     rev = "g${version}";
-    sha256 = "1c4vhnvvwy1rs8xm01kqd486h5xsiccwkf95fjx7912zr49yalks";
+    sha256 = "0x06069ywl3mndspyi4pq91myivpf3jkclwagbcvcd48zapfkvfh";
   };
 
   nativeBuildInputs = [ cmake makeWrapper ];

--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -1,66 +1,85 @@
-{ stdenv, fetchFromGitHub, cmake, makeWrapper
-, openal, fluidsynth_1, soundfont-fluid, libGL, SDL2
-, bzip2, zlib, libjpeg, libsndfile, mpg123, game-music-emu }:
+{ stdenv, fetchFromGitHub, cmake, makeWrapper, openal, fluidsynth_1
+, soundfont-fluid, libGL, SDL2, bzip2, zlib, libjpeg, libsndfile, mpg123
+, game-music-emu, pkgconfig }:
 
-zmusic-src = fetchFromGitHub {
+let
+  zmusic-src = fetchFromGitHub {
     owner = "coelckers";
     repo = "zmusic";
-    rev = "${version}";
-    sha256 = "0cr48xdyg4d7wckxp3vvxyw7axzyik79p72yv1i1lyacbj04advk";
-  }
+    rev = "2d0ea861174f9e2031400ab29f5bcc8425521cc6";
+    sha256 = "1ac7lhbzwfr0fsyv7n70hvb8imzngxn1qyanmv9j26j0h90hhl8a";
+  };
+  zmusic = stdenv.mkDerivation {
+    pname = "zmusic";
+    version = "1.1.0";
 
+    src = zmusic-src;
 
-stdenv.mkDerivation rec {
-  pname = "gzdoom";
-  version = "4.4.2";
+    nativeBuildInputs = [ cmake pkgconfig ];
 
-  src = fetchFromGitHub {
-    owner = "coelckers";
-    repo = "gzdoom";
-    rev = "g${version}";
-    sha256 = "1xkkmbsdv64wyb9r2fv5mwyqw0bjryk528jghdrh47pndmjs9a38";
-    fetchSubmodules = true;
+    preConfigure = ''
+      sed -i \
+        -e "s@/usr/share/sounds/sf2/@${soundfont-fluid}/share/soundfonts/@g" \
+        -e "s@FluidR3_GM.sf2@FluidR3_GM2-2.sf2@g" \
+        source/mididevices/music_fluidsynth_mididevice.cpp
+    '';
+
   };
 
-  prePatch = ''cp -r ${zmusic-source} ./libraries/zmusic'';
+  gzdoom = stdenv.mkDerivation rec {
+    pname = "gzdoom";
+    version = "4.4.2";
 
-  nativeBuildInputs = [ cmake makeWrapper ];
-  buildInputs = [
-    SDL2 libGL openal fluidsynth_1 bzip2 zlib libjpeg libsndfile mpg123
-    game-music-emu
-  ];
+    src = fetchFromGitHub {
+      owner = "coelckers";
+      repo = "gzdoom";
+      rev = "g${version}";
+      sha256 = "1xkkmbsdv64wyb9r2fv5mwyqw0bjryk528jghdrh47pndmjs9a38";
+      fetchSubmodules = true;
+    };
 
-  enableParallelBuilding = true;
+    nativeBuildInputs = [ cmake makeWrapper pkgconfig ];
+    buildInputs = [
+      SDL2
+      libGL
+      openal
+      fluidsynth_1
+      bzip2
+      zlib
+      libjpeg
+      libsndfile
+      mpg123
+      game-music-emu
+      zmusic
+    ];
 
-  NIX_CFLAGS_LINK = "-lopenal -lfluidsynth";
+    enableParallelBuilding = true;
 
-  preConfigure = ''
-    sed -i \
-      -e "s@/usr/share/sounds/sf2/@${soundfont-fluid}/share/soundfonts/@g" \
-      -e "s@FluidR3_GM.sf2@FluidR3_GM2-2.sf2@g" \
-      libraries/zmusic/mididevices/music_fluidsynth_mididevice.cpp
-  '';
+    NIX_CFLAGS_LINK = "-lopenal -lfluidsynth";
 
-  installPhase = ''
-    install -Dm755 gzdoom "$out/lib/gzdoom/gzdoom"
-    for i in *.pk3; do
-      install -Dm644 "$i" "$out/lib/gzdoom/$i"
-    done
-    for i in fm_banks/*; do
-      install -Dm644 "$i" "$out/lib/gzdoom/$i"
-    done
-    for i in soundfonts/*; do
-      install -Dm644 "$i" "$out/lib/gzdoom/$i"
-    done
-    mkdir $out/bin
-    makeWrapper $out/lib/gzdoom/gzdoom $out/bin/gzdoom
-  '';
+    installPhase = ''
+      install -Dm755 gzdoom "$out/lib/gzdoom/gzdoom"
+      for i in *.pk3; do
+        install -Dm644 "$i" "$out/lib/gzdoom/$i"
+      done
+      for i in fm_banks/*; do
+        install -Dm644 "$i" "$out/lib/gzdoom/$i"
+      done
+      for i in soundfonts/*; do
+        install -Dm644 "$i" "$out/lib/gzdoom/$i"
+      done
+      mkdir $out/bin
+      makeWrapper $out/lib/gzdoom/gzdoom $out/bin/gzdoom
+    '';
 
-  meta = with stdenv.lib; {
-    homepage = "https://github.com/coelckers/gzdoom";
-    description = "A Doom source port based on ZDoom. It features an OpenGL renderer and lots of new features";
-    license = licenses.gpl3;
-    platforms = ["x86_64-linux"];
-    maintainers = with maintainers; [ lassulus ];
+    meta = with stdenv.lib; {
+      homepage = "https://github.com/coelckers/gzdoom";
+      description =
+        "A Doom source port based on ZDoom. It features an OpenGL renderer and lots of new features";
+      license = licenses.gpl3;
+      platforms = [ "x86_64-linux" ];
+      maintainers = with maintainers; [ lassulus ];
+    };
   };
-}
+
+in gzdoom

--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "coelckers";
     repo = "gzdoom";
     rev = "g${version}";
-    sha256 = "0x06069ywl3mndspyi4pq91myivpf3jkclwagbcvcd48zapfkvfh";
+    sha256 = "1xkkmbsdv64wyb9r2fv5mwyqw0bjryk528jghdrh47pndmjs9a38";
   };
 
   nativeBuildInputs = [ cmake makeWrapper ];

--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
     repo = "gzdoom";
     rev = "g${version}";
     sha256 = "1xkkmbsdv64wyb9r2fv5mwyqw0bjryk528jghdrh47pndmjs9a38";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake makeWrapper ];

--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -11,8 +11,8 @@ zmusic = stdenv.mkDerivation {
     repo = "zmusic";
     rev = "${version}";
     sha256 = "0cr48xdyg4d7wckxp3vvxyw7axzyik79p72yv1i1lyacbj04advk";
-  }
-};
+  };
+}
 
 stdenv.mkDerivation rec {
   pname = "gzdoom";

--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -12,7 +12,7 @@ zmusic = stdenv.mkDerivation {
     rev = "${version}";
     sha256 = "0cr48xdyg4d7wckxp3vvxyw7axzyik79p72yv1i1lyacbj04advk";
   }
-}
+};
 
 stdenv.mkDerivation rec {
   pname = "gzdoom";

--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -2,6 +2,18 @@
 , openal, fluidsynth_1, soundfont-fluid, libGL, SDL2
 , bzip2, zlib, libjpeg, libsndfile, mpg123, game-music-emu }:
 
+zmusic = stdenv.mkDerivation {
+  pname = "zmusic";
+  version = "1.1.0";
+  
+  src = fetchFromGitHub {
+    owner = "coelckers";
+    repo = "zmusic";
+    rev = "${version}";
+    sha256 = "0cr48xdyg4d7wckxp3vvxyw7axzyik79p72yv1i1lyacbj04advk";
+  }
+}
+
 stdenv.mkDerivation rec {
   pname = "gzdoom";
   version = "4.4.2";
@@ -17,7 +29,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [
     SDL2 libGL openal fluidsynth_1 bzip2 zlib libjpeg libsndfile mpg123
-    game-music-emu
+    game-music-emu zmusic
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -2,17 +2,13 @@
 , openal, fluidsynth_1, soundfont-fluid, libGL, SDL2
 , bzip2, zlib, libjpeg, libsndfile, mpg123, game-music-emu }:
 
-zmusic = stdenv.mkDerivation {
-  pname = "zmusic";
-  version = "1.1.0";
-  
-  src = fetchFromGitHub {
+zmusic-src = fetchFromGitHub {
     owner = "coelckers";
     repo = "zmusic";
     rev = "${version}";
     sha256 = "0cr48xdyg4d7wckxp3vvxyw7axzyik79p72yv1i1lyacbj04advk";
-  };
-}
+  }
+
 
 stdenv.mkDerivation rec {
   pname = "gzdoom";
@@ -26,10 +22,12 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  prePatch = ''cp -r ${zmusic-source} ./libraries/zmusic'';
+
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [
     SDL2 libGL openal fluidsynth_1 bzip2 zlib libjpeg libsndfile mpg123
-    game-music-emu zmusic
+    game-music-emu
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
4.4.0 increased the ZScript version number, GZDoom 4.4.1 and 4.4.2 have some bugfixes. I was unable to test this at all because I can't figure out how to get home-manager to install GZDoom with a specified version attribute.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Keeping up with current release version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
