### PR TITLE
cryptsetup: 2.1.0 -> 2.3.3

### DIFF
--- a/pkgs/development/python-modules/blivet/default.nix
+++ b/pkgs/development/python-modules/blivet/default.nix
@@ -1,11 +1,8 @@
 { stdenv, fetchFromGitHub, buildPythonPackage, pykickstart, pyparted, pyblock
-, pyudev, six, libselinux, cryptsetup, multipath-tools, lsof, utillinux
+, pyudev, six, libselinux, multipath-tools, lsof, utillinux
 }:
 
-let
-  pyenable = { enablePython = true; };
-  cryptsetupWithPython = cryptsetup.override pyenable;
-in buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "blivet";
   version = "0.67";
 
@@ -30,7 +27,7 @@ in buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
-    pykickstart pyparted pyblock pyudev libselinux cryptsetupWithPython
+    pykickstart pyparted pyblock pyudev libselinux
     six
   ];
 

--- a/pkgs/os-specific/linux/cryptsetup/default.nix
+++ b/pkgs/os-specific/linux/cryptsetup/default.nix
@@ -1,17 +1,15 @@
 { stdenv, fetchurl, lvm2, json_c
-, openssl, libuuid, pkgconfig, popt
-, enablePython ? false, python2 ? null }:
-
-assert enablePython -> python2 != null;
+, openssl, libuuid, pkgconfig, popt }:
 
 stdenv.mkDerivation rec {
-  name = "cryptsetup-2.1.0";
+  pname = "cryptsetup";
+  version = "2.3.3";
 
   outputs = [ "out" "dev" "man" ];
 
   src = fetchurl {
-    url = "mirror://kernel/linux/utils/cryptsetup/v2.1/${name}.tar.xz";
-    sha256 = "15y8n547garz0x5kqv09gscdsrz0c0y1y6c5cp8pccwg3xsb5vm3";
+    url = "mirror://kernel/linux/utils/cryptsetup/v2.3/${pname}-${version}.tar.xz";
+    sha256 = "1pw2bq4nv2z3xyycckxkbp7dp9kkp2n6bspna3plryg277z4zjiv";
   };
 
   # Disable 4 test cases that fail in a sandbox
@@ -19,9 +17,6 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs tests
-    ${stdenv.lib.optionalString enablePython ''
-      patchShebangs ./python/pycryptsetup-test.py
-    ''}
 
     # O_DIRECT is filesystem dependent and fails in a sandbox (on tmpfs)
     # and on several filesystem types (btrfs, zfs) without sandboxing.
@@ -34,11 +29,10 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-cryptsetup-reencrypt"
     "--with-crypto_backend=openssl"
-  ] ++ stdenv.lib.optional enablePython "--enable-python";
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ lvm2 json_c openssl libuuid popt ]
-    ++ stdenv.lib.optional enablePython python2;
+  buildInputs = [ lvm2 json_c openssl libuuid popt ];
 
   doCheck = true;
 


### PR DESCRIPTION
Changes:
- https://gitlab.com/cryptsetup/cryptsetup/-/blob/master/docs/v2.2.0-ReleaseNotes
- https://gitlab.com/cryptsetup/cryptsetup/-/blob/master/docs/v2.2.1-ReleaseNotes
- https://gitlab.com/cryptsetup/cryptsetup/-/blob/master/docs/v2.2.2-ReleaseNotes
- https://gitlab.com/cryptsetup/cryptsetup/-/blob/master/docs/v2.3.0-ReleaseNotes
- https://gitlab.com/cryptsetup/cryptsetup/-/blob/master/docs/v2.3.1-ReleaseNotes
- https://gitlab.com/cryptsetup/cryptsetup/-/blob/master/docs/v2.3.2-ReleaseNotes
- https://gitlab.com/cryptsetup/cryptsetup/-/blob/master/docs/v2.3.3-ReleaseNotes

The python bindings were removed in 2.1.0.

Successfully booted my 20.03 on LUKS-encrypted root using this package.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Release notes told me:
> All users of cryptsetup 2.x should upgrade to this version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
