### PR TITLE
hercules-ci-agent: init at 0.7.2

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2659,6 +2659,9 @@ package-maintainers:
     - Agda
   roberth:
     - arion-compose
+    - hercules-ci-agent
+    - hercules-ci-api-core
+    - hercules-ci-api-agent
   cdepillabout:
     - pretty-simple
     - spago

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -96,6 +96,7 @@ self: super: builtins.intersectAttrs super {
 
   # profiling is disabled to allow C++/C mess to work, which is fixed in GHC 8.8
   cachix = disableLibraryProfiling super.cachix;
+  hercules-ci-agent = disableLibraryProfiling super.hercules-ci-agent;
 
   # avoid compiling twice by providing executable as a separate output (with small closure size)
   niv = enableSeparateBinOutput super.niv;

--- a/pkgs/development/tools/continuous-integration/hercules-ci-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/hercules-ci-agent/default.nix
@@ -1,0 +1,21 @@
+{ gnutar, gzip, git, haskell, haskellPackages, lib, makeWrapper }:
+let
+  inherit (haskell.lib) overrideCabal addBuildDepends;
+  inherit (lib) makeBinPath;
+  pkg =
+    # justStaticExecutables is needed due to https://github.com/NixOS/nix/issues/2990
+    overrideCabal
+      (addBuildDepends (haskell.lib.justStaticExecutables haskellPackages.hercules-ci-agent) [ makeWrapper ])
+      (o: {
+        postInstall = ''
+          ${o.postInstall or ""}
+          mkdir -p $out/libexec
+          mv $out/bin/hercules-ci-agent $out/libexec
+          makeWrapper $out/libexec/hercules-ci-agent $out/bin/hercules-ci-agent --prefix PATH : ${makeBinPath [ gnutar gzip git ]}
+        '';
+      });
+in pkg // {
+    meta = pkg.meta // {
+      position = toString ./default.nix + ":1";
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11411,6 +11411,8 @@ in
   # justStaticExecutables is needed due to https://github.com/NixOS/nix/issues/2990
   cachix = haskell.lib.justStaticExecutables haskellPackages.cachix;
 
+  hercules-ci-agent = callPackage ../development/tools/continuous-integration/hercules-ci-agent { };
+
   niv = haskellPackages.niv.bin;
 
   ormolu = haskellPackages.ormolu.bin;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Hercules CI is a continuous integration system that uses Nix as its foundation. Users run `hercules-ci-agent` themselves to execute their CI jobs. Packaging it in Nixpkgs will make installation easier. A NixOS module will be provided in a separate PR.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date -> meta fields are up to date and complete compared to `pkgs.nix`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
