### PR TITLE
i3ipc-autotiling: init at d521cd6

### DIFF
--- a/pkgs/applications/window-managers/i3/i3ipc-autotiling.nix
+++ b/pkgs/applications/window-managers/i3/i3ipc-autotiling.nix
@@ -15,7 +15,8 @@ python3Packages.buildPythonApplication rec {
    doCheck = false;
    installPhase = ''
     mkdir -p "$out/bin"
-    cp autotiling.py "$out/bin/autotiling"'';
+    cp autotiling.py "$out/bin/autotiling"
+  '';
    postInstall = ''
     makeWrapper ${python3Packages.python.interpreter} $out/bin/${pname}-python-interpreter
     '';

--- a/pkgs/applications/window-managers/i3/i3ipc-autotiling.nix
+++ b/pkgs/applications/window-managers/i3/i3ipc-autotiling.nix
@@ -1,0 +1,28 @@
+{ lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "i3ipc-autotiling";
+  version = "d521cd6d26d0b3aadbd283fe4165235b5df386f2";
+  src = fetchTarball {
+    name = pname;
+    url = "https://github.com/nwg-piotr/autotiling/archive/${version}.tar.gz";
+     # Hash obtained using `nix-prefetch-url --unpack <url>`
+     sha256 = "1lz1fasm4586vw9y0hdl2fn56swb7jbsgi71n1jwdfl3bnhawv0s";
+   };
+   propagatedBuildInputs = [ python3Packages.i3ipc ];
+
+   dontBuild = true;
+   doCheck = false;
+   installPhase = ''
+    mkdir -p "$out/bin"
+    cp autotiling.py "$out/bin/autotiling"'';
+   postInstall = ''
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/${pname}-python-interpreter
+    '';
+   meta = with lib; {
+     homepage = https://github.com/nwg-piotr/autotiling;
+     description = "Script for sway and i3 to automatically switch the horizontal / vertical window split orientation";
+     license = licenses.gpl3;
+     maintainers = with maintainers; [ nwg-piotr ];
+   };
+ }


### PR DESCRIPTION
Useful autotiling script for i3 & sway.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Used it on my other machine, a simple script for automatic switch the tile mode from vertical to horizontal when the window is higher than bigger.. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
