### PR TITLE
fastmod: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3536,6 +3536,12 @@
     githubId = 117874;
     name = "Jeroen de Haas";
   };
+  jduan = {
+    name = "Jingjing Duan";
+    email = "duanjingjing@gmail.com";
+    github = "jduan";
+    githubId = 452450;
+  };
   jefdaj = {
     email = "jefdaj@gmail.com";
     github = "jefdaj";

--- a/pkgs/tools/text/fastmod/default.nix
+++ b/pkgs/tools/text/fastmod/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "fastmod";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "facebookincubator";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0089a17h0wgan3fs6x1la35lzjs1pib7p81wqkh3zcwvx8ffa8z8";
+  };
+
+  cargoSha256 = "02nkxjwfiljndmi0pv98chfsw9vmjzgmp5r14mchpayp4943qk9m";
+
+  buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
+
+  meta = with stdenv.lib; {
+    description = "A utility that makes sweeping changes to large, shared code bases";
+    homepage = "https://github.com/facebookincubator/fastmod";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jduan ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -955,6 +955,10 @@ in
 
   libfx2 = with python3Packages; toPythonApplication fx2;
 
+  fastmod = callPackage ../tools/text/fastmod {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   fitnesstrax = callPackage ../applications/misc/fitnesstrax/default.nix { };
 
   fxlinuxprintutil = callPackage ../tools/misc/fxlinuxprintutil { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This adds a package for https://github.com/facebookincubator/fastmod, a CLI tool for refactoring code.

###### Things done
I ran `nix-build -A fastmod default.nix` and tested the binary built. It worked as expected.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
