### PR TITLE
ytree: init at 2.02

### DIFF
--- a/pkgs/tools/misc/ytree/default.nix
+++ b/pkgs/tools/misc/ytree/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, fetchurl
+, ncurses
+, readline
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ytree";
+  version = "2.02";
+
+  src = fetchurl {
+    url = "https://han.de/~werner/${pname}-${version}.tar.gz";
+    sha256 = "1v70l244rc22f20gac1zha1smrhqkag45jn0iwgcyngfdfml3gz5";
+  };
+
+  buildInputs = [
+    ncurses readline
+  ];
+
+  # don't save timestamp, in order to improve reproducibility
+  postPatch = ''
+    substituteInPlace Makefile --replace 'gzip' 'gzip -n'
+  '';
+
+  preBuild = ''
+    makeFlagsArray+=(CC="cc"
+                     ADD_CFLAGS=""
+                     COLOR="-DCOLOR_SUPPORT"
+                     CLOCK="-DCLOCK_SUPPORT"
+                     READLINE="-DREADLINE_SUPPORT"
+                     CFLAGS="-D_GNU_SOURCE -DWITH_UTF8 $(ADD_CFLAGS) $(COLOR) $(CLOCK) $(READLINE)"
+                     LDFLAGS="-lncursesw -lreadline")
+  '';
+
+  installFlags = [ "DESTDIR=${placeholder "out"}" ];
+
+  preInstall = ''
+    mkdir -p $out/bin $out/share/man/man1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A curses-based file manager similar to DOS Xtree(TM)";
+    homepage = "https://www.han.de/~werner/ytree.html";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; unix;
+  };
+}
+# TODO: X11 support

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7847,6 +7847,8 @@ in
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };
 
+  ytree = callPackage ../tools/misc/ytree { };
+
   yggdrasil = callPackage ../tools/networking/yggdrasil { };
 
   # To expose more packages for Yi, override the extraPackages arg.


### PR DESCRIPTION
ytree is a simple file manager, inspired in the venerable DOS xtree command.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
