### PR TITLE
openrgb: init at 0.2

### DIFF
--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -1,0 +1,36 @@
+{ mkDerivation, lib, fetchFromGitHub, qmake, libusb1, hidapi }:
+
+mkDerivation rec {
+  pname = "openrgb";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "CalcProgrammer1";
+    repo = "OpenRGB";
+    rev = "release_${version}";
+    sha256 = "0b1mkp4ca4gdzk020kp6dkd3i9a13h4ikrn3417zscsvv5y9kv0s";
+  };
+
+  nativeBuildInputs = [ qmake ];
+  buildInputs = [ libusb1 hidapi ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp OpenRGB $out/bin
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/OpenRGB --help > /dev/null
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Open source RGB lighting control";
+    homepage = "https://gitlab.com/CalcProgrammer1/OpenRGB";
+    maintainers = with maintainers; [ jonringer ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5692,6 +5692,8 @@ in
 
   openresolv = callPackage ../tools/networking/openresolv { };
 
+  openrgb = libsForQt5.callPackage ../applications/misc/openrgb { };
+
   opensc = callPackage ../tools/security/opensc {
     inherit (darwin.apple_sdk.frameworks) Carbon PCSC;
   };


### PR DESCRIPTION
###### Motivation for this change
Add the OpenRGB program for controlling RGB lights on a computer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
