### PR TITLE
pythonPackages.flask-basicauth: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/flask-basicauth/default.nix
+++ b/pkgs/development/python-modules/flask-basicauth/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, flask }:
+
+buildPythonPackage rec {
+  pname = "Flask-BasicAuth";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-3169SJ3AkUwiRBnaBZ2ZHrcpiKAc3UuVbVKTLOfVAf8=";
+  };
+
+  propagatedBuildInputs = [ flask ];
+
+  # fails because use a deprecated flask style
+  doCheck = false;
+
+  meta = with lib; {
+    description = "HTTP basic access authentication for Flask.";
+    homepage = "https://github.com/jpvanhal/flask-basicauth://github.com/miguelgrinberg/Flask-HTTPAuth";
+    license = licenses.mit;
+    maintainers = with maintainers; [ teto ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3749,6 +3749,8 @@ in {
 
   flask-babelex = callPackage ../development/python-modules/flask-babelex { };
 
+  flask-basicauth = callPackage ../development/python-modules/flask-basicauth { };
+
   flask-bcrypt = callPackage ../development/python-modules/flask-bcrypt { };
 
   flask-bootstrap = callPackage ../development/python-modules/flask-bootstrap { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I updated the locustio package but it required this one. Last release seems
quite old so the tests fail because they haven't been updated to match modern
flask. Hopefully the locust package will drop this dependency in future
releases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
