### PR TITLE
google-cloud-secret-manager: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/google_cloud_secret_manager/default.nix
+++ b/pkgs/development/python-modules/google_cloud_secret_manager/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchPypi
+, grpc_google_iam_v1, google_api_core
+, pytest, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-secret-manager";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1cm3xqacxnbpv2706bd2jl86mvcsphpjlvhzngz2k2p48a0jjx8r";
+  };
+
+  propagatedBuildInputs = [
+    google_api_core
+    grpc_google_iam_v1
+  ];
+
+  checkInputs = [
+    mock
+    pytest
+  ];
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Secret Manager API: Stores, manages, and secures access to application secrets";
+    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ siriobalmelli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4049,6 +4049,8 @@ in {
 
   google_cloud_runtimeconfig = callPackage ../development/python-modules/google_cloud_runtimeconfig { };
 
+  google_cloud_secret_manager = callPackage ../development/python-modules/google_cloud_secret_manager { };
+
   google_cloud_securitycenter = callPackage ../development/python-modules/google_cloud_securitycenter { };
 
   google_cloud_spanner = callPackage ../development/python-modules/google_cloud_spanner { };


### PR DESCRIPTION
Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Require this module for a Nix CI build I maintain.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
