### PR TITLE
pc-ble-driver: init at 4.1.1

### DIFF
--- a/pkgs/development/tools/misc/pc-ble-driver/default.nix
+++ b/pkgs/development/tools/misc/pc-ble-driver/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, fetchFromGitHub
+# buildInputs
+, cmake
+, git
+, pkgconfig
+# propagatedBuildInputs
+, asio
+, catch2
+, IOKit
+, udev
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pc-ble-driver";
+  version = "4.1.1";
+
+  src = fetchFromGitHub {
+    owner = "NordicSemiconductor";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1llhkpbdbsq9d91m873vc96bprkgpb5wsm5fgs1qhzdikdhg077q";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    git
+    pkgconfig
+  ];
+
+  propagatedBuildInputs = [
+    asio
+    catch2
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    IOKit
+  ] ++ stdenv.lib.optionals stdenv.isLinux [
+    udev
+  ];
+
+  cmakeFlags = [
+    "-DNRF_BLE_DRIVER_VERSION=${version}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Desktop library for Bluetooth low energy development";
+    homepage = "https://github.com/NordicSemiconductor/pc-ble-driver";
+    platforms = platforms.unix;
+    license = licenses.unfreeRedistributable;
+    maintainers = [ stdenv.lib.maintainers.siriobalmelli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10895,6 +10895,10 @@ in
 
   nrfutil = callPackage ../development/tools/misc/nrfutil { };
 
+  pc-ble-driver = callPackage ../development/tools/misc/pc-ble-driver {
+    inherit (darwin.apple_sdk.frameworks) IOKit;
+  };
+
   obelisk = callPackage ../development/tools/ocaml/obelisk { };
 
   obuild = callPackage ../development/tools/ocaml/obuild { };


### PR DESCRIPTION
This is a requirement for the already-existing pc-ble-driver-py python module.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

###### Motivation for this change

This utility required to maintain a Nix CI

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
