### PR TITLE
snapper: 0.8.9 -> 0.8.10

### DIFF
--- a/pkgs/tools/misc/snapper/default.nix
+++ b/pkgs/tools/misc/snapper/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchFromGitHub
 , autoreconfHook, pkgconfig, docbook_xsl, libxslt, docbook_xml_dtd_45
 , acl, attr, boost, btrfs-progs, dbus, diffutils, e2fsprogs, libxml2
-, lvm2, pam, python, utillinux, fetchpatch, json_c }:
+, lvm2, pam, python, utillinux, fetchpatch, json_c, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "snapper";
-  version = "0.8.9";
+  version = "0.8.10";
 
   src = fetchFromGitHub {
     owner = "openSUSE";
     repo = "snapper";
     rev = "v${version}";
-    sha256 = "1flqhfpx9dipim22wq7wh1590ra4gydwii1jjp99pi03mdhavlbn";
+    sha256 = "0bw8aal3a9823zcwini3an9zdxmf7vm912jbyb95rjac0wilqfw7";
   };
 
   nativeBuildInputs = [
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
     acl attr boost btrfs-progs dbus diffutils e2fsprogs libxml2
     lvm2 pam python utillinux json_c
   ];
+
+  passthru.tests.snapper = nixosTests.snapper;
 
   patches = [
     # Don't use etc/dbus-1/system.d


### PR DESCRIPTION
###### Motivation for this change
Regular update 

###### Things done
Added `passthru.tests.snapper`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
