### PR TITLE
bcache-tools: Fix the cross compilation

### DIFF
--- a/pkgs/tools/filesystems/bcache-tools/default.nix
+++ b/pkgs/tools/filesystems/bcache-tools/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
     sed -e "/INSTALL.*initramfs\/hook/d" \
         -e "/INSTALL.*initcpio\/install/d" \
         -e "/INSTALL.*dracut\/module-setup.sh/d" \
+        -e "s/pkg-config/$PKG_CONFIG/" \
         -i Makefile
   '';
 
@@ -28,8 +29,12 @@ stdenv.mkDerivation rec {
     ./fix-static.patch
   ];
 
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "UDEVLIBDIR=${placeholder "out"}/lib/udev/"
+  ];
+
   preBuild = ''
-    export makeFlags="$makeFlags PREFIX=\"$out\" UDEVLIBDIR=\"$out/lib/udev/\"";
     sed -e "s|/bin/sh|${bash}/bin/sh|" -i *.rules
   '';
 


### PR DESCRIPTION
Fix #90726.

---

<details>
<summary>Build log</summary>
<pre>
these derivations will be built:
  /nix/store/q6zsrp2l2fmq0lc1950yz0mszdxj0cvq-bcache-tools-1.0.7-aarch64-unknown-linux-gnu.drv
building '/nix/store/q6zsrp2l2fmq0lc1950yz0mszdxj0cvq-bcache-tools-1.0.7-aarch64-unknown-linux-gnu.drv'...
unpacking sources
unpacking source archive /nix/store/rgwm01hfhmbba4nbfbayimb81v9wqrnb-bcache-tools-1.0.7.tar.gz
source root is bcache-tools-1.0.7
setting SOURCE_DATE_EPOCH to timestamp 1399729101 of file bcache-tools-1.0.7/probe-bcache.c
patching sources
applying patch /nix/store/2q3z7587yhlz0i2xvfvvap42zk5carlv-bcache-udev-modern.patch
patching file 69-bcache.rules
patching file Makefile
Hunk #1 succeeded at 9 with fuzz 1.
patching file bcache-register
applying patch /nix/store/03sl46khd8gmjpsad7223m32ma965vy9-fix-static.patch
patching file bcache.c
updateAutotoolsGnuConfigScriptsPhase
configuring
no configure script, doing nothing
building
build flags: SHELL=/nix/store/n313xks5ym0s0a5v8a5285rmnmvy6ms9-bash-4.4-p23/bin/bash PREFIX=/nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu UDEVLIBDIR=/nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu/lib/udev/
aarch64-unknown-linux-gnu-gcc -O2 -Wall -g `aarch64-unknown-linux-gnu-pkg-config --cflags uuid blkid`   -c -o bcache.o bcache.c
aarch64-unknown-linux-gnu-gcc -O2 -Wall -g `aarch64-unknown-linux-gnu-pkg-config --cflags uuid blkid`    make-bcache.c bcache.o  `aarch64-unknown-linux-gnu-pkg-config --libs uuid blkid` -o make-bcache
aarch64-unknown-linux-gnu-gcc -O2 -Wall -g `aarch64-unknown-linux-gnu-pkg-config --cflags uuid blkid`    probe-bcache.c  `aarch64-unknown-linux-gnu-pkg-config --libs uuid blkid` -o probe-bcache
aarch64-unknown-linux-gnu-gcc -O2 -Wall -g -std=gnu99    bcache-super-show.c bcache.o  `aarch64-unknown-linux-gnu-pkg-config --libs uuid` -o bcache-super-show
installing
install flags: SHELL=/nix/store/n313xks5ym0s0a5v8a5285rmnmvy6ms9-bash-4.4-p23/bin/bash PREFIX=/nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu UDEVLIBDIR=/nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu/lib/udev/ install
install -m0755 make-bcache bcache-super-show    /nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu/sbin/
install -m0644 69-bcache.rules  /nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu/lib/udev//rules.d/
install -m0644 -- *.8 /nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu/share/man/man8/
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu
shrinking /nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu/sbin/bcache-super-show
shrinking /nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu/sbin/make-bcache
gzipping man pages under /nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu/share/man/
aarch64-unknown-linux-gnu-strip is /nix/store/5yman7cwrilchfs2npckj1zchnj1ss0f-aarch64-unknown-linux-gnu-binutils-2.31.1/bin/aarch64-unknown-linux-gnu-strip
stripping (with command aarch64-unknown-linux-gnu-strip and flags -S) in /nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu/lib  /nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu/sbin
patching script interpreter paths in /nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu
checking for references to /build/ in /nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu...
moving /nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu/sbin/* to /nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu/bin
/nix/store/p8s4q80cysn4cjcn2b7ad7yr8wm84sy0-bcache-tools-1.0.7-aarch64-unknown-linux-gnu
</pre>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
