### PR TITLE
tracy: add capture and update binaries

### DIFF
--- a/pkgs/development/tools/tracy/default.nix
+++ b/pkgs/development/tools/tracy/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, darwin, fetchFromGitHub, tbb, gtk2, glfw, pkgconfig, freetype, Carbon, AppKit, capstone }:
 
 stdenv.mkDerivation rec {
-  name = "tracy-${version}";
+  pname = "tracy";
   version = "0.7";
 
   src = fetchFromGitHub {
@@ -24,11 +24,15 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     make -j $NIX_BUILD_CORES -C profiler/build/unix release
     make -j $NIX_BUILD_CORES -C import-chrome/build/unix/ release
+    make -j $NIX_BUILD_CORES -C capture/build/unix/ release
+    make -j $NIX_BUILD_CORES -C update/build/unix/ release
   '';
 
   installPhase = ''
     install -D ./profiler/build/unix/Tracy-release $out/bin/Tracy
     install -D ./import-chrome/build/unix/import-chrome-release $out/bin/import-chrome
+    install -D ./capture/build/unix/capture-release $out/bin/capture
+    install -D ./update/build/unix/update-release $out/bin/update
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/tracy/default.nix
+++ b/pkgs/development/tools/tracy/default.nix
@@ -1,23 +1,23 @@
-{ stdenv, lib, darwin, fetchFromGitHub, tbb, gtk2, glfw, pkgconfig, freetype, Carbon, AppKit }:
+{ stdenv, lib, darwin, fetchFromGitHub, tbb, gtk2, glfw, pkgconfig, freetype, Carbon, AppKit, capstone }:
 
 stdenv.mkDerivation rec {
-  name    = "tracy-${version}";
-  version = "0.6.3";
+  name = "tracy-${version}";
+  version = "0.7";
 
   src = fetchFromGitHub {
     owner = "wolfpld";
     repo = "tracy";
     rev = "v${version}";
-    sha256 = "0pgq8h5gq141zq1k4cgj6cp74kh4zqbp7h4wh29q4grjb04yy06i";
+    sha256 = "07cmz2w7iv10f9i9q3fhg80s6riy9bxnk9xvc3q4lw47mc150skp";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ glfw ]
+  buildInputs = [ glfw capstone ]
     ++ lib.optionals stdenv.isDarwin [ Carbon AppKit freetype ]
     ++ lib.optionals stdenv.isLinux [ gtk2 tbb ];
 
-  NIX_CFLAGS_COMPILE = []
+  NIX_CFLAGS_COMPILE = [ ]
     ++ lib.optional stdenv.isLinux "-ltbb"
     ++ lib.optional stdenv.cc.isClang "-faligned-allocation";
 


### PR DESCRIPTION
#### Motivation for this change

These are used to capture the trace without using the GUI tool and
update the saved trace files from older to newer versions. `update` also
allows to re-compress the trace files for whatever reason one might want
to do it.

Based on top of #91228 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @mpickering @cpcloud 