### PR TITLE
httpie: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/tools/networking/httpie/default.nix
+++ b/pkgs/tools/networking/httpie/default.nix
@@ -1,21 +1,30 @@
-{ stdenv, fetchFromGitHub, python3Packages, docutils, }:
+{ stdenv, fetchFromGitHub, python3Packages, docutils, fetchpatch }:
 
 python3Packages.buildPythonApplication rec {
   pname = "httpie";
-  version = "2.1.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "jakubroztocil";
     repo = "httpie";
     rev = version;
-    sha256 = "1vwjlzx830q4dcm3r7j9cl8yzka37dw42rl1r05m5ysb1081cbj2";
+    sha256 = "0caazv24jr0844c4mdx77vzwwi5m869n10wa42cydb08ppx1xxj6";
   };
 
   outputs = [ "out" "doc" "man" ];
 
   propagatedBuildInputs = with python3Packages; [ pygments requests setuptools ];
   dontUseSetuptoolsCheck = true;
-  patches = [ ./strip-venv.patch ];
+  patches = [
+    ./strip-venv.patch
+
+    # Fix `test_ciphers_none_can_be_selected`
+    # TODO: remove on next release
+    (fetchpatch {
+      url = "https://github.com/jakubroztocil/httpie/commit/49e71d252f54871a6bc49cb1cba103d385a543b8.patch";
+      sha256 = "12dh3mkwvpg57m2hsf7nnnjy4852m38x45p13dcw9i2si8qbczqp";
+    })
+  ];
 
   checkInputs = with python3Packages; [
     mock


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/jakubroztocil/httpie/releases/tag/2.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
