### PR TITLE
pcloud: Init at 1.8.8

### DIFF
--- a/pkgs/applications/networking/pcloud/default.nix
+++ b/pkgs/applications/networking/pcloud/default.nix
@@ -1,0 +1,110 @@
+# Even though pCloud Drive is redistributed as a plug-n-play AppImage, it
+# requires a little bit more love because of the way Nix launches those types
+# of applications.
+#
+# What Nix does, simplifying a bit, is that it extracts an AppImage and starts
+# it via buildFHSUserEnv - this is totally fine for majority of apps, but makes
+# it by-design *impossible* to launch SUID wrappers [^1]; in case of pCloud,
+# it's fusermount.
+# (so pCloud starts, but silently fails to mount the FUSE drive.)
+#
+# To overcome this issue, we're manually extracting the AppImage and then treat
+# it as if it was a regular, good-ol' application requiring some standard path
+# fixes.
+#
+# ^1 https://github.com/NixOS/nixpkgs/issues/69338
+
+{
+  # Build dependencies
+  appimageTools, autoPatchelfHook, fetchzip, stdenv,
+
+  # Runtime dependencies;
+  # A few additional ones (e.g. Node) are already shipped together with the
+  # AppImage, so we don't have to duplicate them here.
+  alsaLib, dbus-glib, fuse, gnome3, libdbusmenu-gtk2, udev, nss
+}:
+
+let
+  pname = "pcloud";
+  version = "1.8.8";
+  name = "${pname}-${version}";
+
+  # Archive link's code thanks to: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=pcloud-drive
+  src = fetchzip {
+    url = "https://api.pcloud.com/getpubzip?code=XZpnMpXZPWyhRfdvXUhyY6XpdfmQmJiLRmmV&filename=${name}.zip";
+    hash = "sha256-z9OeFkH6EVthg5Dz2mN3jlBTMhiMt/6bUIYFeMO6EXk=";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name;
+    src = "${src}/pcloud";
+  };
+
+in stdenv.mkDerivation {
+  inherit pname version;
+
+  src = appimageContents;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    alsaLib
+    dbus-glib
+    fuse
+    gnome3.gtk
+    libdbusmenu-gtk2
+    nss
+    udev
+  ];
+
+  installPhase = ''
+    mkdir "$out"
+    cp -ar . "$out/app"
+    cd "$out"
+
+    # Remove the AppImage runner, since users are not supposed to use it; the
+    # actual entry point is the `pcloud` binary
+    rm app/AppRun
+
+    # Adjust directory structure, so that the `.desktop` etc. files are
+    # properly detected
+    mkdir bin
+    mv app/usr/share .
+    mv app/usr/lib .
+
+    # Adjust the `.desktop` file
+    mkdir share/applications
+
+    substitute \
+      app/pcloud.desktop \
+      share/applications/pcloud.desktop \
+      --replace "Name=pcloud" "Name=pCloud" \
+      --replace "Exec=AppRun" "Exec=$out/bin/pcloud"
+
+    # Build the main executable
+    cat > bin/pcloud <<EOF
+    #! $SHELL -e
+
+    # This is required for the file picker dialog - otherwise pcloud just
+    # crashes
+    export XDG_DATA_DIRS="${gnome3.gsettings-desktop-schemas}/share/gsettings-schemas/${gnome3.gsettings-desktop-schemas.name}:${gnome3.gtk}/share/gsettings-schemas/${gnome3.gtk.name}:$XDG_DATA_DIRS"
+
+    exec "$out/app/pcloud"
+    EOF
+
+    chmod +x bin/pcloud
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Secure and simple to use cloud storage for your files; pCloud Drive, Electron Edition";
+    homepage = "https://www.pcloud.com/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ patryk27 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22802,6 +22802,8 @@ in
 
   pbrt = callPackage ../applications/graphics/pbrt { };
 
+  pcloud = callPackage ../applications/networking/pcloud { };
+
   pcsxr = callPackage ../misc/emulators/pcsxr {
     ffmpeg = ffmpeg_2;
   };


### PR DESCRIPTION
##### Motivation for this change

Just a new application: pCloud.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
