### PR TITLE
treewide: remove deprecated value `Application` from makeDesktopItem

### DIFF
--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
     icon = "monero";
     desktopName = "Monero";
     genericName = "Wallet";
-    categories  = "Application;Network;Utility;";
+    categories  = "Network;Utility;";
   };
 
   postInstall = ''

--- a/pkgs/applications/blockchains/wasabiwallet/default.nix
+++ b/pkgs/applications/blockchains/wasabiwallet/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     desktopName = "Wasabi";
     genericName = "Bitcoin wallet";
     comment = meta.description;
-    categories = "Application;Network;Utility;";
+    categories = "Network;Utility;";
   };
 
   installPhase = ''

--- a/pkgs/applications/editors/eclipse/build-eclipse.nix
+++ b/pkgs/applications/editors/eclipse/build-eclipse.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     comment = "Integrated Development Environment";
     desktopName = "Eclipse IDE";
     genericName = "Integrated Development Environment";
-    categories = "Application;Development;";
+    categories = "Development;";
   };
 
   buildInputs = [

--- a/pkgs/applications/editors/netbeans/default.nix
+++ b/pkgs/applications/editors/netbeans/default.nix
@@ -10,7 +10,7 @@ let
     comment = "Integrated Development Environment";
     desktopName = "Apache NetBeans IDE";
     genericName = "Integrated Development Environment";
-    categories = "Application;Development;";
+    categories = "Development;";
     icon = "netbeans";
   };
 in

--- a/pkgs/applications/graphics/avocode/default.nix
+++ b/pkgs/applications/graphics/avocode/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     icon = "avocode";
     desktopName = "Avocode";
     genericName = "Design Inspector";
-    categories = "Application;Development;";
+    categories = "Development;";
     comment = "The bridge between designers and developers";
   };
 

--- a/pkgs/applications/graphics/swingsane/default.nix
+++ b/pkgs/applications/graphics/swingsane/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
       desktopName = "SwingSane";
       genericName = "Scan from local or remote SANE servers";
       comment = meta.description;
-      categories = "Office;Application;";
+      categories = "Office;";
     };
 
   in ''

--- a/pkgs/applications/misc/airtame/default.nix
+++ b/pkgs/applications/misc/airtame/default.nix
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
     desktopName = "Airtame";
     icon = name;
     genericName = comment;
-    categories = "Application;Network;";
+    categories = "Network;";
   };
 
   installPhase = ''

--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     desktopName = "dbeaver";
     comment = "SQL Integrated Development Environment";
     genericName = "SQL Integrated Development Environment";
