### PR TITLE
Fix GCC cross compilation

### DIFF
--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation ({
 
   inherit patches;
 
-  outputs = [ "out" "man" "info" ] ++ stdenv.lib.optional (!langJit) "lib";
+  outputs = [ "out" "man" "info" ] ++ stdenv.lib.optional (!langJit && targetPlatform == hostPlatform) "lib";
   setOutputFlags = false;
   NIX_NO_SELF_RPATH = true;
 


### PR DESCRIPTION
When cross compiling ghc, we end up with the sanitizer libraries in $lib,
however they still refer to  (in their rpaths in the so's).  Thus we
have a cycle  $lib -> $out -> $lib, and nix will complain.  I'm not sure
why they multi-output logic doesn't patchelf the rpaths, but it apparently
doesn't.