### PR TITLE
vim_configurable: fix error of gvim when guiSupport = false

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -156,8 +156,7 @@ in stdenv.mkDerivation rec {
   '' + stdenv.lib.optionalString stdenv.isLinux ''
     patchelf --set-rpath \
       "$(patchelf --print-rpath $out/bin/vim):${stdenv.lib.makeLibraryPath buildInputs}" \
-      "$out"/bin/{vim,gvim}
-
+      "$out"/bin/vim ${stdenv.lib.optionalString (guiSupport == "gtk2" || guiSupport == "gtk3") "$out/bin/gvim"}
     ln -sfn '${nixosRuntimepath}' "$out"/share/vim/vimrc
   '' + stdenv.lib.optionalString wrapPythonDrv ''
     wrapProgram "$out/bin/vim" --prefix PATH : "${python}/bin"


### PR DESCRIPTION
##### Motivation for this change

Otherwise, with the following overlay:

```nix
self: super:
{
  vim_configurable = super.vim_configurable.override {
    guiSupport = "false";
  };
}
```

The build fails for me with:

```
make[1]: Leaving directory '/build/source/src'
patchelf: getting info about '/nix/store/lqzr05k54c9g9dq3x84savln6l0gvbmd-vim_configurable-8.2.0701/bin/gvim': No such file or directory
builder for '/nix/store/rlillrjcg6isab31j30z6nvgxn7yz248-vim_configurable-8.2.0701.drv' failed with exit code 1
error: build of '/nix/store/rlillrjcg6isab31j30z6nvgxn7yz248-vim_configurable-8.2.0701.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
