### PR TITLE
beancount_docverif: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7266,6 +7266,16 @@
     githubId = 2770647;
     name = "Simon Vandel Sillesen";
   };
+  siriobalmelli = {
+    email = "sirio@b-ad.ch";
+    github = "siriobalmelli";
+    githubId = 23038812;
+    name = "Sirio Balmelli";
+    keys = [{
+      longkeyid = "ed25519/0xF72C4A887F9A24CA";
+      fingerprint = "B234 EFD4 2B42 FE81 EE4D  7627 F72C 4A88 7F9A 24CA";
+    }];
+  };
   sivteck = {
     email = "sivaram1992@gmail.com";
     github = "sivteck";

--- a/pkgs/development/python-modules/beancount_docverif/default.nix
+++ b/pkgs/development/python-modules/beancount_docverif/default.nix
@@ -1,0 +1,46 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k
+, beancount
+, pytest, sh
+}:
+
+buildPythonPackage rec {
+  version = "1.0.0";
+  pname = "beancount_docverif";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kjc0axrxpvm828lqq5m2ikq0ls8xksbmm7312zw867gdx56x5aj";
+  };
+
+  propagatedBuildInputs = [
+    beancount
+  ];
+
+  checkInputs = [
+    pytest
+    sh
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/siriobalmelli/beancount_docverif";
+    description = "Document verification plugin for Beancount";
+    longDescription = ''
+        Docverif is the "Document Verification" plugin for beancount, fulfilling the following functions:
+
+        - Require that every transaction touching an account have an accompanying document on disk.
+        - Explictly declare the name of a document accompanying a transaction.
+        - Explicitly declare that a transaction is expected not to have an accompanying document.
+        - Look for an "implicit" PDF document matching transaction data.
+        - Associate (and require) a document with any type of entry, including open entries themselves.
+        - Guarantee integrity: verify that every document declared does in fact exist on disk.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ siriobalmelli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -517,6 +517,8 @@ in {
 
   beanstalkc = callPackage ../development/python-modules/beanstalkc { };
 
+  beancount_docverif = callPackage ../development/python-modules/beancount_docverif { };
+
   bitarray = callPackage ../development/python-modules/bitarray { };
 
   bitcoinlib = callPackage ../development/python-modules/bitcoinlib { };


### PR DESCRIPTION
Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Required this package in own runtime environment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
