### PR TITLE
openssh: don’t include fido2 on musl

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -5,7 +5,7 @@
 , withGssapiPatches ? false
 , kerberos
 , libfido2
-, withFIDO ? stdenv.hostPlatform.isUnix
+, withFIDO ? stdenv.hostPlatform.isUnix && !stdenv.hostPlatform.isMusl
 , linkOpenssl? true
 }:
 


### PR DESCRIPTION
libselinux pulls in openssh transitively, so can’t use fido here

Fixes #89246

(cherry picked from commit 59616b291d60886606ca300c20107722f284cdf7)