### PR TITLE
fix NUR by fixing python3.pkgs.{jaraco_itertools,jaraco_logging,tempora}

### DIFF
--- a/pkgs/development/python-modules/jaraco_itertools/0001-Don-t-run-flake8-checks-during-the-build.patch
+++ b/pkgs/development/python-modules/jaraco_itertools/0001-Don-t-run-flake8-checks-during-the-build.patch
@@ -1,0 +1,27 @@
+From fd56b0d85393d684bd3bf99f33d8638da884282f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Thu, 25 Jun 2020 09:52:11 +0100
+Subject: [PATCH] disable flake8/black8/coverage from tests
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ pytest.ini | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pytest.ini b/pytest.ini
+index 5027d34..4e2a2d2 100644
+--- a/pytest.ini
++++ b/pytest.ini
+@@ -1,5 +1,5 @@
+ [pytest]
+ norecursedirs=dist build .tox .eggs
+-addopts=--doctest-modules --flake8 --black --cov
++addopts=--doctest-modules
+ doctest_optionflags=ALLOW_UNICODE ELLIPSIS ALLOW_BYTES
+ filterwarnings=
+-- 
+2.27.0
+

--- a/pkgs/development/python-modules/jaraco_itertools/default.nix
+++ b/pkgs/development/python-modules/jaraco_itertools/default.nix
@@ -12,6 +12,11 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ setuptools_scm ];
+
+  patches = [
+    ./0001-Don-t-run-flake8-checks-during-the-build.patch
+  ];
+
   propagatedBuildInputs = [ inflect more-itertools six ];
   checkInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/pytest-freezegun/default.nix
+++ b/pkgs/development/python-modules/pytest-freezegun/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, freezegun
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-freezegun";
+  version = "0.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "060cdf192848e50a4a681a5e73f8b544c4ee5ebc1fab3cb7223a0097bac2f83f";
+  };
+
+  propagatedBuildInputs = [
+    freezegun
+    pytest
+  ];
+
+  meta = with lib; {
+    description = "Wrap tests with fixtures in freeze_time";
+    homepage = "https://github.com/ktosiek/pytest-freezegun";
+    license = licenses.mit;
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/development/python-modules/tempora/0001-pytest-remove-flake8-black-coverage.patch
+++ b/pkgs/development/python-modules/tempora/0001-pytest-remove-flake8-black-coverage.patch
@@ -1,0 +1,28 @@
+From 9dfd2a8fac4a643fd007390762ccc8564588b4bf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Thu, 25 Jun 2020 10:16:52 +0100
+Subject: [PATCH] pytest: remove flake8/black/coverage
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ pytest.ini | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pytest.ini b/pytest.ini
+index bd6998d..a464529 100644
+--- a/pytest.ini
++++ b/pytest.ini
+@@ -1,6 +1,6 @@
+ [pytest]
+ norecursedirs=dist build .tox .eggs
+-addopts=--doctest-modules --flake8 --black --cov
++addopts=--doctest-modules
+ doctest_optionflags=ALLOW_UNICODE ELLIPSIS
+ filterwarnings=
+ 	# suppress known warning
+-- 
+2.27.0
+

--- a/pkgs/development/python-modules/tempora/default.nix
+++ b/pkgs/development/python-modules/tempora/default.nix
@@ -1,6 +1,6 @@
 { lib, buildPythonPackage, fetchPypi
 , setuptools_scm, pytest, pytest-freezegun, freezegun, backports_unittest-mock
-, six, pytz, jaraco_functools }:
+, six, pytz, jaraco_functools, pythonOlder }:
 
 buildPythonPackage rec {
   pname = "tempora";
@@ -10,6 +10,8 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "e370d822cf48f5356aab0734ea45807250f5120e291c76712a1d766b49ae34f8";
   };
+
+  disabled = pythonOlder "3.2";
 
   nativeBuildInputs = [ setuptools_scm ];
 

--- a/pkgs/development/python-modules/tempora/default.nix
+++ b/pkgs/development/python-modules/tempora/default.nix
@@ -1,6 +1,5 @@
 { lib, buildPythonPackage, fetchPypi
-, setuptools_scm, pytest, freezegun, backports_unittest-mock
-, pytest-black, pytestcov, pytest-flake8
+, setuptools_scm, pytest, pytest-freezegun, freezegun, backports_unittest-mock
 , six, pytz, jaraco_functools }:
 
 buildPythonPackage rec {
@@ -14,13 +13,18 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools_scm ];
 
+  patches = [
+    ./0001-pytest-remove-flake8-black-coverage.patch
+  ];
+
   propagatedBuildInputs = [ six pytz jaraco_functools ];
 
-  checkInputs = [ pytest pytest-flake8 pytest-black pytestcov freezegun backports_unittest-mock ];
+  checkInputs = [
+    pytest-freezegun pytest freezegun backports_unittest-mock
+  ];
 
-  # missing pytest-freezegun package
   checkPhase = ''
-    pytest -k 'not get_nearest_year_for_day'
+    pytest
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -950,6 +950,8 @@ in {
     mpi = pkgs.openmpi;
   };
 
+  pytest-freezegun = callPackage ../development/python-modules/pytest-freezegun { };
+
   python-baseconv = callPackage ../development/python-modules/python-baseconv { };
 
   pycognito = callPackage ../development/python-modules/pycognito { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).