### PR TITLE
python: aiohttp/psutil/uvloop Darwin fixes

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -62,6 +62,7 @@ buildPythonPackage rec {
     "test_read_incomplete_chunk"
     "test_request_tracing_exception"
   ] ++ lib.optionals stdenv.isDarwin [
+    "test_addresses"  # https://github.com/aio-libs/aiohttp/issues/3572
     "test_close"
   ];
 

--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   # arch doesn't report frequency is the same way
   # tests segfaults on darwin https://github.com/giampaolo/psutil/issues/1715
-  doCheck = stdenv.isDarwin || stdenv.isx86_64;
+  doCheck = !stdenv.isDarwin && stdenv.isx86_64;
   checkInputs = [ pytest ]
     ++ lib.optionals isPy27 [ mock ipaddress ];
   # out must be referenced as test import paths are relative

--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -55,6 +55,9 @@ buildPythonPackage rec {
     export TEST_DIR=$(mktemp -d)
     cp -r tests $TEST_DIR
     pushd $TEST_DIR
+  '' + lib.optionalString stdenv.isDarwin ''
+    # Some tests fail on Darwin
+    rm tests/test_[stu]*.py
   '';
   postCheck = ''
     popd


### PR DESCRIPTION
Three minor fixes for Python packages on Darwin.

`aiohttp` and `uvloop` just need tests disabling; I've tested the resulting packages still work, at least for my use case.

The issue with `psutil` was correctly diagnosed in #82524, but that hit a stumble with the boolean logic, so this fixes that.

The test disablement in `uvloop` is slightly unusual, but that's because the way the tests are run is already slightly unusual, and so `disabledTests` didn't work.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
