### PR TITLE
nixos/zsa: init at unstable-2020-12-16

### DIFF
--- a/nixos/modules/hardware/keyboard/zsa.nix
+++ b/nixos/modules/hardware/keyboard/zsa.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkOption mkIf types;
+  cfg = config.hardware.keyboard.zsa;
+in
+{
+  # TODO: make group configurable like in https://github.com/NixOS/nixpkgs/blob/0b2b4b8c4e729535a61db56468809c5c2d3d175c/pkgs/tools/security/nitrokey-app/udev-rules.nix ?
+  options.hardware.keyboard.zsa = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enables udev rules for keyboards from ZSA like the ErgoDox EZ, Planck EZ and Moonlander Mark I.
+        You need it when you want to flash a new configuration on the keyboard
+        or use their live training in the browser.
+        Access to the keyboard is granted to users in the "plugdev" group.
+        You may want to install the wally-cli package.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.udev.packages = [ pkgs.zsa-udev-rules ];
+    users.groups.plugdev = {};
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -47,6 +47,7 @@
   ./hardware/digitalbitbox.nix
   ./hardware/device-tree.nix
   ./hardware/sensor/iio.nix
+  ./hardware/keyboard/zsa.nix
   ./hardware/ksm.nix
   ./hardware/ledger.nix
   ./hardware/logitech.nix

--- a/pkgs/os-specific/linux/zsa-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/zsa-udev-rules/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "zsa-udev-rules";
+  version = "unstable-2020-12-16";
+
+  # TODO: use version and source from nixpkgs/pkgs/development/tools/wally-cli/default.nix after next release
+  src = fetchFromGitHub {
+    owner = "zsa";
+    repo = "wally";
+    rev = "e5dde3c700beab39fb941c6941e55535bf9b2af6";
+    sha256 = "0pkybi32r1hrmpa1mc8qlzhv7xy5n5rr5ah25lbr0cipp1bda417";
+  };
+
+  # it only installs files
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    mkdir -p $out/lib/udev/rules.d
+    cp dist/linux64/50-oryx.rules $out/lib/udev/rules.d/
+    cp dist/linux64/50-wally.rules $out/lib/udev/rules.d/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "udev rules for ZSA devices";
+    license = licenses.mit;
+    maintainers = with maintainers; [ davidak ];
+    platforms = platforms.linux;
+    homepage = "https://github.com/zsa/wally/wiki/Linux-install#2-create-a-udev-rule-file";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16462,6 +16462,7 @@ in
   waffle = callPackage ../development/libraries/waffle { };
 
   wally-cli = callPackage ../development/tools/wally-cli { };
+  zsa-udev-rules = callPackage ../os-specific/linux/zsa-udev-rules { };
 
   wavpack = callPackage ../development/libraries/wavpack { };
 


### PR DESCRIPTION
###### Motivation for this change

be able to configure ZSA keyboards

Related: https://github.com/zsa/wally/issues/19

cc @spacekookie might want to test?

###### Things done

- [x] tested flashing keyboard
- [x] tested live training

--

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
