### PR TITLE
industrializer: init at 0.2.6

### DIFF
--- a/pkgs/applications/audio/industrializer/default.nix
+++ b/pkgs/applications/audio/industrializer/default.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, fetchurl
+, alsaLib
+, audiofile
+, autoconf
+, automake
+, gnome2
+, gtk2
+, libjack2
+, libtool
+, libxml2
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "industrializer";
+  version = "0.2.6";
+  src = fetchurl {
+    url = "mirror://sourceforge/project/${pname}/ps${pname}-${version}.tar.bz2";
+    sha256 = "0vls94hqpkk8h17da6fddgqbl5dgm6250av3raimhhzwvm5r1gfi";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    alsaLib
+    audiofile
+    autoconf
+    automake
+    gnome2.gtkglext
+    gtk2
+    libjack2
+    libtool
+    libxml2
+  ];
+
+  preConfigure = "./autogen.sh";
+
+  meta = {
+    description = "This program generates synthesized percussion sounds using physical modelling";
+    longDescription = ''
+      The range of sounds possible include but is not limited to cymbal sounds, metallic noises, bubbly sounds, and chimes.
+      After a sound is rendered, it can be played and then saved to a .WAV file.
+    '';
+    homepage = "https://sourceforge.net/projects/industrializer/";
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = [ stdenv.lib.maintainers.magnetophon ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4321,6 +4321,8 @@ in
 
   incron = callPackage ../tools/system/incron { };
 
+  industrializer = callPackage ../applications/audio/industrializer { };
+
   inetutils = callPackage ../tools/networking/inetutils { };
 
   inform7 = callPackage ../development/compilers/inform7 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
