### PR TITLE
[20.03] backport: nixos/btrfs autoScrub: don't fail when scrub finishes successfully

### DIFF
--- a/nixos/modules/tasks/filesystems/btrfs.nix
+++ b/nixos/modules/tasks/filesystems/btrfs.nix
@@ -128,7 +128,10 @@ in
             Nice = 19;
             IOSchedulingClass = "idle";
             ExecStart = "${pkgs.btrfs-progs}/bin/btrfs scrub start -B ${fs}";
-            ExecStop  = "${pkgs.btrfs-progs}/bin/btrfs scrub cancel ${fs}";
+            # if the service is stopped before scrub end, cancel it
+            ExecStop  = pkgs.writeShellScript "btrfs-scrub-maybe-cancel" ''
+              (${pkgs.btrfs-progs}/bin/btrfs scrub status ${fs} | ${pkgs.gnugrep}/bin/grep finished) || ${pkgs.btrfs-progs}/bin/btrfs scrub cancel ${fs}
+            '';
           };
         };
       in listToAttrs (map scrubService cfgScrub.fileSystems);


### PR DESCRIPTION
(cherry picked from commit 55d16d533446a815c5d266b72ff84bc97300fddc)

I tested that a scrub can finish successfully and be cancelled successfully.