### PR TITLE
micro: 2.0.3 -> 2.0.5

### DIFF
--- a/pkgs/applications/editors/micro/default.nix
+++ b/pkgs/applications/editors/micro/default.nix
@@ -2,21 +2,25 @@
 
 buildGoPackage  rec {
   pname = "micro";
-  version = "2.0.3";
+  version = "2.0.5";
 
   goPackagePath = "github.com/zyedidia/micro";
 
   src = fetchFromGitHub {
     owner = "zyedidia";
-    repo = "micro";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "017m9kb3gfrgzd06f1nma1i3m5rb0hzpgdikb86lsyv8ik18y12z";
+    sha256 = "12fyyax1mr0n82s5yhmk90iyyzbh32rppkkpj37c25pal73czdhc";
     fetchSubmodules = true;
   };
 
   subPackages = [ "cmd/micro" ];
 
-  buildFlagsArray = [ "-ldflags=" "-X ${goPackagePath}/internal/util.Version=${version}" ];
+  buildFlagsArray = let t = "${goPackagePath}/internal/util"; in ''
+    -ldflags=
+      -X ${t}.Version=${version}
+      -X ${t}.CommitHash=${src.rev}
+  '';
 
   goDeps = ./deps.nix;
 

--- a/pkgs/applications/editors/micro/deps.nix
+++ b/pkgs/applications/editors/micro/deps.nix
@@ -203,8 +203,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/zyedidia/clipboard";
-      rev = "241f98e9b197";
-      sha256 = "1glc8w30sijpbppcvaf3503rmx5nxqkcgw87dr2pr3q3vv1bg3zi";
+      rev = "7c45b8673834";
+      sha256 = "0ag36wd3830d4s6fvpj05v6f662c5rymgdydsj2gq8aaqplfb0v4";
     };
   }
   {
@@ -257,8 +257,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/zyedidia/tcell";
-      rev = "v1.4.4";
-      sha256 = "0d62a9csab15b64y09jcbvq71065wliw4bd5m7lfpl5k8rmrrdyi";
+      rev = "v1.4.7";
+      sha256 = "1ddaznp0haz35mxfjjh2fmamdrlk1igqg65fz22l5r6vvhcdsfxa";
     };
   }
   {


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/zyedidia/micro/releases)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
