### PR TITLE
nushell: add checkPhase without --target which causes failing tests

### DIFF
--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -39,6 +39,13 @@ rustPlatform.buildRustPackage rec {
     export HOME=$TMPDIR
   '';
 
+  checkPhase = ''
+    runHook preCheck
+    echo "Running cargo test"
+    cargo test
+    runHook postCheck
+  '';
+
   meta = with lib; {
     description = "A modern shell written in Rust";
     homepage = "https://www.nushell.sh/";


### PR DESCRIPTION
###### Motivation for this change

The current version on master did break, because the default `checkPhase` which is used after removing the custom checkPhase by #90137 uses `--target`, which caused failing tests.


###### Things done

Readded the custom simplified `checkPhase`

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
