### PR TITLE
nixos/mbim-network: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -652,6 +652,7 @@
   ./services/networking/mailpile.nix
   ./services/networking/magic-wormhole-mailbox-server.nix
   ./services/networking/matterbridge.nix
+  ./services/networking/mbim-network.nix
   ./services/networking/mjpg-streamer.nix
   ./services/networking/minidlna.nix
   ./services/networking/miniupnpd.nix

--- a/nixos/modules/services/networking/mbim-network.nix
+++ b/nixos/modules/services/networking/mbim-network.nix
@@ -1,0 +1,124 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.mbim-network;
+
+  # Transforms "/dev/cdc-wdm0" into "mbim-network-dev-cdc-wdm0" for file and
+  # systemd unit names.
+  cleanName = name: "mbim-network${replaceStrings [ "/" ] [ "-" ] name}";
+
+  makeSystemdUnit = dcfg: name:
+    let
+      path = getBin pkgs.libmbim;
+
+      # Config file format defined in 'man 1 mbim-network'.
+      configFile = with dcfg;
+        pkgs.writeText "${cleanName name}.conf" ''
+          APN=${apn}
+          PROXY=${if cfg.proxy then "yes" else "no"}
+          ${optionalString (apnUser != "") "APN_USER=${apnUser}"}
+          ${optionalString (apnPass != "") "APN_PASS=${apnPass}"}
+          ${optionalString (apnAuth != "") "APN_AUTH=${apnAuth}"}
+        '';
+
+      # Mimic the format of the commands run by mbim-network, including the
+      # optional use of mbim-proxy.
+      cliCmd = "${path}/bin/mbimcli -d ${name}${optionalString cfg.proxy " --device-open-proxy"}";
+      netCmd = "${path}/bin/mbim-network --profile ${configFile} ${name}";
+    in {
+      description = "mbim-network for '${name}'";
+      wantedBy = [ "multi-user.target" ];
+      path = [ path ];
+
+      serviceConfig = {
+        # 'mbim-network start' is a one-shot command which establishes the proper
+        # state for MBIM modem communications. The equivalent 'stop' command
+        # tears down the connection when the systemd unit stopped.
+        User = "root";
+        Type = "oneshot";
+        RemainAfterExit = "yes";
+        ExecStart = "${netCmd} start";
+        ExecStop = "${netCmd} stop";
+      };
+
+      # Ensure the connection was started and an IP configuration can be fetched.
+      postStart = ''
+        ${netCmd} status | grep -q 'Status: activated'
+        ${cliCmd} --query-ip-configuration
+      '';
+      postStop = "${netCmd} status | grep -q 'Status: deactivated'";
+    };
+in {
+  options.services.mbim-network = {
+    # Allow configuring zero or more MBIM devices with differing configurations.
+    devices = mkOption {
+      default = { };
+      example = { "/dev/cdc-wdm0".apn = "internet"; };
+      description = ''
+        Each attribute of this option specifies an MBIM device (example:
+        "/dev/cdc-wdm0") which will be managed by a systemd unit (example:
+        "mbim-network-dev-cdc-wdm0".
+      '';
+      type = with types;
+        attrsOf (submodule {
+          options = {
+            apn = mkOption {
+              type = types.str;
+              example = "internet";
+              description = ''
+                The Access Point Name (APN) to use when starting mbim-network for
+                this device. For a list of common APN values, see
+                <link xlink:href="https://customer.cradlepoint.com/s/article/access-point-names-by-carrier"/>.
+              '';
+            };
+
+            apnUser = mkOption {
+              type = types.str;
+              default = "";
+              example = "user";
+              description =
+                "An optional username to use for APN authentication.";
+            };
+
+            apnPass = mkOption {
+              type = types.str;
+              default = "";
+              example = "password";
+              description = ''
+                An optional password to use for APN authentication. Note that any
+                password specified here will be persisted world-readable in
+                the Nix store.
+              '';
+            };
+
+            apnAuth = mkOption {
+              type = types.enum [ "" "PAP" "CHAP" "MSCHAPV2" ];
+              default = "";
+              description = ''
+                An optional authentication protocol to use for APN authentication:
+                one of "" (none), "PAP", "CHAP", or "MSCHAPV2".
+              '';
+            };
+          };
+        });
+    };
+
+    proxy = mkOption {
+      type = types.bool;
+      # It seems that mbim-proxy greatly improves the responsiveness of
+      # mbimcli commands, so we should encourage users to use it by default.
+      default = true;
+      description =
+        "Whether or not to spawn mbim-proxy to proxy communications with MBIM devices.";
+    };
+  };
+
+  # For each configured device, create a systemd unit to run mbim-network.
+  config = mkIf (cfg.devices != { }) {
+    systemd.services = listToAttrs (mapAttrsFlatten
+      (name: value: nameValuePair (cleanName name) (makeSystemdUnit value name))
+      cfg.devices);
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I'd like to control my Sierra Wireless MC7455 LTE modem in MBIM mode using `mbim-network` in a native, NixOS-configured way. This PR is loosely based on the configuration of the OpenVPN module which allows for multiple instances to be running.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Here's a `dmesg` snippet showing the kernel initializing the device:

```
[matt@routnerr-2:~]$ dmesg | grep cdc
[   10.425295] usbcore: registered new interface driver cdc_ncm
[   10.467144] usbcore: registered new interface driver cdc_wdm
[   10.525180] cdc_mbim 1-1.3:1.12: cdc-wdm0: USB WDM device
[   10.526210] cdc_mbim 1-1.3:1.12 wwan0: register 'cdc_mbim' at usb-0000:00:13.0-1.3, CDC MBIM, 46:56:cd:f5:dc:d6
[   10.526450] usbcore: registered new interface driver cdc_mbim
[   11.315462] cdc_mbim 1-1.3:1.12 wwp0s19u1u3i12: renamed from wwan0
```

My relevant Nix config for using this device with Project Fi (no authentication, using mbim-proxy by default):

```
services.mbim-network.devices."/dev/cdc-wdm0".apn = "h2g2";
```

Starting the systemd unit brings the device up and shows that an IP configuration can be fetched successfully, with a few anonymizations:

```
Jun 23 14:49:24 routnerr-2 systemd[1]: Starting mbim-network for '/dev/cdc-wdm0'...
Jun 23 14:49:24 routnerr-2 mbim-network[22404]: Loading profile at /nix/store/8352hirv32jh9miadvynq0vm3bkal1vn-mbim-network-dev-cdc-wdm0.conf...
Jun 23 14:49:24 routnerr-2 mbim-network[22404]:     APN: h2g2
Jun 23 14:49:24 routnerr-2 mbim-network[22404]:     APN auth protocol: unset
Jun 23 14:49:24 routnerr-2 mbim-network[22404]:     APN user: unset
Jun 23 14:49:24 routnerr-2 mbim-network[22404]:     APN password: unset
Jun 23 14:49:24 routnerr-2 mbim-network[22404]:     mbim-proxy: yes
Jun 23 14:49:24 routnerr-2 mbim-network[22404]: Querying subscriber ready status 'mbimcli -d /dev/cdc-wdm0 --query-subscriber-ready-status --no-close --device-open-proxy'...
Jun 23 14:49:28 routnerr-2 mbim-network[22404]: [/dev/cdc-wdm0] Subscriber ready status retrieved: Ready state: 'initialized' Subscriber ID: 'xxx' SIM ICCID: 'xxx' Ready info: 'none' Telephone numbers: (1) 'xxx' [/dev/cdc-wdm0] Session not closed: TRID: '4'
Jun 23 14:49:28 routnerr-2 mbim-network[22404]: Saving state at /tmp/mbim-network-state-cdc-wdm0... (TRID: 4)
Jun 23 14:49:28 routnerr-2 mbim-network[22404]: Querying registration state 'mbimcli -d /dev/cdc-wdm0 --query-registration-state --no-open=4 --no-close --device-open-proxy'...
Jun 23 14:49:28 routnerr-2 mbim-network[22404]: [/dev/cdc-wdm0] Registration status: Network error: 'unknown' Register state: 'home' Register mode: 'automatic' Available data classes: 'lte' Current cellular class: 'gsm' Provider ID: '310260' Provider name: 'Project Fi' Roaming text: 'unknown' Registration flags: 'packet-service-automatic-attach' [/dev/cdc-wdm0] Session not closed: TRID: '6'
Jun 23 14:49:28 routnerr-2 mbim-network[22404]: Saving state at /tmp/mbim-network-state-cdc-wdm0... (TRID: 6)
Jun 23 14:49:28 routnerr-2 mbim-network[22404]: Attaching to packet service with 'mbimcli -d /dev/cdc-wdm0 --attach-packet-service --no-open=6 --no-close --device-open-proxy'...
Jun 23 14:49:28 routnerr-2 mbim-network[22404]: Saving state at /tmp/mbim-network-state-cdc-wdm0... (TRID: 8)
Jun 23 14:49:28 routnerr-2 mbim-network[22404]: Starting network with 'mbimcli -d /dev/cdc-wdm0 --connect=apn='h2g2' --no-open=8 --no-close --device-open-proxy'...
Jun 23 14:49:28 routnerr-2 mbim-network[22404]: Network started successfully
Jun 23 14:49:28 routnerr-2 mbim-network[22404]: Saving state at /tmp/mbim-network-state-cdc-wdm0... (TRID: 11)
Jun 23 14:49:29 routnerr-2 j84f9wl2m4knm6m2psny4jnvm6jqarrw-unit-script-mbim-network-dev-cdc-wdm0-post-start[22491]: [/dev/cdc-wdm0] IPv4 configuration available: 'address, gateway, dns, mtu'
Jun 23 14:49:29 routnerr-2 j84f9wl2m4knm6m2psny4jnvm6jqarrw-unit-script-mbim-network-dev-cdc-wdm0-post-start[22491]:      IP [0]: '192.0.2.10/28'
Jun 23 14:49:29 routnerr-2 j84f9wl2m4knm6m2psny4jnvm6jqarrw-unit-script-mbim-network-dev-cdc-wdm0-post-start[22491]:     Gateway: '192.0.2.1'
Jun 23 14:49:29 routnerr-2 j84f9wl2m4knm6m2psny4jnvm6jqarrw-unit-script-mbim-network-dev-cdc-wdm0-post-start[22491]:     DNS [0]: '10.177.0.34'
Jun 23 14:49:29 routnerr-2 j84f9wl2m4knm6m2psny4jnvm6jqarrw-unit-script-mbim-network-dev-cdc-wdm0-post-start[22491]:     DNS [1]: '10.177.0.210'
Jun 23 14:49:29 routnerr-2 j84f9wl2m4knm6m2psny4jnvm6jqarrw-unit-script-mbim-network-dev-cdc-wdm0-post-start[22491]:         MTU: '1500'
Jun 23 14:49:29 routnerr-2 j84f9wl2m4knm6m2psny4jnvm6jqarrw-unit-script-mbim-network-dev-cdc-wdm0-post-start[22491]: [/dev/cdc-wdm0] IPv6 configuration available: 'address, gateway, dns, mtu'
Jun 23 14:49:29 routnerr-2 j84f9wl2m4knm6m2psny4jnvm6jqarrw-unit-script-mbim-network-dev-cdc-wdm0-post-start[22491]:      IP [0]: '2001:db8::10/64'
Jun 23 14:49:29 routnerr-2 j84f9wl2m4knm6m2psny4jnvm6jqarrw-unit-script-mbim-network-dev-cdc-wdm0-post-start[22491]:     Gateway: '2001:db8::1'
Jun 23 14:49:29 routnerr-2 j84f9wl2m4knm6m2psny4jnvm6jqarrw-unit-script-mbim-network-dev-cdc-wdm0-post-start[22491]:     DNS [0]: 'fd00:976a::9'
Jun 23 14:49:29 routnerr-2 j84f9wl2m4knm6m2psny4jnvm6jqarrw-unit-script-mbim-network-dev-cdc-wdm0-post-start[22491]:     DNS [1]: 'fd00:976a::10'
Jun 23 14:49:29 routnerr-2 j84f9wl2m4knm6m2psny4jnvm6jqarrw-unit-script-mbim-network-dev-cdc-wdm0-post-start[22491]:         MTU: '1500'
Jun 23 14:49:29 routnerr-2 systemd[1]: Started mbim-network for '/dev/cdc-wdm0'.
```

And stopping the systemd unit brings the device down and clears the transaction ID state:

```
Jun 23 14:56:31 routnerr-2 systemd[1]: Stopping mbim-network for '/dev/cdc-wdm0'...
Jun 23 14:56:32 routnerr-2 mbim-network[25473]: Loading profile at /nix/store/8352hirv32jh9miadvynq0vm3bkal1vn-mbim-network-dev-cdc-wdm0.conf...
Jun 23 14:56:32 routnerr-2 mbim-network[25473]:     APN: h2g2
Jun 23 14:56:32 routnerr-2 mbim-network[25473]:     APN auth protocol: unset
Jun 23 14:56:32 routnerr-2 mbim-network[25473]:     APN user: unset
Jun 23 14:56:32 routnerr-2 mbim-network[25473]:     APN password: unset
Jun 23 14:56:32 routnerr-2 mbim-network[25473]:     mbim-proxy: yes
Jun 23 14:56:32 routnerr-2 mbim-network[25473]: Loading previous state from /tmp/mbim-network-state-cdc-wdm0...
Jun 23 14:56:32 routnerr-2 mbim-network[25473]:     Previous Transaction ID: 13
Jun 23 14:56:32 routnerr-2 mbim-network[25473]: Stopping network with 'mbimcli -d /dev/cdc-wdm0 --disconnect --no-open=13 --device-open-proxy'...
Jun 23 14:56:32 routnerr-2 mbim-network[25473]: Network stopped successfully
Jun 23 14:56:32 routnerr-2 mbim-network[25473]: Clearing state at /tmp/mbim-network-state-cdc-wdm0...
Jun 23 14:56:35 routnerr-2 systemd[1]: mbim-network-dev-cdc-wdm0.service: Succeeded.
Jun 23 14:56:35 routnerr-2 systemd[1]: Stopped mbim-network for '/dev/cdc-wdm0'.
```

---

I have a few open questions:

1) Unfortunately, I have absolutely no idea how to test this change with a NixOS test as it relies on the physical modem device attached to my router. Any suggestions?

1) Does this belong under `services.mbim-network` or maybe something like `networking.mbim`?

1) I don't intend to implement it in this initial PR, but how should I deal with IP address configuration via the MBIM out-of-band signaling (note the post-start systemd unit output above)? My particular modem only supports `raw-ip` mode rather than `802-3`, so I can't use DHCP.

I'm considering parsing the output of the IP query command and plumbing that into the NixOS networking config in some way but have no idea how that should work. Suggestions appreciated! A hand-wavey hypothetical config:

```
services.mbim-network.devices."/dev/cdc-wdm0" = {
  apn = "h2g2";
  netdev = {
    # Specifies which device which will have the configuration applied, and which parts of the configuration.
    name = "wwp0s19u1u3i12";
    configure = [ "address" "gateway" "dns" "mtu" ];
  };
};
```

/cc @flokli per our conversation in #nixos-on-your-router.