### PR TITLE
tracy: 0.6.3 -> 0.7

### DIFF
--- a/pkgs/development/tools/tracy/default.nix
+++ b/pkgs/development/tools/tracy/default.nix
@@ -1,23 +1,23 @@
-{ stdenv, lib, darwin, fetchFromGitHub, tbb, gtk2, glfw, pkgconfig, freetype, Carbon, AppKit }:
+{ stdenv, lib, darwin, fetchFromGitHub, tbb, gtk2, glfw, pkgconfig, freetype, Carbon, AppKit, capstone }:
 
 stdenv.mkDerivation rec {
-  name    = "tracy-${version}";
-  version = "0.6.3";
+  name = "tracy-${version}";
+  version = "0.7";
 
   src = fetchFromGitHub {
     owner = "wolfpld";
     repo = "tracy";
     rev = "v${version}";
-    sha256 = "0pgq8h5gq141zq1k4cgj6cp74kh4zqbp7h4wh29q4grjb04yy06i";
+    sha256 = "07cmz2w7iv10f9i9q3fhg80s6riy9bxnk9xvc3q4lw47mc150skp";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ glfw ]
+  buildInputs = [ glfw capstone ]
     ++ lib.optionals stdenv.isDarwin [ Carbon AppKit freetype ]
     ++ lib.optionals stdenv.isLinux [ gtk2 tbb ];
 
-  NIX_CFLAGS_COMPILE = []
+  NIX_CFLAGS_COMPILE = [ ]
     ++ lib.optional stdenv.isLinux "-ltbb"
     ++ lib.optional stdenv.cc.isClang "-faligned-allocation";
 


### PR DESCRIPTION
###### Motivation for this change

Update tracy from 0.6.3 to 0.7.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  * before: `/nix/store/16p9m62xlb5swnard38ixf4rlaw7pxf8-tracy-0.6.3  621.2M`
  * after: `/nix/store/z1xc6rl6a98v1vsjzmm8pq8dxvxk9w3z-tracy-0.7    645.5M`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).