### PR TITLE
WIP: postgresqlPackages.multicorn: init at 1.4.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -206,6 +206,7 @@ in
   morty = handleTest ./morty.nix {};
   mosquitto = handleTest ./mosquitto.nix {};
   mpd = handleTest ./mpd.nix {};
+  multicorn = handleTest ./multicorn.nix {};
   mumble = handleTest ./mumble.nix {};
   munin = handleTest ./munin.nix {};
   mutableUsers = handleTest ./mutable-users.nix {};

--- a/nixos/tests/multicorn.nix
+++ b/nixos/tests/multicorn.nix
@@ -1,0 +1,45 @@
+import ./make-test-python.nix ({ pkgs, ...} :
+let
+  test-sql1 = pkgs.writeText "postgresql-test" ''
+    \set ON_ERROR_STOP on
+    CREATE SERVER multicorn_imap FOREIGN DATA WRAPPER multicorn options (wrapper 'multicorn.imapfdw.ImapFdw');
+  '';
+  test-sql2 = pkgs.writeText "postgresql-test" ''
+    \set ON_ERROR_STOP on
+    CREATE SERVER csv_srv FOREIGN DATA WRAPPER multicorn options (wrapper 'multicorn.csvfdw.CsvFdw');
+  '';
+in
+{
+  name = "multicorn";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ bbigras ];
+  };
+
+  nodes = {
+    master =
+      { pkgs, ... }:
+
+      {
+        services.postgresql = let mypg = pkgs.postgresql; in {
+            enable = true;
+            package = mypg;
+            extraPlugins = with mypg.pkgs; [
+              multicorn
+            ];
+        };
+      };
+  };
+
+  testScript = ''
+    start_all()
+    master.wait_for_unit("postgresql")
+    master.sleep(10)  # Hopefully this is long enough!!
+    master.succeed("sudo -u postgres psql -c 'CREATE EXTENSION multicorn;'")
+    master.succeed(
+        "cat ${test-sql1} | sudo -u postgres psql"
+    )
+    master.succeed(
+        "cat ${test-sql2} | sudo -u postgres psql"
+    )
+  '';
+})

--- a/pkgs/servers/sql/postgresql/ext/multicorn.nix
+++ b/pkgs/servers/sql/postgresql/ext/multicorn.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, python, postgresql, which }:
+
+stdenv.mkDerivation rec {
+  pname = "multicorn";
+  version = "1.4.0";
+
+  nativeBuildInputs = [ python which ];
+  buildInputs = [ postgresql ];
+
+  src = fetchFromGitHub {
+    owner = "Segfault-Inc";
+    repo = "Multicorn";
+    rev = "v${version}";
+    sha256 = "1sp5cs92w2d6x5jz0gj5nif5ii1fp59djw43idcck4jf20hlxnf7";
+  };
+
+  preConfigure = ''
+    patchShebangs ./preflight-check.sh
+  '';
+
+  installPhase = ''
+    install -D multicorn.so                                         -t $out/lib
+    install -D {multicorn.control,sql/multicorn{--${version},}.sql} -t $out/share/postgresql/extension
+  '';
+
+  meta = with stdenv.lib; {
+    description = "PostgreSQL 9.1+ extension meant to make Foreign Data Wrapper development easy";
+    homepage = "https://multicorn.org/";
+    maintainers = with maintainers; [ bbigras ];
+    license = licenses.postgresql;
+    inherit (postgresql.meta) platforms;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -1,5 +1,7 @@
 self: super: {
 
+    multicorn = super.callPackage ./ext/multicorn.nix { };
+
     periods = super.callPackage ./ext/periods.nix { };
 
     postgis = super.callPackage ./ext/postgis.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
In the nixos test, `CREATE EXTENSION` works but not the 2 `CREATE SERVER`.

`CREATE EXTENSION` would fail if I didn't install multicorn at all

```
master: must succeed: sudo -u postgres psql -c 'CREATE EXTENSION multicorn;'
master # [   23.683311] sudo[816]:     root : TTY=hvc0 ; PWD=/tmp ; USER=postgres ; COMMAND=/run/current-system/sw/bin/psql -c CREATE EXTENSION multicorn;
master # [   23.689987] sudo[816]: pam_unix(sudo:session): session opened for user postgres by (uid=0)
master # [   23.861224] sudo[816]: pam_unix(sudo:session): session closed for user postgres
(0.24 seconds)
master: must succeed: cat /nix/store/prrbpdvqbbfqiw09rn3hazyvv0c4ca0q-postgresql-test | sudo -u postgres psql
master # [   23.897364] sudo[821]:     root : TTY=hvc0 ; PWD=/tmp ; USER=postgres ; COMMAND=/run/current-system/sw/bin/psql
master # [   23.904081] sudo[821]: pam_unix(sudo:session): session opened for user postgres by (uid=0)
master # [   23.976365] postgresql-start[823]: [823] ERROR:  Error in python: ImportError
master # [   23.978526] postgresql-startERROR:  Error in python: ImportError
master # DETAIL:  No module named multicorn
master # [823]: [823] DETAIL:
master # [   23.984437] postgresql-start[823]: [823] STATEMENT:  CREATE SERVER multicorn_imap FOREIGN DATA WRAPPER multicorn options (wrapper 'multicorn.imapfdw.ImapFdw');
master: output:
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