-    categories = "Application;Development;";
+    categories = "Development;";
   };
 
   buildInputs = [

--- a/pkgs/applications/misc/ganttproject-bin/default.nix
+++ b/pkgs/applications/misc/ganttproject-bin/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       desktopName = "GanttProject";
       genericName = "Shedule and manage projects";
       comment = meta.description;
-      categories = "Office;Application;";
+      categories = "Office;";
     };
 
     javaOptions = [

--- a/pkgs/applications/misc/golden-cheetah/default.nix
+++ b/pkgs/applications/misc/golden-cheetah/default.nix
@@ -12,7 +12,7 @@ let
     desktopName = "GoldenCheetah";
     genericName = "GoldenCheetah";
     comment = "Performance software for cyclists, runners and triathletes";
-    categories = "Application;Utility;";
+    categories = "Utility;";
   };
 in mkDerivation rec {
   pname = "golden-cheetah";

--- a/pkgs/applications/misc/keepass/default.nix
+++ b/pkgs/applications/misc/keepass/default.nix
@@ -68,7 +68,7 @@ with builtins; buildDotnetPackage rec {
     icon = "keepass";
     desktopName = "Keepass";
     genericName = "Password manager";
-    categories = "Application;Utility;";
+    categories = "Utility;";
     mimeType = stdenv.lib.concatStringsSep ";" [
       "application/x-keepass2"
       ""

--- a/pkgs/applications/misc/pdfsam-basic/default.nix
+++ b/pkgs/applications/misc/pdfsam-basic/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     desktopName = "PDFsam Basic";
     genericName = "PDF Split and Merge";
     mimeType = "application/pdf;";
-    categories = "Office;Application;";
+    categories = "Office;";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/pgadmin/default.nix
+++ b/pkgs/applications/misc/pgadmin/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
       exec = "pgadmin3";
       icon = "pgAdmin3";
       type = "Application";
-      categories = "Application;Development;";
+      categories = "Development;";
       mimeType = "text/html";
     };
   in ''

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
     comment = "G-code generator for 3D printers";
     desktopName = "PrusaSlicer";
     genericName = "3D printer tool";
-    categories = "Application;Development;";
+    categories = "Development;";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/slic3r/default.nix
+++ b/pkgs/applications/misc/slic3r/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     comment = "G-code generator for 3D printers";
     desktopName = "Slic3r";
     genericName = "3D printer tool";
-    categories = "Application;Development;";
+    categories = "Development;";
   };
 
   prePatch = ''

--- a/pkgs/applications/misc/sweethome3d/default.nix
+++ b/pkgs/applications/misc/sweethome3d/default.nix
@@ -24,7 +24,7 @@ let
       icon = pname;
       comment =  description;
       genericName = "Computer Aided (Interior) Design";
-      categories = "Application;Graphics;2DGraphics;3DGraphics;";
+      categories = "Graphics;2DGraphics;3DGraphics;";
     };
 
     patchPhase = ''

--- a/pkgs/applications/misc/sweethome3d/editors.nix
+++ b/pkgs/applications/misc/sweethome3d/editors.nix
@@ -20,7 +20,7 @@ let
       name = pname;
       comment =  description;
       genericName = "Computer Aided (Interior) Design";
-      categories = "Application;Graphics;2DGraphics;3DGraphics;";
+      categories = "Graphics;2DGraphics;3DGraphics;";
     };
 
     buildInputs = [ ant jre jdk makeWrapper gtk3 gsettings-desktop-schemas ];

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -85,7 +85,7 @@ let
         comment = "";
         desktopName = "${desktopName}${nameSuffix}${lib.optionalString gdkWayland " (Wayland)"}";
         genericName = "Web Browser";
-        categories = "Application;Network;WebBrowser;";
+        categories = "Network;WebBrowser;";
         mimeType = stdenv.lib.concatStringsSep ";" [
           "text/html"
           "text/xml"

--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
     icon = "palemoon";
     desktopName = "Pale Moon";
     genericName = "Web Browser";
-    categories = "Application;Network;WebBrowser;";
+    categories = "Network;WebBrowser;";
     mimeType = lib.concatStringsSep ";" [
       "text/html"
       "text/xml"

--- a/pkgs/applications/networking/instant-messengers/blink/default.nix
+++ b/pkgs/applications/networking/instant-messengers/blink/default.nix
@@ -39,7 +39,7 @@ mkDerivationWith pythonPackages.buildPythonApplication rec {
     desktopName = "Blink";
     icon = "blink";
     genericName = "Instant Messaging";
-    categories = "Application;Internet;";
+    categories = "Internet;";
   };
 
   dontWrapQtApps = true;

--- a/pkgs/applications/networking/instant-messengers/jitsi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jitsi/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     comment = "VoIP and Instant Messaging client";
     desktopName = "Jitsi";
     genericName = "Instant Messaging";
-    categories = "Application;X-Internet;";
+    categories = "X-Internet;";
   };
 
   libPath = lib.makeLibraryPath ([

--- a/pkgs/applications/networking/remote/anydesk/default.nix
+++ b/pkgs/applications/networking/remote/anydesk/default.nix
@@ -22,7 +22,7 @@ let
     icon = "anydesk";
     desktopName = "AnyDesk";
     genericName = description;
-    categories = "Application;Network;";
+    categories = "Network;";
     startupNotify = "false";
   };
 

--- a/pkgs/applications/office/jabref/default.nix
+++ b/pkgs/applications/office/jabref/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     name = "jabref";
     desktopName = "JabRef";
     genericName = "Bibliography manager";
-    categories = "Application;Office;";
+    categories = "Office;";
     icon = "jabref";
     exec = "jabref";
   };

--- a/pkgs/applications/science/electronics/eagle/eagle.nix
+++ b/pkgs/applications/science/electronics/eagle/eagle.nix
@@ -27,7 +27,7 @@ let
       comment = "Schematic capture and PCB layout";
       desktopName = "Eagle";
       genericName = "Schematic editor";
-      categories = "Application;Development;";
+      categories = "Development;";
     };
 
     buildInputs =

