### PR TITLE
bazel: 3.2.0 -> 3.3.0

### DIFF
--- a/pkgs/applications/virtualization/gvisor/default.nix
+++ b/pkgs/applications/virtualization/gvisor/default.nix
@@ -76,7 +76,7 @@ in buildBazelPackage rec {
       rm -f "$bazelOut"/java.log "$bazelOut"/java.log.*
     '';
 
-    sha256 = "164r8m95g7njh232xfc7zcn1nssaw9bnin9k7ssj9mk6z7z9zy5v";
+    sha256 = "0mkgbw08f6kgklvjmlfpyld35q7dvxm9pvrhaf7m7nx69sich6jq";
   };
 
   buildAttrs = {

--- a/pkgs/development/python-modules/dm-sonnet/default.nix
+++ b/pkgs/development/python-modules/dm-sonnet/default.nix
@@ -36,7 +36,7 @@ let
     bazelTarget = ":install";
 
     fetchAttrs = {
-      sha256 = "1xwrha692if7rwqc0qalgpx9b8indgdan8ppwlcs2v47wjvgg6h3";
+      sha256 = "1gag2xghik68zblhwbdd206hs8nxp2sclw182x2qi78jqgfnq5ci";
     };
 
     bazelFlags = [

--- a/pkgs/development/python-modules/tensorflow-probability/default.nix
+++ b/pkgs/development/python-modules/tensorflow-probability/default.nix
@@ -61,7 +61,7 @@ let
     bazelTarget = ":pip_pkg";
 
     fetchAttrs = {
-      sha256 = "1snj7fxfxzvrqv9cpir1daxcg3fip6cvbk94y3mi2h50k3ni826i";
+      sha256 = "1bh6lsi0732fzhrfs6p33qg2qfvq73r6qmijbpnv592aq8yiy1h5";
     };
 
     buildAttrs = {

--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -56,7 +56,7 @@ buildBazelPackage rec {
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
     '';
 
-    sha256 = "16zgjd6zww9skk34ggfx5l3kbsdyv98zxawrvmx1arv5gaj63pp9";
+    sha256 = "17vdqs3dpaqc4llmzh4rd8mkm19q192w5gp90jlry3dpwj6b4kdf";
   };
 
   buildAttrs = {

--- a/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
@@ -64,7 +64,7 @@ buildBazelPackage rec {
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
     '';
 
-    sha256 = "0rfjyvw370yn4rp1f2772b2h3jbycymdw26zx38krzy5zq0iajyp";
+    sha256 = "04wbimzjxxmm8kh57q11zvyardb6ilyffc4nkdp6mb87p1l8fmww";
   };
 
   buildAttrs = {

--- a/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
@@ -25,11 +25,11 @@
 }:
 
 let
-  version = "3.2.0";
+  version = "3.3.0";
 
   src = fetchurl {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    sha256 = "1ylbfdcb6rhnc3sr292c6shl754i0h0i050f4gr4bppn6sa15v24";
+    sha256 = "09p8xv8ni4g4wcyaapxsx8gjc3x3l3c6lxn575c7gm89vrh3k805";
   };
 
   # Update with `eval $(nix-build -A bazel.updater)`,
@@ -53,8 +53,8 @@ let
        else srcs."java_tools_javac11_linux-v8.0.zip")
       srcs."coverage_output_generator-v2.1.zip"
       srcs.build_bazel_rules_nodejs
-      srcs."android_tools_pkg-0.16.0.tar.gz"
-      srcs."3.1.0.tar.gz"
+      srcs."android_tools_pkg-0.17.0.tar.gz"
+      srcs."bazel-toolchains-3.1.0.tar.gz"
       srcs.rules_pkg
       srcs.rules_cc
       srcs.rules_java

--- a/pkgs/development/tools/build-managers/bazel/bazel_3/src-deps.json
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/src-deps.json
@@ -7,20 +7,20 @@
             "https://github.com/bazelbuild/rules_sass/archive/1.25.0.zip"
         ]
     },
+    "1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz": {
+        "name": "1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz",
+        "sha256": "5a725b777976b77aa122b707d1b6f0f39b6020f66cd427bb111a585599c857b1",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/stardoc/archive/1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz",
+            "https://github.com/bazelbuild/stardoc/archive/1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz"
+        ]
+    },
     "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": {
         "name": "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz",
         "sha256": "c00ceec469dbcf7929972e3c79f20c14033824538038a554952f5c31d8832f96",
         "urls": [
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz",
             "https://github.com/bazelbuild/bazel-skylib/archive/2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz"
-        ]
-    },
-    "3.1.0.tar.gz": {
-        "name": "3.1.0.tar.gz",
-        "sha256": "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
-        "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.1.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz"
         ]
     },
     "46993efdd33b73649796c5fc5c9efb193ae19d51.zip": {
@@ -65,14 +65,22 @@
         "patch_cmds_win": [
             "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
         ],
-        "sha256": "e2cbd43a9d23aa32197c29d689a7e017f205acb07053f5dd584f500a1a9d4361",
-        "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.16.0.tar.gz"
+        "sha256": "8d0bf8ab83c9e38ec6ed5ce7bf425dbdc6469cec9e078559d4e8da42b705410f",
+        "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.17.0.tar.gz"
     },
