### PR TITLE
ZFS: Ask for stage 2 encryption passwords using systemd-ask-password

### DIFF
--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -102,6 +102,8 @@ in
     systemd.services.plymouth-poweroff.wantedBy = [ "poweroff.target" ];
     systemd.services.plymouth-reboot.wantedBy = [ "reboot.target" ];
     systemd.services.plymouth-read-write.wantedBy = [ "sysinit.target" ];
+    systemd.services.systemd-ask-password-plymouth.wantedBy = ["multi-user.target"];
+    systemd.paths.systemd-ask-password-plymouth.wantedBy = ["multi-user.target"];
 
     boot.initrd.extraUtilsCommands = ''
       copy_bin_and_libs ${pkgs.plymouth}/bin/plymouthd
@@ -146,6 +148,7 @@ in
     # We use `mkAfter` to ensure that LUKS password prompt would be shown earlier than the splash screen.
     boot.initrd.preLVMCommands = mkAfter ''
       mkdir -p /etc/plymouth
+      mkdir -p /run/plymouth
       ln -s ${configFile} /etc/plymouth/plymouthd.conf
       ln -s $extraUtils/share/plymouth/plymouthd.defaults /etc/plymouth/plymouthd.defaults
       ln -s $extraUtils/share/plymouth/logo.png /etc/plymouth/logo.png

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -490,7 +490,11 @@ in
             description = "Import ZFS pool \"${pool}\"";
             # we need systemd-udev-settle until https://github.com/zfsonlinux/zfs/pull/4943 is merged
             requires = [ "systemd-udev-settle.service" ];
-            after = [ "systemd-udev-settle.service" "systemd-modules-load.service" ];
+            after = [
+              "systemd-udev-settle.service"
+              "systemd-modules-load.service"
+              "systemd-ask-password-console.service"
+            ];
             wantedBy = (getPoolMounts pool) ++ [ "local-fs.target" ];
             before = (getPoolMounts pool) ++ [ "local-fs.target" ];
             unitConfig = {
@@ -515,7 +519,20 @@ in
               done
               poolImported "${pool}" || poolImport "${pool}"  # Try one last time, e.g. to import a degraded pool.
               if poolImported "${pool}"; then
-                ${optionalString cfgZfs.requestEncryptionCredentials "\"${packages.zfsUser}/sbin/zfs\" load-key -r \"${pool}\""}
+                ${optionalString cfgZfs.requestEncryptionCredentials ''
+                  ${packages.zfsUser}/sbin/zfs list -rHo name,keylocation ${pool} | while read ds kl; do
+                    case "$kl" in
+                      none )
+                        ;;
+                      prompt )
+                        ${config.systemd.package}/bin/systemd-ask-password "Enter key for $ds:" | ${packages.zfsUser}/sbin/zfs load-key "$ds"
+                        ;;
+                      * )
+                        ${packages.zfsUser}/sbin/zfs load-key "$ds"
+                        ;;
+                      esac
+                  done
+                ''}
                 echo "Successfully imported ${pool}"
               else
                 exit 1

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -520,7 +520,7 @@ in
               poolImported "${pool}" || poolImport "${pool}"  # Try one last time, e.g. to import a degraded pool.
               if poolImported "${pool}"; then
                 ${optionalString cfgZfs.requestEncryptionCredentials ''
-                  ${packages.zfsUser}/sbin/zfs list -rHo name,keylocation ${pool} | while read ds kl; do
+                  ${packages.zfsUser}/sbin/zfs list -rHo name,keylocation ${pool} | while IFS=$'\t' read ds kl; do
                     (case "$kl" in
                       none )
                         ;;

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -521,7 +521,7 @@ in
               if poolImported "${pool}"; then
                 ${optionalString cfgZfs.requestEncryptionCredentials ''
                   ${packages.zfsUser}/sbin/zfs list -rHo name,keylocation ${pool} | while read ds kl; do
-                    case "$kl" in
+                    (case "$kl" in
                       none )
                         ;;
                       prompt )
@@ -530,7 +530,7 @@ in
                       * )
                         ${packages.zfsUser}/sbin/zfs load-key "$ds"
                         ;;
-                      esac
+                    esac) < /dev/null # To protect while read ds kl in case anything reads stdin
                   done
                 ''}
                 echo "Successfully imported ${pool}"


### PR DESCRIPTION
###### Motivation for this change

Currently, ZFS pools that do not contain the system root file system can only have encrypted datasets that use key files. They cannot use `keylocation=prompt`. This PR fixes this by prompting for passphrases using `systemd-ask-password`.

This PR also ensures Plymouth users can take advantage of this by enabling `systemd-ask-password-plymouth.service`. I did have to steal one line from #84158, specifically `mkdir /run/plymouth`. This will have the added benefit of allowing other services to use `systemd-ask-password` during boot without breaking for plymouth users. Note that you need to set `virtualisation.useBootLoader = true` in order to test plymouth with `nixos-rebuild build-vm`.

Relevant: #84158, #88789

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
