### PR TITLE
discord: fix appindicator tray icon support

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/base.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/base.nix
@@ -4,7 +4,7 @@
 , freetype, gdk-pixbuf, glib, gtk3, libcxx, libdrm, libnotify, libpulseaudio, libuuid
 , libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
 , libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb
-, mesa, nspr, nss, pango, systemd
+, mesa, nspr, nss, pango, systemd, libappindicator-gtk3
 }:
 
 let
@@ -35,6 +35,7 @@ in stdenv.mkDerivation rec {
     gdk-pixbuf glib gtk3 libnotify libX11 libXcomposite libuuid
     libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
     libXtst nspr nss libxcb pango systemd libXScrnSaver
+    libappindicator-gtk3
    ];
 
   installPhase = ''


### PR DESCRIPTION
Include libappindicator-gtk3 in discord's library path so it's able to create an indicator icon.

###### Motivation for this change
Appindicator / system tray icon wasn't working for Discord.  Found an explanation at https://github.com/electron/electron/issues/10427 of the need for libappindicator-gtk3, and this indeed seems to fix the problem.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
