### PR TITLE
python3Packages.pycryptodome: Fix the cross compilation

### DIFF
--- a/pkgs/development/python-modules/pycryptodome/default.nix
+++ b/pkgs/development/python-modules/pycryptodome/default.nix
@@ -9,6 +9,10 @@ buildPythonPackage rec {
     sha256 = "f1add21b6d179179b3c177c33d18a2186a09cc0d3af41ff5ed3f377360b869f2";
   };
 
+  preBuild = ''
+    export LDSHARED="$CC -shared" # Fix cross compilation, defaults to gcc instead of $CC
+  '';
+
   meta = {
     homepage = "https://www.pycryptodome.org/";
     description = "Python Cryptography Toolkit";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

```console
[nix-review@ava:~/nixpkgs]$ nix-build -A python3Packages.pycryptodome -A pkgsCross.aarch64-multiplatform.python3Packages.pycryptodome
/nix/store/zd4mv1k88y8w9dp32l3f611yl6khc4zn-python3.7-pycryptodome-3.9.7
/nix/store/w3a3h99p8gaaw7xwlnfx7yzh7q0pci9k-python3.7-pycryptodome-3.9.7-aarch64-unknown-linux-gnu
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