--- a/pkgs/applications/science/electronics/eagle/eagle7.nix
+++ b/pkgs/applications/science/electronics/eagle/eagle7.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     comment = "Schematic capture and PCB layout";
     desktopName = "Eagle";
     genericName = "Schematic editor";
-    categories = "Application;Development;";
+    categories = "Development;";
   };
 
   buildInputs =

--- a/pkgs/applications/science/logic/tlaplus/toolbox.nix
+++ b/pkgs/applications/science/logic/tlaplus/toolbox.nix
@@ -13,7 +13,7 @@ let
     comment = "IDE for TLA+";
     desktopName = name;
     genericName = comment;
-    categories = "Application;Development";
+    categories = "Development";
     extraEntries = ''
       StartupWMClass=TLA+ Toolbox
     '';

--- a/pkgs/applications/version-management/gitkraken/default.nix
+++ b/pkgs/applications/version-management/gitkraken/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     icon = "gitkraken";
     desktopName = "GitKraken";
     genericName = "Git Client";
-    categories = "Application;Development;";
+    categories = "Development;";
     comment = "Graphical Git client from Axosoft";
   };
 

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     comment = "Scientific Python Development Environment";
     desktopName = "Spyder";
     genericName = "Python IDE";
-    categories = "Application;Development;IDE;";
+    categories = "Development;IDE;";
   };
 
   postPatch = ''

--- a/pkgs/development/tools/database/sqldeveloper/default.nix
+++ b/pkgs/development/tools/database/sqldeveloper/default.nix
@@ -10,7 +10,7 @@ let
     desktopName = "Oracle SQL Developer";
     genericName = "Oracle SQL Developer";
     comment = "Oracle's Oracle DB GUI client";
-    categories = "Application;Development;";
+    categories = "Development;";
   };
 in
   stdenv.mkDerivation {

--- a/pkgs/development/tools/java/visualvm/default.nix
+++ b/pkgs/development/tools/java/visualvm/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
       comment = "Java Troubleshooting Tool";
       desktopName = "VisualVM";
       genericName = "Java Troubleshooting Tool";
-      categories = "Application;Development;";
+      categories = "Development;";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/development/tools/misc/saleae-logic/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     comment = "Software for Saleae logic analyzers";
     desktopName = "Saleae Logic";
     genericName = "Logic analyzer";
-    categories = "Application;Development";
+    categories = "Development";
   };
 
   buildInputs = [ unzip ];

--- a/pkgs/development/tools/misc/stm32cubemx/default.nix
+++ b/pkgs/development/tools/misc/stm32cubemx/default.nix
@@ -6,7 +6,7 @@ let
     name = "stm32CubeMX";
     exec = "stm32cubemx";
     desktopName = "STM32CubeMX";
-    categories = "Application;Development;";
+    categories = "Development;";
     icon = "stm32cubemx";
   };
 in

--- a/pkgs/development/tools/winpdb/default.nix
+++ b/pkgs/development/tools/winpdb/default.nix
@@ -18,7 +18,7 @@ pythonPackages.buildPythonApplication rec {
     comment = "Platform independend Python debugger";
     desktopName = "Winpdb";
     genericName = "Python Debugger";
-    categories = "Application;Development;Debugger;";
+    categories = "Development;Debugger;";
   };
 
   # Don't call gnome-terminal with "--disable-factory" flag, which is

