### PR TITLE
librespot: init at 0.1.1

### DIFF
--- a/pkgs/applications/audio/librespot/default.nix
+++ b/pkgs/applications/audio/librespot/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl
+, withRodio ? true
+, withALSA ? true, alsaLib ? null
+, withPulseAudio ? false, libpulseaudio ? null
+, withPortAudio ? false, portaudio ? null
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "librespot";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "librespot-org";
+    repo = "librespot";
+    rev = "v${version}";
+    sha256 = "1sdbjv8w2mfpv82rx5iy4s532l1767vmlrg9d8khnvh8vrm2lshy";
+  };
+
+  cargoSha256 = "0zi50imjvalwl6pxl35qrmbg74j5xdfaws8v69am4g9agbfjvlms";
+
+  cargoBuildFlags = with stdenv.lib; [
+    "--no-default-features"
+    "--features"
+    (concatStringsSep "," (filter (x: x != "") [
+      (optionalString withRodio "rodio-backend")
+      (optionalString withALSA "alsa-backend")
+      (optionalString withPulseAudio "pulseaudio-backend")
+      (optionalString withPortAudio "portaudio-backend")
+
+    ]))
+  ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ openssl ]
+    ++ stdenv.lib.optional withALSA alsaLib
+    ++ stdenv.lib.optional withPulseAudio libpulseaudio
+    ++ stdenv.lib.optional withPortAudio portaudio;
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Open Source Spotify client library and playback daemon";
+    homepage = "https://github.com/librespot-org/librespot";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ bennofs ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19927,6 +19927,12 @@ in
 
   libquvi = callPackage ../applications/video/quvi/library.nix { };
 
+  librespot = callPackage ../applications/audio/librespot {
+    withALSA = stdenv.isLinux;
+    withPulseAudio = config.pulseaudio or stdenv.isLinux;
+    withPortAudio = stdenv.isDarwin;
+  };
+
   linssid = libsForQt5.callPackage ../applications/networking/linssid { };
 
   lollypop = callPackage ../applications/audio/lollypop { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add a package for the librespot application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
