### PR TITLE
bitcoind-knots: init at 0.20.0

### DIFF
--- a/pkgs/applications/blockchains/bitcoin-knots.nix
+++ b/pkgs/applications/blockchains/bitcoin-knots.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchFromGitHub
+, pkgconfig
+, autoreconfHook
+, db5
+, openssl
+, boost
+, zlib
+, miniupnpc
+, libevent
+, protobuf
+, utillinux
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bitcoind-knots";
+  version = "0.20.0";
+  versionDate = "20200614";
+
+  src = fetchFromGitHub {
+    owner = "bitcoinknots";
+    repo = "bitcoin";
+    rev = "v${version}.knots${versionDate}";
+    sha256 = "0c8k1154kcwz6q2803wx0zigvqaij1fi5akgfqlj3yl57jjw48jj";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ openssl db5 openssl utillinux
+                  protobuf boost zlib miniupnpc libevent ];
+
+  configureFlags = [ "--with-incompatible-bdb"
+                     "--with-boost-libdir=${boost.out}/lib" ];
+
+  meta = with stdenv.lib; {
+    description = "An enhanced Bitcoin node software";
+    homepage = "https://bitcoinknots.org/";
+    license = licenses.mit;
+    maintainers = [ maintainers.mmahut ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23409,6 +23409,9 @@ in
 
   bitcoin  = libsForQt5.callPackage ../applications/blockchains/bitcoin.nix { miniupnpc = miniupnpc_2; withGui = true; };
   bitcoind = callPackage ../applications/blockchains/bitcoin.nix { miniupnpc = miniupnpc_2; withGui = false; };
+
+  bitcoind-knots = callPackage ../applications/blockchains/bitcoin-knots.nix { miniupnpc = miniupnpc_2; };
+
   clightning = callPackage ../applications/blockchains/clightning.nix { };
 
   bitcoin-abc  = libsForQt5.callPackage ../applications/blockchains/bitcoin-abc.nix { boost = boost165; withGui = true; };


### PR DESCRIPTION
###### Motivation for this change

Adding bitcoin knots.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
