### PR TITLE
chewing-editor: init at 0.1.1 Add package `chewing-editor`

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7148,6 +7148,12 @@
     githubId = 24496705;
     name = "Scott Hamilton";
   };
+  ShamrockLee = {
+    name = "Shamrock Lee";
+    email = "44064051+ShamrockLee@users.noreply.github.com";
+    github = "ShamrockLee";
+    githubId = 44064051;
+  };
   shanemikel = {
     email = "shanepearlman@pm.me";
     github = "shanemikel";

--- a/pkgs/applications/misc/chewing-editor/default.nix
+++ b/pkgs/applications/misc/chewing-editor/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, mkDerivation, fetchFromGitHub, cmake, pkgconfig, libchewing, qtbase
+, qttools }:
+
+mkDerivation rec {
+  pname = "chewing-editor";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "chewing";
+    repo = "${pname}";
+    rev = "${version}";
+    sha256 = "0kc2hjx1gplm3s3p1r5sn0cyxw3k1q4gyv08q9r6rs4sg7xh2w7w";
+  };
+
+  doCheck = true;
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ libchewing qtbase qttools ];
+
+  meta = with stdenv.lib; {
+    description = "Cross platform chewing user phrase editor";
+    longDescription = ''
+      chewing-editor is a cross platform chewing user phrase editor. It provides a easy way to manage user phrase. With it, user can customize their user phrase to increase input performance.
+    '';
+    homepage = "https://github.com/chewing/chewing-editor";
+    license = licenses.gpl2Plus;
+    maintainers = [ ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/misc/chewing-editor/default.nix
+++ b/pkgs/applications/misc/chewing-editor/default.nix
@@ -24,7 +24,7 @@ mkDerivation rec {
     '';
     homepage = "https://github.com/chewing/chewing-editor";
     license = licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = [ maintainers.ShamrockLee ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3400,6 +3400,8 @@ in
 
   fcitx-configtool = callPackage ../tools/inputmethods/fcitx/fcitx-configtool.nix { };
 
+  chewing-editor = libsForQt5.callPackage ../applications/misc/chewing-editor { };
+
   fcppt = callPackage ../development/libraries/fcppt { };
 
   fcrackzip = callPackage ../tools/security/fcrackzip { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
chewing-editor is the user phrase editor
for Chewing input method
(one of the most popular bopomofo Chinese input method)
Chewing IM memorize phrases input by the user automatically
or when the hot keys are pressed.
If applied, the commit will enable Chewing user to correct the phrases in the
database or add new ones, which is a crucial functionality of Chewing IM
that haven't been in NixOS.
The corresponded Packaging Request is #89554.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