-    "android_tools_pkg-0.16.0.tar.gz": {
-        "name": "android_tools_pkg-0.16.0.tar.gz",
-        "sha256": "e2cbd43a9d23aa32197c29d689a7e017f205acb07053f5dd584f500a1a9d4361",
+    "android_tools_pkg-0.17.0.tar.gz": {
+        "name": "android_tools_pkg-0.17.0.tar.gz",
+        "sha256": "8d0bf8ab83c9e38ec6ed5ce7bf425dbdc6469cec9e078559d4e8da42b705410f",
         "urls": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.16.0.tar.gz"
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.17.0.tar.gz"
+        ]
+    },
+    "bazel-toolchains-3.1.0.tar.gz": {
+        "name": "bazel-toolchains-3.1.0.tar.gz",
+        "sha256": "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz"
         ]
     },
     "bazel_j2objc": {
@@ -114,8 +122,17 @@
         "sha256": "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
         "strip_prefix": "bazel-toolchains-3.1.0",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.1.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
             "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz"
+        ]
+    },
+    "bazel_website": {
+        "build_file_content": "\nexports_files([\"_sass/style.scss\"])\n",
+        "name": "bazel_website",
+        "sha256": "a5f531dd1d62e6947dcfc279656ffc2fdf6f447c163914c5eabf7961b4cb6eb4",
+        "strip_prefix": "bazel-website-c174fa288aa079b68416d2ce2cc97268fa172f42",
+        "urls": [
+            "https://github.com/bazelbuild/bazel-website/archive/c174fa288aa079b68416d2ce2cc97268fa172f42.tar.gz"
         ]
     },
     "build_bazel_rules_nodejs": {
@@ -124,14 +141,6 @@
         "urls": [
             "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz",
             "https://github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz"
-        ]
-    },
-    "c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz": {
-        "name": "c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz",
-        "sha256": "e6a76586b264f30679688f65f7e71ac112d1446681010a13bf22d9ca071f34b7",
-        "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/skydoc/archive/c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz",
-            "https://github.com/bazelbuild/skydoc/archive/c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz"
         ]
     },
     "com_google_googletest": {
@@ -201,11 +210,11 @@
     },
     "io_bazel_skydoc": {
         "name": "io_bazel_skydoc",
-        "sha256": "e6a76586b264f30679688f65f7e71ac112d1446681010a13bf22d9ca071f34b7",
-        "strip_prefix": "skydoc-c7bbde2950769aac9a99364b0926230060a3ce04",
+        "sha256": "5a725b777976b77aa122b707d1b6f0f39b6020f66cd427bb111a585599c857b1",
+        "strip_prefix": "stardoc-1ef781ced3b1443dca3ed05dec1989eca1a4e1cd",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/skydoc/archive/c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz",
-            "https://github.com/bazelbuild/skydoc/archive/c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz"
+            "https://mirror.bazel.build/github.com/bazelbuild/stardoc/archive/1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz",
+            "https://github.com/bazelbuild/stardoc/archive/1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz"
         ]
     },
     "java_tools_javac11_darwin-v8.0.zip": {
@@ -335,6 +344,15 @@
         "sha256": "91f7d52f695c681d4e21499b4319d548aadef249a6b3053e306308992e1e29ae",
         "urls": [
             "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64-minimal-b23d4e05466f2aa1fdcd72d3d3a8e962206b64bf-1581689068.tar.gz"
+        ]
+    },
+    "openjdk_linux_ppc64le_vanilla": {
+        "downloaded_file_path": "adoptopenjdk-ppc64le-vanilla.tar.gz",
+        "name": "openjdk_linux_ppc64le_vanilla",
+        "sha256": "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+            "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz"
         ]
     },
     "openjdk_linux_vanilla": {
@@ -587,6 +605,24 @@
         "strip_prefix": "zulu11.37.17-ca-jdk11.0.6-linux_x64",
         "urls": [
             "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz"
+        ]
+    },
+    "remotejdk11_linux_ppc64le_for_testing": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "name": "remotejdk11_linux_ppc64le_for_testing",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a",
+        "strip_prefix": "jdk-11.0.7+10",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+            "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz"
         ]
     },
     "remotejdk11_macos_for_testing": {

--- a/pkgs/development/tools/build-managers/bazel/update-srcDeps.py
+++ b/pkgs/development/tools/build-managers/bazel/update-srcDeps.py
@@ -35,6 +35,7 @@ def list_source_repository(**kw): pass
 def new_local_repository(**kw): pass
 def local_repository(**kw): pass
 DOC_VERSIONS = []
+def stardoc_repositories(**kw): pass
 def skydoc_repositories(**kw): pass
 def rules_sass_dependencies(**kw): pass
 def node_repositories(**kw): pass


### PR DESCRIPTION
###### Motivation for this change

[Bazel 3.3.0 release](https://blog.bazel.build/2020/06/17/bazel-3-3.html)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