--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     comment = "API Development Environment";
     desktopName = "Postman";
     genericName = "Postman";
-    categories = "Application;Development;";
+    categories = "Development;";
   };
 
   buildInputs = [

--- a/pkgs/games/assaultcube/default.nix
+++ b/pkgs/games/assaultcube/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     desktopName = "AssaultCube";
     comment = "A multiplayer, first-person shooter game, based on the CUBE engine. Fast, arcade gameplay.";
     genericName = "First-person shooter";
-    categories = "Application;Game;ActionGame;Shooter";
+    categories = "Game;ActionGame;Shooter";
     icon = "assaultcube.png";
     exec = pname;
   };

--- a/pkgs/games/eduke32/default.nix
+++ b/pkgs/games/eduke32/default.nix
@@ -12,7 +12,7 @@ let
     comment = "Duke Nukem 3D port";
     desktopName = "Enhanced Duke Nukem 3D";
     genericName = "Duke Nukem 3D port";
-    categories = "Application;Game;";
+    categories = "Game;";
   };
 
   wrapper = "eduke32-wrapper";

--- a/pkgs/games/frogatto/default.nix
+++ b/pkgs/games/frogatto/default.nix
@@ -12,7 +12,7 @@ let
     comment = description;
     desktopName = "Frogatto";
     genericName = "frogatto";
-    categories = "Application;Game;ArcadeGame;";
+    categories = "Game;ArcadeGame;";
   };
   version = "unstable-2018-12-18";
 in buildEnv {

--- a/pkgs/games/minecraft/default.nix
+++ b/pkgs/games/minecraft/default.nix
@@ -36,7 +36,7 @@ let
     icon = "minecraft-launcher";
     comment = "Official launcher for Minecraft, a sandbox-building game";
     desktopName = "Minecraft Launcher";
-    categories = "Game;Application;";
+    categories = "Game;";
   };
 
   envLibPath = stdenv.lib.makeLibraryPath [

--- a/pkgs/games/runelite/default.nix
+++ b/pkgs/games/runelite/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     terminal = "false";
     desktopName = "RuneLite";
     genericName = "Oldschool Runescape";
-    categories = "Application;Game";
+    categories = "Game";
     startupNotify = null;
   };
 

--- a/pkgs/games/ut2004/wrapper.nix
+++ b/pkgs/games/ut2004/wrapper.nix
@@ -27,7 +27,7 @@ let
     desktopName = "Unreal Tournament 2004";
     comment = "A first-person shooter video game developed by Epic Games and Digital Extreme";
     genericName = "First-person shooter";
-    categories = "Application;Game;";
+    categories = "Game;";
     exec = "ut2004";
   };
 

--- a/pkgs/misc/emulators/ccemux/default.nix
+++ b/pkgs/misc/emulators/ccemux/default.nix
@@ -29,7 +29,7 @@ let
     comment = "A modular ComputerCraft emulator";
     desktopName = "CCEmuX";
     genericName = "ComputerCraft Emulator";
-    categories = "Application;Emulator;";
+    categories = "Emulator;";
   };
 in
 

--- a/pkgs/misc/emulators/dosbox/default.nix
+++ b/pkgs/misc/emulators/dosbox/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     comment = "x86 emulator with internal DOS";
     desktopName = "DOSBox";
     genericName = "DOS emulator";
-    categories = "Application;Emulator;";
+    categories = "Emulator;";
   };
 
   postInstall = ''

--- a/pkgs/misc/emulators/vice/default.nix
+++ b/pkgs/misc/emulators/vice/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     comment = "Commodore 64 emulator";
     desktopName = "VICE";
     genericName = "Commodore 64 emulator";
-    categories = "Application;Emulator;";
+    categories = "Emulator;";
   };
 
   preBuild = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

```
Running desktop-file validation
/nix/store/3mrrr9l2d28xj2j3i8b097fh19xznwlb-firefox.desktop/share/applications/firefox.desktop:
warning: value "Application;Network;WebBrowser;" for key "Categories" in group "Desktop Entry" contains a deprecated value "Application"

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
