### PR TITLE
prometheus: 2.18.1 -> 2.19.1

### DIFF
--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -1,13 +1,13 @@
 { lib, go, buildGoPackage, fetchFromGitHub, mkYarnPackage }:
 
 let
-  version = "2.18.1";
+  version = "2.19.1";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "prometheus";
     repo = "prometheus";
-    sha256 = "0ixgjp3j9dkdb0vv5n83h8w48xgi70m83im660z97y7mflr5s2cf";
+    sha256 = "1isv66dnn61mm76r577qqafsn6w5msb0a6i9dykg4z7crcpsnq70";
   };
 
   webui = mkYarnPackage {

--- a/pkgs/servers/monitoring/prometheus/webui-package.json
+++ b/pkgs/servers/monitoring/prometheus/webui-package.json
@@ -24,7 +24,7 @@
     "fuzzy": "^0.1.3",
     "i": "^0.3.6",
     "jest-fetch-mock": "^2.1.2",
-    "jquery": "^3.3.1",
+    "jquery": "^3.5",
     "jquery.flot.tooltip": "^0.9.0",
     "jsdom": "^15.2.0",
     "moment": "^2.24.0",

--- a/pkgs/servers/monitoring/prometheus/webui-yarndeps.nix
+++ b/pkgs/servers/monitoring/prometheus/webui-yarndeps.nix
@@ -6634,11 +6634,11 @@
       };
     }
     {
-      name = "jquery___jquery_3.4.1.tgz";
+      name = "jquery___jquery_3.5.1.tgz";
       path = fetchurl {
-        name = "jquery___jquery_3.4.1.tgz";
-        url  = "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz";
-        sha1 = "714f1f8d9dde4bdfa55764ba37ef214630d80ef2";
+        name = "jquery___jquery_3.5.1.tgz";
+        url  = "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz";
+        sha1 = "d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5";
       };
     }
     {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/prometheus/prometheus/releases/tag/v2.19.0
https://github.com/prometheus/prometheus/releases/tag/v2.19.1

###### Things done

I updated an existing prometheus installation and had a quick look at grafana and the new prometheus react ui.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
