### PR TITLE
whitebox-tools: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/applications/gis/whitebox-tools/default.nix
+++ b/pkgs/applications/gis/whitebox-tools/default.nix
@@ -1,25 +1,22 @@
 { stdenv, rustPlatform , fetchFromGitHub, Security }:
 rustPlatform.buildRustPackage rec {
   pname = "whitebox_tools";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "jblindsay";
     repo = "whitebox-tools";
     rev = "v${version}";
-    sha256 = "0zi32d0wrbl2763dcllv2g0liwacsfiza5lkx52620prjjbhby8i";
+    sha256 = "0c9jmfjz6ys65y65zlllv9xvaaavr9jpqc1dc217iywhj07j8k2v";
   };
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
 
-  cargoSha256 = "13k21akyfqgamywj39bw73sldby1s02vyvxfglxbaqq1x96xcy4i";
-
-  # failures: structures::polyline::test::test_polyline_split
-  doCheck = false;
+  cargoSha256 = "05w2jimmygg7dc93i8bpjpjc5yj5xfpfkjnbbgw2sq4kh06r5ii4";
 
   meta = with stdenv.lib; {
     description = "An advanced geospatial data analysis platform";
-    homepage = "http://www.uoguelph.ca/~hydrogeo/WhiteboxTools/index.html";
+    homepage = "https://jblindsay.github.io/ghrg/WhiteboxTools/index.html";
     license = licenses.mit;
     maintainers = [ maintainers.mpickering ];
     platforms = platforms.all;


### PR DESCRIPTION
###### Motivation for this change
* [Changelog](https://github.com/jblindsay/whitebox-tools/releases/tag/v1.3.0)
* enable tests

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
