### PR TITLE
pythonPackages.gdown: init at 3.11.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1133,6 +1133,12 @@
     githubId = 7716744;
     name = "Berno Strik";
   };
+  breakds = {
+    email = "breakds@gmail.com";
+    github = "breakds";
+    githubId = 1111035;
+    name = "Break Yang";
+  };
   brettlyons = {
     email = "blyons@fastmail.com";
     github = "brettlyons";

--- a/pkgs/development/python-modules/gdown/default.nix
+++ b/pkgs/development/python-modules/gdown/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, filelock
+, requests
+, tqdm
+, setuptools
+}:
+
+buildPythonApplication rec {
+  pname = "gdown";
+  version = "3.11.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1p023812hh7w7d08njjsfn0xzldl4m73yx8p243yb2q49ypjl6nz";
+  };
+
+  propagatedBuildInputs = [ filelock requests tqdm setuptools ];
+
+  checkPhase = ''
+    $out/bin/gdown --help > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "A CLI tool for downloading large files from Google Drive";
+    homepage = "https://github.com/wkentaro/gdown";
+    license = licenses.mit;
+    maintainers = with maintainers; [ breakds ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3876,6 +3876,8 @@ in
 
   google-cloud-cpp = callPackage ../development/libraries/google-cloud-cpp { };
 
+  gdown = with python3Packages; toPythonApplication gdown;
+
   gopro = callPackage ../tools/video/gopro { };
 
   gource = callPackage ../applications/version-management/gource { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2953,6 +2953,8 @@ in {
 
   googletrans = callPackage ../development/python-modules/googletrans { };
 
+  gdown = callPackage ../development/python-modules/gdown { };
+
   gpapi = callPackage ../development/python-modules/gpapi { };
   gplaycli = callPackage ../development/python-modules/gplaycli { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add gdown which provides both a CLI tool as well as a python package for downloading artifacts from Google Drive.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
