### PR TITLE
Sway 1.5

### DIFF
--- a/pkgs/applications/window-managers/sway/contrib.nix
+++ b/pkgs/applications/window-managers/sway/contrib.nix
@@ -18,23 +18,11 @@
 
 grimshot = stdenv.mkDerivation rec {
   pname = "grimshot";
-  version = "2020-05-08";
-  rev = "b1d08db5f5112ab562f89564825e3e791b0682c4";
+  version = sway-unwrapped.version;
 
-  # master has new fixes and features, and a man page
-  # after sway-1.5 these may be switched to sway-unwrapped.src
-  bsrc = fetchurl {
-    url = "https://raw.githubusercontent.com/swaywm/sway/${rev}/contrib/grimshot";
-    sha256 = "1awzmzkib8a7q5s78xyh8za03lplqfpbasqp3lidqqmjqs882jq9";
-  };
-
-  msrc = fetchurl {
-    url = "https://raw.githubusercontent.com/swaywm/sway/${rev}/contrib/grimshot.1";
-    sha256 = "191xxjfhf61gkxl3b0f694h0nrwd7vfnyp5afk8snhhr6q7ia4jz";
-  };
+  src = sway-unwrapped.src;
 
   dontBuild = true;
-  dontUnpack = true;
   dontConfigure = true;
 
   outputs = [ "out" "man" ];
@@ -42,9 +30,9 @@ grimshot = stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper installShellFiles ];
 
   installPhase = ''
-    installManPage ${msrc}
+    installManPage contrib/grimshot.1
 
-    install -Dm 0755 ${bsrc} $out/bin/grimshot
+    install -Dm 0755 contrib/grimshot $out/bin/grimshot
     wrapProgram $out/bin/grimshot --set PATH \
       "${stdenv.lib.makeBinPath [
         sway-unwrapped

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -1,20 +1,19 @@
 { stdenv, fetchFromGitHub, makeWrapper
-, meson, ninja
-, pkgconfig, scdoc
-, wayland, libxkbcommon, pcre, json_c, dbus, libevdev
+, meson, ninja, pkg-config, wayland, scdoc
+, libxkbcommon, pcre, json_c, dbus, libevdev
 , pango, cairo, libinput, libcap, pam, gdk-pixbuf, librsvg
 , wlroots, wayland-protocols
 }:
 
 stdenv.mkDerivation rec {
   pname = "sway-unwrapped";
-  version = "1.4";
+  version = "1.5";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "sway";
     rev = version;
-    sha256 = "11qf89y3q92g696a6f4d23qb44gqixg6qxq740vwv2jw59ms34ja";
+    sha256 = "0r3b7h778l9i20z3him9i2qsaynpn9y78hzfgv3cqi8fyry2c4f9";
   };
 
   patches = [
@@ -22,8 +21,12 @@ stdenv.mkDerivation rec {
     ./load-configuration-from-etc.patch
   ];
 
+  postPatch = ''
+    substituteInPlace meson.build --replace "v1.5" "1.5"
+  '';
+
   nativeBuildInputs = [
-    pkgconfig meson ninja scdoc
+    meson ninja pkg-config wayland scdoc
   ];
 
   buildInputs = [
@@ -32,16 +35,23 @@ stdenv.mkDerivation rec {
     wlroots wayland-protocols
   ];
 
-  enableParallelBuilding = true;
-
   mesonFlags = [
-    "-Ddefault-wallpaper=false" "-Dxwayland=enabled" "-Dgdk-pixbuf=enabled"
-    "-Dtray=enabled" "-Dman-pages=enabled"
+    "-Ddefault-wallpaper=false"
   ];
 
   meta = with stdenv.lib; {
-    description = "i3-compatible tiling Wayland compositor";
+    description = "An i3-compatible tiling Wayland compositor";
+    longDescription = ''
+      Sway is a tiling Wayland compositor and a drop-in replacement for the i3
+      window manager for X11. It works with your existing i3 configuration and
+      supports most of i3's features, plus a few extras.
+      Sway allows you to arrange your application windows logically, rather
+      than spatially. Windows are arranged into a grid by default which
+      maximizes the efficiency of your screen and can be quickly manipulated
+      using only the keyboard.
+    '';
     homepage    = "https://swaywm.org";
+    changelog   = "https://github.com/swaywm/sway/releases/tag/${version}";
     license     = licenses.mit;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ primeos synthetica ma27 ];

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "wlroots";
-  version = "0.10.1";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "wlroots";
     rev = version;
-    sha256 = "0j2lh9vc92zhn44rjbia5aw3y1rpgfng1x1h17lcvj5m4i6vj0pc";
+    sha256 = "08d5d52m8wy3imfc6mdxpx8swhh2k4s1gmfaykg02j59z84awc6p";
   };
 
   # $out for the library and $examples for the example programs (in examples):
@@ -21,10 +21,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ meson ninja pkg-config wayland ];
 
   buildInputs = [
-    libGL wayland-protocols libinput libxkbcommon pixman
+    libGL wayland wayland-protocols libinput libxkbcommon pixman
     xcbutilwm libX11 libcap xcbutilimage xcbutilerrors mesa
     libpng ffmpeg
   ];
