### PR TITLE
unicode: 2.6 -> 2.7

### DIFF
--- a/pkgs/tools/misc/unicode/default.nix
+++ b/pkgs/tools/misc/unicode/default.nix
@@ -1,24 +1,30 @@
-{ stdenv, fetchFromGitHub, fetchurl, python3Packages }:
+{ stdenv, fetchFromGitHub, fetchurl, python3Packages, installShellFiles }:
 
 python3Packages.buildPythonApplication rec {
   pname = "unicode";
-  version = "2.6";
+  version = "2.7";
 
   src = fetchFromGitHub {
     owner = "garabik";
     repo = "unicode";
     rev = "v${version}";
-    sha256 = "17hh4nwl5njsh7lnff583j2axn6rfvfbiqwp72n7vcsgkiszw4kg";
+    sha256 = "15d9yvarxsiy0whx1mxzsjnnkrjdm3ga4qv2yy398mk0jh763q9v";
   };
 
   ucdtxt = fetchurl {
-    url = "http://www.unicode.org/Public/11.0.0/ucd/UnicodeData.txt";
-    sha256 = "16b0jzvvzarnlxdvs2izd5ia0ipbd87md143dc6lv6xpdqcs75s9";
+    url = "https://www.unicode.org/Public/13.0.0/ucd/UnicodeData.txt";
+    sha256 = "1fz8fcd23lxyl97ay8h42zvkcgcg8l81b2dm05nklkddr2zzpgxx";
   };
+
+  nativeBuildInputs = [ installShellFiles ];
 
   postFixup = ''
     substituteInPlace "$out/bin/.unicode-wrapped" \
       --replace "/usr/share/unicode/UnicodeData.txt" "$ucdtxt"
+  '';
+
+  postInstall = ''
+    installManPage paracode.1 unicode.1
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
After reading #91033 I wanted to switch to https. Update to unicode-13 included.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
