### PR TITLE
rockbox-utility: 1.4.0 -> 1.4.1

### DIFF
--- a/pkgs/tools/misc/rockbox-utility/default.nix
+++ b/pkgs/tools/misc/rockbox-utility/default.nix
@@ -1,19 +1,20 @@
-{ stdenv, fetchurl, pkgconfig, libusb1
-, qtbase, qttools, makeWrapper, qmake
-, withEspeak ? false, espeak ? null, qt5 }:
+{ stdenv, fetchurl, pkgconfig, cryptopp
+, libusb1, qtbase, qttools, makeWrapper
+, qmake, withEspeak ? false, espeak ? null
+, qt5 }:
 
 let inherit (stdenv.lib) getDev; in
 
 stdenv.mkDerivation  rec {
   pname = "rockbox-utility";
-  version = "1.4.0";
+  version = "1.4.1";
 
   src = fetchurl {
     url = "https://download.rockbox.org/rbutil/source/RockboxUtility-v${version}-src.tar.bz2";
-    sha256 = "0k3ycga3b0jnj13whwiip2l0gx32l50pnbh7kfima87nq65aaa5w";
+    sha256 = "0zm9f01a810y7aq0nravbsl0vs9vargwvxnfl4iz9qsqygwlj69y";
   };
 
-  buildInputs = [ libusb1 qtbase qttools ]
+  buildInputs = [ cryptopp libusb1 qtbase qttools ]
     ++ stdenv.lib.optional withEspeak espeak;
   nativeBuildInputs = [ makeWrapper pkgconfig qmake qt5.wrapQtAppsHook ];
 
@@ -24,6 +25,7 @@ stdenv.mkDerivation  rec {
 
   preConfigure = ''
     cd rbutil/rbutilqt
+    lrelease rbutilqt.pro
   '';
 
   installPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New release of rockbox-utility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
