### PR TITLE
libgpg-error: Fix cross build

### DIFF
--- a/pkgs/development/libraries/libgpg-error/default.nix
+++ b/pkgs/development/libraries/libgpg-error/default.nix
@@ -34,6 +34,16 @@ in stdenv.mkDerivation (rec {
   '' + lib.optionalString (stdenv.hostPlatform.isAarch32 && stdenv.hostPlatform.isMusl) ''
     ln -s src/syscfg/lock-obj-pub.arm-unknown-linux-gnueabi.h src/syscfg/lock-obj-pub.arm-unknown-linux-musleabihf.h
     ln -s src/syscfg/lock-obj-pub.arm-unknown-linux-gnueabi.h src/syscfg/lock-obj-pub.linux-musleabihf.h
+  ''
+  # This file was accidentally excluded from the sdist until
+  # 013720333c6ec1d38791689bc49ba039d98e16b3, post release.
+  # TODO make unconditional next mass rebuild
+  + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    cp ${fetchurl {
+      url = "https://raw.githubusercontent.com/gpg/libgpg-error/50e62b36ea01ed25d12c443088b85d4f41a2b3e1/src/gen-lock-obj.sh";
+      sha256 = "10cslipa6npalj869asaamj0w941dhmx0yjafpyyh69ypsg2m2c3";
+    }} ./src/gen-lock-obj.sh
+    chmod +x ./src/gen-lock-obj.sh
   '';
 
   outputs = [ "out" "dev" "info" ];


### PR DESCRIPTION
###### Motivation for this change

See comment for details

Fixes #91016

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
