### PR TITLE
nixos/systemPackages: clean up

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -659,7 +659,7 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
    </listitem>
    <listitem>
     <para>
-      The packages perl, rsync and strace where removed from systemPackages. If you need them, install them again with <literal>environment.systemPackages = with pkgs; [ perl rsync strace ];</literal> in your <literal>configuration.nix</literal>.
+      The packages <package>perl</package>, <package>rsync</package> and <package>strace</package> where removed from <option>systemPackages</option>. If you need them, install them again with <code><xref linkend="opt-environment.systemPackages"/> = with pkgs; [ perl rsync strace ];</code> in your <filename>configuration.nix</filename>.
     </para>
    </listitem>
   </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -659,7 +659,7 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
    </listitem>
    <listitem>
     <para>
-      The packages <package>perl</package>, <package>rsync</package> and <package>strace</package> where removed from <option>systemPackages</option>. If you need them, install them again with <code><xref linkend="opt-environment.systemPackages"/> = with pkgs; [ perl rsync strace ];</code> in your <filename>configuration.nix</filename>.
+      The packages <package>perl</package>, <package>rsync</package> and <package>strace</package> were removed from <option>systemPackages</option>. If you need them, install them again with <code><xref linkend="opt-environment.systemPackages"/> = with pkgs; [ perl rsync strace ];</code> in your <filename>configuration.nix</filename>.
     </para>
    </listitem>
   </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -657,6 +657,11 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
      since Nextcloud doesn't support upgrades across multiple major versions.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      The packages perl, rsync and strace where removed from systemPackages. If you need them, install them again with <literal>environment.systemPackages = with pkgs; [ perl rsync strace ];</literal> in your <literal>configuration.nix</literal>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -33,14 +33,11 @@ let
       pkgs.ncurses
       pkgs.netcat
       config.programs.ssh.package
-      pkgs.perl
       pkgs.procps
-      pkgs.rsync
-      pkgs.strace
       pkgs.su
       pkgs.time
       pkgs.utillinux
-      pkgs.which # 88K size
+      pkgs.which
       pkgs.zstd
     ];
 

--- a/nixos/modules/profiles/base.nix
+++ b/nixos/modules/profiles/base.nix
@@ -26,6 +26,7 @@
     pkgs.fuse
     pkgs.fuse3
     pkgs.sshfs-fuse
+    pkgs.rsync
     pkgs.socat
     pkgs.screen
 


### PR DESCRIPTION
###### Motivation for this change

clean up unneeded packages, reduce NixOS closure size

in detail:

- perl (there shouldn't be a script that depend on it implicitly. [nixos-generate-config.pl](https://github.com/NixOS/nixpkgs/blob/f76d7b5e418b17faac5953e4fc617fbd8d9622c1/nixos/modules/installer/tools/nixos-generate-config.pl) does not)
- rsync (was needed for nixos-install, but not anymore https://github.com/NixOS/nixpkgs/commit/0aa75206705afc71b991cceeede644c87088d583)
- strace (not really an enduser tool)

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

ran some random tests

tests.login.x86_64-linux
tests.env.x86_64-linux
nix-build nixos/tests/installer.nix Killed because it needs more than 40 GB RAM
nix-build nixos/tests/misc.nix
nix-build nixos/tests/boot.nix

- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)

the closure size is not different:

```
[davidak@gaming:~/code/nixpkgs]$ nix-build -I nixpkgs=/home/davidak/code/nixpkgs nixos/release.nix -A containerTarball.x86_64-linux

[davidak@gaming:~/code/nixpkgs]$ du -sclh $(nix-store -qR ./result)
141M	/nix/store/74ja4msci7dgc67b1x5nijwk0qqdqlbb-tarball
141M	total

[davidak@gaming:~/code/nixpkgs]$ du -sclh $(nix-store -qR ./result)
141M	/nix/store/zz2575f226dbkiydqhvghh1wacwwz5fs-tarball
141M	total
```


the difference:
```
these derivations will be built:
  /nix/store/1cbghy1ahiacglpahix2i2xp4mkcba38-system-path.drv
  /nix/store/nh4k6q73ld8b5jdr8gs5lqwl348gj0q1-dbus-1.drv
  /nix/store/c365dnl3ahqvz0ysa6fqgaa5l2g4mgl0-unit-dbus.service.drv
  /nix/store/r0psm5vmx2vdxza0n7ld5picxrz17p5g-unit-polkit.service.drv
  /nix/store/zlvqbp5ddbc6fb76f2nh51iwfas2nrmr-unit-systemd-fsck-.service.drv
  /nix/store/f0ywnddw6qmqzk0ypmvlywknzwskrprq-system-units.drv
  /nix/store/5gvkvjqs0gr9iisksf3yk2f76avb98f5-unit-dbus.service.drv
  /nix/store/p43i555b9nlymcf7fhsqs00kql6xppzw-user-units.drv
  /nix/store/1cm5vvcnlyahp9vqfjmp8z8brlpsfh65-etc.drv
  /nix/store/dqwcjx8762f7b1nz6kvg0nhhnwklvhg9-nixos-20.09pre130979.gfedcba.drv
  /nix/store/l1nh855k4gdkzm0y99z2xvv6pfgx4l6w-local-cmds.drv
  /nix/store/krrn5h1910man8qk6x604x3spbfmlms5-stage-2-init.sh.drv
  /nix/store/0lwd9iy6zzmcgsj97b7h12qcis5qmghr-nixos-system-nixos-20.09pre130979.gfedcba.drv
  /nix/store/wdp3705pa6hy0m81w48jkkq26qh773fw-closure-info.drv
  /nix/store/8nnnjg0lszvip6bhwlghr0vvdx1dld7b-tarball.drv
these paths will be fetched (4.03 MiB download, 5.53 MiB unpacked):
  /nix/store/gzp6iwfqai2695745ll1japqqv00kh5h-perl-5.30.3-man
  /nix/store/jvvx1r502zp5sqnknd7r986zvjv0xhgm-strace-5.7
  /nix/store/ps9d4h1brmbwv67z0kkk2lhxmn6dgg7l-rsync-3.1.3
  /nix/store/r84yia1yf5w0rf6vxmk1x026kjr8q62g-libunwind-1.4.0
  /nix/store/z72xf9frcp3vk2pjx8xq0c3km8lyammp-popt-1.16
```


- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
