### PR TITLE
pythonPackages.mido: init at 1.2.9

### DIFF
--- a/pkgs/development/python-modules/mido/default.nix
+++ b/pkgs/development/python-modules/mido/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, buildPythonPackage, fetchPypi, substituteAll
+, portmidi, pygame, python-rtmidi, rtmidi-python
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "mido";
+  version = "1.2.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1k3sgkxc7j49bapib3b5jnircb1yhyyd8mi0mbfd78zgix9db9y4";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./libportmidi-cdll.patch;
+      libportmidi = "${portmidi.out}/lib/libportmidi${stdenv.targetPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    pygame
+    python-rtmidi
+    rtmidi-python
+  ];
+
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    py.test . -rs -q
+  '';
+
+  meta = with lib; {
+    description = "MIDI Objects for Python";
+    homepage = "https://mido.readthedocs.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/mido/libportmidi-cdll.patch
+++ b/pkgs/development/python-modules/mido/libportmidi-cdll.patch
@@ -1,0 +1,19 @@
+diff --git a/mido/backends/portmidi_init.py b/mido/backends/portmidi_init.py
+index 84bb128..5efcdaa 100644
+--- a/mido/backends/portmidi_init.py
++++ b/mido/backends/portmidi_init.py
+@@ -10,13 +10,7 @@ from ctypes import (CDLL, CFUNCTYPE, POINTER, Structure, c_char_p,
+                     create_string_buffer, byref)
+ import ctypes.util
+ 
+-dll_name = ''
+-if sys.platform == 'darwin':
+-    dll_name = ctypes.util.find_library('libportmidi.dylib')
+-elif sys.platform in ('win32', 'cygwin'):
+-    dll_name = 'portmidi.dll'
+-else:
+-    dll_name = 'libportmidi.so'
++dll_name = '@libportmidi@'
+ 
+ lib = CDLL(dll_name)
+ 

--- a/pkgs/development/python-modules/python-rtmidi/default.nix
+++ b/pkgs/development/python-modules/python-rtmidi/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, tox, flake8, alabaster
+}:
+
+buildPythonPackage rec {
+  pname = "python-rtmidi";
+  version = "1.4.1";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0b0y3hnjl2fvm3jyfvp1msfikp19vbqqqi7lawgy3azisvdyrgq7";
+  };
+
+  checkInputs = [
+    tox
+    flake8
+    alabaster
+  ];
+
+  meta = with lib; {
+    description = "A Python binding for the RtMidi C++ library implemented using Cython";
+    homepage = "https://chrisarndt.de/projects/python-rtmidi/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/rtmidi-python/default.nix
+++ b/pkgs/development/python-modules/rtmidi-python/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi
+, alsaLib
+}:
+
+buildPythonPackage rec {
+  pname = "rtmidi-python";
+  version = "0.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1wpcaxfpbmsjc78g8841kpixr0a3v6zn0ak058s3mm25kcysp4m0";
+  };
+
+  buildInputs = [ alsaLib ];
+
+  # package has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "rtmidi_python"
+  ];
+
+  meta = with lib; {
+    description = "Python wrapper for RtMidi";
+    homepage = "https://github.com/superquadratic/rtmidi-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1476,6 +1476,8 @@ in {
 
   rq = callPackage ../development/python-modules/rq { };
 
+  rtmidi-python = callPackage ../development/python-modules/rtmidi-python { };
+
   rx = callPackage ../development/python-modules/rx { };
 
   sabyenc = callPackage ../development/python-modules/sabyenc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1420,6 +1420,8 @@ in {
 
   python-redis-lock = callPackage ../development/python-modules/python-redis-lock { };
 
+  python-rtmidi = callPackage ../development/python-modules/python-rtmidi { };
+
   python-sql = callPackage ../development/python-modules/python-sql { };
 
   python-snappy = callPackage ../development/python-modules/python-snappy {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3190,6 +3190,8 @@ in {
 
   midiutil = callPackage ../development/python-modules/midiutil {};
 
+  mido = callPackage ../development/python-modules/mido { };
+
   misaka = callPackage ../development/python-modules/misaka {};
 
   mlrose = callPackage ../development/python-modules/mlrose { };


### PR DESCRIPTION
##### Motivation for this change

I got a request for packaging the mido from @piegamesde.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
