### PR TITLE
tanka: init at 0.10.0

### DIFF
--- a/pkgs/applications/networking/cluster/tanka/default.nix
+++ b/pkgs/applications/networking/cluster/tanka/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchFromGitHub, buildGoPackage }:
+
+buildGoPackage rec {
+  pname = "tanka";
+  version = "0.10.0";
+
+  goPackagePath = "github.com/grafana/tanka";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "grafana";
+    repo = "tanka";
+    sha256 = "02nm56iyxvyfyz6l150nqqy9dsn5r03hvmjqm9xxvs2bqlqfpnqy";
+  };
+
+  subPackages = [ "cmd/tk" ];
+
+  goDeps = ./deps.nix;
+
+  meta = {
+    description = "Flexible, reusable and concise configuration for Kubernetes";
+    license = lib.licenses.asl20;
+    homepage = "https://tanka.dev/";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/applications/networking/cluster/tanka/deps.nix
+++ b/pkgs/applications/networking/cluster/tanka/deps.nix
@@ -1,0 +1,669 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/Masterminds/semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Masterminds/semver";
+      rev = "v1.4.2";
+      sha256 = "0k2fpk2x8jbvqkqxx5hkx1ygrsppzmzypqb90i1r33yq7ac7zlxj";
+    };
+  }
+  {
+    goPackagePath = "github.com/NYTimes/gziphandler";
+    fetch = {
+      type = "git";
+      url = "https://github.com/NYTimes/gziphandler";
+      rev = "56545f4a5d46";
+      sha256 = "1fwk9wz6vrvq72f2gq8jhvd1nvv6grqgwrjq66vjpm0726pxar72";
+    };
+  }
+  {
+    goPackagePath = "github.com/PuerkitoBio/purell";
+    fetch = {
+      type = "git";
+      url = "https://github.com/PuerkitoBio/purell";
+      rev = "v1.0.0";
+      sha256 = "1qhsy1nm96b9kb63svkvkqmmw15xg6irwcysisxdgzk64adfwqv1";
+    };
+  }
+  {
+    goPackagePath = "github.com/PuerkitoBio/urlesc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/PuerkitoBio/urlesc";
+      rev = "5bd2802263f2";
+      sha256 = "15y5r3asvm7196m3nza5xvdvlc2k11p6lfs6hi917hl7r9vgi6mp";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
+    goPackagePath = "github.com/docker/spdystream";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/spdystream";
+      rev = "449fdfce4d96";
+      sha256 = "1412cpiis971iq1kxrirzirhj2708ispjh0x0dh879b66x8507sl";
+    };
+  }
+  {
+    goPackagePath = "github.com/elazarl/goproxy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/elazarl/goproxy";
+      rev = "947c36da3153";
+      sha256 = "0lmsnr5xmda89wig8sw62llg6acjb5caghz5jmdhnm85rm6rnssk";
+    };
+  }
+  {
+    goPackagePath = "github.com/emicklei/go-restful";
+    fetch = {
+      type = "git";
+      url = "https://github.com/emicklei/go-restful";
+      rev = "ff4f55a20633";
+      sha256 = "1v5lj5142abz3gvbygp6xghpdx4ps2lwswl8559ivaidahwnc21c";
+    };
+  }
+  {
+    goPackagePath = "github.com/evanphx/json-patch";
+    fetch = {
+      type = "git";
+      url = "https://github.com/evanphx/json-patch";
+      rev = "v4.2.0";
+      sha256 = "0cfvyhl3hjfc4z8hbkfc40yafv6r7y513zgp3jwf88isbd13r7a6";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev = "v1.9.0";
+      sha256 = "086z8ssmr1fn9ba4mqnw7pnccfpys6l5yfhvycv1gdrsk7n27mvs";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/structs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/structs";
+      rev = "v1.1.0";
+      sha256 = "1wrhb8wp8zpzggl61lapb627lw8yv281abvr6vqakmf569nswa9q";
+    };
+  }
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "github.com/ghodss/yaml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ghodss/yaml";
+      rev = "73d445a93680";
+      sha256 = "0pg53ky4sy3sp9j4n7vgf1p3gw4nbckwqfldcmmi9rf13kjh0mr7";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-clix/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-clix/cli";
+      rev = "v0.1.1";
+      sha256 = "03hvkkxmnwj2vxc58bdjd8f2fsb2s5hg9pghr4gap9vpl30frhz9";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-logr/logr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-logr/logr";
+      rev = "v0.1.0";
+      sha256 = "0fhijjhxz4n2j5i24ckzv8r9kri3v44jdyklgbqjfq0xm7izqg14";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-openapi/jsonpointer";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-openapi/jsonpointer";
+      rev = "46af16f9f7b1";
+      sha256 = "0w0fphmdycjzbsm1vppdcjc9aqinkcdzcq3pxikdvdqh5p791gsc";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-openapi/jsonreference";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-openapi/jsonreference";
+      rev = "13c6e3589ad9";
+      sha256 = "1fh4xcl9ijww4bdq656sx981d57w2c9zx5148jsxlsg4bsvxmwis";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-openapi/spec";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-openapi/spec";
+      rev = "6aced65f8501";
+      sha256 = "0yf0nw7167yjpiqrikns5djarjpf2r07q6xnq9xb1cfsc4m7ynm4";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-openapi/swag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-openapi/swag";
+      rev = "1d0bd113de87";
+      sha256 = "0fmk42chj20679n87n6sig3czs25lavyj6w208000n6kccv1ns3c";
+    };
+  }
+  {
+    goPackagePath = "github.com/gobwas/glob";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gobwas/glob";
+      rev = "v0.2.3";
+      sha256 = "0jxk1x806zn5x86342s72dq2qy64ksb3zrvrlgir2avjhwb18n6z";
+    };
+  }
+  {
+    goPackagePath = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev = "v1.3.1";
+      sha256 = "0x77x64sxjgfhmbijqfzmj8h4ar25l2w97h01q3cqs1wk7zfnkhp";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/groupcache";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/groupcache";
+      rev = "02826c3e7903";
+      sha256 = "0w46bsllddfij66nrg8jbfjsr54birvfww8a2fj9fmgyig5syn2x";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.3.2";
+      sha256 = "1k1wb4zr0qbwgpvz9q5ws9zhlal8hq7dmq62pwxxriksayl6hzym";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev = "v0.3.0";
+      sha256 = "1hyxx3434zshl2m9ja78gwlkg1rx9yl6diqa7dnjb31xz5x4gbjj";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-jsonnet";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-jsonnet";
+      rev = "4f4aa80dd785";
+      sha256 = "0hfvxx026y8wmicjqmyzyn0spmjjzkhl3vmysp0sbnismd3w1wd1";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/gofuzz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/gofuzz";
+      rev = "v1.1.0";
+      sha256 = "0si2fiigj45vr4jnw4grjhls7nw56wkwinnn93gqbl9ng9ynw8rx";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/uuid";
+      rev = "v1.1.1";
+      sha256 = "0hfxcf9frkb57k6q0rdkrmnfs78ms21r1qfk9fhlqga2yh5xg8zb";
+    };
+  }
+  {
+    goPackagePath = "github.com/googleapis/gnostic";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/gnostic";
+      rev = "v0.1.0";
+      sha256 = "0vsahn8fxmiv1647j1qspn57fhiky0xh4g34vh62lyk7nfz0lszi";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/errwrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/errwrap";
+      rev = "v1.0.0";
+      sha256 = "0slfb6w3b61xz04r32bi0a1bygc82rjzhqkxj2si2074wynqnr1c";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-multierror";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-multierror";
+      rev = "v1.0.0";
+      sha256 = "00nyn8llqzbfm8aflr9kwsvpzi4kv8v45c141v88xskxp5xf6z49";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/golang-lru";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/golang-lru";
+      rev = "v0.5.1";
+      sha256 = "13f870cvk161bzjj6x41l45r5x9i1z9r2ymwmvm7768kg08zznpy";
+    };
+  }
+  {
+    goPackagePath = "github.com/hpcloud/tail";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hpcloud/tail";
+      rev = "v1.0.0";
+      sha256 = "1njpzc0pi1acg5zx9y6vj9xi6ksbsc5d387rd6904hy6rh2m6kn0";
+    };
+  }
+  {
+    goPackagePath = "github.com/json-iterator/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/json-iterator/go";
+      rev = "v1.1.8";
+      sha256 = "1kbp9fj6fxfql0ir59zb6v68l4bpwlmk76xm8vaikw1hp6y9bcss";
+    };
+  }
+  {
+    goPackagePath = "github.com/karrick/godirwalk";
+    fetch = {
+      type = "git";
+      url = "https://github.com/karrick/godirwalk";
+      rev = "v1.15.5";
+      sha256 = "0ylidkpvy2cgwhskb1dp27c271fmqdk2z5mnz2w8xpswbymam7sj";
+    };
+  }
+  {
+    goPackagePath = "github.com/kisielk/errcheck";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kisielk/errcheck";
+      rev = "v1.2.0";
+      sha256 = "0am6g10ipdxw84byscm7shda654882wjcbinq5c4696m6mhi2qrd";
+    };
+  }
+  {
+    goPackagePath = "github.com/kisielk/gotool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kisielk/gotool";
+      rev = "v1.0.0";
+      sha256 = "14af2pa0ssyp8bp2mvdw184s5wcysk6akil3wzxmr05wwy951iwn";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pretty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pretty";
+      rev = "v0.1.0";
+      sha256 = "18m4pwg2abd0j9cn5v3k2ksk9ig4vlwxmlw9rrglanziv9l967qp";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pty";
+      rev = "v1.1.1";
+      sha256 = "0383f0mb9kqjvncqrfpidsf8y6ns5zlrc91c6a74xpyxjwvzl2y6";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/text";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/text";
+      rev = "v0.1.0";
+      sha256 = "1gm5bsl01apvc84bw06hasawyqm4q84vx1pm32wr9jnd7a8vjgj1";
+    };
+  }
+  {
+    goPackagePath = "github.com/mailru/easyjson";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mailru/easyjson";
+      rev = "d5b7844b561a";
+      sha256 = "1g84l4wns28xjpn6nl1g33dcj3sfgxlkqqsa6w8fbq2kwyd50xka";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev = "v0.1.4";
+      sha256 = "1yxcz08kminqr1221zxpibnbzfcgs3fafin0z9zqb3gqvf74jywz";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "v0.0.11";
+      sha256 = "0h671sv7hfprja495kavazkalkx7xzaqksjh13brcnwq67ijrali";
+    };
+  }
+  {
+    goPackagePath = "github.com/modern-go/concurrent";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/concurrent";
+      rev = "bacd9c7ef1dd";
+      sha256 = "0s0fxccsyb8icjmiym5k7prcqx36hvgdwl588y0491gi18k5i4zs";
+    };
+  }
+  {
+    goPackagePath = "github.com/modern-go/reflect2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/reflect2";
+      rev = "v1.0.1";
+      sha256 = "06a3sablw53n1dqqbr2f53jyksbxdmmk8axaas4yvnhyfi55k4lf";
+    };
+  }
+  {
+    goPackagePath = "github.com/munnerz/goautoneg";
+    fetch = {
+      type = "git";
+      url = "https://github.com/munnerz/goautoneg";
+      rev = "a547fc61f48d";
+      sha256 = "19khhn5xhqv1yp7d6k987gh5w5rhrjnp4p0c6fyrd8z6lzz5h9qi";
+    };
+  }
+  {
+    goPackagePath = "github.com/mxk/go-flowrate";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mxk/go-flowrate";
+      rev = "cca7078d478f";
+      sha256 = "0zqs39923ja0yypdmiqk6x8pgmfs3ms5x5sl1dqv9z6zyx2xy541";
+    };
+  }
+  {
+    goPackagePath = "github.com/onsi/ginkgo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/ginkgo";
+      rev = "v1.11.0";
+      sha256 = "1vxmb5k89bq50m2kzcw5l3bdvci4czpifkgxd4nbq1yzv5ir03kp";
+    };
+  }
+  {
+    goPackagePath = "github.com/onsi/gomega";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/gomega";
+      rev = "v1.7.0";
+      sha256 = "09j6wq425wgzzsbwm9ckhfgl2capv3yyqbrf45qyrjwkzm49i02y";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev = "v0.8.1";
+      sha256 = "0g5qcb4d4fd96midz0zdk8b9kz8xkzwfa8kr1cliqbg8sxsy5vd1";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/posener/complete";
+    fetch = {
+      type = "git";
+      url = "https://github.com/posener/complete";
+      rev = "v1.2.3";
+      sha256 = "0nri6hkfb0z3dkxf2fsfidr4bxbn91rjsqhg5s0c2jplf0aclppz";
+    };
+  }
+  {
+    goPackagePath = "github.com/sergi/go-diff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sergi/go-diff";
+      rev = "v1.1.0";
+      sha256 = "0ir8ali2vx0j7pipmlfd6k8c973akyy2nmbjrf008fm800zcp7z2";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev = "v1.0.5";
+      sha256 = "0gpmacngd0gpslnbkzi263f5ishigzgh6pbdv9hp092rnjl4nd31";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.2.0";
+      sha256 = "0pcdvakxgddaiwcdj73ra4da05a3q4cgwbpm2w75ycq4kzv8ij8k";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.4.0";
+      sha256 = "187i5g88sxfy4vxpm7dw1gwv29pa2qaq475lxrdh5livh69wqfjb";
+    };
+  }
+  {
+    goPackagePath = "github.com/thoas/go-funk";
+    fetch = {
+      type = "git";
+      url = "https://github.com/thoas/go-funk";
+      rev = "v0.4.0";
+      sha256 = "07s3swq8kp204nr5x3rh84qyvsaqngn0aill0rlpgqm6rbcjbzn0";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "60c769a6c586";
+      sha256 = "1wy2pg38dz29vf1h48yfqf8m3jqvwnbdw8vkk3ldlj5d8fbbbmv8";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "13f9640d40b9";
+      sha256 = "1ba2767lvklnmfvb9jkwvd4m7z6326gaiz3rgylh795g88hy34g1";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "1d60e4601c6f";
+      sha256 = "046jlanz2lkxq1r57x9bl6s4cvfqaic6p2xybsj8mq1120jv4rs6";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "33540a1f6037";
+      sha256 = "0fjcv0vzvi6za0b4xmnk3932pr9f9gczzf03y0kgq3ry9rqg169y";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.2";
+      sha256 = "0flv9idw0jm5nm8lx25xqanbkqgfiym6619w575p7nrdh0riqwqh";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "6c7e314b6563";
+      sha256 = "1m1n6r8v6mrlh0yvlz3qxz4s7jc7nis0zf3dfl1i6hqh5xblkwnw";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "41f04d3bba15";
+      sha256 = "0vfk9czmlxmp6wndq8k17rhnjxal764mxfhrccza7nwlia760pjy";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/fsnotify.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/fsnotify.v1";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/inf.v0";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/inf.v0";
+      rev = "v0.9.1";
+      sha256 = "00k5iqjcp371fllqxncv7jkf80hn1zww92zm78cclbcn4ybigkng";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/tomb.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/tomb.v1";
+      rev = "dd632973f1e7";
+      sha256 = "1lqmq1ag7s4b3gc3ddvr792c5xb5k6sfn0cchr3i2s7f1c231zjv";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.2.8";
+      sha256 = "1inf7svydzscwv9fcjd2rm61a4xjk6jkswknybmns2n58shimapw";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v3";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v3";
+      rev = "fc94e3f71652";
+      sha256 = "1mka8xdr6q359lq55kg0q8np5c59cq6b5r059i4xbbn8yhrwnx1m";
+    };
+  }
+  {
+    goPackagePath = "k8s.io/apimachinery";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/apimachinery";
+      rev = "v0.18.3";
+      sha256 = "0mrcd4pr4s8b5xv9cbi8pysykc5gch2vzz9sllrvvr6ibhbmkxpv";
+    };
+  }
+  {
+    goPackagePath = "k8s.io/gengo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/gengo";
+      rev = "0689ccc1d7d6";
+      sha256 = "10c0kbm07pzxwdxpsmcgqkcxqxaijyywvwj1rciw6ssfcgx7kdc5";
+    };
+  }
+  {
+    goPackagePath = "k8s.io/klog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/klog";
+      rev = "v1.0.0";
+      sha256 = "1cgannfmldcrcksb2wqdn2b5qabqyxl9r25w9y4qbljw24hhnlvn";
+    };
+  }
+  {
+    goPackagePath = "k8s.io/kube-openapi";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/kube-openapi";
+      rev = "61e04a5be9a6";
+      sha256 = "08aps89bm5c0z277isql25sc3j23zsq71iqnkv0hnq41cw51q9jk";
+    };
+  }
+  {
+    goPackagePath = "sigs.k8s.io/structured-merge-diff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes-sigs/structured-merge-diff";
+      rev = "v3.0.0";
+      sha256 = "1ckk4l2ljx1wfk0rz8n7m7hnhbdqqrhhi6zvdy6r5d0l2cr0mdjg";
+    };
+  }
+  {
+    goPackagePath = "sigs.k8s.io/yaml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes-sigs/yaml";
+      rev = "v1.2.0";
+      sha256 = "059a1chkd6afyvqszrx7h93k6cgik3ia92x29f5whpwi66461pzq";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20599,6 +20599,8 @@ in
 
   kubectl = callPackage ../applications/networking/cluster/kubectl { };
 
+  tanka = callPackage ../applications/networking/cluster/tanka { };
+
   kubeless = callPackage ../applications/networking/cluster/kubeless { };
 
   k9s = callPackage ../applications/networking/cluster/k9s { };


### PR DESCRIPTION
I am very new to nix. I assumed a good way to start and learn was by contributing adding a new package.

###### Motivation for this change

I want to use tanka and it was not in nixpkgs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions -> debian testing
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
