### PR TITLE
libpromhttp: init at 0.1.1

### DIFF
--- a/pkgs/development/libraries/libpromhttp/default.nix
+++ b/pkgs/development/libraries/libpromhttp/default.nix
@@ -1,0 +1,50 @@
+{ gccStdenv
+, fetchFromGitHub
+, cmake
+, libmicrohttpd
+, libprom
+, fetchpatch
+}:
+let
+  stdenv = gccStdenv; # Darwin is clang by default and it doesn't work for this.
+in
+stdenv.mkDerivation rec {
+  pname = "libpromhttp";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "digitalocean";
+    repo = "prometheus-client-c";
+    rev = "v${version}";
+    sha256 = "0g69s24xwrv5974acshrhnp6i8rpby8c6bhz15m3d8kpgjw3cm8f";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libmicrohttpd libprom ];
+  doCheck = false;
+
+  patches = [
+     # Required so CMAKE_INSTALL_PREFIX is honored, otherwise it
+     # installs headers in /usr/include (absolute)
+    (fetchpatch {
+      url = "https://github.com/digitalocean/prometheus-client-c/commit/5fcedeb506b7d47dd7bab35797f2c3f23db6fe10.patch";
+      sha256 = "10hzg8v5jcgxz224kdq0nha9vs78wz098b0ys7gig2iwgrg018fy";
+    }) 
+    (fetchpatch {
+      url = "https://github.com/digitalocean/prometheus-client-c/commit/0c15e7e45ad0c3726593591fdd7d8f2fde845fe3.patch";
+      sha256 = "06899v1xz3lpsdxww4p3q7pv8nrymnibncdc472056znr5fidlp0";
+    }) 
+  ];
+
+  preConfigure = ''
+    cd promhttp
+  '';
+
+  meta = {
+    homepage = "https://github.com/digitalocean/prometheus-client-c/";
+    description = "A Prometheus HTTP Endpoint in C";
+    platforms = stdenv.lib.platforms.unix;
+    license = stdenv.lib.licenses.asl20;
+    maintainers = [ stdenv.lib.maintainers.cfsmp3 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13427,6 +13427,8 @@ in
 
   libprom = callPackage ../development/libraries/libprom { };
 
+  libpromhttp = callPackage ../development/libraries/libpromhttp { };
+
   libproxy = callPackage ../development/libraries/libproxy {
     inherit (darwin.apple_sdk.frameworks) SystemConfiguration CoreFoundation JavaScriptCore;
   };


### PR DESCRIPTION
###### Motivation for this change

Build the HTTP endpoint for prometheus C library. It's needed to expose the metrics.

###### Things done

Simple derivation that is based on its sister "libprom", pretty much identical to it except for the dependency to libprom itself.

It's an addition, not a change, so it does not break anything. 

- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions

- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
