### PR TITLE
[nixos-20.03 backport] Backport mutt 1.14.4 security issue patch

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -40,6 +40,15 @@ stdenv.mkDerivation rec {
       url = "https://github.com/muttmua/mutt/commit/3e88866dc60b5fa6aaba6fd7c1710c12c1c3cd01.patch";
       sha256 = "1md4krh76kjbg6nkyvbpjn6iz17c7m7xvdj6gjvjr7akqjhfw48h";
     })
+
+    # Patch for security issue released in 1.14.4, see
+    # https://marc.info/?l=mutt-users&m=159252929418100&w=2
+    # and
+    # https://marc.info/?l=mutt-users&m=159268982901013&w=2
+    (fetchpatch {
+      url = "https://github.com/muttmua/mutt/commit/dc909119b3433a84290f0095c0f43a23b98b3748.patch";
+      sha256 = "sha256:1qqbl9qd2k1bn6qa5gssb6kqhw275hp2wrz7yhqrp9ijx3nzy281";
+    })
   ] ++ optional smimeSupport (fetchpatch {
     url = "https://salsa.debian.org/mutt-team/mutt/raw/debian/1.10.1-2/debian/patches/misc/smime.rc.patch";
     sha256 = "0b4i00chvx6zj9pcb06x2jysmrcb2znn831lcy32cgfds6gr3nsi";


### PR DESCRIPTION
This was not yet tested by me and I am not able to verify that the issue is actually fixed by backporting this patch without modification to an old release of mutt.

Reviewers, please be careful

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
