### PR TITLE
stdenv: fix backward multiple outputs conditional

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -34,8 +34,6 @@ stdenv.mkDerivation rec {
     "-DUSE_KWALLET=OFF"
   ];
 
-  # Reduce the risk of collisions
-  postInstall = "rm -r $out/share/doc";
 
   # darktable changed its rpath handling in commit
   # 83c70b876af6484506901e6b381304ae0d073d3c and as a result the

--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -72,9 +72,6 @@ in stdenv.mkDerivation {
 
   NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-framework CoreFoundation";
 
-  # Reduce the risk of collisions
-  postInstall = "rm -r $out/share/doc";
-
   meta = {
     description = "A fast, easy and free BitTorrent client";
     longDescription = ''

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -61,7 +61,7 @@ _multioutConfig() {
             local shareDocName="$(sed -n "s/^PACKAGE_TARNAME='\(.*\)'$/\1/p" < "$confScript")"
         fi
                                     # PACKAGE_TARNAME sometimes contains garbage.
-        if [ -n "$shareDocName" ] || echo "$shareDocName" | grep -q '[^a-zA-Z0-9_-]'; then
+        if [ -z "$shareDocName" ] || echo "$shareDocName" | grep -q '[^a-zA-Z0-9_-]'; then
             shareDocName="$(echo "$name" | sed 's/-[^a-zA-Z].*//')"
         fi
     fi

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -68,19 +68,24 @@ cmakeConfigurePhase() {
     # nix/store directory.
     cmakeFlags="-DCMAKE_INSTALL_NAME_DIR=${!outputLib}/lib $cmakeFlags"
 
-    # This ensures correct paths with multiple output derivations
-    # It requires the project to use variables from GNUInstallDirs module
-    # https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
-    cmakeFlags="-DCMAKE_INSTALL_BINDIR=${!outputBin}/bin $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_SBINDIR=${!outputBin}/sbin $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_INCLUDEDIR=${!outputInclude}/include $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_OLDINCLUDEDIR=${!outputInclude}/include $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_MANDIR=${!outputMan}/share/man $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_INFODIR=${!outputInfo}/share/info $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_DOCDIR=${!outputDoc}/share/doc/${shareDocName} $cmakeFlags"
+    if [ "$outputs" != "out" -a -n "${setOutputFlags-1}" ]; then
+        # This ensures correct paths with multiple output derivations
+        # It requires the project to use variables from GNUInstallDirs module
+        # https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
+        cmakeFlags="-DCMAKE_INSTALL_BINDIR=${!outputBin}/bin $cmakeFlags"
+        cmakeFlags="-DCMAKE_INSTALL_SBINDIR=${!outputBin}/sbin $cmakeFlags"
+        cmakeFlags="-DCMAKE_INSTALL_INCLUDEDIR=${!outputInclude}/include $cmakeFlags"
+        cmakeFlags="-DCMAKE_INSTALL_OLDINCLUDEDIR=${!outputInclude}/include $cmakeFlags"
+        cmakeFlags="-DCMAKE_INSTALL_MANDIR=${!outputMan}/share/man $cmakeFlags"
+        cmakeFlags="-DCMAKE_INSTALL_INFODIR=${!outputInfo}/share/info $cmakeFlags"
+        cmakeFlags="-DCMAKE_INSTALL_DOCDIR=${!outputDoc}/share/doc/${shareDocName} $cmakeFlags"
+        cmakeFlags="-DCMAKE_INSTALL_LIBEXECDIR=${!outputLib}/libexec $cmakeFlags"
+        cmakeFlags="-DCMAKE_INSTALL_LOCALEDIR=${!outputLib}/share/locale $cmakeFlags"
+    fi
+
+    # This output flag must always be set, unlike the others, because
+    # otherwise we end up with lib64.
     cmakeFlags="-DCMAKE_INSTALL_LIBDIR=${!outputLib}/lib $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_LIBEXECDIR=${!outputLib}/libexec $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_LOCALEDIR=${!outputLib}/share/locale $cmakeFlags"
 
     # Don’t build tests when doCheck = false
     if [ -z "${doCheck-}" ]; then
@@ -115,7 +120,6 @@ cmakeConfigurePhase() {
 }
 
 if [ -z "${dontUseCmakeConfigure-}" -a -z "${configurePhase-}" ]; then
-    setOutputFlags=
     configurePhase=cmakeConfigurePhase
 fi
 

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -99,9 +99,6 @@ stdenv.mkDerivation rec {
 
     cp -r Resource "$out/share/ghostscript/${version}"
 
-    mkdir -p "$doc/share/doc/ghostscript"
-    mv "$doc/share/doc/${version}" "$doc/share/doc/ghostscript/"
-
     ln -s "${fonts}" "$out/share/ghostscript/fonts"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     for file in $out/lib/*.dylib* ; do


### PR DESCRIPTION
This is supposed to shareDocName to a fallback value if it can't be
determined from looking at the configure script.  But the conditional
checked whether shareDocName was set, rather than if it wasn't.  This
meant that if shareDocName had been detected from a configure script,
it would be immediately overridden by the package name, and if it
couldn't be detected, shareDocName would remain unset.

This resulted in QEMU installing files like $out/share/doc/index.html,
which should of course have been in $out/share/doc/qemu/index.html.

An interesting side effect of this is that, since
9f8751528cd89d343258dd718afa56f8590917bb when this code was added, the
detected package name has never actually been used for installing
documentation, because it would always be overridden.  So this patch
will actually enable that for the first time, four years later.

_We should probably consider, seeing as we’ve been getting by without it for four years, do we want the configure detection at all? I think we probably do, but it’s worth thinking about._