### PR TITLE
nixos/fontconfig: Move deprecated ultimate removals to relevant module

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -278,7 +278,14 @@ in
     (mkRemovedOptionModule [ "fonts" "fontconfig" "hinting" "style" ] "")
     (mkRemovedOptionModule [ "fonts" "fontconfig" "forceAutohint" ] "")
     (mkRemovedOptionModule [ "fonts" "fontconfig" "renderMonoTTFAsBitmap" ] "")
-  ];
+  ] ++ lib.forEach [ "enable" "substitutions" "preset" ]
+     (opt: lib.mkRemovedOptionModule [ "fonts" "fontconfig" "ultimate" "${opt}" ] ''
+       The fonts.fontconfig.ultimate module and configuration is obsolete.
+       The repository has since been archived and activity has ceased.
+       https://github.com/bohoomil/fontconfig-ultimate/issues/171.
+       No action should be needed for font configuration, as the fonts.fontconfig
+       module is already used by default.
+     '');
 
   options = {
 

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -168,15 +168,6 @@ in
        (opt: lib.mkRemovedOptionModule [ "services" "prometheus" "${opt}" ] ''
          The prometheus exporters are now configured using `services.prometheus.exporters'.
          See the 18.03 release notes for more information.
-       '' ))
-
-    ++ (lib.forEach [ "enable" "substitutions" "preset" ]
-       (opt: lib.mkRemovedOptionModule [ "fonts" "fontconfig" "ultimate" "${opt}" ] ''
-         The fonts.fontconfig.ultimate module and configuration is obsolete.
-         The repository has since been archived and activity has ceased.
-         https://github.com/bohoomil/fontconfig-ultimate/issues/171.
-         No action should be needed for font configuration, as the fonts.fontconfig
-         module is already used by default.
        '' ));
 
   options.services.prometheus.exporters = mkOption {


### PR DESCRIPTION
###### Motivation for this change

This was a mistake in https://github.com/NixOS/nixpkgs/pull/61570, this
does not belong to prometheus

Thanks for [bringing this to my attention](https://github.com/NixOS/nixpkgs/pull/61570#commitcomment-39998080), @WilliButz.

###### Things done

- [x] Made sure no syntax was messed up by evaluating a system with this change
- [x] Made sure the removal warning triggers when using the relevant option