### PR TITLE
zziplib: convert back to autotools build

### DIFF
--- a/pkgs/development/libraries/zziplib/default.nix
+++ b/pkgs/development/libraries/zziplib/default.nix
@@ -1,7 +1,6 @@
 { stdenv
-, cmake
+, perl
 , pkg-config
-, ninja
 , fetchFromGitHub
 , fetchpatch
 , zip
@@ -23,12 +22,6 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # Fix ninja parsing
-    (fetchpatch {
-      url = "https://github.com/gdraheim/zziplib/commit/75e22f3c365b62acbad8d8645d5404242800dfba.patch";
-      sha256 = "IB0am3K0x4+Ug1CKvowTtkS8JD6zHJJ247A7guJOw80=";
-    })
-
     # Install man pages
     (fetchpatch {
       url = "https://github.com/gdraheim/zziplib/commit/5583ccc7a247ee27556ede344e93d3ac1dc72e9b.patch";
@@ -44,9 +37,8 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    cmake
+    perl
     pkg-config
-    ninja # make fails, unable to find test2.zip
     zip
     python3
     xmlto
@@ -58,10 +50,6 @@ stdenv.mkDerivation rec {
 
   checkInputs = [
     unzip
-  ];
-
-  cmakeFlags = [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # for tests
   ];
 
   # tests are broken (https://github.com/gdraheim/zziplib/issues/20),


### PR DESCRIPTION
The cmake support in the v0.13.x branch is not very good. It heavily
relies on add_custom_command and is fragile.

The specific problem we ran into is that the install phase would not
create some of the symlinks on darwin. This breaks reverse
dependencies (e.g. texlive).

Fixes: 4f701dd3 ('zziplib: 0.13.69 → 0.13.71')

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

zziplib on darwin after #85147 is missing libzzip.dylib, libzzip.la, but provides libzzip-0.13.0.71.dylib:
```
# diff -u <(ls -1 old/lib | sort) <(ls -1 new/lib | sort)
--- /dev/fd/11  2020-06-21 18:33:23.000000000 -0400
+++ /dev/fd/12  2020-06-21 18:33:23.000000000 -0400
@@ -1,13 +1,13 @@
+libzzip-0.13.0.71.dylib
 libzzip-0.13.dylib
-libzzip.dylib
-libzzip.la
+libzzip-0.dylib
+libzzipfseeko-0.13.0.71.dylib
 libzzipfseeko-0.13.dylib
-libzzipfseeko.dylib
-libzzipfseeko.la
+libzzipfseeko-0.dylib
+libzzipmmapped-0.13.0.71.dylib
 libzzipmmapped-0.13.dylib
-libzzipmmapped.dylib
-libzzipmmapped.la
+libzzipmmapped-0.dylib
+libzzipwrap-0.13.0.71.dylib
 libzzipwrap-0.13.dylib
-libzzipwrap.dylib
-libzzipwrap.la
+libzzipwrap-0.dylib
 pkgconfig
```
This PR unbreaks `texlive.bin.core-big` on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