+
+  mesonFlags = [ "-Dlogind-provider=systemd" ];
 
   postInstall = ''
     # Copy the library to $examples


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Status

Basic functionality works, but I didn't review the changelogs yet.
Feedback about bugs, possible improvements, etc. is welcome :)

TODOs:
- [x] Test wlroots incompatibilities (rebuilds)
  - All good. Changes: `cage-unstable sway-contrib.grimshot (2020-05-08 → 1.5-rc1) hikari sway (1.4 → 1.5-rc1) sway-contrib.inactive-windows-transparency (1.4 → 1.5-rc1) sway-unwrapped (1.4 → 1.5-rc1) waybar wlroots (0.10.1 → 2020-06-08)`
  - Final `nixpkgs-review` (the `sway-contrib.inactive-windows-transparency` failure is unrelated to this PR):
    ```
    8 packages updated:
    cage-unstable sway-contrib.grimshot (2020-05-08 → 1.5) hikari sway (1.4 → 1.5) sway-contrib.inactive-windows-transparency (1.4 → 1.5) sway-unwrapped (1.4 → 1.5) waybar wlroots (0.10.1 → 0.11.0)
    
    $ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/nix-review/.cache/nixpkgs-review/rev-6ab6fbe7442b037d03121e64babc34daceb275ad/build.nix
    warning: ignoring the user-specified setting 'sandbox', because it is a restricted setting and you are not a trusted user
    builder for '/nix/store/blycqf23hysgfxfykca8fh35hcpzz0gl-python3.8-i3ipc-2.1.1.drv' failed with exit code 1; last 10 log lines:
          res = hook_impl.function(*args)
        File "/nix/store/4p440acz02ccpa8w1h9i9dy95k6vvv43-python3.8-pytest-xvfb-1.2.0/lib/python3.8/site-packages/pytest_xvfb.py", line 99, in pytest_unconfigure
          config.xvfb.stop()
        File "/nix/store/4p440acz02ccpa8w1h9i9dy95k6vvv43-python3.8-pytest-xvfb-1.2.0/lib/python3.8/site-packages/pytest_xvfb.py", line 61, in stop
          self._virtual_display.stop()
        File "/nix/store/vym7aglbs81c1rwv9m10n1h2mj0hn3ms-python3.8-PyVirtualDisplay-1.3.2/lib/python3.8/site-packages/pyvirtualdisplay/display.py", line 76, in stop
          self._obj.stop()
        File "/nix/store/vym7aglbs81c1rwv9m10n1h2mj0hn3ms-python3.8-PyVirtualDisplay-1.3.2/lib/python3.8/site-packages/pyvirtualdisplay/abstractdisplay.py", line 318, in stop
          raise XStartError("stop() is called before start().")
      pyvirtualdisplay.abstractdisplay.XStartError: stop() is called before start().
    cannot build derivation '/nix/store/b3r1nr85880izr51i10waixh8j475mgh-sway-inactive-windows-transparency-1.5.drv': 1 dependencies couldn't be built
    cannot build derivation '/nix/store/csc595v9m2m7d4vybhwwk1r0r1a8xi4m-env.drv': 1 dependencies couldn't be built
    [10 built (1 failed), 265 copied (700.6 MiB), 161.1 MiB DL]
    error: build of '/nix/store/csc595v9m2m7d4vybhwwk1r0r1a8xi4m-env.drv' failed
    1 package failed to build:
    sway-contrib.inactive-windows-transparency
    
    7 packages built:
    cage hikari sway sway-contrib.grimshot sway-unwrapped waybar wlroots
    ```
- [x] Wait for the final release and squash the commits

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
