### PR TITLE
use latest protobuf (3.12), remove overrides where possible

### DIFF
--- a/pkgs/applications/blockchains/monero/default.nix
+++ b/pkgs/applications/blockchains/monero/default.nix
@@ -2,7 +2,7 @@
 , cmake, pkgconfig
 , boost, miniupnpc, openssl, unbound
 , zeromq, pcsclite, readline, libsodium, hidapi
-, pythonProtobuf, randomx, rapidjson, libusb-compat-0_1
+, protobuf, randomx, rapidjson, libusb-compat-0_1
 , CoreData, IOKit, PCSC
 }:
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     boost miniupnpc openssl unbound
     zeromq pcsclite readline
     libsodium hidapi randomx rapidjson
-    pythonProtobuf libusb-compat-0_1
+    protobuf libusb-compat-0_1
   ] ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit CoreData PCSC ];
 
   cmakeFlags = [

--- a/pkgs/applications/misc/ola/default.nix
+++ b/pkgs/applications/misc/ola/default.nix
@@ -1,31 +1,43 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, bison, flex, pkgconfig
-, libuuid, cppunit, protobuf3_1, zlib, avahi, libmicrohttpd
-, perl, python36 # Replace by python3 after the next update
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, bison
+, flex
+, pkgconfig
+, libuuid
+, cppunit
+, protobuf
+, zlib
+, avahi
+, libmicrohttpd
+, perl
+, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "ola";
-  version = "0.10.7";
+  version = "unstable-2020-07-17";
 
   src = fetchFromGitHub {
     owner = "OpenLightingProject";
     repo = "ola";
-    rev = version;
-    sha256 = "18krwrw7w1qzwih8gnmv7r4sah5ppvq7ax65r7l5yjxn3ihwp2kf";
+    rev = "e2cd699c7792570500578fd092fb6bfb3d511023"; # HEAD of "0.10" branch
+    sha256 = "17a3z3zhx00rjk58icd3zlqfw3753f3y8bwy2sza0frdim09lqr4";
   };
 
   nativeBuildInputs = [ autoreconfHook bison flex pkgconfig perl ];
-  buildInputs = [ libuuid cppunit protobuf3_1 zlib avahi libmicrohttpd python36 ];
+  buildInputs = [ libuuid cppunit protobuf zlib avahi libmicrohttpd python3 ];
   propagatedBuildInputs = [
-    (python36.pkgs.protobuf.override { protobuf = protobuf3_1; })
-    python36.pkgs.numpy
+    python3.pkgs.protobuf
+    python3.pkgs.numpy
   ];
 
   configureFlags = [ "--enable-python-libs" ];
 
   meta = with stdenv.lib; {
     description = "A framework for controlling entertainment lighting equipment.";
-    maintainers = [ maintainers.globin ];
+    homepage = "https://www.openlighting.org/ola/";
+    maintainers = with maintainers; [ globin ];
     license = with licenses; [ lgpl21 gpl2Plus ];
     platforms = platforms.all;
   };

--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -1,20 +1,16 @@
 { stdenv, fetchFromGitHub, cmake, abseil-cpp, gflags, which
-, lsb-release, glog, protobuf3_11, cbc, zlib
+, lsb-release, glog, protobuf, cbc, zlib
 , ensureNewerSourcesForZipFilesHook, python, swig }:
 
-let
-  protobuf = protobuf3_11;
-  pythonProtobuf = python.pkgs.protobuf.override { inherit protobuf; };
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "or-tools";
-  version = "7.6";
+  version = "7.7";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "or-tools";
     rev = "v${version}";
-    sha256 = "0605q3y7vh7x7m9azrbkx44blq12zrab6v28b9wmpcn1lmykbw1b";
+    sha256 = "06ig9a1afmzgzcg817y0rdq49ahll0q9y7bhhg9d89x6zy959ypv";
   };
 
   # The original build system uses cmake which does things like pull
