### PR TITLE
octoprint: freeze deps and fix build

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -16,11 +16,17 @@ let
   py = python3.override {
     self = py;
     packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([
-      (mkOverride "flask"       "0.12.5" "fac2b9d443e49f7e7358a444a3db5950bdd0324674d92ba67f8f1f15f876b14f")
-      (mkOverride "flaskbabel"  "0.12.2" "11jwp8vvq1gnm31qh6ihy2h393hy18yn9yjp569g60r0wj1x2sii")
-      (mkOverride "tornado"     "4.5.3"  "02jzd23l4r6fswmwxaica9ldlyc2p6q8dk6dyff7j58fmdzf853d")
-      (mkOverride "psutil"      "5.6.7"  "ffad8eb2ac614518bbe3c0b8eb9dffdb3a8d2e3a7d5da51c5b974fb723a5c5aa")
-      (mkOverride "watchdog"    "0.9.0"  "07cnvvlpif7a6cg4rav39zq8fxa5pfqawchr46433pij0y6napwn")
+      (mkOverride "flask"            "0.12.5" "fac2b9d443e49f7e7358a444a3db5950bdd0324674d92ba67f8f1f15f876b14f")
+      (mkOverride "flask_assets"     "0.12"   "0ivqsihk994rxw58vdgzrx4d77d7lpzjm4qxb38hjdgvi5xm4cb0")
+      (mkOverride "flaskbabel"       "0.12.2" "11jwp8vvq1gnm31qh6ihy2h393hy18yn9yjp569g60r0wj1x2sii")
+      (mkOverride "flask_login"      "0.4.1"  "1v2j8zd558xfmgn3rfbw0xz4vizjcnk8kqw52q4f4d9ygfnc25f8")
+      (mkOverride "markdown"         "3.1.1"  "2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a")
+      (mkOverride "tornado"          "4.5.3"  "02jzd23l4r6fswmwxaica9ldlyc2p6q8dk6dyff7j58fmdzf853d")
+      (mkOverride "psutil"           "5.6.7"  "ffad8eb2ac614518bbe3c0b8eb9dffdb3a8d2e3a7d5da51c5b974fb723a5c5aa")
+      (mkOverride "watchdog"         "0.9.0"  "07cnvvlpif7a6cg4rav39zq8fxa5pfqawchr46433pij0y6napwn")
+      (mkOverride "werkzeug"         "0.16.1" "010zmhyfbp4d56c1rgalwi188imjlkv9g7rm25jrvify6xnqalxk")
+      (mkOverride "websocket_client" "0.56.0" "0fpxjyr74klnyis3yf6m54askl0h5dchxcwbfjsq92xng0455m8z")
+      (mkOverride "wrapt"            "1.11.2" "1q81762dgsgrd12f8qc39zk8s5wll3m5xc32jdmlf6cls4gh4njn")
 
       # Octoprint holds back jinja2 to 2.8.1 due to breaking changes.
       # This old version does not have updated test config for pytest 4,

--- a/pkgs/applications/office/trytond/default.nix
+++ b/pkgs/applications/office/trytond/default.nix
@@ -1,40 +1,48 @@
-{ stdenv, python2Packages
-, withPostgresql ? true }:
+{ stdenv
+, python3Packages
+, withPostgresql ? true
+}:
 
 with stdenv.lib;
 
-python2Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "trytond";
-  version = "4.8.4";
-  src = python2Packages.fetchPypi {
+  version = "5.6.2";
+  src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1935045b1b4674de602b4279a9cfd0a14431624a28ccb490234cffecb81fbca7";
+    sha256 = "0mlfl34zmmqrwip39mvhkk0h6dsljqwff2mk1ldahm253d4vzflp";
   };
 
   # Tells the tests which database to use
   DB_NAME = ":memory:";
 
-  buildInputs = with python2Packages; [
+  buildInputs = with python3Packages; [
     mock
   ];
-  propagatedBuildInputs = with python2Packages; ([
-    dateutil
+  propagatedBuildInputs = with python3Packages; [
     lxml
+    relatorio
+    genshi
+    dateutil
     polib
     python-sql
-    relatorio
     werkzeug
     wrapt
-    ipaddress
+    passlib
 
     # extra dependencies
     bcrypt
     pydot
     python-Levenshtein
     simplejson
-    cdecimal
     html2text
-  ] ++ stdenv.lib.optional withPostgresql psycopg2);
+  ] ++ stdenv.lib.optional withPostgresql psycopg2;
+
+  # If unset, trytond will try to mkdir /homeless-shelter
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
   meta = {
     description = "The server of the Tryton application platform";
     longDescription = ''

--- a/pkgs/development/python-modules/sentry-sdk/default.nix
+++ b/pkgs/development/python-modules/sentry-sdk/default.nix
@@ -17,6 +17,8 @@
 , stdenv
 , tornado
 , urllib3
+, trytond
+, werkzeug
 }:
 
 buildPythonPackage rec {
@@ -28,10 +30,10 @@ buildPythonPackage rec {
     sha256 = "0e5e947d0f7a969314aa23669a94a9712be5a688ff069ff7b9fc36c66adc160c";
   };
 
-  checkInputs = [ django flask tornado bottle rq falcon sqlalchemy ]
+  checkInputs = [ django flask tornado bottle rq falcon sqlalchemy werkzeug ]
   ++ stdenv.lib.optionals isPy3k [ celery pyramid sanic aiohttp ];
 
-  propagatedBuildInputs = [ urllib3 certifi ];
+  propagatedBuildInputs = [ urllib3 certifi trytond ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/getsentry/sentry-python";

--- a/pkgs/development/python-modules/trytond/default.nix
+++ b/pkgs/development/python-modules/trytond/default.nix
@@ -1,14 +1,31 @@
 { stdenv
-, python3Packages
+, buildPythonApplication
+, fetchPypi
+, mock
+, lxml
+, relatorio
+, genshi
+, dateutil
+, polib
+, python-sql
+, werkzeug
+, wrapt
+, passlib
+, bcrypt
+, pydot
+, python-Levenshtein
+, simplejson
+, html2text
+, psycopg2
 , withPostgresql ? true
 }:
 
 with stdenv.lib;
 
-python3Packages.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "trytond";
   version = "5.6.2";
-  src = python3Packages.fetchPypi {
+  src = fetchPypi {
     inherit pname version;
     sha256 = "0mlfl34zmmqrwip39mvhkk0h6dsljqwff2mk1ldahm253d4vzflp";
   };
@@ -16,10 +33,10 @@ python3Packages.buildPythonApplication rec {
   # Tells the tests which database to use
   DB_NAME = ":memory:";
 
-  buildInputs = with python3Packages; [
+  buildInputs = [
     mock
   ];
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = [
     lxml
     relatorio
     genshi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7193,7 +7193,7 @@ in
 
   tryton = callPackage ../applications/office/tryton { };
 
-  trytond = callPackage ../applications/office/trytond { };
+  trytond = with python3Packages; toPythonApplication trytond;
 
   omapd = callPackage ../tools/security/omapd { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6056,6 +6056,8 @@ in {
 
   tqdm = callPackage ../development/python-modules/tqdm { };
 
+  trytond = callPackage ../development/python-modules/trytond { };
+
   smmap = callPackage ../development/python-modules/smmap { };
 
   smmap2 = throw "smmap2 has been deprecated, use smmap instead."; # added 2020-03-14


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Octoprint requires an older version of Werkzeug than in nixpkgs, causing a build failure. This pins the dependency version using the already established approach in the octoprint package and fixes the build.
Also the other build dependencies were fixed.

###### Things done
Pinned and fixed dependencies.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
