### PR TITLE
python3: improve cross-compilation of extension modules, fixes #91171

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.8/0001-On-all-posix-systems-not-just-Darwin-set-LDSHARED-if.patch
+++ b/pkgs/development/interpreters/python/cpython/3.8/0001-On-all-posix-systems-not-just-Darwin-set-LDSHARED-if.patch
@@ -1,0 +1,33 @@
+From 1911995b1a1252d80bf2b9651840e185a1a6baf5 Mon Sep 17 00:00:00 2001
+From: Hong Xu <hong@topbug.net>
+Date: Thu, 25 Jul 2019 10:25:55 -0700
+Subject: [PATCH] On all posix systems, not just Darwin, set LDSHARED (if not
+ set) according to CC
+
+This patch is slightly different from https://bugs.python.org/issue24935
+, except that we now handle LDSHARED according to CC on all posix
+systems, not just Darwin or Linux.
+---
+ Lib/distutils/sysconfig.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Lib/distutils/sysconfig.py b/Lib/distutils/sysconfig.py
+index 37feae5df7..9fdce6896d 100644
+--- a/Lib/distutils/sysconfig.py
++++ b/Lib/distutils/sysconfig.py
+@@ -199,10 +199,10 @@ def customize_compiler(compiler):
+ 
+         if 'CC' in os.environ:
+             newcc = os.environ['CC']
+-            if (sys.platform == 'darwin'
++            if (os.name == 'posix'
+                     and 'LDSHARED' not in os.environ
+                     and ldshared.startswith(cc)):
+-                # On OS X, if CC is overridden, use that as the default
++                # On POSIX systems, if CC is overridden, use that as the default
+                 #       command for LDSHARED as well
+                 ldshared = newcc + ldshared[len(cc):]
+             cc = newcc
+-- 
+2.25.1
+

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -140,6 +140,9 @@ in with passthru; stdenv.mkDerivation {
           sha256 = "1h18lnpx539h5lfxyk379dxwr8m2raigcjixkf133l4xy3f4bzi2";
         }
     )
+  ] ++ [
+    # LDSHARED now uses $CC instead of gcc. Fixes cross-compilation of extension modules.
+    ./3.8/0001-On-all-posix-systems-not-just-Darwin-set-LDSHARED-if.patch
   ];
 
   postPatch = ''

--- a/pkgs/tools/filesystems/btrfs-progs/default.nix
+++ b/pkgs/tools/filesystems/btrfs-progs/default.nix
@@ -20,10 +20,6 @@ stdenv.mkDerivation rec {
 
   # for python cross-compiling
   _PYTHON_HOST_PLATFORM = stdenv.hostPlatform.config;
-  # The i686 case is a quick hack; I don't know what's wrong.
-  postConfigure = stdenv.lib.optionalString (!stdenv.isi686) ''
-    export LDSHARED="$LD -shared"
-  '';
 
   # gcc bug with -O1 on ARM with gcc 4.8
   # This should be fine on all platforms so apply universally


### PR DESCRIPTION
Fixes #91171.
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
