### PR TITLE
pythonPackages.qscintilla-qt5: Do not copy pyqt5 tree

### DIFF
--- a/pkgs/development/python-modules/qscintilla-qt5/default.nix
+++ b/pkgs/development/python-modules/qscintilla-qt5/default.nix
@@ -1,7 +1,6 @@
 { lib
 , pythonPackages
 , qscintilla
-, lndir
 , qtbase
 }:
 with pythonPackages;
@@ -11,8 +10,9 @@ buildPythonPackage {
   src = qscintilla.src;
   format = "other";
 
-  nativeBuildInputs = [ lndir sip qtbase ];
-  buildInputs = [ qscintilla pyqt5 ];
+  nativeBuildInputs = [ sip qtbase ];
+  buildInputs = [ qscintilla ];
+  propagatedBuildInputs = [ pyqt5 ];
 
   postPatch = ''
     substituteInPlace Python/configure.py \
@@ -22,9 +22,9 @@ buildPythonPackage {
   '';
 
   preConfigure = ''
-    mkdir -p $out
-    lndir ${pyqt5} $out
-    rm -rf "$out/nix-support"
+    # configure.py will look for this folder
+    mkdir -p $out/share/sip/PyQt5
+
     cd Python
     substituteInPlace configure.py \
       --replace "qmake = {'CONFIG': 'qscintilla2'}" "qmake = {'CONFIG': 'qscintilla2', 'QT': 'widgets printsupport'}"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5637,7 +5637,6 @@ in {
 
   qscintilla-qt5 = pkgs.libsForQt5.callPackage ../development/python-modules/qscintilla-qt5 {
     pythonPackages = self;
-    lndir = pkgs.xorg.lndir;
   };
 
   qscintilla = self.qscintilla-qt4;


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This commit ensures the entire PyQt5 tree is not included inside
qscintilla as pointed out by
https://github.com/NixOS/nixpkgs/issues/73975#issuecomment-639178216

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
