### PR TITLE
liburing: bump version and fix cross compilation

### DIFF
--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -17,12 +17,15 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" "dev" "man" ];
 
+  # Don't use the default configure phase because ./configure isn't
+  # an autoconf script.
   configurePhase = ''
     ./configure \
       --prefix=$out \
       --includedir=$dev/include \
       --libdir=$lib/lib \
       --mandir=$man/share/man \
+      --cc=${stdenv.cc.targetPrefix}cc
   '';
 
   # Copy the examples into $out.

--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -4,12 +4,12 @@
 
 stdenv.mkDerivation rec {
   pname = "liburing";
-  version = "0.6pre600_${builtins.substring 0 8 src.rev}";
+  version = "0.7pre700_${builtins.substring 0 8 src.rev}";
 
   src = fetchgit {
     url    = "http://git.kernel.dk/${pname}";
-    rev    = "f2e1f3590f7bed3040bd1691676b50839f7d5c39";
-    sha256 = "0wg0pgcbilbb2wg08hsvd18q1m8vdk46b3piz7qb1pvgyq01idj2";
+    rev    = "94ba6378bea8db499bedeabb54ab20fcf41555cf";
+    sha256 = "1idg4jwqqhjrdn1gc843z6hdhi34v1q67n6x205h75pkax24pyig";
   };
 
   separateDebugInfo = true;


### PR DESCRIPTION
@thoughtpolice, I didn't know what to do with the number following `pre`
so I just incremented it to scale with the version number

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [s] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).