### PR TITLE
gitea: 1.11.6 -> 1.12.0

### DIFF
--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -1,6 +1,5 @@
 { stdenv, buildGoPackage, fetchurl, makeWrapper
 , git, bash, gzip, openssh, pam
-, fetchpatch
 , sqliteSupport ? true
 , pamSupport ? true
 }:
@@ -9,11 +8,11 @@ with stdenv.lib;
 
 buildGoPackage rec {
   pname = "gitea";
-  version = "1.11.6";
+  version = "1.12.0";
 
   src = fetchurl {
     url = "https://github.com/go-gitea/gitea/releases/download/v${version}/gitea-src-${version}.tar.gz";
-    sha256 = "11nyq5faq0hy1pi3yhmc6y8is7jyiyfrb162fq9l33pkyw6qihqs";
+    sha256 = "1nsi7d2jackkjvinp5wglrzb61f2hihrn6qgwlp1zb185k2qpd23";
   };
 
   unpackPhase = ''
@@ -25,10 +24,6 @@ buildGoPackage rec {
 
   patches = [
     ./static-root-path.patch
-    (fetchpatch {
-      url = "https://github.com/go-gitea/gitea/commit/1830d0ed5f4a67e3360ecbb55933b5540b6affce.patch";
-      sha256 = "163531pcki28qfs56l64vv4xxaavxgksf038da1sn21j5l2jm81i";
-    })
   ];
 
   postPatch = ''


### PR DESCRIPTION

###### Motivation for this change

https://github.com/go-gitea/gitea/releases/tag/v1.12.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
