### PR TITLE
WiiUse: Init at 0.15.5

### DIFF
--- a/pkgs/development/libraries/wiiuse/default.nix
+++ b/pkgs/development/libraries/wiiuse/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, bluez
+}:
+stdenv.mkDerivation rec {
+
+  pname = "WiiUse";
+  version = "0.15.5";
+
+  src = fetchFromGitHub {
+    owner = "wiiuse";
+    repo = "wiiuse";
+    rev = "${version}";
+    sha256 = "05gc3s0wxx7ga4g32yyibyxdh46rm9bbslblrc72ynrjxq98sg13";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ (lib.getDev bluez) ];
+
+  cmakeFlags = [ "-DBUILD_EXAMPLE_SDL=NO" ];
+
+  meta = with lib; {
+    description = "Feature complete cross-platform Wii Remote access library";
+    license = licenses.gpl3;
+    homepage = "https://github.com/wiiuse/wiiuse";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = with platforms; linux;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
I need this library, SuperTuxKart needs it too.

###### Things done
Packaged WiiUse at 0.15.5.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
