### PR TITLE
efibootmgr,openldap: Cross compilation fixes

### DIFF
--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -40,8 +40,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional stdenv.isFreeBSD "--with-pic";
 
   postBuild = ''
-    make $makeFlags -C contrib/slapd-modules/passwd/sha2
-    make $makeFlags -C contrib/slapd-modules/passwd/pbkdf2
+    make $makeFlags CC=$CC -C contrib/slapd-modules/passwd/sha2
+    make $makeFlags CC=$CC -C contrib/slapd-modules/passwd/pbkdf2
   '';
 
   doCheck = false; # needs a running LDAP server

--- a/pkgs/tools/system/efibootmgr/default.nix
+++ b/pkgs/tools/system/efibootmgr/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   # We have no LTO here since commit 22284b07.
   postPatch = if stdenv.isi686 then "sed '/^CFLAGS/s/-flto//' -i Make.defaults" else null;
 
-  makeFlags = [ "EFIDIR=nixos" ];
+  makeFlags = [ "EFIDIR=nixos" "PKG_CONFIG=${stdenv.cc.targetPrefix}pkg-config" ];
 
   installFlags = [ "prefix=$(out)" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

```console
[nix-review@ava:~/nixpkgs]$ nix-build -A efibootmgr -A pkgsCross.aarch64-multiplatform.efibootmgr -A openldap -A pkgsCross.aarch64-multiplatform.openldap
/nix/store/8m8cisgdjpzbrn2mrljbcaf9yvafgdkc-efibootmgr-17
/nix/store/52g903z38xwpyg03qnyi0p2xhqh2n9f7-efibootmgr-17-aarch64-unknown-linux-gnu
/nix/store/r54mh08dlmv86cb6c8p20904ljiyrvw9-openldap-2.4.50
/nix/store/kgs9smc6j0vs7734fn7yl04wps3bmwv5-openldap-2.4.50-aarch64-unknown-linux-gnu
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
