### PR TITLE
v2ray-plugin: init at 1.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9145,4 +9145,14 @@
     github = "deifactor";
     githubId = 30192992;
   };
+  hmenke = {
+    name = "Henri Menke";
+    email = "henrimenke@gmail.com";
+    github = "hmenke";
+    githubId = 1903556;
+    keys = [{
+      longkeyid = "rsa4096/0xD65C9AFB4C224DA3";
+      fingerprint = "F1C5 760E 45B9 9A44 72E9  6BFB D65C 9AFB 4C22 4DA3";
+    }];
+  };
 }

--- a/nixos/modules/services/networking/shadowsocks.nix
+++ b/nixos/modules/services/networking/shadowsocks.nix
@@ -11,8 +11,13 @@ let
     method = cfg.encryptionMethod;
     mode = cfg.mode;
     user = "nobody";
-    fast_open = true;
-  } // optionalAttrs (cfg.password != null) { password = cfg.password; };
+    fast_open = cfg.fastOpen;
+  } // optionalAttrs (cfg.plugin != null) {
+    plugin = cfg.plugin;
+    plugin_opts = cfg.pluginOpts;
+  } // optionalAttrs (cfg.password != null) {
+    password = cfg.password;
+  };
 
   configFile = pkgs.writeText "shadowsocks.json" (builtins.toJSON opts);
 
@@ -74,6 +79,14 @@ in
         '';
       };
 
+      fastOpen = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          use TCP fast-open
+        '';
+      };
+
       encryptionMethod = mkOption {
         type = types.str;
         default = "chacha20-ietf-poly1305";
@@ -82,6 +95,21 @@ in
         '';
       };
 
+      plugin = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          SIP003 plugin for shadowsocks
+        '';
+      };
+
+      pluginOpts = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Options for plugin
+        '';
+      };
     };
 
   };
@@ -99,7 +127,7 @@ in
       description = "shadowsocks-libev Daemon";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.shadowsocks-libev ] ++ optional (cfg.passwordFile != null) pkgs.jq;
