### PR TITLE
searx: fix werkzeug.contrib import

### DIFF
--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, fetchFromGitHub }:
+{ lib, python3Packages, fetchFromGitHub, fetchpatch }:
 
 with python3Packages;
 
@@ -13,6 +13,11 @@ buildPythonApplication rec {
     rev = "v${version}";
     sha256 = "0hfa4nmis98yvghxw866rzjpmhb2ln8l6l8g9yx4m79b2lk76xcs";
   };
+
+  patches = [(fetchpatch {
+    url = "https://github.com/asciimoo/searx/commit/b8b13372c8fd3bfe978a1c724ab98b05348df054.patch";
+    sha256 = "1zc3dx8pgqfg0bj48ihckjk9xrrm33jlnmj8k02g17gfcmj7566a";
+  })];
 
   postPatch = ''
     substituteInPlace requirements.txt \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Building searx failed with the following error message: 

```
tests.unit.test_webapp (unittest.loader._FailedTest) ... ERROR

======================================================================
ERROR: webapp (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: webapp
Traceback (most recent call last):
  File "/nix/store/jli50q24fvik6pfsnjs1jd90g3dy4p6y-python3-3.8.3/lib/python3.8/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/build/source/searx/webapp.py", line 50, in <module>
    from werkzeug.contrib.fixers import ProxyFix
ModuleNotFoundError: No module named 'werkzeug.contrib'


======================================================================
ERROR: test_webapp (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_webapp
Traceback (most recent call last):
  File "/nix/store/jli50q24fvik6pfsnjs1jd90g3dy4p6y-python3-3.8.3/lib/python3.8/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/build/source/tests/unit/test_webapp.py", line 5, in <module>
    from searx import webapp
  File "/build/source/searx/webapp.py", line 50, in <module>
    from werkzeug.contrib.fixers import ProxyFix
ModuleNotFoundError: No module named 'werkzeug.contrib'


======================================================================
ERROR: tests.unit.test_webapp (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: tests.unit.test_webapp
Traceback (most recent call last):
  File "/nix/store/jli50q24fvik6pfsnjs1jd90g3dy4p6y-python3-3.8.3/lib/python3.8/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/nix/store/jli50q24fvik6pfsnjs1jd90g3dy4p6y-python3-3.8.3/lib/python3.8/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/build/source/tests/unit/test_webapp.py", line 5, in <module>
    from searx import webapp
  File "/build/source/searx/webapp.py", line 50, in <module>
    from werkzeug.contrib.fixers import ProxyFix
ModuleNotFoundError: No module named 'werkzeug.contrib'


----------------------------------------------------------------------
Ran 61 tests in 0.110s

FAILED (errors=3)
Test failed: <unittest.runner.TextTestResult run=61 errors=3 failures=0>
error: Test failed: <unittest.runner.TextTestResult run=61 errors=3 failures=0>
builder for '/nix/store/844dfa093nh0g1913wd5njv6fqsr5w3h-searx-0.16.0.drv' failed with exit code 1
error: build of '/nix/store/844dfa093nh0g1913wd5njv6fqsr5w3h-searx-0.16.0.drv' failed
```

###### Things done

Applied the patch from upstream https://github.com/asciimoo/searx/pull/1831.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
