### PR TITLE
nixos: added navidrome service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -472,6 +472,7 @@
   ./services/misc/mesos-slave.nix
   ./services/misc/metabase.nix
   ./services/misc/mwlib.nix
+  ./services/misc/navidrome.nix
   ./services/misc/nix-daemon.nix
   ./services/misc/nix-gc.nix
   ./services/misc/nix-optimise.nix

--- a/nixos/modules/services/misc/navidrome.nix
+++ b/nixos/modules/services/misc/navidrome.nix
@@ -1,0 +1,116 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.navidrome;
+  configFile = "/etc/navidrome/settings.json";
+  dataFolder = "/var/lib/navidrome";
+in {
+  options = {
+
+    services.navidrome = {
+      enable = mkEnableOption "Enable Navidrome music server and streamer";
+
+      settings = lib.mkOption {
+        type = types.attrs;
+        default = {};
+        example = {
+          LogLevel = "INFO";
+          BaseURL = "/music";
+          ScanInterval = "10s";
+          TranscodingCacheSize = "15MB";
+          MusicFolder = "/Media/Music";
+        };
+        description = ''
+        Configuration for Navidrome, see <link xlink:href="https://www.navidrome.org/docs/usage/configuration-options/"/> for supported values.
+      '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "navidrome";
+        description = "User account under which Navidrome runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "navidrome";
+        description = "Group account under which Navidrome runs.";
+      };
+
+      musicFolderPermissions = mkOption {
+        type = types.str;
+        default = "775";
+        description = ''
+        The permissions to set for the music folder.
+        They will be applied on every service start.
+        '';
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.tmpfiles.rules = [
+      "d '${cfg.settings.MusicFolder}' '${cfg.musicFolderPermissions}' '${cfg.user}' '${cfg.group}' - -"
+    ];
+
+    environment.etc."navidrome/settings.json".text = builtins.toJSON (cfg.settings // {
+      # These settings are always overwritten by NixOS i.e. they are not settable
+      DataFolder = dataFolder;
+      ConfigFile = configFile;
+    } // (if (attrsets.hasAttrByPath ["Port"] cfg.settings)
+          then {Port = builtins.toString cfg.settings.Port;}
+          else {})); 
+    
+    systemd.services.navidrome = {
+      description = "Navidrome Music Server and Streamer compatible with Subsonic/Airsonic";
+      after = [ "remote-fs.target" "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = {
+        ND_CONFIGFILE = configFile;
+      };
+      serviceConfig = {
+        ExecStart = "${pkgs.navidrome}/bin/navidrome";
+        WorkingDirectory = dataFolder;
+        TimeoutStopSec = "20";
+        KillMode = "process";
+        Restart = "on-failure";
+        User = cfg.user;
+        Group = cfg.group;
+        DevicePolicy = "closed";
+        NoNewPrivileges= " yes";
+        PrivateTmp = "yes";
+        PrivateUsers = "yes";
+        ProtectControlGroups = "yes";
+        ProtectKernelModules = "yes";
+        ProtectKernelTunables = "yes";
+        RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
+        RestrictNamespaces = "yes";
+        RestrictRealtime = "yes";
+        SystemCallFilter = "~@clock @debug @module @mount @obsolete @privileged @reboot @setuid @swap";
+        ReadWritePaths = dataFolder;
+      };
+    };
+
+    users.users = optionalAttrs (cfg.user == "navidrome") ({
+      navidrome = {
+        description = "Navidrome service user";
+        name = cfg.user;
+        group = cfg.group;
+        home = dataFolder;
+        createHome = true;
+        isSystemUser = true;
+      };
+    });
+
+    users.groups = optionalAttrs (cfg.group == "navidrome") ({
+      navidrome = {
+        name = "navidrome";
+      };
+    });
+    
+  };
+}

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -27,7 +27,7 @@
 , libXinerama
 , libXrender
 , libXt
-, libcanberra-gtk2
+, libcanberra
 , libgnome
 , libgnomeui
 , libnotify
