### PR TITLE
nanopb: include C sources

### DIFF
--- a/pkgs/development/libraries/nanopb/default.nix
+++ b/pkgs/development/libraries/nanopb/default.nix
@@ -50,6 +50,8 @@ in stdenv.mkDerivation rec {
       --subst-var-by python ${pythonRuntime}/bin/python \
       --subst-var-by out $out
     chmod +x $out/bin/protoc-gen-nanopb
+
+    cp ../pb_common.c ../pb_decode.c ../pb_encode.c $out/include/
   '';
 
   passthru.tests = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The C source files are required if the package (i.e nanopb) is used by a non-Nix Docker container to cross-compile dependencies to other architectures. I wouldn't think it's a problem on our end to include these files as they don't depend on anything else besides the header files themselves.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
