### PR TITLE
coqPackages.equations: 1.2.1 → 1.2.2

### DIFF
--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -33,9 +33,15 @@ let
     };
 
     "8.11" = {
-      version = "1.2.1";
-      rev = "v1.2.1-8.11";
-      sha256 = "06k0h7lansxs479is3vj5ikg8s5k4c6svnqcwmxbni4wx8bhmg17";
+      version = "1.2.2";
+      rev = "v1.2.2-8.11";
+      sha256 = "0g2y0s8kb2imbqyrx9hmvjzpwmicid7shv7ma10fnb8dgk2dqkf9";
+    };
+
+    "8.12" = {
+      version = "1.2.2";
+      rev = "v1.2.2-8.12";
+      sha256 = "0fkz78i2gn9x9scfa7n8fl2sq7czppsicy7w5mq919qqfp0w1aj0";
     };
   };
   param = params.${coq.coq-version};


### PR DESCRIPTION
###### Motivation for this change

Support for Coq 8.12

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
