### PR TITLE
asuka: init at 0.8.0

### DIFF
--- a/pkgs/applications/networking/browsers/asuka/cargo-lock.patch
+++ b/pkgs/applications/networking/browsers/asuka/cargo-lock.patch
@@ -1,0 +1,1351 @@
+diff --git i/Cargo.lock w/Cargo.lock
+index 6807c00..00b2c60 100644
+--- i/Cargo.lock
++++ w/Cargo.lock
+@@ -4,29 +4,34 @@
+ name = "aho-corasick"
+ version = "0.7.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+ dependencies = [
+- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "memchr",
+ ]
+ 
+ [[package]]
+ name = "arc-swap"
+ version = "0.4.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
+ 
+ [[package]]
+ name = "array-macro"
+ version = "1.0.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7d034edd76d4e7adc314c95400941dedc89bd4337d565bf87f6b69d3b20dc4de"
+ 
+ [[package]]
+ name = "arrayref"
+ version = "0.3.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
+ 
+ [[package]]
+ name = "arrayvec"
+ version = "0.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+ 
+ [[package]]
+ name = "asuka"
+@@ -38,8 +43,6 @@ dependencies = [
+  "lazy_static",
+  "native-tls",
+  "open",
+- "openssl",
+- "openssl-sys",
+  "regex",
+  "tempfile",
+  "textwrap",
+@@ -50,769 +53,861 @@ dependencies = [
+ name = "autocfg"
+ version = "0.1.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+ 
+ [[package]]
+ name = "backtrace"
+ version = "0.3.40"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
+ dependencies = [
+- "backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
++ "backtrace-sys",
++ "cfg-if",
++ "libc",
++ "rustc-demangle",
+ ]
+ 
+ [[package]]
+ name = "backtrace-sys"
+ version = "0.1.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
+ dependencies = [
+- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cc",
++ "libc",
+ ]
+ 
+ [[package]]
+ name = "base64"
+ version = "0.10.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+ dependencies = [
+- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "byteorder",
+ ]
+ 
+ [[package]]
+ name = "bitflags"
+ version = "1.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+ 
+ [[package]]
+ name = "blake2b_simd"
+ version = "0.5.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0"
+ dependencies = [
+- "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+- "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "arrayref",
++ "arrayvec",
++ "constant_time_eq",
+ ]
+ 
+ [[package]]
+ name = "byteorder"
+ version = "1.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+ 
+ [[package]]
+ name = "c2-chacha"
+ version = "0.2.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
+ dependencies = [
+- "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "ppv-lite86",
+ ]
+ 
+ [[package]]
+ name = "cc"
+ version = "1.0.47"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8"
+ 
+ [[package]]
+ name = "cfg-if"
+ version = "0.1.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+ 
+ [[package]]
+ name = "chrono"
+ version = "0.4.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
+ dependencies = [
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc",
++ "num-integer",
++ "num-traits",
++ "time",
+ ]
+ 
+ [[package]]
+ name = "cloudabi"
+ version = "0.0.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+ dependencies = [
+- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "bitflags",
+ ]
+ 
+ [[package]]
+ name = "constant_time_eq"
+ version = "0.1.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
+ 
+ [[package]]
+ name = "core-foundation"
+ version = "0.6.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+ dependencies = [
+- "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
++ "core-foundation-sys",
++ "libc",
+ ]
+ 
+ [[package]]
+ name = "core-foundation-sys"
+ version = "0.6.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+ 
+ [[package]]
+ name = "crossbeam-channel"
+ version = "0.3.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
+ dependencies = [
+- "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "crossbeam-utils",
+ ]
+ 
+ [[package]]
+ name = "crossbeam-utils"
+ version = "0.6.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+ dependencies = [
+- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if",
++ "lazy_static",
+ ]
+ 
+ [[package]]
+ name = "cursive"
+ version = "0.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "6261747aa936aab19fc4ac3a2c1a8eee8fb5862ba96fb1e524ee56cb520d9caf"
+ dependencies = [
+- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+- "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+- "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+- "enum-map 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "enumset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "ncurses 5.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "signal-hook 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+- "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+- "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "xi-unicode 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if",
++ "chrono",
++ "crossbeam-channel",
++ "enum-map",
++ "enumset",
++ "hashbrown",
++ "lazy_static",
++ "libc",
++ "log",
++ "maplit",
++ "ncurses",
++ "num",
++ "owning_ref",
++ "signal-hook",
++ "term_size",
++ "toml",
++ "unicode-segmentation",
++ "unicode-width",
++ "xi-unicode",
+ ]
+ 
+ [[package]]
+ name = "darling"
+ version = "0.10.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+ dependencies = [
+- "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "darling_core",
++ "darling_macro",
+ ]
+ 
+ [[package]]
+ name = "darling_core"
+ version = "0.10.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+ dependencies = [
+- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "fnv",
++ "ident_case",
++ "proc-macro2",
++ "quote",
++ "strsim",
++ "syn",
+ ]
+ 
+ [[package]]
+ name = "darling_macro"
+ version = "0.10.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+ dependencies = [
+- "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "darling_core",
++ "quote",
++ "syn",
+ ]
+ 
+ [[package]]
+ name = "dirs"
+ version = "2.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+ dependencies = [
+- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+- "dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if",
++ "dirs-sys",
+ ]
+ 
+ [[package]]
+ name = "dirs-sys"
+ version = "0.3.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+ dependencies = [
+- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if",
++ "libc",
++ "redox_users",
++ "winapi 0.3.8",
+ ]
+ 
+ [[package]]
+ name = "enum-map"
+ version = "0.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "75eb4afb8170adb4120b13700c1af58c3137cd72e4c56e282045af5c29ab5329"
+ dependencies = [
+- "array-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "enum-map-derive 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "array-macro",
++ "enum-map-derive",
+ ]
+ 
+ [[package]]
+ name = "enum-map-derive"
+ version = "0.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e57001dfb2532f5a103ff869656887fae9a8defa7d236f3e39d2ee86ed629ad7"
+ dependencies = [
+- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "proc-macro2",
++ "quote",
++ "syn",
+ ]
+ 
+ [[package]]
+ name = "enumset"
+ version = "0.4.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "57b811aef4ff1cc938f13bbec348f0ecbfc2bb565b7ab90161c9f0b2805edc8a"
+ dependencies = [
+- "enumset_derive 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "enumset_derive",
++ "num-traits",
+ ]
+ 
+ [[package]]
+ name = "enumset_derive"
+ version = "0.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b184c2d0714bbeeb6440481a19c78530aa210654d99529f13d2f860a1b447598"
+ dependencies = [
+- "darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "darling",
++ "proc-macro2",
++ "quote",
++ "syn",
+ ]
+ 
+ [[package]]
+ name = "failure"
+ version = "0.1.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
+ dependencies = [
+- "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
+- "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "backtrace",
++ "failure_derive",
+ ]
+ 
+ [[package]]
+ name = "failure_derive"
+ version = "0.1.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
+ dependencies = [
+- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "proc-macro2",
++ "quote",
++ "syn",
++ "synstructure",
+ ]
+ 
+ [[package]]
+ name = "fnv"
+ version = "1.0.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+ 
+ [[package]]
+ name = "foreign-types"
+ version = "0.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+ dependencies = [
+- "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "foreign-types-shared",
+ ]
+ 
+ [[package]]
+ name = "foreign-types-shared"
+ version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+ 
+ [[package]]
+ name = "fuchsia-cprng"
+ version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+ 
+ [[package]]
+ name = "getrandom"
+ version = "0.1.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
+ dependencies = [
+- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if",
++ "libc",
++ "wasi",
+ ]
+ 
+ [[package]]
+ name = "hashbrown"
+ version = "0.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
+ 
+ [[package]]
+ name = "ident_case"
+ version = "1.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+ 
+ [[package]]
+ name = "idna"
+ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+ dependencies = [
+- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "unicode-normalization 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "matches",
++ "unicode-bidi",
++ "unicode-normalization",
+ ]
+ 
+ [[package]]
+ name = "json"
+ version = "0.12.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b3ca41abbeb7615d56322a984e63be5e5d0a117dfaca86c14393e32a762ccac1"
+ 
+ [[package]]
+ name = "kernel32-sys"
+ version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+ dependencies = [
+- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.2.8",
++ "winapi-build",
+ ]
+ 
+ [[package]]
+ name = "lazy_static"
+ version = "1.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+ 
+ [[package]]
+ name = "libc"
+ version = "0.2.65"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
+ 
+ [[package]]
+ name = "log"
+ version = "0.4.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+ dependencies = [
+- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if",
+ ]
+ 
+ [[package]]
+ name = "maplit"
+ version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+ 
+ [[package]]
+ name = "matches"
+ version = "0.1.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+ 
+ [[package]]
+ name = "maybe-uninit"
+ version = "2.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+ 
+ [[package]]
+ name = "memchr"
+ version = "2.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+ 
+ [[package]]
+ name = "native-tls"
+ version = "0.2.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
+ dependencies = [
+- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "openssl 0.10.25 (registry+https://github.com/rust-lang/crates.io-index)",
+- "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "openssl-sys 0.9.52 (registry+https://github.com/rust-lang/crates.io-index)",
+- "schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+- "security-framework 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "lazy_static",
++ "libc",
++ "log",
++ "openssl",
++ "openssl-probe",
++ "openssl-sys",
++ "schannel",
++ "security-framework",
++ "security-framework-sys",
++ "tempfile",
+ ]
+ 
+ [[package]]
+ name = "ncurses"
+ version = "5.99.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "15699bee2f37e9f8828c7b35b2bc70d13846db453f2d507713b758fabe536b82"
+ dependencies = [
+- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cc",
++ "libc",
++ "pkg-config",
+ ]
+ 
+ [[package]]
+ name = "num"
+ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
+ dependencies = [
+- "num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-complex",
++ "num-integer",
++ "num-iter",
++ "num-rational",
++ "num-traits",
+ ]
+ 
+ [[package]]
+ name = "num-complex"
+ version = "0.2.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"
+ dependencies = [
+- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "autocfg",
++ "num-traits",
+ ]
+ 
+ [[package]]
+ name = "num-integer"
+ version = "0.1.41"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
+ dependencies = [
+- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "autocfg",
++ "num-traits",
+ ]
+ 
+ [[package]]
+ name = "num-iter"
+ version = "0.1.39"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e"
+ dependencies = [
+- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "autocfg",
++ "num-integer",
++ "num-traits",
+ ]
+ 
+ [[package]]
+ name = "num-rational"
+ version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
+ dependencies = [
+- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "autocfg",
++ "num-integer",
++ "num-traits",
+ ]
+ 
+ [[package]]
+ name = "num-traits"
+ version = "0.2.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "443c53b3c3531dfcbfa499d8893944db78474ad7a1d87fa2d94d1a2231693ac6"
+ dependencies = [
+- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "autocfg",
+ ]
+ 
+ [[package]]
+ name = "open"
+ version = "1.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "94b424e1086328b0df10235c6ff47be63708071881bead9e76997d9291c0134b"
+ dependencies = [
+- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.8",
+ ]
+ 
+ [[package]]
+ name = "openssl"
+ version = "0.10.25"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "2f372b2b53ce10fb823a337aaa674e3a7d072b957c6264d0f4ff0bd86e657449"
+ dependencies = [
+- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+- "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "openssl-sys 0.9.52 (registry+https://github.com/rust-lang/crates.io-index)",
++ "bitflags",
++ "cfg-if",
++ "foreign-types",
++ "lazy_static",
++ "libc",
++ "openssl-sys",
+ ]
+ 
+ [[package]]
+ name = "openssl-probe"
+ version = "0.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+ 
+ [[package]]
+ name = "openssl-sys"
+ version = "0.9.52"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c977d08e1312e2f7e4b86f9ebaa0ed3b19d1daff75fae88bbb88108afbd801fc"
+ dependencies = [
+- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+- "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "autocfg",
++ "cc",
++ "libc",
++ "pkg-config",
++ "vcpkg",
+ ]
+ 
+ [[package]]
+ name = "owning_ref"
+ version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
+ dependencies = [
+- "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "stable_deref_trait",
+ ]
+ 
+ [[package]]
+ name = "percent-encoding"
+ version = "2.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+ 
+ [[package]]
+ name = "pkg-config"
+ version = "0.3.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+ 
+ [[package]]
+ name = "ppv-lite86"
+ version = "0.2.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+ 
+ [[package]]
+ name = "proc-macro2"
+ version = "1.0.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
+ dependencies = [
+- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicode-xid",
+ ]
+ 
+ [[package]]
+ name = "quote"
+ version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+ dependencies = [
+- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "proc-macro2",
+ ]
+ 
+ [[package]]
+ name = "rand"
+ version = "0.7.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
+ dependencies = [
+- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "getrandom",
++ "libc",
++ "rand_chacha",
++ "rand_core 0.5.1",
++ "rand_hc",
+ ]
+ 
+ [[package]]
+ name = "rand_chacha"
+ version = "0.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+ dependencies = [
+- "c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "c2-chacha",
++ "rand_core 0.5.1",
+ ]
+ 
+ [[package]]
+ name = "rand_core"
+ version = "0.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+ dependencies = [
+- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.4.2",
+ ]
+ 
+ [[package]]
+ name = "rand_core"
+ version = "0.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+ 
+ [[package]]
+ name = "rand_core"
+ version = "0.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+ dependencies = [
+- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
++ "getrandom",
+ ]
+ 
+ [[package]]
+ name = "rand_hc"
+ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+ dependencies = [
+- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.5.1",
+ ]
+ 
+ [[package]]
+ name = "rand_os"
+ version = "0.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+ dependencies = [
+- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cloudabi",
++ "fuchsia-cprng",
++ "libc",
++ "rand_core 0.4.2",
++ "rdrand",
++ "winapi 0.3.8",
+ ]
+ 
+ [[package]]
+ name = "rdrand"
+ version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+ dependencies = [
+- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.3.1",
+ ]
+ 
+ [[package]]
+ name = "redox_syscall"
+ version = "0.1.56"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+ 
+ [[package]]
+ name = "redox_users"
+ version = "0.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d"
+ dependencies = [
+- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "failure",
++ "rand_os",
++ "redox_syscall",
++ "rust-argon2",
+ ]
+ 
+ [[package]]
+ name = "regex"
+ version = "1.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+ dependencies = [
+- "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "aho-corasick",
++ "memchr",
++ "regex-syntax",
++ "thread_local",
+ ]
+ 
+ [[package]]
+ name = "regex-syntax"
+ version = "0.6.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+ 
+ [[package]]
+ name = "remove_dir_all"
+ version = "0.5.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+ dependencies = [
+- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.8",
+ ]
+ 
+ [[package]]
+ name = "rust-argon2"
+ version = "0.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
+ dependencies = [
+- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "blake2b_simd 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+- "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "base64",
++ "blake2b_simd",
++ "crossbeam-utils",
+ ]
+ 
+ [[package]]
+ name = "rustc-demangle"
+ version = "0.1.16"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+ 
+ [[package]]
+ name = "schannel"
+ version = "0.1.16"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
+ dependencies = [
+- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "lazy_static",
++ "winapi 0.3.8",
+ ]
+ 
+ [[package]]
+ name = "security-framework"
+ version = "0.3.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "301c862a6d0ee78f124c5e1710205965fc5c553100dcda6d98f13ef87a763f04"
+ dependencies = [
+- "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "core-foundation",
++ "core-foundation-sys",
++ "libc",
++ "security-framework-sys",
+ ]
+ 
+ [[package]]
+ name = "security-framework-sys"
+ version = "0.3.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
+ dependencies = [
+- "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "core-foundation-sys",
+ ]
+ 
+ [[package]]
+ name = "serde"
+ version = "1.0.102"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
+ 
+ [[package]]
+ name = "signal-hook"
+ version = "0.1.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cb543aecec4ba8b867f41284729ddfdb7e8fcd70ec3d7d37fca3007a4b53675f"
+ dependencies = [
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc",
++ "signal-hook-registry",
+ ]
+ 
+ [[package]]
+ name = "signal-hook-registry"
+ version = "1.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc"
+ dependencies = [
+- "arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
++ "arc-swap",
++ "libc",
+ ]
+ 
+ [[package]]
+ name = "smallvec"
+ version = "0.6.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
+ dependencies = [
+- "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "maybe-uninit",
+ ]
+ 
+ [[package]]
+ name = "stable_deref_trait"
+ version = "1.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+ 
+ [[package]]
+ name = "strsim"
+ version = "0.9.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
+ 
+ [[package]]
+ name = "syn"
+ version = "1.0.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
+ dependencies = [
+- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "proc-macro2",
++ "quote",
++ "unicode-xid",
+ ]
+ 
+ [[package]]
+ name = "synstructure"
+ version = "0.12.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+ dependencies = [
+- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "proc-macro2",
++ "quote",
++ "syn",
++ "unicode-xid",
+ ]
+ 
+ [[package]]
+ name = "tempfile"
+ version = "3.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+ dependencies = [
+- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+- "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if",
++ "libc",
++ "rand",
++ "redox_syscall",
++ "remove_dir_all",
++ "winapi 0.3.8",
+ ]
+ 
+ [[package]]
+ name = "term_size"
+ version = "0.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
+ dependencies = [
+- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "kernel32-sys",
++ "libc",
++ "winapi 0.2.8",
+ ]
+ 
+ [[package]]
+@@ -828,225 +923,126 @@ dependencies = [
+ name = "thread_local"
+ version = "0.3.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+ dependencies = [
+- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "lazy_static",
+ ]
+ 
+ [[package]]
+ name = "time"
+ version = "0.1.42"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+ dependencies = [
+- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc",
++ "redox_syscall",
++ "winapi 0.3.8",
+ ]
+ 
+ [[package]]
+ name = "toml"
+ version = "0.5.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
+ dependencies = [
+- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde",
+ ]
+ 
+ [[package]]
+ name = "unicode-bidi"
+ version = "0.3.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+ dependencies = [
+- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "matches",
+ ]
+ 
+ [[package]]
+ name = "unicode-normalization"
+ version = "0.1.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "09c8070a9942f5e7cfccd93f490fdebd230ee3c3c9f107cb25bad5351ef671cf"
+ dependencies = [
+- "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
++ "smallvec",
+ ]
+ 
+ [[package]]
+ name = "unicode-segmentation"
+ version = "1.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+ 
+ [[package]]
+ name = "unicode-width"
+ version = "0.1.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
+ 
+ [[package]]
+ name = "unicode-xid"
+ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+ 
+ [[package]]
+ name = "url"
+ version = "2.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
+ dependencies = [
+- "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "idna",
++ "matches",
++ "percent-encoding",
+ ]
+ 
+ [[package]]
+ name = "vcpkg"
+ version = "0.2.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
+ 
+ [[package]]
+ name = "wasi"
+ version = "0.7.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
+ 
+ [[package]]
+ name = "winapi"
+ version = "0.2.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+ 
+ [[package]]
+ name = "winapi"
+ version = "0.3.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+ dependencies = [
+- "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi-i686-pc-windows-gnu",
++ "winapi-x86_64-pc-windows-gnu",
+ ]
+ 
+ [[package]]
+ name = "winapi-build"
+ version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+ 
+ [[package]]
+ name = "winapi-i686-pc-windows-gnu"
+ version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+ 
+ [[package]]
+ name = "winapi-x86_64-pc-windows-gnu"
+ version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+ 
+ [[package]]
+ name = "xi-unicode"
+ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+-[metadata]
+-"checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+-"checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
+-"checksum array-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7d034edd76d4e7adc314c95400941dedc89bd4337d565bf87f6b69d3b20dc4de"
+-"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
+-"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+-"checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+-"checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
+-"checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
+-"checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+-"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+-"checksum blake2b_simd 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0"
+-"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+-"checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
+-"checksum cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)" = "aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8"
+-"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+-"checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
+-"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+-"checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
+-"checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+-"checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+-"checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
+-"checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+-"checksum cursive 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6261747aa936aab19fc4ac3a2c1a8eee8fb5862ba96fb1e524ee56cb520d9caf"
+-"checksum darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+-"checksum darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+-"checksum darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+-"checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+-"checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+-"checksum enum-map 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "75eb4afb8170adb4120b13700c1af58c3137cd72e4c56e282045af5c29ab5329"
+-"checksum enum-map-derive 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e57001dfb2532f5a103ff869656887fae9a8defa7d236f3e39d2ee86ed629ad7"
+-"checksum enumset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "57b811aef4ff1cc938f13bbec348f0ecbfc2bb565b7ab90161c9f0b2805edc8a"
+-"checksum enumset_derive 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b184c2d0714bbeeb6440481a19c78530aa210654d99529f13d2f860a1b447598"
+-"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
+-"checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
+-"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+-"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+-"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+-"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+-"checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
+-"checksum hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
+-"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+-"checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+-"checksum json 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3ca41abbeb7615d56322a984e63be5e5d0a117dfaca86c14393e32a762ccac1"
+-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+-"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+-"checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
+-"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+-"checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+-"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+-"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+-"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+-"checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
+-"checksum ncurses 5.99.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15699bee2f37e9f8828c7b35b2bc70d13846db453f2d507713b758fabe536b82"
+-"checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
+-"checksum num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"
+-"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
+-"checksum num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e"
+-"checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
+-"checksum num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "443c53b3c3531dfcbfa499d8893944db78474ad7a1d87fa2d94d1a2231693ac6"
+-"checksum open 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "94b424e1086328b0df10235c6ff47be63708071881bead9e76997d9291c0134b"
+-"checksum openssl 0.10.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2f372b2b53ce10fb823a337aaa674e3a7d072b957c6264d0f4ff0bd86e657449"
+-"checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+-"checksum openssl-sys 0.9.52 (registry+https://github.com/rust-lang/crates.io-index)" = "c977d08e1312e2f7e4b86f9ebaa0ed3b19d1daff75fae88bbb88108afbd801fc"
+-"checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
+-"checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+-"checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+-"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+-"checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
+-"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+-"checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
+-"checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+-"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+-"checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+-"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+-"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+-"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+-"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+-"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+-"checksum redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d"
+-"checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+-"checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+-"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+-"checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
+-"checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+-"checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
+-"checksum security-framework 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "301c862a6d0ee78f124c5e1710205965fc5c553100dcda6d98f13ef87a763f04"
+-"checksum security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
+-"checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
+-"checksum signal-hook 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cb543aecec4ba8b867f41284729ddfdb7e8fcd70ec3d7d37fca3007a4b53675f"
+-"checksum signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc"
+-"checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
+-"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+-"checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
+-"checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
+-"checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+-"checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+-"checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
+-"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+-"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+-"checksum toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
+-"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+-"checksum unicode-normalization 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "09c8070a9942f5e7cfccd93f490fdebd230ee3c3c9f107cb25bad5351ef671cf"
+-"checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+-"checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
+-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+-"checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
+-"checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
+-"checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
+-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+-"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+-"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+-"checksum xi-unicode 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7395cdb9d0a6219fa0ea77d08c946adf9c1984c72fcd443ace30365f3daadef7"
++checksum = "7395cdb9d0a6219fa0ea77d08c946adf9c1984c72fcd443ace30365f3daadef7"

--- a/pkgs/applications/networking/browsers/asuka/default.nix
+++ b/pkgs/applications/networking/browsers/asuka/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, rustPlatform, fetchurl, pkgconfig, ncurses, openssl, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "asuka";
+  version = "0.8.0";
+
+  src = fetchurl {
+    url = "https://git.sr.ht/~julienxx/${pname}/archive/${version}.tar.gz";
+    sha256 = "10hmsdwf2nrsmpycqa08vd31c6vhx7w5fhvv5a9f92sqp0lcavf0";
+  };
+
+  cargoPatches = [ ./cargo-lock.patch ];
+
+  cargoSha256 = "0csj63x77nkdh543pzl9cbaip6xp8anw0942hc6j19y7yicd29ns";
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ ncurses openssl ]
+    ++ stdenv.lib.optional stdenv.isDarwin Security;
+
+  meta = with stdenv.lib; {
+    description = "Gemini Project client written in Rust with NCurses";
+    homepage = "https://git.sr.ht/~julienxx/asuka";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18809,6 +18809,10 @@ in
 
   arora = callPackage ../applications/networking/browsers/arora { };
 
+  asuka = callPackage ../applications/networking/browsers/asuka {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   artha = callPackage ../applications/misc/artha { };
 
   atlassian-cli = callPackage ../applications/office/atlassian-cli { };


### PR DESCRIPTION
###### Motivation for this change
[**asuka**](https://git.sr.ht/~julienxx/asuka) - Gemini Project client written in Rust with NCurses.
Resolves https://github.com/NixOS/nixpkgs/issues/87783.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

![asuka](https://user-images.githubusercontent.com/688044/85640235-ed8b5280-b693-11ea-91ea-5068a6d1a502.png)