@@ -33,7 +29,7 @@ in stdenv.mkDerivation rec {
 
   makeFlags = [
     "prefix=${placeholder "out"}"
-    "PROTOBUF_PYTHON_DESC=${pythonProtobuf}/${python.sitePackages}/google/protobuf/descriptor_pb2.py"
+    "PROTOBUF_PYTHON_DESC=${python.pkgs.protobuf}/${python.sitePackages}/google/protobuf/descriptor_pb2.py"
   ];
   buildFlags = [ "cc" "pypi_archive" ];
 
@@ -54,7 +50,7 @@ in stdenv.mkDerivation rec {
   ];
   propagatedBuildInputs = [
     abseil-cpp gflags glog protobuf cbc
-    pythonProtobuf python.pkgs.six
+    python.pkgs.protobuf python.pkgs.six
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/python-modules/cirq/default.nix
+++ b/pkgs/development/python-modules/cirq/default.nix
@@ -10,7 +10,7 @@
 , networkx
 , numpy
 , pandas
-, pythonProtobuf  # pythonPackages.protobuf
+, protobuf
 , requests
 , scipy
 , sortedcontainers
@@ -28,15 +28,15 @@
 
 buildPythonPackage rec {
   pname = "cirq";
-  version = "0.8.0";
+  version = "0.8.2";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "quantumlib";
     repo = "cirq";
     rev = "v${version}";
-    sha256 = "01nnv7r595sp60wvp7750lfdjwdsi4q0r4lmaj6li09zsdw0r4b3";
+    sha256 = "0xs46s19idh8smf80zhgraxwh3lphcdbljdrhxwhi5xcc41dfsmf";
   };
 
   patches = [
@@ -48,14 +48,6 @@ buildPythonPackage rec {
     })
   ];
 
-  # Cirq locks protobuf==3.8.0, but tested working with default pythonPackages.protobuf (3.7). This avoids overrides/pythonPackages.protobuf conflicts
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "networkx~=2.4" "networkx" \
-      --replace "protobuf==3.8.0" "protobuf" \
-      --replace "freezegun~=0.3.15" "freezegun"
-  '';
-
   propagatedBuildInputs = [
     freezegun
     google_api_core
@@ -63,7 +55,7 @@ buildPythonPackage rec {
     matplotlib
     networkx
     pandas
-    pythonProtobuf
+    protobuf
     requests
     scipy
     sortedcontainers

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14402,7 +14402,7 @@ in
     python = python37;
   };
 
-  protobuf = protobuf3_8;
+  protobuf = protobuf3_12;
 
   protobuf3_12 = callPackage ../development/libraries/protobuf/3.12.nix { };
   protobuf3_11 = callPackage ../development/libraries/protobuf/3.11.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23772,12 +23772,10 @@ in
   monero = callPackage ../applications/blockchains/monero {
     inherit (darwin.apple_sdk.frameworks) CoreData IOKit PCSC;
     boost = boost17x;
-    pythonProtobuf = python3Packages.protobuf.override { protobuf = protobuf3_10; };
   };
 
   monero-gui = libsForQt5.callPackage ../applications/blockchains/monero-gui {
     boost = boost17x;
-    protobuf = protobuf3_10;
   };
 
   masari = callPackage ../applications/blockchains/masari.nix { boost = boost165; };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2080,9 +2080,7 @@ in {
 
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };
 
-  cirq = callPackage ../development/python-modules/cirq {
-    pythonProtobuf = self.protobuf;
-  };
+  cirq = callPackage ../development/python-modules/cirq { };
 
   citeproc-py = callPackage ../development/python-modules/citeproc-py { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5322,7 +5322,7 @@ in {
   protobuf = callPackage ../development/python-modules/protobuf {
     disabled = isPyPy;
     doCheck = !isPy3k;
-    protobuf = pkgs.protobuf3_8;
+    protobuf = pkgs.protobuf3_12;
   };
 
   psd-tools = callPackage ../development/python-modules/psd-tools { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The goal of this PR is to set protobuf to the latest available version (currently 3.12) and remove all protobuf overrides where possible. Some of the changes are possible when a package is updated to more recent version, so this PR contains a couple of version updates (in separate commits) too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
