### PR TITLE
gildas: 20200201_a -> 20200601_b

### DIFF
--- a/pkgs/applications/science/astronomy/gildas/default.nix
+++ b/pkgs/applications/science/astronomy/gildas/default.nix
@@ -7,8 +7,8 @@ let
 in
 
 stdenv.mkDerivation rec {
-  srcVersion = "feb20a";
-  version = "20200201_a";
+  srcVersion = "jun20b";
+  version = "20200601_b";
   pname = "gildas";
 
   src = fetchurl {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     # source code of the previous release to a different directory
     urls = [ "http://www.iram.fr/~gildas/dist/gildas-src-${srcVersion}.tar.xz"
       "http://www.iram.fr/~gildas/dist/archive/gildas/gildas-src-${srcVersion}.tar.xz" ];
-    sha256 = "05f34kpi3pfgf4dsyka7mkcln26yzb2mixnnc306krq0isjm7m26";
+    sha256 = "190na9p9kaif4hviraksig6hsq35i1q3nlrm50l00kpj2n8knisk";
   };
 
   nativeBuildInputs = [ pkgconfig groff perl getopt gfortran which ];

--- a/pkgs/applications/science/astronomy/gildas/wrapper.patch
+++ b/pkgs/applications/science/astronomy/gildas/wrapper.patch
@@ -1,12 +1,13 @@
 diff --new-file -r -u gildas-src-feb17d.orig/admin/wrapper.sh gildas-src-feb17d/admin/wrapper.sh
 --- gildas-src-feb17d.orig/admin/wrapper.sh	1970-01-01 01:00:00.000000000 +0100
 +++ gildas-src-feb17d/admin/wrapper.sh	2017-05-18 21:00:01.660778782 +0200
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,16 @@
 +#!/bin/sh -e
 +
 +export GAG_ROOT_DIR="%%OUT%%"
 +export GAG_PATH="${GAG_ROOT_DIR}/etc"
 +export GAG_EXEC_SYSTEM="libexec"
++export GAG_GAG="${HOME}/.gag"
 +export PYTHONHOME="%%PYTHONHOME%%"
 +if [ -z "\$PYTHONPATH" ]; then
 +  PYTHONPATH="${GAG_ROOT_DIR}/${GAG_EXEC_SYSTEM}/python"


### PR DESCRIPTION
###### Motivation for this change

Update gildas to the latest upstream.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
