### PR TITLE
coc-nvim hardcode nodejs path

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -13,6 +13,8 @@
 , nodePackages
 , dasht
 
+, nodejs
+
 # coc-go dependency
 , go
 
@@ -122,6 +124,15 @@ self: super: {
       sed "/^let g:clighter8_libclang_path/s|')$|${llvmPackages.clang.cc.lib}/lib/libclang.so')|" \
         -i "$out"/share/vim-plugins/clighter8/plugin/clighter8.vim
     '';
+  });
+
+  coc-nvim = super.coc-nvim.overrideAttrs(old: {
+    patches = [
+      (substituteAll {
+        src = ./patches/coc-nvim/nodejs-path.patch;
+        nodejs = "${nodejs}/bin/node";
+      })
+    ];
   });
 
   coc-go = super.coc-go.overrideAttrs(old: {

--- a/pkgs/misc/vim-plugins/patches/coc-nvim/nodejs-path.patch
+++ b/pkgs/misc/vim-plugins/patches/coc-nvim/nodejs-path.patch
@@ -1,0 +1,39 @@
+diff --git a/autoload/coc/util.vim b/autoload/coc/util.vim
+index 5c4f4bb1..d6397be7 100644
+--- a/autoload/coc/util.vim
++++ b/autoload/coc/util.vim
+@@ -325,7 +325,7 @@ function! coc#util#job_command()
+   if (has_key(g:, 'coc_node_path'))
+     let node = expand(g:coc_node_path)
+   else
+-    let node = $COC_NODE_PATH == '' ? 'node' : $COC_NODE_PATH
++    let node = $COC_NODE_PATH == '' ? '@nodejs@' : $COC_NODE_PATH
+   endif
+   if !executable(node)
+     echohl Error | echom '[coc.nvim] "'.node.'" is not executable, checkout https://nodejs.org/en/download/' | echohl None
+diff --git a/autoload/health/coc.vim b/autoload/health/coc.vim
+index fe789b9c..83ae5330 100644
+--- a/autoload/health/coc.vim
++++ b/autoload/health/coc.vim
+@@ -6,7 +6,7 @@ function! s:checkEnvironment() abort
+     let valid = 0
+     call health#report_error('Neovim version not satisfied, 0.3.0 and above required')
+   endif
+-  let node = get(g:, 'coc_node_path', $COC_NODE_PATH == '' ? 'node' : $COC_NODE_PATH)
++  let node = get(g:, 'coc_node_path', $COC_NODE_PATH == '' ? '@nodejs@' : $COC_NODE_PATH)
+   if !executable(node)
+     let valid = 0
+     call health#report_error('Executable node.js not found, install node.js from http://nodejs.org/')
+diff --git a/plugin/coc.vim b/plugin/coc.vim
+index 9d8d7b7e..f123867d 100644
+--- a/plugin/coc.vim
++++ b/plugin/coc.vim
+@@ -360,7 +360,7 @@ function! s:ShowInfo()
+   else
+     let lines = []
+     echomsg 'coc.nvim service not started, checking environment...'
+-    let node = get(g:, 'coc_node_path', $COC_NODE_PATH == '' ? 'node' : $COC_NODE_PATH)
++    let node = get(g:, 'coc_node_path', $COC_NODE_PATH == '' ? '@nodejs@' : $COC_NODE_PATH)
+     if !executable(node)
+       call add(lines, 'Error: '.node.' is not executable!')
+     else


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

coc-nvim complains that it cannot find the nodejs executable.  This PR fixes that by patching the path.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
