### PR TITLE
[haskell-updates] haskellPackages: Fix gtk2hs packages 

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1297,59 +1297,10 @@ self: super: {
     '';
   });
 
-  # Several gtk2hs-provided packages at v0.13.8.0 fail to build on Darwin
-  # until we pick up https://github.com/gtk2hs/gtk2hs/pull/293 so apply that
-  # patch here. That single patch is for the gtk2hs super-repo, out of which
-  # we extract the patch for each indvidiual project (glib/gio/pango/gtk/gtk3).
-  glib = appendPatch super.glib (pkgs.fetchpatch {
-    url = "https://github.com/gtk2hs/gtk2hs/commit/1cf2f9bff2427d39986e32880d1383cfff49ab0e.patch";
-    includes = [ "glib.cabal" ];
-    stripLen = 1;
-    sha256 = "1zdss1xgsbijs3kx8dp5a81qryrfc1zm1xrd20whna3dqakf8b7g";
-  });
-  gio = appendPatch super.gio (pkgs.fetchpatch {
-    url = "https://github.com/gtk2hs/gtk2hs/commit/1cf2f9bff2427d39986e32880d1383cfff49ab0e.patch";
-    includes = [ "gio.cabal" ];
-    stripLen = 1;
-    sha256 = "0d72k6gqvgax9jcqi3gz1gqnar7jg8p5065z3mw2fcwvdw46s2zv";
-  });
-  pango = appendPatch super.pango (pkgs.fetchpatch {
-    url = "https://github.com/gtk2hs/gtk2hs/commit/1cf2f9bff2427d39986e32880d1383cfff49ab0e.patch";
-    includes = [ "pango.cabal" ];
-    stripLen = 1;
-    sha256 = "0dc221wlmyhc24h6ybfhbkxmcx4i6bvkbr1zgqidbnj3yp6w0l5w";
-  });
-  # gtk/gtk3 have an additional complication: independent of the above
-  # 0.13.8.0-specific fix, they need to be told on Darwin to use the Quartz
+  # gtk/gtk3 needs to be told on Darwin to use the Quartz
   # rather than X11 backend (see eg https://github.com/gtk2hs/gtk2hs/issues/249).
-  gtk3 =
-    let
-      patchedGtk3 = appendPatch super.gtk3 (pkgs.fetchpatch {
-        url = "https://github.com/gtk2hs/gtk2hs/commit/1cf2f9bff2427d39986e32880d1383cfff49ab0e.patch";
-        includes = [ "gtk3.cabal" ];
-        stripLen = 1;
-        sha256 = "0zvj0dzfwf9bksfhi0m4v0h5aij236gd0qhyr1adpdcjrkd8zbkd";
-      });
-    in
-      # The appendConfigureFlags should remain even after we can drop patchedGtk3.
-      appendConfigureFlags patchedGtk3 (pkgs.lib.optional pkgs.stdenv.isDarwin "-f have-quartz-gtk");
-  gtk =
-    let
-      patchedGtk = appendPatch super.gtk (pkgs.fetchpatch {
-        url = "https://github.com/gtk2hs/gtk2hs/commit/1cf2f9bff2427d39986e32880d1383cfff49ab0e.patch";
-        includes = [ "gtk.cabal-renamed" ];
-        stripLen = 1;
-        sha256 = "0wb0scvmhg8b42hxpns9m6zak3r8b25a2z7wg6vl56n17nb635l7";
-        # One final complication: the gtk cabal file in the source repo (as seen
-        # by the patch) is `gtk.cabal-renamed`, but this gets changed to the usual
-        # `gtk.cabal` before uploading to Hackage by a script.
-        postFetch = ''
-          substituteInPlace $out --replace "-renamed" ""
-        '';
-      });
-    in
-      # The appendConfigureFlags should remain even after we can drop patchedGtk.
-      appendConfigureFlags patchedGtk (pkgs.lib.optional pkgs.stdenv.isDarwin "-f have-quartz-gtk");
+  gtk3 = appendConfigureFlags super.gtk3 (pkgs.lib.optional pkgs.stdenv.isDarwin "-f have-quartz-gtk");
+  gtk = appendConfigureFlags super.gtk (pkgs.lib.optional pkgs.stdenv.isDarwin "-f have-quartz-gtk");
 
   # Chart-tests needs and compiles some modules from Chart itself
   Chart-tests = (addExtraLibrary super.Chart-tests self.QuickCheck).overrideAttrs (old: {


### PR DESCRIPTION
glib and friends have been bumped to 0.13.8.1 so we can drop a patch
picked from that version.

I don‘t have a darwin system available, but the removed patch was fixing a darwin problem.
From looking at the changes I am confident I am doing the right thing, but I‘d appreciate if someone could test those packages on darwin.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
