### PR TITLE
mp4v2: 2.0.0 -> 4.1.3

### DIFF
--- a/pkgs/development/libraries/mp4v2/default.nix
+++ b/pkgs/development/libraries/mp4v2/default.nix
@@ -1,39 +1,39 @@
-{ stdenv, lib, fetchurl }:
+{ stdenv, lib, fetchFromGitHub, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "mp4v2-2.0.0";
+  pname = "mp4v2";
+  version = "4.1.3";
 
-  src = fetchurl {
-    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mp4v2/${name}.tar.bz2";
-    sha256 = "0f438bimimsvxjbdp4vsr8hjw2nwggmhaxgcw07g2z361fkbj683";
+  src = fetchFromGitHub {
+    # 2020-06-20: THE current upstream, maintained and used in distros fork.
+    owner = "TechSmith";
+    repo = "mp4v2";
+    rev = "Release-ThirdParty-MP4v2-${version}";
+    sha256 = "053a0lgy819sbz92cfkq0vmkn2ky39bva554pj4ypky1j6vs04fv";
   };
 
   patches = [
     (fetchurl {
-      name = "gcc-7.patch";
-      url = "https://src.fedoraproject.org/cgit/rpms/libmp4v2.git/plain/"
-          + "0004-Fix-GCC7-build.patch?id=d7aeedabb";
+      # 2020-06-19: NOTE: # Fix build with C++11
+      # Close when https://github.com/TechSmith/mp4v2/pull/36 merged/closed.
+      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/libmp4v2-c++11.patch?id=203f5a72bc97ffe089b424c47b07dd9eaea35713";
       sha256 = "0sbn0il7lmk77yrjyb4f0a3z3h8gsmdkscvz5n9hmrrrhrwf672w";
     })
   ];
 
-  buildFlags = [ "CXXFLAGS=-std=c++03" ];
-
   # `faac' expects `mp4.h'.
   postInstall = "ln -s mp4v2/mp4v2.h $out/include/mp4.h";
-
-  hardeningDisable = [ "format" ];
 
   enableParallelBuilding = true;
 
   meta = {
-    description = "Abandoned library. Provides functions to read, create, and modify mp4 files";
+    description = "Provides functions to read, create, and modify mp4 files";
     longDescription = ''
       MP4v2 library provides an API to work with mp4 files
       as defined by ISO-IEC:14496-1:2001 MPEG-4 Systems.
       This container format is derived from Apple's QuickTime format.
     '';
-    homepage = "https://code.google.com/archive/p/mp4v2/";
+    homepage = "https://github.com/TechSmith/mp4v2";
     maintainers = [ lib.maintainers.Anton-Latukha ];
     platforms = lib.platforms.unix;
     license = lib.licenses.mpl11;


### PR DESCRIPTION
Switch into the maintainable fork. It is the community central fork.

To compile, removed old patch URL, and using new upstream patch URL that corresponds with maintenance of `4.1.3`.

I weighted-in upstream on the patch reasoning to be merged.

Strictify the hardening.

Documentation update.

###### Motivation for this change

Found that there is good, maintainable fork of the project.

Fork already used in Arch-based distros for quite some time: https://repology.org/project/libmp4v2/versions

Should close the "Vulnerability roundup 85: mp4v2-2.0.0: 6 advisories [9.8]" https://github.com/NixOS/nixpkgs/issues/90888, until this version goes through the new scan.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
