### PR TITLE
apache-kafka: 2.4.0 -> 2.4.1/2.5.0

### DIFF
--- a/nixos/tests/kafka.nix
+++ b/nixos/tests/kafka.nix
@@ -90,4 +90,5 @@ in with pkgs; {
   kafka_2_2  = makeKafkaTest "kafka_2_2"  apacheKafka_2_2;
   kafka_2_3  = makeKafkaTest "kafka_2_3"  apacheKafka_2_3;
   kafka_2_4  = makeKafkaTest "kafka_2_4"  apacheKafka_2_4;
+  kafka_2_5  = makeKafkaTest "kafka_2_5"  apacheKafka_2_5;
 }

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -49,9 +49,14 @@ let
       sha256 = "0bldfrvd351agm237icnvn36va67crpnzmbh6dlq84ip910xsgas";
     };
     "2.4" = {
-      kafkaVersion = "2.4.0";
+      kafkaVersion = "2.4.1";
       scalaVersion = "2.12";
-      sha256 = "1vng5ipkjzqy0wijc706w2m1rjl5d0nsgbxiacci739y1jmjnn5r";
+      sha256 = "0ahsprmpjz026mhbr79187wfdrxcg352iipyfqfrx68q878wnxr1";
+    };
+    "2.5" = {
+      kafkaVersion = "2.5.0";
+      scalaVersion = "2.13";
+      sha256 = "0w3g7ii8x63m2blv2a8c491d0diczpliaqm9f7w5yn98hikh0aqi";
     };
   };
 in

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9996,7 +9996,7 @@ in
   apacheAnt_1_9 = callPackage ../development/tools/build-managers/apache-ant/1.9.nix { };
   ant = apacheAnt;
 
-  apacheKafka = apacheKafka_2_4;
+  apacheKafka = apacheKafka_2_5;
   apacheKafka_0_9 = callPackage ../servers/apache-kafka { majorVersion = "0.9"; };
   apacheKafka_0_10 = callPackage ../servers/apache-kafka { majorVersion = "0.10"; };
   apacheKafka_0_11 = callPackage ../servers/apache-kafka { majorVersion = "0.11"; };
@@ -10007,6 +10007,7 @@ in
   apacheKafka_2_2 = callPackage ../servers/apache-kafka { majorVersion = "2.2"; };
   apacheKafka_2_3 = callPackage ../servers/apache-kafka { majorVersion = "2.3"; };
   apacheKafka_2_4 = callPackage ../servers/apache-kafka { majorVersion = "2.4"; };
+  apacheKafka_2_5 = callPackage ../servers/apache-kafka { majorVersion = "2.5"; };
 
   kt = callPackage ../tools/misc/kt {};
 


### PR DESCRIPTION
###### Motivation for this change

Update kafka versions

###### Things done
- [ x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ x] other Linux distributions
- [ x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
