### PR TITLE
displaylink: 5.2.14 -> 5.3.1

### DIFF
--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -11,17 +11,17 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "displaylink";
-  version = "5.2.14";
+  version = "5.3.1";
 
   src = requireFile rec {
     name = "displaylink.zip";
-    sha256 = "03b176y95f04rg3lcnjps9llsjbvd8yksh1fpvjwaciz48mnxh2i";
+    sha256 = "1c1kbjgpb71f73qnyl44rvwi6l4ivddq789rwvvh0ahw2jm324hy";
     message = ''
       In order to install the DisplayLink drivers, you must first
       comply with DisplayLink's EULA and download the binaries and
       sources from here:
 
-      http://www.displaylink.com/downloads/file?id=1369
+      http://www.displaylink.com/downloads/file?id=1576
 
       Once you have downloaded the file, please use the following
       commands and re-run the installation:


### PR DESCRIPTION
##### Motivation for this change
DisplayLink driver is failing to build on my device. Found this:

>@Luc45 Just something I noticed in your combinations of tries, DisplayLink 5.2.14 does not work with evdi 1.7.0.  You need the latest DisplayLink drivers which is 5.3.1 if you are installing evdi 1.7.0.

_Originally posted by @elguero in https://github.com/DisplayLink/evdi/issues/199#issuecomment-628134194_

I don't know how to test this change. I'm trying to get it to build on my own device. How can I use my local nixpkgs over the nixos channel?

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
