### PR TITLE
php7{2,3}: fix darwin build

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -8,7 +8,7 @@ let
     { callPackage, lib, stdenv, nixosTests, config, fetchurl, makeWrapper
     , symlinkJoin, writeText, autoconf, automake, bison, flex, libtool
     , pkgconfig, re2c, apacheHttpd, libargon2, libxml2, pcre, pcre2
-    , systemd, valgrind
+    , systemd, valgrind, xcbuild
 
     , version
     , sha256
@@ -143,7 +143,8 @@ let
 
           enableParallelBuilding = true;
 
-          nativeBuildInputs = [ autoconf automake bison flex libtool pkgconfig re2c ];
+          nativeBuildInputs = [ autoconf automake bison flex libtool pkgconfig re2c ]
+            ++ lib.optional stdenv.isDarwin xcbuild;
 
           buildInputs =
             # PCRE extension
@@ -177,7 +178,10 @@ let
             ++ lib.optional (!cliSupport) "--disable-cli"
             ++ lib.optional fpmSupport    "--enable-fpm"
             ++ lib.optional pearSupport [ "--with-pear=$(out)/lib/php/pear" "--enable-xml" "--with-libxml" ]
-            ++ lib.optional (pearSupport && (lib.versionOlder version "7.4")) "--enable-libxml"
+            ++ lib.optionals (pearSupport && (lib.versionOlder version "7.4")) [
+              "--enable-libxml"
+              "--with-libxml-dir=${libxml2.dev}"
+            ]
             ++ lib.optional pharSupport   "--enable-phar"
             ++ lib.optional phpdbgSupport "--enable-phpdbg"
 

--- a/pkgs/development/interpreters/php/zlib-darwin-tests.patch
+++ b/pkgs/development/interpreters/php/zlib-darwin-tests.patch
@@ -1,0 +1,44 @@
+diff --git a/ext/zlib/tests/bug55544.phpt b/ext/zlib/tests/bug55544.phpt
+index a0d22f4fcebf4846da6781f424f87821626de5ea..e650fe6909f555d04834f4c08f7fd0d354b783e2 100644
+--- a/ext/zlib/tests/bug55544.phpt
++++ b/ext/zlib/tests/bug55544.phpt
+@@ -6,6 +6,9 @@ extension_loaded("zlib") or die("skip");
+ if (substr(PHP_OS, 0, 3) == 'WIN') {
+        die("skip not for windows");
+ }
++if (PHP_OS == "Darwin") {
++       die("skip not for darwin");
++}
+ ?>
+ --INI--
+ output_handler=ob_gzhandler
+diff --git a/ext/zlib/tests/gzencode_variation1.phpt b/ext/zlib/tests/gzencode_variation1.phpt
+index c966b2cbc5b7..2f953168fa22 100644
+--- a/ext/zlib/tests/gzencode_variation1.phpt
++++ b/ext/zlib/tests/gzencode_variation1.phpt
+@@ -10,6 +10,10 @@ if( substr(PHP_OS, 0, 3) == "WIN" ) {
+ if (!extension_loaded("zlib")) {
+ 	print "skip - ZLIB extension not loaded";
+ }
++
++if (PHP_OS == "Darwin") {
++    print "skip - OS is encoded in headers, tested header is non Darwin";
++}
+ ?>
+ --FILE--
+ <?php
+diff --git a/ext/zlib/tests/gzencode_variation2.phpt b/ext/zlib/tests/gzencode_variation2.phpt
+index 94ac42a5f1cd..9160cf519751 100644
+--- a/ext/zlib/tests/gzencode_variation2.phpt
++++ b/ext/zlib/tests/gzencode_variation2.phpt
+@@ -10,6 +10,10 @@ if( substr(PHP_OS, 0, 3) == "WIN" ) {
+ if (!extension_loaded("zlib")) {
+ 	print "skip - ZLIB extension not loaded";
+ }
++
++if (PHP_OS == "Darwin") {
++    print "skip - OS is encoded in headers, tested header is non Darwin";
++}
+ ?>
+ --FILE--
+ <?php

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -947,6 +947,12 @@ in
         enable = lib.versionOlder php.version "7.4"; }
       { name = "gettext";
         buildInputs = [ gettext ];
+        patches = lib.optionals (lib.versionOlder php.version "7.4") [
+          (fetchpatch {
+            url = "https://github.com/php/php-src/commit/632b6e7aac207194adc3d0b41615bfb610757f41.patch";
+            sha256 = "0xn3ivhc4p070vbk5yx0mzj2n7p04drz3f98i77amr51w0vzv046";
+          })
+        ];
         postPhpize = ''substituteInPlace configure --replace 'as_fn_error $? "Cannot locate header file libintl.h" "$LINENO" 5' ':' '';
         configureFlags = "--with-gettext=${gettext}"; }
       { name = "gmp";
@@ -1163,6 +1169,10 @@ in
         doCheck = false; }
       { name = "zlib";
         buildInputs = [ zlib ];
+        patches = lib.optionals (lib.versionOlder php.version "7.4") [
+          # Derived from https://github.com/php/php-src/commit/f16b012116d6c015632741a3caada5b30ef8a699
+          ../development/interpreters/php/zlib-darwin-tests.patch
+        ];
         configureFlags = [ "--with-zlib" ]
           ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-zlib-dir=${zlib.dev}" ]; }
     ];


### PR DESCRIPTION
###### Motivation for this change



* Backported patches from `php-7.4` which fixes the env for all
  `gettext` and `zlib` tests.
* Setting `--with-libxml-dir` is still needed for versions 7.2 and 7.3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
