### PR TITLE
python37Packages.quandl: fix build

### DIFF
--- a/pkgs/development/python-modules/quandl/default.nix
+++ b/pkgs/development/python-modules/quandl/default.nix
@@ -1,7 +1,7 @@
 {
-  lib, fetchPypi, buildPythonPackage, isPy3k,
+  lib, fetchPypi, buildPythonPackage, isPy3k, pythonOlder,
   # runtime dependencies
-  pandas, numpy, requests, inflection, python-dateutil, six, more-itertools,
+  pandas, numpy, requests, inflection, python-dateutil, six, more-itertools, importlib-metadata,
   # test suite dependencies
   nose, unittest2, flake8, httpretty, mock, jsondate, parameterized, faker, factory_boy,
   # additional runtime dependencies are required on Python 2.x
@@ -45,6 +45,8 @@ buildPythonPackage rec {
     pyOpenSSL
     ndg-httpsclient
     pyasn1
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken when reviewing #91364

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
