### PR TITLE
diskonaut: init at 0.3.0

### DIFF
--- a/pkgs/tools/misc/diskonaut/default.nix
+++ b/pkgs/tools/misc/diskonaut/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "diskonaut";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "imsnif";
+    repo = "diskonaut";
+    rev = version;
+    sha256 = "0vnmch2cac0j9b44vlcpqnayqhfdfdwvfa01bn7lwcyrcln5cd0z";
+  };
+
+  cargoSha256 = "03hqdg6pnfxnhwk0xwhwmbrk4dicjpjllbbai56a3391xac5wmi6";
+
+  # some tests fail due to non-portable (in terms of filesystems) measurements of block sizes
+  # try to re-enable tests once actual-file-size is added
+  # see https://github.com/imsnif/diskonaut/issues/50 for more info
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Terminal disk space navigator";
+    homepage = "https://github.com/imsnif/diskonaut";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ evanjs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -921,6 +921,8 @@ in
 
   detect-secrets = python3Packages.callPackage ../development/tools/detect-secrets { };
 
+  diskonaut = callPackage ../tools/misc/diskonaut { };
+
   diskus = callPackage ../tools/misc/diskus {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change
[Diskonaut](https://github.com/imsnif/diskonaut) — A disk usage explorer / terminal disk space navigator 
Featured as crate of the week in **This Week In Rust** 344 ([23 Jun 2020](https://this-week-in-rust.org/blog/2020/06/23/this-week-in-rust-344/))

###### Tests currently failing
```
builder for '/nix/store/7i727mk7dif5jmvh06xrj77162yl8s3k-diskonaut-1.15.1.drv' failed with exit code 101; last 10 log lines:
  thread 'tests::cases::ui::small_files_with_x_as_zero' panicked at 'snapshot assertion for 'small_files_with_x_as_zero' failed in line 2108', /build/diskonaut-1.15.1-vendor.tar.gz/insta/src/runtime.rs:995:9
  
  
  failures:
      tests::cases::ui::small_files_with_x_as_zero
      tests::cases::ui::small_files_with_y_as_zero
  
  test result: FAILED. 35 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
  
  error: test failed, to rerun pass '--bin diskonaut'
[0 built (1 failed)]
error: build of '/nix/store/7i727mk7dif5jmvh06xrj77162yl8s3k-diskonaut-1.15.1.drv' failed
```
