### PR TITLE
cpuminer: 2.5.0 -> 2.5.1

### DIFF
--- a/pkgs/tools/misc/cpuminer/default.nix
+++ b/pkgs/tools/misc/cpuminer/default.nix
@@ -1,17 +1,25 @@
-{ stdenv, fetchurl, curl, jansson, perl }:
+{ stdenv
+, fetchFromGitHub
+, curl
+, jansson
+, perl
+, autoreconfHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "cpuminer";
-  version = "2.5.0";
+  version = "2.5.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/cpuminer/pooler-${pname}-${version}.tar.gz";
-    sha256 = "1xalrfrk5hvh1jh9kbqhib2an82ypd46vl9glaxhz3rbjld7c5pa";
+  src = fetchFromGitHub {
+    owner = "pooler";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0f44i0z8rid20c2hiyp92xq0q0mjj537r05sa6vdbc0nl0a5q40i";
   };
 
   patchPhase = if stdenv.cc.isClang then "${perl}/bin/perl ./nomacro.pl" else null;
 
-  buildInputs = [ curl jansson ];
+  buildInputs = [ curl jansson autoreconfHook ];
 
   configureFlags = [ "CFLAGS=-O3" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Includes fixes and new features such as Bech32 support (https://github.com/pooler/cpuminer/commit/7e8960212f0055d6dafaa3c80812c50cec291de3)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
