### PR TITLE
emu2: init at unstable-2020-06-04

### DIFF
--- a/pkgs/misc/emulators/emu2/default.nix
+++ b/pkgs/misc/emulators/emu2/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "emu2";
+  version = "unstable-2020-06-04";
+
+  src = fetchFromGitHub {
+    owner  = "dmsc";
+    repo   = "emu2";
+    rev    = "f9599d347aab07d9281400ec8b214aabd187fbcd";
+    sha256 = "0d8fb3wp477kfi0p4mmr69lxsbgb4gl9pqmm68g9ixzrfch837v4";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/dmsc/emu2/";
+    description = "A simple text-mode x86 + DOS emulator";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dramaturg ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25651,6 +25651,8 @@ in
 
   dosbox = callPackage ../misc/emulators/dosbox { };
 
+  emu2 = callPackage ../misc/emulators/emu2 { };
+
   dpkg = callPackage ../tools/package-management/dpkg { };
 
   dumb = callPackage ../misc/dumb { };


### PR DESCRIPTION

###### Motivation for this change

This adds the emu2 DOS emulator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
