### PR TITLE
[20.03] mp4v2: 2.0.0 -> 4.1.3

### DIFF
--- a/pkgs/development/libraries/mp4v2/default.nix
+++ b/pkgs/development/libraries/mp4v2/default.nix
@@ -1,39 +1,39 @@
-{ stdenv, lib, fetchurl }:
+{ stdenv, lib, fetchFromGitHub, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "mp4v2-2.0.0";
+  pname = "mp4v2";
+  version = "4.1.3";
 
-  src = fetchurl {
-    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mp4v2/${name}.tar.bz2";
-    sha256 = "0f438bimimsvxjbdp4vsr8hjw2nwggmhaxgcw07g2z361fkbj683";
+  src = fetchFromGitHub {
+    # 2020-06-20: THE current upstream, maintained and used in distros fork.
+    owner = "TechSmith";
+    repo = "mp4v2";
+    rev = "Release-ThirdParty-MP4v2-${version}";
+    sha256 = "053a0lgy819sbz92cfkq0vmkn2ky39bva554pj4ypky1j6vs04fv";
   };
 
   patches = [
     (fetchurl {
-      name = "gcc-7.patch";
-      url = "https://src.fedoraproject.org/cgit/rpms/libmp4v2.git/plain/"
-          + "0004-Fix-GCC7-build.patch?id=d7aeedabb";
+      # 2020-06-19: NOTE: # Fix build with C++11
+      # Close when https://github.com/TechSmith/mp4v2/pull/36 merged/closed.
+      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/libmp4v2-c++11.patch?id=203f5a72bc97ffe089b424c47b07dd9eaea35713";
       sha256 = "0sbn0il7lmk77yrjyb4f0a3z3h8gsmdkscvz5n9hmrrrhrwf672w";
     })
   ];
 
-  buildFlags = [ "CXXFLAGS=-std=c++03" ];
-
   # `faac' expects `mp4.h'.
   postInstall = "ln -s mp4v2/mp4v2.h $out/include/mp4.h";
-
-  hardeningDisable = [ "format" ];
 
   enableParallelBuilding = true;
 
   meta = {
-    description = "Abandoned library. Provides functions to read, create, and modify mp4 files";
+    description = "Provides functions to read, create, and modify mp4 files";
     longDescription = ''
       MP4v2 library provides an API to work with mp4 files
       as defined by ISO-IEC:14496-1:2001 MPEG-4 Systems.
       This container format is derived from Apple's QuickTime format.
     '';
-    homepage = https://code.google.com/archive/p/mp4v2/;
+    homepage = "https://github.com/TechSmith/mp4v2";
     maintainers = [ lib.maintainers.Anton-Latukha ];
     platforms = lib.platforms.unix;
     license = lib.licenses.mpl11;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This switches to a new upstream for mp4v2. I searched the git logs and the commit message indicate that the following CVEs are fixed:

* CVE-2018-14054
* CVE-2018-14403
* CVE-2018-14379
* CVE-2018-14326
* CVE-2018-14446
* CVE-2018-14325

Given the CVEs, this should probably be backported to 20.03. 

Also see: #90888

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
