### PR TITLE
python3Packages.PyRMVtransport: init at 0.2.9

### DIFF
--- a/pkgs/development/python-modules/PyRMVtransport/default.nix
+++ b/pkgs/development/python-modules/PyRMVtransport/default.nix
@@ -1,0 +1,48 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, flit
+, lxml, aiohttp
+, pytest, pytestcov, pytest-asyncio, pytest-mock, pytest-aiohttp, aresponses
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "PyRMVtransport";
+  version = "0.2.9";
+  format = "pyproject";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "cgtobi";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1h3d0yxzrfi47zil5gr086v0780q768z8v5psvcikqw852f93vxb";
+  };
+
+  nativeBuildInputs = [
+    flit
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    lxml
+  ];
+
+  checkInputs = [
+    pytest
+    pytestcov
+    pytest-asyncio
+    pytest-mock
+    pytest-aiohttp
+    aresponses
+  ];
+  checkPhase = ''
+    pytest --cov=RMVtransport tests
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/cgtobi/PyRMVtransport";
+    description = "Get transport information from opendata.rmv.de";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -657,7 +657,7 @@
     "rfxtrx" = ps: with ps; [ ]; # missing inputs: pyRFXtrx
     "ring" = ps: with ps; [ ha-ffmpeg]; # missing inputs: ring_doorbell
     "ripple" = ps: with ps; [ ]; # missing inputs: python-ripple-api
-    "rmvtransport" = ps: with ps; [ ]; # missing inputs: PyRMVtransport
+    "rmvtransport" = ps: with ps; [ PyRMVtransport];
     "rocketchat" = ps: with ps; [ ]; # missing inputs: rocketchat-API
     "roku" = ps: with ps; [ ]; # missing inputs: rokuecp
     "roomba" = ps: with ps; [ ]; # missing inputs: roombapy

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1287,6 +1287,8 @@ in {
 
   pyres = callPackage ../development/python-modules/pyres { };
 
+  PyRMVtransport = callPackage ../development/python-modules/PyRMVtransport { };
+
   pyqt4 = callPackage ../development/python-modules/pyqt/4.x.nix {
     inherit (pkgs) pkgconfig;
   };


### PR DESCRIPTION
##### Motivation for this change

Bindings for the public transport API of  the Rhein-Main-Verkehrsverbund (Hessen, Germany).

It's required for https://www.home-assistant.io/integrations/rmvtransport/ and I have it up and running in my home-assistant right now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@Mic92