### PR TITLE
pulsar: init at 2.6.0

### DIFF
--- a/pkgs/servers/pulsar/default.nix
+++ b/pkgs/servers/pulsar/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, jre, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "pulsar";
+  version = "2.6.0";
+
+  src = fetchurl {
+    url = "mirror://apache/pulsar/${pname}-${version}/apache-${pname}-${version}-bin.tar.gz";
+    sha256 = "0979nvv018brgyc3mn71sbm7yxxbid112lv85y5b8xh58vj96psv";
+  };
+
+  buildInputs = [ makeWrapper jre ];
+
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R bin instances lib conf $out
+    patchShebangs $out/bin
+    for i in $out/bin/*; do
+      if [ -f $i ]; then
+        wrapProgram $i --set JAVA_HOME "${jre}"
+      fi
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://pulsar.apache.org";
+    description = "An open-source distributed pub-sub messaging system, part of the Apache Software Foundation";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ samdroid-apps ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16498,6 +16498,8 @@ in
 
   zookeeper_mt = callPackage ../development/libraries/zookeeper_mt { };
 
+  pulsar = callPackage ../servers/pulsar { };
+
   xqilla = callPackage ../development/tools/xqilla { };
 
   xquartz = callPackage ../servers/x11/xquartz { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds a package for Apache Pulsar, based on the Apache Zookeeper package.  In a followup PR, I'll add a service to run Pulsar.

###### Testing pulsar

<details>
  <summary>Pulsar requires configuration to start, here's an example script to start all the pieces:</summary>

After building pulsar to `./result` (`nix-build -A pulsar ~/nixpkgs/default.nix`):

```
export PULSAR_LOG_DIR=/tmp/pulsar/logs
mkdir -p /tmp/pulsar/conf
export PULSAR_ZK_CONF=/tmp/pulsar/conf/zookeeper.conf
cat <<-EOF > /tmp/pulsar/conf/zookeeper.conf
  # remember to "echo 1 > /tmp/pulsar/zookeeper/myid"
  clientPort=2181
  dataDir=/tmp/pulsar/zookeeper
  autopurge.purgeInterval=1
  initLimit=5
  syncLimit=2
  tickTime=2000
EOF
export PULSAR_BOOKKEEPER_CONF=/tmp/pulsar/conf/bookkeeper.conf
cat <<-EOF > /tmp/pulsar/conf/bookkeeper.conf
  zkServers=localhost:2181
  advertisedAddress=127.0.0.1

  journalDirectories=/tmp/pulsar/bk-journal
  ledgerDirectories=/tmp/pulsar/bk-ledger
  storage.range.store.dirs=/tmp/pulsar/bk-range-store-dirs
EOF
export PULSAR_BROKER_CONF=/tmp/pulsar/conf/broker.conf
cat <<-EOF > /tmp/pulsar/conf/broker.conf
  zookeeperServers=127.0.0.1:2181
  configurationStoreServers=127.0.0.1:2181
  clusterName=pulsar-cluster-1

  # to not conflict with the bookkeeper admin interface
  webServicePort=8081

  # running it locally, we only have 1 bookkeeper node
  managedLedgerDefaultEnsembleSize=1
  managedLedgerDefaultWriteQuorum=1
  managedLedgerDefaultAckQuorum=1
EOF
export PULSAR_CLIENT_CONF=/tmp/pulsar/conf/client.conf
cat <<-EOF > /tmp/pulsar/conf/client.conf
  webServiceUrl=http://127.0.0.1:8081
  brokerServiceurl=pulsar://127.0.0.1:6650
EOF

# Start zookeeper, using the bundled pulsar version
result/bin/pulsar zookeeper &
# One time setup, required to start bookkeeper
result/bin/pulsar initialize-cluster-metadata \
    --cluster pulsar-cluster-1 \
    --zookeeper 127.0.0.1:2181 \
    --configuration-store 127.0.0.1:2181 \
    --web-service-url http://127.0.0.1:8080 \
    --broker-service-url pulsar://127.0.0.1:6650
# Start bookkeeper using the bundled pulsar version
result/bin/pulsar bookie &

# Start pulsar message broker
result/bin/pulsar broker
```

You can create a test message consumer in another terminal:

```
result/bin/pulsar-client consume "test-topic" --subscription-name "test-subscription"
```

And send a message in a separate terminal:

```
result/bin/pulsar-client produce "test-topic" --messages "Yay a test message!"
```

</details>

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
