### PR TITLE
[20.03] monero: 0.15 -> 0.16

### DIFF
--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -4,7 +4,7 @@
 , qtmultimedia, qtxmlpatterns
 , qtquickcontrols, qtquickcontrols2
 , monero, unbound, readline, boost, libunwind
-, libsodium, pcsclite, zeromq, cppzmq
+, libsodium, pcsclite, zeromq, libgcrypt, libgpgerror
 , hidapi, libusb, protobuf, randomx
 }:
 
@@ -12,13 +12,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "monero-gui";
-  version = "0.15.0.4";
+  version = "0.16.0.0";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "12m5fgnxkr11q2arx1m5ccpxqm5ljcvm6l547dwqn297zs5jim4z";
+    sha256 = "06vdrsj5y9k0zn32hspyxc7sw1kkyrvi3chzkdbnxk9jvyj8k4ld";
   };
 
   nativeBuildInputs = [ qmake pkgconfig wrapQtAppsHook ];
@@ -27,9 +27,9 @@ stdenv.mkDerivation rec {
     qtbase qtdeclarative qtgraphicaleffects
     qtmultimedia qtquickcontrols qtquickcontrols2
     qtxmlpatterns
-    monero unbound readline
+    monero unbound readline libgcrypt libgpgerror
     boost libunwind libsodium pcsclite zeromq
-    cppzmq hidapi libusb protobuf randomx
+    hidapi libusb protobuf randomx
   ];
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=format-security" ];
@@ -52,6 +52,10 @@ stdenv.mkDerivation rec {
   preBuild = ''
     sed -i s#/opt/monero-wallet-gui##g Makefile
     make -C src/zxcvbn-c
+
+    # use nixpkgs monero sources
+    rmdir monero
+    ln -s "${monero.src}" monero
   '';
 
   desktopItem = makeDesktopItem {

--- a/pkgs/applications/blockchains/monero/default.nix
+++ b/pkgs/applications/blockchains/monero/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , cmake, pkgconfig
-, boost, miniupnpc, openssl, unbound, cppzmq
+, boost, miniupnpc, openssl, unbound
 , zeromq, pcsclite, readline, libsodium, hidapi
 , pythonProtobuf, randomx, rapidjson, libusb
 , CoreData, IOKit, PCSC
@@ -10,13 +10,13 @@ assert stdenv.isDarwin -> IOKit != null;
 
 stdenv.mkDerivation rec {
   pname = "monero";
-  version = "0.15.0.1";
+  version = "0.16.0.0";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero";
     rev = "v${version}";
-    sha256 = "0sypa235lf2bbib4b71xpaw39h9304slgsvnsz8wmy9fq1zx009m";
+    sha256 = "0x74h5z0nxxxip97ibc854pqmrgd8r4d6w62m424f66i8gbzfskh";
     fetchSubmodules = true;
   };
 
@@ -24,13 +24,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     boost miniupnpc openssl unbound
-    cppzmq zeromq pcsclite readline
+    zeromq pcsclite readline
     libsodium hidapi randomx rapidjson
     pythonProtobuf libusb
   ] ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit CoreData PCSC ];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
+    "-DUSE_DEVICE_TREZOR=ON"
     "-DBUILD_GUI_DEPS=ON"
     "-DReadline_ROOT_DIR=${readline.dev}"
   ] ++ stdenv.lib.optional stdenv.isDarwin "-DBoost_USE_MULTITHREADED=OFF";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22779,6 +22779,7 @@ in
 
   monero = callPackage ../applications/blockchains/monero {
     inherit (darwin.apple_sdk.frameworks) CoreData IOKit PCSC;
+    boost = boost17x;
     pythonProtobuf = python3Packages.protobuf.override { protobuf = protobuf3_10; };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22784,7 +22784,7 @@ in
   };
 
   monero-gui = libsForQt5.callPackage ../applications/blockchains/monero-gui {
-    boost = boost16x;
+    boost = boost17x;
     protobuf = protobuf3_10;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Version bump with several bug fixes.
This release doesn't introduce breaking changes so it's safe to backport.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
