### PR TITLE
poica: init at 0.2.0

### DIFF
--- a/pkgs/development/libraries/poica/default.nix
+++ b/pkgs/development/libraries/poica/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "poica";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "Hirrolot";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1ghc946g8idygp1ski5ii9b5bgrgrbjfrsk35ngx7gyav794acmi";
+  };
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r include/ $out
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Hirrolot/poica";
+    description = "ADTs with pattern matching and type introspection for pure C";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ chessai ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6057,6 +6057,8 @@ in
 
   poedit = callPackage ../tools/text/poedit { };
 
+  poica = callPackage ../development/libraries/poica { };
+
   polipo = callPackage ../servers/polipo { };
 
   polkit_gnome = callPackage ../tools/security/polkit-gnome { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add poica, a header-only C library for ADTs with pattern matching and type introspection

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
