### PR TITLE
openttd-jgrpp: init at 0.34.4

### DIFF
--- a/pkgs/games/openttd/jgrpp.nix
+++ b/pkgs/games/openttd/jgrpp.nix
@@ -1,0 +1,13 @@
+{ fetchFromGitHub, openttd, ... }:
+
+openttd.overrideAttrs (oldAttrs: rec {
+  pname = "openttd-jgrpp";
+  version = "0.34.4";
+
+  src = fetchFromGitHub rec {
+    owner = "JGRennison";
+    repo = "OpenTTD-patches";
+    rev = "jgrpp-${version}";
+    sha256 = "125mgia5hgcsn8314xyiip3z8y23rc3kdv7jczbncqlzsc75624v";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24061,6 +24061,11 @@ in
       static = true;
     };
   };
+  openttd-jgrpp = callPackage ../games/openttd/jgrpp.nix {
+    zlib = zlib.override {
+      static = true;
+    };
+  };
 
   opentyrian = callPackage ../games/opentyrian { };
 


### PR DESCRIPTION
##### Motivation for this change

This is a popular patched variant of the original OpenTTD game available at https://github.com/JGRennison/OpenTTD-patches.

It is available since 2015 and its features are being actively discussed at https://www.tt-forums.net/viewtopic.php?f=33&t=73469.

A few friends are hosting such a patched server and I wanted to join.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
