### PR TITLE
consul.passthru.tests: Fix failure on current consul versions, add more tests

### DIFF
--- a/nixos/tests/consul.nix
+++ b/nixos/tests/consul.nix
@@ -128,10 +128,18 @@ in {
             )
 
 
+    def wait_for_all_machines_alive():
+        """
+        Note that Serf-"alive" does not mean "Raft"-healthy;
+        see `wait_for_healthy_servers()` for that instead.
+        """
+        for m in machines:
+            m.wait_until_succeeds("[ $(consul members | grep -o alive | wc -l) == 5 ]")
+
+
     wait_for_healthy_servers()
     # Also wait for clients to be alive.
-    for m in machines:
-        m.wait_until_succeeds("[ $(consul members | grep -o alive | wc -l) == 5 ]")
+    wait_for_all_machines_alive()
 
     client1.succeed("consul kv put testkey 42")
     client2.succeed("[ $(consul kv get testkey) == 42 ]")

--- a/nixos/tests/consul.nix
+++ b/nixos/tests/consul.nix
@@ -73,6 +73,10 @@ let
             extraConfig = defaultExtraConfig // {
               server = true;
               bootstrap_expect = numConsensusServers;
+              # Tell Consul that we never intend to drop below this many servers.
+              # Ensures to not permanently lose consensus after temporary loss.
+              # See https://github.com/hashicorp/consul/issues/8118#issuecomment-645330040
+              autopilot.min_quorum = numConsensusServers;
               retry_join =
                 # If there's only 1 node in the network, we allow self-join;
                 # otherwise, the node must not try to join itself, and join only the other servers.

--- a/nixos/tests/consul.nix
+++ b/nixos/tests/consul.nix
@@ -55,6 +55,7 @@ let
 
   server = index: { pkgs, ... }:
     let
+      numConsensusServers = builtins.length allConsensusServerHosts;
       thisConsensusServerHost = builtins.elemAt allConsensusServerHosts index;
       ip = thisConsensusServerHost; # since we already use IPs to identify servers
     in
@@ -71,12 +72,12 @@ let
             inherit webUi;
             extraConfig = defaultExtraConfig // {
               server = true;
-              bootstrap_expect = builtins.length allConsensusServerHosts;
+              bootstrap_expect = numConsensusServers;
               retry_join =
                 # If there's only 1 node in the network, we allow self-join;
                 # otherwise, the node must not try to join itself, and join only the other servers.
                 # See https://github.com/hashicorp/consul/issues/2868
-                if builtins.length allConsensusServerHosts == 1
+                if numConsensusServers == 1
                   then allConsensusServerHosts
                   else builtins.filter (h: h != thisConsensusServerHost) allConsensusServerHosts;
               bind_addr = ip;

--- a/nixos/tests/consul.nix
+++ b/nixos/tests/consul.nix
@@ -66,6 +66,7 @@ let
         services.consul =
           let
             thisConsensusServerHost = builtins.elemAt allConsensusServerHosts index;
+            numConsensusServers = builtins.length allConsensusServerHosts;
           in
           assert builtins.elem thisConsensusServerHost allConsensusServerHosts;
           {
@@ -73,12 +74,12 @@ let
             inherit webUi;
             extraConfig = defaultExtraConfig // {
               server = true;
-              bootstrap_expect = builtins.length allConsensusServerHosts;
+              bootstrap_expect = numConsensusServers;
               retry_join =
                 # If there's only 1 node in the network, we allow self-join;
                 # otherwise, the node must not try to join itself, and join only the other servers.
                 # See https://github.com/hashicorp/consul/issues/2868
-                if builtins.length allConsensusServerHosts == 1
+                if numConsensusServers == 1
                   then allConsensusServerHosts
                   else builtins.filter (h: h != thisConsensusServerHost) allConsensusServerHosts;
               bind_addr = ip;


### PR DESCRIPTION
###### Motivation for this change

Fixes #90613. Based on feedback in upstream issue https://github.com/hashicorp/consul/issues/8118.

See commit messages for details. 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
