### PR TITLE
openlp: init at 2.4.6

### DIFF
--- a/pkgs/applications/misc/openlp/default.nix
+++ b/pkgs/applications/misc/openlp/default.nix
@@ -1,0 +1,86 @@
+# This file contains all runtime glue: Bindings to optional runtime dependencies
+# for pdfSupport, presentationSupport, and media playback.
+{ lib, mkDerivation, wrapGAppsHook, python3Packages
+
+# qt deps
+, qtbase, qtmultimedia
+
+# optional deps
+, pdfSupport ? false, mupdf  # alternatively could use ghostscript
+, presentationSupport ? false, libreoffice-unwrapped
+, vlcSupport ? false
+, gstreamerSupport ? false, gst_all_1, gstPlugins ? (gst: [
+    gst.gst-plugins-base
+    gst.gst-plugins-good
+    gst.gst-plugins-bad
+    gst.gst-plugins-ugly
+  ])
+
+#, enableMySql ? false      # Untested. If interested, contact maintainer.
+#, enablePostgreSql ? false # Untested. If interested, contact maintainer.
+#, enableJenkinsApi ? false # Untested. If interested, contact maintainer.
+}:
+
+let p = gstPlugins gst_all_1;
+# If gstreamer is activated but no plugins are given, it will at runtime
+# create the false illusion of being usable.
+in assert gstreamerSupport -> (builtins.isList p && builtins.length p > 0);
+
+let
+  # optional packages
+  libreofficePath = "${libreoffice-unwrapped}/lib/libreoffice/program";
+
+  # lib functions
+  inherit (lib.lists) optional optionals;
+  wrapSetVar = var: ''--set ${var} "''$${var}"'';
+
+  # base pkg/lib
+  baseLib = python3Packages.callPackage ./lib.nix { };
+in mkDerivation {
+  inherit (baseLib) pname version src;
+
+  nativeBuildInputs = [ python3Packages.wrapPython wrapGAppsHook ];
+  buildInputs = [ qtbase ] ++ optionals gstreamerSupport
+    ([ qtmultimedia.bin gst_all_1.gstreamer ] ++ gstPlugins gst_all_1);
+  propagatedBuildInputs = optional pdfSupport mupdf
+    ++ optional presentationSupport libreoffice-unwrapped;
+  pythonPath = [ baseLib ] ++ optional vlcSupport python3Packages.python-vlc;
+    # ++ optional enableMySql mysql-connector  # Untested. If interested, contact maintainer.
+    # ++ optional enablePostgreSql psycopg2    # Untested. If interested, contact maintainer.
+    # ++ optional enableJenkinsApi jenkinsapi  # Untested. If interested, contact maintainer.
+
+  PYTHONPATH = libreofficePath;
+  URE_BOOTSTRAP = "vnd.sun.star.pathname:${libreofficePath}/fundamentalrc";
+  UNO_PATH = libreofficePath;
+  LD_LIBRARY_PATH = libreofficePath;
+  JAVA_HOME = "${libreoffice-unwrapped.jdk.home}";
+
+  dontWrapQtApps = true;
+  dontWrapGApps = true;
+
+  # defined in gappsWrapperHook
+  wrapPrefixVariables = optionals presentationSupport
+    [ "PYTHONPATH" "LD_LIBRARY_PATH" "JAVA_HOME" ];
+  makeWrapperArgs = [
+    "\${gappsWrapperArgs[@]}"
+    "\${qtWrapperArgs[@]}"
+  ] ++ optionals presentationSupport
+    ([ "--prefix PATH : ${libreoffice-unwrapped}/bin" ]
+      ++ map wrapSetVar [ "URE_BOOTSTRAP" "UNO_PATH" ]);
+
+  installPhase = ''
+    install -D openlp.py $out/bin/openlp
+  '';
+
+  preFixup = ''
+    wrapPythonPrograms
+  '';
+
+  meta = baseLib.meta // {
+    hydraPlatforms = [ ]; # this is only the wrapper; baseLib gets built
+  };
+
+  passthru = {
+    inherit baseLib;
+  };
+}

