### PR TITLE
[20.03] mwprocapture: 1.2.4054 -> 1.2.4177

### DIFF
--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -15,11 +15,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "mwprocapture-1.2.${version}-${kernel.version}";
-  version = "4054";
+  version = "4177";
 
   src = fetchurl {
     url = "http://www.magewell.com/files/drivers/ProCaptureForLinux_${version}.tar.gz";
-    sha256 = "0ylx75jcwlqds8w6lm11nxdlzxvy7xlz4rka2k5d6gmqa5fv19c2";
+    sha256 = "1nf51w9yixpvr767k49sfdb9n9rv5qc72f5yki1mkghbmabw7vys";
   };
 
   nativeBuildInputs = [ kernel.moduleBuildDependencies ];


### PR DESCRIPTION
###### Motivation for this change
Version bump provides compatibility with Linux kernels in the 5.x series. 

This is the 20.03 version of #91074. The package is broken as-is on 20.03 (doesn't even build), this allows it to build and work.

###### Things done
Tested driver and utilities with Pro Capture HDMI hardware.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
   - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
