### PR TITLE
xow: 0.4 -> 0.5

### DIFF
--- a/pkgs/misc/drivers/xow/default.nix
+++ b/pkgs/misc/drivers/xow/default.nix
@@ -1,14 +1,19 @@
-{ stdenv, fetchFromGitHub, libusb1 }:
+{ stdenv, cabextract, fetchurl, fetchFromGitHub, libusb1 }:
 
 stdenv.mkDerivation rec {
   pname = "xow";
-  version = "0.4";
+  version = "0.5";
 
   src = fetchFromGitHub {
     owner = "medusalix";
     repo = "xow";
     rev = "v${version}";
-    sha256 = "1xkwcx2gqip9v2h3zjmrn7sgcck3midl5alhsmr3zivgdipamynv";
+    sha256 = "071r2kx44k1sc49cad3i607xg618mf34ki1ykr5lnfx9y6qyz075";
+  };
+
+  firmware = fetchurl {
+    url = "http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab";
+    sha256 = "013g1zngxffavqrk5jy934q3bdhsv6z05ilfixdn8dj0zy26lwv5";
   };
 
   makeFlags = [
@@ -20,7 +25,14 @@ stdenv.mkDerivation rec {
     "MODPDIR=${placeholder ''out''}/lib/modprobe.d"
     "SYSDDIR=${placeholder ''out''}/lib/systemd/system"
   ];
+
+  postUnpack = ''
+    cabextract -F FW_ACC_00U.bin ${firmware}
+    mv FW_ACC_00U.bin source/firmware.bin
+  '';
+
   enableParallelBuilding = true;
+  nativeBuildInputs = [ cabextract ];
   buildInputs = [ libusb1 ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Upstream update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
