### PR TITLE
nixos/generic-extlinux-compatible: fix docbook syntax

### DIFF
--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
@@ -44,7 +44,7 @@ in
         readOnly = true;
         description = ''
           Contains the builder command used to populate an image,
-          honoring all options except the -c <path-to-default-configuration>
+          honoring all options except the <literal>-c &lt;path-to-default-configuration&gt;</literal>
           argument.
           Useful to have for sdImage.populateRootCommands
         '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix invalid docbook syntax introduced by #91195.

<details>
  <summary>options-docbook.xml.drv-log</summary>
  
```log
intermediate.xml:772: parser error : Opening and ending tag mismatch: path-to-default-configuration line 769 and para
</para></nixos:option-description><para><emphasis>Type:</emphasis> string <empha
       ^
intermediate.xml:772: parser error : Opening and ending tag mismatch: para line 769 and nixos:option-description
</para></nixos:option-description><para><emphasis>Type:</emphasis> string <empha
                                  ^
intermediate.xml:774: parser error : Opening and ending tag mismatch: option-description line 769 and listitem
            </filename></member></simplelist></listitem></varlistentry><varliste
                                                        ^
intermediate.xml:774: parser error : Opening and ending tag mismatch: listitem line 769 and varlistentry
            </filename></member></simplelist></listitem></varlistentry><varliste
                                                                       ^
intermediate.xml:72188: parser error : Opening and ending tag mismatch: varlistentry line 769 and variablelist
      </filename></member></simplelist></listitem></varlistentry></variablelist>
                                                                               ^
intermediate.xml:72188: parser error : Opening and ending tag mismatch: variablelist line 769 and appendix
lename></member></simplelist></listitem></varlistentry></variablelist></appendix
                                                                               ^
intermediate.xml:72190: parser error : EndTag: '</' not found

^
unable to parse intermediate.xml
```
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @flokli 