### PR TITLE
pythonPackages.debugpy: init at 1.0.0b12

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -1,0 +1,68 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, substituteAll, gdb
+, colorama, django, flask, gevent, psutil, pytest
+, pytest-timeout, pytest_xdist, requests
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "debugpy";
+  version = "1.0.0b12";
+
+  src = fetchFromGitHub {
+    owner = "Microsoft";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0sz33aq5qldl7kh4qjf5w3d08l9s77ipcj4i9wfklj8f6vf9w1wh";
+  };
+
+  patches = [
+    # Hard code GDB path (used to attach to process)
+    (substituteAll {
+      src = ./hardcode-gdb.patch;
+      inherit gdb;
+    })
+
+    # Fix importing debugpy in:
+    # - test_nodebug[module-launch(externalTerminal)]
+    # - test_nodebug[module-launch(integratedTerminal)]
+    #
+    # NOTE: The import failures seen in these tests without the patch
+    # will be seen if a user "installs" debugpy by adding it to PYTHONPATH.
+    # To avoid this issue, debugpy should be installed using python.withPackages:
+    # python.withPackages (ps: with ps; [ debugpy ])
+    ./fix-test-pythonpath.patch
+  ];
+
+  # Remove pre-compiled "attach" libraries and recompile for host platform
+  # Compile flags taken from linux_and_mac/compile_linux.sh & linux_and_mac/compile_mac.sh
+  preBuild = ''(
+    set -x
+    cd src/debugpy/_vendored/pydevd/pydevd_attach_to_process
+    rm *.so *.dylib *.dll *.exe *.pdb
+    ${stdenv.cc}/bin/c++ linux_and_mac/attach.cpp -Ilinux_and_mac -fPIC -nostartfiles ${{
+      "x86_64-linux"  = "-shared -m64 -o attach_linux_amd64.so";
+      "i686-linux"    = "-shared -m32 -o attach_linux_x86.so";
+      "x86_64-darwin" = "-std=c++11 -lc -D_REENTRANT -dynamiclib -arch x86_64 -o attach_x86_64.dylib";
+      "i686-darwin"   = "-std=c++11 -lc -D_REENTRANT -dynamiclib -arch i386 -o attach_x86.dylib";
+    }.${stdenv.hostPlatform.system}}
+  )'';
+
+  checkInputs = [
+    colorama django flask gevent psutil pytest
+    pytest-timeout pytest_xdist requests
+  ];
+
+  # Override default arguments in pytest.ini
+  checkPhase = "pytest --timeout 0 -n $NIX_BUILD_CORES"
+               # gevent fails to import zope.interface with Python 2.7
+               + stdenv.lib.optionalString isPy27 " -k 'not test_gevent'";
+
+  meta = with stdenv.lib; {
+    description = "An implementation of the Debug Adapter Protocol for Python";
+    homepage = "https://github.com/microsoft/debugpy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ metadark ];
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "i686-darwin" ];
+  };
+}

--- a/pkgs/development/python-modules/debugpy/fix-test-pythonpath.patch
+++ b/pkgs/development/python-modules/debugpy/fix-test-pythonpath.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/debug/session.py b/tests/debug/session.py
+index 2b39106..6d45a10 100644
+--- a/tests/debug/session.py
++++ b/tests/debug/session.py
+@@ -625,6 +625,7 @@ class Session(object):
+         if "PYTHONPATH" in self.config.env:
+             # If specified, launcher will use it in lieu of PYTHONPATH it inherited
+             # from the adapter when spawning debuggee, so we need to adjust again.
++            self.config.env.prepend_to("PYTHONPATH", os.environ["PYTHONPATH"])
+             self.config.env.prepend_to("PYTHONPATH", DEBUGGEE_PYTHONPATH.strpath)
+         return self._request_start("launch")
+ 

--- a/pkgs/development/python-modules/debugpy/hardcode-gdb.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-gdb.patch
@@ -1,0 +1,13 @@
+diff --git a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
+index 6d031b4..ecf21f2 100644
+--- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
++++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
+@@ -293,7 +293,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
+     is_debug = 0
+     # Note that the space in the beginning of each line in the multi-line is important!
+     cmd = [
+-        'gdb',
++        '@gdb@/bin/gdb',
+         '--nw',  # no gui interface
+         '--nh',  # no ~/.gdbinit
+         '--nx',  # no .gdbinit

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2718,6 +2718,10 @@ in {
   # Alias that we should deprecate
   dateutil = self.python-dateutil;
 
+  debugpy = callPackage ../development/python-modules/debugpy {
+    django = if isPy27 then self.django_1_11 else self.django;
+  };
+
   decorator = callPackage ../development/python-modules/decorator { };
 
   deform = callPackage ../development/python-modules/deform { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes #89592

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of server through `dap-mode` in Emacs
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
