### PR TITLE
json-c: 0.13.1 -> 0.14

### DIFF
--- a/pkgs/development/libraries/json-c/default.nix
+++ b/pkgs/development/libraries/json-c/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, fetchurl, fetchpatch, autoconf }:
+{ stdenv, fetchurl, fetchpatch, cmake }:
 
 stdenv.mkDerivation rec {
-  name = "json-c-0.13.1";
+  name = "json-c-0.14";
   src = fetchurl {
     url    = "https://s3.amazonaws.com/json-c_releases/releases/${name}-nodoc.tar.gz";
-    sha256 = "0ch1v18wk703bpbyzj7h1mkwvsw4rw4qdwvgykscypvqq10678ll";
+    sha256 = "1yia8417qljmczs9w3rn4c4i2p2iywq098pgrj11s81599j4x4cr";
   };
 
   patches = [
     # https://nvd.nist.gov/vuln/detail/CVE-2020-12762
     (fetchpatch {
       name = "CVE-2020-12762.patch";
-      url = "https://github.com/json-c/json-c/commit/865b5a65199973bb63dff8e47a2f57e04fec9736.patch";
-      sha256 = "1g5afk4khhm1sb70xrva1pyznshcw3ipzp1g5z60dpzxy303pp6h";
+      url = "https://github.com/json-c/json-c/commit/5d6fa331418d49f1bd488553fd1cfa9ab023fabb.patch";
+      sha256 = "0aar7kgbycqxnhh0lrr61adfbb903nbapalhs5i6h8anxwy1ylcm";
     })
   ];
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ autoconf ];  # for autoheader
+  nativeBuildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
     description = "A JSON implementation in C";

