### PR TITLE
Unbreak dsniff by partially reverting a commit to libpcap

### DIFF
--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -28,6 +28,12 @@ stdenv.mkDerivation rec {
     substituteInPlace configure --replace " -arch i386" ""
   '';
 
+  postInstall = ''
+    if [ "$dontDisableStatic" -ne "1" ]; then
+      rm -f $out/lib/libpcap.a
+    fi
+  '';
+
   meta = {
     homepage = "https://www.tcpdump.org";
     description = "Packet Capture Library";

--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -28,10 +28,6 @@ stdenv.mkDerivation rec {
     substituteInPlace configure --replace " -arch i386" ""
   '';
 
-  postInstall = ''
-    rm -f $out/lib/libpcap.a
-  '';
-
   meta = {
     homepage = "https://www.tcpdump.org";
     description = "Packet Capture Library";

--- a/pkgs/tools/networking/dsniff/default.nix
+++ b/pkgs/tools/networking/dsniff/default.nix
@@ -14,7 +14,7 @@ let
   };
   pcap = symlinkJoin {
     inherit (libpcap) name;
-    paths = [ libpcap ];
+    paths = [ (libpcap.overrideAttrs(old: { dontDisableStatic = true; })) ];
     postBuild = ''
       cp -rs $out/include/pcap $out/include/net
       # prevent references to libpcap


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

In current master, dsniff is [broken](https://hydra.nixos.org/build/122531595/nixlog/1). This is because in commit 34aff7f6973743a5e6e672c01016c4280d471453 we [changed](https://github.com/NixOS/nixpkgs/commit/34aff7f6973743a5e6e672c01016c4280d471453#diff-f14b5b28cf6a58c55c8a89490aed5b31) our libpcap package to no longer provide the static library `libpcap.a`.

This pull request reverts the addition of `rm -f $out/lib/libpcap.a` in the libpcap build, thereby unbreaking dsniff, but I'm not sure whether this is the right approach. @matthewbauer, perhaps you can comment on this? According to your commit message, you just wanted to strip more things. Perhaps the removal of the static library was in error?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
