### PR TITLE
pythonPackages.yamale: Init at 2.2.0

### DIFF
--- a/pkgs/development/python-modules/yamale/default.nix
+++ b/pkgs/development/python-modules/yamale/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pytest, pyyaml, }:
+
+buildPythonPackage rec {
+  version = "2.2.0";
+  pname = "yamale";
+
+  src = fetchFromGitHub {
+    owner = "23andMe";
+    repo = "Yamale";
+    rev = "${version}";
+    sha256 = "1xhxy3xk4bhy0fcnqif5cj0rf2sd1ifa1z077gp01r4j9vb65s0q";
+  };
+
+  propagatedBuildInputs = [ pyyaml ];
+
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    description = "A schema and validator for YAML.";
+    homepage = "https://github.com/23andMe/Yamale";
+    license = licenses.mit;
+    maintainers = with maintainers; [ chkno ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6098,6 +6098,8 @@ in {
 
   xxhash = callPackage ../development/python-modules/xxhash { };
 
+  yamale = callPackage ../development/python-modules/yamale { };
+
   ydiff = callPackage ../development/python-modules/ydiff { };
 
   yoda = toPythonModule (pkgs.yoda.override {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Make Yamale available, so we can validate yaml files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    0 -> 107458312
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
