### PR TITLE
[20.03] qemu: patch CVE-2020-1711

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -84,6 +84,11 @@ stdenv.mkDerivation rec {
       stripLen = 1;
       extraPrefix = "slirp/";
     })
+    (fetchpatch {
+      name = "CVE-2020-1711.patch";
+      url = "https://git.qemu.org/?p=qemu.git;a=patch;h=693fd2acdf14dd86c0bf852610f1c2cca80a74dc";
+      sha256 = "0dh09h6q26fm6691shvsbr2prrak8vcnpzlg4nlj57a1v7ndka8k";
+    })
     # patches listed at: https://nvd.nist.gov/vuln/detail/CVE-2020-7039
     (fetchpatch {
       name = "CVE-2020-7039-1.patch";


### PR DESCRIPTION
###### Motivation for this change

This is a high profile risk identified in https://github.com/NixOS/nixpkgs/issues/88387 and a patch is readily available. So we should fix this one first.

No action required on nixos-unstable.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions _Ubuntu_
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) _qemu used in any test; ran tests/login.nix to verify_
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