--- a/pkgs/applications/misc/openlp/lib.nix
+++ b/pkgs/applications/misc/openlp/lib.nix
@@ -1,0 +1,103 @@
+# This file contains the base package, some of which is compiled.
+# Runtime glue to optinal runtime dependencies is in 'default.nix'.
+{ fetchurl, lib, qt5
+
+# python deps
+, python, buildPythonPackage
+, alembic, beautifulsoup4, chardet, lxml, Mako, pyenchant
+, pyqt5_with_qtwebkit, pyxdg, sip, sqlalchemy, sqlalchemy_migrate
+}:
+
+buildPythonPackage rec {
+  pname = "openlp";
+  version = "2.4.6";
+
+  src = fetchurl {
+    url = "https://get.openlp.org/${version}/OpenLP-${version}.tar.gz";
+    sha256 = "f63dcf5f1f8a8199bf55e806b44066ad920d26c9cf67ae432eb8cdd1e761fc30";
+  };
+
+  doCheck = false;
+  # FIXME: checks must be disabled because they are lacking the qt env.
+  #        They fail like this, even if built and wrapped with all Qt and
+  #        runtime dependencies:
+  #
+  #     running install tests
+  #     qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
+  #     This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
+  #
+  #     Available platform plugins are: wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx.
+  #
+  # See also https://discourse.nixos.org/t/qt-plugin-path-unset-in-test-phase/
+
+  #checkInputs = [ mock nose ];
+  nativeBuildInputs = [ qt5.qttools ];
+  propagatedBuildInputs = [
+    alembic
+    beautifulsoup4
+    chardet
+    lxml
+    Mako
+    pyenchant
+    pyqt5_with_qtwebkit
+    pyxdg
+    sip
+    sqlalchemy
+    sqlalchemy_migrate
+  ];
+
+  prePatch = ''
+    echo 'from vlc import *' > openlp/core/ui/media/vendor/vlc.py
+  '';
+
+  dontWrapQtApps = true;
+  dontWrapGApps = true;
+  postInstall = ''
+    ( # use subshell because of cd
+      tdestdir="$out/i18n"
+      mkdir -p "$tdestdir"
+      cd ./resources/i18n
+      for file in *.ts; do
+          lconvert -i "$file" -o "$tdestdir/''${file%%ts}qm"
+      done
+    )
+  '';
+
+  preFixup = ''
+    rm -r $out/${python.sitePackages}/tests
+    rm -r $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Free church presentation software";
+    homepage = "https://openlp.org/";
+    downloadPage = "https://openlp.org/#downloads";
+    platforms = platforms.unix;
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.jorsn ];
+
+    longDescription = ''
+      OpenLP is a free church presentation software.
+
+      Features:
+
+      * Cross platform between Linux, Windows, OS X and FreeBSD
+      * Display songs, Bible verses, presentations, images, audio and video
+      * Control OpenLP remotely via the Android remote, iOS remote or mobile web browser
+      * Quickly and easily import songs from other popular presentation packages
+      * Easy enough to use to get up and running in less than 10 minutes
+
+      Remark: This pkg only supports sqlite dbs. If you wish to have support for
+            mysql or postgresql dbs, or Jenkins, please contact the maintainer.
+
+      Bugs which affect this software packaged in Nixpkgs:
+
+      1. The package must disable checks, because they are lacking the qt env.
+         (see pkg source and https://discourse.nixos.org/t/qt-plugin-path-unset-in-test-phase/)
+      2. There is a segfault on exit. Not a real problem, according to debug log, everything
+         shuts down correctly. Maybe related to https://forums.openlp.org/discussion/3620/crash-on-exit.
+         Plan: Wait for OpenLP-3, since it is already in beta 1
+         (2021-02-09; news: https://openlp.org/blog/).
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27737,6 +27737,14 @@ in
 
   octopus = callPackage ../applications/science/chemistry/octopus { };
 
+  openlp = libsForQt5.callPackage ../applications/misc/openlp { };
+  openlpFull = appendToName "full" (openlp.override {
+    pdfSupport = true;
+    presentationSupport = true;
+    vlcSupport = true;
+    gstreamerSupport = true;
+  });
+
   openmolcas = callPackage ../applications/science/chemistry/openmolcas { };
 
   pymol = callPackage ../applications/science/chemistry/pymol { };


### PR DESCRIPTION
free church presentation software

The package is split in two parts: The main python package to build (`lib.nix`) and a wrapper package pulling in configurable runtime dependencies (`default.nix`), so that rebuilds are unnecessary when changing runtime deps/features.

###### Review notes

1. The critical parts to test are: Video playback ([manual](https://manual.openlp.org/mediamanager.html#media)) via the 3 backends (system, webkit, vlc) and presentation support ([manual](https://manual.openlp.org/mediamanager.html#presentations)) via mupdf and libreoffice (uno).
2. All these tests require the package `openlpFull`. In `openlp` they aren't used, as they are optional.
3. When switching the video backend, it is best to restart OpenLP *afterwards* to make sure only the right one is initialized. To switch, select only one backend in *Settings → Configure OpenLP → Players*.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

*(na)* means “not applicable”

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] *(na)* Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] *(na)* Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) \
      package `openlp`: 676.1 MB, package `openlpFull`: 3.0 GB.
- [ ] *(na)* Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Additionally:
- [x] Tested in a pure nix-shell. There, audio does not work, as pulseaudio cannot be connected, but this is also the case using plain vlc.