### PR TITLE
blackbox-exporter: 0.16.0 -> 0.17.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/blackbox-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/blackbox-exporter.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "blackbox_exporter";
-  version = "0.16.0";
+  version = "0.17.0";
   rev = version;
 
   goPackagePath = "github.com/prometheus/blackbox_exporter";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "prometheus";
     repo = "blackbox_exporter";
-    sha256 = "1zbf3ljasv0r91rrmk3mj5nhimaf7xg3aih1ldz27rh5yww7gyzg";
+    sha256 = "00ganz6wfwyb9avkp2fr4bwpzvfiffsmpgndl8zp80bk7m1b3mnz";
   };
 
   # dns-lookup is performed for the tests

--- a/pkgs/servers/monitoring/prometheus/blackbox-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/blackbox-exporter.nix
@@ -21,7 +21,7 @@ buildGoPackage rec {
     description = "Blackbox probing of endpoints over HTTP, HTTPS, DNS, TCP and ICMP";
     homepage = "https://github.com/prometheus/blackbox_exporter";
     license = licenses.asl20;
-    maintainers = with maintainers; [ globin fpletz willibutz ];
+    maintainers = with maintainers; [ globin fpletz willibutz Frostman ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/prometheus/blackbox_exporter/releases/tag/v0.17.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/91115)
<!-- Reviewable:end -->