@@ -122,7 +122,7 @@ stdenv.mkDerivation {
       libXinerama
       libXrender
       libXt
-      libcanberra-gtk2
+      libcanberra
       libgnome
       libgnomeui
       libnotify

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -8,7 +8,6 @@
 , dbus
 , fontconfig
 , freetype
-, gconf
 , gdk-pixbuf
 , glib
 , glibc
@@ -101,7 +100,6 @@ stdenv.mkDerivation {
       dbus
       fontconfig
       freetype
-      gconf
       gdk-pixbuf
       glib
       glibc

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -28,8 +28,6 @@
 , libXrender
 , libXt
 , libcanberra
-, libgnome
-, libgnomeui
 , libnotify
 , gnome3
 , libGLU, libGL
@@ -123,8 +121,6 @@ stdenv.mkDerivation {
       libXrender
       libXt
       libcanberra
-      libgnome
-      libgnomeui
       libnotify
       libGLU libGL
       nspr

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -2,7 +2,7 @@
 , src, unpackPhase ? null, patches ? []
 , extraNativeBuildInputs ? [], extraConfigureFlags ? [], extraMakeFlags ? [] }:
 
-{ lib, stdenv, pkgconfig, pango, perl, python2, python3, zip, libIDL
+{ lib, stdenv, pkgconfig, pango, perl, python2, python3, zip
 , libjpeg, zlib, dbus, dbus-glib, bzip2, xorg
 , freetype, fontconfig, file, nspr, nss, libnotify
 , yasm, libGLU, libGL, sqlite, unzip, makeWrapper
@@ -104,7 +104,7 @@ stdenv.mkDerivation ({
   patchFlags = [ "-p1" "-l" ];
 
   buildInputs = [
-    gtk2 perl zip libIDL libjpeg zlib bzip2
+    gtk2 perl zip libjpeg zlib bzip2
     dbus dbus-glib pango freetype fontconfig xorg.libXi xorg.libXcursor
     xorg.libX11 xorg.libXrender xorg.libXft xorg.libXt file
     libnotify xorg.pixman yasm libGLU libGL

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -28,8 +28,6 @@
 , libXt
 , libxcb
 , libcanberra
-, libgnome
-, libgnomeui
 , gnome3
 , libGLU, libGL
 , nspr
@@ -108,8 +106,6 @@ stdenv.mkDerivation {
       libXt
       libxcb
       libcanberra
-      libgnome
-      libgnomeui
       libGLU libGL
       nspr
       nss

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -1,5 +1,4 @@
 { stdenv, fetchurl, config, makeWrapper
-, gconf
 , alsaLib
 , at-spi2-atk
 , atk
@@ -80,7 +79,6 @@ stdenv.mkDerivation {
 
   libPath = stdenv.lib.makeLibraryPath
     [ stdenv.cc.cc
-      gconf
       alsaLib
       at-spi2-atk
       atk

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -13,8 +13,6 @@
 , gdk-pixbuf
 , glib
 , glibc
-, gst-plugins-base
-, gstreamer
 , gtk2
 , gtk3
 , kerberos
@@ -96,8 +94,6 @@ stdenv.mkDerivation {
       gdk-pixbuf
       glib
       glibc
-      gst-plugins-base
-      gstreamer
       gtk2
       gtk3
       kerberos

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -27,7 +27,7 @@
 , libXrender
 , libXt
 , libxcb
-, libcanberra-gtk2
+, libcanberra
 , libgnome
 , libgnomeui
 , gnome3
@@ -107,7 +107,7 @@ stdenv.mkDerivation {
       libXrender
       libXt
       libxcb
-      libcanberra-gtk2
+      libcanberra
       libgnome
       libgnomeui
       libGLU libGL

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -18,7 +18,6 @@
 , lib
 , libGL
 , libGLU
-, libIDL
 , libevent
 , libjpeg
 , libnotify
@@ -113,7 +112,6 @@ stdenv.mkDerivation rec {
     jemalloc
     libGL
     libGLU
-    libIDL
     libevent
     libjpeg
     libnotify

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19794,7 +19794,6 @@ in
     channel = "release";
     generated = import ../applications/networking/browsers/firefox-bin/release_sources.nix;
     gconf = pkgs.gnome2.GConf;
-    inherit (pkgs.gnome2) libgnome libgnomeui;
   };
 
   firefox-bin = wrapFirefox firefox-bin-unwrapped {
@@ -19807,7 +19806,6 @@ in
     channel = "beta";
     generated = import ../applications/networking/browsers/firefox-bin/beta_sources.nix;
     gconf = pkgs.gnome2.GConf;
-    inherit (pkgs.gnome2) libgnome libgnomeui;
   };
 
   firefox-beta-bin = res.wrapFirefox firefox-beta-bin-unwrapped {
@@ -19820,7 +19818,6 @@ in
     channel = "devedition";
     generated = import ../applications/networking/browsers/firefox-bin/devedition_sources.nix;
     gconf = pkgs.gnome2.GConf;
-    inherit (pkgs.gnome2) libgnome libgnomeui;
   };
 
   firefox-devedition-bin = res.wrapFirefox firefox-devedition-bin-unwrapped {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22484,7 +22484,6 @@ in
   thunderbolt = callPackage ../os-specific/linux/thunderbolt {};
 
   thunderbird-bin = callPackage ../applications/networking/mailreaders/thunderbird-bin {
-    gconf = pkgs.gnome2.GConf;
     inherit (pkgs.gnome2) libgnome libgnomeui;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19773,7 +19773,6 @@ in
 
   firefoxPackages = recurseIntoAttrs (callPackage ../applications/networking/browsers/firefox/packages.nix {
     callPackage = pkgs.newScope {
-      inherit (gnome2) libIDL;
       libpng = libpng_apng;
       python = python2;
       gnused = gnused_422;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22483,9 +22483,7 @@ in
 
   thunderbolt = callPackage ../os-specific/linux/thunderbolt {};
 
-  thunderbird-bin = callPackage ../applications/networking/mailreaders/thunderbird-bin {
-    inherit (pkgs.gnome2) libgnome libgnomeui;
-  };
+  thunderbird-bin = callPackage ../applications/networking/mailreaders/thunderbird-bin { };
 
   ticpp = callPackage ../development/libraries/ticpp { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19793,7 +19793,6 @@ in
   firefox-bin-unwrapped = callPackage ../applications/networking/browsers/firefox-bin {
     channel = "release";
     generated = import ../applications/networking/browsers/firefox-bin/release_sources.nix;
-    gconf = pkgs.gnome2.GConf;
   };
 
   firefox-bin = wrapFirefox firefox-bin-unwrapped {
@@ -19805,7 +19804,6 @@ in
   firefox-beta-bin-unwrapped = firefox-bin-unwrapped.override {
     channel = "beta";
     generated = import ../applications/networking/browsers/firefox-bin/beta_sources.nix;
-    gconf = pkgs.gnome2.GConf;
   };
 
   firefox-beta-bin = res.wrapFirefox firefox-beta-bin-unwrapped {
@@ -19817,7 +19815,6 @@ in
   firefox-devedition-bin-unwrapped = callPackage ../applications/networking/browsers/firefox-bin {
     channel = "devedition";
     generated = import ../applications/networking/browsers/firefox-bin/devedition_sources.nix;
-    gconf = pkgs.gnome2.GConf;
   };
 
   firefox-devedition-bin = res.wrapFirefox firefox-devedition-bin-unwrapped {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22475,7 +22475,6 @@ in
   thonny = callPackage ../applications/editors/thonny { };
 
   thunderbird = callPackage ../applications/networking/mailreaders/thunderbird {
-    inherit (gnome2) libIDL;
     inherit (rustPackages_1_42) rustc;
     libpng = libpng_apng;
     gtk3Support = true;


### PR DESCRIPTION
## Motivation for this change
I recently added the navidrome support with #88928, now should be nice to have the corresponding module service.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


I was inspired by the `airsonic` and the `transmission` modules, I tested it and it works great.
However since this is my first NixOS module I'm sure that something needs to be improved, even for for this reasons the commits name aren't nice.
When someone will say that's fine I'll do `git rebase` to squash the commits into a single one with the correct message.

@rnhmjoj Since you have merged the `navidrome` package, maybe you are the most suitable for a review here. Thank you.