### PR TITLE
[haskell-updates] hackagePackages.hnix: Disable completion to fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -219,10 +219,12 @@ self: super: {
   # base bound
   digit = doJailbreak super.digit;
 
-  # 2020-06-05: HACK: does not passes own build suite - `dontCheck`
-  hnix = generateOptparseApplicativeCompletion "hnix" (
-    dontCheck super.hnix
-    );
+  # 2020-06-05: HACK: does not passes own build suite - `dontCheck` We should
+  # generate optparse-applicative completions for the hnix executable.  Sadly
+  # building of the executable has been disabled for ghc < 8.10 in hnix.
+  # Generating the completions should be activated again, once we default to
+  # ghc 8.10.
+  hnix = dontCheck super.hnix;
 
   # Fails for non-obvious reasons while attempting to use doctest.
   search = dontCheck super.search;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -132,4 +132,7 @@ self: super: {
     excludes = ["package.yaml"];
   });
 
+  # hnix 0.9.0 does not provide an executable for ghc < 8.10, so define completions here for now.
+  hnix = generateOptparseApplicativeCompletion "hnix" super.hnix;
+
 }


### PR DESCRIPTION
The optparse-applicative completion generation does not work for hnix
0.9.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
