### PR TITLE
ocamlPackages.mirage-crypto*: 0.7.0 → 0.8.0

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -4,11 +4,11 @@ buildDunePackage rec {
   minimumOCamlVersion = "4.08";
 
   pname = "mirage-crypto";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-crypto/releases/download/v${version}/mirage-crypto-v${version}.tbz";
-    sha256 = "0k7kllv3bh192yj6p9dk2z81r56w7x2kyr46pxygb5gnhqqxcncf";
+    sha256 = "1wb2923v17z179v866ragil0r601w5b3kvpnbkmkwlijp4i5grih";
   };
 
   useDune2 = true;

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
@@ -1,0 +1,18 @@
+{ buildDunePackage, mirage-crypto-rng, duration, cstruct, mirage-runtime
+, mirage-time, mirage-clock, mirage-unix, mirage-time-unix, mirage-clock-unix }:
+
+buildDunePackage {
+  pname = "mirage-crypto-rng-mirage";
+
+  inherit (mirage-crypto-rng) version src useDune2 minimumOCamlVersion;
+
+  doCheck = true;
+  checkInputs = [ mirage-unix mirage-clock-unix mirage-time-unix ];
+
+  propagatedBuildInputs = [ duration cstruct mirage-crypto-rng mirage-runtime
+                            mirage-time mirage-clock ];
+
+  meta = mirage-crypto-rng.meta // {
+    description = "Entropy collection for a cryptographically secure PRNG";
+  };
+}

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
@@ -1,6 +1,5 @@
 { buildDunePackage, mirage-crypto, ounit, randomconv, dune-configurator
-, cstruct, duration, logs, mtime, ocaml_lwt, mirage-runtime, mirage-time
-, mirage-clock, mirage-time-unix, mirage-clock-unix, mirage-unix }:
+, cstruct, duration, logs, mtime, ocaml_lwt }:
 
 buildDunePackage {
   pname = "mirage-crypto-rng";
@@ -11,9 +10,7 @@ buildDunePackage {
   checkInputs = [ ounit randomconv ];
 
   nativeBuildInputs = [ dune-configurator ];
-  propagatedBuildInputs = [ cstruct mirage-crypto duration logs mtime ocaml_lwt
-                            mirage-runtime mirage-time mirage-clock mirage-time-unix
-                            mirage-clock-unix mirage-unix ];
+  propagatedBuildInputs = [ cstruct mirage-crypto duration logs mtime ocaml_lwt ];
 
   meta = mirage-crypto.meta // {
     description = "A cryptographically secure PRNG";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -531,6 +531,8 @@ let
 
     mirage-crypto-rng = callPackage ../development/ocaml-modules/mirage-crypto/rng.nix { };
 
+    mirage-crypto-rng-mirage = callPackage ../development/ocaml-modules/mirage-crypto/rng-mirage.nix { };
+
     mirage-device = callPackage ../development/ocaml-modules/mirage-device { };
 
     mirage-flow = callPackage ../development/ocaml-modules/mirage-flow { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/mirage/mirage-crypto/releases/tag/v0.8.0>

Splits out MirageOS related RNG into new package `mirage-crypto-rng-mirage`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
