### PR TITLE
mkFont derivation for unified font packaging

### DIFF
--- a/pkgs/build-support/mkfont.nix
+++ b/pkgs/build-support/mkfont.nix
@@ -1,0 +1,60 @@
+{ lib, stdenvNoCC }:
+
+args:
+
+let
+  noUnpackFonts = lib.hasAttr "noUnpackFonts" args && args.noUnpackFonts;
+  hasMultipleSources = lib.hasAttr "srcs" args;
+in
+stdenvNoCC.mkDerivation ({
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  doCheck = false;
+  dontFixup = true;
+
+  sourceRoot = if noUnpackFonts || hasMultipleSources then "." else null;
+  unpackCmd = if noUnpackFonts then ''
+    filename="$(basename "$(stripHash "$curSrc")")"
+    cp $curSrc "./$filename"
+  '' else null;
+
+  /*
+  installPhase = ''
+    # these come up in some source trees, but are never useful to us
+    find -iname __MACOSX -type d -print0 | xargs -0 rm -rf
+    # find -type f,l
+
+    for pattern in "*.ttf" "*.ttc" "*.ttf" "*.otf" "*.eot" "*.bdf" "*.otb" "*.psf"; do
+      find -ipath "$pattern" | while IFS= read -r filename; do
+        case "$(basename "$filename")" in
+          *.ttf) fontdir=$out/share/fonts/truetype/ ;;
+          *.ttc) fontdir=$out/share/fonts/truetype/ ;;
+          *.ttf) fontdir=$out/share/fonts/truetype/ ;;
+          *.otf) fontdir=$out/share/fonts/opentype/ ;;
+          *.eot) fontdir=$out/share/fonts/eot/ ;;
+          *.bdf) fontdir=$out/share/fonts/misc/ ;;
+          *.otb) fontdir=$out/share/fonts/misc/ ;;
+          *.psf) fontdir=$out/share/consolefonts/ ;;
+          *) echo "File has invalid extension: $filename"; exit 1 ;;
+        esac
+
+        install -v -m644 --target $fontdir -D "$filename"
+      done
+    done
+  '';
+  */
+
+  installPhase = ''
+    # these come up in some source trees, but are never useful to us
+    find -iname __MACOSX -type d -print0 | xargs -0 rm -rf
+    find -type f,l
+
+    find -iname '*.ttc' -print0 | xargs -0 -r install -v -m644 --target $out/share/fonts/truetype/ -D
+    find -iname '*.ttf' -print0 | xargs -0 -r install -v -m644 --target $out/share/fonts/truetype/ -D
+    find -iname '*.otf' -print0 | xargs -0 -r install -v -m644 --target $out/share/fonts/opentype/ -D
+    find -iname '*.bdf' -print0 | xargs -0 -r install -v -m644 --target $out/share/fonts/misc/ -D
+    find -iname '*.otb' -print0 | xargs -0 -r install -v -m644 --target $out/share/fonts/misc/ -D
+    find -iname '*.psf' -print0 | xargs -0 -r install -v -m644 --target $out/share/consolefonts/ -D
+  '';
+} // args)

--- a/pkgs/data/fonts/agave/default.nix
+++ b/pkgs/data/fonts/agave/default.nix
@@ -1,19 +1,15 @@
-{ lib, fetchurl }:
+{ lib, mkFont, fetchurl }:
 
-let
+mkFont rec {
   pname = "agave";
   version = "14";
-in fetchurl {
-  name = "${pname}-${version}";
-  url = "https://github.com/agarick/agave/releases/download/v${version}/Agave-Regular.ttf";
 
-  downloadToTemp = true;
-  recursiveHash = true;
-  postFetch = ''
-    install -D $downloadedFile $out/share/fonts/truetype/Agave-Regular.ttf
-  '';
+  src = fetchurl {
+    url = "https://github.com/agarick/agave/releases/download/v${version}/Agave-Regular.ttf";
+    sha256 = "0n47xfg5grdvbxnygim5yz6qi8vy2bgk99xhns2pq6psb670yn4h";
+  };
 
-  sha256 = "14hr6cdn5xbfpszj4qyfqbwmjyrkmi83yl0g9j3y3jw561jwy27j";
+  noUnpackFonts = true;
 
   meta = with lib; {
     description = "truetype monospaced typeface designed for X environments";

--- a/pkgs/data/fonts/aileron/default.nix
+++ b/pkgs/data/fonts/aileron/default.nix
@@ -1,24 +1,17 @@
-{ lib, fetchzip }:
+{ lib, fetchzip, mkFont }:
 
-let
-  majorVersion = "0";
-  minorVersion = "102";
+mkFont rec {
   pname = "aileron";
-in
+  version = "0.102";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
-
-  url = "http://dotcolon.net/DL/font/${pname}.zip";
-  sha256 = "04xnzdy9plzd2p02yq367h37m5ygx0w8cpkdv39cc3754ljlsxim";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
-  '';
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${pname}_${lib.replaceStrings ["."] [""] version}.zip";
+    sha256 = "1hawb176dd90nq95q5blpmpv93v7qyl9fwldiqfpvbjr0a1krphy";
+    stripRoot = false;
+  };
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${pname}/";
+    homepage = "https://dotcolon.net/font/${pname}/";
     description = "A helvetica font in nine weights";
     platforms = platforms.all;
     maintainers = with maintainers; [ leenaars ];

--- a/pkgs/data/fonts/amiri/default.nix
+++ b/pkgs/data/fonts/amiri/default.nix
@@ -1,20 +1,13 @@
-{ lib, fetchzip }:
+{ lib, fetchzip, mkFont }:
 
-let
+mkFont rec {
   version = "0.113";
-
-in fetchzip rec {
   name = "Amiri-${version}";
 
-  url = "https://github.com/alif-type/amiri/releases/download/${version}/${name}.zip";
-
-  sha256 = "0v5xm4spyww8wy6j9kpb01ixrakw7wp6jng4xnh220iy6yqcxm7v";
-
-  postFetch = ''
-    unzip $downloadedFile
-    install -m444 -Dt $out/share/fonts/truetype ${name}/*.ttf
-    install -m444 -Dt $out/share/doc/${name}    ${name}/{*.txt,*.pdf}
-  '';
+  src = fetchzip {
+    url = "https://github.com/alif-type/amiri/releases/download/${version}/${name}.zip";
+    sha256 = "0cf0brihs1pilbrz0bpyg4xh8xsdhysy3m77ibz28wwyfy7wv09k";
+  };
 
   meta = with lib; {
     description = "A classical Arabic typeface in Naskh style";
@@ -24,4 +17,3 @@ in fetchzip rec {
     platforms = platforms.all;
   };
 }
-

--- a/pkgs/data/fonts/andagii/default.nix
+++ b/pkgs/data/fonts/andagii/default.nix
@@ -1,18 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont {
+  pname = "andagii";
   version = "1.0.2";
-in fetchzip {
-  name = "andagii-${version}";
 
-  url = "http://www.i18nguy.com/unicode/andagii.zip";
-  curlOpts = "--user-agent 'Mozilla/5.0'";
-  postFetch = ''
-    unzip $downloadedFile
-    mkdir -p $out/share/fonts/truetype
-    cp -v ANDAGII_.TTF $out/share/fonts/truetype/andagii.ttf
-  '';
-  sha256 = "0j5kf2fmyqgnf5ji6h0h79lq9n9d85hkfrr4ya8hqj4gwvc0smb2";
+  src = fetchzip {
+    url = "http://www.i18nguy.com/unicode/andagii.zip";
+    curlOpts = "--user-agent 'Mozilla/5.0'";
+    sha256 = "0a0c43y1fd5ksj50axhng7p00kgga0i15p136g68p35wj7kh5g2k";
+  };
 
   # There are multiple claims that the font is GPL, so I include the
   # package; but I cannot find the original source, so use it on your

--- a/pkgs/data/fonts/andika/default.nix
+++ b/pkgs/data/fonts/andika/default.nix
@@ -1,31 +1,24 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "andika";
   version = "5.000";
-in
-  fetchzip rec {
-    name = "andika-${version}";
 
+  src = fetchzip {
     url = "https://software.sil.org/downloads/r/andika/Andika-${version}.zip";
+    sha256 = "0ds0g3wh685ifp6aip8nanw2x7mxi13rbpv3pjhchnjb9g6lk6yp";
+  };
 
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+  meta = with lib; {
+    homepage = "https://software.sil.org/andika";
+    description = "A family designed especially for literacy use taking into account the needs of beginning readers";
+    longDescription = ''
+    Andika is a sans serif, Unicode-compliant font designed especially for literacy use, taking into account the needs of beginning readers. The focus is on clear, easy-to-perceive letterforms that will not be readily confused with one another.
+
+    A sans serif font is preferred by some literacy personnel for teaching people to read. Its forms are simpler and less cluttered than those of most serif fonts. For years, literacy workers have had to make do with fonts that were not really suitable for beginning readers and writers. In some cases, literacy specialists have had to tediously assemble letters from a variety of fonts in order to get all of the characters they need for their particular language project, resulting in confusing and unattractive publications. Andika addresses those issues.
     '';
-
-    sha256 = "1jy9vpcprpd1k48p20wh6jhyn909ibia8lr5i747p41l0s8a7lqy";
-
-    meta = with lib; {
-      homepage = "https://software.sil.org/andika";
-      description = "A family designed especially for literacy use taking into account the needs of beginning readers";
-      longDescription = ''
-      Andika is a sans serif, Unicode-compliant font designed especially for literacy use, taking into account the needs of beginning readers. The focus is on clear, easy-to-perceive letterforms that will not be readily confused with one another.
-
-      A sans serif font is preferred by some literacy personnel for teaching people to read. Its forms are simpler and less cluttered than those of most serif fonts. For years, literacy workers have had to make do with fonts that were not really suitable for beginning readers and writers. In some cases, literacy specialists have had to tediously assemble letters from a variety of fonts in order to get all of the characters they need for their particular language project, resulting in confusing and unattractive publications. Andika addresses those issues.
-      '';
-      license = licenses.ofl;
-      platforms = platforms.all;
-      maintainers = [ maintainers.f--t ];
-    };
-  }
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.f--t ];
+  };
+}

--- a/pkgs/data/fonts/ankacoder/condensed.nix
+++ b/pkgs/data/fonts/ankacoder/condensed.nix
@@ -1,17 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let version = "1.100"; in
-fetchzip {
-  name = "ankacoder-condensed-${version}";
-  url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/anka-coder-fonts/AnkaCoderCondensed.${version}.zip";
+mkFont rec {
+  pname = "ankacoder-condensed";
+  version = "1.100";
 
-  postFetch = ''
-    unzip $downloadedFile
-    mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
-  '';
-
-  sha256 = "0i80zpr2y9368rg2i6x8jv0g7d03kdyr5h7w9yz7pjd7i9xd8439";
+  src = fetchzip {
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/anka-coder-fonts/AnkaCoderCondensed.${version}.zip";
+    sha256 = "09pflcanxikagycarc1yjbga2dk30hx9bf471f1jzvlvhiby8yil";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     description = "Anka/Coder Condensed font";

--- a/pkgs/data/fonts/ankacoder/default.nix
+++ b/pkgs/data/fonts/ankacoder/default.nix
@@ -1,17 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let version = "1.100"; in
-fetchzip {
-  name = "ankacoder-${version}";
-  url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/anka-coder-fonts/AnkaCoder.${version}.zip";
+mkFont rec {
+  pname = "ankacoder";
+  version = "1.100";
 
-  postFetch = ''
-    unzip $downloadedFile
-    mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
-  '';
-
-  sha256 = "1jqx9micfmiarqh9xp330gl96v3vxbwzz9cmg2vi845n9md4im85";
+  src = fetchzip {
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/anka-coder-fonts/AnkaCoder.${version}.zip";
+    sha256 = "09mkvfz2jb08b5mj4sr4rn460xjsqqjy23md1vbfyz1z4iljv0np";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     description = "Anka/Coder fonts";

--- a/pkgs/data/fonts/anonymous-pro/default.nix
+++ b/pkgs/data/fonts/anonymous-pro/default.nix
@@ -1,17 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "anonymousPro";
   version = "1.002";
-in fetchzip rec {
-  name = "anonymousPro-${version}";
 
-  url = "http://www.marksimonson.com/assets/content/fonts/AnonymousPro-${version}.zip";
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf                           -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.txt                           -d "$out/share/doc/${name}"
-  '';
-  sha256 = "05rgzag38qc77b31sm5i2vwwrxbrvwzfsqh3slv11skx36pz337f";
+  src = fetchzip {
+    url = "http://www.marksimonson.com/assets/content/fonts/AnonymousPro-${version}.zip";
+    sha256 = "0iadz9qvg1yykqps2mrfapp7ysff4w4r1bjcyj6p5wbjh1bv670n";
+  };
 
   meta = with lib; {
     homepage = "https://www.marksimonson.com/fonts/view/anonymous-pro";

--- a/pkgs/data/fonts/arkpandora/default.nix
+++ b/pkgs/data/fonts/arkpandora/default.nix
@@ -1,23 +1,17 @@
-{ fetchurl }:
+{ mkFont, fetchurl }:
 
-let
+mkFont rec {
+  pname = "arkpandora";
   version = "2.04";
-in fetchurl {
-  name = "arkpandora-${version}";
 
-  urls = [
-    "http://distcache.FreeBSD.org/ports-distfiles/ttf-arkpandora-${version}.tgz"
-    "ftp://ftp.FreeBSD.org/pub/FreeBSD/ports/distfiles/ttf-arkpandora-${version}.tgz"
-    "http://www.users.bigpond.net.au/gavindi/ttf-arkpandora-${version}.tgz"
-  ];
-  downloadToTemp = true;
-  recursiveHash = true;
-  postFetch = ''
-    tar -xzvf $downloadedFile --strip-components=1
-    mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
-  '';
-  sha256 = "177k0fbs0787al0snkl8w68d2qkg7snnnq6qp28j9s98vaabs04k";
+  src = fetchurl {
+    urls = [
+      "http://distcache.FreeBSD.org/ports-distfiles/ttf-arkpandora-${version}.tgz"
+      "ftp://ftp.FreeBSD.org/pub/FreeBSD/ports/distfiles/ttf-arkpandora-${version}.tgz"
+      "http://www.users.bigpond.net.au/gavindi/ttf-arkpandora-${version}.tgz"
+    ];
+    sha256 = "16mfxwlgn6vs3xn00hha5dnmz6bhjiflq138y4zcq3yhk0y9bz51";
+  };
 
   meta = {
     description = "Font, metrically identical to Arial and Times New Roman";

--- a/pkgs/data/fonts/aurulent-sans/default.nix
+++ b/pkgs/data/fonts/aurulent-sans/default.nix
@@ -1,15 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  name = "aurulent-sans-0.1";
-  owner = "deepfire";
-  repo = "hartke-aurulent-sans";
-  rev = name;
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    tar xf $downloadedFile -C $out/share/fonts --strip=1
-  '';
-  sha256 = "1l60psfv9x0x9qx9vp1qnhmck7a7kks385m5ycrd3d91irz1j5li";
+mkFont rec {
+  pname = "aurulent-sans";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "deepfire";
+    repo = "hartke-aurulent-sans";
+    rev = "${pname}-${version}";
+    sha256 = "01hvpvbrks40g9k1xr2f1gxnd5wd0sxidgfbwrm94pdi1a36xxrk";
+  };
 
   meta = {
     description = "Aurulent Sans";

--- a/pkgs/data/fonts/b612/default.nix
+++ b/pkgs/data/fonts/b612/default.nix
@@ -1,19 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   version = "1.008";
-  pname = "b612";
-in fetchFromGitHub {
-  name = "${pname}-font-${version}";
-  owner = "polarsys";
-  repo = "b612";
-  rev = version;
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    mkdir -p $out/share/fonts/truetype/${pname}
-    cp fonts/ttf/*.ttf $out/share/fonts/truetype/${pname}
-  '';
-  sha256 = "0r3lana1q9w3siv8czb3p9rrb5d9svp628yfbvvmnj7qvjrmfsiq";
+  pname = "b612-font";
+
+  src = fetchFromGitHub {
+    owner = "polarsys";
+    repo = "b612";
+    rev = version;
+    sha256 = "0j4cwr9j782gs3l5c2hy5nvjng2qdrvgalbq3m13phsf8gql485v";
+  };
 
   meta = with lib; {
     homepage = "http://b612-font.com/";

--- a/pkgs/data/fonts/babelstone-han/default.nix
+++ b/pkgs/data/fonts/babelstone-han/default.nix
@@ -1,17 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont {
+  pname = "babelstone-han";
   version = "13.0.3";
-in fetchzip {
-  name = "babelstone-han-${version}";
 
-  # upstream download links are unversioned, so hash changes
-  url = "https://web.archive.org/web/20200210125314/https://www.babelstone.co.uk/Fonts/Download/BabelStoneHan.zip";
-  postFetch = ''
-    mkdir -p $out/share/fonts/truetype
-    unzip $downloadedFile '*.ttf' -d $out/share/fonts/truetype
-  '';
-  sha256 = "018isk3hbzsihzrxavgjbn485ngzvlm96npqx9y7zpkxsssslc4w";
+  src = fetchzip {
+    url = "https://web.archive.org/web/20200210125314/https://www.babelstone.co.uk/Fonts/Download/BabelStoneHan.zip";
+    sha256 = "1k8n916x506wga3j8xacxgld2g2pxsr4mmb5cd1ix1mngfs4vf1c";
+  };
 
   meta = with lib; {
     description = "Unicode CJK font with over 36000 Han characters";

--- a/pkgs/data/fonts/baekmuk-ttf/default.nix
+++ b/pkgs/data/fonts/baekmuk-ttf/default.nix
@@ -1,20 +1,18 @@
-{ fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-fetchzip rec {
-  name = "baekmuk-ttf-2.2";
+mkFont rec {
+  pname = "baekmuk-ttf";
+  version = "2.2";
 
-  url = "http://kldp.net/baekmuk/release/865-${name}.tar.gz";
-  postFetch = ''
-    tar -xzvf $downloadedFile --strip-components=1
-    install -m444 -Dt $out/share/fonts        ttf/*.ttf
-    install -m444 -Dt $out/share/doc/${name}  COPYRIGHT*
-  '';
-  sha256 = "1jgsvack1l14q8lbcv4qhgbswi30mf045k37rl772hzcmx0r206g";
+  src = fetchzip {
+    url = "https://kldp.net/baekmuk/release/865-${pname}-${version}.tar.gz";
+    sha256 = "126zkgsrphgxqjwi0km4l8g9lnjvv233ikbp870bpkxnf6wgrwwm";
+  };
 
-  meta = {
+  meta = with lib; {
     description = "Korean font";
-    homepage = "http://kldp.net/projects/baekmuk/";
-    license = "BSD-like";
+    homepage = "https://kldp.net/projects/baekmuk/";
+    license = licenses.free; # BSD-like
   };
 }
 

--- a/pkgs/data/fonts/bakoma-ttf/default.nix
+++ b/pkgs/data/fonts/bakoma-ttf/default.nix
@@ -1,17 +1,14 @@
-{ fetchzip }:
+{ mkFont, fetchurl }:
 
-fetchzip {
-  name = "bakoma-ttf";
+mkFont {
+  pname = "bakoma-ttf";
+  version = "2015-12-15";
 
-  url = "http://tarballs.nixos.org/sha256/1j1y3cq6ys30m734axc0brdm2q9n2as4h32jws15r7w5fwr991km";
-
-  postFetch = ''
-    tar xjvf $downloadedFile --strip-components=1
-    mkdir -p $out/share/fonts/truetype
-    cp ttf/*.ttf $out/share/fonts/truetype
-  '';
-
-  sha256 = "0g7i723n00cqx2va05z1h6v3a2ar69gqw4hy6pjj7m0ml906rngc";
+  src = fetchurl {
+    name = "bakoma-ttf.tar.bz2";
+    url = "http://tarballs.nixos.org/sha256/1j1y3cq6ys30m734axc0brdm2q9n2as4h32jws15r7w5fwr991km";
+    sha256 = "1j1y3cq6ys30m734axc0brdm2q9n2as4h32jws15r7w5fwr991km";
+  };
 
   meta = {
     description = "TrueType versions of the Computer Modern and AMS TeX Fonts";

--- a/pkgs/data/fonts/behdad-fonts/default.nix
+++ b/pkgs/data/fonts/behdad-fonts/default.nix
@@ -1,19 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "behdad-fonts";
   version = "0.0.3";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "font-store";
-  repo = "BehdadFont";
-  rev = "v${version}";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/behrad-fonts {} \;
-  '';
-  sha256 = "0c57232462cv1jrfn0m2bl7jzcfkacirrdd2qimrc8iqhkz0ajfz";
+  src = fetchFromGitHub {
+    owner = "font-store";
+    repo = "BehdadFont";
+    rev = "v${version}";
+    sha256 = "0rlmyv82qmyy90zvkjnlva44ia7dyhiyk7axbq526v7zip3g79w0";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/font-store/BehdadFont";

--- a/pkgs/data/fonts/cabin/default.nix
+++ b/pkgs/data/fonts/cabin/default.nix
@@ -1,19 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  name = "cabin-1.005";
+mkFont {
+  pname = "cabin";
+  version = "1.005";
 
-  owner = "impallari";
-  repo = "Cabin";
-  rev = "982839c790e9dc57c343972aa34c51ed3b3677fd";
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -m444 -Dt $out/share/fonts/opentype fonts/OTF/*.otf
-    install -m444 -Dt $out/share/doc/${name}    README.md FONTLOG.txt
-  '';
-
-  sha256 = "1bl7h217m695jn4rbniialfk573aa44fslp2rjxnhkicakpcm44h";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Cabin";
+    rev = "982839c790e9dc57c343972aa34c51ed3b3677fd";
+    sha256 = "16v7spviphvdh2rrr8klv11lc9hxphg12ddf0qs7xdx801ri0ppn";
+  };
 
   meta = with lib; {
     description = "A humanist sans with 4 weights and true italics";

--- a/pkgs/data/fonts/camingo-code/default.nix
+++ b/pkgs/data/fonts/camingo-code/default.nix
@@ -1,20 +1,17 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont {
+  pname = "camingo-code";
   version = "1.0";
-in fetchzip rec {
-  name = "camingo-code-${version}";
 
-  url = "https://github.com/chrissimpkins/codeface/releases/download/font-collection/codeface-fonts.zip";
-  postFetch = ''
-    unzip $downloadedFile
-    install -m444 -Dt $out/share/fonts/truetype fonts/camingo-code/*.ttf
-    install -m444 -Dt $out/share/doc/${name}    fonts/camingo-code/*.txt
-  '';
-  sha256 = "16iqjwwa7pnswvcc4w8nglkd0m0fz50qsz96i1kcpqip3nwwvw7y";
+  src = fetchzip {
+    url = "https://janfromm.de/_data/downloads/CamingoCode-v1.0.zip";
+    sha256 = "1skmw445ziizw28v1da8194gs2icrqrrl3s069sghfd7ynwkwm3h";
+    stripRoot = false;
+  };
 
   meta = with lib; {
-    homepage = "https://www.myfonts.com/fonts/jan-fromm/camingo-code/";
+    homepage = "https://www.janfromm.de/typefaces/camingomono/camingocode/";
     description = "A monospaced typeface designed for source-code editors";
     platforms = platforms.all;
     license = licenses.cc-by-nd-30;

--- a/pkgs/data/fonts/cascadia-code/default.nix
+++ b/pkgs/data/fonts/cascadia-code/default.nix
@@ -1,44 +1,31 @@
-{ stdenv, fetchurl }:
+{ lib, mkFont, fetchurl }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "cascadia-code";
   version = "1911.21";
 
-  srcs = [
-    (fetchurl {
+  srcs = map fetchurl [
+    {
       url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/Cascadia.ttf";
       sha256 = "1m5ymbngjg3n1g3p6vhcq7d825bwwln9afih651ar3jn7j9njnyg";
-     })
-    (fetchurl {
+    }
+    {
       url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/CascadiaMono.ttf";
       sha256 = "0vkhm6rhspzd1iayxrzaag099wsc94azfqa3ips7f4x9s8fmbp80";
-    })
-    (fetchurl {
+    }
+    {
       url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/CascadiaMonoPL.ttf";
       sha256 = "0xxqd8m2ydn97jngp1a3ik1mzpjbm65pfq02a82gfbbvajq5d673";
-    })
-    (fetchurl {
+    }
+    {
       url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/CascadiaPL.ttf";
       sha256 = "1s83c9flvifd05nbhnk8knwnik7p621sr7i94smknigc7d72wqav";
-    })
+    }
   ];
 
-  unpackCmd = ''
-    ttfName=$(basename $(stripHash $curSrc))
-    cp $curSrc ./$ttfName
-  '';
+  noUnpackFonts = true;
 
-  sourceRoot = ".";
-
-  installPhase = ''
-    install -Dm444 -t $out/share/fonts/truetype *.ttf
-  '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "1gkjs7qa409r4ykdy4ik8i0c3z49hzpklw6kyijhhifhyyyzhz4h";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Monospaced font that includes programming ligatures and is designed to enhance the modern look and feel of the Windows Terminal";
     homepage = "https://github.com/microsoft/cascadia-code";
     license = licenses.ofl;

--- a/pkgs/data/fonts/charis-sil/default.nix
+++ b/pkgs/data/fonts/charis-sil/default.nix
@@ -1,31 +1,24 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "charis-sil";
   version = "5.000";
-in
-  fetchzip rec {
-    name = "charis-sil-${version}";
 
+  src = fetchzip {
     url = "https://software.sil.org/downloads/r/charis/CharisSIL-${version}.zip";
+    sha256 = "152182hmr9wmpffc54iqzjf9gww3rvbvkkcgmfd04ryq4rxnqmx6";
+  };
 
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+  meta = with lib; {
+    homepage = "https://software.sil.org/charis";
+    description = "A family of highly readable fonts for broad multilingual use";
+    longDescription = ''
+    This Charis SIL font is essentially the same design as the SIL Charis font first released by SIL in 1997. Charis is similar to Bitstream Charter, one of the first fonts designed specifically for laser printers. It is highly readable and holds up well in less-than-ideal reproduction environments. It also has a full set of styles – regular, italic, bold, bold italic. Charis is a serif, proportionally-spaced font optimized for readability in long printed documents.
+
+    The goal for this product was to provide a single Unicode-based font family that would contain a comprehensive inventory of glyphs needed for almost any Roman- or Cyrillic-based writing system, whether used for phonetic or orthographic needs. In addition, there is provision for other characters and symbols useful to linguists. This font makes use of state-of-the-art font technologies to support complex typographic issues, such as the need to position arbitrary combinations of base glyphs and diacritics optimally.
     '';
-
-    sha256 = "1a220s8n0flvcdkazqf5g10v6r55s2an308slvvarynpj6l7x27n";
-
-    meta = with lib; {
-      homepage = "https://software.sil.org/charis";
-      description = "A family of highly readable fonts for broad multilingual use";
-      longDescription = ''
-      This Charis SIL font is essentially the same design as the SIL Charis font first released by SIL in 1997. Charis is similar to Bitstream Charter, one of the first fonts designed specifically for laser printers. It is highly readable and holds up well in less-than-ideal reproduction environments. It also has a full set of styles – regular, italic, bold, bold italic. Charis is a serif, proportionally-spaced font optimized for readability in long printed documents.
-
-      The goal for this product was to provide a single Unicode-based font family that would contain a comprehensive inventory of glyphs needed for almost any Roman- or Cyrillic-based writing system, whether used for phonetic or orthographic needs. In addition, there is provision for other characters and symbols useful to linguists. This font makes use of state-of-the-art font technologies to support complex typographic issues, such as the need to position arbitrary combinations of base glyphs and diacritics optimally.
-      '';
-      license = licenses.ofl;
-      platforms = platforms.all;
-      maintainers = [ maintainers.f--t ];
-    };
-  }
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.f--t ];
+  };
+}

--- a/pkgs/data/fonts/cm-unicode/default.nix
+++ b/pkgs/data/fonts/cm-unicode/default.nix
@@ -1,19 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "cm-unicode";
   version = "0.7.0";
-in fetchzip rec {
-  name = "cm-unicode-${version}";
 
-  url = "mirror://sourceforge/cm-unicode/cm-unicode/${version}/${name}-otf.tar.xz";
-
-  postFetch = ''
-    tar -xJvf $downloadedFile --strip-components=1
-    install -m444 -Dt $out/share/fonts/opentype *.otf
-    install -m444 -Dt $out/share/doc/${name}    README FontLog.txt
-  '';
-
-  sha256 = "1rzz7yhqq3lljyqxbg46jfzfd09qgpgx865lijr4sgc94riy1ypn";
+  src = fetchzip {
+    url = "mirror://sourceforge/cm-unicode/cm-unicode/${version}/${pname}-${version}-otf.tar.xz";
+    sha256 = "1l9ql47xl6nbfxrmvhs0pjbscs4nbqxi98v1a7c7llznywffkm2s";
+  };
 
   meta = with lib; {
     homepage = "http://canopus.iacp.dvo.ru/~panov/cm-unicode/";

--- a/pkgs/data/fonts/cnstrokeorder/default.nix
+++ b/pkgs/data/fonts/cnstrokeorder/default.nix
@@ -1,24 +1,19 @@
-{ lib, fetchurl }:
+{ lib, mkFont, fetchurl }:
 
-let
+mkFont rec {
+  pname = "cnstrokeorder";
   version = "0.0.4.7";
-in fetchurl {
-  name = "cnstrokeorder-${version}";
 
-  url = "http://rtega.be/chmn/CNstrokeorder-${version}.ttf";
+  src = fetchurl {
+    url = "https://rtega.be/chmn/CNstrokeorder-${version}.ttf";
+    sha256 = "11m416p3iciiqbpjldj945h2dmwn9bzvsgqbq01mvmgd9dqlx2v1";
+  };
 
-  recursiveHash = true;
-  downloadToTemp = true;
-
-  postFetch = ''
-    install -D $downloadedFile $out/share/fonts/truetype/CNstrokeorder-${version}.ttf
-  '';
-
-  sha256 = "0cizgfdgbq9av5c8234mysr2q54iw9pkxrmq5ga8gv32hxhl5bx4";
+  noUnpackFonts = true;
 
   meta = with lib; {
     description = "Chinese font that shows stroke order for HSK 1-4";
-    homepage = "http://rtega.be/chmn/index.php?subpage=68";
+    homepage = "https://rtega.be/chmn/index.php?subpage=68";
     license = [ licenses.arphicpl ];
     maintainers = with maintainers; [ johnazoidberg ];
     platforms = platforms.all;

--- a/pkgs/data/fonts/comic-neue/default.nix
+++ b/pkgs/data/fonts/comic-neue/default.nix
@@ -1,26 +1,17 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "comic-neue";
   version = "2.3";
-in fetchzip rec {
-  name = "comic-neue-${version}";
 
-  url = "http://comicneue.com/${name}.zip";
-
-  postFetch = ''
-    mkdir -vp $out/share/{doc,fonts}
-    unzip -j $downloadedFile OTF/\*.otf   -d $out/share/fonts/opentype
-    unzip -j $downloadedFile Web/\*.ttf   -d $out/share/fonts/truetype
-    unzip -j $downloadedFile Web/\*.eot   -d $out/share/fonts/EOT
-    unzip -j $downloadedFile Web/\*.woff  -d $out/share/fonts/WOFF
-    unzip -j $downloadedFile Web/\*.woff2 -d $out/share/fonts/WOFF2
-    unzip -j $downloadedFile \*.pdf FONTLOG.txt OFL-FAQ.txt SIL-License.txt -d $out/share/doc/${name}
-  '';
-
-  sha256 = "1gs4vhys0m3qsw06qaxzyi81f06w5v66kbyl64yw3pq2rb656779";
+  src = fetchzip {
+    url = "https://comicneue.com/${pname}-${version}.zip";
+    sha256 = "1d8hgd045bj0aswd9lis1mb8vfnkknvnpskmg229vrf3rc6cq5zm";
+    stripRoot = false;
+  };
 
   meta = with lib; {
-    homepage = "http://comicneue.com/";
+    homepage = "https://comicneue.com/";
     description = "A casual type face: Make your lemonade stand look like a fortune 500 company";
     longDescription = ''
       It is inspired by Comic Sans but more regular.  The font was

--- a/pkgs/data/fonts/cooper-hewitt/default.nix
+++ b/pkgs/data/fonts/cooper-hewitt/default.nix
@@ -1,16 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-fetchzip {
-  name = "cooper-hewitt-2014-06-09";
+mkFont {
+  pname = "cooper-hewitt";
+  version = "2014-06-09";
 
-  url = "https://www.cooperhewitt.org/wp-content/uploads/fonts/CooperHewitt-OTF-public.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype/
-  '';
-
-  sha256 = "01iwqmjvqkc6fmc2r0486vk06s6f51n9wxzl1pf9z48n0igj4gqd";
+  src = fetchzip {
+    url = "https://www.cooperhewitt.org/wp-content/uploads/fonts/CooperHewitt-OTF-public.zip";
+    sha256 = "1gamnypkfzv16np8aa8jnw38v84z944bspbkpqlxnd4q0xfl8fbd";
+  };
 
   meta = with lib; {
     homepage = "https://www.cooperhewitt.org/open-source-at-cooper-hewitt/cooper-hewitt-the-typeface-by-chester-jenkins/";

--- a/pkgs/data/fonts/cozette/default.nix
+++ b/pkgs/data/fonts/cozette/default.nix
@@ -1,51 +1,27 @@
-{ stdenv, fetchurl, mkfontscale }:
+{ lib, mkFont, fetchurl }:
 
-let
-  version = "1.5.1";
-  releaseUrl =
-    "https://github.com/slavfox/Cozette/releases/download/v.${version}";
-in stdenv.mkDerivation rec {
+mkFont rec {
   pname = "Cozette";
-  inherit version;
+  version = "1.5.1";
 
   srcs = map fetchurl [
     {
-      url = "${releaseUrl}/cozette.otb";
+      url = "https://github.com/slavfox/Cozette/releases/download/v.${version}/cozette.otb";
       sha256 = "05k45n7jar11gnng2awpmc7zk9jdlzd6wz87xx49cp75jm4z9xm8";
     }
     {
-      url = "${releaseUrl}/CozetteVector.otf";
+      url = "https://github.com/slavfox/Cozette/releases/download/v.${version}/CozetteVector.otf";
       sha256 = "1sqhnjpizn1wi26lc7z2zml7yr7zkcpa72mh1drvd74rlcs1ip30";
     }
     {
-      url = "${releaseUrl}/CozetteVector.ttf";
+      url = "https://github.com/slavfox/Cozette/releases/download/v.${version}/CozetteVector.ttf";
       sha256 = "1q4ml8shv9lmyc6bwhffwvbvl92s73j7xkb0rkqvci4f0zbz7mcy";
     }
   ];
 
-  nativeBuildInputs = [ mkfontscale ];
+  noUnpackFonts = true;
 
-  sourceRoot = "./";
-
-  unpackCmd = ''
-    otName=$(stripHash "$curSrc")
-    cp $curSrc ./$otName
-  '';
-
-  installPhase = ''
-
-    install -D -m 644 *.otf -t "$out/share/fonts/opentype"
-    install -D -m 644 *.ttf -t "$out/share/fonts/truetype"
-    install -D -m 644 *.otb -t "$out/share/fonts/misc"
-
-    mkfontdir "$out/share/fonts/misc"
-    mkfontscale "$out/share/fonts/truetype"
-    mkfontscale "$out/share/fonts/opentype"
-  '';
-
-  outputs = [ "out" ];
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A bitmap programming font optimized for coziness.";
     homepage = "https://github.com/slavfox/cozette";
     license = licenses.mit;

--- a/pkgs/data/fonts/creep/default.nix
+++ b/pkgs/data/fonts/creep/default.nix
@@ -1,8 +1,6 @@
-{ stdenv, fetchFromGitHub, libfaketime
-, fonttosfnt, mkfontscale
-}:
+{ lib, mkFont, fetchFromGitHub, libfaketime, fonttosfnt, mkfontscale }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "creep";
   version = "0.31";
 
@@ -14,21 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ libfaketime fonttosfnt mkfontscale ];
-
+  dontBuild = false;
   buildPhase = ''
     faketime -f "1970-01-01 00:00:01" fonttosfnt -g 2 -m 2 -o creep.otb creep.bdf
   '';
 
-  installPhase = ''
-    install -D -m644 creep.bdf "$out/share/fonts/misc/creep.bdf"
-    mkfontdir "$out/share/fonts/misc"
-    install -D -m644 creep.otb "$otb/share/fonts/misc/creep.otb"
-    mkfontdir "$otb/share/fonts/misc"
-  '';
-
-  outputs = [ "out" "otb" ];
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A pretty sweet 4px wide pixel font";
     homepage = "https://github.com/romeovs/creep";
     license = licenses.mit;

--- a/pkgs/data/fonts/crimson/default.nix
+++ b/pkgs/data/fonts/crimson/default.nix
@@ -1,19 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "crimson";
   version = "2014.10";
-in fetchzip rec {
-  name = "crimson-${version}";
 
-  url = "https://github.com/skosch/Crimson/archive/fonts-october2014.tar.gz";
-
-  postFetch = ''
-    tar -xzvf $downloadedFile --strip-components=1
-    install -m444 -Dt $out/share/fonts/opentype "Desktop Fonts/OTF/"*.otf
-    install -m444 -Dt $out/share/doc/${name}    README.md
-  '';
-
-  sha256 = "0mg65f0ydyfmb43jqr1f34njpd10w8npw15cbb7z0nxmy4nkl842";
+  src = fetchzip {
+    url = "https://github.com/skosch/Crimson/archive/fonts-october2014.tar.gz";
+    sha256 = "00b8gpfp31fb9bqpzlaql6vb82gnhy43zx0amik39pdxpbplp7ss";
+  };
 
   meta = with lib; {
     homepage = "https://aldusleaf.org/crimson.html";

--- a/pkgs/data/fonts/culmus/default.nix
+++ b/pkgs/data/fonts/culmus/default.nix
@@ -1,10 +1,15 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "culmus";
   version = "0.133";
-in fetchzip {
-  name = "culmus-${version}";
-  url = "mirror://sourceforge/culmus/culmus/${version}/culmus-${version}.tar.gz";
+
+  src = fetchzip {
+    url = "mirror://sourceforge/culmus/culmus/${version}/culmus-${version}.tar.gz";
+    sha256 = "0q80j3vixn364sc23hcy6098rkgy0kb4p91lky6224am1dwn2qmr";
+  };
+
+  /*
   postFetch = ''
     tar xf $downloadedFile --strip=1
     mkdir -p $out/share/fonts/{truetype,type1}
@@ -15,7 +20,7 @@ in fetchzip {
     cp -v *.otf $out/share/fonts/truetype/
     cp -v fonts.scale-ttf $out/share/fonts/truetype/fonts.scale
   '';
-  sha256 = "0zqqjcrqmbd4389hqz2dwymkkcxjrq9ylyriiv3gbmzl6l1ffk3g";
+  */
 
   meta = {
     description = "Culmus Hebrew fonts";

--- a/pkgs/data/fonts/d2coding/default.nix
+++ b/pkgs/data/fonts/d2coding/default.nix
@@ -1,19 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
-  version = "1.3.2";
+mkFont rec {
   pname = "d2codingfont";
+  version = "1.3.2";
 
-in fetchzip {
-  name = "${pname}-${version}";
-  url = "https://github.com/naver/${pname}/releases/download/VER${version}/D2Coding-Ver${version}-20180524.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*-all.ttc -d $out/share/fonts/truetype/
-  '';
-
-  sha256 = "1812r82530wzfki7k9cm35fy6k2lvis7j6w0w8svc784949m1wwj";
+  src = fetchzip {
+    url = "https://github.com/naver/${pname}/releases/download/VER${version}/D2Coding-Ver${version}-20180524.zip";
+    sha256 = "081qc82d5gqs0dn32fc3wb1aqiqw712jai85vznqr0wm8ils4bl8";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     description = "Monospace font with support for Korean and latin characters";

--- a/pkgs/data/fonts/dosis/default.nix
+++ b/pkgs/data/fonts/dosis/default.nix
@@ -1,19 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  name = "dosis-1.007";
+mkFont rec {
+  pname = "dosis";
+  version = "1.007";
 
-  owner = "impallari";
-  repo = "Dosis";
-  rev = "12df1e13e58768f20e0d48ff15651b703f9dd9dc";
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    find . -name '*.otf' -exec install -m444 -Dt $out/share/fonts/opentype {} \;
-    install -m444 -Dt $out/share/doc/${name} README.md FONTLOG.txt
-  '';
-
-  sha256 = "0vz25w45i8flfvppymr5h83pa2n1r37da20v7691p44018fdsdny";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Dosis";
+    rev = "12df1e13e58768f20e0d48ff15651b703f9dd9dc";
+    sha256 = "0glniyg07z5gx5gsa1ymarg2gsncjyf94wi6j9bf68v5s2w3v7md";
+  };
 
   meta = with lib; {
     description = "A very simple, rounded, sans serif family";

--- a/pkgs/data/fonts/doulos-sil/default.nix
+++ b/pkgs/data/fonts/doulos-sil/default.nix
@@ -1,31 +1,24 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "doulos-sil";
   version = "5.000";
-in
-  fetchzip rec {
-    name = "doulos-sil-${version}";
 
+  src = fetchzip {
     url = "https://software.sil.org/downloads/r/doulos/DoulosSIL-${version}.zip";
+    sha256 = "1zxkixa6is4yb8h6icmjlb3im20msw5f7mc5ihzbvzhi1k4s1ymb";
+  };
 
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+  meta = with lib; {
+    homepage = "https://software.sil.org/doulos";
+    description = "A font that provides complete support for the International Phonetic Alphabet";
+    longDescription = ''
+    This Doulos SIL font is essentially the same design as the SIL Doulos font first released by SIL in 1992. The design has been changed from the original in that it has been scaled down to be a better match with contemporary digital fonts, such as Times New Roman®. This current release is a regular typeface, with no bold or italic version available or planned. It is intended for use alongside other Times-like fonts where a range of styles (italic, bold) are not needed. Therefore, just one font is included in the Doulos SIL release: Doulos SIL Regular.
+
+    The goal for this product was to provide a single Unicode-based font family that would contain a comprehensive inventory of glyphs needed for almost any Roman- or Cyrillic-based writing system, whether used for phonetic or orthographic needs. In addition, there is provision for other characters and symbols useful to linguists. This font makes use of state-of-the-art font technologies to support complex typographic issues, such as the need to position arbitrary combinations of base glyphs and diacritics optimally.
     '';
-
-    sha256 = "04a9cr7jbw7d8llcj8xsqp9rp8w6gcgbd9sdwvi02kz7jhqa0vad";
-
-    meta = with lib; {
-      homepage = "https://software.sil.org/doulos";
-      description = "A font that provides complete support for the International Phonetic Alphabet";
-      longDescription = ''
-      This Doulos SIL font is essentially the same design as the SIL Doulos font first released by SIL in 1992. The design has been changed from the original in that it has been scaled down to be a better match with contemporary digital fonts, such as Times New Roman®. This current release is a regular typeface, with no bold or italic version available or planned. It is intended for use alongside other Times-like fonts where a range of styles (italic, bold) are not needed. Therefore, just one font is included in the Doulos SIL release: Doulos SIL Regular.
-
-      The goal for this product was to provide a single Unicode-based font family that would contain a comprehensive inventory of glyphs needed for almost any Roman- or Cyrillic-based writing system, whether used for phonetic or orthographic needs. In addition, there is provision for other characters and symbols useful to linguists. This font makes use of state-of-the-art font technologies to support complex typographic issues, such as the need to position arbitrary combinations of base glyphs and diacritics optimally.
-      '';
-      license = licenses.ofl;
-      platforms = platforms.all;
-      maintainers = [ maintainers.f--t ];
-    };
-  }
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.f--t ];
+  };
+}

--- a/pkgs/data/fonts/eb-garamond/default.nix
+++ b/pkgs/data/fonts/eb-garamond/default.nix
@@ -1,19 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "eb-garamond";
   version = "0.016";
-in fetchzip rec {
-  name = "eb-garamond-${version}";
 
-  url = "https://bitbucket.org/georgd/eb-garamond/downloads/EBGaramond-${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.otf                                          -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*Changes \*README.markdown \*README.xelualatex -d "$out/share/doc/${name}"
-  '';
-
-  sha256 = "04jq4mpln85zzbla8ybsjw7vn9qr3r0snmk5zykrm24imq7ripv3";
+  src = fetchzip {
+    url = "https://bitbucket.org/georgd/eb-garamond/downloads/EBGaramond-${version}.zip";
+    sha256 = "0j40bg1di39q7zis64il67xchldyznrl8wij9il10c4wr8nl4r9z";
+  };
 
   meta = with lib; {
     homepage = "http://www.georgduffner.at/ebgaramond/";

--- a/pkgs/data/fonts/emacs-all-the-icons-fonts/default.nix
+++ b/pkgs/data/fonts/emacs-all-the-icons-fonts/default.nix
@@ -1,18 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "emacs-all-the-icons-fonts";
   version = "3.2.0";
-in fetchzip {
-  name = "emacs-all-the-icons-fonts-${version}";
 
-  url = "https://github.com/domtronn/all-the-icons.el/archive/${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/all-the-icons
-  '';
-
-  sha256 = "0ps8q9nkx67ivgn8na4s012360v36jwr0951rsg7j6dyyw9g41jq";
+  src = fetchzip {
+    url = "https://github.com/domtronn/all-the-icons.el/archive/${version}.zip";
+    sha256 = "1sdl33117lccznj38021lwcdnpi9nxmym295q6y460y4dm4lx0jn";
+  };
 
   meta = with lib; {
     description = "Icon fonts for emacs all-the-icons";
@@ -22,13 +17,7 @@ in fetchzip {
       the fonts needed to make the package work properly.
     '';
     homepage = "https://github.com/domtronn/all-the-icons.el";
-
-    /*
-    The fonts come under a mixture of licenses - the MIT license,
-    SIL OFL license, and Apache license v2.0. See the GitHub page
-    for further information.
-    */
-    license = licenses.free;
+    license = licenses.free; # MIT, SIL OFL, and Apache v2.0
     platforms = platforms.all;
     maintainers = with maintainers; [ rlupton20 ];
   };

--- a/pkgs/data/fonts/encode-sans/default.nix
+++ b/pkgs/data/fonts/encode-sans/default.nix
@@ -1,17 +1,15 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchFromGitHub }:
 
-fetchzip rec {
-  name = "encode-sans-1.002";
+mkFont {
+  pname = "encode-sans";
+  version = "1.002";
 
-  url = "https://github.com/impallari/Encode-Sans/archive/11162b46892d20f55bd42a00b48cbf06b5871f75.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf                    -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*README.md \*FONTLOG.txt -d "$out/share/doc/${name}"
-  '';
-
-  sha256 = "16mx894zqlwrhnp4rflgayxhxppmsj6k7haxdngajhb30rlwf08p";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Encode-Sans";
+    rev = "11162b46892d20f55bd42a00b48cbf06b5871f75";
+    sha256 = "1v5k79qlsl6nggilmjw56axwwr2b3838x6vqch4lh0dck5ri9w2c";
+  };
 
   meta = with lib; {
     description = "A versatile sans serif font family";

--- a/pkgs/data/fonts/envypn-font/default.nix
+++ b/pkgs/data/fonts/envypn-font/default.nix
@@ -1,20 +1,17 @@
-{ stdenv, fetchurl, libfaketime
-, fonttosfnt, mkfontscale
-}:
+{ lib, mkFont, fetchurl, libfaketime , fonttosfnt }:
 
-stdenv.mkDerivation {
-  name = "envypn-font-1.7.1";
+mkFont {
+  pname = "envypn-font";
+  version = "1.7.1";
 
   src = fetchurl {
     url = "https://ywstd.fr/files/p/envypn-font/envypn-font-1.7.1.tar.gz";
     sha256 = "bda67b6bc6d5d871a4d46565d4126729dfb8a0de9611dae6c68132a7b7db1270";
   };
 
-  nativeBuildInputs = [ libfaketime fonttosfnt mkfontscale ];
+  nativeBuildInputs = [ libfaketime fonttosfnt ];
 
-  unpackPhase = ''
-    tar -xzf $src --strip-components=1
-  '';
+  dontBuild = false;
 
   buildPhase = ''
     # convert pcf fonts to otb
@@ -24,16 +21,7 @@ stdenv.mkDerivation {
     done
   '';
 
-  installPhase = ''
-    install -D -m 644 -t "$out/share/fonts/misc" *.pcf.gz
-    install -D -m 644 -t "$otb/share/fonts/misc" *.otb
-    mkfontdir "$out/share/fonts/misc"
-    mkfontdir "$otb/share/fonts/misc"
-  '';
-
-  outputs = [ "out" "otb" ];
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = ''
       Readable bitmap font inspired by Envy Code R
     '';

--- a/pkgs/data/fonts/et-book/default.nix
+++ b/pkgs/data/fonts/et-book/default.nix
@@ -1,20 +1,19 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, mkFont, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  rev = "7e8f02dadcc23ba42b491b39e5bdf16e7b383031";
-  name = "et-book-${builtins.substring 0 6 rev}";
-  owner = "edwardtufte";
-  repo = "et-book";
-  sha256 = "1bfb1l8k7fzgk2l8cikiyfn5x9m0fiwrnsbc1483p8w3qp58s5n2";
+mkFont {
+  pname = "et-book";
+  version = "2015-10-05";
 
-  postFetch = ''
-    tar -xzf $downloadedFile
-    mkdir -p $out/share/fonts/truetype
-    cp -t $out/share/fonts/truetype et-book-${rev}/source/4-ttf/*.ttf
-  '';
+  src = fetchFromGitHub rec {
+    owner = "edwardtufte";
+    repo = "et-book";
+    rev = "7e8f02dadcc23ba42b491b39e5bdf16e7b383031";
+    sha256 = "16n6pid29m64bsrlgm7wbylz0wa89c7zyhijy5s8ldlvv05z5ah7";
+  };
 
   meta = with stdenv.lib; {
     description = "The typeface used in Edward Tufte’s books.";
+    homepage = "https://github.com/edwardtufte/et-book";
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = with maintainers; [ jethro ];

--- a/pkgs/data/fonts/eunomia/default.nix
+++ b/pkgs/data/fonts/eunomia/default.nix
@@ -1,24 +1,17 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
-  majorVersion = "0";
-  minorVersion = "200";
+mkFont rec {
   pname = "eunomia";
-in
+  version = "0.200";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
-
-  url = "http://dotcolon.net/DL/font/${pname}_${majorVersion}${minorVersion}.zip";
-  sha256 = "0lpmczs1d4p9dy4s0dnvv7bl5cd0f6yzyasfrkxij5s86glps38b";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
-  '';
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${pname}_${lib.replaceStrings ["."] [""] version}.zip";
+    sha256 = "0vhl46s8n5h5r71ghz05jn0dgxl3w1sb8d2x27l3qnlk8rm89pa5";
+    stripRoot = false;
+  };
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/eunomia/";
+    homepage = "https://dotcolon.net/font/eunomia/";
     description = "A futuristic decorative font.";
     platforms = platforms.all;
     maintainers = with maintainers; [ leenaars ];

--- a/pkgs/data/fonts/f5_6/default.nix
+++ b/pkgs/data/fonts/f5_6/default.nix
@@ -1,21 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
-  majorVersion = "0";
-  minorVersion = "110";
+mkFont rec {
   pname = "f5_6";
-in
+  version = "0.110";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
-
-  url = "http://dotcolon.net/DL/font/${pname}_${majorVersion}${minorVersion}.zip";
-  sha256 = "04p6lccd26rhjbpq3ddxi5vkk3lk8lqbpnk8lakjzixp3fgdqpp4";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
-  '';
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${pname}_${lib.replaceStrings ["."] [""] version}.zip";
+    sha256 = "1qfykpdhd8br9yrg4icn7wdfj6wysijyyj1cnswj7lnidkx99q0m";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";

--- a/pkgs/data/fonts/fantasque-sans-mono/default.nix
+++ b/pkgs/data/fonts/fantasque-sans-mono/default.nix
@@ -1,21 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "fantasque-sans-mono";
   version = "1.8.0";
-in
 
-fetchzip rec {
-  name = "fantasque-sans-mono-${version}";
-
-  url = "https://github.com/belluzj/fantasque-sans/releases/download/v${version}/FantasqueSansMono-Normal.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.otf    -d $out/share/fonts/opentype
-    unzip -j $downloadedFile README.md -d $out/share/doc/${name}
-  '';
-
-  sha256 = "07y2w6xzkbaj6vr95fvvnmwq1pw9jib4z02xf8937dx812yic9ni";
+  src = fetchzip {
+    url = "https://github.com/belluzj/fantasque-sans/releases/download/v${version}/FantasqueSansMono-Normal.zip";
+    sha256 = "0msql67gndixnw3pvhb1c5kfzbg9ylqh15bi3mbqrnz26fhdkm9h";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/belluzj/fantasque-sans";

--- a/pkgs/data/fonts/ferrum/default.nix
+++ b/pkgs/data/fonts/ferrum/default.nix
@@ -1,21 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
-  majorVersion = "0";
-  minorVersion = "200";
+mkFont rec {
   pname = "ferrum";
-in
+  version = "0.200";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
-
-  url = "http://dotcolon.net/DL/font/${pname}.zip";
-  sha256 = "1w1b3ch7ik4264f05lxms01ls0aargvlx770a9szm682dfmizn8w";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
-  '';
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${pname}_${lib.replaceStrings ["."] [""] version}.zip";
+    sha256 = "11s0fdiv313hfjvpgfx31q9jcslpg679amk4j162i0wran070cil";
+  };
 
   meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";

--- a/pkgs/data/fonts/fira-code/default.nix
+++ b/pkgs/data/fonts/fira-code/default.nix
@@ -1,18 +1,14 @@
-{ stdenv, fetchzip }:
+{ stdenv, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "fira-code";
   version = "5.2";
-in fetchzip {
-  name = "fira-code-${version}";
 
-  url = "https://github.com/tonsky/FiraCode/releases/download/${version}/Fira_Code_v${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
-
-  sha256 = "16v62wj872ba4w7qxn4l6zjgqh7lrpwh1xax1bp1x9dpz08mnq06";
+  src = fetchzip {
+    url = "https://github.com/tonsky/FiraCode/releases/download/${version}/Fira_Code_v${version}.zip";
+    sha256 = "0dqy6w55jq542v11d0b2kjwvch9pp66p2y5s27dwl1z028ckhmfy";
+    stripRoot = false;
+  };
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/tonsky/FiraCode";

--- a/pkgs/data/fonts/fira-code/symbols.nix
+++ b/pkgs/data/fonts/fira-code/symbols.nix
@@ -1,16 +1,13 @@
-{ stdenv, fetchzip }:
+{ stdenv, mkFont, fetchzip }:
 
-fetchzip {
-  name = "fira-code-symbols-20160811";
+mkFont rec {
+  pname = "fira-code-symbols";
+  version = "20160811";
 
-  url = "https://github.com/tonsky/FiraCode/files/412440/FiraCode-Regular-Symbol.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile -d $out/share/fonts/opentype
-  '';
-
-  sha256 = "19krsp22rin74ix0i19v4bh1c965g18xkmz1n55h6n6qimisnbkm";
+  src = fetchzip {
+    url = "https://github.com/tonsky/FiraCode/files/412440/FiraCode-Regular-Symbol.zip";
+    sha256 = "1bi118v4ga13ja88a27zamyjv66c7jnv9wmcy4gypl17a5p7abpg";
+  };
 
   meta = with stdenv.lib; {
     description = "FiraCode unicode ligature glyphs in private use area";

--- a/pkgs/data/fonts/fira/default.nix
+++ b/pkgs/data/fonts/fira/default.nix
@@ -1,21 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
+  pname = "fira";
   version = "4.202";
-in fetchFromGitHub {
-  name = "fira-${version}";
 
-  owner = "mozilla";
-  repo = "Fira";
-  rev = version;
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    mkdir -p $out/share/fonts/opentype
-    cp otf/*.otf $out/share/fonts/opentype
-  '';
-
-  sha256 = "1iwxbp7kw5kghh5nbycb05zby7p2ib61mywva3h6giv2wd4lpxnz";
+  src = fetchFromGitHub {
+    owner = "mozilla";
+    repo = "Fira";
+    rev = version;
+    sha256 = "116j26gdj5g1r124b4669372f7490vfjqw7apiwp2ggl0am5xd0w";
+  };
 
   meta = with lib; {
     homepage = "https://mozilla.github.io/Fira/";

--- a/pkgs/data/fonts/fixedsys-excelsior/default.nix
+++ b/pkgs/data/fonts/fixedsys-excelsior/default.nix
@@ -1,30 +1,25 @@
-{ stdenv, fetchurl } :
+{ lib, mkFont, fetchurl } :
 
-let
-  major = "3";
-  minor = "00";
-  version = "${major}.${minor}";
-in fetchurl rec {
-  name = "fixedsys-excelsior-${version}";
+mkFont rec {
+  pname = "fixedsys-excelsior";
+  version = "3.00";
 
-  urls = [
-    "http://www.fixedsysexcelsior.com/fonts/FSEX300.ttf"
-    "https://raw.githubusercontent.com/chrissimpkins/codeface/master/fonts/fixed-sys-excelsior/FSEX300.ttf"
-    "http://tarballs.nixos.org/sha256/6ee0f3573bc5e33e93b616ef6282f49bc0e227a31aa753ac76ed2e3f3d02056d"
-  ];
-  downloadToTemp = true;
-  recursiveHash = true;
-  postFetch = ''
-    install -m444 -D $downloadedFile $out/share/fonts/truetype/${name}.ttf
-  '';
+  src = fetchurl {
+    urls = [
+      "http://www.fixedsysexcelsior.com/fonts/FSEX300.ttf"
+      "https://raw.githubusercontent.com/chrissimpkins/codeface/master/fonts/fixed-sys-excelsior/FSEX300.ttf"
+      "http://tarballs.nixos.org/sha256/6ee0f3573bc5e33e93b616ef6282f49bc0e227a31aa753ac76ed2e3f3d02056d"
+    ];
+    sha256 = "0v8508ykybpdfsn579qslcky5h4vyj165vqnns9kxqy57dbz7q3f";
+  };
 
-  sha256 = "32d6f07f1ff08c764357f8478892b2ba5ade23427af99759f34a0ba24bcd2e37";
+  noUnpackFonts = true;
 
-  meta = {
+  meta = with lib; {
     description = "Pan-unicode version of Fixedsys, a classic DOS font.";
     homepage = "http://www.fixedsysexcelsior.com/";
-    platforms = stdenv.lib.platforms.all;
-    license = stdenv.lib.licenses.publicDomain;
-    maintainers = [ stdenv.lib.maintainers.ninjatrappeur ];
+    platforms = platforms.all;
+    license = licenses.publicDomain;
+    maintainers = with maintainers; [ ninjatrappeur ];
   };
 }

--- a/pkgs/data/fonts/freefont-ttf/default.nix
+++ b/pkgs/data/fonts/freefont-ttf/default.nix
@@ -1,16 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-fetchzip rec {
-  name = "freefont-ttf-20120503";
+mkFont rec {
+  pname = "freefont-ttf";
+  version = "20120503";
 
-  url = "mirror://gnu/freefont/${name}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
-
-  sha256 = "0h0x2hhr7kvjiycf7fv800xxwa6hcpiz54bqx06wsqc7z61iklvd";
+  src = fetchzip {
+    url = "mirror://gnu/freefont/${pname}-${version}.zip";
+    sha256 = "02rdzifgz46hfibppn6kfwx1w41410dsirvmm62sjd237701hvpf";
+    stripRoot = false;
+  };
 
   meta = {
     description = "GNU Free UCS Outline Fonts";

--- a/pkgs/data/fonts/gandom-fonts/default.nix
+++ b/pkgs/data/fonts/gandom-fonts/default.nix
@@ -1,19 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "gandom-fonts";
   version = "0.6";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "rastikerdar";
-  repo = "gandom-font";
-  rev = "v${version}";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/gandom-fonts {} \;
-  '';
-  sha256 = "0zsq6s9ziyb5jz0v8aj00dlxd1aly0ibxgszd05dfvykmgz051lc";
+  src = fetchFromGitHub  {
+    owner = "rastikerdar";
+    repo = "gandom-font";
+    rev = "v${version}";
+    sha256 = "1pdbqhvcsz6aq3qgarhfd05ip0wmh7bxqkmxrwa0kgxsly6zxz9x";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/gandom-font";

--- a/pkgs/data/fonts/gelasio/default.nix
+++ b/pkgs/data/fonts/gelasio/default.nix
@@ -1,19 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont {
+  pname = "gelasio";
   version = "unstable-2018-08-12";
-in fetchFromGitHub {
-  name = "gelasio-${version}";
-  owner = "SorkinType";
-  repo = "Gelasio";
-  rev = "5bced461d54bcf8e900bb3ba69455af35b0d2ff1";
-  sha256 = "0dfskz2vpwsmd88rxqsxf0f01g4f2hm6073afcm424x5gc297n39";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype/
-  '';
+  src = fetchFromGitHub {
+    owner = "SorkinType";
+    repo = "Gelasio";
+    rev = "5bced461d54bcf8e900bb3ba69455af35b0d2ff1";
+    sha256 = "19vmdi9zy5rs52mwwwi88kcgpfnwqyz12kw19bz5hfwzjrr7jdsn";
+  };
 
   meta = with lib; {
     description = "a font which is metric-compatible with Microsoft's Georgia";

--- a/pkgs/data/fonts/gentium-book-basic/default.nix
+++ b/pkgs/data/fonts/gentium-book-basic/default.nix
@@ -1,21 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
-  major = "1";
-  minor = "102";
-  version = "${major}.${minor}";
-in fetchzip rec {
-  name = "gentium-book-basic-${version}";
+mkFont rec {
+  pname = "gentium-book-basic";
+  version = "1.102";
 
-  url = "http://software.sil.org/downloads/r/gentium/GentiumBasic_${major}${minor}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf                            -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*/FONTLOG.txt \*/GENTIUM-FAQ.txt -d $out/share/doc/${name}
-  '';
-
-  sha256 = "0598zr5f7d6ll48pbfbmmkrybhhdks9b2g3m2g67wm40070ffzmd";
+  src = fetchzip {
+    url = "http://software.sil.org/downloads/r/gentium/GentiumBasic_${lib.replaceStrings ["."] [""] version}.zip";
+    sha256 = "109yiqwdfb1bn7d6bjp8d50k1h3z3kz86p3faz11f9acvsbsjad0";
+  };
 
   meta = with lib; {
     homepage = "https://software.sil.org/gentium/";

--- a/pkgs/data/fonts/gentium/default.nix
+++ b/pkgs/data/fonts/gentium/default.nix
@@ -1,21 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "gentium";
   version = "5.000";
-in fetchzip rec {
-  name = "gentium-${version}";
 
-  url = "http://software.sil.org/downloads/r/gentium/GentiumPlus-${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -l $downloadedFile
-    unzip -j $downloadedFile \*.ttf                                          -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*/FONTLOG.txt \*/GENTIUM-FAQ.txt \*/README.txt -d $out/share/doc/${name}
-    unzip -j $downloadedFile \*/documentation/\*                             -d $out/share/doc/${name}/documentation
-  '';
-
-  sha256 = "1qr2wjdmm93167b0w9cidlf3wwsyjx4838ja9jmm4jkyian5whhp";
+  src = fetchzip {
+    url = "http://software.sil.org/downloads/r/gentium/GentiumPlus-${version}.zip";
+    sha256 = "0g9sx38wh7f0m16gr64g2xggjwak2q6jw9y4zhrvhmp4aq4xfqm6";
+  };
 
   meta = with lib; {
     homepage = "https://software.sil.org/gentium/";

--- a/pkgs/data/fonts/go-font/default.nix
+++ b/pkgs/data/fonts/go-font/default.nix
@@ -1,22 +1,15 @@
-{ stdenv, fetchgit }:
+{ stdenv, mkFont, fetchgit }:
 
-let
+mkFont {
+  pname = "go-font";
   version = "2017-03-30";
-in (fetchgit {
-  name = "go-font-${version}";
-  url = "https://go.googlesource.com/image";
-  rev = "f03a046406d4d7fbfd4ed29f554da8f6114049fc";
 
-  postFetch = ''
-    mv $out/* .
-    mkdir -p $out/share/fonts/truetype
-    mkdir -p $out/share/doc/go-font
-    cp font/gofont/ttfs/* $out/share/fonts/truetype
-    mv $out/share/fonts/truetype/README $out/share/doc/go-font/LICENSE
-  '';
+  src = fetchgit {
+    url = "https://go.googlesource.com/image";
+    rev = "f03a046406d4d7fbfd4ed29f554da8f6114049fc";
+    sha256 = "1aq6mnjayks55gd9ahavk6jfydlq5lm4xm0xk4pd5sqa74p5p74d";
+  };
 
-  sha256 = "1488426ya2nzmwjas947fx9h5wzxrp9wasn8nkjqf0y0mpd4f1xz";
-}) // {
   meta = with stdenv.lib; {
     homepage = "https://blog.golang.org/go-fonts";
     description = "The Go font family";

--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-stdenv.mkDerivation {
+mkFont {
   pname = "google-fonts";
   version = "2019-07-14";
 
@@ -10,8 +10,6 @@ stdenv.mkDerivation {
     rev = "f113126dc4b9b1473d9354a86129c9d7b837aa1a";
     sha256 = "0safw5prpa63mqcyfw3gr3a535w4c9hg5ayw5pkppiwil7n3pyxs";
   };
-
-  phases = [ "unpackPhase" "patchPhase" "installPhase" ];
 
   patchPhase = ''
     # These directories need to be removed because they contain
@@ -38,12 +36,7 @@ stdenv.mkDerivation {
     fi
   '';
 
-  installPhase = ''
-    dest=$out/share/fonts/truetype
-    find . -name '*.ttf' -exec install -m 444 -Dt $dest '{}' +
-  '';
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://fonts.google.com";
     description = "Font files available from Google Fonts";
     license = with licenses; [ asl20 ofl ufl ];

--- a/pkgs/data/fonts/gubbi/default.nix
+++ b/pkgs/data/fonts/gubbi/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, fontforge }:
+{ lib, mkFont, fetchFromGitHub, fontforge }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "gubbi-font";
   version = "1.3";
 
@@ -12,14 +12,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ fontforge ];
-
-  dontConfigure = true;
-
+  dontBuild = false;
   preBuild = "patchShebangs generate.pe";
 
-  installPhase = "install -Dm444 -t $out/share/fonts/truetype/ Gubbi.ttf";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     inherit (src.meta) homepage;
     description = "A Kannada font";
     license = licenses.gpl3Plus;

--- a/pkgs/data/fonts/gyre/default.nix
+++ b/pkgs/data/fonts/gyre/default.nix
@@ -1,19 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
-  baseName = "gyre-fonts";
+mkFont rec {
+  pname = "gyre-fonts";
   version = "2.005";
-in fetchzip {
-  name="${baseName}-${version}";
 
-  url = "http://www.gust.org.pl/projects/e-foundry/tex-gyre/whole/tg-${version}otf.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/truetype
-  '';
-
-  sha256 = "17amdpahs6kn7hk3dqxpff1s095cg1caxzij3mxjbbxp8zy0l111";
+  src = fetchzip {
+    url = "http://www.gust.org.pl/projects/e-foundry/tex-gyre/whole/tg-${version}otf.zip";
+    sha256 = "0f1sxvghy3zcshci2d6hma213n2hqxbkwi46bq5qmy2zw5z2x8pv";
+    stripRoot = false;
+  };
 
   meta = {
     description = "OpenType fonts from the Gyre project, suitable for use with (La)TeX";

--- a/pkgs/data/fonts/hack/default.nix
+++ b/pkgs/data/fonts/hack/default.nix
@@ -1,18 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "hack-font";
   version = "3.003";
-in fetchzip {
-  name = "hack-font-${version}";
 
-  url = "https://github.com/chrissimpkins/Hack/releases/download/v${version}/Hack-v${version}-ttf.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/hack
-  '';
-
-  sha256 = "1l6ih6v7dqali5c7zh6z2xnbf9h2wz0ag6fdgszmqd5lnhw39v6s";
+  src = fetchzip {
+    url = "https://github.com/chrissimpkins/Hack/releases/download/v${version}/Hack-v${version}-ttf.zip";
+    sha256 = "04qmmgq3m203a7hwnggyvxd779qmmqm9w56i5zyvys3xia8ph4ab";
+  };
 
   meta = with lib; {
     description = "A typeface designed for source code";

--- a/pkgs/data/fonts/hanazono/default.nix
+++ b/pkgs/data/fonts/hanazono/default.nix
@@ -1,19 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "hanazono";
   version = "20170904";
-in fetchzip {
-  name = "hanazono-${version}";
 
-  url = "mirror://osdn/hanazono-font/68253/hanazono-${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.txt -d $out/share/doc/hanazono
-  '';
-
-  sha256 = "0qiyd1vk3w8kqmwc6xi5d390wdr4ln8xhfbx3n8r1hhad9iz14p6";
+  src = fetchzip {
+    url = "mirror://osdn/hanazono-font/68253/hanazono-${version}.zip";
+    sha256 = "0m8gf4afbkrxf8cw7ca2fh5g2y9q48153gmh9y5i27170kijmpd9";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     description = "Japanese Mincho-typeface TrueType font";

--- a/pkgs/data/fonts/hasklig/default.nix
+++ b/pkgs/data/fonts/hasklig/default.nix
@@ -1,18 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "hasklig";
   version = "1.1";
-in fetchzip {
-  name = "hasklig-${version}";
 
-  url = "https://github.com/i-tu/Hasklig/releases/download/${version}/Hasklig-${version}.zip";
-
-  postFetch = ''
-    unzip $downloadedFile
-    install -m444 -Dt $out/share/fonts/opentype *.otf
-  '';
-
-  sha256 = "0xxyx0nkapviqaqmf3b610nq17k20afirvc72l32pfspsbxz8ybq";
+  src = fetchzip {
+    url = "https://github.com/i-tu/Hasklig/releases/download/${version}/Hasklig-${version}.zip";
+    sha256 = "0jmjgy3y5sj6d8nqq1ap5hnpkbcsgpbdahcbny7wg04y7fvd1hwf";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/i-tu/Hasklig";

--- a/pkgs/data/fonts/helvetica-neue-lt-std/default.nix
+++ b/pkgs/data/fonts/helvetica-neue-lt-std/default.nix
@@ -1,18 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
-  version = "2013.06.07"; # date of most recent file in distribution
-in fetchzip {
-  name = "helvetica-neue-lt-std-${version}";
+mkFont {
+  pname = "helvetica-neue-lt-std";
+  version = "2013-06-07";
 
-  url = "http://www.ephifonts.com/downloads/helvetica-neue-lt-std.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile Helvetica\ Neue\ LT\ Std/\*.otf -d $out/share/fonts/opentype
-  '';
-
-  sha256 = "0ampp9vf9xw0sdppl4lb9i9h75ywljhdcqmzh45mx2x9m7h6xgg9";
+  src = fetchzip {
+    url = "http://www.ephifonts.com/downloads/helvetica-neue-lt-std.zip";
+    sha256 = "14nmv495fbzy3jqivk2nbssvw2j40cpca4zqqd65jdzhp5717nna";
+    stripRoot = false;
+  };
 
   meta = {
     homepage = "http://www.ephifonts.com/free-helvetica-font-helvetica-neue-lt-std.html";

--- a/pkgs/data/fonts/hermit/default.nix
+++ b/pkgs/data/fonts/hermit/default.nix
@@ -1,18 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
   pname = "hermit";
   version = "2.0";
-in fetchzip rec {
-  name = "${pname}-${version}";
 
-  url = "https://pcaro.es/d/otf-${name}.tar.gz";
-
-  postFetch = ''
-    tar xf $downloadedFile
-    install -m444 -Dt $out/share/fonts/opentype *.otf
-  '';
-  sha256 = "127hnpxicqya7v1wmzxxqafq3aj1n33i4j5ncflbw6gj5g3bizwl";
+  src = fetchzip {
+    url = "https://pcaro.es/d/otf-${pname}-${version}.tar.gz";
+    sha256 = "0r2r692332x34mlgcc74dmc6fhw3zdy8ac71h5n8q13w4bdxk1a5";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     description = "monospace font designed to be clear, pragmatic and very readable";

--- a/pkgs/data/fonts/hyperscrypt/default.nix
+++ b/pkgs/data/fonts/hyperscrypt/default.nix
@@ -1,19 +1,13 @@
-{ fetchzip, lib }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "hyperscrypt-font";
   version = "1.1";
-  pname = "HyperScrypt";
-in
 
-fetchzip {
-  name = "${lib.toLower pname}-font-${version}";
-  url = "https://gitlab.com/StudioTriple/Hyper-Scrypt/-/archive/${version}/Hyper-Scrypt-${version}.zip";
-  sha256 = "01pf5p2scmw02s0gxnibiwxbpzczphaaapv0v4s7svk9aw2gmc0m";
-  postFetch = ''
-    mkdir -p $out/share/fonts/{truetype,opentype}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/${pname}.ttf
-    unzip -j $downloadedFile \*${pname}.otf -d $out/share/fonts/opentype/${pname}.otf
-  '';
+  src = fetchzip {
+    url = "https://gitlab.com/StudioTriple/Hyper-Scrypt/-/archive/${version}/Hyper-Scrypt-${version}.zip";
+    sha256 = "1swxk5qhr3g9l8kkbpahx7l15f8jk1q8i6k35ax846dzs03l1n9q";
+  };
 
   meta = with lib; {
     homepage = "http://velvetyne.fr/fonts/hyper-scrypt/";

--- a/pkgs/data/fonts/ia-writer-duospace/default.nix
+++ b/pkgs/data/fonts/ia-writer-duospace/default.nix
@@ -1,20 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont {
+  pname = "ia-writer-duospace";
   version = "20180721";
-in fetchFromGitHub {
-  name = "ia-writer-duospace-${version}";
 
-  owner = "iaolo";
-  repo = "iA-Fonts";
-  rev = "55edf60f544078ab1e14987bc67e9029a200e0eb";
-  sha256 = "0932lcxf861vb3hz52z1xj8r99ag9sdyqsnq9brv7gc4kp2l339c";
-
-  postFetch = ''
-    tar --strip-components=1 -xzvf $downloadedFile
-    mkdir -p $out/share/fonts/opentype
-    cp "iA Writer Duospace/OTF (Mac)/"*.otf $out/share/fonts/opentype/
-  '';
+  src = fetchFromGitHub {
+    owner = "iaolo";
+    repo = "iA-Fonts";
+    rev = "55edf60f544078ab1e14987bc67e9029a200e0eb";
+    sha256 = "1582n676gbwjrblmcshyb1x9rc02njf84j1ija2vnb084wwz69zy";
+  };
 
   meta = with lib; {
     description = "iA Writer Duospace Typeface";

--- a/pkgs/data/fonts/ibm-plex/default.nix
+++ b/pkgs/data/fonts/ibm-plex/default.nix
@@ -1,19 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "ibm-plex";
   version = "5.0.0";
 
-in fetchzip {
-  name = "ibm-plex-${version}";
-
-  url = "https://github.com/IBM/plex/releases/download/v${version}/OpenType.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile "OpenType/*/*.otf" -d $out/share/fonts/opentype
-  '';
-
-  sha256 = "1m8a9p0bryrj05v7sg9kqvyp0ddhgdwd0zjbn0i4l296cj5s2k97";
+  src = fetchzip {
+    url = "https://github.com/IBM/plex/releases/download/v${version}/OpenType.zip";
+    sha256 = "0bp4xlg7w2kvivn8sr2dfclfdm8xgdhgc7nx2lfahllx5zj1rjyg";
+  };
 
   meta = with lib; {
     description = "IBM Plex Typeface";

--- a/pkgs/data/fonts/inconsolata/lgc.nix
+++ b/pkgs/data/fonts/inconsolata/lgc.nix
@@ -1,6 +1,6 @@
-{stdenv, fetchFromGitHub, fontforge}:
+{ stdenv, mkFont, fetchFromGitHub, fontforge }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "inconsolata-lgc";
   version = "1.3";
 
@@ -12,12 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ fontforge ];
-
-  installPhase = ''
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/truetype {} \;
-    find . -name '*.otf' -exec install -m444 -Dt $out/share/fonts/opentype {} \;
-    install -m444 -Dt $out/share/doc/${pname}-${version} LICENSE README
-  '';
+  dontBuild = false;
 
   meta = with stdenv.lib; {
     description = "Fork of Inconsolata font, with proper support of Cyrillic and Greek";

--- a/pkgs/data/fonts/input-fonts/default.nix
+++ b/pkgs/data/fonts/input-fonts/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, requireFile, unzip }:
+{ lib, mkFont, requireFile, unzip }:
 
-stdenv.mkDerivation {
+mkFont {
   pname = "input-fonts";
   version = "2019-11-25"; # date of the download and checksum
 
@@ -11,23 +11,9 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ unzip ];
-
-  phases = [ "unpackPhase" "installPhase" ];
-
   sourceRoot = ".";
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    find Input_Fonts -name "*.ttf" -exec cp -a {} "$out"/share/fonts/truetype/ \;
-    mkdir -p "$out"/share/doc
-    cp -a *.txt "$out"/share/doc/
-  '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "15sdhqqqd4jgk80fw7ncx49avi9cxbdgyrvnrfya0066x4q4r6lv";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Fonts for Code, from Font Bureau";
     longDescription = ''
       Input is a font family designed for computer programming, data,

--- a/pkgs/data/fonts/inriafonts/default.nix
+++ b/pkgs/data/fonts/inriafonts/default.nix
@@ -1,20 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "inriafonts";
   version = "1.200";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "BlackFoundry";
-  repo = "InriaFonts";
-  rev = "v${version}";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -m444 -Dt $out/share/fonts/truetype fonts/*/TTF/*.ttf
-    install -m444 -Dt $out/share/fonts/opentype fonts/*/OTF/*.otf
-  '';
-  sha256 = "0wrwcyycyzvgvgnlmwi1ncdvwb8f6bbclynd1105rsyxgrz5dd70";
+  src = fetchFromGitHub {
+    owner = "BlackFoundry";
+    repo = "InriaFonts";
+    rev = "v${version}";
+    sha256 = "06775y99lyh6hj5hzvrx56iybdck8a8xfqkipqd5c4cldg0a9hh8";
+  };
 
   meta = with lib; {
     homepage = "https://black-foundry.com/work/inria";

--- a/pkgs/data/fonts/iosevka/bin.nix
+++ b/pkgs/data/fonts/iosevka/bin.nix
@@ -1,18 +1,14 @@
-{ stdenv, fetchzip }:
+{ stdenv, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "iosevka-bin";
   version = "2.3.3";
-in fetchzip {
-  name = "iosevka-bin-${version}";
 
-  url = "https://github.com/be5invis/Iosevka/releases/download/v${version}/ttc-iosevka-${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttc -d $out/share/fonts/iosevka
-  '';
-
-  sha256 = "1dfm1888rii5kfmkxp5hnx8ycji57cbs5gazpgkxg1mnmn7i35wl";
+  src = fetchzip {
+    url = "https://github.com/be5invis/Iosevka/releases/download/v${version}/ttc-iosevka-${version}.zip";
+    sha256 = "1drni30kjcsfz3rfflkk8nqrj0yklsx467knpwqsg69683848fld";
+    stripRoot = false;
+  };
 
   meta = with stdenv.lib; {
     homepage = "https://be5invis.github.io/Iosevka/";

--- a/pkgs/data/fonts/ipaexfont/default.nix
+++ b/pkgs/data/fonts/ipaexfont/default.nix
@@ -1,16 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-fetchzip {
-  name = "ipaexfont-003.01";
+mkFont {
+  pname = "ipaexfont";
+  version = "003.01";
 
-  url = "http://web.archive.org/web/20160616003021/http://dl.ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/opentype
-  '';
-
-  sha256 = "02a6sj990cnig5lq0m54nmbmfkr3s57jpxl9fiyzrjmigvd1qmhj";
+  src = fetchzip {
+    url = "http://web.archive.org/web/20160616003021/http://dl.ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip";
+    sha256 = "1dh8vir0hzq0149xh7cka1wbvdb9arq56n1f0i8xkxivf84744kk";
+  };
 
   meta = with lib; {
     description = "Japanese font package with Mincho and Gothic fonts";

--- a/pkgs/data/fonts/ipafont/default.nix
+++ b/pkgs/data/fonts/ipafont/default.nix
@@ -3,6 +3,8 @@
 fetchzip {
   name = "ipafont-003.03";
 
+  # 2020-06-17: this link results in a 404 error, and the file does not seem
+  # to be available from the homepage anymore.
   url = "http://ipafont.ipa.go.jp/old/ipafont/IPAfont00303.php";
 
   postFetch = ''

--- a/pkgs/data/fonts/ir-standard-fonts/default.nix
+++ b/pkgs/data/fonts/ir-standard-fonts/default.nix
@@ -1,19 +1,13 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
   pname = "ir-standard-fonts";
-  version = "unstable-2017-01-21";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "morealaz";
-  repo = pname;
-  rev = "d36727d6c38c23c01b3074565667a2fe231fe18f";
+  version = "20170121";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/ir-standard-fonts {} \;
-  '';
-  sha256 = "0i2vzhwk77pm6fx5z5gxl026z9f35rhh3cvl003mry2lcg1x5rhp";
+  src = fetchzip {
+    url = "https://github.com/molaeiali/ir-standard-fonts/archive/${version}.zip";
+    sha256 = "0p8dlk859dqm3qif4h6kn4v8nbs5i7zkhy38x3hgx7gp2m47qmx3";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/morealaz/ir-standard-fonts";

--- a/pkgs/data/fonts/iwona/default.nix
+++ b/pkgs/data/fonts/iwona/default.nix
@@ -1,16 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "iwona";
   version = "0_995";
-in fetchzip {
-  name = "iwona-${version}";
-  url = "http://jmn.pl/pliki/Iwona-otf-${version}.zip";
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -j $downloadedFile *.otf -d $out/share/fonts/opentype
-  '';
-  sha256 = "1dcpn13bd31dw7ir0s722bv3nk136dy6qsab0kznjbzfqd7agswa";
+  src = fetchzip {
+    url = "http://jmn.pl/pliki/Iwona-otf-${version}.zip";
+    sha256 = "1wj5bxbxpz5a8p3rhw708cyjc0lgqji8g0iv6brmmbrrkpb3jq2s";
+  };
 
   meta = with lib; {
     description = "A two-element sans-serif typeface, created by Małgorzata Budyta";

--- a/pkgs/data/fonts/jetbrains-mono/default.nix
+++ b/pkgs/data/fonts/jetbrains-mono/default.nix
@@ -1,22 +1,13 @@
-{ lib, fetchzip }:
+{ lib, fetchzip, mkFont }:
 
-let
+mkFont rec {
+  pname = "JetBrainsMono";
   version = "1.0.6";
-in
-fetchzip rec {
-  name = "JetBrainsMono-${version}";
 
-  url = "https://github.com/JetBrains/JetBrainsMono/releases/download/v${version}/JetBrainsMono-${version}.zip";
-
-  sha256 = "1198k5zw91g85h6n7rg3y7wcj1nrbby9zlr6zwlmiq0nb37n0d3g";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.eot -d $out/share/fonts/eot
-    unzip -j $downloadedFile \*.woff -d $out/share/fonts/woff
-    unzip -j $downloadedFile \*.woff2 -d $out/share/fonts/woff2
-  '';
+  src = fetchzip {
+    url = "https://github.com/JetBrains/JetBrainsMono/releases/download/v${version}/JetBrainsMono-${version}.zip";
+    sha256 = "1jgbc9v5j3kcbzbwgkh7pzvb99g8j0v61hbm5306a9r8xv8l0yky";
+  };
 
   meta = with lib; {
     description = "A typeface made for developers";

--- a/pkgs/data/fonts/jost/default.nix
+++ b/pkgs/data/fonts/jost/default.nix
@@ -1,19 +1,15 @@
-{stdenv, fetchzip}:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "jost";
   version = "3.5";
-in fetchzip {
-  name = "jost-${version}";
-  url = "https://github.com/indestructible-type/Jost/releases/download/${version}/Jost.zip";
 
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
+  src = fetchzip {
+    url = "https://github.com/indestructible-type/Jost/releases/download/${version}/Jost.zip";
+    sha256 = "0qw8dlycrzy3vm4yhasbygv7b209wyzcv231zick6kv6r1n3bvwx";
+  };
 
-  sha256="0l78vhmbsyfmrva5wc76pskhxqryyg8q5xddpj9g5wqsddy525dq";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/indestructible-type/Jost";
     description = "A sans serif font by Indestructible Type";
     license = licenses.ofl;

--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl }:
+{ lib, mkFont, fetchurl }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "joypixels";
   version = "5.5.0";
 
@@ -9,13 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "0w3r50l0knrncwv6zihyx01gs995y76xjcwsysx5bmvc1b43yijb";
   };
 
-  dontUnpack = true;
+  noUnpackFonts = true;
 
-  installPhase = ''
-    install -Dm644 $src $out/share/fonts/truetype/joypixels.ttf
-  '';
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Emoji as a Service (formerly EmojiOne)";
     homepage = "https://www.joypixels.com/";
     license = licenses.unfree;

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -1,19 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
   pname = "junicode";
   version = "1.002";
-in fetchzip {
-  name = "${pname}-${version}";
 
-  url = "mirror://sourceforge/junicode/junicode/junicode-${version}/junicode-${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/junicode-ttf
-  '';
-
-  sha256 = "1n170gw41lr0zr5958z5cgpg6i1aa7kj7iq9s6gdh1cqq7hhgd08";
+  src = fetchzip {
+    url = "mirror://sourceforge/junicode/junicode/junicode-${version}/junicode-${version}.zip";
+    sha256 = "1n86kxc2szdivh0nglizwdr7s8vw5pxmj6xa7fp9ql73scsrzbyn";
+    stripRoot = false;
+  };
 
   meta = {
     homepage = "http://junicode.sourceforge.net/";

--- a/pkgs/data/fonts/kanji-stroke-order-font/default.nix
+++ b/pkgs/data/fonts/kanji-stroke-order-font/default.nix
@@ -1,21 +1,17 @@
-{ stdenv, fetchzip }:
+{ lib, mkFont, fetchzip, fetchurl, unzip }:
 
-let
+mkFont rec {
+  pname = "kanji-stroke-order-font";
   version = "4.002";
-in fetchzip {
-  name = "kanji-stroke-order-font-${version}";
 
-  url = "https://sites.google.com/site/nihilistorguk/KanjiStrokeOrders_v${version}.zip?attredirects=0";
+  src = fetchzip {
+    url = "https://drive.google.com/uc?export=download&id=1gd5vUzwgfUSggn8ZbEG2m03x3bbwYPfL";
+    sha256 = "10zbwbcvb07ma727d3illnarywmr6vvxb4ymzgiwgk21zfcc63cs";
+    # for some reason, unpack fails without this
+    postFetch = "unzip $downloadedFile -d $out";
+  };
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/kanji-stroke-order $out/share/doc/kanji-stroke-order
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/kanji-stroke-order
-    unzip -j $downloadedFile \*.txt -d $out/share/doc/kanji-stroke-order
-  '';
-
-  sha256 = "194ylkx5p7r1461wnnd3hisv5dz1xl07fyxmg8gv47zcwvdmwkc0";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Font containing stroke order diagrams for over 6500 kanji, 180 kana and other characters";
     homepage = "https://sites.google.com/site/nihilistorguk/";
 

--- a/pkgs/data/fonts/kawkab-mono/default.nix
+++ b/pkgs/data/fonts/kawkab-mono/default.nix
@@ -1,16 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-fetchzip {
-  name = "kawkab-mono-20151015";
+mkFont rec {
+  pname = "kawkab-mono";
+  version = "0.1";
 
-  url = "http://makkuk.com/kawkab-mono/downloads/kawkab-mono-0.1.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
-
-  sha256 = "1vfrb7xs817najplncg7zl9j5yxj8qnwb7aqm2v9p9xwafa4d2yd";
+  src = fetchzip {
+    url = "http://makkuk.com/kawkab-mono/downloads/${pname}-${version}.zip";
+    sha256 = "0pl3wpgv0q10yshzhm0qxf28v8rm8sapjxv1w53aw1gvg36m7dka";
+    stripRoot = false;
+  };
 
   meta = {
     description = "An arab fixed-width font";

--- a/pkgs/data/fonts/kochi-substitute-naga10/default.nix
+++ b/pkgs/data/fonts/kochi-substitute-naga10/default.nix
@@ -1,20 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let version = "20030809";
-in
-fetchzip {
-  name = "kochi-substitute-naga10-${version}";
+mkFont rec {
+  pname = "kochi-substitute-naga10";
+  version = "20030809";
 
-  url = "mirror://osdn/efont/5411/kochi-substitute-${version}.tar.bz2";
-
-  postFetch = ''
-    tar -xjf $downloadedFile --strip-components=1
-    mkdir -p $out/share/fonts/truetype
-    cp ./kochi-gothic-subst.ttf $out/share/fonts/truetype/kochi-gothic-subst-naga10.ttf
-    cp ./kochi-mincho-subst.ttf $out/share/fonts/truetype/kochi-mincho-subst-naga10.ttf
-  '';
-
-  sha256 = "1bjb5cr3wf3d5y7xj1ly2mkv4ndwvg615rb1ql6lsqc2icjxk7j9";
+  src = fetchzip {
+    url = "mirror://osdn/efont/5411/kochi-substitute-${version}.tar.bz2";
+    sha256 = "191b7lyvx3j12gv82m4jp04sb24vprl4ymk4czr3r8asl4di417s";
+  };
 
   meta = {
     description = "Japanese font, non-free replacement for MS Gothic and MS Mincho";

--- a/pkgs/data/fonts/kochi-substitute/default.nix
+++ b/pkgs/data/fonts/kochi-substitute/default.nix
@@ -1,10 +1,8 @@
-{ stdenv, fetchurl, dpkg }:
+{ lib, mkFont, fetchurl, dpkg }:
 
-let version = "20030809";
-in
-stdenv.mkDerivation {
+mkFont rec {
   pname = "kochi-substitute";
-  inherit version;
+  version = "20030809";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/t/ttf-kochi/ttf-kochi-gothic_${version}-15_all.deb";
@@ -18,22 +16,12 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ dpkg ];
 
-  unpackCmd = ''
+  unpackPhase = ''
     dpkg-deb --fsys-tarfile $src | tar xf - ./usr/share/fonts/truetype/kochi/kochi-gothic-subst.ttf
     dpkg-deb --fsys-tarfile $src2 | tar xf - ./usr/share/fonts/truetype/kochi/kochi-mincho-subst.ttf
   '';
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp ./share/fonts/truetype/kochi/kochi-gothic-subst.ttf $out/share/fonts/truetype/
-    cp ./share/fonts/truetype/kochi/kochi-mincho-subst.ttf $out/share/fonts/truetype/
-  '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "10hcrf51npc1w2jsz5aiw07dgw96vs4wmsz4ai9zyaswipvf8ddy";
-
-  meta = {
+  meta = with lib; {
     description = "Japanese font, a free replacement for MS Gothic and MS Mincho";
     longDescription = ''
       Kochi Gothic and Kochi Mincho were developed as free replacements for the
@@ -42,7 +30,7 @@ stdenv.mkDerivation {
       from the naga10 font.
     '';
     homepage = "https://osdn.net/projects/efont/";
-    license = stdenv.lib.licenses.wadalab;
-    maintainers = [ stdenv.lib.maintainers.auntie ];
+    license = licenses.wadalab;
+    maintainers = with maintainers; [ maintainers.auntie ];
   };
 }

--- a/pkgs/data/fonts/lalezar-fonts/default.nix
+++ b/pkgs/data/fonts/lalezar-fonts/default.nix
@@ -1,20 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "lalezar-fonts";
   version = "unstable-2017-02-28";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "BornaIz";
-  repo = "Lalezar";
-  rev = "238701c4241f207e92515f845a199be9131c1109";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    mkdir -p $out/share/fonts/lalezar-fonts
-    cp -v $( find . -name '*.ttf') $out/share/fonts/lalezar-fonts
-  '';
-  sha256 = "0jmwhr2dqgj3vn0v26jh6c0id6n3wd6as3bq39xa870zlk7v307b";
+  src = fetchFromGitHub {
+    owner = "BornaIz";
+    repo = "Lalezar";
+    rev = "238701c4241f207e92515f845a199be9131c1109";
+    sha256 = "1j3zg9qw4ahw52i0i2c69gv5gjc1f4zsdla58kd9visk03qgk77p";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/BornaIz/Lalezar";

--- a/pkgs/data/fonts/lato/default.nix
+++ b/pkgs/data/fonts/lato/default.nix
@@ -1,16 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-fetchzip {
-  name = "lato-2.0";
+mkFont {
+  pname = "lato";
+  version = "2.0";
 
-  url = "http://www.latofonts.com/download/Lato2OFL.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/lato
-  '';
-
-  sha256 = "1amwn6vcaggxrd2s4zw21s2pr47zmzdf2xfy4x9lxa2cd9bkhvg5";
+  src = fetchzip {
+    url = "http://www.latofonts.com/download/Lato2OFL.zip";
+    sha256 = "0wmrq1vj1d8xm9kikhc2z1zq2ywcxlr4xik2r2m82h0252mfqm4z";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     homepage = "http://www.latofonts.com/";

--- a/pkgs/data/fonts/liberastika/default.nix
+++ b/pkgs/data/fonts/liberastika/default.nix
@@ -1,19 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "liberastika";
   version = "1.1.5";
-in fetchzip rec {
-  name = "liberastika-${version}";
 
-  url = "mirror://sourceforge/project/lib-ka/liberastika-ttf-${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf                           -d $out/share/fonts/truetype
-    unzip -j $downloadedFile AUTHORS ChangeLog COPYING README -d "$out/share/doc/${name}"
-  '';
-
-  sha256 = "1a9dvl1pzch2vh8sqyyn1d1wz4n624ffazl6hzlc3s5k5lzrb6jp";
+  src = fetchzip {
+    url = "mirror://sourceforge/project/lib-ka/liberastika-ttf-${version}.zip";
+    sha256 = "0gg7fabnpybkqihjd07l30wkgjs56b0jgjmkqf2ag3v1dhx2k1f2";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     description = "Liberation Sans fork with improved cyrillic support";

--- a/pkgs/data/fonts/liberation-sans-narrow/default.nix
+++ b/pkgs/data/fonts/liberation-sans-narrow/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, fontforge, python3Packages, python3 }:
+{ lib, mkFont, fetchFromGitHub, fontforge, python3Packages, python3 }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "liberation-sans-narrow";
   version = "1.07.6";
 
@@ -12,13 +12,9 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ fontforge python3Packages.fonttools python3 ];
+  dontBuild = false;
 
-  installPhase = ''
-    find . -name '*Narrow*.ttf' -exec install -m444 -Dt $out/share/fonts/truetype {} \;
-    install -m444 -Dt $out/doc/${pname}-${version} AUTHORS ChangeLog COPYING License.txt README.rst
-  '';
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Liberation Sans Narrow Font Family is a replacement for Arial Narrow";
     longDescription = ''
       Liberation Sans Narrow is a font originally created by Ascender

--- a/pkgs/data/fonts/libertinus/default.nix
+++ b/pkgs/data/fonts/libertinus/default.nix
@@ -1,20 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
+  pname = "libertinus";
   version = "6.9";
-in fetchFromGitHub rec {
-  name = "libertinus-${version}";
 
-  owner  = "alif-type";
-  repo   = "libertinus";
-  rev    = "v${version}";
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -m444 -Dt $out/share/fonts/opentype *.otf
-    install -m444 -Dt $out/share/doc/${name}    *.txt
-  '';
-  sha256 = "0765a7w0askkhrjmjk638gcm9h6fcm1jpaza8iw9afr3sz1s0xlq";
+  src = fetchFromGitHub {
+    owner = "alif-type";
+    repo = "libertinus";
+    rev = "v${version}";
+    sha256 = "1996qfc9x23f4xxxyc02nc3z1fcnbaqv6awfhz17hi0544qpz5d2";
+  };
 
   meta = with lib; {
     description = "A fork of the Linux Libertine and Linux Biolinum fonts";

--- a/pkgs/data/fonts/libre-baskerville/default.nix
+++ b/pkgs/data/fonts/libre-baskerville/default.nix
@@ -1,19 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  name = "libre-baskerville-1.000";
+mkFont {
+  pname = "libre-baskerville";
+  version = "1.000";
 
-  owner = "impallari";
-  repo = "Libre-Baskerville";
-  rev = "2fba7c8e0a8f53f86efd3d81bc4c63674b0c613f";
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -m444 -Dt $out/share/fonts/truetype *.ttf
-    install -m444 -Dt $out/share/doc/${name}    README.md FONTLOG.txt
-  '';
-
-  sha256 = "1kpji85d1mgwq8b4fh1isznrhsrv32la3wf058rwjmhx5a3l7yaj";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Libre-Baskerville";
+    rev = "2fba7c8e0a8f53f86efd3d81bc4c63674b0c613f";
+    sha256 = "0i9ra6ip81zzjxl71p8zwa6ymlmkf4yi5ny22vlwx9a53kbf4ifl";
+  };
 
   meta = with lib; {
     description = "A webfont family optimized for body text";

--- a/pkgs/data/fonts/libre-bodoni/default.nix
+++ b/pkgs/data/fonts/libre-bodoni/default.nix
@@ -1,19 +1,17 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  name = "libre-bodoni-2.000";
+mkFont rec {
+  pname = "libre-bodoni";
+  version = "2.000";
 
-  owner = "impallari";
-  repo = "Libre-Bodoni";
-  rev = "995a40e8d6b95411d660cbc5bb3f726ffd080c7d";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Libre-Bodoni";
+    rev = "995a40e8d6b95411d660cbc5bb3f726ffd080c7d";
+    sha256 = "1ncfkvmcxh2lphfra43h8482qglpd965v96agvz092697xwrbyn9";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -m444 -Dt $out/share/fonts/opentype */v2000\ -\ initial\ glyphs\ migration/OTF/*.otf
-    install -m444 -Dt $out/share/doc/${name}    README.md FONTLOG.txt
-  '';
-
-  sha256 = "0my0i5a7f0d27m6dcdirjmlcnswqqfp8gl3ccxa5f2wkn3qlzkvz";
+  sourceRoot = "source/fonts/v2000 - initial glyphs migration";
 
   meta = with lib; {
     description = "Bodoni fonts adapted for today's web requirements";

--- a/pkgs/data/fonts/libre-caslon/default.nix
+++ b/pkgs/data/fonts/libre-caslon/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+mkFont {
   pname = "libre-caslon";
   version = "1.002";
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
       owner = "impallari";
       repo = "Libre-Caslon-Text";
       rev = "c31e21f7e8cf91f18d90f778ce20e66c68219c74";
-      name = "libre-caslon-text-${version}-src";
+      name = "libre-caslon-text";
       sha256 = "0zczv9qm8cgc7w1p64mnf0p0fi7xv89zhf1zzf1qcna15kbgc705";
     })
 
@@ -17,26 +17,12 @@ stdenv.mkDerivation rec {
       owner = "impallari";
       repo = "Libre-Caslon-Display";
       rev = "3491f6a9cfde2bc15e736463b0bc7d93054d5da1";
-      name = "libre-caslon-display-${version}-src";
+      name = "libre-caslon-display";
       sha256 = "12jrny3y8w8z61lyw470drnhliji5b24lgxap4w3brp6z3xjph95";
     })
   ];
 
-  sourceRoot = ".";
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/opentype
-    mkdir -p $out/share/doc/${pname}-${version}
-    cp -v "libre-caslon-text-${version}-src/fonts/OTF/"*.otf $out/share/fonts/opentype/
-    cp -v "libre-caslon-display-${version}-src/fonts/OTF/"*.otf $out/share/fonts/opentype/
-    cp -v libre-caslon-text-${version}-src/README.md libre-caslon-text-${version}-src/FONTLOG.txt $out/share/doc/${pname}-${version}
-  '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "05aajwny99yqzn1nnq1blx6h7rl54x056y12hyawfbigkzxhscns";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Caslon fonts based on hand-lettered American Caslons of 1960s";
     homepage = "http://www.impallari.com/librecaslon";
     license = licenses.ofl;

--- a/pkgs/data/fonts/libre-franklin/default.nix
+++ b/pkgs/data/fonts/libre-franklin/default.nix
@@ -1,19 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  name = "libre-franklin-1.014";
+mkFont rec {
+  pname = "libre-franklin";
+  version = "1.014";
 
-  owner = "impallari";
-  repo = "Libre-Franklin";
-  rev = "006293f34c47bd752fdcf91807510bc3f91a0bd3";
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -m444 -Dt $out/share/fonts/opentype */OTF/*.otf
-    install -m444 -Dt $out/share/doc/${name}    README.md FONTLOG.txt
-  '';
-
-  sha256 = "0aq280m01pbirkzga432340aknf2m5ggalw0yddf40sqz7falykf";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Libre-Franklin";
+    rev = "006293f34c47bd752fdcf91807510bc3f91a0bd3";
+    sha256 = "0df41cqhw5dz3g641n4nd2jlqjf5m4fkv067afk3759m4hg4l78r";
+  };
 
   meta = with lib; {
     description = "A reinterpretation and expansion based on the 1912 Morris Fuller Benton’s classic.";

--- a/pkgs/data/fonts/line-awesome/default.nix
+++ b/pkgs/data/fonts/line-awesome/default.nix
@@ -1,27 +1,15 @@
-{ lib, stdenv, fetchurl, unzip }:
+{ lib, mkFont, fetchzip }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "line-awesome";
   version = "1.3.0";
 
-  src = fetchurl {
-    url =
-      "https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/${version}/line-awesome-${version}.zip";
-    sha256 = "07qkz8s1wjh5xwqlq1b4lpihr1zah3kh6bnqvfwvncld8l9wjqfk";
+  src = fetchzip {
+    url = "https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/${version}/line-awesome-${version}.zip";
+    sha256 = "1sv517g8vpf1r58zczyqbbkfmajrypfilfblhqz9r2cw4rkfpwkb";
   };
 
-  nativeBuildInputs = [ unzip ];
-
-  sourceRoot = "${version}/fonts";
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    mkdir -p $out/share/fonts/woff
-    mkdir -p $out/share/fonts/woff2
-    cp *.ttf $out/share/fonts/truetype
-    cp *.woff $out/share/fonts/woff
-    cp *.woff2 $out/share/fonts/woff2
-  '';
+  sourceRoot = "source/fonts";
 
   meta = with lib; {
     description = "Replace Font Awesome with modern line icons";

--- a/pkgs/data/fonts/lmmath/default.nix
+++ b/pkgs/data/fonts/lmmath/default.nix
@@ -1,18 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "lmmath";
   version = "1.959";
-in fetchzip rec {
-  name = "lmmath-${version}";
 
-  url = "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip";
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/
-    mkdir -p $out/share/doc/latinmodern-math-${version}/
-    unzip -j $downloadedFile "*/otf/*.otf" -d $out/share/fonts/opentype/
-    unzip -j $downloadedFile "*/doc/*.txt" -d $out/share/doc/latinmodern-math-${version}/
-  '';
-  sha256 = "05k145bxgxjh7i9gx1ahigxfpc2v2vwzsy2mc41jvvg51kjr8fnn";
+  src = fetchzip {
+    url = "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip";
+    sha256 = "15l3lxjciyjmbh0q6jjvzz16ibk4ij79in9fs47qhrfr2wrddpvs";
+  };
 
   meta = with lib; {
     description = "The Latin Modern Math (LM Math) font completes the modernization of the Computer Modern family of typefaces designed and programmed by Donald E. Knuth.";

--- a/pkgs/data/fonts/luculent/default.nix
+++ b/pkgs/data/fonts/luculent/default.nix
@@ -1,17 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let version = "2.0.0"; in
-fetchzip {
-  name = "luculent-${version}";
-  url =  "http://www.eastfarthing.com/luculent/luculent.tar.xz";
+mkFont {
+  pname = "luculent";
+  version = "2.0.0";
 
-  postFetch = ''
-    tar -xJf $downloadedFile --strip-components=1
-    mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
-  '';
-
-  sha256 = "1m3g64galwna1xjxb1fczmfplm6c1fn3ra1ln7f0vkm0ah5m4lbv";
+  src = fetchzip {
+    url =  "http://www.eastfarthing.com/luculent/luculent.tar.xz";
+    sha256 = "1kd6dccribwxfghnp7qxbjjjlcmd0spmxvk5z9c9h36r46vcb46x";
+  };
 
   meta = with lib; {
     description = "luculent font";

--- a/pkgs/data/fonts/manrope/default.nix
+++ b/pkgs/data/fonts/manrope/default.nix
@@ -1,18 +1,18 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "manrope";
   version = "3";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "sharanda";
-  repo = pname;
-  rev = "3bd68c0c325861e32704470a90dfc1868a5c37e9";
-  sha256 = "1h4chkfbp75hrrqqarf28ld4yb7hfrr7q4w5yz96ivg94lbwlnld";
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -Dm644 -t $out/share/fonts/opentype "desktop font"/*
-  '';
+
+  src = fetchFromGitHub {
+    owner = "sharanda";
+    repo = pname;
+    rev = "3bd68c0c325861e32704470a90dfc1868a5c37e9";
+    sha256 = "1k6nmczbl97b9j2a8vx6a1r3q4gd1c2qydv0y9gn8xyl7x8fcvhs";
+  };
+
+  sourceRoot = "source/desktop font";
+
   meta = with lib; {
     description = "Open-source modern sans-serif font family";
     homepage = "https://github.com/sharanda/manrope";

--- a/pkgs/data/fonts/marathi-cursive/default.nix
+++ b/pkgs/data/fonts/marathi-cursive/default.nix
@@ -1,19 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "marathi-cursive";
   version = "2.0";
-in fetchzip rec {
-  name = "marathi-cursive-${version}";
 
-  url = "https://github.com/MihailJP/MarathiCursive/releases/download/v${version}/MarathiCursive-${version}.tar.xz";
-
-  postFetch = ''
-    tar -xJf $downloadedFile --strip-components=1
-    install -m444 -Dt $out/share/fonts/marathi-cursive *.otf *.ttf
-    install -m444 -Dt $out/share/doc/${name} README *.txt
-  '';
-
-  sha256 = "17pj60ajnjghxhxka8a046mz6vfwr79wnby7xd6pg5hgncin2hgg";
+  src = fetchzip {
+    url = "https://github.com/MihailJP/MarathiCursive/releases/download/v${version}/MarathiCursive-${version}.tar.xz";
+    sha256 = "10vzn1lzlsd0yg3ma7h9l74ypg8m411c7arsgv4f8wpyn0qpv6xn";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/MihailJP/MarathiCursive";

--- a/pkgs/data/fonts/material-design-icons/default.nix
+++ b/pkgs/data/fonts/material-design-icons/default.nix
@@ -1,22 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
+  pname = "material-design-icons";
   version = "4.7.95";
-in fetchFromGitHub {
-  name = "material-design-icons-${version}";
-  owner  = "Templarian";
-  repo   = "MaterialDesign-Webfont";
-  rev    = "v${version}";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    mkdir -p $out/share/fonts/{eot,truetype,woff,woff2}
-    cp fonts/*.eot $out/share/fonts/eot/
-    cp fonts/*.ttf $out/share/fonts/truetype/
-    cp fonts/*.woff $out/share/fonts/woff/
-    cp fonts/*.woff2 $out/share/fonts/woff2/
-  '';
-  sha256 = "0da92kz8ryy60kb5xm52md13w28ih4sfap8g3v9b4ziyww66zjhz";
+  src = fetchFromGitHub {
+    owner  = "Templarian";
+    repo   = "MaterialDesign-Webfont";
+    rev    = "v${version}";
+    sha256 = "1509r16hn72j83yz5hbdv23c71svj34wxgdnsd5l9gfzg84wyy0r";
+  };
 
   meta = with lib; {
     description = "3200+ Material Design Icons from the Community";

--- a/pkgs/data/fonts/material-icons/default.nix
+++ b/pkgs/data/fonts/material-icons/default.nix
@@ -1,20 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
+  pname = "material-icons";
   version = "3.0.1";
-in fetchFromGitHub {
-  name = "material-icons-${version}";
 
-  owner  = "google";
-  repo   = "material-design-icons";
-  rev    = version;
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    mkdir -p $out/share/fonts/truetype
-    cp iconfont/*.ttf $out/share/fonts/truetype
-  '';
-  sha256 = "1syy6v941lb8nqxhdf7mfx28v05lwrfnq53r3c1ym13x05l9kchp";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "material-design-icons";
+    rev = version;
+    sha256 = "17q5brcqyyc8gbjdgpv38p89s60cwxjlwy2ljnrvas5cj0s62np0";
+  };
 
   meta = with lib; {
     description = "System status icons by Google, featuring material design";

--- a/pkgs/data/fonts/medio/default.nix
+++ b/pkgs/data/fonts/medio/default.nix
@@ -1,21 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
-  majorVersion = "0";
-  minorVersion = "200";
+mkFont rec {
   pname = "medio";
-in
+  version = "0.200";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
-
-  url = "http://dotcolon.net/DL/font/${pname}.zip";
-  sha256 = "0gxcmhjlsh2pzsmj78vw4v935ax7hfk533ddlhfhfma52zyxyh7x";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
-  '';
+  src = fetchzip {
+    url = "http://dotcolon.net/download/fonts/${pname}_${lib.replaceStrings ["."] [""] version}.zip";
+    sha256 = "1d3hw6mfzfch1ikq9ay9db93z4cy1npfhhw1f0xmj69k7v09rq2b";
+  };
 
   meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";

--- a/pkgs/data/fonts/merriweather-sans/default.nix
+++ b/pkgs/data/fonts/merriweather-sans/default.nix
@@ -1,9 +1,6 @@
-{ stdenvNoCC
-, lib
-, fetchFromGitHub
-}:
+{ lib, mkFont, fetchFromGitHub }:
 
-stdenvNoCC.mkDerivation rec {
+mkFont rec {
   pname = "merriweather-sans";
   version = "1.008";
 
@@ -16,13 +13,6 @@ stdenvNoCC.mkDerivation rec {
 
   # TODO: it would be nice to build this from scratch, but lots of
   # Python dependencies to package (fontmake, gftools)
-
-  installPhase = ''
-    install -m444 -Dt $out/share/fonts/truetype/${pname} fonts/ttfs/*.ttf
-    install -m444 -Dt $out/share/fonts/woff/${pname} fonts/woff/*.woff
-    install -m444 -Dt $out/share/fonts/woff2/${pname} fonts/woff2/*.woff2
-    # TODO: install variable version?
-  '';
 
   meta = with lib; {
     homepage = "https://github.com/SorkinType/Merriweather-Sans";

--- a/pkgs/data/fonts/merriweather/default.nix
+++ b/pkgs/data/fonts/merriweather/default.nix
@@ -1,9 +1,6 @@
-{ stdenvNoCC
-, lib
-, fetchFromGitHub
-}:
+{ lib, mkFont, fetchFromGitHub }:
 
-stdenvNoCC.mkDerivation rec {
+mkFont rec {
   pname = "merriweather";
   version = "2.005";
 
@@ -16,14 +13,6 @@ stdenvNoCC.mkDerivation rec {
 
   # TODO: it would be nice to build this from scratch, but lots of
   # Python dependencies to package (fontmake, gftools)
-
-  installPhase = ''
-    install -m444 -Dt $out/share/fonts/opentype/${pname} fonts/otf/*.otf
-    install -m444 -Dt $out/share/fonts/truetype/${pname} fonts/ttfs/*.ttf
-    install -m444 -Dt $out/share/fonts/woff/${pname} fonts/woff/*.woff
-    install -m444 -Dt $out/share/fonts/woff2/${pname} fonts/woff2/*.woff2
-    # TODO: install variable version?
-  '';
 
   meta = with lib; {
     homepage = "https://github.com/SorkinType/Merriweather";

--- a/pkgs/data/fonts/meslo-lg/default.nix
+++ b/pkgs/data/fonts/meslo-lg/default.nix
@@ -1,46 +1,30 @@
-{ stdenv, fetchurl, unzip }:
+{ lib, mkFont, fetchurl, unzip }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
+  pname = "meslo-lg";
   version = "1.2.1";
 
-  pname = "meslo-lg";
+  srcs = [
+    (fetchurl {
+      url="https://github.com/andreberg/Meslo-Font/blob/master/dist/v${version}/Meslo%20LG%20v${version}.zip?raw=true";
+      name="${pname}-${version}.zip";
+      sha256="1l08mxlzaz3i5bamnfr49s2k4k23vdm64b8nz2ha33ysimkbgg6h";
+    })
 
-  meslo-lg = fetchurl {
-    url="https://github.com/andreberg/Meslo-Font/blob/master/dist/v${version}/Meslo%20LG%20v${version}.zip?raw=true";
-    name="${pname}-${version}";
-    sha256="1l08mxlzaz3i5bamnfr49s2k4k23vdm64b8nz2ha33ysimkbgg6h";
-  };
-
-  meslo-lg-dz = fetchurl {
-    url="https://github.com/andreberg/Meslo-Font/blob/master/dist/v${version}/Meslo%20LG%20DZ%20v${version}.zip?raw=true";
-    name="${pname}-${version}-dz";
-    sha256="0lnbkrvcpgz9chnvix79j6fiz36wj6n46brb7b1746182rl1l875";
-  };
+    (fetchurl {
+      url="https://github.com/andreberg/Meslo-Font/blob/master/dist/v${version}/Meslo%20LG%20DZ%20v${version}.zip?raw=true";
+      name="${pname}-${version}-dz.zip";
+      sha256="0lnbkrvcpgz9chnvix79j6fiz36wj6n46brb7b1746182rl1l875";
+    })
+  ];
 
   nativeBuildInputs = [ unzip ];
 
-  sourceRoot = ".";
-
-  phases = [ "unpackPhase" "installPhase" ];
-  unpackPhase = ''
-    unzip -j ${meslo-lg}
-    unzip -j ${meslo-lg-dz}
-  '';
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
-  '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "1cppf8sk6r5wjnnas9n6iyag6pj9jvaic66lvwpqg3742s5akx6x";
-
-  meta = {
+  meta = with lib; {
     description = "A customized version of Apple’s Menlo-Regular font";
     homepage = "https://github.com/andreberg/Meslo-Font/";
-    license = stdenv.lib.licenses.asl20;
-    maintainers = with stdenv.lib.maintainers; [ balajisivaraman ];
-    platforms = with stdenv.lib.platforms; all;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ balajisivaraman ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/data/fonts/migmix/default.nix
+++ b/pkgs/data/fonts/migmix/default.nix
@@ -1,39 +1,33 @@
-{ stdenv, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "migmix";
   version = "20150712";
 
   srcs = [
     (fetchzip {
+      name = "migmix-1p-${version}.zip";
       url = "mirror://osdn/mix-mplus-ipa/63544/migmix-1p-${version}.zip";
       sha256 = "0wp44axcalaak04nj3dgpx0vk13nqa3ihx2vjv4acsgv83x8ciph";
     })
     (fetchzip {
+      name = "migmix-2p-${version}.zip";
       url = "mirror://osdn/mix-mplus-ipa/63544/migmix-2p-${version}.zip";
       sha256 = "0y7s3rbxrp5bv56qgihk8b847lqgibfhn2wlkzx7z655fbzdgxw9";
     })
     (fetchzip {
+      name = "migmix-1m-${version}.zip";
       url = "mirror://osdn/mix-mplus-ipa/63544/migmix-1m-${version}.zip";
       sha256 = "1sfym0chy8ilyd9sr3mjc0bf63vc33p05ynpdc11miivxn4qsshx";
     })
     (fetchzip {
+      name = "migmix-2m-${version}.zip";
       url = "mirror://osdn/mix-mplus-ipa/63544/migmix-2m-${version}.zip";
       sha256 = "0hg04rvm39fh4my4akmv4rhfc14s3ipz2aw718h505k9hppkhkch";
     })
   ];
 
-  dontUnpack = true;
-
-  installPhase = ''
-    find $srcs -name '*.ttf' -exec install -m644 -Dt $out/share/fonts/truetype/migmix {} \;
-  '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "1fhh8wg6lxwrnsg9rl4ihffl0bsp1wqa5gps9fx60kr6j9wpvmbg";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A high-quality Japanese font based on M+ fonts and IPA fonts";
     homepage = "http://mix-mplus-ipa.osdn.jp/migmix";
     license = licenses.ipa;

--- a/pkgs/data/fonts/migu/default.nix
+++ b/pkgs/data/fonts/migu/default.nix
@@ -1,39 +1,33 @@
-{ stdenv, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "migu";
   version = "20150712";
 
   srcs = [
     (fetchzip {
+      name = "migu-1p-${version}.zip";
       url = "mirror://osdn/mix-mplus-ipa/63545/migu-1p-${version}.zip";
       sha256 = "04wpbk5xbbcv2rzac8yzj4ww7sk2hy2rg8zs96yxc5vzj9q7svf6";
     })
     (fetchzip {
+      name = "migu-1c-${version}.zip";
       url = "mirror://osdn/mix-mplus-ipa/63545/migu-1c-${version}.zip";
       sha256 = "1k7ymix14ac5fb44bjvbaaf24784zzpyc1jj2280c0zdnpxksyk6";
     })
     (fetchzip {
+      name = "migu-1m-${version}.zip";
       url = "mirror://osdn/mix-mplus-ipa/63545/migu-1m-${version}.zip";
       sha256 = "07r8id83v92hym21vrqmfsfxb646v8258001pkjhgfnfg1yvw8lm";
     })
     (fetchzip {
+      name = "migu-2m-${version}.zip";
       url = "mirror://osdn/mix-mplus-ipa/63545/migu-2m-${version}.zip";
       sha256 = "1pvzbrawh43589j8rfxk86y1acjbgzzdy5wllvdkpm1qnx28zwc2";
     })
   ];
 
-  dontUnpack = true;
-
-  installPhase = ''
-    find $srcs -name '*.ttf' | xargs install -m644 --target $out/share/fonts/truetype/migu -D
-  '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "0nbpn21cxdd6gsgr3fadzjsnz84f2swpf81wmscmjgvd56ngndzh";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A high-quality Japanese font based on modified M+ fonts and IPA fonts";
     homepage = "http://mix-mplus-ipa.osdn.jp/migu/";
     license = licenses.ipa;

--- a/pkgs/data/fonts/mno16/default.nix
+++ b/pkgs/data/fonts/mno16/default.nix
@@ -1,21 +1,18 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
   pname = "mno16";
   version = "1.0";
-in fetchzip rec {
-  name = "${pname}-${version}";
-  url = "https://github.com/sevmeyer/${pname}/releases/download/${version}/${name}.zip";
-  sha256 = "1x06nl281fcjk6g1p4cgrgxakmwcci6vvasskaygsqlzxd8ig87w";
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/
-  '';
+  src = fetchzip {
+    url = "https://github.com/sevmeyer/${pname}/releases/download/${version}/${pname}-${version}.zip";
+    sha256 = "1qq3w39gx9w3wnyfblcm5bm95sa9gxcn0sl8g72486d5n5bkv564";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     description = "minimalist monospaced font";
-    homepage = "https://sev.dev/fonts/mno16"; 
+    homepage = "https://sev.dev/fonts/mno16";
     license = licenses.cc0;
   };
 }

--- a/pkgs/data/fonts/mononoki/default.nix
+++ b/pkgs/data/fonts/mononoki/default.nix
@@ -1,18 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "mononoki";
   version = "1.2";
-in fetchzip {
-  name = "mononoki-${version}";
 
-  url = "https://github.com/madmalik/mononoki/releases/download/${version}/mononoki.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/mononoki
-    unzip -j $downloadedFile -d $out/share/fonts/mononoki
-  '';
-
-  sha256 = "19y4xg7ilm21h9yynyrwcafdqn05zknpmmjrb37qim6p0cy2glff";
+  src = fetchzip {
+    url = "https://github.com/madmalik/mononoki/releases/download/${version}/mononoki.zip";
+    sha256 = "07ghz2981daxzzqg4kjcya7x46rsvr7p4z4l4gpq8b9l4j2xygfa";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/madmalik/mononoki";

--- a/pkgs/data/fonts/montserrat/default.nix
+++ b/pkgs/data/fonts/montserrat/default.nix
@@ -1,23 +1,13 @@
-# Originally packaged for ArchLinux.
-#
-# https://aur.archlinux.org/packages/ttf-montserrat/
+{ lib, mkFont, fetchzip }:
 
-{ lib, fetchzip }:
-
-let
+mkFont rec {
+  pname = "montserrat";
   version = "1.0";
-in fetchzip {
-  name = "montserrat-${version}";
 
-  url = "https://marvid.fr/~eeva/mirror/Montserrat.tar.gz";
-
-  postFetch = ''
-    tar -xzf $downloadedFile --strip-components=1
-    mkdir -p $out/share/fonts/montserrat
-    cp *.ttf $out/share/fonts/montserrat
-  '';
-
-  sha256 = "11sdgvhaqg59mq71aqwqp2mb428984hjxy7hd1vasia9kgk8259w";
+  src = fetchzip {
+    url = "https://marvid.fr/~eeva/mirror/Montserrat.tar.gz";
+    sha256 = "09mr17gf2dnh2r10s5p6kgi34q7s4rwdqmmsvn1ysf8ljq4k7b5p";
+  };
 
   meta = with lib; {
     description = "A geometric sans serif font with extended latin support (Regular, Alternates, Subrayada)";

--- a/pkgs/data/fonts/mph-2b-damase/default.nix
+++ b/pkgs/data/fonts/mph-2b-damase/default.nix
@@ -1,16 +1,13 @@
-{ fetchzip }:
+{ mkFont, fetchzip }:
 
-fetchzip {
-  name = "MPH-2B-Damase-2";
+mkFont rec {
+  pname = "MPH-2B-Damase";
+  version = "2";
 
-  url = "http://www.wazu.jp/downloads/damase_v.2.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
-
-  sha256 = "0yzf12z6fpbgycqwiz88f39iawdhjabadfa14wxar3nhl9n434ql";
+  src = fetchzip {
+    url = "http://www.wazu.jp/downloads/damase_v.${version}.zip";
+    sha256 = "1xf61w6vhy5qbhnn45s77fxyryn66blf641lhmgiqr1pww7zq7p3";
+  };
 
   meta = {
   };

--- a/pkgs/data/fonts/mplus-outline-fonts/default.nix
+++ b/pkgs/data/fonts/mplus-outline-fonts/default.nix
@@ -1,19 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "mplus";
   version = "063a";
-in fetchzip {
-  name = "mplus-${version}";
 
-  url = "mirror://osdn/mplus-fonts/62344/mplus-TESTFLIGHT-${version}.tar.xz";
-
-  postFetch = ''
-    tar -xJf $downloadedFile --strip-components=1
-    mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
-  '';
-
-  sha256 = "1khbkch2r96ppifc93bmy1v047pgciyhfmcjb98ggncp5ix885xz";
+  src = fetchzip {
+    url = "mirror://osdn/mplus-fonts/62344/mplus-TESTFLIGHT-${version}.tar.xz";
+    sha256 = "0nhxlmm9akz7r3ngilfl27dbmy4c327kk5br3ii7pps28zdym3j4";
+  };
 
   meta = with lib; {
     description = "M+ Outline Fonts";

--- a/pkgs/data/fonts/mro-unicode/default.nix
+++ b/pkgs/data/fonts/mro-unicode/default.nix
@@ -1,13 +1,15 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchurl }:
 
-fetchzip {
-  name = "mro-unicode-2013-05-25";
+mkFont {
+  pname = "mro-unicode";
+  version = "2013-05-25";
 
-  url = "https://github.com/phjamr/MroUnicode/raw/f297de070f7eba721a47c850e08efc119d3bfbe8/MroUnicode-Regular.ttf";
+  src = fetchurl {
+    url = "https://github.com/phjamr/MroUnicode/raw/f297de070f7eba721a47c850e08efc119d3bfbe8/MroUnicode-Regular.ttf";
+    sha256 = "1za74ych0sh97ks6qp9iqq9jankgnkrq65s350wsbianwi72di45";
+  };
 
-  postFetch = "install -Dm644 $downloadedFile $out/share/fonts/truetype/MroUnicode-Regular.ttf";
-
-  sha256 = "1i71bjd9gdyn8ladfncbfhz6xz1h8xx8yf876j1z8lh719410c8g";
+  noUnpackFonts = true;
 
   meta = with lib; {
     homepage = "https://github.com/phjamr/MroUnicode";

--- a/pkgs/data/fonts/myrica/default.nix
+++ b/pkgs/data/fonts/myrica/default.nix
@@ -1,18 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-fetchFromGitHub {
-  name = "myrica-2.011.20160403";
+mkFont {
+  pname = "myrica";
+  version = "2.011.20160403";
 
-  owner = "tomokuni";
-  repo = "Myrica";
-  rev = "b737107723bfddd917210f979ccc32ab3eb6dc20";
-  sha256 = "187rklcibbkai6m08173ca99qn8v7xpdfdv0izpymmavj85axm12";
-
-  postFetch = ''
-    tar --strip-components=1 -xzvf $downloadedFile
-    mkdir -p $out/share/fonts/truetype
-    cp product/*.TTC $out/share/fonts/truetype
-  '';
+  src = fetchFromGitHub {
+    owner = "tomokuni";
+    repo = "Myrica";
+    rev = "b737107723bfddd917210f979ccc32ab3eb6dc20";
+    sha256 = "0p95kanf1682d9idq4v9agxlvxh08vhvfid2sjyc63knndsrl7wk";
+  };
 
   meta = with lib; {
     homepage = "https://myrica.estable.jp/";

--- a/pkgs/data/fonts/nafees/default.nix
+++ b/pkgs/data/fonts/nafees/default.nix
@@ -1,48 +1,35 @@
-{stdenv, fetchurl, unzip}:
+{ lib, mkFont, fetchurl, unzip }:
 
-stdenv.mkDerivation {
-  name = "nafees";
+mkFont {
+  pname = "nafees";
+  version = "2010-08-25";
 
-  srcs = [(fetchurl {
-    url = "http://www.cle.org.pk/Downloads/localization/fonts/NafeesNastaleeq/Nafees_Nastaleeq_v1.02.zip";
-    sha256 = "1h1k5d74pg2gs782910v7i9rz2633wdacy34ds7ybxbpjiz6pqix";
-  })
+  srcs = [
+    (fetchurl {
+      url = "http://www.cle.org.pk/Downloads/localization/fonts/NafeesNastaleeq/Nafees_Nastaleeq_v1.02.zip";
+      sha256 = "1h1k5d74pg2gs782910v7i9rz2633wdacy34ds7ybxbpjiz6pqix";
+    })
+    (fetchurl {
+      url = "http://www.cle.org.pk/Downloads/localization/fonts/NafeesRiqa/Nafees_Riqa_v1.0.zip";
+      sha256 = "1liismsyaj69y40vs9a9db4l95n25n8vnjnx7sbk70nxppwngd8i";
+    })
+    (fetchurl {
+      url = "http://www.cle.org.pk/Downloads/localization/fonts/NafeesNaskh/Nafees_Naskh_v2.01.zip";
+      sha256 = "1qbbj6w6bvrlymv7z6ld609yhp0l2f27z14180w5n8kzzl720vly";
+    })
+    (fetchurl {
+      url = "http://www.cle.org.pk/Downloads/localization/fonts/NafeesTahreerNaskh/Nafees_Tahreer_Naskh_v1.0.zip";
+      sha256 = "006l87drbi4zh52kpvn8wl9wbwm9srfn406rzsnf4gv0spzhqrxl";
+    })
+    (fetchurl {
+      url = "http://www.cle.org.pk/Downloads/localization/fonts/NafeesPakistaniNaskh/Nafees_Pakistani_Naskh_v2.01.zip";
+      sha256 = "1i5ip60gq1cgc9fc96kvlahdpia8dxdgcisglvbm2d212bz0s5nb";
+    })
+  ];
 
-  (fetchurl {
-    url = "http://www.cle.org.pk/Downloads/localization/fonts/NafeesRiqa/Nafees_Riqa_v1.0.zip";
-    sha256 = "1liismsyaj69y40vs9a9db4l95n25n8vnjnx7sbk70nxppwngd8i";
-  })
+  nativeBuildInputs = [ unzip ];
 
-  (fetchurl {
-    url = "http://www.cle.org.pk/Downloads/localization/fonts/NafeesNaskh/Nafees_Naskh_v2.01.zip";
-    sha256 = "1qbbj6w6bvrlymv7z6ld609yhp0l2f27z14180w5n8kzzl720vly";
-  })
-
-  (fetchurl {
-    url = "http://www.cle.org.pk/Downloads/localization/fonts/NafeesTahreerNaskh/Nafees_Tahreer_Naskh_v1.0.zip";
-    sha256 = "006l87drbi4zh52kpvn8wl9wbwm9srfn406rzsnf4gv0spzhqrxl";
-  })
-  (fetchurl {
-    url = "http://www.cle.org.pk/Downloads/localization/fonts/NafeesPakistaniNaskh/Nafees_Pakistani_Naskh_v2.01.zip";
-    sha256 = "1i5ip60gq1cgc9fc96kvlahdpia8dxdgcisglvbm2d212bz0s5nb";
-  })
-];
-
-  nativeBuildInputs = [unzip];
-
-  sourceRoot = ".";
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
-    # cp $riqa/*.ttf $out/share/fonts/truetype
-  '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "1wa0j65iz20ij37dazd1rjg8x625m6q1y8g5h7ia48pbc88sr01q";
-
-  meta = {
+  meta = with lib; {
     description = "OpenType Urdu font from the Center for Research in Urdu Language Processing";
     longDescription = ''
       The Nafees font family is developed according
@@ -56,7 +43,6 @@ stdenv.mkDerivation {
     # more like a modified BSD, but still contains the GPLv2 embedded
     # font exception, and some not-for-resale language.
     license = "unknown";
-    platforms = stdenv.lib.platforms.all;
-    maintainers = with stdenv.lib.maintainers; [ bergey ];
+    maintainers = with maintainers; [ bergey ];
   };
 }

--- a/pkgs/data/fonts/nahid-fonts/default.nix
+++ b/pkgs/data/fonts/nahid-fonts/default.nix
@@ -1,19 +1,16 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "nahid-fonts";
   version = "0.3.0";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "rastikerdar";
-  repo = "nahid-font";
-  rev = "v${version}";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/nahid-fonts {} \;
-  '';
-  sha256 = "0df169sibq14j2mj727sq86c00jm1nz8565v85hkvh4zgz2plb7c";
+  src = fetchFromGitHub {
+    name = "${pname}-${version}";
+    owner = "rastikerdar";
+    repo = "nahid-font";
+    rev = "v${version}";
+    sha256 = "0df169sibq14j2mj727sq86c00jm1nz8565v85hkvh4zgz2plb7c";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/nahid-font";

--- a/pkgs/data/fonts/nanum-gothic-coding/default.nix
+++ b/pkgs/data/fonts/nanum-gothic-coding/default.nix
@@ -1,19 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
-  version = "VER2.5";
-  fullName = "NanumGothicCoding-2.5";
+mkFont rec {
+  pname = "nanum-gothic-coding";
+  version = "2.5";
 
-in fetchzip {
-  name = "nanum-gothic-coding";
-  url = "https://github.com/naver/nanumfont/releases/download/${version}/${fullName}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/NanumGothicCoding
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/NanumGothicCoding
-  '';
-
-  sha256 = "0b3pkhd6xn6393zi0dhj3ah08w1y1ji9fl6584bi0c8lanamf2pc";
+  src = fetchzip {
+    url = "https://github.com/naver/nanumfont/releases/download/VER${version}/NanumGothicCoding-${version}.zip";
+    sha256 = "1mwijjnww477y9hv4b5r5z387h5g6xi037f280i9x7riql4dnxlc";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     description = "A contemporary monospaced sans-serif typeface with a warm touch";

--- a/pkgs/data/fonts/national-park/default.nix
+++ b/pkgs/data/fonts/national-park/default.nix
@@ -1,18 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
   pname = "national-park-typeface";
   version = "206464";
-in fetchzip {
-  name = "${pname}-${version}";
-  url = "https://files.cargocollective.com/c${version}/NationalPark.zip";
 
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile National\*.otf -d $out/share/fonts/opentype/
-  '';
-
-  sha256 = "044gh4xcasp8i9ny6z4nmns1am2pk5krc4ann2afq35v9bnl2q5d";
+  src = fetchzip {
+    url = "https://files.cargocollective.com/c${version}/NationalPark.zip";
+    sha256 = "03lzlyjnjn8mhbqm1bxb55i09lbsf5sa7mw1kslsnz29jmjyhijm";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     description = ''Typeface designed to mimic the national park service

--- a/pkgs/data/fonts/navilu/default.nix
+++ b/pkgs/data/fonts/navilu/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, fontforge }:
+{ lib, mkFont, fetchFromGitHub, fontforge }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "navilu-font";
   version = "1.2";
 
@@ -11,15 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "1vm6n04siaa0zf6jzp5s2gzgr2qxs3vdnmcmg4dcy07py2kd2fla";
   };
 
+  dontBuild = false;
   nativeBuildInputs = [ fontforge ];
-
-  dontConfigure = true;
-
   preBuild = "patchShebangs generate.pe";
 
-  installPhase = "install -Dm444 -t $out/share/fonts/truetype/ Navilu.ttf";
-
-  meta = with stdenv.lib; src.meta // {
+  meta = with lib; src.meta // {
     description = "A Kannada handwriting font";
     license = licenses.gpl3Plus;
     platforms = platforms.all;

--- a/pkgs/data/fonts/nika-fonts/default.nix
+++ b/pkgs/data/fonts/nika-fonts/default.nix
@@ -1,19 +1,16 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "nika-fonts";
   version = "1.0.0";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "font-store";
-  repo = "NikaFont";
-  rev = "v${version}";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/nika-fonts {} \;
-  '';
-  sha256 = "1x34b2dqn1dymi1vmj5vrjcy2z8s0f3rr6cniyrz85plvid6x40i";
+  src = fetchFromGitHub {
+    name = "${pname}-${version}";
+    owner = "font-store";
+    repo = "NikaFont";
+    rev = "v${version}";
+    sha256 = "1x34b2dqn1dymi1vmj5vrjcy2z8s0f3rr6cniyrz85plvid6x40i";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/font-store/NikaFont/";

--- a/pkgs/data/fonts/norwester/default.nix
+++ b/pkgs/data/fonts/norwester/default.nix
@@ -1,19 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont {
   version = "1.2";
   pname = "norwester";
-in fetchzip {
-  name = "${pname}-${version}";
 
-  url = "http://jamiewilson.io/norwester/assets/norwester.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -D -j $downloadedFile ${pname}-v${version}/${pname}.otf -d $out/share/fonts/opentype/
-  '';
-
-  sha256 = "1npsaiiz9g5z6315lnmynwcnrfl37fyxc7w1mhkw1xbzcnv74z4r";
+  src = fetchzip {
+    url = "http://jamiewilson.io/norwester/assets/norwester.zip";
+    sha256 = "1j3zb3g8d4hya6fqdczyyzhpnflmb4cj4gvb37cga4yhpahyfkq2";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     homepage = "http://jamiewilson.io/norwester";

--- a/pkgs/data/fonts/office-code-pro/default.nix
+++ b/pkgs/data/fonts/office-code-pro/default.nix
@@ -1,21 +1,16 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+
+mkFont rec {
   pname = "office-code-pro";
   version = "1.004";
-in fetchFromGitHub rec {
-  name = "${pname}-${version}";
 
-  owner = "nathco";
-  repo = "Office-Code-Pro";
-  rev = version;
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -m644 -Dt $out/share/doc/${name} README.md
-    install -m444 -Dt $out/share/fonts/opentype 'Fonts/Office Code Pro/OTF/'*.otf 'Fonts/Office Code Pro D/OTF/'*.otf
-  '';
-  sha256 = "1bagwcaicn6q8qkqazz6wb3x30y4apmkga0mkv8fh6890hfhywr9";
+  src = fetchFromGitHub {
+    owner = "nathco";
+    repo = "Office-Code-Pro";
+    rev = version;
+    sha256 = "0znmjjyn5q83chiafy252bhsmw49r2nx2ls2cmhjp4ihidfr6cmb";
+  };
 
   meta = with lib; {
     description = "A customized version of Source Code Pro";

--- a/pkgs/data/fonts/oldsindhi/default.nix
+++ b/pkgs/data/fonts/oldsindhi/default.nix
@@ -1,19 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "oldsindhi";
   version = "1.0";
-in fetchzip rec {
-  name = "oldsindhi-${version}";
 
-  url = "https://github.com/MihailJP/oldsindhi/releases/download/v${version}/OldSindhi-${version}.tar.xz";
-
-  postFetch = ''
-    tar -xJf $downloadedFile --strip-components=1
-    install -m444 -Dt $out/share/fonts/truetype *.ttf
-    install -m444 -Dt $out/share/doc/${name} README *.txt
-  '';
-
-  sha256 = "03c483vbrwz2fpdfbys42fmik9788zxfmjmc4fgq4s2d0mraa0j1";
+  src = fetchzip {
+    url = "https://github.com/MihailJP/oldsindhi/releases/download/v${version}/OldSindhi-${version}.tar.xz";
+    sha256 = "1pchv360ff0vgjl36rqn939mngspxlmzrz1n9py4hxpl6h8i9zs4";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/MihailJP/oldsindhi";

--- a/pkgs/data/fonts/oldstandard/default.nix
+++ b/pkgs/data/fonts/oldstandard/default.nix
@@ -1,19 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "oldstandard";
   version = "2.2";
-in fetchzip rec {
-  name = "oldstandard-${version}";
 
-  url = "https://github.com/akryukov/oldstand/releases/download/v${version}/${name}.otf.zip";
-
-  postFetch = ''
-    unzip $downloadedFile
-    install -m444 -Dt $out/share/fonts/opentype *.otf
-    install -m444 -Dt $out/share/doc/${name}    FONTLOG.txt
-  '';
-
-  sha256 = "1qwfsyp51grr56jcnkkmnrnl3r20pmhp9zh9g88kp64m026cah6n";
+  src = fetchzip {
+    url = "https://github.com/akryukov/oldstand/releases/download/v${version}/${pname}-${version}.otf.zip";
+    sha256 = "1hl78jw5szdjq9dhbcv2ln75wpp2lzcxrnfc36z35v5wk4l7jc3h";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/akryukov/oldstand";

--- a/pkgs/data/fonts/open-dyslexic/default.nix
+++ b/pkgs/data/fonts/open-dyslexic/default.nix
@@ -1,19 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont {
+  pname = "open-dyslexic";
   version = "2016-06-23";
-in fetchzip {
-  name = "open-dyslexic-${version}";
 
-  url = "https://github.com/antijingoist/open-dyslexic/archive/20160623-Stable.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.otf       -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*/README.md -d $out/share/doc/open-dyslexic
-  '';
-
-  sha256 = "1vl8z5rknh2hpr2f0v4b2qgs5kclx5pzyk8al7243k5db82a2cyi";
+  src = fetchzip {
+    url = "https://github.com/antijingoist/open-dyslexic/archive/20160623-Stable.zip";
+    sha256 = "0nr7s92nk1kbr459154idnib977ixc70z6g9mbra3lp73nyrmyvz";
+  };
 
   meta = with lib; {
     homepage = "https://opendyslexic.org/";

--- a/pkgs/data/fonts/open-sans/default.nix
+++ b/pkgs/data/fonts/open-sans/default.nix
@@ -1,21 +1,16 @@
-{ lib, fetchFromGitLab }:
+{ lib, mkFont, fetchFromGitLab }:
 
-let
+mkFont {
   pname = "open-sans";
   version = "1.11";
-in fetchFromGitLab {
-  name = "${pname}-${version}";
 
-  domain = "salsa.debian.org";
-  owner = "fonts-team";
-  repo = "fonts-open-sans";
-  rev = "debian%2F1.11-1"; # URL-encoded form of "debian/1.11-1" tag
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
-  '';
-  sha256 = "146ginwx18z624z582lrnhil8jvi9bjg6843265bgxxrfmf75vhp";
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "fonts-team";
+    repo = "fonts-open-sans";
+    rev = "debian%2F1.11-1"; # URL-encoded form of "debian/1.11-1" tag
+    sha256 = "077hkvpmk3ghbqyb901w43b2m2a27lh8ddasyx1x7pdwyr2bjjl2";
+  };
 
   meta = with lib; {
     description = "Open Sans fonts";

--- a/pkgs/data/fonts/orbitron/default.nix
+++ b/pkgs/data/fonts/orbitron/default.nix
@@ -1,21 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
-  version = "20110526";
-in fetchFromGitHub {
-  name = "orbitron-${version}";
+mkFont {
+  pname = "orbitron";
+  version = "2011-05-26";
 
-  owner = "theleagueof";
-  repo = "orbitron";
-  rev = "13e6a52";
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -m444 -Dt $out/share/fonts/opentype/orbitron *.otf
-    install -m444 -Dt $out/share/fonts/ttf/orbitron      *.ttf
-  '';
-
-  sha256 = "1y9yzvpqs2v3ssnqk2iiglrh8amgsscnk8vmfgnqgqi9f4dhdvnv";
+  src = fetchFromGitHub {
+    owner = "theleagueof";
+    repo = "orbitron";
+    rev = "13e6a52";
+    sha256 = "1c6jb7ayr07j1pbnzf3jxng9x9bbqp3zydf8mqdw9ifln1b4ycyf";
+  };
 
   meta = with lib; {
     homepage = "https://www.theleagueofmoveabletype.com/orbitron";

--- a/pkgs/data/fonts/overpass/default.nix
+++ b/pkgs/data/fonts/overpass/default.nix
@@ -1,18 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "overpass";
   version = "3.0.4";
-in fetchzip rec {
-  name = "overpass-${version}";
 
-  url = "https://github.com/RedHatBrand/Overpass/archive/${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype ; unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    mkdir -p $out/share/doc/${name}    ; unzip -j $downloadedFile \*.md  -d $out/share/doc/${name}
-  '';
-
-  sha256 = "13b4yam0nycclccxidzj2fa3nwms5qji7gfkixdnl4ybf0f56b64";
+  src = fetchzip {
+    url = "https://github.com/RedHatBrand/Overpass/archive/${version}.zip";
+    sha256 = "1pl7zpwlx0j2xv23ahnpmbb4a5d6ib2cjck5mxqzi3jjk25rk9kb";
+  };
 
   meta = with lib; {
     homepage = "https://overpassfont.org/";

--- a/pkgs/data/fonts/oxygenfonts/default.nix
+++ b/pkgs/data/fonts/oxygenfonts/default.nix
@@ -1,19 +1,20 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-fetchFromGitHub {
-  name = "oxygenfonts-20160824";
+mkFont {
+  pname = "oxygenfonts";
+  version = "2016-08-24";
 
-  owner = "vernnobile";
-  repo = "oxygenFont";
-  rev = "62db0ebe3488c936406685485071a54e3d18473b";
+  src = fetchFromGitHub {
+    owner = "vernnobile";
+    repo = "oxygenFont";
+    rev = "62db0ebe3488c936406685485071a54e3d18473b";
+    sha256 = "134kx3d0g3zdkw8kl8p6j37fzw3bl163jv2dx4dk1451f3ramcnh";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    mkdir -p $out/share/fonts/truetype
-    cp */Oxygen-Sans.ttf */Oxygen-Sans-Bold.ttf */OxygenMono-Regular.ttf $out/share/fonts/truetype
-  '';
-
-  sha256 = "17m86p1s7a7d90zqjsr46h5bpmas4vxsgj7kd0j5c8cb7lw92jyf";
+  # cp */Oxygen-Sans.ttf */Oxygen-Sans-Bold.ttf */OxygenMono-Regular.ttf $out/share/fonts/truetype
+  installOnly = [
+    "Oxygen-Mono/OxygenMono-Regular.ttf"
+  ];
 
   meta = with lib; {
     description = "Desktop/gui font for integrated use with the KDE desktop";

--- a/pkgs/data/fonts/parastoo-fonts/default.nix
+++ b/pkgs/data/fonts/parastoo-fonts/default.nix
@@ -1,20 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "parastoo-fonts";
   version = "1.0.0-alpha5";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "rastikerdar";
-  repo = "parastoo-font";
-  rev = "v${version}";
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/parastoo-fonts {} \;
-  '';
-  sha256 = "10jbii6rskcy4akjl5yfcqv4mfwk3nqnx36l6sbxks43va9l04f4";
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "parastoo-font";
+    rev = "v${version}";
+    sha256 = "1nya9cbbs6sgv2w3zyah3lb1kqylf922q3fazh4l7bi6zgm8q680";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/parastoo-font";

--- a/pkgs/data/fonts/paratype-pt/mono.nix
+++ b/pkgs/data/fonts/paratype-pt/mono.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchzip }:
+{ lib, mkFont, fetchurl, unzip }:
 
-fetchzip {
-  name = "paratype-pt-mono";
+mkFont {
+  pname = "paratype-pt-mono";
+  version = "2017-04-16";
 
-  url = [
-    "https://company.paratype.com/system/attachments/631/original/ptmono.zip"
-    "http://rus.paratype.ru/system/attachments/631/original/ptmono.zip"
-  ];
+  src = fetchurl {
+    urls = [
+      "https://company.paratype.com/system/attachments/631/original/ptmono.zip"
+      "http://rus.paratype.ru/system/attachments/631/original/ptmono.zip"
+    ];
+    sha256 = "1wqaai7d6xh552vvr5svch07kjn1q89ab5jimi2z0sbd0rbi86vl";
+  };
 
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.txt -d $out/share/doc/paratype
-  '';
+  nativeBuildInputs = [ unzip ];
+  sourceRoot = ".";
 
-  sha256 = "07kl82ngby55khvzsvn831ddpc0q8djgz2y6gsjixkyjfdk2xjjm";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "http://www.paratype.ru/public/";
     description = "An open Paratype font";
 

--- a/pkgs/data/fonts/paratype-pt/sans.nix
+++ b/pkgs/data/fonts/paratype-pt/sans.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchzip }:
+{ lib, mkFont, fetchurl, unzip }:
 
-fetchzip {
-  name = "paratype-pt-sans";
+mkFont {
+  pname = "paratype-pt-sans";
+  version = "2017-04-16";
 
-  url = [
-    "https://company.paratype.com/system/attachments/629/original/ptsans.zip"
-    "http://rus.paratype.ru/system/attachments/629/original/ptsans.zip"
-  ];
+  src = fetchurl {
+    urls = [
+      "https://company.paratype.com/system/attachments/629/original/ptsans.zip"
+      "http://rus.paratype.ru/system/attachments/629/original/ptsans.zip"
+    ];
+    sha256 = "1j9gkbqyhxx8pih5agr9nl8vbpsfr9vdqmhx73ji3isahqm3bhv5";
+  };
 
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.txt -d $out/share/doc/paratype
-  '';
+  nativeBuildInputs = [ unzip ];
+  sourceRoot = ".";
 
-  sha256 = "01fkd417gv98jf3a6zyfi9w2dkqsbddy1vacga2672yf0kh1z1r0";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "http://www.paratype.ru/public/";
     description = "An open Paratype font";
 

--- a/pkgs/data/fonts/paratype-pt/serif.nix
+++ b/pkgs/data/fonts/paratype-pt/serif.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchzip }:
+{ lib, mkFont, fetchurl, unzip }:
 
-fetchzip {
-  name = "paratype-pt-serif";
+mkFont {
+  pname = "paratype-pt-serif";
+  version = "2017-04-16";
 
-  url = [
-    "https://company.paratype.com/system/attachments/634/original/ptserif.zip"
-    "http://rus.paratype.ru/system/attachments/634/original/ptserif.zip"
-  ];
+  src = fetchurl {
+    urls = [
+      "https://company.paratype.com/system/attachments/634/original/ptserif.zip"
+      "http://rus.paratype.ru/system/attachments/634/original/ptserif.zip"
+    ];
+    sha256 = "0x3l58c1rvwmh83bmmgqwwbw9av1mvvq68sw2hdkyyihjvamyvvs";
+  };
 
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.txt -d $out/share/doc/paratype
-  '';
+  nativeBuildInputs = [ unzip ];
+  sourceRoot = ".";
 
-  sha256 = "1iw5qi4ag3yp1lwmi91lb18gr768bqwl46xskaqnkhr9i9qp0v6d";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "http://www.paratype.ru/public/";
     description = "An open Paratype font";
 

--- a/pkgs/data/fonts/pecita/default.nix
+++ b/pkgs/data/fonts/pecita/default.nix
@@ -1,29 +1,21 @@
-{ lib, fetchurl }:
+{ lib, mkFont, fetchurl }:
 
-let
+mkFont {
+  pname = "pecita";
   version = "5.4";
-in
 
-fetchurl {
-  name = "pecita-${version}";
+  src = fetchurl {
+    url = "http://pecita.eu/b/Pecita.otf";
+    sha256 = "1ppajx60hqpr51iaa8dxqan7lk5z5wzfr7nrnw6pa50lkvx1klhg";
+  };
 
-  url = "http://pecita.eu/b/Pecita.otf";
-
-  downloadToTemp = true;
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    cp -v $downloadedFile $out/share/fonts/opentype/Pecita.otf
-  '';
-
-  recursiveHash = true;
-  sha256 = "0pwm20f38lcbfkdqkpa2ydpc9kvmdg0ifc4h2dmipsnwbcb5rfwm";
+  noUnpackFonts = true;
 
   meta = with lib; {
     homepage = "http://pecita.eu/police-en.php";
     description = "Handwritten font with connected glyphs";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = [maintainers.rycee];
+    maintainers = with maintainers; [ rycee ];
   };
 }

--- a/pkgs/data/fonts/penna/default.nix
+++ b/pkgs/data/fonts/penna/default.nix
@@ -1,21 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
-  majorVersion = "0";
-  minorVersion = "10";
+mkFont rec {
   pname = "penna";
-in
+  version = "0.100";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
-
-  url = "http://dotcolon.net/DL/font/${pname}.zip";
-  sha256 = "0hk15yndm56l6rbdykpkry2flffx0567mgjcqcnsx1iyzwwla5km";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
-  '';
+  src = fetchzip {
+    url = "http://dotcolon.net/download/fonts/${pname}_${lib.replaceStrings ["."] [""] version}.zip";
+    sha256 = "170zhaxi65gq52avlnqiwflgi44vaar2gdwjyib6fl588sf8jq3y";
+  };
 
   meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";

--- a/pkgs/data/fonts/poly/default.nix
+++ b/pkgs/data/fonts/poly/default.nix
@@ -1,37 +1,25 @@
-{ stdenv, fetchurl, unzip }:
+{ lib, mkFont, fetchurl, unzip }:
 
-stdenv.mkDerivation rec {
-  name = "poly";
+mkFont rec {
+  pname = "poly";
+  version = "2020-06-23";
 
-  regular = fetchurl {
-    # Finally a mirror that has a sha256 that doesn't change.
-    url = "https://googlefontdirectory.googlecode.com/hg-history/d7441308e589c9fa577f920fc4152fa32477a267/poly/src/Poly-Regular.otf";
-    sha256 = "1mxp2lvki6b1h7r9xcj1ld0g4z5y3dmsal85xam4yr764zpjzaiw";
-  };
+  srcs = map fetchurl [
+    {
+      # Finally a mirror that has a sha256 that doesn't change.
+      url = "https://googlefontdirectory.googlecode.com/hg-history/d7441308e589c9fa577f920fc4152fa32477a267/poly/src/Poly-Regular.otf";
+      sha256 = "1mxp2lvki6b1h7r9xcj1ld0g4z5y3dmsal85xam4yr764zpjzaiw";
+    }
+    {
+      # Finally a mirror that has a sha256 that doesn't change.
+      url = "https://googlefontdirectory.googlecode.com/hg-history/d7441308e589c9fa577f920fc4152fa32477a267/poly/src/Poly-Italic.otf";
+      sha256 = "1chzcy3kyi7wpr4iq4aj1v24fq1wwph1v5z96dimlqcrnvm66h2l";
+    }
+  ];
 
-  italic = fetchurl {
-    # Finally a mirror that has a sha256 that doesn't change.
-    url = "https://googlefontdirectory.googlecode.com/hg-history/d7441308e589c9fa577f920fc4152fa32477a267/poly/src/Poly-Italic.otf";
-    sha256 = "1chzcy3kyi7wpr4iq4aj1v24fq1wwph1v5z96dimlqcrnvm66h2l";
-  };
+  noUnpackFonts = true;
 
-  nativeBuildInputs = [unzip];
-
-  sourceRoot = ".";
-
-  dontUnpack = true;
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/opentype
-    cp ${regular} $out/share/fonts/opentype/Poly-Regular.otf
-    cp ${italic} $out/share/fonts/opentype/Poly-Italic.otf
-  '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "11d7ldryfxi0wzfrg1bhw23a668a44vdb8gggxryvahmp5ahmq2h";
-
-  meta = {
+  meta = with lib; {
     description = "Medium contrast serif font";
     longDescription = ''
       With short ascenders and a very high x-height, Poly is efficient in small
@@ -44,7 +32,7 @@ stdenv.mkDerivation rec {
       and languages that use the Latin script and its variants.
     '';
     homepage = "http://www.fontsquirrel.com/fonts/poly";
-    license = stdenv.lib.licenses.ofl;
-    maintainers = with stdenv.lib.maintainers; [ relrod ];
+    license = licenses.ofl;
+    maintainers = with maintainers; [ relrod ];
   };
 }

--- a/pkgs/data/fonts/powerline-fonts/default.nix
+++ b/pkgs/data/fonts/powerline-fonts/default.nix
@@ -1,22 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-fetchFromGitHub {
-  name = "powerline-fonts-2018-11-11";
+mkFont {
+  name = "powerline-fonts";
+  version = "2018-11-11";
 
-  owner = "powerline";
-  repo = "fonts";
-  rev = "e80e3eba9091dac0655a0a77472e10f53e754bb0";
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    find . -name '*.otf'    -exec install -Dt $out/share/fonts/opentype {} \;
-    find . -name '*.ttf'    -exec install -Dt $out/share/fonts/truetype {} \;
-    find . -name '*.bdf'    -exec install -Dt $out/share/fonts/bdf      {} \;
-    find . -name '*.pcf.gz' -exec install -Dt $out/share/fonts/pcf      {} \;
-    find . -name '*.psf.gz' -exec install -Dt $out/share/consolefonts   {} \;
-  '';
-
-  sha256 = "0r8p4z3db17f5p8jr7sv80nglmjxhg83ncfvwg1dszldswr0dhvr";
+  src = fetchFromGitHub {
+    owner = "powerline";
+    repo = "fonts";
+    rev = "e80e3eba9091dac0655a0a77472e10f53e754bb0";
+    sha256 = "0n8yhc8y1vpiyza58d4fj5lyf03ncymrxc81a31crlbzlqvwwrqq";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/powerline/fonts";

--- a/pkgs/data/fonts/profont/default.nix
+++ b/pkgs/data/fonts/profont/default.nix
@@ -1,43 +1,36 @@
-{ stdenv, fetchzip, mkfontscale }:
+{ lib, mkFont, fetchurl, unzip }:
 
-stdenv.mkDerivation {
+mkFont {
   pname = "profont";
   version = "2019-11";
 
-  # Note: stripRoot doesn't work because the archive
-  # constains the metadata directory `__MACOSX`.
-  src = fetchzip {
-    url = "https://tobiasjung.name/downloadfile.php?file=profont-x11.zip";
-    sha256 = "12dbm87wvcpmn7nzgzwlk45cybp091diara8blqm6129ps27z6kb";
-    stripRoot = false;
-  } + /profont-x11;
+  srcs = [
+    (fetchurl {
+      name = "profont-x11.zip";
+      url = "https://tobiasjung.name/downloadfile.php?file=profont-x11.zip";
+      sha256 = "19ww5iayxzxxgixa9hgb842xd970mwghxfz2vsicp8wfwjh6pawr";
+    })
 
-  srcOtb = fetchzip {
-    url = "https://tobiasjung.name/downloadfile.php?file=profont-otb.zip";
-    sha256 = "18rfhfqrsj3510by0w1a7ak5as6r2cxh8xv02xc1y30mfa6g24x6";
-    stripRoot = false;
-  } + /profont-otb;
+    (fetchurl {
+      name = "profont-otb.zip";
+      url = "https://tobiasjung.name/downloadfile.php?file=profont-otb.zip";
+      sha256 = "07lh237w68s5fmv466jpahn8vlnkr82sjw9vr91w36k8nfsiyx24";
+    })
+  ];
 
-  dontBuild = true;
+  nativeBuildInputs = [ unzip ];
 
-  nativeBuildInputs = [ mkfontscale ];
-
-  installPhase = ''
-    mkdir -p "$out/share/fonts/misc"
+  dontBuild = false;
+  sourceRoot = ".";
+  buildPhase = ''
+    cd profont-x11
     for f in *.pcf; do
-      gzip -n -9 -c "$f" > "$out/share/fonts/misc/$f.gz"
+      gzip -n -9 "$f"
     done
-    install -D -m 644 LICENSE -t "$out/share/doc/$pname"
-    mkfontdir "$out/share/fonts/misc"
-
-    cd $srcOtb
-    install -D -m 644 profontn.otb -t $otb/share/fonts/misc
-    mkfontdir "$otb/share/fonts/misc"
+    cd ..
   '';
 
-  outputs = [ "out" "otb" ];
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://tobiasjung.name/profont/";
     description = "A monospaced font created to be a most readable font for programming";
     maintainers = with maintainers; [ myrl ];

--- a/pkgs/data/fonts/proggyfonts/default.nix
+++ b/pkgs/data/fonts/proggyfonts/default.nix
@@ -1,37 +1,24 @@
-{ stdenv, fetchurl, mkfontscale }:
+{ lib, mkFont, fetchurl }:
 
-stdenv.mkDerivation {
-  name = "proggyfonts-0.1";
+mkFont {
+  pname = "proggyfonts";
+  version = "0.1";
 
   src = fetchurl {
     url = "https://web.archive.org/web/20150801042353/http://kaictl.net/software/proggyfonts-0.1.tar.gz";
     sha256 = "1plcm1sjpa3hdqhhin48fq6zmz3ndm4md72916hd8ff0w6596q0n";
   };
 
-  nativeBuildInputs = [ mkfontscale ];
+  dontBuild = false;
+  buildPhase = ''
+    # duplicated as Speedy11.pcf
+    rm Speedy.pcf
+    for f in *.pcf; do
+      gzip -n -9 "$f"
+    done
+  '';
 
-  installPhase =
-    ''
-      # compress pcf fonts
-      mkdir -p $out/share/fonts/misc
-      rm Speedy.pcf # duplicated as Speedy11.pcf
-      for f in *.pcf; do
-        gzip -n -9 -c "$f" > $out/share/fonts/misc/"$f".gz
-      done
-
-      install -D -m 644 *.bdf -t "$out/share/fonts/misc"
-      install -D -m 644 *.ttf -t "$out/share/fonts/truetype"
-      install -D -m 644 Licence.txt -t "$out/share/doc/$name"
-
-      mkfontscale "$out/share/fonts/truetype"
-      mkfontdir   "$out/share/fonts/misc"
-    '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "1x196rp3wqjd7m57bgp5kfy5jmj97qncxi1vwibs925ji7dqzfgf";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "http://upperbounds.net";
     description = "A set of fixed-width screen fonts that are designed for code listings";
     license = licenses.mit;

--- a/pkgs/data/fonts/public-sans/default.nix
+++ b/pkgs/data/fonts/public-sans/default.nix
@@ -1,22 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "public-sans";
   version = "1.008";
-in fetchzip {
-  name = "public-sans-${version}";
 
-  url = "https://github.com/uswds/public-sans/releases/download/v${version}/public-sans-v${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile binaries/otf/\*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile binaries/variable/\*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile binaries/webfonts/\*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile binaries/webfonts/\*.woff -d $out/share/fonts/woff
-    unzip -j $downloadedFile binaries/webfonts/\*.woff2 -d $out/share/fonts/woff2
-  '';
-
-  sha256 = "1s4xmliri3r1gcn1ws3wa6davj6giliqjdbcv0bh9ryg3dfpjz74";
+  src = fetchzip {
+    url = "https://github.com/uswds/public-sans/releases/download/v${version}/public-sans-v${version}.zip";
+    sha256 = "0cxx65hdz9q795ypr708p44a2p4y0nf6x1y138zpj29vll0cgmp5";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     description = "A strong, neutral, principles-driven, open source typeface for text or display";

--- a/pkgs/data/fonts/quattrocento-sans/default.nix
+++ b/pkgs/data/fonts/quattrocento-sans/default.nix
@@ -1,25 +1,20 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  name = "quattrocento-sans";
   version = "2.0";
-in fetchzip rec {
-  name = "quattrocento-sans-${version}";
 
-  url = "http://web.archive.org/web/20170709124317/http://www.impallari.com/media/releases/quattrocento-sans-v${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{fonts,doc}
-    unzip -j $downloadedFile '*/QuattrocentoSans*.otf' -d $out/share/fonts/opentype
-    unzip -j $downloadedFile '*/FONTLOG.txt'           -d $out/share/doc/${name}
-  '';
-
-  sha256 = "0g8hnn92ks4y0jbizwj7yfa097lk887wqkqpqjdmc09sd2n44343";
+  src = fetchzip {
+    url = "http://web.archive.org/web/20170709124317/http://www.impallari.com/media/releases/quattrocento-sans-v${version}.zip";
+    sha256 = "1jlynv2mamqizpiin4mpa8i1r6h6sb3afv7w01yq1xw0crk8axig";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     homepage = "http://www.impallari.com/quattrocentosans/";
     description = "A classic, elegant and sober sans-serif typeface";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = [maintainers.rycee];
+    maintainers = with maintainers; [ rycee ];
   };
 }

--- a/pkgs/data/fonts/quattrocento/default.nix
+++ b/pkgs/data/fonts/quattrocento/default.nix
@@ -1,19 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "quattrocento";
   version = "1.1";
-in fetchzip rec {
-  name = "quattrocento-${version}";
 
-  url = "http://web.archive.org/web/20170707001804/http://www.impallari.com/media/releases/quattrocento-v${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{fonts,doc}
-    unzip -j $downloadedFile \*.otf        -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*FONTLOG.txt -d $out/share/doc/${name}
-  '';
-
-  sha256 = "0f8l19y61y20sszn8ni8h9kgl0zy1gyzychg22z5k93ip4h7kfd0";
+  src = fetchzip {
+    url = "http://web.archive.org/web/20170707001804/http://www.impallari.com/media/releases/quattrocento-v${version}.zip";
+    sha256 = "1l9f9xkwi4zjxv4lpxikia1mbv3l4qzwhk1895xw28wkbrd3mmly";
+  };
 
   meta = with lib; {
     homepage = "http://www.impallari.com/quattrocento/";

--- a/pkgs/data/fonts/raleway/default.nix
+++ b/pkgs/data/fonts/raleway/default.nix
@@ -1,23 +1,19 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont {
+  pname = "raleway";
   version = "2016-08-30";
-in fetchFromGitHub {
-  name = "raleway-${version}";
 
-  owner = "impallari";
-  repo = "Raleway";
-  rev = "fa27f47b087fc093c6ae11cfdeb3999ac602929a";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Raleway";
+    rev = "fa27f47b087fc093c6ae11cfdeb3999ac602929a";
+    sha256 = "1i6a14ynm29gqjr7kfk118v69vjpd3g4ylwfvhwa66xax09jkhlr";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    find . -name "*-Original.otf" -exec install -Dt $out/share/fonts/opentype {} \;
-    cp *.txt *.md -d $out
-  '';
+  sourceRoot = "source/fonts/OTF v3.000 Fontlab/";
 
-  sha256 = "16jr7drqg2wib2q48ajlsa7rh1jxjibl1wd4rjndi49vfl463j60";
-
-  meta = {
+  meta = with lib; {
     description = "Raleway is an elegant sans-serif typeface family";
 
     longDescription = ''
@@ -35,8 +31,7 @@ in fetchFromGitHub {
     '';
 
     homepage = "https://github.com/impallari/Raleway";
-    license = lib.licenses.ofl;
-
-    maintainers = with lib.maintainers; [ Profpatsch ];
+    license = licenses.ofl;
+    maintainers = with maintainers; [ Profpatsch ];
   };
 }

--- a/pkgs/data/fonts/recursive/default.nix
+++ b/pkgs/data/fonts/recursive/default.nix
@@ -1,20 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "recursive";
   version = "1.052";
-in
-fetchzip {
-  name = "recursive-${version}";
 
-  url = "https://github.com/arrowtype/recursive/releases/download/${version}/Recursive-Beta_${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.ttf   -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.woff2 -d $out/share/fonts/woff2
-  '';
-
-  sha256 = "1kam7wcn0rg89gw52pn174sz0r9lc2kjdz88l0jg20gwa3bjbpc6";
+  src = fetchzip {
+    url = "https://github.com/arrowtype/recursive/releases/download/${version}/Recursive-Beta_${version}.zip";
+    sha256 = "1sgywyxymys0si3wazmq2mvfcbcwq9m3fkyp29c0vcml0hhxjrh1";
+  };
 
   meta = with lib; {
     homepage = "https://recursive.design/";

--- a/pkgs/data/fonts/redhat-official/default.nix
+++ b/pkgs/data/fonts/redhat-official/default.nix
@@ -1,16 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let version = "2.2.0"; in
-fetchzip {
-  name = "redhat-official-${version}";
-  url = "https://github.com/RedHatOfficial/RedHatFont/archive/${version}.zip";
+mkFont rec {
+  pname = "redhat-official";
+  version = "2.2.0";
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
-
-  sha256 = "0yb6shgq6jrv3kq9faky66qpdbv4g580c3jl942844grwyngymyj";
+  src = fetchzip {
+    url = "https://github.com/RedHatOfficial/RedHatFont/archive/${version}.zip";
+    sha256 = "1vahpsg2qni9d73jkpfqp2jymvixdmwykwrcbhh0qafhcgg1iiwi";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/RedHatOfficial/RedHatFont";

--- a/pkgs/data/fonts/rhodium-libre/default.nix
+++ b/pkgs/data/fonts/rhodium-libre/default.nix
@@ -1,22 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "RhodiumLibre";
   version = "1.2.0";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "DunwichType";
-  repo = pname;
-  rev = version;
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -Dm444 -t $out/share/fonts/opentype/ RhodiumLibre-Regular.otf
-    install -Dm444 -t $out/share/fonts/truetype/ RhodiumLibre-Regular.ttf
-  '';
-
-  sha256 = "04ax6bri5vsji465806p8d7zbdf12r5bpvcm9nb8isfqm81ggj0r";
+  src = fetchFromGitHub {
+    owner = "DunwichType";
+    repo = pname;
+    rev = version;
+    sha256 = "1ihj2vx6yqqggah53dxh3alj5p7q6hil90jmxw33w0n4v18jy930";
+  };
 
   meta = with lib; {
     description = "F/OSS/Libre font for Latin and Devanagari";

--- a/pkgs/data/fonts/roboto-mono/default.nix
+++ b/pkgs/data/fonts/roboto-mono/default.nix
@@ -1,73 +1,59 @@
-{ stdenv, fetchurl }:
+{ lib, mkFont, fetchurl }:
 
 let
   # Latest commit touching the robotomono tree
   commit = "5338537ef835a3d9ccf8faf386399f13a30605e2";
 in
-stdenv.mkDerivation {
+mkFont {
   pname = "roboto-mono";
   version = "2.002-20190125";
 
-  srcs = [
-    (fetchurl {
+  srcs = map fetchurl [
+    {
       url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-Regular.ttf";
       sha256 = "1f96r4by67hzqpr4p2wkrfnpj9b7x9qrmwns0312w2l2rnp2qajx";
-    })
-    (fetchurl {
+    }
+    {
       url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-Bold.ttf";
       sha256 = "10wg4dchdq4s89r9pd4h8y5l1bf8mix32pksph2wafyr3815kfnm";
-    })
-    (fetchurl {
+    }
+    {
       url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-Italic.ttf";
       sha256 = "1cayhm3wj36q748xd0zdgrhm4pz7wnrskrlf7khxx2s41m3win5b";
-    })
-    (fetchurl {
+    }
+    {
       url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-BoldItalic.ttf";
       sha256 = "04238dxizdlhnnnyzhnqckxf8ciwlnwyzxby6qgpyg232abx0n2z";
-    })
-    (fetchurl {
+    }
+    {
       url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-Medium.ttf";
       sha256 = "00rh49d0dbycbkjgd2883w7iqzd6hcry08ycjipsvk091p5nq6qy";
-    })
-    (fetchurl {
+    }
+    {
       url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-MediumItalic.ttf";
       sha256 = "0fxl6lblj7anhqmhplnpvjwckjh4g8m6r9jykxdrvpl5hk8mr65b";
-    })
-    (fetchurl {
+    }
+    {
       url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-Light.ttf";
       sha256 = "1h8rbc2p70fabkplsafzah1wcwy92qc1wzkmc1cnb4yq28gxah4a";
-    })
-    (fetchurl {
+    }
+    {
       url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-LightItalic.ttf";
       sha256 = "08y2qngwy61mc22f8i00gshgmcf7hwmfxh1f4j824svy4n16zhsc";
-    })
-    (fetchurl {
+    }
+    {
       url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-Thin.ttf";
       sha256 = "0fmij9zlfjiyf0vb8n8gvrwi35l830zpmkbhcy1xgx0m8za6mmmy";
-    })
-    (fetchurl {
+    }
+    {
       url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-ThinItalic.ttf";
       sha256 = "0mpwdhjnsk8311nw8fqzy1b7v0wzb4pw639ply1j38a0vibrsmn7";
-    })
+    }
   ];
 
-  sourceRoot = "./";
+  noUnpackFonts = true;
 
-  unpackCmd = ''
-    ttfName=$(basename $(stripHash $curSrc))
-    cp $curSrc ./$ttfName
-  '';
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp -a *.ttf $out/share/fonts/truetype/
-  '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "0fkx2z97k29n1392bf76iwdyz44yp86hmqah7ai6bikzlia38qa0";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://www.google.com/fonts/specimen/Roboto+Mono";
     description = "Google Roboto Mono fonts";
     longDescription = ''
@@ -83,6 +69,6 @@ stdenv.mkDerivation {
     '';
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = [ maintainers.romildo ];
+    maintainers = with maintainers; [ romildo ];
   };
 }

--- a/pkgs/data/fonts/roboto-slab/default.nix
+++ b/pkgs/data/fonts/roboto-slab/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-stdenv.mkDerivation {
+mkFont {
   pname = "roboto-slab";
   version = "2.000";
 
@@ -11,16 +11,9 @@ stdenv.mkDerivation {
     sha256 = "1v6z0a2xgwgf9dyj62sriy8ckwpbwlxkki6gfax1f4h4livvzpdn";
   };
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp -a fonts/static/*.ttf $out/share/fonts/truetype/
-  '';
+  sourceRoot = "./source/fonts";
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "0g663npi5lkvwcqafd4cjrm90ph0nv1lig7d19xzfymnj47qpj8x";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://www.google.com/fonts/specimen/Roboto+Slab";
     description = "Roboto Slab Typeface by Google";
     longDescription = ''
@@ -36,6 +29,6 @@ stdenv.mkDerivation {
     '';
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = [ maintainers.romildo ];
+    maintainers = with maintainers; [ romildo ];
   };
 }

--- a/pkgs/data/fonts/roboto/default.nix
+++ b/pkgs/data/fonts/roboto/default.nix
@@ -1,18 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "roboto";
   version = "2.138";
-in fetchzip {
-  name = "roboto-${version}";
 
-  url = "https://github.com/google/roboto/releases/download/v${version}/roboto-unhinted.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -x __MACOSX/\* -d $out/share/fonts/truetype
-  '';
-
-  sha256 = "1s3c48wwvvwd3p4w3hfkri5v2c54j2bdxmd3bjv54klc5mrlh6z3";
+  src = fetchzip {
+    url = "https://github.com/google/roboto/releases/download/v${version}/roboto-unhinted.zip";
+    sha256 = "0wa176l9718m39sm66iz0zpfb8fly2ddas18h4c9f1m7k18wzvdr";
+    stripRoot = false;
+  };
 
   meta = {
     homepage = "https://github.com/google/roboto";

--- a/pkgs/data/fonts/rounded-mgenplus/default.nix
+++ b/pkgs/data/fonts/rounded-mgenplus/default.nix
@@ -1,17 +1,16 @@
-{ lib, fetchzip, p7zip }:
+{ lib, mkFont, fetchurl, p7zip }:
 
-let
+mkFont rec {
   pname = "rounded-mgenplus";
   version = "20150602";
-in fetchzip rec {
-  name = "${pname}-${version}";
 
-  url = "https://osdn.jp/downloads/users/8/8598/${name}.7z";
-  postFetch = ''
-    ${p7zip}/bin/7z x $downloadedFile
-    install -m 444 -D -t $out/share/fonts/${pname} ${pname}-*.ttf
-  '';
-  sha256 = "0vwdknagdrl5dqwpb1x5lxkbfgvbx8dpg7cb6yamgz71831l05v1";
+  src = fetchurl {
+    url = "https://osdn.jp/downloads/users/8/8598/${pname}-${version}.7z";
+    sha256 = "1k15xvzd3s5ppp151wv31wrfq2ri8v96xh7i71i974rxjxj6gspc";
+  };
+
+  nativeBuildInputs = [ p7zip ];
+  sourceRoot = ".";
 
   meta = with lib; {
     description = "A Japanese font based on Rounded M+ and Noto Sans Japanese";

--- a/pkgs/data/fonts/route159/default.nix
+++ b/pkgs/data/fonts/route159/default.nix
@@ -1,24 +1,17 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
-  majorVersion = "1";
-  minorVersion = "10";
+mkFont rec {
   pname = "route159";
-in
+  version = "1.10";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
-
-  url = "http://dotcolon.net/DL/font/${pname}_${majorVersion}${minorVersion}.zip";
-  sha256 = "1nv5csg73arvvwpac7ylh4j9n0s3qp79rbv2s4jvs2bf6gqhsq7h";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
-  '';
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${pname}_${lib.replaceStrings ["."] [""] version}.zip";
+    sha256 = "0dd58yjiy4awhj9xa9giqkf1cpjgmzcrgsjg45zvl6abdl2z52fl";
+    stripRoot = false;
+  };
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${pname}/";
+    homepage = "https://dotcolon.net/font/${pname}/";
     description = "A weighted sans serif font";
     platforms = platforms.all;
     maintainers = with maintainers; [ leenaars ];

--- a/pkgs/data/fonts/sahel-fonts/default.nix
+++ b/pkgs/data/fonts/sahel-fonts/default.nix
@@ -1,26 +1,21 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "sahel-fonts";
   version = "1.0.0-alpha22";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "rastikerdar";
-  repo = "sahel-font";
-  rev = "v${version}";
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/sahel-fonts {} \;
-  '';
-  sha256 = "0vj8ydv50rjanb0favd7rh4r9rv5fl39vqwvzkpgfdcdawn0xjm7";
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "sahel-font";
+    rev = "v${version}";
+    sha256 = "1kx7byzb5zxspq0i4cvgf4q7sm6xnhdnfyw9zrb1wfmdv3jzaz7p";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/sahel-font";
     description = "A Persian (farsi) Font - فونت (قلم) فارسی ساحل";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = [ maintainers.linarcx ];
+    maintainers = with maintainers; [ linarcx ];
   };
 }

--- a/pkgs/data/fonts/samim-fonts/default.nix
+++ b/pkgs/data/fonts/samim-fonts/default.nix
@@ -1,26 +1,21 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "samim-fonts";
   version = "3.1.0";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "rastikerdar";
-  repo = "samim-font";
-  rev = "v${version}";
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/samim-fonts {} \;
-  '';
-  sha256 = "0mmhncqg48dp0d7l725dv909zswbkk22dlqzcdfh6k6cgk2gn08q";
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "samim-font";
+    rev = "v${version}";
+    sha256 = "1mp0pgbn9r098ilajwzag7c21shwb13mq61ly9av0mfbpnhkkjqk";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/samim-font";
     description = "A Persian (Farsi) Font - فونت (قلم) فارسی صمیم";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = [ maintainers.linarcx ];
+    maintainers = with maintainers; [ linarcx ];
   };
 }

--- a/pkgs/data/fonts/sampradaya/default.nix
+++ b/pkgs/data/fonts/sampradaya/default.nix
@@ -1,13 +1,15 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchurl }:
 
-fetchzip {
-  name = "sampradaya-2015-05-26";
+mkFont {
+  pname = "sampradaya";
+  version = "0.1.0";
 
-  url = "https://bitbucket.org/OorNaattaan/sampradaya/raw/afa9f7c6ab17e14bd7dd74d0acaec2f75454dfda/Sampradaya.ttf";
+  src = fetchurl {
+    url = "https://github.com/deepestblue/Sampradaya/releases/download/v0.1.0/Sampradaya-osx.ttf";
+    sha256 = "1l8asiqbc6q0xcmjypw7z2gl9w32pnar46dh6lap38nqr1aykh07";
+  };
 
-  postFetch = "install -Dm644 $downloadedFile $out/share/fonts/truetype/Sampradaya.ttf";
-
-  sha256 = "1pqyj5r5jc7dk8yyzl7i6qq2m9zvahcjj49a66wwzdby5zyw8dqv";
+  noUnpackFonts = true;
 
   meta = with lib; {
     homepage = "https://bitbucket.org/OorNaattaan/sampradaya/";

--- a/pkgs/data/fonts/sarasa-gothic/default.nix
+++ b/pkgs/data/fonts/sarasa-gothic/default.nix
@@ -1,20 +1,16 @@
-{ lib, fetchurl, libarchive }:
+{ lib, mkFont, fetchurl, p7zip }:
 
-let
+mkFont rec {
+  pname = "sarasa-gothic";
   version = "0.12.6";
-in fetchurl {
-  name = "sarasa-gothic-${version}";
 
-  url = "https://github.com/be5invis/Sarasa-Gothic/releases/download/v${version}/sarasa-gothic-ttc-${version}.7z";
-  sha256 = "1b15gsmv2jr0r8xssr8216s8xsghr6w5wm3w3imm3qlh3kqk1qg8";
+  src = fetchurl {
+    url = "https://github.com/be5invis/Sarasa-Gothic/releases/download/v${version}/sarasa-gothic-ttc-${version}.7z";
+    sha256 = "1g6k9d5lajchbhsh3g12fk5cgilyy6yw09fals9vc1f9wsqvac86";
+  };
 
-  recursiveHash = true;
-  downloadToTemp = true;
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    ${libarchive}/bin/bsdtar -xf $downloadedFile -C $out/share/fonts
-  '';
+  nativeBuildInputs = [ p7zip ];
+  sourceRoot = ".";
 
   meta = with lib; {
     description = "SARASA GOTHIC is a Chinese & Japanese programming font based on Iosevka and Source Han Sans";

--- a/pkgs/data/fonts/scheherazade/default.nix
+++ b/pkgs/data/fonts/scheherazade/default.nix
@@ -1,21 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "scheherazade";
   version = "2.100";
-in fetchzip rec {
-  name = "scheherazade-${version}";
 
-  url = "http://software.sil.org/downloads/r/scheherazade/Scheherazade-${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -l $downloadedFile
-    unzip -j $downloadedFile \*.ttf                        -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*/FONTLOG.txt  \*/README.txt -d $out/share/doc/${name}
-    unzip -j $downloadedFile \*/documentation/\*           -d $out/share/doc/${name}/documentation
-  '';
-
-  sha256 = "1g5f5f9gzamkq3kqyf7vbzvl4rdj3wmjf6chdrbxksrm3rnb926z";
+  src = fetchzip {
+    url = "http://software.sil.org/downloads/r/scheherazade/Scheherazade-${version}.zip";
+    sha256 = "0zapz17vdphwvrs0hiyp5r0fbgbc6nrj4cicgid4v657wcw34rbp";
+  };
 
   meta = with lib; {
     homepage = "https://software.sil.org/scheherazade/";

--- a/pkgs/data/fonts/seshat/default.nix
+++ b/pkgs/data/fonts/seshat/default.nix
@@ -1,21 +1,13 @@
-{ lib,  fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
-  majorVersion = "0";
-  minorVersion = "100";
+mkFont rec {
   pname = "seshat";
-in
+  version = "0.100";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
-
-  url = "http://dotcolon.net/DL/font/${pname}.zip";
-  sha256 = "1zzgc2d0jrris92p3irmxjhdq8aj99alz0z7dlz25qf37lcilrir";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
-  '';
+  src = fetchzip {
+    url = "http://dotcolon.net/download/fonts/${pname}_${lib.replaceStrings ["."] [""] version}.zip";
+    sha256 = "0r1v626zjm0az162k6cq2xiaqfwz8853p40dczrw8vf03h76n2jy";
+  };
 
   meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";

--- a/pkgs/data/fonts/shabnam-fonts/default.nix
+++ b/pkgs/data/fonts/shabnam-fonts/default.nix
@@ -1,20 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "shabnam-fonts";
   version = "4.0.0";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "rastikerdar";
-  repo = "shabnam-font";
-  rev = "v${version}";
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/shabnam-fonts {} \;
-  '';
-  sha256 = "0wfyaaj2pq2knz12l7rsc4wc703cbz0r8gkcya5x69p0aixch8ba";
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "shabnam-font";
+    rev = "v${version}";
+    sha256 = "1y4w16if2y12028b9vyc5l5c5bvcglhxacv380ixb8fcc4hfakmb";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/shabnam-font";

--- a/pkgs/data/fonts/shrikhand/default.nix
+++ b/pkgs/data/fonts/shrikhand/default.nix
@@ -1,15 +1,15 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchurl }:
 
-let
+mkFont {
+  pname = "shrikhand";
   version = "2016-03-03";
-in fetchzip {
-  name = "shrikhand-${version}";
 
-  url = "https://github.com/jonpinhorn/shrikhand/raw/c11c9b0720fba977fad7cb4f339ebacdba1d1394/build/Shrikhand-Regular.ttf";
+  src = fetchurl {
+    url = "https://github.com/jonpinhorn/shrikhand/raw/c11c9b0720fba977fad7cb4f339ebacdba1d1394/build/Shrikhand-Regular.ttf";
+    sha256 = "1h0h78q15fb6x8jmw29jzjx2f6xnwrx3h0qwz7d0sqxr1c3zawy0";
+  };
 
-  postFetch = "install -D -m644 $downloadedFile $out/share/fonts/truetype/Shrikhand-Regular.ttf";
-
-  sha256 = "0s54k9cs1g2yz6lwg5gakqb12vg5qkfdz3pc8mh7mib2s6q926hs";
+  noUnpackFonts = true;
 
   meta = with lib; {
     homepage = "https://jonpinhorn.github.io/shrikhand/";

--- a/pkgs/data/fonts/signwriting/default.nix
+++ b/pkgs/data/fonts/signwriting/default.nix
@@ -1,21 +1,23 @@
-{ lib, runCommand, fetchurl }:
+{ lib, mkFont, fetchurl }:
 
-runCommand "signwriting-1.1.4" {
-  src1 = fetchurl {
-    url = "https://github.com/Slevinski/signwriting_2010_fonts/raw/61c8e7123a1168657b5d34d85266a637f67b9d2b/fonts/SignWriting%202010.ttf";
-    name = "SignWriting_2010.ttf";
-    sha256 = "1abjzykbjx2hal8mrxp51rvblv3q84akyn9qhjfaj20rwphkf5zj";
-  };
+mkFont {
+  pname = "signwriting";
+  version = "2014-11-11";
 
-  src2 = fetchurl {
-    url = "https://github.com/Slevinski/signwriting_2010_fonts/raw/61c8e7123a1168657b5d34d85266a637f67b9d2b/fonts/SignWriting%202010%20Filling.ttf";
-    name = "SignWriting_2010_Filling.ttf";
-    sha256 = "0am5wbf7jdy9szxkbsc5f3959cxvbj7mr0hy1ziqmkz02c6xjw2m";
-  };
+  srcs = map fetchurl [
+    {
+      url = "https://github.com/Slevinski/signwriting_2010_fonts/raw/61c8e7123a1168657b5d34d85266a637f67b9d2b/fonts/SignWriting%202010.ttf";
+      name = "SignWriting_2010.ttf";
+      sha256 = "1abjzykbjx2hal8mrxp51rvblv3q84akyn9qhjfaj20rwphkf5zj";
+    }
+    {
+      url = "https://github.com/Slevinski/signwriting_2010_fonts/raw/61c8e7123a1168657b5d34d85266a637f67b9d2b/fonts/SignWriting%202010%20Filling.ttf";
+      name = "SignWriting_2010_Filling.ttf";
+      sha256 = "0am5wbf7jdy9szxkbsc5f3959cxvbj7mr0hy1ziqmkz02c6xjw2m";
+    }
+  ];
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "0cn37s3lc7gbr8036l7ia2869qmxglkmgllh3r9q5j54g3sfjc7q";
+  noUnpackFonts = true;
 
   meta = with lib; {
     homepage = "https://github.com/Slevinski/signwriting_2010_fonts";
@@ -25,8 +27,3 @@ runCommand "signwriting-1.1.4" {
     platforms = platforms.all;
   };
 }
-''
-  mkdir -p $out/share/fonts/truetype
-  cp $src1 $out/share/fonts/truetype/SignWriting_2010.ttf
-  cp $src2 $out/share/fonts/truetype/SignWriting_2010_Filling.ttf
-''

--- a/pkgs/data/fonts/siji/default.nix
+++ b/pkgs/data/fonts/siji/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchzip, libfaketime, fonttosfnt, mkfontscale }:
+{ lib, mkFont, fetchzip, libfaketime, fonttosfnt, mkfontscale }:
 
-stdenv.mkDerivation rec {
-  name = "siji-${version}";
+mkFont rec {
+  pname = "siji";
   version = "2016-05-13";
 
   src = fetchzip {
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ libfaketime fonttosfnt mkfontscale ];
 
+  dontBuild = false;
   buildPhase = ''
     # compress pcf fonts
     gzip -n -9 pcf/*
@@ -23,22 +24,11 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  postInstall = ''
-    install -m 644 -D pcf/* -t "$out/share/fonts/misc"
-    install -m 644 -D bdf/* -t "$bdf/share/fonts/misc"
-    install -m 644 -D *.otb -t "$otb/share/fonts/misc"
-    mkfontdir "$out/share/fonts/misc"
-    mkfontdir "$bdf/share/fonts/misc"
-    mkfontdir "$otb/share/fonts/misc"
-  '';
-
-  outputs = [ "out" "bdf" "otb" ];
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/stark/siji";
     description = "An iconic bitmap font based on Stlarch with additional glyphs";
     license = licenses.gpl2;
     platforms = platforms.all;
-    maintainers = [ maintainers.asymmetric ];
+    maintainers = with maintainers; [ asymmetric ];
   };
 }

--- a/pkgs/data/fonts/source-code-pro/default.nix
+++ b/pkgs/data/fonts/source-code-pro/default.nix
@@ -1,18 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont {
+  pname = "source-code-pro";
   version = "2.030";
-in fetchzip {
-  name = "source-code-pro-${version}";
 
-  url = "https://github.com/adobe-fonts/source-code-pro/archive/2.030R-ro/1.050R-it.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
-
-  sha256 = "0d8qwzjgnz264wlm4qim048z3236z4hbblvc6yplw13f6b65j6fv";
+  src = fetchzip {
+    url = "https://github.com/adobe-fonts/source-code-pro/archive/2.030R-ro/1.050R-it.zip";
+    sha256 = "0hc5kflr8xzqgdm0c3gbgb1paygznxmnivkylid69ipc7wnicx1n";
+  };
 
   meta = {
     description = "A set of monospaced OpenType fonts designed for coding environments";

--- a/pkgs/data/fonts/source-han-code-jp/default.nix
+++ b/pkgs/data/fonts/source-han-code-jp/default.nix
@@ -1,25 +1,19 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
   pname = "source-han-code-jp";
-  version = "2.011R";
-in fetchzip {
-  name = "${pname}-${version}";
+  version = "2.011";
 
-  url = "https://github.com/adobe-fonts/${pname}/archive/${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/adobe-fonts/${pname}/archive/${version}R.zip";
+    sha256 = "1grcnmfp74pc7l448jswyyrixfklrm45pkyznw5vz9q3ygfdx4y6";
+  };
 
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
-
-  sha256 = "184vrjkymcm29k1cx00cdvjchzqr1w17925lmh85f0frx7vwljcd";
-
-  meta = {
+  meta = with lib; {
     description = "A monospaced Latin font suitable for coding";
-    maintainers = with lib.maintainers; [ mt-caret ];
-    platforms = with lib.platforms; all;
     homepage = "https://blogs.adobe.com/CCJKType/2015/06/source-han-code-jp.html";
-    license = lib.licenses.ofl;
+    license = licenses.ofl;
+    platforms = with platforms; all;
+    maintainers = with maintainers; [ mt-caret ];
   };
 }

--- a/pkgs/data/fonts/source-sans-pro/default.nix
+++ b/pkgs/data/fonts/source-sans-pro/default.nix
@@ -1,20 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "source-sans-pro";
   version = "3.006";
-in fetchzip {
-  name = "source-sans-pro-${version}";
 
-  url = "https://github.com/adobe-fonts/source-sans-pro/releases/download/${version}R/source-sans-pro-${version}R.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/{opentype,truetype,variable}
-    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
-    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
-    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
-  '';
-
-  sha256 = "11jd50cqiq2s0z39rclg73iiw2j5yzgs1glfs9psw5wbbisgysmr";
+  src = fetchzip {
+    url = "https://github.com/adobe-fonts/source-sans-pro/releases/download/${version}R/source-sans-pro-${version}R.zip";
+    sha256 = "1asm5s68ay57wiq7aydcw4x0g3zg5lfk2gfza1p87p1a725ay9nm";
+  };
 
   meta = with lib; {
     homepage = "https://adobe-fonts.github.io/source-sans-pro/";

--- a/pkgs/data/fonts/source-serif-pro/default.nix
+++ b/pkgs/data/fonts/source-serif-pro/default.nix
@@ -1,20 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "source-serif-pro";
   version = "3.000";
-in fetchzip {
-  name = "source-serif-pro-${version}";
 
-  url = "https://github.com/adobe-fonts/source-serif-pro/releases/download/${version}R/source-serif-pro-${version}R.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/{opentype,truetype,variable}
-    unzip -j $downloadedFile "OTF/*.otf" -d $out/share/fonts/opentype
-    unzip -j $downloadedFile "TTF/*.ttf" -d $out/share/fonts/truetype
-    unzip -j $downloadedFile "VAR/*.otf" -d $out/share/fonts/variable
-  '';
-
-  sha256 = "06yp8y79mqk02qzp81h8zkmzqqlhicgrkwmzkd0bm338xh8grsiz";
+  src = fetchzip {
+    url = "https://github.com/adobe-fonts/source-serif-pro/releases/download/${version}R/source-serif-pro-${version}R.zip";
+    sha256 = "1l0bcb6czlrm6raldlvr3aq1rz8l1c83dqqv1pavgc5yc15c239j";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     homepage = "https://adobe-fonts.github.io/source-serif-pro/";

--- a/pkgs/data/fonts/spleen/default.nix
+++ b/pkgs/data/fonts/spleen/default.nix
@@ -1,14 +1,15 @@
-{ lib, fetchurl, mkfontscale }:
+{ lib, mkFont, fetchzip, mkfontscale }:
 
-let
+mkFont rec {
   pname = "spleen";
   version = "1.7.0";
-in fetchurl {
-  name = "${pname}-${version}";
-  url = "https://github.com/fcambus/spleen/releases/download/${version}/spleen-${version}.tar.gz";
 
-  downloadToTemp = true;
-  recursiveHash = true;
+  src = fetchzip {
+    url = "https://github.com/fcambus/spleen/releases/download/${version}/spleen-${version}.tar.gz";
+    sha256 = "02193806fp2dw4114y0j61skv8wb2z8r1zg3hp4g9i9v579jbwir";
+  };
+
+  /*
   postFetch = ''
     tar xvf $downloadedFile --strip=1
     d="$out/share/fonts/misc"
@@ -19,7 +20,7 @@ in fetchurl {
     # create fonts.dir so NixOS xorg module adds to fp
     ${mkfontscale}/bin/mkfontdir "$d"
   '';
-  sha256 = "17dn6spfr8wv63sy009djb4q12q635m13wsyirzn074qabhr9ggg";
+  */
 
   meta = with lib; {
     description = "Monospaced bitmap fonts";

--- a/pkgs/data/fonts/stix-otf/default.nix
+++ b/pkgs/data/fonts/stix-otf/default.nix
@@ -1,24 +1,20 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "stix-otf";
   version = "1.1.1";
-in fetchzip {
-  name = "stix-otf-${version}";
 
-  url = "http://ftp.fi.muni.cz/pub/linux/gentoo/distfiles/STIXv${version}-word.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
-
-  sha256 = "04d4qxq3i9fyapsmxk6d9v1xirjam8c74fyxs6n24d3gf2945zmw";
+  src = fetchzip {
+    url = "http://ftp.fi.muni.cz/pub/linux/gentoo/distfiles/STIXv${version}-word.zip";
+    sha256 = "0kqglki9wnp90idyn5k2l1hdjlkmfjavln864sy7hg4ixywr6x1k";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     homepage = "http://www.stixfonts.org/";
     description = "Fonts for Scientific and Technical Information eXchange";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = [maintainers.rycee];
+    maintainers = with maintainers; [ rycee ];
   };
 }

--- a/pkgs/data/fonts/stix-two/default.nix
+++ b/pkgs/data/fonts/stix-two/default.nix
@@ -1,28 +1,24 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
+  pname = "stix-two";
   version = "2.0.2";
-in fetchFromGitHub {
-  name = "stix-two-${version}";
 
-  owner = "stipub";
-  repo = "stixfonts";
-  rev = "v${version}";
+  src = fetchFromGitHub {
+    owner = "stipub";
+    repo = "stixfonts";
+    rev = "v${version}";
+    sha256 = "1w8dgsf798njhgch92dyvldiwkhcavkrrxfgy9yfxb4zbdgwrarg";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -m444 -Dt $out/share/fonts/opentype/ OTF/*.otf
-    install -m444 -Dt $out/share/fonts/woff/     WOFF/*.woff
-    install -m444 -Dt $out/share/fonts/woff2/    WOFF2/*.woff2
-  '';
+  dontBuild = false;
+  buildPhase = "rm -rf archive";
 
-  sha256 = "1ah8s0cb67yv4ll8zfs01mdh9m5i2lbkrfbmkhi1xdid6pxsk32x";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "http://www.stixfonts.org/";
     description = "Fonts for Scientific and Technical Information eXchange";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = [ maintainers.rycee ];
+    maintainers = with maintainers; [ rycee ];
   };
 }

--- a/pkgs/data/fonts/sudo/default.nix
+++ b/pkgs/data/fonts/sudo/default.nix
@@ -1,18 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
   version = "0.42";
-in fetchzip {
-  name = "sudo-font-${version}";
-  url = "https://github.com/jenskutilek/sudo-font/releases/download/v${version}/sudo.zip";
-  sha256 = "1rqpwihf2sakrhkaw041r3xc9fhafaqn22n79haqkmwv4vmnspch";
+  pname = "sudo-font";
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/
-    unzip -j $downloadedFile \*.woff -d $out/share/fonts/woff/
-    unzip -j $downloadedFile \*.woff2 -d $out/share/fonts/woff2/
-  '';
+  src = fetchzip {
+    url = "https://github.com/jenskutilek/sudo-font/releases/download/v${version}/sudo.zip";
+    sha256 = "1dav0mqkdk18wcgmk0nhx53v92fdzfdfqq61sx532rihrvgxcfh6";
+  };
+
   meta = with lib; {
     description = "Font for programmers and command line users";
     homepage = "https://www.kutilek.de/sudo-font/";

--- a/pkgs/data/fonts/tai-languages/default.nix
+++ b/pkgs/data/fonts/tai-languages/default.nix
@@ -1,23 +1,26 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchurl }:
 
 {
-tai-ahom = fetchzip {
-  name = "tai-ahom-2015-07-06";
+  tai-ahom = mkFont {
+    pname = "tai-ahom";
+    version = "2015-07-06";
 
-  url = "https://github.com/enabling-languages/tai-languages/blob/b57a3ea4589af69bb8e87c6c4bb7cd367b52f0b7/ahom/.fonts/ttf/.original/AhomUnicode_FromMartin.ttf?raw=true";
+    src = fetchurl {
+      url = "https://github.com/enabling-languages/tai-languages/blob/b57a3ea4589af69bb8e87c6c4bb7cd367b52f0b7/ahom/.fonts/ttf/.original/AhomUnicode_FromMartin.ttf?raw=true";
+      sha256 = "0zpjsylm29qc3jdv5kv0689pcirai46j7xjp5dppi0fmzxaxqnsk";
+      name = "AhomUnicode_FromMartin.ttf";
+    };
 
-  postFetch = "install -Dm644 $downloadedFile $out/share/fonts/truetype/AhomUnicode.ttf";
+    noUnpackFonts = true;
 
-  sha256 = "03h8ql9d5bzq4j521j0cz08ddf717bzim1nszh2aar6kn0xqnp9q";
-
-  meta = with lib; {
-    homepage = "https://github.com/enabling-languages/tai-languages";
-    description = "Unicode-compliant Tai Ahom font";
-    maintainers = with maintainers; [ mathnerd314 ];
-    license = licenses.ofl; # See font metadata
-    platforms = platforms.all;
+    meta = with lib; {
+      homepage = "https://github.com/enabling-languages/tai-languages";
+      description = "Unicode-compliant Tai Ahom font";
+      license = licenses.ofl; # See font metadata
+      platforms = platforms.all;
+      maintainers = with maintainers; [ mathnerd314 ];
+    };
   };
-};
 
 # TODO: package others (Khamti Shan, Tai Aiton, Tai Phake, and/or Assam Tai)
 

--- a/pkgs/data/fonts/tamsyn/default.nix
+++ b/pkgs/data/fonts/tamsyn/default.nix
@@ -1,23 +1,18 @@
-{ stdenv, fetchurl, fontforge, mkfontscale }:
+{ lib, mkFont, fetchurl, fontforge, mkfontscale }:
 
-let
-  version = "1.11";
-in stdenv.mkDerivation {
+mkFont rec {
   pname = "tamsyn-font";
-  inherit version;
+  version = "1.11";
 
   src = fetchurl {
-    url = "http://www.fial.com/~scott/tamsyn-font/download/tamsyn-font-${version}.tar.gz";
+    url = "https://www.fial.com/~scott/tamsyn-font/download/${pname}-${version}.tar.gz";
     sha256 = "0kpjzdj8sv5871b8827mjgj9dswk75h94jj5iia2bds18ih1pglp";
    };
 
   nativeBuildInputs = [ fontforge mkfontscale ];
 
-  unpackPhase = ''
-    tar -xzf $src --strip-components=1
-  '';
-
-  postBuild = ''
+  dontBuild = false;
+  buildPhase = ''
     # convert pcf fonts to otb
     for i in *.pcf; do
       name=$(basename "$i" .pcf)
@@ -28,27 +23,17 @@ in stdenv.mkDerivation {
     gzip -n -9 *.pcf
   '';
 
-  installPhase = ''
-    install -m 644 -D *.pcf.gz -t "$out/share/fonts/misc"
-    install -m 644 -D *.psf.gz -t "$out/share/consolefonts"
-    install -m 644 -D *.otb    -t "$otb/share/fonts/misc"
-    mkfontdir "$out/share/fonts/misc"
-    mkfontdir "$otb/share/fonts/misc"
-  '';
-
-  outputs = [ "out" "otb" ];
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A monospace bitmap font aimed at programmers";
     longDescription = ''Tamsyn is a monospace bitmap font, primarily aimed at
     programmers. It was derived from Gilles Boccon-Gibod's MonteCarlo. Tamsyn
     font was further inspired by Gohufont, Terminus, Dina, Proggy, Fixedsys, and
     Consolas.
     '';
-    homepage = "http://www.fial.com/~scott/tamsyn-font/";
-    downloadPage = "http://www.fial.com/~scott/tamsyn-font/download";
+    homepage = "https://www.fial.com/~scott/tamsyn-font/";
+    downloadPage = "https://www.fial.com/~scott/tamsyn-font/download";
     license = licenses.free;
-    maintainers = [ maintainers.rps ];
+    maintainers = with maintainers; [ rps ];
   };
 }
 

--- a/pkgs/data/fonts/tamzen/default.nix
+++ b/pkgs/data/fonts/tamzen/default.nix
@@ -1,6 +1,6 @@
-{ fetchFromGitHub, mkfontscale, stdenv }:
+{ lib, mkFont, fetchFromGitHub, mkfontscale }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "tamzen-font";
   version = "1.11.5";
 
@@ -11,19 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "00x5fipzqimglvshhqwycdhaqslbvn3rl06jnswhyxfvz16ymj7s";
   };
 
-  nativeBuildInputs = [ mkfontscale ];
-
-  installPhase = ''
-    install -m 644 -D pcf/*.pcf -t "$out/share/fonts/misc"
-    install -m 644 -D psf/*.psf -t "$out/share/consolefonts"
-    install -m 644 -D otb/*.otb -t "$otb/share/fonts/misc"
-    mkfontdir "$out/share/fonts/misc"
-    mkfontdir "$otb/share/fonts/misc"
-  '';
-
-  outputs = [ "out" "otb" ];
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Bitmapped programming font based on Tamsyn";
     longDescription = ''
     Tamzen is a monospace bitmap font. It is programatically forked

--- a/pkgs/data/fonts/tenderness/default.nix
+++ b/pkgs/data/fonts/tenderness/default.nix
@@ -1,21 +1,16 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
-  majorVersion = "0";
-  minorVersion = "601";
+mkFont rec {
   pname = "tenderness";
-in
+  version = "0.601";
+  # for compatibility
+  name = "${pname}-font-${version}";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
-
-  url = "http://dotcolon.net/DL/font/${pname}_${majorVersion}${minorVersion}.zip";
-  sha256 = "0d88l5mzq0k63zsmb8d5w3hfqxy04vpv4j0j8nmj1xv6kikhhybh";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
-  '';
+  src = fetchzip {
+    url = "http://dotcolon.net/download/fonts/${pname}_${lib.replaceStrings ["."] [""] version}.zip";
+    sha256 = "03175rkbcy7mv9b4gwfliyq4r94mv2hh74hhlkvgmvyqx9dll0kg";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";

--- a/pkgs/data/fonts/terminus-font-ttf/default.nix
+++ b/pkgs/data/fonts/terminus-font-ttf/default.nix
@@ -1,24 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "terminus-font-ttf";
   version = "4.47.0";
-in fetchzip {
-  name = "terminus-font-ttf-${version}";
 
-  url = "http://files.ax86.net/terminus-ttf/files/${version}/terminus-ttf-${version}.zip";
-
-  postFetch = ''
-    unzip -j $downloadedFile
-
-    for i in *.ttf; do
-      local destname="$(echo "$i" | sed -E 's|-[[:digit:].]+\.ttf$|.ttf|')"
-      install -Dm 644 "$i" "$out/share/fonts/truetype/$destname"
-    done
-
-    install -Dm 644 COPYING "$out/share/doc/terminus-font-ttf/COPYING"
-  '';
-
-  sha256 = "1mnx3vlnl0r15yzsa4zb9qqab4hpi603gdwhlbw960wg03i3xn8z";
+  src = fetchzip {
+    url = "http://files.ax86.net/terminus-ttf/files/${version}/terminus-ttf-${version}.zip";
+    sha256 = "13kalpyn75hrxhggs9yijrcrb00qdphlvbg69cvn6xryfnrrfan6";
+  };
 
   meta = with lib; {
     description = "A clean fixed width TTF font";

--- a/pkgs/data/fonts/theano/default.nix
+++ b/pkgs/data/fonts/theano/default.nix
@@ -1,20 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "theano";
   version = "2.0";
-in fetchzip rec {
-  name = "theano-${version}";
 
-  url = "https://github.com/akryukov/theano/releases/download/v${version}/theano-${version}.otf.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    mkdir -p $out/share/doc/${name}
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.txt -d "$out/share/doc/${name}"
-  '';
-
-  sha256 = "1my1symb7k80ys33iphsxvmf6432wx6vjdnxhzhkgrang1rhx1h8";
+  src = fetchzip {
+    url = "https://github.com/akryukov/theano/releases/download/v${version}/theano-${version}.otf.zip";
+    sha256 = "1z3c63rcp4vfjyfv8xwc3br10ydwjyac3ipbl09y01s7qhfz02gp";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/akryukov/theano";

--- a/pkgs/data/fonts/tlwg/default.nix
+++ b/pkgs/data/fonts/tlwg/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, fontforge }:
+{ lib, mkFont, fetchFromGitHub, autoreconfHook, fontforge }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "tlwg";
   version = "0.6.4";
 
@@ -11,16 +11,16 @@ stdenv.mkDerivation rec {
     sha256 = "13bx98ygyyizb15ybdv3856lkxhx1fss8f7aiqmp0lk9zgw4mqyk";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook fontforge ];
 
-  buildInputs = [ fontforge ];
-
+  dontBuild = false;
+  dontConfigure = false;
   preAutoreconf = "echo ${version} > VERSION";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A collection of Thai scalable fonts available under free licenses";
     homepage = "https://linux.thai.net/projects/fonts-tlwg";
     license = with licenses; [ gpl2 publicDomain lppl13c free ];
-    maintainers = [ maintainers.yrashk ];
+    maintainers = with maintainers; [ yrashk ];
   };
 }

--- a/pkgs/data/fonts/tt2020/default.nix
+++ b/pkgs/data/fonts/tt2020/default.nix
@@ -1,27 +1,21 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "TT2020";
   version = "2020-01-05";
-in
-fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "ctrlcctrlv";
-  repo = pname;
-  rev = "2b418fab5f99f72a18b3b2e7e2745ac4e03aa612";
-  sha256 = "1z0nizvs0gp0xl7pn6xcjvsysxhnfm7aqfamplkyvya3fxvhncds";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -Dm644 -t $out/share/fonts/truetype dist/*.ttf
-    install -Dm644 -t $out/share/fonts/woff2 dist/*.woff2
-  '';
+  src = fetchFromGitHub {
+    owner = "ctrlcctrlv";
+    repo = pname;
+    rev = "2b418fab5f99f72a18b3b2e7e2745ac4e03aa612";
+    sha256 = "1amaps1clq6qb70a7c11y01bgvgzjvjda5vjqh1cv98dgqpdzjj8";
+  };
 
   meta = with lib; {
     description = "An advanced, open source, hyperrealistic, multilingual typewriter font for a new decade";
     homepage = "https://ctrlcctrlv.github.io/TT2020";
     license = licenses.ofl;
-    maintainers = with maintainers; [ sikmir ];
     platforms = platforms.all;
+    maintainers = with maintainers; [ sikmir ];
   };
 }

--- a/pkgs/data/fonts/ttf-bitstream-vera/default.nix
+++ b/pkgs/data/fonts/ttf-bitstream-vera/default.nix
@@ -1,19 +1,13 @@
-{ stdenv, fetchzip }:
-let
+{ stdenv, mkFont, fetchzip }:
+
+mkFont rec {
   pname = "ttf-bitstream-vera";
   version = "1.10";
-in
-fetchzip rec {
-  name = "${pname}-${version}";
 
-  url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.bz2";
-
-  postFetch = ''
-    tar -xjf $downloadedFile --strip-components=1
-    install -m444 -Dt $out/share/fonts/truetype *.ttf
-  '';
-
-  sha256 = "179hal4yi3367jg8rsvqx6h2w4s0kn9zzrv8c47sslyg28g39s4m";
+  src = fetchzip {
+    url = "mirror://gnome/sources/${pname}/${version}/${pname}-${version}.tar.bz2";
+    sha256 = "0p9zdv9kg0fagj5kbrpcwafhpaasacs3qbklknz9qnsprarcs2b7";
+  };
 
   meta = {
   };

--- a/pkgs/data/fonts/ttf-envy-code-r/default.nix
+++ b/pkgs/data/fonts/ttf-envy-code-r/default.nix
@@ -1,25 +1,20 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
   pname = "ttf-envy-code-r";
   version = "PR7";
-in fetchzip {
+  # kept for compatibility
   name = "${pname}-0.${version}";
 
-  url = "http://download.damieng.com/fonts/original/EnvyCodeR-${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.txt -d "$out/share/doc/${pname}"
-  '';
-
-  sha256 = "0x0r07nax68cmz7490x2crzzgdg4j8fg63wppcmjqm0230bggq2z";
+  src = fetchzip {
+    url = "http://download.damieng.com/fonts/original/EnvyCodeR-${version}.zip";
+    sha256 = "1hys10zibam4jk8sq3ppyk73j4ih2xd0kxjpdlq133ydqvz856m4";
+  };
 
   meta = with lib; {
     homepage = "https://damieng.com/blog/tag/envy-code-r";
     description = "Free scalable coding font by DamienG";
     license = licenses.unfree;
-    maintainers = [ maintainers.lyt ];
+    maintainers = with maintainers; [ lyt ];
   };
 }

--- a/pkgs/data/fonts/ubuntu-font-family/default.nix
+++ b/pkgs/data/fonts/ubuntu-font-family/default.nix
@@ -1,16 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-fetchzip {
-  name = "ubuntu-font-family-0.83";
+mkFont rec {
+  pname = "ubuntu-font-family";
+  version = "0.83";
 
-  url = "https://assets.ubuntu.com/v1/fad7939b-ubuntu-font-family-0.83.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/ubuntu
-  '';
-
-  sha256 = "090y665h4kf2bi623532l6wiwkwnpd0xds0jr7560xwfwys1hiqh";
+  src = fetchzip {
+    url = "https://assets.ubuntu.com/v1/fad7939b-ubuntu-font-family-0.83.zip";
+    sha256 = "18w84svvk4d2z0w671l7r2j8j4rl1f0d0lr2xw0z6yq5mg87yxvg";
+    stripRoot = false;
+  };
 
   meta = {
     description = "Ubuntu Font Family";
@@ -18,7 +16,7 @@ fetchzip {
     created to complement the Ubuntu tone of voice. It has a
     contemporary style and contains characteristics unique to
     the Ubuntu brand that convey a precise, reliable and free attitude.";
-    homepage = "http://font.ubuntu.com/";
+    homepage = "https://font.ubuntu.com/";
     license = lib.licenses.free;
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.antono ];

--- a/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
+++ b/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
@@ -1,17 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "ultimate-oldschool-pc-font-pack";
   version = "1.0";
-in
-fetchzip {
-  name = "ultimate-oldschool-pc-font-pack-${version}";
-  url = "https://int10h.org/oldschool-pc-fonts/download/ultimate_oldschool_pc_font_pack_v${version}.zip";
-  sha256 = "0hid4dgqfy2w26734vcw2rxmpacd9vd1r2qpdr9ww1n3kgc92k9y";
 
-  postFetch= ''
-    mkdir -p $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
+  src = fetchzip {
+    url = "https://int10h.org/oldschool-pc-fonts/download/ultimate_oldschool_pc_font_pack_v${version}.zip";
+    sha256 = "0mxdm1r3v9qm6vsag673yqa61kwqsz73f2dkj8nhjwmprq688lg1";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     description = "The Ultimate Oldschool PC Font Pack (TTF Fonts)";

--- a/pkgs/data/fonts/undefined-medium/default.nix
+++ b/pkgs/data/fonts/undefined-medium/default.nix
@@ -1,16 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-fetchzip rec {
-  name = "undefined-medium-1.0";
+mkFont rec {
+  pname = "undefined-medium";
+  version = "1.0";
 
-  url = "https://github.com/andirueckel/undefined-medium/archive/v1.0.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile ${name}/fonts/otf/\*.otf -d $out/share/fonts/opentype
-  '';
-
-  sha256 = "1wa04jzbffshwcxm705yb5wja8wakn8j7fvim1mlih2z1sqw0njk";
+  src = fetchzip rec {
+    url = "https://github.com/andirueckel/undefined-medium/archive/v1.0.zip";
+    sha256 = "1bkzvwpmz0rx5sra18sxqrdjazqpzh7hl8pa5lx34x3v6kp9avqw";
+  };
 
   meta = with lib; {
     homepage = "https://undefined-medium.com/";

--- a/pkgs/data/fonts/unifont/default.nix
+++ b/pkgs/data/fonts/unifont/default.nix
@@ -1,55 +1,36 @@
-{ stdenv, fetchurl, mkfontscale
-, libfaketime, fonttosfnt
-}:
+{ lib, mkFont, fetchurl, mkfontscale , libfaketime, fonttosfnt }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "unifont";
   version = "13.0.01";
 
-  ttf = fetchurl {
-    url = "mirror://gnu/unifont/${pname}-${version}/${pname}-${version}.ttf";
-    sha256 = "0y5bd7i5hp9ks6d3qq0bshywba7g90i3074wckpn9m8shh98ngcg";
-  };
-
-  pcf = fetchurl {
-    url = "mirror://gnu/unifont/${pname}-${version}/${pname}-${version}.pcf.gz";
-    sha256 = "05zgz00n514cijqh9qcvr4iz0bla4hd028cvi1jlh0ic6fkafix8";
-  };
+  srcs = map fetchurl [
+    {
+      url = "mirror://gnu/unifont/${pname}-${version}/${pname}-${version}.ttf";
+      sha256 = "0y5bd7i5hp9ks6d3qq0bshywba7g90i3074wckpn9m8shh98ngcg";
+    }
+    {
+      url = "mirror://gnu/unifont/${pname}-${version}/${pname}-${version}.pcf.gz";
+      sha256 = "05zgz00n514cijqh9qcvr4iz0bla4hd028cvi1jlh0ic6fkafix8";
+    }
+  ];
 
   nativeBuildInputs = [ libfaketime fonttosfnt mkfontscale ];
+  noUnpackFonts = true;
 
-  phases = [ "buildPhase" "installPhase" ];
+  dontBuild = false;
+  buildPhase = ''
+    # convert pcf font to otb
+    faketime -f "1970-01-01 00:00:01" fonttosfnt -g 2 -m 2 -v -o "unifont.otb" unifont-${version}.pcf.gz
+  '';
 
-  buildPhase =
-    ''
-      # convert pcf font to otb
-      faketime -f "1970-01-01 00:00:01" \
-      fonttosfnt -g 2 -m 2 -v -o "unifont.otb" "${pcf}"
-    '';
-
-  installPhase =
-    ''
-      # install otb fonts
-      install -m 644 -D unifont.otb "$otb/share/fonts/unifont.otb"
-      mkfontdir "$otb/share/fonts"
-
-      # install pcf and ttf fonts
-      install -m 644 -D ${pcf} $out/share/fonts/unifont.pcf.gz
-      install -m 644 -D ${ttf} $out/share/fonts/truetype/unifont.ttf
-      cd "$out/share/fonts"
-      mkfontdir
-      mkfontscale
-    '';
-
-  outputs = [ "out" "otb" ];
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Unicode font for Base Multilingual Plane";
     homepage = "http://unifoundry.com/unifont.html";
 
     # Basically GPL2+ with font exception.
     license = "http://unifoundry.com/LICENSE.txt";
-    maintainers = [ maintainers.rycee maintainers.vrthra ];
     platforms = platforms.all;
+    maintainers = with maintainers; [ rycee vrthra ];
   };
 }

--- a/pkgs/data/fonts/unifont_upper/default.nix
+++ b/pkgs/data/fonts/unifont_upper/default.nix
@@ -1,23 +1,23 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchurl }:
 
-let
+mkFont rec {
+  pname = "unifont_upper";
   version = "12.1.03";
-in fetchzip rec {
-  name = "unifont_upper-${version}";
 
-  url = "mirror://gnu/unifont/unifont-${version}/${name}.ttf";
+  src = fetchurl {
+    url = "mirror://gnu/unifont/unifont-${version}/${pname}-${version}.ttf";
+    sha256 = "0f12kf1vxajlm88sqj0dpw8vmfbx2r353yw0z3q138rla1zmd874";
+  };
 
-  postFetch = "install -Dm644 $downloadedFile $out/share/fonts/truetype/unifont_upper.ttf";
-
-  sha256 = "1w0bg276cyv6xs6clld8gv4w88rj9fw9rc8zs9ahc6y9hv677knj";
+  noUnpackFonts = true;
 
   meta = with lib; {
     description = "Unicode font for glyphs above the Unicode Basic Multilingual Plane";
-    homepage = "http://unifoundry.com/unifont.html";
+    homepage = "https://unifoundry.com/unifont.html";
 
     # Basically GPL2+ with font exception.
     license = "http://unifoundry.com/LICENSE.txt";
-    maintainers = [ maintainers.mathnerd314 maintainers.vrthra ];
     platforms = platforms.all;
+    maintainers = with maintainers; [ mathnerd314 vrthra ];
   };
 }

--- a/pkgs/data/fonts/vazir-fonts/default.nix
+++ b/pkgs/data/fonts/vazir-fonts/default.nix
@@ -1,20 +1,16 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
   pname = "vazir-fonts";
   version = "22.1.0";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "rastikerdar";
-  repo = "vazir-font";
-  rev = "v${version}";
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "vazir-font";
+    rev = "v${version}";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/truetype {} \;
-  '';
-  sha256 = "1nh3pyyw3082aizdwgyihh4z122z7kzp45ry7lzdhq9lshkpzglc";
+    sha256 = "0k34xcf3r7pfpsvyk0rzcgiz0x34ynaa7i1rmwp7c6v7lkfri14l";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/vazir-font";

--- a/pkgs/data/fonts/vdrsymbols/default.nix
+++ b/pkgs/data/fonts/vdrsymbols/default.nix
@@ -1,16 +1,13 @@
-{ lib, fetchzip }:
+{ lib, fetchzip, mkFont }:
 
-fetchzip {
-  name = "vdrsymbols-20100612";
+mkFont rec {
+  pname = "vdrsymbols";
+  version = "20100612";
 
-  url = "http://andreas.vdr-developer.org/fonts/download/vdrsymbols-ttf-20100612.tgz";
-
-  sha256 = "0wpxns8zqic98c84j18dr4zmj092v07yq07vwwgzblr0rw9n6gzr";
-
-  postFetch = ''
-    tar xvzf "$downloadedFile"
-    install -Dm444 -t "$out/share/fonts/truetype" */*.ttf
-  '';
+  src = fetchzip {
+    url = "http://andreas.vdr-developer.org/fonts/download/vdrsymbols-ttf-20100612.tgz";
+    sha256 = "0yjprvwdfb0wr22qjb3m449fbksa67i9drbwrzmx5k6hwb6yx1bi";
+  };
 
   meta = with lib; {
     description = "DejaVu fonts with additional symbols used by VDR";

--- a/pkgs/data/fonts/vegur/default.nix
+++ b/pkgs/data/fonts/vegur/default.nix
@@ -1,20 +1,19 @@
-{ lib, buildPackages, fetchzip }:
+{ lib, buildPackages, mkFont, fetchzip }:
 
-let
+mkFont rec {
   version = "0.701";
-in fetchzip {
-  name = "vegur-font-${version}";
+  pname = "vegur-font";
 
-  # Upstream doesn't version their URLs.
-  # http://dotcolon.net/font/vegur/ → http://dotcolon.net/DL/font/vegur.zip
-  url = "http://download.opensuse.org/repositories/M17N:/fonts/SLE_12_SP3/src/dotcolon-vegur-fonts-0.701-1.4.src.rpm";
-
-  postFetch = ''
-    ${buildPackages.rpmextract}/bin/rpmextract $downloadedFile
-    unzip vegur.zip
-    install -m444 -Dt $out/share/fonts/Vegur *.otf
-  '';
-  sha256 = "0iisi2scq72lyj7pc1f36fhfjnm676n5byl4zaavhbxpdrbc6d1v";
+    src = fetchzip {
+    # Upstream doesn't version their URLs.
+    # http://dotcolon.net/font/vegur/ → http://dotcolon.net/DL/font/vegur.zip
+    url = "http://download.opensuse.org/repositories/M17N:/fonts/SLE_12_SP3/src/dotcolon-vegur-fonts-0.701-1.4.src.rpm";
+    sha256 = "1w1csykf45hgiy7b7918qp6bqp4y3bq13cahi5cmx0zp8scgfrmh";
+    postFetch = ''
+      ${buildPackages.rpmextract}/bin/rpmextract $downloadedFile
+      unzip vegur.zip -d $out
+    '';
+  };
 
   meta = with lib; {
     homepage = "http://dotcolon.net/font/vegur/";

--- a/pkgs/data/fonts/victor-mono/default.nix
+++ b/pkgs/data/fonts/victor-mono/default.nix
@@ -1,32 +1,31 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub, unzip }:
 
-let
+mkFont rec {
   pname = "victor-mono";
   version = "1.3.1";
-in fetchFromGitHub rec {
-  name = "${pname}-${version}";
 
-  owner = "rubjo";
-  repo = pname;
-  rev = "v${version}";
+  src = fetchFromGitHub rec {
+    owner = "rubjo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0xfqf2i1z86vd2b2jm5v2nz4amyyl95vlc1s1lc9y00am193pc88";
 
-  # Upstream prefers we download from the website,
-  # but we really insist on a more versioned resource.
-  # Happily, tagged releases on github contain the same
-  # file `VictorMonoAll.zip` as from the website,
-  # so we extract it from the tagged release.
-  # Both methods produce the same file, but this way
-  # we can safely reason about what version it is.
-  postFetch = ''
-    tar xvf $downloadedFile --strip-components=2 ${pname}-${version}/public/VictorMonoAll.zip
+    # Upstream prefers we download from the website,
+    # but we really insist on a more versioned resource.
+    # Happily, tagged releases on github contain the same
+    # file `VictorMonoAll.zip` as from the website,
+    # so we extract it from the tagged release.
+    # Both methods produce the same file, but this way
+    # we can safely reason about what version it is.
+    name = "VictorMonoAll.zip";
+    postFetch = ''
+      tar xvf $downloadedFile --strip-components=2 ${pname}-${version}/public/VictorMonoAll.zip
+      mv VictorMonoAll.zip $out
+    '';
+  };
 
-    mkdir -p $out/share/fonts/{true,open}type/${pname}
-
-    unzip -j VictorMonoAll.zip \*.ttf -d $out/share/fonts/truetype/${pname}
-    unzip -j VictorMonoAll.zip \*.otf -d $out/share/fonts/opentype/${pname}
-  '';
-
-  sha256 = "1yj91rhs9pd705406r4lqabdfzjclbz837nzm6z1rziy6mbpd61s";
+  nativeBuildInputs = [ unzip ];
+  sourceRoot = ".";
 
   meta = with lib; {
     description = "Free programming font with cursive italics and ligatures";

--- a/pkgs/data/fonts/weather-icons/default.nix
+++ b/pkgs/data/fonts/weather-icons/default.nix
@@ -1,18 +1,15 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "weather-icons";
   version = "2.0.10";
-in fetchzip {
-  name = "weather-icons-${version}";
 
-  url = "https://github.com/erikflowers/weather-icons/archive/${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/erikflowers/weather-icons/archive/${version}.zip";
+    sha256 = "0fz9mbrd4s7w8rahda51jascrjkiyprnir39k9d56cni90pvcvbs";
+  };
 
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile weather-icons-${version}/_docs/font-source/weathericons-regular.otf -d $out/share/fonts/opentype
-  '';
-
-  sha256 = "10zny9987wybq55sm803hrjkp33dq1lgmnxc15kssr8yb81g6qrl";
+  sourceRoot = "source/font";
 
   meta = with lib; {
     description = "Weather Icons";

--- a/pkgs/data/fonts/work-sans/default.nix
+++ b/pkgs/data/fonts/work-sans/default.nix
@@ -1,23 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont rec {
+  pname = "work-sans";
   version = "1.6";
-in fetchFromGitHub {
-  name = "work-sans-${version}";
 
-  owner = "weiweihuanghuang";
-  repo = "Work-Sans";
-  rev = "v${version}";
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -m444 -Dt $out/share/fonts/opentype/ fonts/desktop/*.otf
-    install -m444 -Dt $out/share/fonts/truetype/ fonts/webfonts/ttf/*.ttf
-    install -m444 -Dt $out/share/fonts/woff/     fonts/webfonts/woff/*.woff
-    install -m444 -Dt $out/share/fonts/woff2/    fonts/webfonts/woff2/*.woff2
-  '';
-
-  sha256 = "01kjidk6zv80rqxapcdwhd9wxzrjfc6lj4gkf6dwa4sskw5x3b8a";
+  src = fetchFromGitHub {
+    owner = "weiweihuanghuang";
+    repo = "Work-Sans";
+    rev = "v${version}";
+    sha256 = "1qpjfj4pkh03y3nc8d8sbnhpq4v4wh4z3w6mbp8mh740afamia10";
+  };
 
   meta = with lib; {
     description = "A grotesque sans";

--- a/pkgs/data/fonts/wqy-microhei/default.nix
+++ b/pkgs/data/fonts/wqy-microhei/default.nix
@@ -1,16 +1,13 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-fetchzip rec {
-  name = "wqy-microhei-0.2.0-beta";
+mkFont rec {
+  pname = "wqy-microhei";
+  version = "0.2.0-beta";
 
-  url = "mirror://sourceforge/wqy/${name}.tar.gz";
-
-  postFetch = ''
-    tar -xzf $downloadedFile --strip-components=1
-    install -Dm644 wqy-microhei.ttc $out/share/fonts/wqy-microhei.ttc
-  '';
-
-  sha256 = "0i5jh7mkp371fxqmsvn7say075r641yl4hq26isjyrqvb8cv92a9";
+  src = fetchzip {
+    url = "mirror://sourceforge/wqy/${pname}-${version}.tar.gz";
+    sha256 = "15g5acz29yk1kv8167h1bf71ixycql0dwgxxsincx448fpd2hkym";
+  };
 
   meta = {
     description = "A (mainly) Chinese Unicode font";

--- a/pkgs/data/fonts/wqy-zenhei/default.nix
+++ b/pkgs/data/fonts/wqy-zenhei/default.nix
@@ -1,25 +1,19 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "wqy-zenhei";
   version = "0.9.45";
-in fetchzip rec {
-  name = "wqy-zenhei-${version}";
 
-  url = "mirror://sourceforge/wqy/${name}.tar.gz";
+  src = fetchzip {
+    url = "mirror://sourceforge/wqy/${pname}-${version}.tar.gz";
+    sha256 = "0iikyr04kg76bn2qghg1mwm17ra0x3xgck8ly3lvhxpyibnl7zwd";
+  };
 
-  postFetch = ''
-    tar -xzf $downloadedFile --strip-components=1
-    mkdir -p $out/share/fonts
-    install -m644 *.ttc $out/share/fonts/
-  '';
-
-  sha256 = "0hbjq6afcd63nsyjzrjf8fmm7pn70jcly7fjzjw23v36ffi0g255";
-
-  meta = {
+  meta = with lib; {
     description = "A (mainly) Chinese Unicode font";
     homepage = "http://wenq.org";
-    license = lib.licenses.gpl2; # with font embedding exceptions
-    maintainers = [ lib.maintainers.pkmx ];
-    platforms = lib.platforms.all;
+    license = licenses.gpl2; # with font embedding exceptions
+    platforms = platforms.all;
+    maintainers = with maintainers; [ pkmx ];
   };
 }

--- a/pkgs/data/fonts/xits-math/default.nix
+++ b/pkgs/data/fonts/xits-math/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, python3Packages}:
+{ lib, mkFont, fetchFromGitHub, python3Packages }:
 
-stdenv.mkDerivation rec {
+mkFont rec {
   pname = "xits-math";
   version = "1.301";
 
@@ -13,15 +13,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = (with python3Packages; [ python fonttools fontforge ]);
 
+  dontPatch = false;
   postPatch = ''
     rm *.otf
   '';
+  dontBuild = false;
 
-  installPhase = ''
-    install -m444 -Dt $out/share/fonts/opentype *.otf
-  '';
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/alif-type/xits";
     description = "OpenType implementation of STIX fonts with math support";
     license = licenses.ofl;

--- a/pkgs/data/fonts/xkcd-font/default.nix
+++ b/pkgs/data/fonts/xkcd-font/default.nix
@@ -1,21 +1,15 @@
-{ lib, fetchFromGitHub }:
+{ lib, mkFont, fetchFromGitHub }:
 
-let
+mkFont {
   pname = "xkcd-font";
   version = "unstable-2017-08-24";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "ipython";
-  repo = pname;
-  rev = "5632fde618845dba5c22f14adc7b52bf6c52d46d";
-
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -Dm444 -t $out/share/fonts/opentype/ xkcd/build/xkcd.otf
-    install -Dm444 -t $out/share/fonts/truetype/ xkcd-script/font/xkcd-script.ttf
-  '';
-  sha256 = "0xhwa53aiz20763jb9nvbr2zq9k6jl69p07dc4b0apwrrwz0jfr1";
+  src = fetchFromGitHub {
+    owner = "ipython";
+    repo = "xkcd-font";
+    rev = "5632fde618845dba5c22f14adc7b52bf6c52d46d";
+    sha256 = "01wpfc1yp93b37r472mx2b459il5gywnv5sl7pp9afpycb3i4f6l";
+  };
 
   meta = with lib; {
     description = "The xkcd font";

--- a/pkgs/data/fonts/yanone-kaffeesatz/default.nix
+++ b/pkgs/data/fonts/yanone-kaffeesatz/default.nix
@@ -1,16 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-fetchzip {
-  name = "yanone-kaffeesatz-2004";
+mkFont {
+  pname = "yanone-kaffeesatz";
+  version = "2004";
 
-  url = "https://yanone.de/2015/data/UIdownloads/Yanone%20Kaffeesatz.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
-
-  sha256 = "190c4wx7avy3kp98lsyml7kc0jw7csf5n79af2ypbkhsadfsy8di";
+  src = fetchzip {
+    url = "https://yanone.de/2015/data/UIdownloads/Yanone%20Kaffeesatz.zip";
+    sha256 = "11hakl6j8gmjbapiyfik2jhasljgbqhsljzmygfbzvq9fpph287k";
+    stripRoot = false;
+  };
 
   meta = {
     description = "The free font classic";

--- a/pkgs/data/fonts/zilla-slab/default.nix
+++ b/pkgs/data/fonts/zilla-slab/default.nix
@@ -1,17 +1,14 @@
-{ lib, fetchzip }:
+{ lib, mkFont, fetchzip }:
 
-let
+mkFont rec {
+  pname = "zilla-slab";
   version = "1.002";
-in fetchzip {
-  name = "zilla-slab-${version}";
 
-  url = "https://github.com/mozilla/zilla-slab/releases/download/v${version}/Zilla-Slab-Fonts-v${version}.zip";
-  postFetch = ''
-    unzip $downloadedFile
-    mkdir -p $out/share/fonts/truetype
-    cp -v zilla-slab/ttf/*.ttf $out/share/fonts/truetype/
-  '';
-  sha256 = "1b1ys28hyjcl4qwbnsyi6527nj01g3d6id9jl23fv6f8fjm4ph0f";
+  src = fetchzip {
+    url = "https://github.com/mozilla/zilla-slab/releases/download/v${version}/Zilla-Slab-Fonts-v${version}.zip";
+    sha256 = "09q4dakx9hl0jn0b5n983fk4a7gm0ghvaxakqcxj55wnskwyxqf8";
+    stripRoot = false;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/mozilla/zilla-slab";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5358,7 +5358,7 @@ in
 
   nat-traverse = callPackage ../tools/networking/nat-traverse { };
 
-  navilu-font = callPackage ../data/fonts/navilu { stdenv = stdenvNoCC; };
+  navilu-font = callPackage ../data/fonts/navilu { };
 
   nawk = callPackage ../tools/text/nawk { };
 
@@ -18050,7 +18050,7 @@ in
   encode-sans = callPackage ../data/fonts/encode-sans { };
 
   envypn-font = callPackage ../data/fonts/envypn-font
-    { inherit (buildPackages.xorg) fonttosfnt mkfontscale; };
+    { inherit (buildPackages.xorg) fonttosfnt; };
 
   envdir = callPackage ../tools/misc/envdir-go { };
 
@@ -18380,8 +18380,7 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  profont = callPackage ../data/fonts/profont
-    { inherit (buildPackages.xorg) mkfontscale; };
+  profont = callPackage ../data/fonts/profont { };
 
   proggyfonts = callPackage ../data/fonts/proggyfonts { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -437,6 +437,8 @@ in
       inherit kernel firmware rootModules allowMissing;
     };
 
+  mkFont = callPackage ../build-support/mkfont.nix { };
+
   mkShell = callPackage ../build-support/mkshell { };
 
   nixBufferBuilders = import ../build-support/emacs/buffer.nix { inherit (pkgs) lib writeText; inherit (emacsPackages) inherit-local; };


### PR DESCRIPTION
###### Motivation for this change

Font package derivations in nixpkgs aren't particularly organized: They fall into just a handful of patterns, but in a cargo culted rather than organized fashion. Several decisions that should be subject to policy are pretty much taken at random, e.g. whether license files should be packaged, whether woff/woff2/eot/svg files should be packaged, what path to use for each particular font type, etc.

###### Things done

This PR introduces a `mkFont` derivation, which specifies a generic installPhase that fits for the majority of font packages. @puzzlewolf and I migrated some ~190 font packages over to it, and most of them are now trivial derivations that contain only `pname+version+src+meta`. We also did a general cleanup for consistency. Between all those files we dropped some 1k lines of code :)

Obviously we picked the low hanging fruit here, and the remaining font derivations are slightly more complicated to rewrite for `mkFont`.

###### Open questions

This PR is a draft currently, and there are still some open questions. In particular I'd appreciate some thoughts on the following points:

* Should woff/woff2/eot files be packaged? Other distributions seem to eschew these formats, see this [fontconfig issue](https://gitlab.freedesktop.org/fontconfig/fontconfig/-/issues/92).
* Some derivations used different outputs for different font formats. I don't do that now, but perhaps it's useful? Either way, `mkFont` can consistently apply those kinds of policies for whatever font packages it's used for :)
* Should license files be packaged? This was inconsistent between derivations, and my overall impression was that only OFL fonts had their license shipped - however the OFL [explicitly allows](http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL_web) (in paragraph two) to simply reference it from machine-readable metadata fields.
* The `installPhase` *could* be made more complicated to offer more features, such as `includeOnly` or `renameFiles` directives. I decided to keep it simple for now, derivations can always override whatever they want (or just use `mkDerivation`, of course).

Anyways, overall I think this is a significant improvement wrt font packaging consistency :tada: 