### PR TITLE
LindeBuzoGrayStippling: init -> 1.0

### DIFF
--- a/pkgs/tools/graphics/LindeBuzoGrayStippling/default.nix
+++ b/pkgs/tools/graphics/LindeBuzoGrayStippling/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, cmake, qtbase, wrapQtAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "LindeBuzoGrayStippling";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "MarcSpicker";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256:1k5izyrw560pyk64v63vjq4vj5n2hp1nxfb6f24h6cjn7ilh21c7";
+  };
+
+  buildInputs = [ qtbase ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp LBGStippling $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://graphics.uni-konstanz.de/publikationen/Deussen2017LindeBuzoGray/index.html";
+    description = "Interactive Stippling tool to create stippled version of images";
+    longDescription = ''
+      Stippling is the creation of a pattern simulating varying
+      degrees of solidity or shading by using small dots of various
+      sizes. The technique can be used both for artistic purposes, but
+      also to avoid the use of photographs for websites and print.
+      This tool by Marc Spicker from the department of Visual
+      Computing from the University of Konstanz was created to support
+      a paper for the ACM Transactions on Graphics called "Weighted
+      Linde-Buzo-Gray Stippling". Best results are achieved by using
+      graphics with high contrast; especially with portraits this
+      means you should preprocess with a photo editor. The tool
+      on an adaptive version of Lloyd's optimization method that
+      distributes points based on Voronoi diagrams.
+    '';
+    maintainers = with maintainers; [ leenaars ];
+    platforms = platforms.all;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20699,6 +20699,8 @@ in
     portaudio = portaudio2014;
   };
 
+  LindeBuzoGrayStippling = libsForQt5.callPackage ../tools/graphics/LindeBuzoGrayStippling { };
+
   lingot = callPackage ../applications/audio/lingot { };
 
   linuxband = callPackage ../applications/audio/linuxband { };


### PR DESCRIPTION
###### Motivation for this change

Introduction of a new graphics tool that performs stippling, as currently no such tool is available in nixpkgs.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