+      path = [ pkgs.shadowsocks-libev cfg.plugin ] ++ optional (cfg.passwordFile != null) pkgs.jq;
       serviceConfig.PrivateTmp = true;
       script = ''
         ${optionalString (cfg.passwordFile != null) ''

--- a/pkgs/tools/networking/v2ray-plugin/default.nix
+++ b/pkgs/tools/networking/v2ray-plugin/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+let
+  version = "1.3.1";
+in buildGoPackage {
+  name = "v2ray-plugin-${version}";
+
+  goPackagePath = "github.com/shadowsocks/v2ray-plugin";
+
+  src = fetchFromGitHub {
+    owner = "shadowsocks";
+    repo = "v2ray-plugin";
+    rev = "v${version}";
+    sha256 = "0aq445gnqk9dxs1hkw7rvk86wg0iyiy0h740lvyh6d9zsqhf61wb";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = {
+    description = "Yet another SIP003 plugin for shadowsocks, based on v2ray";
+    homepage = "https://github.com/shadowsocks/v2ray-plugin";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hmenke ];
+  };
+}

--- a/pkgs/tools/networking/v2ray-plugin/deps.nix
+++ b/pkgs/tools/networking/v2ray-plugin/deps.nix
@@ -1,0 +1,237 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/gocloud";
+      rev = "v0.26.0";
+      sha256 = "149v3ci17g6wd2pm18mzcncq5qpl9hwdjnz3rlbn5rfidyn46la1";
+    };
+  }
+  {
+    goPackagePath = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev = "v0.3.1";
+      sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
+    };
+  }
+  {
+    goPackagePath = "github.com/client9/misspell";
+    fetch = {
+      type = "git";
+      url = "https://github.com/client9/misspell";
+      rev = "v0.3.4";
+      sha256 = "1vwf33wsc4la25zk9nylpbp9px3svlmldkm0bha4hp56jws4q9cs";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/glog";
+      rev = "23def4e6c14b";
+      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/mock";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/mock";
+      rev = "v1.3.1";
+      sha256 = "1wnfa8njxdym1qb664dmfnkpm4pmqy22hqjlqpwaaiqhglb5g9d1";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.3.2";
+      sha256 = "1k1wb4zr0qbwgpvz9q5ws9zhlal8hq7dmq62pwxxriksayl6hzym";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev = "v0.3.0";
+      sha256 = "1hyxx3434zshl2m9ja78gwlkg1rx9yl6diqa7dnjb31xz5x4gbjj";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/websocket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/websocket";
+      rev = "v1.4.1";
+      sha256 = "03n1n0nwz3k9qshmriycqznnnvd3dkzsfwpnfjzzvafjxk9kyapv";
+    };
+  }
+  {
+    goPackagePath = "github.com/miekg/dns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/miekg/dns";
+      rev = "v1.1.14";
+      sha256 = "1d7c6pp80f8ml3dcz9cj1wvb2wnk78azrzlla2bq4p21bbz8mriz";
+    };
+  }
+  {
+    goPackagePath = "github.com/refraction-networking/utls";
+    fetch = {
+      type = "git";
+      url = "https://github.com/refraction-networking/utls";
+      rev = "43c36d3c1f57";
+      sha256 = "0hrilfij4aj72xrwi457h1hdzrjv20mybzw7xl1qa4i2v74f888q";
+    };
+  }
+  {
+    goPackagePath = "go.starlark.net";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/starlark-go";
+      rev = "979af19b165c";
+      sha256 = "15iypn482brrx6agw363hzd7vx9p22h407n9mnzshfv4smsfgj81";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "ea8f1a30c443";
+      sha256 = "1qclw7wfr494qg11mhwfflbzy8gb21pq8yym0cp4vp00h7idbnb1";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/exp";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/exp";
+      rev = "509febef88a4";
+      sha256 = "02isrh39z8znrp5znplzy0dip2gnrl3jm1355raliyvhnhg04j6q";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/lint";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/lint";
+      rev = "d0100b6bd8b3";
+      sha256 = "0b0amr9x4ji66iv9ayfx7zrfx52k1m5g66qfcxkgj80qrb1y2yn7";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "b5b0513f8c1b";
+      sha256 = "0sr4gbiq09izkmm6hcmfnia6lz6ngzzqjbwlrzh7jifbzyck53wz";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev = "d2e6202438be";
+      sha256 = "0wbn75fd10485nb93bm4kqldqifdim5xqy4v7r5sdvimvf3fyhn7";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "112230192c58";
+      sha256 = "05i2k43j2d0llq768hg5pf3hb2yhfzp9la1w5wp0rsnnzblr0lfn";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "e40ef342dc56";
+      sha256 = "1qx7x9arqxrklvzl0w53xf3y52xxfr2kvzqbaqan32fr3fvsgqg7";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.2";
+      sha256 = "0flv9idw0jm5nm8lx25xqanbkqgfiym6619w575p7nrdh0riqwqh";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "2c0ae7006135";
+      sha256 = "1lsi2ssxajclj3bciz2a41v1vjv768ja3v6wnbyhxy8xphwkp4fk";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev = "v1.4.0";
+      sha256 = "06zl7w4sxgdq2pl94wy9ncii6h0z3szl4xpqds0sv3b3wbdlhbnn";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/genproto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/go-genproto";
+      rev = "a7e196e89fd3";
+      sha256 = "1038mss4zxm2fwa9ip6s8s33nnfvbsrgx9qaq3xfv6mmj2h9aqnp";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/grpc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc/grpc-go";
+      rev = "v1.24.0";
+      sha256 = "0h8mwv74vzcfb7p4ai247x094skxca71vjp4wpj2wzmri0x9p4v6";
+    };
+  }
+  {
+    goPackagePath = "h12.io/socks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/h12w/socks";
+      rev = "v1.0.0";
+      sha256 = "05iq2i3idpwv1n087zsmcrva5ix8akngm37a36mg0ndidn7ypgis";
+    };
+  }
+  {
+    goPackagePath = "honnef.co/go/tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dominikh/go-tools";
+      rev = "ea95bdfd59fc";
+      sha256 = "1763nw7pwpzkvzfnm63dgzcgbq9hwmq5l1nffchnhh77vgkaq4ic";
+    };
+  }
+  {
+    goPackagePath = "v2ray.com/core";
+    fetch = {
+      type = "git";
+      url = "https://github.com/v2ray/v2ray-core";
+      rev = "v4.19.1";
+      sha256 = "0j2lb1nw8zm98azfrpd00r42bn0dzxn94sakb58w8vx420mqbadn";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6668,6 +6668,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  v2ray-plugin = callPackage ../tools/networking/v2ray-plugin { };
+
   sharutils = callPackage ../tools/archivers/sharutils { };
 
   shelldap = callPackage ../tools/misc/shelldap { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Some firewalls performs deep packet inspection to block VPN traffic, such as the Greaf Firewall (GFW) of the Chinese government.  Therefore it is required to obfuscate the traffic which can be done using the v2ray software.  This PR introduces the v2ray-plugin for the shadowsocks VPN and makes the shadowsocks service for NixOS aware of plugins.

Personally, I'm using this in production for myself and for a friend in Beijing for a couple of months without problems.  This is what my configuration roughly looks like:
```nix
{
  networking.firewall = {
    enable = true;
    allowedTCPPorts = [ 8488 ];
    allowedUDPPorts = [ 8488 ];
  };
  services.shadowsocks = {
    enable = true;
    encryptionMethod = "chacha20-ietf-poly1305";
    passwordFile = "/path/to/shadowsocks/key";
    localAddress = [ "0.0.0.0" ];
    port = 8488;
    mode = "tcp_and_udp";
    plugin = "${pkgs.v2ray-plugin}/bin/v2ray-plugin";
    pluginOpts = "server;host=henrimenke.com";
  };
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
