### PR TITLE
[20.03] libexif: 0.6.21 -> 0.6.22 for security fixes

### DIFF
--- a/pkgs/development/libraries/libexif/default.nix
+++ b/pkgs/development/libraries/libexif/default.nix
@@ -1,45 +1,24 @@
-{ stdenv, fetchurl, fetchpatch, gettext }:
+{ stdenv, fetchFromGitHub, autoreconfHook, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "libexif-0.6.21";
+  pname = "libexif";
+  version = "0.6.22";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/libexif/${name}.tar.bz2";
-    sha256 = "06nlsibr3ylfwp28w8f5466l6drgrnydgxrm4jmxzrmk5svaxk8n";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "${pname}-${builtins.replaceStrings ["."] ["_"] version}-release";
+    sha256 = "0mzndakdi816zcs13z7yzp7hj031p2dcyfq2p391r63d9z21jmy1";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "CVE-2017-7544.patch";
-      url = "https://github.com/libexif/libexif/commit/c39acd1692023b26290778a02a9232c873f9d71a.patch";
-      sha256 = "0xgx6ly2i4q05shb61mfx6njwf1yp347jkznm0ka4m85i41xm6sd";
-    })
-    (fetchpatch {
-      name = "CVE-2018-20030-1.patch";
-      url = "https://github.com/libexif/libexif/commit/5d28011c40ec86cf52cffad541093d37c263898a.patch";
-      sha256 = "1wv8s962wmbn2m2xypgirf12g6msrbplpsmd5bh86irfwhkcppj3";
-    })
-    (fetchpatch {
-      name = "CVE-2018-20030-2.patch";
-      url = "https://github.com/libexif/libexif/commit/6aa11df549114ebda520dde4cdaea2f9357b2c89.patch";
-      sha256 = "01aqvz63glwq6wg0wr7ykqqghb4abgq77ghvhizbzadg1k4h7drx";
-      excludes = [ "NEWS" ];
-    })
-    (fetchpatch {
-      name = "CVE-2019-9278.patch";
-      url = "https://github.com/libexif/libexif/commit/75aa73267fdb1e0ebfbc00369e7312bac43d0566.patch";
-      sha256 = "10ikg33mips5zq9as7l9xqnyzbg1wwr4sw17517nzf4hafjpasrj";
-    })
-  ];
+  nativeBuildInputs = [ autoreconfHook gettext ];
 
-  buildInputs = [ gettext ];
-
-  meta = {
-    homepage = https://libexif.github.io/;
+  meta = with stdenv.lib; {
+    homepage = "https://libexif.github.io/";
     description = "A library to read and manipulate EXIF data in digital photographs";
-    license = stdenv.lib.licenses.lgpl21;
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.erictapen ];
+    license = licenses.lgpl21;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ erictapen ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/90843.
Closes https://github.com/NixOS/nixpkgs/issues/88340.

When I added four security patches to the already existing four patches I quickly ran into merge problems and decided, that I'd rather backport https://github.com/NixOS/nixpkgs/pull/88100.

I consider the version bump minimal, as [the release page](https://github.com/libexif/libexif/releases/tag/libexif-0_6_22-release) states that 0.6.22 is largely a bugfix release.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
