### PR TITLE
sequoia: unbreak on darwin

### DIFF
--- a/pkgs/tools/security/sequoia/default.nix
+++ b/pkgs/tools/security/sequoia/default.nix
@@ -56,6 +56,10 @@ rustPlatform.buildRustPackage rec {
 
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
+  # Please check if this is still needed when updating.
+  # Exlude tests for sequoia-store, they often error with 'Too many open files' Hydra.
+  CARGO_TEST_ARGS = " --all --exclude sequoia-store";
+
   postPatch = ''
     # otherwise, the check fails because we delete the `.git` in the unpack phase
     substituteInPlace openpgp-ffi/Makefile \

--- a/pkgs/tools/security/sequoia/default.nix
+++ b/pkgs/tools/security/sequoia/default.nix
@@ -9,16 +9,16 @@ assert pythonSupport -> pythonPackages != null;
 
 rustPlatform.buildRustPackage rec {
   pname = "sequoia";
-  version = "0.16.0";
+  version = "0.17.0";
 
   src = fetchFromGitLab {
     owner = "sequoia-pgp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0iwzi2ylrwz56s77cd4vcf89ig6ipy4w6kp2pfwqvd2d00x54dhk";
+    sha256 = "1rf9q67qmjfkgy6r3mz1h9ibfmc04r4j8nzacqv2l75x4mwvf6xb";
   };
 
-  cargoSha256 = "0jsmvs6hr9mhapz3a74wpfgkjkq3w10014j3z30bm659mxqrknha";
+  cargoSha256 = "074bbr7dfk8cqdarrjy4sm37f5jmv2l5gwwh3zcmy2wrfg7vi1h6";
 
   nativeBuildInputs = [
     pkgconfig

--- a/pkgs/tools/security/sequoia/default.nix
+++ b/pkgs/tools/security/sequoia/default.nix
@@ -90,6 +90,5 @@ rustPlatform.buildRustPackage rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ minijackson doronbehar ];
     platforms = platforms.all;
-    broken = stdenv.targetPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This is an attempt to unbreak `sequoia` on darwin. I don't own a Mac, so I'm trying to get ofBorg to do the work :)

`sequoia` has been marked broken on Darwin since #73104 (version 0.11.0). I'd like to check if the build still fails and try to fix it, if it does.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
