### PR TITLE
vim_configurable: improve luajit support

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -104,6 +104,8 @@ in stdenv.mkDerivation rec {
   ++ stdenv.lib.optionals luaSupport [
     "--with-lua-prefix=${lua}"
     "--enable-luainterp"
+  ] ++ stdenv.lib.optional lua.pkgs.isLuaJIT [
+    "--with-luajit"
   ]
   ++ stdenv.lib.optionals pythonSupport [
     "--enable-python${if isPython3 then "3" else ""}interp=yes"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Without this configure flag, Vim uses LuaJIT's Lua which is OK, but it won't use it's JIT features.

While testing this change with the following overlay:

```nix
self: super: {
  vim_configurable = super.vim_configurable.override {
    lua = self.luajit;
    python = self.python3;
  };
}
```

BTW I encountered an unrelated issue at the build:

```
make[1]: Leaving directory '/build/source/src'
patchelf: getting info about '/nix/store/sjfqj8zhj0qrp01w53j35raj822ry8la-vim_configurable-8.2.0701/bin/gvim': No such file or directory
```

When I also added `guiSupport = "false"` to the overlay. I don't know why I never had that error when I disabled GUI support before, but I fixed it at https://github.com/NixOS/nixpkgs/pull/91150 .

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
