### PR TITLE
[20.03] json_c: add patch for CVE-2020-12762

### DIFF
--- a/pkgs/development/libraries/json-c/default.nix
+++ b/pkgs/development/libraries/json-c/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoconf }:
+{ stdenv, fetchurl, fetchpatch, autoconf }:
 
 stdenv.mkDerivation rec {
   name = "json-c-0.13.1";
@@ -6,6 +6,15 @@ stdenv.mkDerivation rec {
     url    = "https://s3.amazonaws.com/json-c_releases/releases/${name}-nodoc.tar.gz";
     sha256 = "0ch1v18wk703bpbyzj7h1mkwvsw4rw4qdwvgykscypvqq10678ll";
   };
+
+  patches = [
+    # https://nvd.nist.gov/vuln/detail/CVE-2020-12762
+    (fetchpatch {
+      name = "CVE-2020-12762.patch";
+      url = "https://github.com/json-c/json-c/commit/865b5a65199973bb63dff8e47a2f57e04fec9736.patch";
+      sha256 = "1g5afk4khhm1sb70xrva1pyznshcw3ipzp1g5z60dpzxy303pp6h";
+    })
+  ];
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
Backport of #90688

----

###### Motivation for this change

Fixes: https://nvd.nist.gov/vuln/detail/CVE-2020-12762
Details: https://github.com/json-c/json-c/pull/592

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` ... ~750 pkgs:(
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
