### PR TITLE
yaxg: Removed unstable from name

### DIFF
--- a/pkgs/tools/graphics/yaxg/default.nix
+++ b/pkgs/tools/graphics/yaxg/default.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   pname = "yaxg";
-  version = "unstable-2018-05-03";
+  version = "2018-05-03";
 
   src = fetchFromGitHub {
     owner = "DanielFGray";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
When I first wrote this package I didn't fully understand how versioning worked in nixos, and I didn't realize the -unstable would end up in the package name rather than the version string. I added unstable because there was no official version tag, however yaxg is actually stable, and hasn't had a change since 2018. This change simplifies installing yaxg in a nix environment from `nix-env -i yaxg-unstable` to just `nix-env -i yaxg`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
