### PR TITLE
Fix RPATH for libraries downloaded by rustup

### DIFF
--- a/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
@@ -1,36 +1,37 @@
 diff --git a/src/dist/component/package.rs b/src/dist/component/package.rs
-index 4b432785..fa45e87e 100644
+index 3beddf54..0f859b8d 100644
 --- a/src/dist/component/package.rs
 +++ b/src/dist/component/package.rs
-@@ -109,10 +109,11 @@ impl Package for DirectoryPackage {
-             match &*part.0 {
-                 "file" => {
-                     if self.copy {
--                        builder.copy_file(path.clone(), &src_path)?
-+                        builder.copy_file(path.clone(), &src_path)?;
+@@ -113,6 +113,7 @@ impl Package for DirectoryPackage {
                      } else {
--                        builder.move_file(path.clone(), &src_path)?
-+                        builder.move_file(path.clone(), &src_path)?;
+                         builder.move_file(path.clone(), &src_path)?
                      }
 +                    nix_patchelf_if_needed(&target.prefix().path().join(path.clone()), &src_path)
                  }
                  "dir" => {
                      if self.copy {
-@@ -135,6 +136,22 @@ impl Package for DirectoryPackage {
+@@ -135,6 +136,29 @@ impl Package for DirectoryPackage {
      }
  }
  
 +fn nix_patchelf_if_needed(dest_path: &Path, src_path: &Path) {
-+    let is_bin = if let Some(p) = src_path.parent() {
-+        p.ends_with("bin")
++    let (is_bin, is_lib) = if let Some(p) = src_path.parent() {
++        (p.ends_with("bin"), p.ends_with("lib"))
 +    } else {
-+        false
++        (false, false)
 +    };
 +
 +    if is_bin {
 +        let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
 +            .arg("--set-interpreter")
 +            .arg("@dynamicLinker@")
++            .arg(dest_path)
++            .output();
++    }
++    else if is_lib {
++        let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
++            .arg("--set-rpath")
++            .arg("@libPath@")
 +            .arg(dest_path)
 +            .output();
 +    }


### PR DESCRIPTION
###### Motivation for this change

Fixes #91314 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
