### PR TITLE
libdrm: 2.4.100 -> 2.4.102

### DIFF
--- a/pkgs/development/libraries/libdrm/cross-build-nm-path.patch
+++ b/pkgs/development/libraries/libdrm/cross-build-nm-path.patch
@@ -17,18 +17,17 @@ Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
  2 files changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index e292554a..64607139 100644
---- a/meson.build
-+++ b/meson.build
-@@ -327,7 +327,7 @@ pkg.generate(
- )
- 
- env_test = environment()
--env_test.set('NM', find_program('nm').path())
-+env_test.set('NM', find_program(get_option('nm-path')).path())
- 
- if with_libkms
-   subdir('libkms')
+--- meson.build.orig	2020-06-18 11:13:57.716321962 +0200
++++ meson.build	2020-06-18 11:19:50.456861311 +0200
+@@ -45,7 +45,7 @@
+ cc = meson.get_compiler('c')
+
+ symbols_check = find_program('symbols-check.py')
+-prog_nm = find_program('nm')
++prog_nm = find_program(get_option('nm-path'))
+
+ # Check for atomics
+ intel_atomics = false
 diff --git a/meson_options.txt b/meson_options.txt
 index 8af33f1c..b4f46a52 100644
 --- a/meson_options.txt

--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "libdrm";
-  version = "2.4.100";
+  version = "2.4.102";
 
   src = fetchurl {
-    url = "https://dri.freedesktop.org/${pname}/${pname}-${version}.tar.bz2";
-    sha256 = "0p8a1l3a3s40i81mawm8nhrbk7p97ss05qkawp1yx73c30lchz67";
+    url = "https://dri.freedesktop.org/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "0nx0bd9dhymdsd99v4ifib77yjirkvkxf5hzdkbr7qr8dhrzkjwb";
   };
 
   outputs = [ "out" "dev" "bin" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New version with support for FB2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I did not run nixpkgs-review because it said it would take 180 GB.