### PR TITLE
linuxPackages.e1000e: 3.3.5.3 -> 3.8.4

### DIFF
--- a/pkgs/os-specific/linux/e1000e/default.nix
+++ b/pkgs/os-specific/linux/e1000e/default.nix
@@ -4,11 +4,11 @@ assert stdenv.lib.versionOlder kernel.version "4.10";
 
 stdenv.mkDerivation rec {
   name = "e1000e-${version}-${kernel.version}";
-  version = "3.3.5.3";
+  version = "3.8.4";
 
   src = fetchurl {
     url = "mirror://sourceforge/e1000/e1000e-${version}.tar.gz";
-    sha256 = "1ajz3vdnf1y307k585w95r6jlh4ah8d74bq36gdkjl1z5hgiqi9q";
+    sha256 = "1q8dbqh14c7r15q6k6iv5k0d6xpi74i71d5r54py60gr099m2ha4";
   };
 
   hardeningDisable = [ "pic" ];
@@ -16,7 +16,8 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     cd src
     kernel_version=${kernel.modDirVersion}
-    sed -i -e 's|/lib/modules|${kernel.dev}/lib/modules|' Makefile
+    substituteInPlace common.mk \
+      --replace "/lib/modules" "${kernel.dev}/lib/modules"
     export makeFlags="BUILD_KERNEL=$kernel_version"
   '';
 


### PR DESCRIPTION
Upgrade e1000e from version 3.3.5.3 to 3.8.4

###### Motivation for this change

I got a new laptop that requires a newer version of `e1000e`, and I saw that the derivation hasn't been updated in a while.

###### Things done

I am a new NixOS user and struggling to test this.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
