### PR TITLE
tokei: 11.2.1 -> 12.0.3

### DIFF
--- a/pkgs/development/tools/misc/tokei/default.nix
+++ b/pkgs/development/tools/misc/tokei/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "tokei";
-  version = "11.2.1";
+  version = "12.0.3";
 
   src = fetchFromGitHub {
     owner = "XAMPPRocky";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1bdq66si9vvvyf5nia8ww77imp0f8jas0yfcvq1rialwm9922dfl";
+    sha256 = "1imfjgjrsqxwrz7n574xpsh6xp44sb3dkccgg7xpn5playilmbgp";
   };
 
-  cargoSha256 = "17666wh4sfzhgxngymd02892mqpkr8jm6a4w95wwsc9iinzbygrm";
+  cargoSha256 = "0350q3jb0b3jmpcfx9jhjfpfb64v2f3h5z59n9ixr0lml0y0idkq";
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [
     libiconv darwin.apple_sdk.frameworks.Security


### PR DESCRIPTION
https://github.com/XAMPPRocky/tokei/releases/tag/v12.0.0

https://github.com/XAMPPRocky/tokei/compare/v12.0.0...v12.0.3

---

Breaking Changes

    The JSON Output and format of `Languages` has changed.

    The JSON feature has been removed and is now included by default.

    `Stats` has been split into `Report` and `CodeStats` to better
    represent the separation between analysing a file versus a blob of
    code.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Saw the update announcement on r/rust.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

<details><summary>Still super fast, even in nixpkgs</summary>

```
vin@scadrial ~/w/v/n/master (tokei)> time ./result/bin/tokei .
===============================================================================
 Language            Files        Lines         Code     Comments       Blanks
===============================================================================
 Autoconf               12          563          462           11           90
 BASH                    9          772          569           91          112
 C                      31         2365         1679          334          352
 C Header                5         1733          870          629          234
 CMake                   3           26           20            0            6
 C#                      1           36           15           17            4
 C++                     3          733          620           51           62
 C++ Header              1            9            7            0            2
 Crystal                 1           42           37            0            5
 CSS                     3          372          275           34           63
 D                       1          142          110           28            4
 Edn                     1           12           12            0            0
 Emacs Lisp              4          543          434           49           60
 Elixir                  3           78           61            3           14
 Go                      2           42           35            0            7
 INI                     1            6            6            0            0
 Java                    1           19           16            0            3
 JavaScript             10          441          270           87           84
 JSON                   65       108537       108537            0            0
 Lisp                    4         1058          888           41          129
 Lua                     1            4            4            0            0
 Makefile                3          149          120            1           28
 Meson                   1            5            3            0            2
 Nix                 18120      1645925      1386233        85325       174367
 Perl                   25         6446         4835          618          993
 PHP                     1            6            4            2            0
 Prolog                  2           39           28            0           11
 Protocol Buffers        4           22           17            0            5
 PureScript              1            9            6            0            3
 Python                 44         7635         5779          571         1285
 R                       1           90           75            2           13
 Rakefile                1           43           30            3           10
 Ruby                    8          655          398          164           93
 Scheme                  2            8            6            2            0
 Shell                 480        24276        18091         2653         3532
 SQL                     1           11           10            0            1
 SVG                     1           81           80            1            0
 Plain Text             17         1548            0         1266          282
 TOML                    3          161          127           13           21
 TypeScript              4          248          213            9           26
 Vim script              1          307          273           16           18
 Visual Studio Sol|      1           20           19            0            1
 XSL                     9          810          633           65          112
 XML                   198        35569        34186           96         1287
 YAML                    2        11159        11098           45           16
-------------------------------------------------------------------------------
 Markdown               39         4791            0         3615         1176
 |- BASH                 7           45           39            2            4
 |- HTML                 1            8            8            0            0
 |- JavaScript           1           21           20            0            1
 |- Nix                 14         1181          978           79          124
 |- Python               1           18           12            6            0
 |- Ruby                 1           11            7            2            2
 |- Shell                6           70           68            0            2
 |- YAML                 1            9            9            0            0
 (Total)                           6154         1141         3704         1309
===============================================================================
 Total               19131      1858909      1578332        95931       184646
===============================================================================

________________________________________________________
Executed in  531.08 millis    fish           external
   usr time  782.11 millis  253.00 micros  781.86 millis
   sys time  594.37 millis   43.00 micros  594.33 millis
```

</details>