### PR TITLE
ocamlPackages.buildOasis: fix handling of installation prefix

### DIFF
--- a/pkgs/build-support/ocaml/oasis.nix
+++ b/pkgs/build-support/ocaml/oasis.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (args // {
   buildPhase = ''
     runHook preBuild
     oasis setup
-    ocaml setup.ml -configure
+    ocaml setup.ml -configure --prefix $OCAMLFIND_DESTDIR --exec-prefix $out
     ocaml setup.ml -build
     runHook postBuild
   '';
@@ -37,9 +37,7 @@ stdenv.mkDerivation (args // {
   installPhase = ''
     runHook preInstall
     mkdir -p $out
-    sed -i s+/usr/local+$out+g setup.ml
-    sed -i s+/usr/local+$out+g setup.data
-    prefix=$OCAMLFIND_DESTDIR ocaml setup.ml -install
+    ocaml setup.ml -install
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Currently, build of `ocaml-ng.ocamlPackages_4_11.tcslib` fails with a mysterious sed error:

> sed: -e expression `#1`, char 70: unknown option to `s'

This PR gives correct arguments to the configure script, hence removes the need for patching its results.

cc @mgttlinger 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
