### PR TITLE
ocamlPackages.odoc: 1.5.0 → 1.5.1

### DIFF
--- a/pkgs/development/ocaml-modules/odoc/default.nix
+++ b/pkgs/development/ocaml-modules/odoc/default.nix
@@ -4,13 +4,13 @@
 
 buildDunePackage rec {
   pname = "odoc";
-  version = "1.5.0";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "ocaml";
     repo = pname;
     rev = version;
-    sha256 = "14ilq2glcvda8mfhj27jqqwx3392q8ssp9bq9agz7k1k6ilp9dai";
+    sha256 = "0z2nisg1vb5xlk41hqw8drvj90v52wli7zvnih6a844cg6xsvvj2";
   };
 
   buildInputs = [ astring cmdliner cppo fpath result tyxml ];


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.11.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
