### PR TITLE
linode-cli: 2.14.1 -> 2.15.0

### DIFF
--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -13,21 +13,21 @@
 let
 
   spec = fetchurl {
-    url = "https://raw.githubusercontent.com/linode/linode-api-docs/v4.63.1/openapi.yaml";
-    sha256 = "03ngzbq24zazfqmfd7xjmxixkcb9vv1jgamplsj633j7sjj708s0";
+    url = "https://raw.githubusercontent.com/linode/linode-api-docs/v4.67.0/openapi.yaml";
+    sha256 = "0vsblprkqlr9508x5rkm0wj6lc3w72xiwiqxia9asgr5k45hhfnr";
   };
 
 in
 
 buildPythonApplication rec {
   pname = "linode-cli";
-  version = "2.14.1";
+  version = "2.15.0";
 
   src = fetchFromGitHub {
     owner = "linode";
     repo = pname;
     rev = version;
-    sha256 = "1hpdmbzs182iag471yvq3kwd1san04a58sczzbmw6vjv2kswn1c2";
+    sha256 = "06iz9xjj6h1ry176558488fl9j18a5vf724zh4cxlcksdy72dnna";
   };
 
   patches = [


### PR DESCRIPTION
linode-cli version -> 2.15.0
linode api version -> 4.67.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Upgrading to a newer version.

linode-cli provides error message after every command that API version 4.63.1 is out of date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
