### PR TITLE
oil: 0.8.pre4 -> 0.8.pre6

### DIFF
--- a/pkgs/shells/oil/default.nix
+++ b/pkgs/shells/oil/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "oil";
-  version = "0.8.pre4";
+  version = "0.8.pre6";
 
   src = fetchurl {
     url = "https://www.oilshell.org/download/oil-${version}.tar.xz";
-    sha256 = "07kj86hrvlz9f1gh3qv4hdaz3qnb4a2qf0dnxhd2r0qilrkjanxh";
+    sha256 = "1gbc74in78lbkciz7wzjplrm185wn6fz57n66xmazayivqmpvgfm";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
A new version of oil shell came out 

###### Things done

```
export NIXPKGS=$HOME/code/nixpkgs/
nix-env -f $NIXPKGS -iA oil
```
