### PR TITLE
python3Packages.pip: allow setting reproducible temporary directory via NIX_PIP_INSTALL_TMPDIR

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
@@ -11,7 +11,9 @@ pipInstallPhase() {
     export PYTHONPATH="$out/@pythonSitePackages@:$PYTHONPATH"
 
     pushd dist || return 1
-    @pythonInterpreter@ -m pip install ./*.whl --no-index --prefix="$out" --no-cache $pipInstallFlags --build tmpbuild
+    mkdir tmpbuild
+    NIX_PIP_INSTALL_TMPDIR=tmpbuild @pythonInterpreter@ -m pip install ./*.whl --no-index --prefix="$out" --no-cache $pipInstallFlags
+    rm -rf tmpbuild
     popd || return 1
 
     runHook postInstall

--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -25,6 +25,10 @@ buildPythonPackage rec {
     name = "${pname}-${version}-source";
   };
 
+  # Remove when solved https://github.com/NixOS/nixpkgs/issues/81441
+  # Also update pkgs/development/interpreters/python/hooks/pip-install-hook.sh accordingly
+  patches = [ ./reproducible.patch ];
+
   nativeBuildInputs = [ bootstrapped-pip ];
 
   # pip detects that we already have bootstrapped_pip "installed", so we need

--- a/pkgs/development/python-modules/pip/reproducible.patch
+++ b/pkgs/development/python-modules/pip/reproducible.patch
@@ -1,0 +1,13 @@
+diff --git a/src/pip/_internal/operations/install/wheel.py b/src/pip/_internal/operations/install/wheel.py
+index e7315ee4..4e36b03d 100644
+--- a/src/pip/_internal/operations/install/wheel.py
++++ b/src/pip/_internal/operations/install/wheel.py
+@@ -615,6 +615,8 @@ def install_wheel(
+     direct_url=None,  # type: Optional[DirectUrl]
+ ):
+     # type: (...) -> None
++    _temp_dir_for_testing = (
++        _temp_dir_for_testing or os.environ.get("NIX_PIP_INSTALL_TMPDIR"))
+     with TempDirectory(
+         path=_temp_dir_for_testing, kind="unpacked-wheel"
+     ) as unpacked_dir, ZipFile(wheel_path, allowZip64=True) as z:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Another approach to https://github.com/NixOS/nixpkgs/issues/81441 as https://github.com/NixOS/nixpkgs/pull/90208 caused too many regressions.

With this patch `pip` will use `NIX_PIP_INSTALL_TMPDIR` as temporary directory when defined, usual code path will be used otherwise.

I've built some packages to make sure it's working:
- [X] `pkgs.python2Packages.flask`
- [X] `pkgs.python2Packages.invoke`
- [X] `pkgs.python3Packages.flask`
- [X] `pkgs.python3Packages.invoke`
- [X] `pkgs.python3Packages.aiohttp` - not reproducible (most likely unrelated)
- [X] `pkgs.gtk-doc`
- [X] `nixos.iso_minimal.x86_64-linux` - not reproducible (obvious)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
