### PR TITLE
python: uvloop: fix build on all platforms

### DIFF
--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -58,10 +58,13 @@ buildPythonPackage rec {
     export TEST_DIR=$(mktemp -d)
     cp -r tests $TEST_DIR
     pushd $TEST_DIR
+    # Drop failing test due to missing .flake8 file in 0.14.0
+    rm tests/test_sourcecode.py
   '' + lib.optionalString stdenv.isDarwin ''
-    # Some tests fail on Darwin
-    rm tests/test_[stu]*.py
+    # Some other tests fail on Darwin
+    rm tests/test_sockets.py tests/test_u*.py
   '';
+
   postCheck = ''
     popd
   '';


### PR DESCRIPTION
`uvloop` builds currently fail on all platforms due to [a file missing from the PyPi tarball](https://github.com/MagicStack/uvloop/issues/330). This temporarily patches the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
