### PR TITLE
ocamlPackages.tls: 0.12.1 → 0.12.2

### DIFF
--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -4,14 +4,14 @@
 , hacl_x25519, fiat-p256, hkdf, logs, alcotest }:
 
 buildDunePackage rec {
-  minimumOCamlVersion = "4.07";
+  minimumOCamlVersion = "4.08";
 
-  version = "0.12.1";
+  version = "0.12.2";
   pname = "tls";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-tls/releases/download/v${version}/tls-v${version}.tbz";
-    sha256 = "09jhzjhni3il5bmy2c6gylmg9s45ppckjc7nm5nyg5dbm699cwxg";
+    sha256 = "1wpgs0cd79wl4lnn1i44xjn8prha793nrbyv68zjiqpq3gmpyy3k";
   };
 
   useDune2 = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/mirleft/ocaml-tls/releases/tag/v0.12.2>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
