### PR TITLE
ocamlPackages.torch: 0.8 → 0.9b

### DIFF
--- a/pkgs/development/ocaml-modules/torch/default.nix
+++ b/pkgs/development/ocaml-modules/torch/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ lib
 , buildDunePackage
 , fetchFromGitHub
 , cmdliner
@@ -15,17 +15,15 @@
 
 buildDunePackage rec {
   pname = "torch";
-  version = "0.8";
-
-  owner = "LaurentMazare";
+  version = "0.9b";
 
   minimumOCamlVersion = "4.07";
 
   src = fetchFromGitHub {
-    inherit owner;
+    owner = "LaurentMazare";
     repo   = "ocaml-${pname}";
     rev    = version;
-    sha256 = "19w31paj24pns2ahk9j9rgpkb5hpcd41kfaarxrlddww5dl6pxvi";
+    sha256 = "1xn8zfs3viz80agckcpl9a4vjbq6j5g280i95jyy5s0zbcnajpnm";
   };
 
   propagatedBuildInputs = [
@@ -47,7 +45,7 @@ buildDunePackage rec {
   doCheck = true;
   checkPhase = "dune runtest";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     inherit (src.meta) homepage;
     description = "Ocaml bindings to Pytorch";
     maintainers = [ maintainers.bcdarwin ];


### PR DESCRIPTION
###### Motivation for this change

Version 0.8 no longer builds: it requires PyTorch 1.4 but `nixpkgs` has version 1.5 now.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
