### PR TITLE
rust-analyzer: 2020-06-01 -> 2020-06-15 and fix version display

### DIFF
--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -2,10 +2,10 @@
 
 {
   rust-analyzer-unwrapped = callPackage ./generic.nix rec {
-    rev = "2020-06-01";
+    rev = "2020-06-15";
     version = "unstable-${rev}";
-    sha256 = "0chm47mrd4hybhvzn4cndq2ck0mj948mm181p1i1j1w0ms7zk1fg";
-    cargoSha256 = "0yaz50f7hirlcs8bxc5dh170lch9l1gscwayan71k3pz23wkvlzs";
+    sha256 = "1qwkhzhgw6sap6vf5ilzr96a88r3snfrf3fcfkzw3n67j7lvsprf";
+    cargoSha256 = "0gcgfgrrjxzcgdci709dvx3904sbqx03w4pkbj89kk44j65cdzsy";
   };
 
   rust-analyzer = callPackage ./wrapper.nix {} {

--- a/pkgs/development/tools/rust/rust-analyzer/generic.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/generic.nix
@@ -15,6 +15,9 @@ rustPlatform.buildRustPackage {
     inherit rev sha256;
   };
 
+  patches = [ ./read-rev-from-env.patch ];
+  REV = rev;
+
   buildAndTestSubdir = "crates/rust-analyzer";
 
   cargoBuildFlags = lib.optional useJemalloc "--features=jemalloc";

--- a/pkgs/development/tools/rust/rust-analyzer/read-rev-from-env.patch
+++ b/pkgs/development/tools/rust/rust-analyzer/read-rev-from-env.patch
@@ -1,0 +1,17 @@
+--- a/crates/rust-analyzer/build.rs
++++ b/crates/rust-analyzer/build.rs
+@@ -5,11 +5,13 @@ use std::{env, path::PathBuf, process::Command};
+ fn main() {
+     set_rerun();
+ 
+-    let rev = rev().unwrap_or_else(|| "???????".to_string());
++    let rev = env::var("REV").ok().or(rev()).unwrap_or_else(|| "???????".to_string());
+     println!("cargo:rustc-env=REV={}", rev)
+ }
+ 
+ fn set_rerun() {
++    println!("cargo:rerun-if-env-changed=REV");
++
+     let mut manifest_dir = PathBuf::from(
+         env::var("CARGO_MANIFEST_DIR").expect("`CARGO_MANIFEST_DIR` is always set by cargo."),
+     );


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bump version.
Fix output when it is called with `--version`. (Used to be `??????`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
