### PR TITLE
bully: 1.1 -> 1.4-00

### DIFF
--- a/pkgs/tools/networking/bully/default.nix
+++ b/pkgs/tools/networking/bully/default.nix
@@ -1,33 +1,32 @@
-{ stdenv, fetchFromGitHub, openssl, libpcap }:
+{ stdenv, fetchFromGitHub, libpcap }:
 
 stdenv.mkDerivation rec {
-
   pname = "bully";
-  version = "1.1";
+  version = "1.4-00";
 
   src = fetchFromGitHub {
-    sha256 = "1qvbbf72ryd85bp4v62fk93ag2sn25rj7kipgagbv22hnq8yl3zd";
-    rev = version;
+    owner = "kimocoder";
     repo = "bully";
-    owner = "aanarchyy";
+    rev = version;
+    sha256 = "1n2754a5z44g414a0hj3cmi9q5lwnzyvmvzskrj2nci8c8m2kgnf";
   };
-  buildInputs = [ openssl libpcap ];
 
-  buildPhase = ''
-    cd src
-    make
-  '';
+  buildInputs = [ libpcap ];
+
+  enableParallelBuilding = true;
+
+  sourceRoot = "./source/src";
 
   installPhase = ''
-    mkdir -p $out/bin
-    mv bully $out/bin
+    install -Dm555 -t $out/bin bully
+    install -Dm444 -t $out/share/doc/${pname} ../*.md
   '';
 
   meta = with stdenv.lib; {
     description = "Retrieve WPA/WPA2 passphrase from a WPS enabled access point";
-    homepage = "https://github.com/aanarchyy/bully";
-    maintainers = with maintainers; [ edwtjo ];
+    homepage = "https://github.com/kimocoder/bully";
     license = licenses.gpl3;
+    maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5934,9 +5934,7 @@ in
 
   brickd = callPackage ../servers/brickd { };
 
-  bully = callPackage ../tools/networking/bully {
-    openssl = openssl_1_0_2;
-  };
+  bully = callPackage ../tools/networking/bully { };
 
   pcapc = callPackage ../tools/networking/pcapc { };
 


### PR DESCRIPTION
###### Motivation for this change

Add documentation and minor cleanups.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).