### PR TITLE
home-assistant: 0.111.0 -> 0.111.4

### DIFF
--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -240,6 +240,7 @@ in {
       '');
       serviceConfig = {
         ExecStart = "${package}/bin/hass --config '${cfg.configDir}'";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         User = "hass";
         Group = "hass";
         Restart = "on-failure";

--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -2,69 +2,53 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
 let
   configDir = "/var/lib/foobar";
-  apiPassword = "some_secret";
-  mqttPassword = "another_secret";
-  hassCli = "hass-cli --server http://hass:8123 --password '${apiPassword}'";
+  mqttPassword = "secret";
 in {
   name = "home-assistant";
   meta = with pkgs.stdenv.lib; {
     maintainers = with maintainers; [ dotlambda ];
   };
 
-  nodes = {
-    hass =
-      { pkgs, ... }:
-      {
-        environment.systemPackages = with pkgs; [
-          mosquitto home-assistant-cli
-        ];
-        services.home-assistant = {
-          inherit configDir;
-          enable = true;
-          package = pkgs.home-assistant.override {
-            extraPackages = ps: with ps; [ hbmqtt ];
-          };
-          config = {
-            homeassistant = {
-              name = "Home";
-              time_zone = "UTC";
-              latitude = "0.0";
-              longitude = "0.0";
-              elevation = 0;
-              auth_providers = [
-                {
-                  type = "legacy_api_password";
-                  api_password = apiPassword;
-                }
-              ];
-            };
-            frontend = { };
-            mqtt = { # Use hbmqtt as broker
-              password = mqttPassword;
-            };
-            binary_sensor = [
-              {
-                platform = "mqtt";
-                state_topic = "home-assistant/test";
-                payload_on = "let_there_be_light";
-                payload_off = "off";
-              }
-            ];
-          };
-          lovelaceConfig = {
-            title = "My Awesome Home";
-            views = [ {
-              title = "Example";
-              cards = [ {
-                type = "markdown";
-                title = "Lovelace";
-                content = "Welcome to your **Lovelace UI**.";
-              } ];
-            } ];
-          };
-          lovelaceConfigWritable = true;
+  nodes.hass = { pkgs, ... }: {
+    environment.systemPackages = with pkgs; [ mosquitto ];
+    services.home-assistant = {
+      inherit configDir;
+      enable = true;
+      config = {
+        homeassistant = {
+          name = "Home";
+          time_zone = "UTC";
+          latitude = "0.0";
+          longitude = "0.0";
+          elevation = 0;
+        };
+        frontend = {};
+        # uses embedded mqtt broker
+        mqtt.password = mqttPassword;
+        binary_sensor = [{
+          platform = "mqtt";
+          state_topic = "home-assistant/test";
+          payload_on = "let_there_be_light";
+          payload_off = "off";
+        }];
+        logger = {
+          default = "info";
+          logs."homeassistant.components.mqtt" = "debug";
         };
       };
+      lovelaceConfig = {
+        title = "My Awesome Home";
+        views = [{
+          title = "Example";
+          cards = [{
+            type = "markdown";
+            title = "Lovelace";
+            content = "Welcome to your **Lovelace UI**.";
+          }];
+        }];
+      };
+      lovelaceConfigWritable = true;
+    };
   };
 
   testScript = ''
@@ -77,28 +61,13 @@ in {
     with subtest("Check that Home Assistant's web interface and API can be reached"):
         hass.wait_for_open_port(8123)
         hass.succeed("curl --fail http://localhost:8123/lovelace")
-        assert "API running" in hass.succeed(
-            "curl --fail -H 'x-ha-access: ${apiPassword}' http://localhost:8123/api/"
-        )
     with subtest("Toggle a binary sensor using MQTT"):
-        assert '"state": "off"' in hass.succeed(
-            "curl http://localhost:8123/api/states/binary_sensor.mqtt_binary_sensor -H 'x-ha-access: ${apiPassword}'"
-        )
+        # wait for broker to become available
         hass.wait_until_succeeds(
-            "mosquitto_pub -V mqttv311 -t home-assistant/test -u homeassistant -P '${mqttPassword}' -m let_there_be_light"
-        )
-        assert '"state": "on"' in hass.succeed(
-            "curl http://localhost:8123/api/states/binary_sensor.mqtt_binary_sensor -H 'x-ha-access: ${apiPassword}'"
-        )
-    with subtest("Toggle a binary sensor using hass-cli"):
-        assert '"state": "on"' in hass.succeed(
-            "${hassCli} --output json state get binary_sensor.mqtt_binary_sensor"
+            "mosquitto_sub -V mqttv311 -t home-assistant/test -u homeassistant -P '${mqttPassword}' -W 1 -t '*'"
         )
         hass.succeed(
-            "${hassCli} state edit binary_sensor.mqtt_binary_sensor --json='{\"state\": \"off\"}'"
-        )
-        assert '"state": "off"' in hass.succeed(
-            "curl http://localhost:8123/api/states/binary_sensor.mqtt_binary_sensor -H 'x-ha-access: ${apiPassword}'"
+            "mosquitto_pub -V mqttv311 -t home-assistant/test -u homeassistant -P '${mqttPassword}' -m let_there_be_light"
         )
     with subtest("Print log to ease debugging"):
         output_log = hass.succeed("cat ${configDir}/home-assistant.log")
@@ -107,5 +76,9 @@ in {
 
     with subtest("Check that no errors were logged"):
         assert "ERROR" not in output_log
+
+    # example line: 2020-06-20 10:01:32 DEBUG (MainThread) [homeassistant.components.mqtt] Received message on home-assistant/test: b'let_there_be_light'
+    with subtest("Check we received the mosquitto message"):
+        assert "let_there_be_light" in output_log
   '';
 })

--- a/pkgs/development/python-modules/influxdb/default.nix
+++ b/pkgs/development/python-modules/influxdb/default.nix
@@ -5,6 +5,8 @@
 , dateutil
 , pytz
 , six
+, msgpack
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -16,9 +18,16 @@ buildPythonPackage rec {
     sha256 = "9bcaafd57ac152b9824ab12ed19f204206ef5df8af68404770554c5b55b475f6";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/influxdata/influxdb-python/commit/cc41e290f690c4eb67f75c98fa9f027bdb6eb16b.patch";
+      sha256 = "1fb9qrq1kp24pixjwvzhdy67z3h0wnj92aj0jw0a25fd0rdxdvg4";
+    })
+  ];
+
   # ImportError: No module named tests
   doCheck = false;
-  propagatedBuildInputs = [ requests dateutil pytz six ];
+  propagatedBuildInputs = [ requests dateutil pytz six msgpack ];
 
   meta = with stdenv.lib; {
     description = "Python client for InfluxDB";

--- a/pkgs/development/python-modules/pyicloud/default.nix
+++ b/pkgs/development/python-modules/pyicloud/default.nix
@@ -38,9 +38,10 @@ buildPythonPackage rec {
 
   postPatch = ''
     sed -i \
-      -e 's!click>=6.0,<7.0!click!' \
-      -e 's!keyring>=8.0,<9.0!keyring!' \
-      -e 's!keyrings.alt>=1.0,<2.0!keyrings.alt!' \
+      -e 's!click>=.*!click!' \
+      -e 's!keyring>=.*!keyring!' \
+      -e 's!keyrings.alt>=.*!keyrings.alt!' \
+      -e 's!tzlocal==.*!tzlocal!' \
       requirements.txt
   '';
 

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.111.0";
+  version = "0.111.4";
   components = {
     "abode" = ps: with ps; [ ]; # missing inputs: abodepy
     "acer_projector" = ps: with ps; [ pyserial];
@@ -796,7 +796,7 @@
     "telnet" = ps: with ps; [ ];
     "temper" = ps: with ps; [ ]; # missing inputs: temperusb
     "template" = ps: with ps; [ ];
-    "tensorflow" = ps: with ps; [ numpy pillow protobuf tensorflow];
+    "tensorflow" = ps: with ps; [ numpy pillow protobuf]; # missing inputs: tensorflow
     "tesla" = ps: with ps; [ ]; # missing inputs: teslajsonpy
     "tfiac" = ps: with ps; [ ]; # missing inputs: pytfiac
     "thermoworks_smoke" = ps: with ps; [ stringcase]; # missing inputs: thermoworks_smoke

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -22,11 +22,6 @@ let
   defaultOverrides = [
     # Override the version of some packages pinned in Home Assistant's setup.py
 
-    # used by check_config script
-    # can be unpinned once https://github.com/home-assistant/home-assistant/issues/11917 is resolved
-    (mkOverride "colorlog" "4.0.2"
-      "3cf31b25cbc8f86ec01fef582ef3b840950dea414084ed19ab922c8b493f9b42")
-
     # required by the sun/moon plugins
     # https://github.com/home-assistant/core/issues/36636
     (mkOverride "astral" "1.10.1"
@@ -72,7 +67,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.111.0";
+  hassVersion = "0.111.4";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -91,7 +86,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "0zg7fng3cfksn4hr8vixsmj8cbag8h4dg4qi69n56hc71rnpl9kw";
+    sha256 = "08dkqczpmdaz8k9fsshgvgma7i7sffzgmhsi49qki7vwn20hl2hf";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchFromGitHub, fetchpatch, python3, protobuf3_6
+{ stdenv, nixosTests, lib, fetchurl, fetchFromGitHub, fetchpatch, python3, protobuf3_6
 
 # Look up dependencies of specified components in component-packages.nix
 , extraComponents ? [ ]
@@ -123,6 +123,9 @@ in with py.pkgs; buildPythonApplication rec {
 
   passthru = {
     inherit (py.pkgs) hass-frontend;
+    tests = {
+      inherit (nixosTests) home-assistant;
+    };
   };
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20200603.2";
+  version = "20200603.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1p99f5q8frk5k5lh1gjxyq539p1iv9fslpbfirh8njx3d0a85l84";
+    sha256 = "12bbvqckry6yr7409dir49pjcaa31z74fy6vb0mgr9xzvri5c2s8";
   };
 
   # no Python tests implemented

--- a/pkgs/servers/home-assistant/update.sh
+++ b/pkgs/servers/home-assistant/update.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p nix -p jq -p curl -p bash -p git -p nix-update -i bash
+
+set -eux
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR"
+
+CURRENT_VERSION=$(nix eval --raw '(with import ../../.. {}; home-assistant.version)')
+TARGET_VERSION=$(curl https://api.github.com/repos/home-assistant/core/releases/latest | jq -r '.name')
+MANIFEST=$(curl https://raw.githubusercontent.com/home-assistant/core/${TARGET_VERSION}/homeassistant/components/frontend/manifest.json)
+FRONTEND_VERSION=$(echo $MANIFEST | jq -r '.requirements[] | select(startswith("home-assistant-frontend")) | sub(".*==(?<vers>.*)"; .vers)')
+
+if [[ "$CURRENT_VERSION" == "$TARGET_VERSION" ]]; then
+    echo "home-assistant is up-to-date: ${CURRENT_VERSION}"
+    exit 0
+fi
+
+
+sed -i -e "s/version =.*/version = \"${TARGET_VERSION}\";/" \
+    component-packages.nix
+
+sed -i -e "s/hassVersion =.*/hassVersion = \"${TARGET_VERSION}\";/" \
+    default.nix
+
+./parse-requirements.py
+(
+    cd ../../..
+    nix-update --version "$FRONTEND_VERSION" home-assistant.hass-frontend
+    nix-update --version "$TARGET_VERSION" --build home-assistant
+)
+
+git add ./component-packages.nix ./default.nix ./frontend.nix
+git commit -m "homeassistant: ${CURRENT_VERSION} -> ${TARGET_VERSION}"


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).