### PR TITLE
openimagedenoise: 1.1.0 -> 1.2.1

### DIFF
--- a/pkgs/development/libraries/openimagedenoise/default.nix
+++ b/pkgs/development/libraries/openimagedenoise/default.nix
@@ -1,18 +1,16 @@
-{ stdenv, fetchFromGitHub, cmake, tbb, python }:
+{ stdenv, fetchzip, cmake, tbb, python, ispc }:
 
 stdenv.mkDerivation rec {
   pname = "openimagedenoise";
-  version = "1.1.0";
+  version = "1.2.1";
 
-  src = fetchFromGitHub {
-    owner = "OpenImageDenoise";
-    repo = "oidn";
-    rev = "v${version}";
-    sha256 = "032s7vablqnmrcc4xf2c94kwj0kbcd64bram10g0yc42fg0a3r9m";
-    fetchSubmodules = true;
+  # The release tarballs include pretrained weights, which would otherwise need to be fetched with git-lfs
+  src = fetchzip {
+    url = "https://github.com/OpenImageDenoise/oidn/releases/download/v${version}/oidn-${version}.src.tar.gz";
+    sha256 = "1f8s69ixv7nsdap9hc2njli2x75zmlrfq8cy79772gz83kph8s25";
   };
 
-  nativeBuildInputs = [ cmake python ];
+  nativeBuildInputs = [ cmake python ispc ];
   buildInputs = [ tbb ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/OpenImageDenoise/oidn/releases/tag/v1.2.1

###### Things done

Practically no testing, particularly not Blender.
Fetching with git-lfs was not fun at all, so fetchzip it is.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
