### PR TITLE
sqlitebrowser: 3.11.2 -> 3.12.0

### DIFF
--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -1,30 +1,30 @@
 { mkDerivation, lib, fetchFromGitHub, cmake, antlr
-, qtbase, qttools, qscintilla, sqlite }:
+, qtbase, qttools, sqlite }:
 
 mkDerivation rec {
   pname = "sqlitebrowser";
-  version = "3.11.2";
+  version = "3.12.0";
 
   src = fetchFromGitHub {
-    owner  = pname;
-    repo   = pname;
-    rev    = "v${version}";
-    sha256 = "0ydd5fg76d5d23byac1f7f8mzx3brmd0cnnkd58qpmlzi7p9hcvx";
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "1arv4rzl8s1vjjqzz35l2b1rfzr2b8b23v97fdw1kdxpwvs63l99";
   };
 
-  buildInputs = [ antlr qtbase qscintilla sqlite ];
+  # We should be using qscintilla from nixpkgs instead of the vendored version,
+  # but qscintilla is currently in a bit of a mess as some consumers expect a
+  # -qt4 or -qt5 prefix while others do not.
+  # We *really* should get that cleaned up.
+  buildInputs = [ antlr qtbase sqlite ];
 
   nativeBuildInputs = [ cmake qttools ];
-
-  NIX_LDFLAGS = "-lQt5PrintSupport";
-
-  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "DB Browser for SQLite";
     homepage = "https://sqlitebrowser.org/";
     license = licenses.gpl3;
-    maintainers = with maintainers; [  ];
+    maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

General update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
