### PR TITLE
libvncserver: 0.9.12 -> 0.9.13 (security)

### DIFF
--- a/pkgs/development/libraries/libvncserver/default.nix
+++ b/pkgs/development/libraries/libvncserver/default.nix
@@ -7,9 +7,9 @@ let
   s = # Generated upstream information
   rec {
     pname = "libvncserver";
-    version = "0.9.12";
+    version = "0.9.13";
     url = "https://github.com/LibVNC/libvncserver/archive/LibVNCServer-${version}.tar.gz";
-    sha256 = "1226hb179l914919f5nm2mlf8rhaarqbf48aa649p4rwmghyx9vm"; # unpacked archive checksum
+    sha256 = "0zz0hslw8b1p3crnfy3xnmrljik359h83dpk64s697dqdcrzy141"; # unpacked archive checksum
   };
 in
 stdenv.mkDerivation {
@@ -17,18 +17,7 @@ stdenv.mkDerivation {
   src = fetchzip {
     inherit (s) url sha256;
   };
-  patches = [
-    (fetchpatch {
-      name = "CVE-2018-20750.patch";
-      url = "https://github.com/LibVNC/libvncserver/commit/09e8fc02f59f16e2583b34fe1a270c238bd9ffec.patch";
-      sha256 = "004h50786nvjl3y3yazpsi2b767vc9gqrwm1ralj3zgy47kwfhqm";
-    })
-    (fetchpatch {
-      name = "CVE-2019-15681.patch";
-      url = "https://github.com/LibVNC/libvncserver/commit/d01e1bb4246323ba6fcee3b82ef1faa9b1dac82a.patch";
-      sha256 = "0hf0ss7all2m50z2kan4mck51ws44yim4ymn8p0d991y465y6l9s";
-    })
-  ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     libjpeg openssl libgcrypt libpng


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/91307
https://github.com/NixOS/nixpkgs/issues/88349

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
