### PR TITLE
[20.03] mutt: patch for CVE-2020-14093

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -34,7 +34,13 @@ stdenv.mkDerivation rec {
     sha256 = "0y3ks10mc7m8c7pd4c4j8pj7n5rqcvzrjs8mzldv7z7jnlb30hkq";
   };
 
-  patches = optional smimeSupport (fetchpatch {
+  patches = [
+    # patch for CVE-2020-14093
+    (fetchpatch {
+      url = "https://github.com/muttmua/mutt/commit/3e88866dc60b5fa6aaba6fd7c1710c12c1c3cd01.patch";
+      sha256 = "1md4krh76kjbg6nkyvbpjn6iz17c7m7xvdj6gjvjr7akqjhfw48h";
+    })
+  ] ++ optional smimeSupport (fetchpatch {
     url = "https://salsa.debian.org/mutt-team/mutt/raw/debian/1.10.1-2/debian/patches/misc/smime.rc.patch";
     sha256 = "0b4i00chvx6zj9pcb06x2jysmrcb2znn831lcy32cgfds6gr3nsi";
   });


### PR DESCRIPTION
###### Motivation for this change
Fix https://github.com/NixOS/nixpkgs/issues/90889

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [x] Tested compilation of all pkgs that depend on this change using
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
