### PR TITLE
systemd: Allow setting the transient hostname via DHCP

### DIFF
--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -97,6 +97,11 @@ import ./make-test-python.nix ({ pkgs, ... }: {
             re.search(r"^Filesystem state: *clean$", extinfo, re.MULTILINE) is not None
         ), ("File system was not cleanly unmounted: " + extinfo)
 
+    # Regression test for https://github.com/NixOS/nixpkgs/pull/91232
+    with subtest("setting transient hostnames works"):
+        machine.succeed("hostnamectl set-hostname --transient machine-transient")
+        machine.fail("hostnamectl set-hostname machine-all")
+
     with subtest("systemd-shutdown works"):
         machine.shutdown()
         machine.wait_for_unit("multi-user.target")

--- a/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
+++ b/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
@@ -14,16 +14,6 @@ diff --git a/src/hostname/hostnamed.c b/src/hostname/hostnamed.c
 index 21f6471495..8c5af7619f 100644
 --- a/src/hostname/hostnamed.c
 +++ b/src/hostname/hostnamed.c
-@@ -422,6 +422,9 @@ static int method_set_hostname(sd_bus_message *m, void *userdata, sd_bus_error *
-         if (r < 0)
-                 return r;
- 
-+        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
-+            "Changing system settings via systemd is not supported on NixOS.");
-+
-         if (isempty(name))
-                 name = c->data[PROP_STATIC_HOSTNAME];
- 
 @@ -478,6 +481,9 @@ static int method_set_static_hostname(sd_bus_message *m, void *userdata, sd_bus_
          if (r < 0)
                  return r;


### PR DESCRIPTION
This permits using method_set_hostname but still denies
method_set_static_hostname. As a result DHCP clients can now always set
the transient hostname via the SetHostname method of the D-Bus interface
of systemd-hostnamed (org.freedesktop.hostname1.set-hostname).
If the NixOS option networking.hostName is set to an empty string (or
"localhost") the static hostname (kernel.hostname but NOT /etc/hostname)
will additionally be updated (this is intended).

From "man hostnamectl": The transient hostname is a fallback value
received from network configuration. If a static hostname is set, and is
valid (something other than localhost), then the transient hostname is
not used.

Fix #74847.

Note: It's possible to restrict access to the org.freedesktop.hostname1
interface using Polkit rules.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

<details>
<summary>Examples</summary>
<pre>
[root@quorra:/var/nixpkgs-test]# hostnamectl --pretty


[root@quorra:/var/nixpkgs-test]# hostnamectl --static
quorra

[root@quorra:/var/nixpkgs-test]# hostnamectl --transient
quorra

[root@quorra:/var/nixpkgs-test]# hostnamectl --transient set-hostname nixos
Could not set property: Changing system settings via systemd is not supported on NixOS.

[root@quorra:/var/nixpkgs-test]# # With this PR:

[root@quorra:/var/nixpkgs-test]# hostnamectl --transient set-hostname nixos

[root@quorra:/var/nixpkgs-test]# hostnamectl --pretty


[root@quorra:/var/nixpkgs-test]# hostnamectl --static
quorra

[root@quorra:/var/nixpkgs-test]# hostnamectl --transient
nixos

[root@quorra:/var/nixpkgs-test]# cat /etc/hostname
quorra

[root@quorra:/var/nixpkgs-test]# sysctl kernel.hostname
kernel.hostname = quorra

[root@quorra:/var/nixpkgs-test]# # With an empty hostname (networking.hostName):

[root@quorra:/var/nixpkgs-test]# cat /etc/hostname
cat: /etc/hostname: No such file or directory

[root@quorra:/var/nixpkgs-test]# sysctl kernel.hostname
kernel.hostname = quorra

[root@quorra:/var/nixpkgs-test]# hostnamectl --pretty


[root@quorra:/var/nixpkgs-test]# hostnamectl --static


[root@quorra:/var/nixpkgs-test]# hostnamectl --transient
quorra

[root@quorra:/var/nixpkgs-test]# hostnamectl --transient set-hostname test

[root@quorra:/var/nixpkgs-test]# cat /etc/hostname
cat: /etc/hostname: No such file or directory

[root@quorra:/var/nixpkgs-test]# sysctl kernel.hostname
kernel.hostname = test

[root@quorra:/var/nixpkgs-test]# hostnamectl --pretty


[root@quorra:/var/nixpkgs-test]# hostnamectl --static


[root@quorra:/var/nixpkgs-test]# hostnamectl --transient
test

[root@quorra:/var/nixpkgs-test]# hostname
test

[root@quorra:/var/nixpkgs-test]# hostnamectl --static set-hostname test
Could not set property: Changing system settings via systemd is not supported on NixOS.
</pre>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
