### PR TITLE
minc-tools: actually build Nifti support

### DIFF
--- a/pkgs/applications/science/biology/minc-tools/default.nix
+++ b/pkgs/applications/science/biology/minc-tools/default.nix
@@ -14,15 +14,19 @@ stdenv.mkDerivation rec {
 
   patches = [ ./fix-netcdf-header.patch ];
 
+  # add missing CMake module to build NIFTI support
+  # (the maintainers normally build libminc and minc-tools in a meta-project)
+  postPatch = ''
+    cp ${libminc.src}/cmake-modules/FindNIFTI.cmake cmake-modules
+  '';
+
   nativeBuildInputs = [ cmake flex bison makeWrapper ];
-  buildInputs = [ libminc libjpeg zlib ];
+  buildInputs = [ libminc libjpeg nifticlib zlib ];
   propagatedBuildInputs = [ perl TextFormat ];
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/"
-                 "-DZNZ_INCLUDE_DIR=${nifticlib}/include/"
-                 "-DZNZ_LIBRARY=${nifticlib}/lib/libznz.a"
-                 "-DNIFTI_INCLUDE_DIR=${nifticlib}/include/nifti/"
-                 "-DNIFTI_LIBRARY=${nifticlib}/lib/libniftiio.a" ];
+                 "-DZNZ_INCLUDE_DIR=${nifticlib}/include/nifti"
+                 "-DNIFTI_INCLUDE_DIR=${nifticlib}/include/nifti" ];
 
   postFixup = ''
     for prog in minccomplete minchistory mincpik; do


### PR DESCRIPTION
Due to a couple of packaging issues, Nifti support wasn't enabled.  (One may confirm that programs such as `nii2mnc` and `mnc2nii` are newly being built.)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
