### PR TITLE
ocamlPackages.js_of_ocaml: 3.5.2 → 3.6.0

### DIFF
--- a/pkgs/applications/science/logic/why3/default.nix
+++ b/pkgs/applications/science/logic/why3/default.nix
@@ -38,6 +38,10 @@ stdenv.mkDerivation {
     })
   ];
 
+  postPatch = ''
+    substituteInPlace Makefile.in --replace js_of_ocaml.ppx js_of_ocaml-ppx
+  '';
+
   configureFlags = [ "--enable-verbose-make" ];
 
   installTargets = [ "install" "install-lib" ];

--- a/pkgs/development/interpreters/eff/default.nix
+++ b/pkgs/development/interpreters/eff/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation {
     sha256 = "1fslfj5d7fhj3f7kh558b8mk5wllwyq4rnhfkyd96fpy144sdcka";
   };
 
+  postPatch = ''
+    substituteInPlace setup.ml --replace js_of_ocaml.ocamlbuild js_of_ocaml-ocamlbuild
+  '';
+
   buildInputs = [ which ] ++ (with ocamlPackages; [
     ocaml findlib ocamlbuild menhir js_of_ocaml js_of_ocaml-ocamlbuild
   ]);

--- a/pkgs/development/ocaml-modules/ocplib-json-typed/browser.nix
+++ b/pkgs/development/ocaml-modules/ocplib-json-typed/browser.nix
@@ -3,6 +3,7 @@
 buildDunePackage {
   pname = "ocplib-json-typed-browser";
   inherit (ocplib-json-typed) version src;
+  useDune2 = true;
 
   propagatedBuildInputs = [ ocplib-json-typed js_of_ocaml ];
 

--- a/pkgs/development/ocaml-modules/xtmpl/default.nix
+++ b/pkgs/development/ocaml-modules/xtmpl/default.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
 
   patches = [ ./jsoo.patch ];
 
+  postPatch = ''
+    substituteInPlace Makefile --replace js_of_ocaml.ppx js_of_ocaml-ppx
+  '';
+
   buildInputs = [ ocaml findlib ppx_tools js_of_ocaml js_of_ocaml-ppx ];
   propagatedBuildInputs = [ iri re ];
 

--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -1,19 +1,18 @@
-{ lib, fetchFromGitHub, buildDunePackage
-, ocaml, findlib, cmdliner, dune, cppo, yojson, ocaml-migrate-parsetree
+{ lib, fetchurl, buildDunePackage
+, ocaml, findlib, cmdliner, dune_2, cppo, yojson, ocaml-migrate-parsetree
 }:
 
 buildDunePackage rec {
 	pname = "js_of_ocaml-compiler";
-	version = "3.5.2";
+	version = "3.6.0";
+	useDune2 = true;
 
-	src = fetchFromGitHub {
-		owner = "ocsigen";
-		repo = "js_of_ocaml";
-		rev = version;
-		sha256 = "1fm855iavljx7rf9hii2qb7ky920zv082d9zlcl504by1bxp1yg8";
+	src = fetchurl {
+		url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
+		sha256 = "51eaa89c83ef3168ef270bf7997cbc35a747936d3f51aa6fac58fb0323b4cbb0";
 	};
 
-	nativeBuildInputs = [ ocaml findlib dune cppo ];
+	nativeBuildInputs = [ ocaml findlib dune_2 cppo ];
   buildInputs = [ cmdliner ];
 
   configurePlatforms = [];
@@ -23,6 +22,6 @@ buildDunePackage rec {
 		description = "Compiler from OCaml bytecode to Javascript";
 		license = lib.licenses.gpl2;
 		maintainers = [ lib.maintainers.vbgl ];
-		inherit (src.meta) homepage;
+		homepage = "https://ocsigen.org/js_of_ocaml/";
 	};
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, ocaml, findlib, dune, js_of_ocaml-compiler
+{ stdenv, ocaml, findlib, dune_2, js_of_ocaml-compiler
 , ocaml-migrate-parsetree, ppx_tools_versioned, uchar
 }:
 
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   inherit (js_of_ocaml-compiler) version src installPhase meta;
 
   buildInputs = [ findlib ocaml-migrate-parsetree ppx_tools_versioned ];
-  nativeBuildInputs = [ ocaml findlib dune ];
+  nativeBuildInputs = [ ocaml findlib dune_2 ];
 
   postPatch = "patchShebangs lib/generate_stubs.sh";
 

--- a/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
@@ -1,4 +1,4 @@
-{ stdenv, ocaml, findlib, dune, js_of_ocaml-compiler, js_of_ocaml-ppx
+{ stdenv, ocaml, findlib, dune_2, js_of_ocaml-compiler, js_of_ocaml-ppx
 , ocaml-migrate-parsetree, ppx_tools_versioned
 , js_of_ocaml, ocaml_lwt, lwt_log
 }:
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
 
 	inherit (js_of_ocaml-compiler) version src installPhase meta;
 
-	buildInputs = [ ocaml findlib dune js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
+	buildInputs = [ ocaml findlib dune_2 js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
 
 	propagatedBuildInputs = [ js_of_ocaml ocaml_lwt lwt_log ];
 

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ocamlbuild.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ocamlbuild.nix
@@ -1,4 +1,4 @@
-{ stdenv, ocaml, findlib, dune, js_of_ocaml-compiler
+{ stdenv, ocaml, findlib, dune_2, js_of_ocaml-compiler
 , ocamlbuild
 }:
 
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
 
 	inherit (js_of_ocaml-compiler) version src installPhase meta;
 
-	buildInputs = [ ocaml findlib dune ];
+	buildInputs = [ ocaml findlib dune_2 ];
 
 	propagatedBuildInputs = [ ocamlbuild ];
 

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
@@ -1,4 +1,4 @@
-{ stdenv, ocaml, findlib, dune, js_of_ocaml-compiler
+{ stdenv, ocaml, findlib, dune_2, js_of_ocaml-compiler
 , ocaml-migrate-parsetree, ppx_tools_versioned
 , js_of_ocaml
 }:
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
 
 	inherit (js_of_ocaml-compiler) version src installPhase meta;
 
-	buildInputs = [ ocaml findlib dune ocaml-migrate-parsetree ppx_tools_versioned js_of_ocaml ];
+	buildInputs = [ ocaml findlib dune_2 ocaml-migrate-parsetree ppx_tools_versioned js_of_ocaml ];
 
 	buildPhase = "dune build -p js_of_ocaml-ppx";
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
@@ -1,4 +1,4 @@
-{ stdenv, ocaml, findlib, dune, js_of_ocaml-compiler
+{ stdenv, ocaml, findlib, dune_2, js_of_ocaml-compiler
 , js_of_ocaml, ppxlib
 }:
 
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
 
 	inherit (js_of_ocaml-compiler) version src installPhase meta;
 
-	buildInputs = [ ocaml findlib dune ];
+	buildInputs = [ ocaml findlib dune_2 ];
 
 	propagatedBuildInputs = [ js_of_ocaml ppxlib ];
 

--- a/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
@@ -1,4 +1,4 @@
-{ stdenv, ocaml, findlib, dune, js_of_ocaml-compiler
+{ stdenv, ocaml, findlib, dune_2, js_of_ocaml-compiler
 , js_of_ocaml-ppx, ocaml-migrate-parsetree, ppx_tools_versioned
 , js_of_ocaml, reactivedata, tyxml
 }:
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
 
 	inherit (js_of_ocaml-compiler) version src installPhase meta;
 
-	buildInputs = [ ocaml findlib dune js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
+	buildInputs = [ ocaml findlib dune_2 js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
 
 	propagatedBuildInputs = [ js_of_ocaml reactivedata tyxml ];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes and improvements: https://github.com/ocsigen/js_of_ocaml/releases/tag/3.6.0

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
