### PR TITLE
coredns: 1.6.9 -> 1.7.0

### DIFF
--- a/pkgs/servers/dns/coredns/default.nix
+++ b/pkgs/servers/dns/coredns/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "coredns";
-  version = "1.6.9";
+  version = "1.7.0";
 
   goPackagePath = "github.com/coredns/coredns";
 
@@ -10,10 +10,10 @@ buildGoModule rec {
     owner = "coredns";
     repo = "coredns";
     rev = "v${version}";
-    sha256 = "18c02ss0sxxg8lkhdmyaac2x5alfxsizf6jqhck8bqkf6hiyv5hc";
+    sha256 = "1wayfr26gwgdl0sfrvskb4hkxfmxfy7idbrpw3z4r05fkr2886xj";
   };
 
-  vendorSha256 = "0ykhqsz4a7bkkxcg7w23jl3qs36law1f8l1b5r3i26qlamibqxl7";
+  vendorSha256 = "17znl3vkg73hnrfl697rw201nsd5sijgalnbkljk1b4m0a01zik1";
 
   meta = with stdenv.lib; {
     homepage = "https://coredns.io";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New release of CoreDNS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Built and tested on NixOS:

```
[matt@servnerr-3:~/src/nixpkgs]$ nix-build -A coredns                                                                                                                                                              
these derivations will be built:                                                                         
  /nix/store/6ffyv6xppzv3r28rg6qgnigv8y5sj2b8-coredns-1.7.0.drv                                                                                                                                                    
building '/nix/store/6ffyv6xppzv3r28rg6qgnigv8y5sj2b8-coredns-1.7.0.drv'...                              
unpacking sources                                                                                        
unpacking source archive /nix/store/cyrz9xwapbydl1iih0p9wb6f7lyfvkqm-source 
...
shrinking RPATHs of ELF executables and libraries in /nix/store/dwrbgxy17b0nh3l4qk5lc7dz9a93r960-coredns-1.7.0
shrinking /nix/store/dwrbgxy17b0nh3l4qk5lc7dz9a93r960-coredns-1.7.0/bin/coredns
strip is /nix/store/bh3r88sv8wckwmfyhjxbqmxcha0hrm8h-binutils-2.31.1/bin/strip
stripping (with command strip and flags -S) in /nix/store/dwrbgxy17b0nh3l4qk5lc7dz9a93r960-coredns-1.7.0/bin
patching script interpreter paths in /nix/store/dwrbgxy17b0nh3l4qk5lc7dz9a93r960-coredns-1.7.0
checking for references to /build/ in /nix/store/dwrbgxy17b0nh3l4qk5lc7dz9a93r960-coredns-1.7.0...
/nix/store/dwrbgxy17b0nh3l4qk5lc7dz9a93r960-coredns-1.7.0

[matt@servnerr-3:~/src/nixpkgs]$ ./result/bin/coredns -version
CoreDNS-1.7.0
linux/amd64, go1.14.4,
```