--- a/pkgs/development/libraries/libu2f-host/default.nix
+++ b/pkgs/development/libraries/libu2f-host/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, json_c, hidapi }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, json_c, hidapi }:
 
 stdenv.mkDerivation rec {
   pname = "libu2f-host";
@@ -8,6 +8,15 @@ stdenv.mkDerivation rec {
     url = "https://developers.yubico.com/${pname}/Releases/${pname}-${version}.tar.xz";
     sha256 = "0vrivl1dwql6nfi48z6dy56fwy2z13d7abgahgrs2mcmqng7hra2";
   };
+
+  patches = [
+    # remove after updating to next release
+    (fetchpatch {
+      name = "json-c-0.14-support.patch";
+      url = "https://github.com/Yubico/libu2f-host/commit/840f01135d2892f45e71b9e90405de587991bd03.patch";
+      sha256 = "0xplx394ppsbsb4h4l8b9m4dv9shbl0zyck3y26vbm9i1g981ki7";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ json_c hidapi ];

--- a/pkgs/development/libraries/libu2f-server/default.nix
+++ b/pkgs/development/libraries/libu2f-server/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, json_c, openssl, check, file, help2man, which, gengetopt }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, json_c, openssl, check, file, help2man, which, gengetopt }:
 
 stdenv.mkDerivation rec {
   name = "libu2f-server-1.1.0";
@@ -6,6 +6,15 @@ stdenv.mkDerivation rec {
     url = "https://developers.yubico.com/libu2f-server/Releases/${name}.tar.xz";
     sha256 = "0xx296nmmqa57w0v5p2kasl5zr1ms2gh6qi4lhv6xvzbmjp3rkcd";
   };
+
+  patches = [
+    # remove after updating to next release
+    (fetchpatch {
+      name = "json-c-0.14-support.patch";
+      url = "https://github.com/Yubico/libu2f-server/commit/f7c4983b31909299c47bf9b2627c84b6bfe225de.patch";
+      sha256 = "10q66w3paii1yhfdmjskpip078fk9p3sjllbqx1yx71qbjki55b0";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ json_c openssl check file help2man which gengetopt ];

--- a/pkgs/os-specific/linux/multipath-tools/default.nix
+++ b/pkgs/os-specific/linux/multipath-tools/default.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "1mgjylklh1cx8px8ffgl12kyc0ln3445vbabd2sy8chq31rpiiq8";
   };
 
+  patches = [
+    # fix build with json-c 0.14 https://www.redhat.com/archives/dm-devel/2020-May/msg00261.html
+    ./json-c-0.14.patch
+  ];
+
   postPatch = ''
     substituteInPlace libmultipath/Makefile --replace /usr/include/libdevmapper.h ${lvm2}/include/libdevmapper.h
     sed -i -re '

--- a/pkgs/os-specific/linux/multipath-tools/json-c-0.14.patch
+++ b/pkgs/os-specific/linux/multipath-tools/json-c-0.14.patch
@@ -1,0 +1,21 @@
+diff --git a/libdmmp/libdmmp_private.h b/libdmmp/libdmmp_private.h
+index ac85b63f..b1a6ddea 100644
+--- a/libdmmp/libdmmp_private.h
++++ b/libdmmp/libdmmp_private.h
+@@ -30,6 +30,7 @@
+ #include <stdint.h>
+ #include <string.h>
+ #include <assert.h>
++#include <stdbool.h>
+ #include <json.h>
+ 
+ #include "libdmmp/libdmmp.h"
+@@ -82,7 +83,7 @@ static out_type func_name(struct dmmp_context *ctx, const char *var_name) { \
+ do { \
+ 	json_type j_type = json_type_null; \
+ 	json_object *j_obj_tmp = NULL; \
+-	if (json_object_object_get_ex(j_obj, key, &j_obj_tmp) != TRUE) { \
++	if (json_object_object_get_ex(j_obj, key, &j_obj_tmp) != true) { \
+ 		_error(ctx, "Invalid JSON output from multipathd IPC: " \
+ 		       "key '%s' not found", key); \
+ 		rc = DMMP_ERR_IPC_ERROR; \

--- a/pkgs/tools/misc/yubikey-personalization/default.nix
+++ b/pkgs/tools/misc/yubikey-personalization/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libusb1, libyubikey, json_c }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, libusb1, libyubikey, json_c }:
 
 stdenv.mkDerivation rec {
   pname = "yubikey-personalization";
@@ -8,6 +8,15 @@ stdenv.mkDerivation rec {
     url = "https://developers.yubico.com/yubikey-personalization/Releases/ykpers-${version}.tar.gz";
     sha256 = "14wvlwqnwj0gllkpvfqiy8ns938bwvjsz8x1hmymmx32m074vj0f";
   };
+
+  patches = [
+    # remove after updating to next release
+    (fetchpatch {
+      name = "json-c-0.14-support.patch";
+      url = "https://github.com/Yubico/yubikey-personalization/commit/0aa2e2cae2e1777863993a10c809bb50f4cde7f8.patch";
+      sha256 = "1wnigf3hbq59i15kgxpq3pwrl1drpbj134x81mmv9xm1r44cjva8";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libusb1 libyubikey json_c ];

--- a/pkgs/tools/networking/connman/connman-ncurses/default.nix
+++ b/pkgs/tools/networking/connman/connman-ncurses/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, dbus, json_c, ncurses, connman }:
+{ stdenv, fetchpatch, fetchFromGitHub, autoreconfHook, pkgconfig, dbus, json_c, ncurses, connman }:
 
 stdenv.mkDerivation {
   pname = "connman-ncurses";
@@ -11,12 +11,21 @@ stdenv.mkDerivation {
     sha256 = "1831r0776fv481g8kgy1dkl750pzv47835dw11sslq2k6mm6i9p1";
   };
 
+  patches = [
+    # Fix build with json-c 0.14
+    (fetchpatch {
+      url = "https://github.com/void-linux/void-packages/raw/5830ce60e922b7dced8157ededda8c995adb3bb9/srcpkgs/connman-ncurses/patches/lowercase-boolean.patch";
+      extraPrefix = "";
+      sha256 = "uK83DeRyXS2Y0ZZpTYvYNh/1ZM2QQ7QpajiBztaEuSM=";
+    })
+  ];
+
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   buildInputs = [ dbus ncurses json_c connman ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
-  
+
   installPhase = ''
     mkdir -p "$out/bin"
     cp -va connman_ncurses "$out/bin/"

--- a/pkgs/tools/security/zmap/cmake-json-0.14-fix.patch
+++ b/pkgs/tools/security/zmap/cmake-json-0.14-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8bd825f..694d9b2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -72,6 +72,8 @@ if(WITH_JSON)
+     endif()
+ 
+     add_definitions("-DJSON")
++    # JSON_CFLAGS is a list, i.e. semicolon-separated, convert it to space-separated
++    string(REPLACE ";" " " JSON_CFLAGS "${JSON_CFLAGS}")
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${JSON_CFLAGS}")
+ endif()
+ 

--- a/pkgs/tools/security/zmap/default.nix
+++ b/pkgs/tools/security/zmap/default.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
     sha256 = "0yaahaiawkjk020hvsb8pndbrk8k10wxkfba1irp12a4sj6rywcs";
   };
 
+  patches = [
+    # fix build with json-c 0.14 https://github.com/zmap/zmap/pull/609
+    ./cmake-json-0.14-fix.patch
+  ];
+
   cmakeFlags = [ "-DRESPECT_INSTALL_PREFIX_CONFIG=ON" ];
   dontUseCmakeBuildDir = true;
 


### PR DESCRIPTION
Changes: https://github.com/json-c/json-c/blob/json-c-0.14-20200419/ChangeLog

Not really sure how to do library upgrade where some packages depend on the old version (until upstream fixes it). Most packages need no changes, I've included patches for those that have them in master, and made the rest to depend on the old version. Let me know is some other structure is preferred.

###### Motivation for this change

New version of popular library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
