### PR TITLE
ocamlPackages.{ipaddr,macaddr}: 3.1.0 → 5.0.0 and update all affected packages (tuntap, conduit, cohttp, …)

### DIFF
--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -1,27 +1,25 @@
-{ lib, fetchFromGitHub, buildDunePackage
-, ppx_fields_conv, ppx_sexp_conv
+{ lib, fetchurl, buildDunePackage
+, ppx_fields_conv, ppx_sexp_conv, stdlib-shims
 , base64, fieldslib, jsonm, re, stringext, uri-sexp
 }:
 
 buildDunePackage rec {
-  pname = "cohttp";
-	version = "2.1.3";
+	pname = "cohttp";
+	version = "2.5.1";
 
-	src = fetchFromGitHub {
-		owner = "mirage";
-		repo = "ocaml-cohttp";
-		rev = "v${version}";
-		sha256 = "16k4ldmz6ljryhr139adlma130frb5wh13qswkrwc5gxx6d2wh8d";
+	src = fetchurl {
+		url = "https://github.com/mirage/ocaml-cohttp/releases/download/v${version}/cohttp-v${version}.tbz";
+		sha256 = "0im91mi3nxzqfd7fs5r0zg5gsparfnf5zaz13mpw247hkd3y3396";
 	};
 
 	buildInputs = [ jsonm ppx_fields_conv ppx_sexp_conv ];
 
-	propagatedBuildInputs = [ base64 fieldslib re stringext uri-sexp ];
+	propagatedBuildInputs = [ base64 fieldslib re stringext uri-sexp stdlib-shims ];
 
 	meta = {
 		description = "HTTP(S) library for Lwt, Async and Mirage";
 		license = lib.licenses.isc;
 		maintainers = [ lib.maintainers.vbgl ];
-		inherit (src.meta) homepage;
+		homepage = "https://github.com/mirage/ocaml-cohttp";
 	};
 }

--- a/pkgs/development/ocaml-modules/cohttp/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt-unix.nix
@@ -11,6 +11,8 @@ buildDunePackage {
 	pname = "cohttp-lwt-unix";
 	inherit (cohttp-lwt) version src meta;
 
+	useDune2 = true;
+
 	buildInputs = [ cmdliner ppx_sexp_conv ];
 
 	propagatedBuildInputs = [ cohttp-lwt conduit-lwt-unix fmt magic-mime ];

--- a/pkgs/development/ocaml-modules/cohttp/lwt.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt.nix
@@ -2,6 +2,8 @@
 
 if !stdenv.lib.versionAtLeast cohttp.version "0.99"
 then cohttp
+else if !stdenv.lib.versionAtLeast ppx_sexp_conv.version "0.13"
+then throw "cohttp-lwt is not available for ppx_sexp_conv version ${ppx_sexp_conv.version}"
 else
 
 buildDunePackage {

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -1,26 +1,26 @@
-{ stdenv, fetchFromGitHub, buildDunePackage
-, ppx_sexp_conv, sexplib
-, astring, ipaddr, macaddr, uri,
+{ stdenv, fetchurl, buildDunePackage
+, ppx_sexp_conv, sexplib, astring, uri, logs
+, ipaddr, ipaddr-sexp
 }:
 
 buildDunePackage rec {
   pname = "conduit";
-  version = "1.4.0";
+  version = "2.2.2";
 
-  src = fetchFromGitHub {
-    owner = "mirage";
-    repo = "ocaml-conduit";
-    rev = "v${version}";
-    sha256 = "1qzamqcmf9ywz04bkwrv17mz9j6zq2w9h1xmnjvp11pnwrs2xq8l";
+  minimumOCamlVersion = "4.07";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-conduit/releases/download/v2.2.2/conduit-v2.2.2.tbz";
+    sha256 = "1zb83w2pq9c8xrappfxa6y5q93772f5dj22x78camsm77a2c2z55";
   };
 
   buildInputs = [ ppx_sexp_conv ];
-  propagatedBuildInputs = [ astring ipaddr macaddr sexplib uri ];
+  propagatedBuildInputs = [ astring ipaddr ipaddr-sexp sexplib uri ];
 
   meta = {
     description = "Network connection library for TCP and SSL";
     license = stdenv.lib.licenses.isc;
     maintainers = with stdenv.lib.maintainers; [ alexfmpe vbgl ];
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/mirage/ocaml-conduit";
   };
 }

--- a/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
@@ -1,16 +1,20 @@
-{ stdenv, buildDunePackage, conduit-lwt
-, logs, ppx_sexp_conv, lwt_ssl
+{ stdenv, buildDunePackage
+, conduit-lwt, ppx_sexp_conv, ocaml_lwt, uri, ipaddr, ipaddr-sexp
+, lwt_ssl, tls
 }:
-
-if !stdenv.lib.versionAtLeast conduit-lwt.version "1.0"
-then conduit-lwt
-else
 
 buildDunePackage {
 	pname = "conduit-lwt-unix";
-	inherit (conduit-lwt) version src meta;
+	inherit (conduit-lwt) version src minimumOCamlVersion;
+
+	useDune2 = true;
 
 	buildInputs = [ ppx_sexp_conv ];
 
-	propagatedBuildInputs = [ conduit-lwt logs lwt_ssl ];
+	propagatedBuildInputs =
+		[ conduit-lwt ocaml_lwt uri ipaddr ipaddr-sexp tls lwt_ssl ];
+
+	meta = conduit-lwt.meta // {
+		description = "A network connection establishment library for Lwt_unix";
+	};
 }

--- a/pkgs/development/ocaml-modules/conduit/lwt.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt.nix
@@ -1,14 +1,14 @@
-{ stdenv, buildDunePackage, ppx_sexp_conv, conduit, ocaml_lwt }:
-
-if !stdenv.lib.versionAtLeast conduit.version "1.0"
-then conduit
-else
+{ stdenv, buildDunePackage, ppx_sexp_conv, conduit, ocaml_lwt, sexplib }:
 
 buildDunePackage {
 	pname = "conduit-lwt";
-	inherit (conduit) version src meta;
+	inherit (conduit) version src minimumOCamlVersion;
 
 	buildInputs = [ ppx_sexp_conv ];
 
-	propagatedBuildInputs = [ conduit ocaml_lwt ];
+	propagatedBuildInputs = [ conduit ocaml_lwt sexplib ];
+
+	meta = conduit.meta // {
+		description = "A network connection establishment library for Lwt";
+	};
 }

--- a/pkgs/development/ocaml-modules/curly/default.nix
+++ b/pkgs/development/ocaml-modules/curly/default.nix
@@ -7,6 +7,8 @@ buildDunePackage rec {
 
   minimumOCamlVersion = "4.02";
 
+  useDune2 = true;
+
   src = fetchFromGitHub {
     owner  = "rgrinberg";
     repo   = pname;

--- a/pkgs/development/ocaml-modules/git-unix/default.nix
+++ b/pkgs/development/ocaml-modules/git-unix/default.nix
@@ -4,6 +4,8 @@ buildDunePackage {
 	pname = "git-unix";
 	inherit (git-http) version src;
 
+	useDune2 = true;
+
 	buildInputs = [ cmdliner mtime ];
 	propagatedBuildInputs = [ cohttp-lwt-unix git-http tls ];
 

--- a/pkgs/development/ocaml-modules/graphql/cohttp.nix
+++ b/pkgs/development/ocaml-modules/graphql/cohttp.nix
@@ -8,6 +8,8 @@ buildDunePackage rec {
 
   inherit (graphql) version src;
 
+  useDune2 = true;
+
   nativeBuildInputs = [ ocaml-crunch ];
   propagatedBuildInputs = [ astring cohttp digestif graphql ocplib-endian ];
 

--- a/pkgs/development/ocaml-modules/ipaddr/cstruct.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/cstruct.nix
@@ -1,0 +1,17 @@
+{ lib, buildDunePackage
+, ipaddr, cstruct
+}:
+
+buildDunePackage rec {
+  pname = "ipaddr-cstruct";
+
+  inherit (ipaddr) version src minimumOCamlVersion;
+
+  propagatedBuildInputs = [ ipaddr cstruct ];
+
+  doCheck = true;
+
+  meta = ipaddr.meta // {
+    description = "A library for manipulation of IP address representations using Cstructs";
+  };
+}

--- a/pkgs/development/ocaml-modules/ipaddr/default.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/default.nix
@@ -1,22 +1,20 @@
 { lib, buildDunePackage
-, macaddr, ounit
+, macaddr, domain-name, stdlib-shims
+, ounit, ppx_sexp_conv
 }:
 
 buildDunePackage rec {
   pname = "ipaddr";
 
-  inherit (macaddr) version src;
+  inherit (macaddr) version src minimumOCamlVersion;
 
-  buildInputs = [ ounit ];
+  propagatedBuildInputs = [ macaddr domain-name stdlib-shims ];
 
-  propagatedBuildInputs = [ macaddr ];
-
+  checkInputs = [ ppx_sexp_conv ounit ];
   doCheck = true;
 
-  meta = with lib; {
-    homepage = "https://github.com/mirage/ocaml-ipaddr";
+  meta = macaddr.meta // {
     description = "A library for manipulation of IP (and MAC) address representations ";
-    license = licenses.isc;
-    maintainers = with maintainers; [ alexfmpe ericbmerritt ];
+    maintainers = with lib.maintainers; [ alexfmpe ericbmerritt ];
   };
 }

--- a/pkgs/development/ocaml-modules/ipaddr/sexp.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/sexp.nix
@@ -1,0 +1,18 @@
+{ lib, buildDunePackage
+, ipaddr, ipaddr-cstruct, ounit, ppx_sexp_conv
+}:
+
+buildDunePackage rec {
+  pname = "ipaddr-sexp";
+
+  inherit (ipaddr) version src minimumOCamlVersion;
+
+  propagatedBuildInputs = [ ipaddr ];
+
+  checkInputs = [ ipaddr-cstruct ounit ppx_sexp_conv ];
+  doCheck = true;
+
+  meta = ipaddr.meta // {
+    description = "A library for manipulation of IP address representations usnig sexp";
+  };
+}

--- a/pkgs/development/ocaml-modules/irmin/git.nix
+++ b/pkgs/development/ocaml-modules/irmin/git.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
 
   inherit (irmin) version src;
 
+  useDune2 = true;
+
   propagatedBuildInputs = [ git irmin ];
 
   checkInputs = lib.optionals doCheck [ git-unix irmin-mem irmin-test ];

--- a/pkgs/development/ocaml-modules/irmin/graphql.nix
+++ b/pkgs/development/ocaml-modules/irmin/graphql.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
 
   inherit (irmin) version src;
 
+  useDune2 = true;
+
   propagatedBuildInputs = [ cohttp-lwt graphql-cohttp graphql-lwt irmin ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/irmin/http.nix
+++ b/pkgs/development/ocaml-modules/irmin/http.nix
@@ -8,6 +8,8 @@ buildDunePackage rec {
 
   inherit (irmin) version src;
 
+  useDune2 = true;
+
   propagatedBuildInputs = [ cohttp-lwt irmin webmachine ];
 
   checkInputs = lib.optionals doCheck [ checkseum git-unix irmin-git irmin-mem irmin-test ];

--- a/pkgs/development/ocaml-modules/irmin/ppx.nix
+++ b/pkgs/development/ocaml-modules/irmin/ppx.nix
@@ -5,6 +5,8 @@ buildDunePackage {
 
   inherit (irmin) version src minimumOCamlVersion;
 
+  useDune2 = true;
+
   buildInputs = [ ocaml-syntax-shims ];
   propagatedBuildInputs = [ ppxlib ];
 

--- a/pkgs/development/ocaml-modules/irmin/unix.nix
+++ b/pkgs/development/ocaml-modules/irmin/unix.nix
@@ -10,6 +10,8 @@ buildDunePackage rec {
 
   inherit (irmin) version src;
 
+  useDune2 = true;
+
   propagatedBuildInputs = [ checkseum cmdliner git-unix yaml
     irmin irmin-fs irmin-git irmin-graphql irmin-http irmin-mem irmin-pack irmin-watcher
   ];

--- a/pkgs/development/ocaml-modules/macaddr/cstruct.nix
+++ b/pkgs/development/ocaml-modules/macaddr/cstruct.nix
@@ -1,0 +1,17 @@
+{ lib, buildDunePackage
+, macaddr, cstruct
+}:
+
+buildDunePackage {
+  pname = "macaddr-cstruct";
+
+  inherit (macaddr) version src minimumOCamlVersion;
+
+  propagatedBuildInputs = [ macaddr cstruct ];
+
+  doCheck = true;
+
+  meta = macaddr.meta // {
+    description = "A library for manipulation of MAC address representations using Cstructs";
+  };
+}

--- a/pkgs/development/ocaml-modules/macaddr/default.nix
+++ b/pkgs/development/ocaml-modules/macaddr/default.nix
@@ -1,21 +1,20 @@
 { lib, fetchurl, buildDunePackage
-, ppx_sexp_conv
+, ppx_sexp_conv, ounit
 }:
 
 buildDunePackage rec {
   pname = "macaddr";
-  version = "3.1.0";
+  version = "5.0.0";
 
   minimumOCamlVersion = "4.04";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-ipaddr/archive/v${version}.tar.gz";
-    sha256 = "1hi3v5dzg6h4qb268ch3h6v61gsc8bv21ajhb35z37v5nsdmyzbh";
+    sha256 = "1j2m2v64g3d81sixxq3g57j1iyk6042ivsszml18akrqvwfpxy66";
   };
 
-  propagatedBuildInputs = [ ppx_sexp_conv ];
-
-  doCheck = false; # ipaddr and macaddr tests are together, which requires mutual dependency
+  checkInputs = [ ppx_sexp_conv ounit ];
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/mirage/ocaml-ipaddr";

--- a/pkgs/development/ocaml-modules/macaddr/sexp.nix
+++ b/pkgs/development/ocaml-modules/macaddr/sexp.nix
@@ -1,0 +1,18 @@
+{ lib, buildDunePackage
+, macaddr, ppx_sexp_conv, macaddr-cstruct, ounit
+}:
+
+buildDunePackage {
+  pname = "macaddr-sexp";
+
+  inherit (macaddr) version src minimumOCamlVersion;
+
+  propagatedBuildInputs = [ ppx_sexp_conv ];
+
+  checkInputs = [ macaddr-cstruct ounit ];
+  doCheck = true;
+
+  meta = macaddr.meta // {
+    description = "A library for manipulation of MAC address representations using sexp";
+  };
+}

--- a/pkgs/development/ocaml-modules/opium/default.nix
+++ b/pkgs/development/ocaml-modules/opium/default.nix
@@ -17,6 +17,8 @@ buildDunePackage {
 	pname = "opium";
 	inherit (opium_kernel) version src meta minimumOCamlVersion;
 
+  useDune2 = true;
+
   doCheck = true;
 
 	buildInputs = [

--- a/pkgs/development/ocaml-modules/tuntap/default.nix
+++ b/pkgs/development/ocaml-modules/tuntap/default.nix
@@ -1,25 +1,27 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, ipaddr }:
+{ lib, buildDunePackage, fetchurl
+, ipaddr, macaddr, cmdliner
+}:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01";
+buildDunePackage rec {
+  pname = "tuntap";
+  version = "2.0.0";
 
-stdenv.mkDerivation {
-  name = "ocaml-tuntap-1.3.0";
+  minimumOCamlVersion = "4.04.2";
 
-  src = fetchzip {
-    url = "https://github.com/mirage/ocaml-tuntap/archive/v1.3.0.tar.gz";
-    sha256 = "1cmd4kky875ks02gm2nb8yr80hmlfcnjdfyc63hvkh49acssy3d5";
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-tuntap/releases/download/v${version}/tuntap-v${version}.tbz";
+    sha256 = "12wmls28h3jzikwyfw08d5f7ycsc9njwzbhd3qk2l8jnf5rakfsa";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
-  propagatedBuildInputs = [ ipaddr ];
+  propagatedBuildInputs = [ ipaddr macaddr cmdliner ];
 
-  createFindlibDestdir = true;
+  # tests manipulate network devices and use network
+  # also depend on LWT 5
+  doCheck = false;
 
   meta = {
     description = "Bindings to the UNIX tuntap facility";
-    license = stdenv.lib.licenses.isc;
+    license = lib.licenses.isc;
     homepage = "https://github.com/mirage/ocaml-tuntap";
-    inherit (ocaml.meta) platforms;
   };
-
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -326,6 +326,10 @@ let
 
     ipaddr = callPackage ../development/ocaml-modules/ipaddr { };
 
+    ipaddr-cstruct = callPackage ../development/ocaml-modules/ipaddr/cstruct.nix { };
+
+    ipaddr-sexp = callPackage ../development/ocaml-modules/ipaddr/sexp.nix { };
+
     irmin_1 = callPackage ../development/ocaml-modules/irmin/1.4.nix { };
 
     iso8601 = callPackage ../development/ocaml-modules/iso8601 { };
@@ -478,6 +482,10 @@ let
     lwt_ssl = callPackage ../development/ocaml-modules/lwt_ssl { };
 
     macaddr = callPackage ../development/ocaml-modules/macaddr { };
+
+    macaddr-cstruct = callPackage ../development/ocaml-modules/macaddr/cstruct.nix { };
+
+    macaddr-sexp = callPackage ../development/ocaml-modules/macaddr/sexp.nix { };
 
     macaque = callPackage ../development/ocaml-modules/macaque { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/mirage/ocaml-ipaddr/releases/tag/v5.0.0> etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
