### PR TITLE
greg: add setuptools to propagatedBuildInputs

### DIFF
--- a/pkgs/applications/audio/greg/default.nix
+++ b/pkgs/applications/audio/greg/default.nix
@@ -13,8 +13,7 @@ with pythonPackages; buildPythonApplication rec {
     sha256 = "0bdzgh2k1ppgcvqiasxwp3w89q44s4jgwjidlips3ixx1bzm822v";
   };
 
-  buildInputs = with pythonPackages; [ feedparser ];
-  propagatedBuildInputs = buildInputs;
+  propagatedBuildInputs = [ setuptools feedparser ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/manolomartinez/greg";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/84353#issuecomment-610750469 
@petersjt014 I don't use greg just added missing dependency, could you test that it works as expected?

```
❯ nix-shell -p greg --run 'greg --version'
Traceback (most recent call last):
  File "/nix/store/s7nib0jpr3xnqv57a8322r1fnmhn5a92-greg-0.4.7/bin/.greg-wrapped", line 6, in <module>
    from greg.parser import main
  File "/nix/store/s7nib0jpr3xnqv57a8322r1fnmhn5a92-greg-0.4.7/lib/python3.8/site-packages/greg/parser.py", line 22, in <module>
    import greg.commands as commands
  File "/nix/store/s7nib0jpr3xnqv57a8322r1fnmhn5a92-greg-0.4.7/lib/python3.8/site-packages/greg/commands.py", line 24, in <module>
    import greg.classes as c
  File "/nix/store/s7nib0jpr3xnqv57a8322r1fnmhn5a92-greg-0.4.7/lib/python3.8/site-packages/greg/classes.py", line 32, in <module>
    from pkg_resources import resource_filename
ModuleNotFoundError: No module named 'pkg_resources'
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

