### PR TITLE
influxdb,lexicon: fix builds

### DIFF
--- a/pkgs/development/python-modules/aioftp/default.nix
+++ b/pkgs/development/python-modules/aioftp/default.nix
@@ -27,9 +27,12 @@ buildPythonPackage rec {
     async-timeout
   ];
 
+  doCheck = false; # requires siosocks, not packaged yet
   checkPhase = ''
     pytest
   '';
+
+  pythonImportsCheck = [ "aioftp" ];
 
   meta = with lib; {
     description = "Ftp client/server for asyncio";

--- a/pkgs/development/python-modules/extension-helpers/default.nix
+++ b/pkgs/development/python-modules/extension-helpers/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, pytestCheckHook
+, setuptools_scm
+}:
+
+buildPythonPackage rec {
+  pname = "extension-helpers";
+  version = "0.1";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10iqjzmya2h4sk765dlm1pbqypwlqyh8rw59a5m9i63d3klnz2mc";
+  };
+
+  nativeBuildInputs = [
+    setuptools_scm
+  ];
+
+  propagatedBuildInputs = [
+    pytestCheckHook
+  ];
+
+  # avoid importing local module
+  preCheck = ''
+    cd extension_helpers
+  '';
+
+  # assumes setup.py is in pwd
+  disabledTests = [ "compiler_module" ];
+
+  meta = with lib; {
+    description = "Helpers to assist with building packages with compiled C/Cython extensions";
+    homepage = "https://github.com/astropy/extension-helpers";
+    license = licenses.bsd3;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/flask-caching/default.nix
+++ b/pkgs/development/python-modules/flask-caching/default.nix
@@ -1,8 +1,9 @@
-{ lib, buildPythonPackage, fetchPypi, flask, pytest, pytestcov, pytest-xprocess, pytestcache }:
+{ lib, buildPythonPackage, fetchPypi, isPy27, flask, pytest, pytestcov, pytest-xprocess, pytestcache }:
 
 buildPythonPackage rec {
   pname = "Flask-Caching";
   version = "1.9.0";
+  disabled = isPy27; # invalid python2 syntax
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pytest-astropy-header/default.nix
+++ b/pkgs/development/python-modules/pytest-astropy-header/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, pytestcov
+, pytestCheckHook
+, numpy
+, astropy
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-astropy-header";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1y87agr324p6x5gvhziymxjlw54pyn4gqnd49papbl941djpkp5g";
+  };
+
+  propagatedBuildInputs = [
+    pytest
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytestcov
+    numpy
+    astropy
+  ];
+
+  meta = with lib; {
+    description = "Plugin to add diagnostic information to the header of the test output";
+    homepage = "https://astropy.org";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-astropy/default.nix
+++ b/pkgs/development/python-modules/pytest-astropy/default.nix
@@ -1,11 +1,15 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, hypothesis
 , pytest
+, pytest-astropy-header
 , pytest-doctestplus
+, pytest-filter-subpackage
 , pytest-remotedata
 , pytest-openfiles
 , pytest-arraydiff
+, setuptools_scm
 }:
 
 buildPythonPackage rec {
@@ -17,16 +21,23 @@ buildPythonPackage rec {
     sha256 = "619800eb2cbf64548fbea25268efe7c6f6ae206cb4825f34abd36f27bcf946a2";
   };
 
+  nativeBuildInputs = [
+    setuptools_scm
+  ];
+
   propagatedBuildInputs = [
+    hypothesis
     pytest
+    pytest-astropy-header
     pytest-doctestplus
+    pytest-filter-subpackage
     pytest-remotedata
     pytest-openfiles
     pytest-arraydiff
   ];
 
   # pytest-astropy is a meta package and has no tests
-  doCheck = false;
+  checkPhase = ":";
 
   meta = with lib; {
     description = "Meta-package containing dependencies for testing";

--- a/pkgs/development/python-modules/pytest-doctestplus/default.nix
+++ b/pkgs/development/python-modules/pytest-doctestplus/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , six
 , pytest
 , numpy
@@ -9,6 +10,7 @@
 buildPythonPackage rec {
   pname = "pytest-doctestplus";
   version = "0.7.0";
+  disabled = isPy27; # abandoned upstream
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pytest-filter-subpackage/default.nix
+++ b/pkgs/development/python-modules/pytest-filter-subpackage/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, pytestcov
+, pytest-doctestplus
+, pytestCheckHook
+, setuptools_scm
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-filter-subpackage";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1s4s2kd31yc65rfvl4xhy8xx806xhy59kc7668h6b6wq88xgrn5p";
+  };
+
+  nativeBuildInputs = [
+    setuptools_scm
+  ];
+
+  propagatedBuildInputs = [
+    pytest
+    pytest-doctestplus
+    pytestcov
+    pytestCheckHook
+  ];
+
+  # missing some files
+  disabledTests = [ "with_rst" ];
+
+  meta = with lib; {
+    description = "Meta-package containing dependencies for testing";
+    homepage = "https://astropy.org";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/reproject/default.nix
+++ b/pkgs/development/python-modules/reproject/default.nix
@@ -6,30 +6,26 @@
 , astropy
 , astropy-healpix
 , astropy-helpers
+, extension-helpers
 , scipy
 , pytest
 , pytest-astropy
+, setuptools_scm
 , cython
 }:
 
 buildPythonPackage rec {
   pname = "reproject";
-  version = "0.6";
+  version = "0.7.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "484fde86d70d972d703038f138d7c2966ddf51171a6e79bd84e82ea270e27af3";
+    sha256 = "1jsc3ad518vyys5987fr1achq8qvnz8rm80zp5an9qxlwr4zmh4m";
   };
 
   propagatedBuildInputs = [ numpy astropy astropy-healpix astropy-helpers scipy ];
 
-  nativeBuildInputs = [ astropy-helpers cython ];
-
-  # Fix tests
-  patches = [ (fetchpatch {
-    url = "https://github.com/astropy/reproject/pull/218/commits/4661e075137424813ed77f1ebcbc251fee1b8467.patch";
-    sha256 = "13g3h824pqn2lgypzg1b87vkd44y7m302lhw3kh4rfww1dkzhm9v";
-  }) ];
+  nativeBuildInputs = [ astropy-helpers cython extension-helpers setuptools_scm ];
 
   # Disable automatic update of the astropy-helper module
   postPatch = ''

--- a/pkgs/development/python-modules/requests-file/default.nix
+++ b/pkgs/development/python-modules/requests-file/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, buildPythonPackage, requests, six }:
+{ lib, fetchPypi, buildPythonPackage, pytestCheckHook, requests, six }:
 
 buildPythonPackage rec {
   pname   = "requests-file";
@@ -10,6 +10,8 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ requests six ];
+
+  checkInputs = [ pytestCheckHook ];
 
   meta = {
     homepage = "https://github.com/dashea/requests-file";

--- a/pkgs/development/python-modules/spectral-cube/default.nix
+++ b/pkgs/development/python-modules/spectral-cube/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchFromGitHub
 , buildPythonPackage
+, aplpy
 , astropy
 , radio_beam
 , pytest
@@ -24,7 +25,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ astropy-helpers ];
 
-  checkInputs = [ pytest pytest-astropy ];
+  checkInputs = [ aplpy pytest pytest-astropy ];
 
   # Disable automatic update of the astropy-helper module
   postPatch = ''

--- a/pkgs/development/python-modules/structlog/default.nix
+++ b/pkgs/development/python-modules/structlog/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pytest
+, pytest-asyncio
 , python-rapidjson
 , pretend
 , freezegun
@@ -20,7 +21,7 @@ buildPythonPackage rec {
     sha256 = "7a48375db6274ed1d0ae6123c486472aa1d0890b08d314d2b016f3aa7f35990b";
   };
 
-  checkInputs = [ pytest pretend freezegun simplejson twisted ]
+  checkInputs = [ pytest pytest-asyncio pretend freezegun simplejson twisted ]
     ++ lib.optionals (pythonAtLeast "3.6") [ python-rapidjson ];
   propagatedBuildInputs = [ six ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2498,6 +2498,8 @@ in {
 
   pytest-astropy-header = callPackage ../development/python-modules/pytest-astropy-header { };
 
+  pytest-filter-subpackage = callPackage ../development/python-modules/pytest-filter-subpackage { };
+
   pytest-benchmark = callPackage ../development/python-modules/pytest-benchmark { };
 
   pytestcache = callPackage ../development/python-modules/pytestcache { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6012,6 +6012,8 @@ in {
 
   extras = callPackage ../development/python-modules/extras { };
 
+  extension-helpers = callPackage ../development/python-modules/extension-helpers { };
+
   texttable = callPackage ../development/python-modules/texttable { };
 
   textwrap3 =  callPackage ../development/python-modules/textwrap3 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2496,6 +2496,8 @@ in {
 
   pytest-astropy = callPackage ../development/python-modules/pytest-astropy { };
 
+  pytest-astropy-header = callPackage ../development/python-modules/pytest-astropy-header { };
+
   pytest-benchmark = callPackage ../development/python-modules/pytest-benchmark { };
 
   pytestcache = callPackage ../development/python-modules/pytestcache { };


### PR DESCRIPTION
###### Motivation for this change
fix `lexicon` and `influxdb` builds, which were failing on a different review

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
