### PR TITLE
SuperTuxKart: Replaced some bundled libraries with system ones

### DIFF
--- a/pkgs/development/libraries/wiiuse/default.nix
+++ b/pkgs/development/libraries/wiiuse/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, bluez
+}:
+stdenv.mkDerivation rec {
+
+  pname = "WiiUse";
+  version = "0.15.5";
+
+  src = fetchFromGitHub {
+    owner = "wiiuse";
+    repo = "wiiuse";
+    rev = "${version}";
+    sha256 = "05gc3s0wxx7ga4g32yyibyxdh46rm9bbslblrc72ynrjxq98sg13";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ (lib.getDev bluez) ];
+
+  cmakeFlags = [ "-DBUILD_EXAMPLE_SDL=NO" ];
+
+  meta = with lib; {
+    description = "Feature complete cross-platform Wii Remote access library";
+    license = licenses.gpl3;
+    homepage = "https://github.com/wiiuse/wiiuse";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -1,7 +1,8 @@
-{ stdenv, fetchFromGitHub, fetchsvn, cmake, pkgconfig, makeWrapper
-, openal, freealut, libGLU, libGL, libvorbis, libogg, gettext, curl, freetype
-, fribidi, libtool, bluez, libjpeg, libpng, zlib, libX11, libXrandr, enet, harfbuzz }:
-
+{ lib, stdenv, fetchFromGitHub, fetchsvn, cmake, pkgconfig, makeWrapper
+, openal, freealut, libGLU, libGL, libvorbis, libogg, gettext, curl, freetype, glew
+, fribidi, libtool, bluez, libjpeg, libpng, zlib, libX11, libXrandr, harfbuzz
+, mcpp, wiiuse, angelscript
+}:
 let
   dir = "stk-code";
   assets = fetchsvn {
@@ -11,34 +12,62 @@ let
     name   = "stk-assets";
   };
 
+  # List of bundled libraries in stk-code/lib to keep
+  # Those are the libraries that cannot be replaced
+  # with system packages.
+  bundledLibraries = [
+    # Bullet 2.87 is incompatible (bullet 2.79 needed whereas 2.87 is packaged)
+    # The api changed in a lot of classes, too much work to adapt
+    "bullet"
+    # Upstream Libenet doesn't yet support IPv6,
+    # So we will use the bundled libenet which
+    # has been fixed to support it.
+    "enet"
+    # Internal library of STK, nothing to do about it
+    "graphics_utils"
+    # This irrlicht is bundled with cmake
+    # whereas upstream irrlicht still uses
+    # archaic Makefiles, too complicated to switch to.
+    "irrlicht"
+    # Not packaged to this date
+    "libraqm"
+    # Not packaged to this date
+    "libsquish"
+  ];
 in stdenv.mkDerivation rec {
+
   pname = "supertuxkart";
   version = "1.1";
 
-  srcs = [
-    (fetchFromGitHub {
-      owner  = "supertuxkart";
-      repo   = "stk-code";
-      rev    = version;
-      sha256 = "01vxxl94583ixswzmi4caz8dk64r56pn3zxh7v63zml60yfvxbvp";
-      name   = dir;
-    })
-  ];
+  src = fetchFromGitHub {
+    owner  = "supertuxkart";
+    repo   = "stk-code";
+    rev    = version;
+    sha256 = "01vxxl94583ixswzmi4caz8dk64r56pn3zxh7v63zml60yfvxbvp";
+    name   = dir;
+  };
+
+  # Deletes all bundled libs in stk-code/lib except those
+  # That couldn't be replaced with system packages
+  postPatch = ''
+    find lib -maxdepth 1 -type d | egrep -v "^lib$|${(lib.concatStringsSep "|" bundledLibraries)}" | xargs -n1 -L1 -r -I{} rm -rf {}
+  '';
 
   nativeBuildInputs = [ cmake gettext libtool pkgconfig makeWrapper ];
 
   buildInputs = [
     libX11 libXrandr
-    openal freealut libGLU libGL libvorbis libogg zlib freetype
-    curl fribidi bluez libjpeg libpng enet harfbuzz
+    openal freealut libGLU libGL libvorbis libogg zlib freetype glew
+    curl fribidi bluez libjpeg libpng harfbuzz
+    mcpp wiiuse angelscript
   ];
-
-  enableParallelBuilding = true;
 
   cmakeFlags = [
     "-DBUILD_RECORDER=OFF"         # libopenglrecorder is not in nixpkgs
     "-DUSE_SYSTEM_ANGELSCRIPT=OFF" # doesn't work with 2.31.2 or 2.32.0
     "-DCHECK_ASSETS=OFF"
+    "-DUSE_SYSTEM_WIIUSE=ON"
+    "-DUSE_SYSTEM_ANGELSCRIPT=ON"
   ];
 
   # Obtain the assets directly from the fetched store path, to avoid duplicating assets across multiple engine builds
@@ -46,9 +75,9 @@ in stdenv.mkDerivation rec {
     wrapProgram $out/bin/supertuxkart --set-default SUPERTUXKART_ASSETS_DIR "${assets}"
   '';
 
-  sourceRoot = dir;
+  enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A Free 3D kart racing game";
     longDescription = ''
       SuperTuxKart is a Free 3D kart racing game, with many tracks,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7691,6 +7691,8 @@ in
 
   whsniff = callPackage ../applications/networking/sniffers/whsniff { };
 
+  wiiuse = callPackage ../development/libraries/wiiuse { };
+
   woeusb = callPackage ../tools/misc/woeusb { };
 
   chase = callPackage ../tools/system/chase { };


### PR DESCRIPTION
###### Motivation for this change
Was packaging [WiiUse](https://github.com/wiiuse/wiiuse) when noticed
that SuperTuxKart was conflicting with it. So I came with
this partially unbundled build. This should also reduce the package size a bit.

###### Things done
Replaced some bundled libs with system ones.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
