### PR TITLE
python3Packages.tokenizers: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/tokenizers/default.nix
+++ b/pkgs/development/python-modules/tokenizers/default.nix
@@ -1,0 +1,121 @@
+{ stdenv
+, rustPlatform
+, fetchFromGitHub
+, fetchurl
+, maturin
+, pipInstallHook
+, pytest
+, python
+, requests
+}:
+
+let
+  robertaVocab = fetchurl {
+    url = "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-base-vocab.json";
+    sha256 = "0m86wpkfb2gdh9x9i9ng2fvwk1rva4p0s98xw996nrjxs7166zwy";
+  };
+  robertaMerges = fetchurl {
+    url = "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-base-merges.txt";
+    sha256 = "1idd4rvkpqqbks51i2vjbd928inw7slij9l4r063w3y5fd3ndq8w";
+  };
+  bertVocab = fetchurl {
+    url = "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-uncased-vocab.txt";
+    sha256 = "18rq42cmqa8zanydsbzrb34xwy4l6cz1y900r4kls57cbhvyvv07";
+  };
+  openaiVocab = fetchurl {
+    url = "https://s3.amazonaws.com/models.huggingface.co/bert/openai-gpt-vocab.json";
+    sha256 = "0y40gc9bixj5rxv674br1rxmxkd3ly29p80x1596h8yywwcrpx7x";
+  };
+  openaiMerges = fetchurl {
+    url = "https://s3.amazonaws.com/models.huggingface.co/bert/openai-gpt-merges.txt";
+    sha256 = "09a754pm4djjglv3x5pkgwd6f79i2rq8ydg0f7c3q1wmwqdbba8f";
+  };
+in rustPlatform.buildRustPackage rec {
+  pname = "tokenizers";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = pname;
+    rev = "python-v${version}";
+    sha256 = "0f5r1wm5ybyk3jvihj1g98y7ihq0iklg0pwkaa11pk1gv0k869w3";
+  };
+
+  cargoSha256 = "131bvf35q5n65mq6zws1rp5fn2qkfwfg9sbxi5y6if24n8fpdz4m";
+
+  sourceRoot = "source/bindings/python";
+
+  nativeBuildInputs = [
+    maturin
+    pipInstallHook
+  ];
+
+  propagatedBuildInputs = [
+    python
+  ];
+
+  # tokenizers uses pyo3, which requires Rust nightly.
+  RUSTC_BOOTSTRAP = 1;
+
+  doCheck = false;
+  doInstallCheck = true;
+
+  postUnpack = ''
+    # Add data files for tests, otherwise tests attempt network access.
+    mkdir $sourceRoot/tests/data
+    ( cd $sourceRoot/tests/data
+      ln -s ${robertaVocab} roberta-base-vocab.json
+      ln -s ${robertaMerges} roberta-base-merges.txt
+      ln -s ${bertVocab} bert-base-uncased-vocab.txt
+      ln -s ${openaiVocab} openai-gpt-vocab.json
+      ln -s ${openaiMerges} openai-gpt-merges.txt )
+  '';
+
+  postPatch = ''
+    # pyo3's build check verifies that Rust is a nightly
+    # version. Disable this check.
+    substituteInPlace $NIX_BUILD_TOP/$cargoDepsCopy/pyo3/build.rs \
+      --replace "check_rustc_version()?;" ""
+
+    # Patching the vendored dependency invalidates the file
+    # checksums, so remove them. This should be safe, since
+    # this is just a copy of the vendored dependencies and
+    # the integrity of the vendored dependencies is validated
+    # by cargoSha256.
+    sed -r -i 's|"files":\{[^}]+\}|"files":{}|' \
+      $NIX_BUILD_TOP/$cargoDepsCopy/pyo3/.cargo-checksum.json
+
+    # Maturin uses the crate name as the wheel name.
+    substituteInPlace Cargo.toml \
+      --replace "tokenizers-python" "tokenizers"
+  '';
+
+  buildPhase = ''
+    maturin build --release --manylinux off
+  '';
+
+  installPhase = ''
+    # Put the wheels where the pip install hook can find them.
+    install -Dm644 -t dist target/wheels/*.whl
+    pipInstallPhase
+  '';
+
+  installCheckInputs = [
+    pytest
+    requests
+  ];
+
+  installCheckPhase = ''
+    # Append paths, or the binding's tokenizer module will be
+    # used, since the test directories have __init__.py
+    pytest --import-mode=append
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/huggingface/tokenizers";
+    description = "Fast State-of-the-Art Tokenizers optimized for Research and Production";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1490,6 +1490,9 @@ in {
     inherit (pkgs) sentencepiece pkgconfig;
   };
 
+  tokenizers = disabledIf (!isPy3k)
+    (toPythonModule (callPackage ../development/python-modules/tokenizers { }));
+
   transformers = callPackage ../development/python-modules/transformers { };
 
   transforms3d = callPackage ../development/python-modules/transforms3d { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I wanted to update the `transformers` Python package. However, newer versions require the `tokenizers` Python package. This package is quite interesting by itself:

* It main package is implemented in Rust.
* It also contains some Python files.
* It uses the Rust `pyo3` crate for binding Python.
* Rust `pyo3` needs Rust nightly.
* We can't just use `RUSTC_BOOTSTRAP`, since `pyo3`s build script checks the actual version.

So, to actually make this work I chose to:

* Use `buildRustPackage` as the main driver, so that Rust crates are properly vendored.
* Use `maturin` to build a Python wheel from the combined Rust + Python sources.
* Use `pip` to install the wheel in the right location.

I had to patch the build script of the vendored `pyo3` to remove the explicit Rust version check or it is not happy with the `RUSTC_BOOTSTRAP` cheat code.

As icing on the :cake:, the tests attempt to download some vocabularies. So, we have to put them in place ourselves for purity.

~~I haven't been able to test this on macOS yet, it will probably need `Security`.~~ Builds without issues on my MacBook.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
