### PR TITLE
dune-release: init at 1.3.3

### DIFF
--- a/pkgs/development/ocaml-modules/opam-core/default.nix
+++ b/pkgs/development/ocaml-modules/opam-core/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildDunePackage, unzip
+, opam, ocamlgraph, re, cppo }:
+
+buildDunePackage rec {
+  pname = "opam-core";
+
+  inherit (opam) src version;
+
+  nativeBuildInputs = [ unzip cppo ];
+  propagatedBuildInputs = [ ocamlgraph re ];
+
+  # get rid of check for curl at configure time
+  # opam-core does not call curl at run time
+  configureFlags = [ "--disable-checks" ];
+
+  meta = opam.meta // {
+    description = "Small standard library extensions, and generic system interaction modules used by opam";
+    maintainers = with lib.maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-format/default.nix
+++ b/pkgs/development/ocaml-modules/opam-format/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildDunePackage, unzip, opam-core, opam-file-format }:
+
+buildDunePackage rec {
+  pname = "opam-format";
+
+  inherit (opam-core) src version;
+
+  minimumOCamlVersion = "4.02.3";
+
+  # get rid of check for curl at configure time
+  # opam-format does not call curl at run time
+  configureFlags = [ "--disable-checks" ];
+
+  nativeBuildInputs = [ unzip ];
+  propagatedBuildInputs = [ opam-core opam-file-format ];
+
+  meta = opam-core.meta // {
+    description = "Definition of opam datastructures and its file interface";
+    maintainers = with lib.maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-repository/default.nix
+++ b/pkgs/development/ocaml-modules/opam-repository/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildDunePackage, unzip, opam-format, curl }:
+
+buildDunePackage rec {
+  pname = "opam-repository";
+
+  minimumOCamlVersion = "4.02";
+
+  inherit (opam-format) src version;
+
+  patches = [ ./download-tool.patch ];
+  postPatch = ''
+    substituteInPlace src/repository/opamRepositoryConfig.ml \
+      --replace "SUBSTITUTE_NIXOS_CURL_PATH" "\"${curl}/bin/curl\""
+  '';
+
+  nativeBuildInputs = [ unzip ];
+  buildInputs = [ curl ];
+  propagatedBuildInputs = [ opam-format ];
+
+  meta = opam-format.meta // {
+    description = "OPAM repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends";
+    maintainers = with lib.maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-repository/download-tool.patch
+++ b/pkgs/development/ocaml-modules/opam-repository/download-tool.patch
@@ -1,0 +1,29 @@
+diff --git a/src/repository/opamRepositoryConfig.ml b/src/repository/opamRepositoryConfig.ml
+index c2954c1d..528fc621 100644
+--- a/src/repository/opamRepositoryConfig.ml
++++ b/src/repository/opamRepositoryConfig.ml
+@@ -27,23 +27,7 @@ type 'a options_fun =
+   'a
+ 
+ let default = {
+-  download_tool = lazy (
+-    try
+-      let tools =
+-        if OpamStd.Sys.(os () = Darwin)
+-        then ["wget", `Default; "curl", `Curl]
+-        else ["curl", `Curl; "wget", `Default]
+-      in
+-      let cmd, kind =
+-        List.find (fun (c,_) -> OpamSystem.resolve_command c <> None) tools
+-      in
+-      [ CIdent cmd, None ], kind
+-    with Not_found ->
+-      OpamConsole.error_and_exit `Configuration_error
+-        "Could not find a suitable download command. Please make sure you \
+-         have either \"curl\" or \"wget\" installed, or specify a custom \
+-         command through variable OPAMFETCH."
+-  );
++  download_tool = lazy ([ CIdent SUBSTITUTE_NIXOS_CURL_PATH, None ], `Curl);
+   validation_hook = None;
+   retries = 3;
+   force_checksums = None;

--- a/pkgs/development/ocaml-modules/opam-state/default.nix
+++ b/pkgs/development/ocaml-modules/opam-state/default.nix
@@ -1,0 +1,19 @@
+{ lib, buildDunePackage, unzip, opam, opam-repository }:
+
+buildDunePackage rec {
+  pname = "opam-state";
+
+  inherit (opam) src version;
+
+  # get rid of check for curl at configure time
+  # opam-state does not call curl at run time
+  configureFlags = [ "--disable-checks" ];
+
+  nativeBuildInputs = [ unzip ];
+  propagatedBuildInputs = [ opam-repository ];
+
+  meta = opam.meta // {
+    description = "OPAM development library handling the ~/.opam hierarchy, repository and switch states";
+    maintainers = with lib.maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/tools/ocaml/dune-release/default.nix
+++ b/pkgs/development/tools/ocaml/dune-release/default.nix
@@ -1,0 +1,48 @@
+{ lib, buildDunePackage, fetchurl, makeWrapper
+, curly, fmt, bos, cmdliner, re, rresult, logs
+, odoc, opam-format, opam-core, opam-state
+, opam, git, findlib, mercurial, bzip2, gnutar, coreutils
+, alcotest, mdx
+}:
+
+# don't include dune as runtime dep, so user can
+# choose between dune and dune_2
+let runtimeInputs = [ opam findlib git mercurial bzip2 gnutar coreutils ];
+in buildDunePackage rec {
+  pname = "dune-release";
+  version = "1.3.3";
+
+  minimumOCamlVersion = "4.06";
+
+  src = fetchurl {
+    url = "https://github.com/ocamllabs/${pname}/releases/download/${version}/${pname}-${version}.tbz";
+    sha256 = "04qmgvjh1233ri878wi5kifdd1070w5pbfkd8yk3nnqnslz35zlb";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ curly fmt cmdliner re opam-format opam-state opam-core
+                  rresult logs odoc bos ];
+  checkInputs = [ alcotest mdx ];
+  doCheck = true;
+
+  useDune2 = true;
+
+  # remove check for curl in PATH, since curly is patched
+  # to have a fixed path to the binary in nix store
+  postPatch = ''
+    sed -i '/must_exist (Cmd\.v "curl"/d' lib/github.ml
+  '';
+
+  # tool specific env vars have been deprecated, use PATH
+  preFixup = ''
+    wrapProgram $out/bin/dune-release \
+      --prefix PATH : "${lib.makeBinPath runtimeInputs}"
+  '';
+
+  meta = with lib; {
+    description = "Release dune packages in opam";
+    homepage = "https://github.com/ocamllabs/dune-release";
+    license = licenses.isc;
+    maintainers = with maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1739,7 +1739,7 @@ in
 
   dua = callPackage ../tools/misc/dua { };
 
-  inherit (ocamlPackages) dune dune_2;
+  inherit (ocamlPackages) dune dune_2 dune-release;
 
   duperemove = callPackage ../tools/filesystems/duperemove { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -668,6 +668,10 @@ let
 
     omd = callPackage ../development/ocaml-modules/omd { };
 
+    opam-core = callPackage ../development/ocaml-modules/opam-core {
+      inherit (pkgs) opam unzip;
+    };
+
     opam-file-format = callPackage ../development/ocaml-modules/opam-file-format { };
 
     opium = callPackage ../development/ocaml-modules/opium { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -228,6 +228,10 @@ let
 
     dune-private-libs = callPackage ../development/ocaml-modules/dune-private-libs { };
 
+    dune-release = callPackage ../development/tools/ocaml/dune-release {
+      inherit (pkgs) opam git mercurial coreutils gnutar bzip2;
+    };
+
     duration =  callPackage ../development/ocaml-modules/duration { };
 
     earley = callPackage ../development/ocaml-modules/earley { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -674,6 +674,10 @@ let
 
     opam-file-format = callPackage ../development/ocaml-modules/opam-file-format { };
 
+    opam-format = callPackage ../development/ocaml-modules/opam-format {
+      inherit (pkgs) unzip;
+    };
+
     opium = callPackage ../development/ocaml-modules/opium { };
 
     opium_kernel = callPackage ../development/ocaml-modules/opium_kernel { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -682,6 +682,10 @@ let
       inherit (pkgs) unzip;
     };
 
+    opam-state = callPackage ../development/ocaml-modules/opam-state {
+      inherit (pkgs) unzip;
+    };
+
     opium = callPackage ../development/ocaml-modules/opium { };
 
     opium_kernel = callPackage ../development/ocaml-modules/opium_kernel { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -678,6 +678,10 @@ let
       inherit (pkgs) unzip;
     };
 
+    opam-repository = callPackage ../development/ocaml-modules/opam-repository {
+      inherit (pkgs) unzip;
+    };
+
     opium = callPackage ../development/ocaml-modules/opium { };
 
     opium_kernel = callPackage ../development/ocaml-modules/opium_kernel { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add `dune-release` the "successor" to `topkg-care`. Also adds some opam libraries as `ocamlPackages`.

###### Things done

Runtime dependencies was kinda tricky here. I solved it the following way:

* For the opam libraries, I disabled the configure check for `curl`. Sadly it is worth nothing, because it only checks *if* `curl` is in `PATH` at configure time, and then assumes it will also be at runtime.
* I patched `opam-repository` which seems to be the only one of those libraries possibly calling `curl` at runtime.
* For `dune-release` I added all runtime dependencies that the user generally wouldn't want to replace with an own version. I don't however supply `dune` and `ocaml` which generally will be called by `dune-release`, since the user would generally have these in their `PATH` when using `dune-release` and we can't know in advance which version they'll use (e. g. `dune` or `dune_2`). `ocamlfind` seems to be safe to provide an OCaml 4.10 version of since it also finds packages of different versions.

Not sure if the messing around in the `opam` libraries is really worth it, since we could also just provide `curl` in `PATH` in `dune-release`, so let me know what you think.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
