### PR TITLE
Haskell: configuration-common: override updates

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1557,4 +1557,11 @@ self: super: {
     })
   ]));
 
+  # add unreleased commit fixing version constraint as a patch
+  # Can be removed if https://github.com/lpeterse/haskell-utc/issues/8 is resolved
+  utc = appendPatch super.utc (pkgs.fetchpatch {
+    url = "https://github.com/lpeterse/haskell-utc/commit/e4502c08591e80d411129bb7c0414539f6302aaf.diff";
+    sha256 = "0v6kv1d4syjzgzc2s7a76c6k4vminlcq62n7jg3nn9xd00gwmmv7";
+  });
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -216,9 +216,7 @@ self: super: {
   digit = doJailbreak super.digit;
 
   # 2020-06-05: HACK: does not passes own build suite - `dontCheck`
-  hnix = generateOptparseApplicativeCompletion "hnix" (
-    dontCheck super.hnix
-    );
+  hnix = dontCheck super.hnix;
 
   # Fails for non-obvious reasons while attempting to use doctest.
   search = dontCheck super.search;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -51,10 +51,6 @@ self: super: {
   # Needs older QuickCheck version
   attoparsec-varword = dontCheck super.attoparsec-varword;
 
-  # Tests are failing
-  # https://github.com/bos/statistics/issues/123
-  statistics = dontCheck super.statistics;
-
   # These packages (and their reverse deps) cannot be built with profiling enabled.
   ghc-heap-view = disableLibraryProfiling super.ghc-heap-view;
   ghc-datasize = disableLibraryProfiling super.ghc-datasize;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1390,7 +1390,7 @@ self: super: {
     })
   ];
 
