### PR TITLE
lutris-unwrapped: 0.5.5 -> 0.5.6, fix dialouge crashing bug

### DIFF
--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -1,9 +1,42 @@
 { buildPythonApplication, lib, fetchFromGitHub, fetchpatch
-, wrapGAppsHook, gobject-introspection, glib-networking, gnome-desktop, libnotify, libgnome-keyring, pango
-, gdk-pixbuf, atk, webkitgtk, gst_all_1
-, dbus-python, evdev, pyyaml, pygobject3, requests, pillow
-, xrandr, pciutils, psmisc, glxinfo, vulkan-tools, xboxdrv, pulseaudio, p7zip, xgamma
-, libstrangle, wine, fluidsynth, xorgserver
+
+# build inputs
+, atk
+, gdk-pixbuf
+, glib-networking
+, gnome-desktop
+, gobject-introspection
+, gst_all_1
+, gtk3
+, libgnome-keyring
+, libnotify
+, pango
+, webkitgtk
+, wrapGAppsHook
+
+# python dependencies
+, dbus-python
+, distro
+, evdev
+, pillow
+, pygobject3
+, pyyaml
+, requests
+
+# commands that lutris needs
+, xrandr
+, pciutils
+, psmisc
+, glxinfo
+, vulkan-tools
+, xboxdrv
+, pulseaudio
+, p7zip
+, xgamma
+, libstrangle
+, wine
+, fluidsynth
+, xorgserver
 }:
 
 let
@@ -25,34 +58,52 @@ let
   ];
 
   gstDeps = with gst_all_1; [
-    gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly
     gst-libav
+    gst-plugins-bad
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-ugly
+    gstreamer
   ];
 
 in buildPythonApplication rec {
   pname = "lutris-original";
-  version = "0.5.5";
+  version = "0.5.6";
 
   src = fetchFromGitHub {
     owner = "lutris";
     repo = "lutris";
     rev = "v${version}";
-    sha256 = "1g093g0difnkjmnm91p20issdsxn9ri4c56zzddj5wfrbmhwdfag";
+    sha256 = "1f78qhyy8xqdg0rhxcwkap1bmg5mfxhb8qw1vbpxr6g62ajpwksa";
   };
 
   nativeBuildInputs = [ wrapGAppsHook ];
   buildInputs = [
-    gobject-introspection glib-networking gnome-desktop libnotify libgnome-keyring pango
-    gdk-pixbuf atk webkitgtk
+    atk
+    gdk-pixbuf
+    glib-networking
+    gnome-desktop
+    gobject-introspection
+    gtk3
+    libgnome-keyring
+    libnotify
+    pango
+    webkitgtk
   ] ++ gstDeps;
 
-  makeWrapperArgs = [
-    "--prefix PATH : ${binPath}"
+  propagatedBuildInputs = [
+    evdev distro pyyaml pygobject3 requests pillow dbus-python
   ];
 
-  propagatedBuildInputs = [
-    evdev pyyaml pygobject3 requests pillow dbus-python
+  # avoid double wrapping
+  dontWrapGApps = true;
+  makeWrapperArgs = [
+    "--prefix PATH : ${binPath}"
+    ''''${gappsWrapperArgs[@]}''
   ];
+  # needed for glib-schemas to work correctly (will crash on dialogues otherwise)
+  # see https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
 
   preCheck = "export HOME=$PWD";
 


### PR DESCRIPTION
###### Motivation for this change
would crash with:
```
GLib-GIO-ERROR **: 06:04:50.903: No GSettings schemas are installed on the system
```

if a dialouge box would open.

closes: #90645

Also:
 - cleaned up expression
 - removed the double wrapping
 - added "distro" package, as lutris would warn about not being able to retrieve host info

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
