### PR TITLE
hyper: 2.1.2 -> 3.1.0-canary.4

### DIFF
--- a/pkgs/applications/misc/hyper/default.nix
+++ b/pkgs/applications/misc/hyper/default.nix
@@ -1,40 +1,46 @@
-{ stdenv, lib, fetchurl, dpkg, atk, glib, pango, gdk-pixbuf, gnome2, gtk2, cairo
+{ stdenv, lib, fetchurl, dpkg, atk, glib, pango, gdk-pixbuf, gnome2, gtk3, cairo
 , freetype, fontconfig, dbus, libXi, libXcursor, libXdamage, libXrandr
 , libXcomposite, libXext, libXfixes, libXrender, libX11, libXtst, libXScrnSaver
-, libxcb, nss, nspr, alsaLib, cups, expat, udev, libpulseaudio }:
+, libxcb, libuuid, nss, nspr, alsaLib, cups, expat, udev, libpulseaudio
+, at-spi2-atk, at-spi2-core }:
 
-let
-  libPath = stdenv.lib.makeLibraryPath [
-    stdenv.cc.cc gtk2 gnome2.GConf atk glib pango gdk-pixbuf cairo freetype fontconfig dbus
-    libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes libxcb
-    libXrender libX11 libXtst libXScrnSaver nss nspr alsaLib cups expat udev libpulseaudio
-  ];
-in
 stdenv.mkDerivation rec {
-  version = "2.1.2";
   pname = "hyper";
+  version = "3.1.0-canary.4";
+
   src = fetchurl {
-    url = "https://github.com/zeit/hyper/releases/download/${version}/hyper_${version}_amd64.deb";
-    sha256 = "1n4qlbk7q9zkhhg72mdks95g15xgyrc6ixf882ghvrqghd4zxplm";
+    url = "https://github.com/vercel/hyper/releases/download/v${version}/hyper_${version}_amd64.deb";
+    sha256 = "0z61sd3r9778d58xs6xjkz88c7crjk9vx9p1iw07i7pjj11wjrdb";
   };
-  buildInputs = [ dpkg ];
-  unpackPhase = ''
-    mkdir pkg
-    dpkg-deb -x $src pkg
-    sourceRoot=pkg
-  '';
+
+  nativeBuildInputs = [ dpkg ];
+
+  unpackPhase = "dpkg-deb -x $src .";
+
   installPhase = ''
     mkdir -p "$out/bin"
     mv opt "$out/"
     ln -s "$out/opt/Hyper/hyper" "$out/bin/hyper"
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${libPath}:\$ORIGIN" "$out/opt/Hyper/hyper"
     mv usr/* "$out/"
   '';
+
+  preFixup = let
+    libPath = stdenv.lib.makeLibraryPath [
+      stdenv.cc.cc gtk3 gnome2.GConf atk glib pango gdk-pixbuf cairo freetype fontconfig dbus
+      libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes libxcb
+      libXrender libX11 libXtst libXScrnSaver libuuid nss nspr alsaLib cups expat udev
+      libpulseaudio at-spi2-atk at-spi2-core
+    ];
+  in ''
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${libPath}:\$ORIGIN" "$out/opt/Hyper/hyper"
+  '';
+
   dontPatchELF = true;
+
   meta = with lib; {
     description = "A terminal built on web technologies";
     homepage    = "https://hyper.is/";
-    maintainers = with maintainers; [ puffnfresh ];
+    maintainers = with maintainers; [ pradyuman puffnfresh ];
     license     = licenses.mit;
     platforms   = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade to the latest Hyper.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