-  # https://github.com/serokell/nixfmt/pull/62
+  # 2020-06-22: NOTE: > 0.4.0 => rm Jailbreak
   nixfmt = doJailbreak super.nixfmt;
 
   # 2020-06-22: NOTE: QuickCheck upstreamed https://github.com/phadej/binary-instances/issues/7

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1474,7 +1474,7 @@ self: super: {
 
   # Requested version bump on upstream https://github.com/obsidiansystems/constraints-extras/issues/32
   constraints-extras = doJailbreak super.constraints-extras;
-  # Requested version bump on upstream https://github.com/srid/rib/issues/160
+  # 2020-06-22: NOTE: > 0.10.0.0 => rm dhall override.
   rib = doJailbreak (super.rib.override {
     dhall = self.dhall_1_30_0;
   });

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1120,8 +1120,8 @@ self: super: {
   # });
   libnix = dontCheck super.libnix;
 
-  # Jailbreak: https://github.com/jaor/xmobar/issues/463
-  # The test suite tries to mess with ALSA, which doesn't work in the build sandbox.
+  # > 0.33 => rm 464.patch
+  # dontCheck: The test suite tries to mess with ALSA, which doesn't work in the build sandbox.
   xmobar = appendPatch (dontCheck super.xmobar) (pkgs.fetchpatch {
     url = "https://github.com/jaor/xmobar/pull/464.patch";
     sha256 = "0y1dd878yzy1cx0cjj0ijd3dmywr7jdmk68vxdjimxzblrdw1al6";

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1363,33 +1363,6 @@ self: super: {
   # Therefore we jailbreak it.
   hakyll-contrib-hyphenation = doJailbreak super.hakyll-contrib-hyphenation;
 
-  # https://github.com/bergmark/feed/issues/43
-  feed = dontCheck super.feed;
-
-  pantry_0_2_0_0 = appendPatches (dontCheck super.pantry_0_2_0_0) [
-    # pantry-0.2.0.0 doesn't build with ghc-8.8, but there is a PR adding support.
-    # https://github.com/commercialhaskell/pantry/pull/6
-    # Currently stack-2.1.3.1 requires pantry-0.2.0.0, but when a newer version of
-    # stack is released, it will probably use the newer pantry version, so we
-    # can completely get rid of pantry-0.2.0.0.
-    (pkgs.fetchpatch {
-      url = "https://github.com/commercialhaskell/pantry/pull/6.diff";
-      sha256 = "0aml06jshpjh3aiscs5av7y33m3d6s6x5pzdvh7pky476izfg87k";
-      excludes = [
-        ".azure/azure-linux-template.yml"
-        ".azure/azure-osx-template.yml"
-        ".azure/azure-windows-template.yml"
-        "package.yaml"
-        "pantry.cabal"
-        "stack-lts-11.yaml"
-        "stack-lts-12.yaml"
-        "stack-nightly.yaml"
-        "stack-windows.yaml"
-        "stack.yaml"
-      ];
-    })
-  ];
-
   # 2020-06-22: NOTE: > 0.4.0 => rm Jailbreak
   nixfmt = doJailbreak super.nixfmt;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1393,7 +1393,7 @@ self: super: {
   # https://github.com/serokell/nixfmt/pull/62
   nixfmt = doJailbreak super.nixfmt;
 
-  # https://github.com/phadej/binary-orphans/issues/45
+  # 2020-06-22: NOTE: QuickCheck upstreamed https://github.com/phadej/binary-instances/issues/7
   binary-instances = dontCheck super.binary-instances;
 
   # Disabling the test suite lets the build succeed on older CPUs

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1496,7 +1496,7 @@ self: super: {
   # Upstream PR: https://github.com/bgamari/monoidal-containers/pull/62
   # Bump these version bound
   monoidal-containers = appendPatch super.monoidal-containers (pkgs.fetchpatch {
-    url = "https://github.com/bgamari/monoidal-containers/pull/62/commits/715093b22a015398a1390f636be6f39a0de83254.patch";
+    url = "https://github.com/bgamari/monoidal-containers/commit/715093b22a015398a1390f636be6f39a0de83254.patch";
     sha256="1lfxvwp8g55ljxvj50acsb0wjhrvp2hvir8y0j5pfjkd1kq628ng";
   });
 
@@ -1504,13 +1504,13 @@ self: super: {
     # Upstream PR: https://github.com/reflex-frp/patch/pull/20
     # Makes tests work with hlint 3
     (pkgs.fetchpatch {
-      url = "https://github.com/reflex-frp/patch/pull/20/commits/3ed23a4e4049ee17e64a1a5bbebf1990cdbe033a.patch";
+      url = "https://github.com/reflex-frp/patch/commit/3ed23a4e4049ee17e64a1a5bbebf1990cdbe033a.patch";
       sha256 ="1hfa980wln8kzbqw1lr8ddszgcibw25xf12ki2jb9xkl464aynzf";
     })
     # Upstream PR: https://github.com/reflex-frp/patch/pull/17
     # Bumps version dependencies
     (pkgs.fetchpatch {
-      url = "https://github.com/reflex-frp/patch/pull/17/commits/a191ed9ded708ed7ff0cf53ad6dafaf54db5b95a.patch";
+      url = "https://github.com/reflex-frp/patch/commit/a191ed9ded708ed7ff0cf53ad6dafaf54db5b95a.patch";
       sha256 ="1x9w5fimhk3a0l2aa5z91nqaa6s2irz1775iidd0191m6w25vszp";
     })
   ];
@@ -1519,30 +1519,30 @@ self: super: {
     # Upstream PR: https://github.com/reflex-frp/reflex/pull/434
     # Bump version bounds
     (pkgs.fetchpatch {
-      url = "https://github.com/reflex-frp/reflex/pull/434/commits/e6104bdfd7f664f524b6765275490722e376df4d.patch";
+      url = "https://github.com/reflex-frp/reflex/commit/e6104bdfd7f664f524b6765275490722e376df4d.patch";
       sha256 ="1awp5p4640cnhfd50dplsvp0kzy6h8r0hpbw1s40blni74r3dhzr";
     })
     # Upstream PR: https://github.com/reflex-frp/reflex/pull/436
     # Fix build with newest dependent-map version
     (pkgs.fetchpatch {
-      url = "https://github.com/reflex-frp/reflex/pull/436/commits/dc3bf44d822d70594e3c474fe3869261776c3554.patch";
+      url = "https://github.com/reflex-frp/reflex/commit/dc3bf44d822d70594e3c474fe3869261776c3554.patch";
       sha256 ="0rbjfj9b8p6zkvd5j4pak5kpgard6cyfvzk750s4xwpc1v84iiqd";
     })
     # Upstream PR: https://github.com/reflex-frp/reflex/pull/437
     # Fix tests with newer dep versions
     (pkgs.fetchpatch {
-      url = "https://github.com/reflex-frp/reflex/pull/437/commits/87c74a1b9d9098eae8a56148c59ed4963a5232c2.patch";
+      url = "https://github.com/reflex-frp/reflex/commit/87c74a1b9d9098eae8a56148c59ed4963a5232c2.patch";
       sha256 ="0qhjjgd6n4fms1hpbblny78c95bfh74izhx9dvrdlnhz6q7xlm9q";
     })
   ];
 
   # Tests disabled and broken override needed because of missing lib chrome-test-utils: https://github.com/reflex-frp/reflex-dom/issues/392
   # Tests disabled because of very old dep: https://github.com/reflex-frp/reflex-dom/issues/393
-  reflex-dom-core = unmarkBroken (dontCheck (appendPatches super.reflex-dom-core [
+  reflex-dom-core = doDistribute (unmarkBroken (dontCheck (appendPatches super.reflex-dom-core [
     # Upstream PR: https://github.com/reflex-frp/reflex-dom/pull/388
     # Fix upper bounds
     (pkgs.fetchpatch {
-      url = "https://github.com/reflex-frp/reflex-dom/pull/388/commits/5ef04d8e478f410d2c63603b84af052c9273a533.patch";
+      url = "https://github.com/reflex-frp/reflex-dom/commit/5ef04d8e478f410d2c63603b84af052c9273a533.patch";
       sha256 ="0d0b819yh8mqw8ih5asdi9qcca2kmggfsi8gf22akfw1n7xvmavi";
       stripLen = 2;
       extraPrefix = "";
@@ -1550,12 +1550,12 @@ self: super: {
     # Upstream PR: https://github.com/reflex-frp/reflex-dom/pull/394
     # Bump dependent-map
     (pkgs.fetchpatch {
-      url = "https://github.com/reflex-frp/reflex-dom/pull/394/commits/695bd17d5dcdb1bf321ee8858670731637f651db.patch";
+      url = "https://github.com/reflex-frp/reflex-dom/commit/695bd17d5dcdb1bf321ee8858670731637f651db.patch";
       sha256 ="0llky3i37rakgsw9vqaqmwryv7s91w8ph8xjkh83nxjs14p5zfyk";
       stripLen = 2;
       extraPrefix = "";
     })
-  ]));
+  ])));
 
   # add unreleased commit fixing version constraint as a patch
   # Can be removed if https://github.com/lpeterse/haskell-utc/issues/8 is resolved

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -10527,7 +10527,6 @@ broken-packages:
   - usb-safe
   - users-mysql-haskell
   - users-persistent
-  - utc
   - utf8-prelude
   - utf8-validator
   - UTFTConverter

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5270,8 +5270,6 @@ broken-packages:
   - gi-gsk
   - gi-gstpbutils
   - gi-gsttag
-  - gi-gtk-declarative
-  - gi-gtk-declarative-app-simple
   - gi-gtkosxapplication
   - gi-handy
   - gi-poppler

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -442,6 +442,9 @@ self: super: builtins.intersectAttrs super {
                             [ pkgs.darwin.apple_sdk.frameworks.OpenCL ];
   });
 
+  # requires an X11 display in test suite
+  gi-gtk-declarative = dontCheck super.gi-gtk-declarative;
+
   # depends on 'hie' executable
   lsp-test = dontCheck super.lsp-test;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Reports and PRs are merging and closing, often overrides await a release.

  * `xmobar`: update patch description
  * `statistics`: free from overriding
  * `rib`: update override description
  * `binary-instances`: update override description
  * `nixfmt`: update override description
  * `pantry`: rm upstreamed patch
  * `hnix`: rm generateOptparseApplicativeCompletion, since according binary not found


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
