### PR TITLE
python3Packages.tinycss2: fix failing tests

### DIFF
--- a/pkgs/development/python-modules/cssselect2/default.nix
+++ b/pkgs/development/python-modules/cssselect2/default.nix
@@ -1,4 +1,5 @@
-{ lib, buildPythonPackage, fetchPypi, tinycss2, pytest, pytestrunner }:
+{ lib, buildPythonPackage, fetchPypi, tinycss2
+, pytest, pytestrunner, pytestcov, pytest-flake8, pytest-isort }:
 
 buildPythonPackage rec {
   pname = "cssselect2";
@@ -9,21 +10,9 @@ buildPythonPackage rec {
     sha256 = "5c2716f06b5de93f701d5755a9666f2ee22cbcd8b4da8adddfc30095ffea3abc";
   };
 
-  # We're not interested in code quality tests
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "pytest-cov" "" \
-      --replace "pytest-flake8" "" \
-      --replace "pytest-isort" ""
-    substituteInPlace setup.cfg \
-      --replace "--cov=cssselect2" "" \
-      --replace "--flake8" "" \
-      --replace "--isort" ""
-  '';
-
   propagatedBuildInputs = [ tinycss2 ];
 
-  checkInputs = [ pytest pytestrunner ];
+  checkInputs = [ pytest pytestrunner pytestcov pytest-flake8 pytest-isort ];
 
   meta = with lib; {
     description = "CSS selectors for Python ElementTree";

--- a/pkgs/development/python-modules/tinycss2/default.nix
+++ b/pkgs/development/python-modules/tinycss2/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, pythonOlder, fetchPypi
+{ lib, buildPythonPackage, pythonOlder, fetchPypi, fetchpatch
 , webencodings
 , pytest, pytestrunner, pytestcov, pytest-flake8, pytest-isort }:
 
@@ -12,7 +12,14 @@ buildPythonPackage rec {
     sha256 = "1kw84y09lggji4krkc58jyhsfj31w8npwhznr7lf19d0zbix09v4";
   };
 
-  patches = [ ./remove-redundant-dependency.patch ];
+  patches = [
+    ./remove-redundant-dependency.patch
+    # fixes tests, remove this patch on next version bump
+    (fetchpatch {
+      url = "https://github.com/Kozea/tinycss2/commit/6556604fb98c2153412384d6f0f705db2da1aa60.patch";
+      sha256 = "1srvdzg1bak65fawd611rlskcgn5abmwmyjnk8qrrrasr554bc59";
+    })
+  ];
 
   propagatedBuildInputs = [ webencodings ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://hydra.nixos.org/build/122651822

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
