### PR TITLE
python3Packages.pylibftdi: 0.18.1 -> 0.19.0

### DIFF
--- a/pkgs/development/python-modules/pylibftdi/default.nix
+++ b/pkgs/development/python-modules/pylibftdi/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ stdenv
+, lib
 , buildPythonPackage
 , fetchPypi
 , libftdi1
@@ -7,11 +8,11 @@
 
 buildPythonPackage rec {
   pname = "pylibftdi";
-  version = "0.18.1";
+  version = "0.19.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "17c5h4xz1grynbpffngjflk3dlw2g2zbhkwb7h5v4n9rjdv41l5x";
+    sha256 = "0ghjjakifcrnvbmrwmg1323k6kfzp67ykwbvld58ivwjy96wf3mv";
   };
 
   propagatedBuildInputs = [
@@ -21,14 +22,16 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pylibftdi/driver.py \
-      --replace "self._load_library('libusb')" "cdll.LoadLibrary('${libusb1.out}/lib/libusb-1.0.so')" \
-      --replace "self._load_library('libftdi')" "cdll.LoadLibrary('${libftdi1.out}/lib/libftdi1.so')"
+      --replace "self._load_library('libusb')" \
+        "cdll.LoadLibrary('${libusb1.out}/lib/libusb-1.0${stdenv.hostPlatform.extensions.sharedLibrary}')" \
+      --replace "self._load_library('libftdi')" \
+        "cdll.LoadLibrary('${libftdi1.out}/lib/libftdi1${stdenv.hostPlatform.extensions.sharedLibrary}')"
   '';
 
   pythonImportsCheck = [ "pylibftdi" ];
 
   meta = with lib; {
-    homepage = "https://bitbucket.org/codedstructure/pylibftdi/src/default/";
+    homepage = "https://github.com/codedstructure/pylibftdi";
     description = "Minimal pythonic wrapper to Intra2net's libftdi driver for FTDI's USB devices";
     license = licenses.mit;
     maintainers = with maintainers; [ matthuszagh ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
pylibftdi has [moved to github](https://github.com/codedstructure/pylibftdi). This also updates to the newest release (0.19.0).

###### Things done
I've tested this with some simple code using real FTDI devices and it works fine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
