### PR TITLE
unciv: init at 3.12.8

### DIFF
--- a/pkgs/games/unciv/default.nix
+++ b/pkgs/games/unciv/default.nix
@@ -1,0 +1,59 @@
+{ stdenv
+, lib
+, fetchurl
+, copyDesktopItems
+, makeDesktopItem
+, makeWrapper
+, jre
+, libpulseaudio
+, libXxf86vm
+}:
+let
+  desktopItem = makeDesktopItem {
+    name = "unciv";
+    exec = "unciv";
+    comment = "An open-source Android/Desktop remake of Civ V";
+    desktopName = "Unciv";
+    categories = "Game;";
+  };
+
+  envLibPath = lib.makeLibraryPath [
+    libpulseaudio
+    libXxf86vm
+  ];
+
+in
+stdenv.mkDerivation rec {
+  pname = "unciv";
+  version = "3.12.8";
+
+  src = fetchurl {
+    url = "https://github.com/yairm210/Unciv/releases/download/${version}/Unciv.jar";
+    sha256 = "178lasa6ahwg2s2hamm13yysg42qm13v6a9pgs6nm66np93nskc7";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ copyDesktopItems makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    makeWrapper ${jre}/bin/java $out/bin/unciv \
+      --prefix LD_LIBRARY_PATH : ${envLibPath} \
+      --prefix PATH : ${lib.makeBinPath [ jre ]} \
+      --add-flags "-jar ${src}"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [ desktopItem ];
+
+  meta = with lib; {
+    description = "An open-source Android/Desktop remake of Civ V";
+    homepage = "https://github.com/yairm210/Unciv";
+    maintainers = with maintainers; [ tex ];
+    license = licenses.mpl20;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27077,6 +27077,8 @@ in
     ffmpeg = ffmpeg_2;
   };
 
+  unciv = callPackage ../games/unciv { };
+
   unnethack = callPackage ../games/unnethack { };
 
   uqm = callPackage ../games/uqm { };


### PR DESCRIPTION
###### Motivation for this change

Fixes #90374

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
