### PR TITLE
awesomebump: 5.1 -> 5.1.1

### DIFF
--- a/pkgs/applications/graphics/awesomebump/default.nix
+++ b/pkgs/applications/graphics/awesomebump/default.nix
@@ -2,12 +2,12 @@
 
 
 let
-  version = "5.1";
+  version = "5.1.1";
 
   src = fetchgit {
     url = "https://github.com/kmkolasinski/AwesomeBump.git";
-    rev = "Winx32v${version}";
-    sha256 = "1c8b9jki0v8kzkvsvyv7q1w3s7j40br6ph15hh2xi0a1mpwckq56";
+    rev = "Linuxv${version}";
+    sha256 = "0qm9sf6la40qc0872qcx09cfpgdpgmk1k89af2kkn7p2p5bdfrfc";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change

the software wasn't able to do 3d renderer (an important part of the software) on some driver/GPU, including mine. 5.1.1 solved this for me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
