### PR TITLE
cq-editor: fix build

### DIFF
--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -12,11 +12,11 @@ buildPythonPackage rec {
     sha256 = "b95e31850f3af163c2283ed40432f053acbc8fc6eba6a069cb518d9dbf71848c";
   };
 
-  nativeBuildInputs = [ pytestrunner toml ];
+  nativeBuildInputs = [ pytestrunner ];
 
   checkInputs = [ pytestCheckHook pytest-benchmark ];
 
-  propagatedBuildInputs = [ astroid isort mccabe ];
+  propagatedBuildInputs = [ astroid isort mccabe toml ];
 
   postPatch = lib.optionalString stdenv.isDarwin ''
     # Remove broken darwin test

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19198,7 +19198,9 @@ in
 
   coyim = callPackage ../applications/networking/instant-messengers/coyim {};
 
-  cq-editor = libsForQt5.callPackage ../applications/graphics/cq-editor { };
+  cq-editor = libsForQt5.callPackage ../applications/graphics/cq-editor {
+    python3Packages = python37Packages;
+  };
 
   cpp_ethereum = callPackage ../applications/misc/cpp-ethereum { };
 


### PR DESCRIPTION
###### Motivation for this change

Will close #91483 and do the `spyder_3` half of #91484 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Unfortunately I can't get cq-editor working with Python 3.8, so I've set it to 3.7.

@jonringer, I see you added toml to pylint's nativeBuildInputs in https://github.com/NixOS/nixpkgs/commit/27f0dabfbfbc15a4233827f08fa36e725f27ca54. I think it needs to be propagated due to the errors in #91484 and https://github.com/PyCQA/pylint/blob/a73585740398052ccd6c67d33869d9049a27e8c7/pylint/__pkginfo__.py#L43 so I've done that in this PR. Is that OK?