### PR TITLE
alda: init at 1.4.2

### DIFF
--- a/pkgs/development/interpreters/alda/default.nix
+++ b/pkgs/development/interpreters/alda/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, jre }:
+
+stdenv.mkDerivation rec {
+  pname = "alda";
+  version = "1.4.2";
+
+  src = fetchurl {
+    url = "https://github.com/alda-lang/alda/releases/download/${version}/alda";
+    sha256 = "1d0412jw37gh1y7i8cmaml8r4sn516i6pxmm8m16yprqmz6glx28";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    install -Dm755 $src $out/bin/alda
+    sed -i -e '1 s!java!${jre}/bin/java!' $out/bin/alda
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A music programming language for musicians.";
+    homepage = "https://alda.io";
+    license = licenses.epl10;
+    maintainers = [ maintainers.ericdallo ];
+    platforms = jre.meta.platforms;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -132,6 +132,8 @@ in
 
   addOpenGLRunpath = callPackage ../build-support/add-opengl-runpath { };
 
+  alda = callPackage ../development/interpreters/alda { };
+
   ankisyncd = callPackage ../servers/ankisyncd { };
 
   avro-tools = callPackage ../development/tools/avro-tools { };


### PR DESCRIPTION
#### Motivation for this change
Add Alda programming language

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
