### PR TITLE
Rewrite raspberrypi-builder.sh based on extlinux

### DIFF
--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi-builder.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi-builder.nix
@@ -3,8 +3,10 @@
 pkgs.substituteAll {
   src = ./raspberrypi-builder.sh;
   isExecutable = true;
-  postInstall = "shellcheck $out";
-  nativeBuildInputs = [ pkgs.buildPackages.shellcheck ];
+
+  checkPhase = "shellcheck $out";
+  checkInputs = [ pkgs.buildPackages.shellcheck ];
+  doCheck = false;
 
   inherit (pkgs.buildPackages) bash;
   path = with pkgs.buildPackages; [coreutils gnused gnugrep];

--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi-builder.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi-builder.nix
@@ -3,6 +3,9 @@
 pkgs.substituteAll {
   src = ./raspberrypi-builder.sh;
   isExecutable = true;
+  postInstall = "shellcheck $out";
+  nativeBuildInputs = [ pkgs.buildPackages.shellcheck ];
+
   inherit (pkgs.buildPackages) bash;
   path = with pkgs.buildPackages; [coreutils gnused gnugrep];
   firmware = pkgs.raspberrypifw;

--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi-builder.sh
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi-builder.sh
@@ -1,4 +1,4 @@
-#! @bash@/bin/sh
+#! @bash@/bin/bash
 
 # This can end up being called disregarding the shebang.
 set -e
@@ -9,24 +9,26 @@ export PATH=/empty
 for i in @path@; do PATH=$PATH:$i/bin; done
 
 usage() {
-    echo "usage: $0 -c <path-to-default-configuration> [-d <boot-dir>]" >&2
+    echo "usage: $0 -c <path-to-default-configuration> [-d <boot-dir>] [-g <num-generations>]" >&2
     exit 1
 }
 
 default=                # Default configuration
 target=/boot            # Target directory
+numGenerations=0        # Number of other generations to include in the menu
 
-while getopts "c:d:" opt; do
+while getopts "c:d:g:" opt; do
     case "$opt" in
         c) default="$OPTARG" ;;
         d) target="$OPTARG" ;;
+        g) numGenerations="$OPTARG" ;;
         \?) usage ;;
     esac
 done
 
 echo "updating the boot generations directory..."
 
-mkdir -p $target/old
+mkdir -p "$target/old"
 
 # Convert a path to a file in the Nix store such as
 # /nix/store/<hash>-<name>/file to <hash>-<name>-<file>.
@@ -35,109 +37,143 @@ cleanName() {
     echo "$path" | sed 's|^/nix/store/||' | sed 's|/|-|g'
 }
 
-# Copy a file from the Nix store to $target/kernels.
+atomicCopy() {
+    local src="$1"
+    local dst="$2"
+    local dstTmp=$dst.tmp.$$
+    cp "$src" "$dstTmp"
+    mv "$dstTmp" "$dst"
+}
+
+# Copy a file from the Nix store to $target/nixos.
 declare -A filesCopied
 
