### PR TITLE
fedora-coreos-config-transpiler: init at 0.6.0

### DIFF
--- a/pkgs/development/tools/fedora-coreos-config-transpiler/default.nix
+++ b/pkgs/development/tools/fedora-coreos-config-transpiler/default.nix
@@ -1,0 +1,34 @@
+{ lib, fetchFromGitHub, buildGoPackage }:
+
+with lib;
+
+buildGoPackage rec {
+  pname = "fcct";
+  version = "0.6.0";
+
+  goPackagePath = "github.com/coreos/fcct";
+
+  src = fetchFromGitHub {
+    owner = "coreos";
+    repo = "fcct";
+    rev = "v${version}";
+    sha256 = "18hmnip1s0smp58q500p8dfbrmi4i3nsyq22ri5cs53wbvz3ih1l";
+  };
+
+  buildFlagsArray = ''
+    -ldflags=-X ${goPackagePath}/internal/version.Raw=v${version}
+  '';
+
+  postInstall = ''
+    mv $out/bin/{internal,fcct}
+  '';
+
+  meta = {
+    description = "Translates Fedora CoreOS configs into Ignition configs";
+    license = licenses.asl20;
+    homepage = "https://github.com/coreos/fcct";
+    maintainers = with maintainers; [ elijahcaine ruuda ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/development/tools/fedora-coreos-config-transpiler/default.nix
+++ b/pkgs/development/tools/fedora-coreos-config-transpiler/default.nix
@@ -1,12 +1,10 @@
-{ lib, fetchFromGitHub, buildGoPackage }:
+{ lib, fetchFromGitHub, buildGoModule }:
 
 with lib;
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "fcct";
   version = "0.6.0";
-
-  goPackagePath = "github.com/coreos/fcct";
 
   src = fetchFromGitHub {
     owner = "coreos";
@@ -15,8 +13,13 @@ buildGoPackage rec {
     sha256 = "18hmnip1s0smp58q500p8dfbrmi4i3nsyq22ri5cs53wbvz3ih1l";
   };
 
+  deleteVendor = true;
+  vendorSha256 = "0qqkaskmyxgwv9qg3y5lckqf6nchn3bxp69fyqdbvki65p445608";
+
+  subPackages = [ "internal" ];
+
   buildFlagsArray = ''
-    -ldflags=-X ${goPackagePath}/internal/version.Raw=v${version}
+    -ldflags=-X github.com/coreos/fcct/internal/version.Raw=v${version}
   '';
 
   postInstall = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -882,6 +882,8 @@ in
 
   container-linux-config-transpiler = callPackage ../development/tools/container-linux-config-transpiler { };
 
+  fedora-coreos-config-transpiler = callPackage ../development/tools/fedora-coreos-config-transpiler { };
+
   ccextractor = callPackage ../applications/video/ccextractor { };
 
   cconv = callPackage ../tools/text/cconv { };


### PR DESCRIPTION
###### Motivation for this change

We package the CoreOS [Container Linux Config Transpiler](https://github.com/coreos/container-linux-config-transpiler), but CoreOS Container Linux [has reached end of life](https://coreos.com/os/eol/), and has been superseded by Fedora CoreOS. The [Fedora CoreOS Config Transpiler](https://github.com/coreos/fcct) (FCCT) is the equivalent config transpiler for Fedora CoreOS.

I am not removing the original Container Linux Config Transpiler, because Container Linux lives on in [Flatcar Linux](https://www.flatcar-linux.org/).

The new package is a copy of the container-linux-config-transpiler package, with metadata updated and `postInstall` slightly simplified.

@pop I added you as a maintainer because you are the maintainer of the original config transpiler package, are you okay with that?

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
