### PR TITLE
corerad: 0.2.6 -> 0.2.7

### DIFF
--- a/nixos/modules/services/networking/corerad.nix
+++ b/nixos/modules/services/networking/corerad.nix
@@ -77,6 +77,8 @@ in {
         AmbientCapabilities = "CAP_NET_ADMIN CAP_NET_RAW";
         NoNewPrivileges = true;
         DynamicUser = true;
+        Type = "notify";
+        NotifyAccess = "main";
         ExecStart = "${getBin cfg.package}/bin/corerad -c=${cfg.configFile}";
         Restart = "on-failure";
       };

--- a/pkgs/tools/networking/corerad/default.nix
+++ b/pkgs/tools/networking/corerad/default.nix
@@ -2,20 +2,20 @@
 
 buildGoModule rec {
   pname = "corerad";
-  version = "0.2.6";
+  version = "0.2.7";
 
   src = fetchFromGitHub {
     owner = "mdlayher";
     repo = "corerad";
     rev = "v${version}";
-    sha256 = "16rwydvqkzi0jlgwpl3d4f8zd35y4lv4h5xa30ybqmwwp1k5ymf0";
+    sha256 = "073hjbwra8ihh11ha5ajqq2r98cc5li4k0xs4p4s055q197zj3aa";
   };
 
-  vendorSha256 = "1431fvi9b0id3zhgkxhiampc5avvp998lncyd5l2gn5py3qz6sdl";
+  vendorSha256 = "19hp8xqr50v8h9vblihalvkb9ll8c0v4p071j9j1zkbjhnb07rca";
 
   buildFlagsArray = ''
     -ldflags=
-    -X github.com/mdlayher/corerad/internal/build.linkTimestamp=1591474872
+    -X github.com/mdlayher/corerad/internal/build.linkTimestamp=1593050100
     -X github.com/mdlayher/corerad/internal/build.linkVersion=v${version}
   '';
 

--- a/pkgs/tools/networking/corerad/default.nix
+++ b/pkgs/tools/networking/corerad/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoModule, fetchFromGitHub }:
+{ stdenv, buildGoModule, fetchFromGitHub, nixosTests }:
 
 buildGoModule rec {
   pname = "corerad";
@@ -18,6 +18,10 @@ buildGoModule rec {
     -X github.com/mdlayher/corerad/internal/build.linkTimestamp=1593050100
     -X github.com/mdlayher/corerad/internal/build.linkVersion=v${version}
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) corerad;
+  };
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/mdlayher/corerad";

--- a/pkgs/tools/networking/corerad/default.nix
+++ b/pkgs/tools/networking/corerad/default.nix
@@ -13,10 +13,16 @@ buildGoModule rec {
 
   vendorSha256 = "19hp8xqr50v8h9vblihalvkb9ll8c0v4p071j9j1zkbjhnb07rca";
 
-  buildFlagsArray = ''
-    -ldflags=
-    -X github.com/mdlayher/corerad/internal/build.linkTimestamp=1593050100
-    -X github.com/mdlayher/corerad/internal/build.linkVersion=v${version}
+  # Since the tarball pulled from GitHub doesn't contain git tag information,
+  # we fetch the expected tag's timestamp from a file in the root of the
+  # repository.
+  preBuild = ''
+    buildFlagsArray=(
+      -ldflags="
+        -X github.com/mdlayher/corerad/internal/build.linkTimestamp=$(<.gittagtime)
+        -X github.com/mdlayher/corerad/internal/build.linkVersion=v${version}
+      "
+    )
   '';
 
   passthru.tests = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New CoreRAD release, support for systemd readiness notification. See second commit for the unit change, and https://www.freedesktop.org/software/systemd/man/sd_notify.html#Description for documentation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Binary builds, tests continue to pass.

```
$ ./result/bin/corerad -h
CoreRAD v0.2.7 BETA (2020-06-24)
flags:
  -c string
        path to configuration file (default "corerad.toml")
  -init
        write out a default configuration file to "corerad.toml" and exit
```

```
client: waiting for success: ping -c 1 fd00:dead:beef:dead::1
(0.02 seconds)
(7.85 seconds)
Verify SLAAC on client
client: waiting for success: rdisc6 -1 -r 10 eth1
(0.32 seconds)
client: waiting for success: ip -6 addr show dev eth1 | grep -q 'fd00:dead:beef:dead:'
(0.02 seconds)
client: must succeed: ip -6 addr show dev eth1
(0.00 seconds)
(0.34 seconds)
Verify HTTP debug server is configured
router: must succeed: curl localhost:9430/metrics
(0.05 seconds)
(0.05 seconds)
(8.35 seconds)
test script finished in 8.37s
cleaning up
killing client (pid 6)
killing router (pid 17)
(0.00 seconds)
/nix/store/b9s5ql4qsfqh69srjdpvry695cbzrbnr-vm-test-run-unnamed
```

/cc @jonringer @marsam per previous PRs (thank you again!)