-copyToKernelsDir() {
-    local src="$1"
-    local dst="$target/old/$(cleanName $src)"
+copyToOldDir() {
+    local src dst
+    src=$(readlink -f "$1")
+    dst="$target/old/$(cleanName "$src")"
     # Don't copy the file if $dst already exists.  This means that we
     # have to create $dst atomically to prevent partially copied
     # kernels or initrd if this script is ever interrupted.
-    if ! test -e $dst; then
-        local dstTmp=$dst.tmp.$$
-        cp $src $dstTmp
-        mv $dstTmp $dst
+    if ! test -e "$dst"; then
+        atomicCopy "$src" "$dst"
     fi
     filesCopied[$dst]=1
-    result=$dst
 }
 
-copyForced() {
+copyDtbDir() {
+    local dtb_dir="$1"
+    local dst_dir="$2"
+    mkdir -p "$dst_dir"
+    for dtb in "$dtb_dir"/{broadcom,}/bcm*.dtb; do
+        local dst
+        dst="$dst_dir/$(basename "$dtb")"
+        local dstTmp=$dst.tmp.$$
+        cp "$dtb" "$dstTmp"
+        mv "$dstTmp" "$dst"
+        filesCopied[$dst]=1
+    done
+    filesCopied[$dst_dir]=1
+}
+
+cpMarked() {
     local src="$1"
     local dst="$2"
-    cp $src $dst.tmp
-    mv $dst.tmp $dst
+    cp "$src" "$dst"
+    filesCopied[$dst]=1
 }
 
-outdir=$target/old
-mkdir -p $outdir || true
+echoMarked() {
+    local src="$1"
+    local dst="$2"
+    echo "$src" >"$dst"
+    filesCopied[$dst]=1
+}
 
-# Copy its kernel and initrd to $target/old.
+# Copy its kernel, initrd and dtbs to $target/old
 addEntry() {
-    local path="$1"
-    local generation="$2"
+    local path
+    path=$(readlink -f "$1")
+    local tag="$2" # Generation number or 'default'
 
-    if ! test -e $path/kernel -a -e $path/initrd; then
+    if ! test -e "$path/kernel" -a -e "$path/initrd"; then
         return
     fi
 
-    local kernel=$(readlink -f $path/kernel)
-    local initrd=$(readlink -f $path/initrd)
-    local dtb_path=$(readlink -f $path/dtbs)
+    local kernel initrd dtb_path init kernel_params
+    kernel=$(readlink -f "$path/kernel")
+    initrd=$(readlink -f "$path/initrd")
+    dtb_path=$(readlink -f "$path/dtbs")
+    init=$(readlink -f "$path/init")
+    kernel_params=$(readlink -f "$path/kernel-params")
 
-    if test -n "@copyKernels@"; then
-        copyToKernelsDir $kernel; kernel=$result
-        copyToKernelsDir $initrd; initrd=$result
-    fi
+    if [ "$tag" = "default" ]; then
+        atomicCopy "$kernel" "$target/kernel.img"
+        atomicCopy "$initrd" "$target/initrd"
+        copyDtbDir "$dtb_path" "$target"
+        atomicCopy "$init" "$target/nixos-init"
 
-    echo $(readlink -f $path) > $outdir/$generation-system
-    echo $(readlink -f $path/init) > $outdir/$generation-init
-    cp $path/kernel-params $outdir/$generation-cmdline.txt
-    echo $initrd > $outdir/$generation-initrd
-    echo $kernel > $outdir/$generation-kernel
+        tmpFile="$target/cmdline.txt.$$"
+        echo "$(cat "$kernel_params") init=$init" >"$tmpFile"
+        mv -f "$tmpFile" "$target/cmdline.txt"
+    else
+        copyToOldDir "$kernel"
+        copyToOldDir "$initrd"
 
-    if test "$generation" = "default"; then
-      copyForced $kernel $target/kernel.img
-      copyForced $initrd $target/initrd
-      for dtb in $dtb_path/{broadcom,}/bcm*.dtb; do
-        dst="$target/$(basename $dtb)"
-        copyForced $dtb "$dst"
-        filesCopied[$dst]=1
-      done
-      cp "$(readlink -f "$path/init")" $target/nixos-init
-      echo "`cat $path/kernel-params` init=$path/init" >$target/cmdline.txt
+        copyDtbDir "$dtb_path" "$target/old/$(cleanName "$dtb_path")"
+
+        echoMarked "$path" "$target/old/$generation-system"
+        echoMarked "$init" "$target/old/$generation-init"
+        cpMarked "$kernel_params" "$target/old/$generation-cmdline.txt"
+        echoMarked "$initrd" "$target/old/$generation-initrd"
+        echoMarked "$kernel" "$target/old/$generation-kernel"
+        echoMarked "$dtb_path" "$target/old/$generation-dtbs"
     fi
 }
 
-addEntry $default default
+addEntry "$default" default
 
-# Add all generations of the system profile to the menu, in reverse
-# (most recent to least recent) order.
-for generation in $(
-    (cd /nix/var/nix/profiles && ls -d system-*-link) \
-    | sed 's/system-\([0-9]\+\)-link/\1/' \
-    | sort -n -r); do
-    link=/nix/var/nix/profiles/system-$generation-link
-    addEntry $link $generation
-done
+if [ "$numGenerations" -gt 0 ]; then
+    # Add up to $numGenerations generations of the system profile to $target/old,
+    # in reverse (most recent to least recent) order.
+    for generation in $(
+            (cd /nix/var/nix/profiles && ls -d system-*-link) \
+            | sed 's/system-\([0-9]\+\)-link/\1/' \
+            | sort -n -r \
+            | head -n "$numGenerations"); do
+        link=/nix/var/nix/profiles/system-$generation-link
+        addEntry "$link" "$generation"
+    done
+fi
 
 # Add the firmware files
 fwdir=@firmware@/share/raspberrypi/boot/
-copyForced $fwdir/bootcode.bin  $target/bootcode.bin
-copyForced $fwdir/fixup.dat     $target/fixup.dat
-copyForced $fwdir/fixup4.dat    $target/fixup4.dat
-copyForced $fwdir/fixup4cd.dat  $target/fixup4cd.dat
-copyForced $fwdir/fixup4db.dat  $target/fixup4db.dat
-copyForced $fwdir/fixup4x.dat   $target/fixup4x.dat
-copyForced $fwdir/fixup_cd.dat  $target/fixup_cd.dat
-copyForced $fwdir/fixup_db.dat  $target/fixup_db.dat
-copyForced $fwdir/fixup_x.dat   $target/fixup_x.dat
-copyForced $fwdir/start.elf     $target/start.elf
-copyForced $fwdir/start4.elf    $target/start4.elf
-copyForced $fwdir/start4cd.elf  $target/start4cd.elf
-copyForced $fwdir/start4db.elf  $target/start4db.elf
-copyForced $fwdir/start4x.elf   $target/start4x.elf
-copyForced $fwdir/start_cd.elf  $target/start_cd.elf
-copyForced $fwdir/start_db.elf  $target/start_db.elf
-copyForced $fwdir/start_x.elf   $target/start_x.elf
+atomicCopy $fwdir/bootcode.bin  "$target/bootcode.bin"
+atomicCopy $fwdir/fixup.dat     "$target/fixup.dat"
+atomicCopy $fwdir/fixup4.dat    "$target/fixup4.dat"
+atomicCopy $fwdir/fixup4cd.dat  "$target/fixup4cd.dat"
+atomicCopy $fwdir/fixup4db.dat  "$target/fixup4db.dat"
+atomicCopy $fwdir/fixup4x.dat   "$target/fixup4x.dat"
+atomicCopy $fwdir/fixup_cd.dat  "$target/fixup_cd.dat"
+atomicCopy $fwdir/fixup_db.dat  "$target/fixup_db.dat"
+atomicCopy $fwdir/fixup_x.dat   "$target/fixup_x.dat"
+atomicCopy $fwdir/start.elf     "$target/start.elf"
+atomicCopy $fwdir/start4.elf    "$target/start4.elf"
+atomicCopy $fwdir/start4cd.elf  "$target/start4cd.elf"
+atomicCopy $fwdir/start4db.elf  "$target/start4db.elf"
+atomicCopy $fwdir/start4x.elf   "$target/start4x.elf"
+atomicCopy $fwdir/start_cd.elf  "$target/start_cd.elf"
+atomicCopy $fwdir/start_db.elf  "$target/start_db.elf"
+atomicCopy $fwdir/start_x.elf   "$target/start_x.elf"
 
 # Add the config.txt
-copyForced @configTxt@ $target/config.txt
+atomicCopy @configTxt@ "$target/config.txt"
 
-# Remove obsolete files from $target and $target/old.
-for fn in $target/old/*linux* $target/old/*initrd-initrd* $target/bcm*.dtb; do
+# Remove obsolete files from $target and $target/nixos.
+for fn in "$target"/old/* "$target"/bcm*.dtb "$target"/cmdline.txt.*; do
     if ! test "${filesCopied[$fn]}" = 1; then
-        rm -vf -- "$fn"
+        echo "Removing no longer needed boot file: $fn"
+        chmod +w -- "$fn"
+        rm -rf -- "$fn"
     fi
 done

--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
@@ -12,9 +12,9 @@ let
 
   builder =
     if cfg.uboot.enable then
-      "${builderUboot} -g ${toString cfg.uboot.configurationLimit} -t ${timeoutStr} -c"
+      "${builderUboot} -g ${toString cfg.configurationLimit} -t ${timeoutStr} -c"
     else
-      "${builderGeneric} -c";
+      "${builderGeneric} -g ${toString cfg.configurationLimit} -c";
 
   blCfg = config.boot.loader;
   timeoutStr = if blCfg.timeout == null then "-1" else toString blCfg.timeout;
@@ -64,6 +64,15 @@ in
         '';
       };
 
+      configurationLimit = mkOption {
+        default = 20;
+        example = 10;
+        type = types.int;
+        description = ''
+          Maximum number of configurations in the boot menu.
+        '';
+      };
+
       uboot = {
         enable = mkOption {
           default = false;
@@ -72,16 +81,6 @@ in
             Enable using uboot as bootmanager for the raspberry pi.
           '';
         };
-
-        configurationLimit = mkOption {
-          default = 20;
-          example = 10;
-          type = types.int;
-          description = ''
-            Maximum number of configurations in the boot menu.
-          '';
-        };
-
       };
 
       firmwareConfig = mkOption {


### PR DESCRIPTION
This adds the ability to set a configuration limit for the raspberry pi
firmware as well, so we can change the
boot.loader.raspberryPi.uboot.configurationLimit option to
boot.loader.raspberryPi.configurationLimit and use it for both uboot and
the raspberry pi firmware.

It also fixes a bug where not everything in /boot/old would be cleaned
up.

In addition, this passes shellcheck with no errors, and runs shellcheck
as a part of the build.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
