### PR TITLE
[20.03] curl: 7.68.0 -> 7.70.0; apply patches for CVE-2020-8169 and CVE-2020-8177

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -28,14 +28,14 @@ assert brotliSupport -> brotli != null;
 assert gssSupport -> libkrb5 != null;
 
 stdenv.mkDerivation rec {
-  name = "curl-7.68.0";
+  name = "curl-7.69.1";
 
   src = fetchurl {
     urls = [
       "https://curl.haxx.se/download/${name}.tar.bz2"
       "https://github.com/curl/curl/releases/download/${lib.replaceStrings ["."] ["_"] name}/${name}.tar.bz2"
     ];
-    sha256 = "1fgf4f33wj25jk6lkpxmrvmfnnxvc66z3k3561rxr8nngn8m8zr0";
+    sha256 = "1s2ddjjif1wkp69vx25nzxklhimgqzaazfzliyl6mpvsa2yybx9g";
   };
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -28,14 +28,15 @@ assert brotliSupport -> brotli != null;
 assert gssSupport -> libkrb5 != null;
 
 stdenv.mkDerivation rec {
-  name = "curl-7.69.1";
+  pname = "curl";
+  version = "7.70.0";
 
   src = fetchurl {
     urls = [
-      "https://curl.haxx.se/download/${name}.tar.bz2"
-      "https://github.com/curl/curl/releases/download/${lib.replaceStrings ["."] ["_"] name}/${name}.tar.bz2"
+      "https://curl.haxx.se/download/${pname}-${version}.tar.bz2"
+      "https://github.com/curl/curl/releases/download/${lib.replaceStrings ["."] ["_"] pname}-${version}/${pname}-${version}.tar.bz2"
     ];
-    sha256 = "1s2ddjjif1wkp69vx25nzxklhimgqzaazfzliyl6mpvsa2yybx9g";
+    sha256 = "1l19b2xmzwjl2fqlbv46kwlz1823miaxczyx2a5lz8k7mmigw2x5";
   };
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];
@@ -119,8 +120,8 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A command line tool for transferring files with URL syntax";
     homepage    = https://curl.haxx.se/;
-    maintainers = with maintainers; [ lovek323 ];
     license = licenses.curl;
+    maintainers = with maintainers; [ lovek323 ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -39,6 +39,22 @@ stdenv.mkDerivation rec {
     sha256 = "1l19b2xmzwjl2fqlbv46kwlz1823miaxczyx2a5lz8k7mmigw2x5";
   };
 
+  patches = [
+    # remove these two patches for cURL >= 7.71.0
+    (fetchurl {
+      # https://www.openwall.com/lists/oss-security/2020/06/24/1
+      name = "CVE-2020-8169.patch";
+      url = "https://github.com/curl/curl/commit/600a8cded447cd.patch";
+      sha256 = "10qdh995mgaxza3va7r7gl1xkyfidbhk09i5srm9h59ml4fqm36r";
+    })
+    (fetchurl {
+      # https://www.openwall.com/lists/oss-security/2020/06/24/2
+      name = "CVE-2020-8177.patch";
+      url = "https://github.com/curl/curl/commit/8236aba58542c5f.patch";
+      sha256 = "08zwizkbwy2blcqza4681099cd13z3ww2lq5ypnf2c5zsysnv48a";
+    })
+  ];
+
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];
   separateDebugInfo = stdenv.isLinux;
 


### PR DESCRIPTION
##### Motivation for this change

Two security advisories were published today:
- https://www.openwall.com/lists/oss-security/2020/06/24/1
- https://www.openwall.com/lists/oss-security/2020/06/24/2

Master fixes them in #91399 
@NinjaTrappeur tried applying the patches to 7.68.0, which did not work.

So I cherry-picked the bumps up to 7.70.0, a known good version that was used on master, and applied the patches there.

This additionally unblocks #86999, where a WolfSSL security bump was stuck because it required an API change to cURL.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
