### PR TITLE
CloudCompare, pdal, libe57format, MeshLabXML

### DIFF
--- a/pkgs/applications/graphics/cloudcompare/default.nix
+++ b/pkgs/applications/graphics/cloudcompare/default.nix
@@ -1,0 +1,83 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, wrapQtAppsHook
+, dxflib
+, eigen
+, flann
+, gdal
+, LASzip
+, libLAS
+, pdal
+, qtbase
+, qtsvg
+, qttools
+, tbb
+, xercesc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cloudcompare";
+  version = "2.11.0";
+
+  src = fetchFromGitHub {
+    owner = "CloudCompare";
+    repo = "CloudCompare";
+    rev = "v${version}";
+    sha256 = "02ahhhivgb9k1aygw1m35wdvhaizag1r98mb0r6zzrs5p4y64wlb";
+    # As of writing includes (https://github.com/CloudCompare/CloudCompare/blob/a1c589c006fc325e8b560c77340809b9c7e7247a/.gitmodules):
+    # * libE57Format
+    # * PoissonRecon
+    # In > 2.11 it will also contain
+    # * CCCoreLib
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    eigen # header-only
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    dxflib
+    flann
+    gdal
+    LASzip
+    libLAS
+    pdal
+    qtbase
+    qtsvg
+    qttools
+    tbb
+    xercesc
+  ];
+
+  cmakeFlags = [
+    # TODO: This will become -DCCCORELIB_USE_TBB=ON in > 2.11.0, see
+    #       https://github.com/CloudCompare/CloudCompare/commit/f5a0c9fd788da26450f3fa488b2cf0e4a08d255f
+    "-DCOMPILE_CC_CORE_LIB_WITH_TBB=ON"
+    "-DOPTION_USE_DXF_LIB=ON"
+    "-DOPTION_USE_GDAL=ON"
+    "-DOPTION_USE_SHAPE_LIB=ON"
+
+    "-DPLUGIN_GL_QEDL=ON"
+    "-DPLUGIN_GL_QSSAO=ON"
+    "-DPLUGIN_IO_QADDITIONAL=ON"
+    "-DPLUGIN_IO_QCORE=ON"
+    "-DPLUGIN_IO_QCSV_MATRIX=ON"
+    "-DPLUGIN_IO_QE57=ON"
+    "-DPLUGIN_IO_QFBX=OFF" # Autodesk FBX SDK is gratis+proprietary; not packaged in nixpkgs
+    "-DPLUGIN_IO_QPDAL=ON" # required for .las/.laz support
+    "-DPLUGIN_IO_QPHOTOSCAN=ON"
+    "-DPLUGIN_IO_QRDB=OFF" # Riegl rdblib is proprietary; not packaged in nixpkgs
+  ];
+
+  meta = with stdenv.lib; {
+    description = "3D point cloud and mesh processing software";
+    homepage = "https://cloudcompare.org";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ nh2 ];
+    platforms = with platforms; linux; # only tested here; might work on others
+  };
+}

--- a/pkgs/development/libraries/LASzip/LASzip2.nix
+++ b/pkgs/development/libraries/LASzip/LASzip2.nix
@@ -11,11 +11,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Turn quickly bulky LAS files into compact LAZ files without information loss";
-    homepage = https://laszip.org;
-    license = stdenv.lib.licenses.lgpl2;
-    maintainers = [ stdenv.lib.maintainers.michelk ];
-    platforms = stdenv.lib.platforms.unix;
+    homepage = "https://laszip.org";
+    license = licenses.lgpl2;
+    maintainers = [ maintainers.michelk ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/LASzip/LASzip2.nix
+++ b/pkgs/development/libraries/LASzip/LASzip2.nix
@@ -1,23 +1,19 @@
-{ stdenv, fetchFromGitHub, cmake }:
+{ stdenv, fetchurl, cmake }:
 
 stdenv.mkDerivation rec {
-  version = "3.4.3";
+  version = "2.2.0";
   pname = "LASzip";
 
-  src = fetchFromGitHub {
-    owner = "LASzip";
-    repo = "LASzip";
-    rev = version;
-    sha256 = "09lcsgxwv0jq50fhsgfhx0npbf1zcwn3hbnq6q78fshqksbxmz7m";
+  src = fetchurl {
+    url = "https://github.com/LASzip/LASzip/archive/v${version}.tar.gz";
+    sha256 = "b8e8cc295f764b9d402bc587f3aac67c83ed8b39f1cb686b07c168579c61fbb2";
   };
 
-  nativeBuildInputs = [
-    cmake
-  ];
+  buildInputs = [cmake];
 
   meta = {
     description = "Turn quickly bulky LAS files into compact LAZ files without information loss";
-    homepage = "https://laszip.org";
+    homepage = https://laszip.org;
     license = stdenv.lib.licenses.lgpl2;
     maintainers = [ stdenv.lib.maintainers.michelk ];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/LASzip/LASzip2.nix
+++ b/pkgs/development/libraries/LASzip/LASzip2.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "b8e8cc295f764b9d402bc587f3aac67c83ed8b39f1cb686b07c168579c61fbb2";
   };
 
-  buildInputs = [cmake];
+  nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "Turn quickly bulky LAS files into compact LAZ files without information loss";

--- a/pkgs/development/libraries/libLAS/default.nix
+++ b/pkgs/development/libraries/libLAS/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, boost, cmake, gdal, libgeotiff, libtiff, LASzip, fixDarwinDylibNames }:
+{ stdenv, fetchurl, boost, cmake, gdal, libgeotiff, libtiff, LASzip2, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
   name = "libLAS-1.8.1";
@@ -9,13 +9,15 @@ stdenv.mkDerivation rec {
     sha256 = "0xjfxb3ydvr2258ji3spzyf81g9caap19ql2pk91wiivqsc4mnws";
   };
 
-  buildInputs = [ boost cmake gdal libgeotiff libtiff LASzip ]
+  buildInputs = [ boost cmake gdal libgeotiff libtiff LASzip2 ]
                 ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   cmakeFlags = [
     "-DGDAL_CONFIG=${gdal}/bin/gdal-config"
     "-DWITH_LASZIP=ON"
-    "-DLASZIP_INCLUDE_DIR=${LASzip}/include"
+    # libLAS is currently not compatible with LASzip 3,
+    # see https://github.com/libLAS/libLAS/issues/144.
+    "-DLASZIP_INCLUDE_DIR=${LASzip2}/include"
     "-DCMAKE_EXE_LINKER_FLAGS=-pthread"
   ];
 

--- a/pkgs/development/libraries/libe57format/default.nix
+++ b/pkgs/development/libraries/libe57format/default.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  boost,
+  xercesc,
+  icu,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libe57format";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "asmaloney";
+    repo = "libE57Format";
+    rev = "v${version}";
+    sha256 = "05z955q68wjbd9gc5fw32nqg69xc82n2x75j5vchxzkgnn3adcpi";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    boost
+    icu
+    xercesc
+  ];
+
+  # The build system by default builds ONLY static libraries, and with
+  # `-DE57_BUILD_SHARED=ON` builds ONLY shared libraries, see:
+  #     https://github.com/asmaloney/libE57Format/issues/48
+  #     https://github.com/asmaloney/libE57Format/blob/f657d470da5f0d185fe371c4c011683f6e30f0cb/CMakeLists.txt#L82-L89
+  # We support building both by building statically and then
+  # building an .so file here manually.
+  # The way this is written makes this Linux-only for now.
+  postInstall = ''
+    cd $out/lib
+    g++ -Wl,--no-undefined -shared -o libE57FormatShared.so -L. -Wl,-whole-archive -lE57Format -Wl,-no-whole-archive -lxerces-c
+    mv libE57FormatShared.so libE57Format.so
+
+    if [ "$dontDisableStatic" -ne "1" ]; then
+      rm libE57Format.a
+    fi
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Library for reading & writing the E57 file format (fork of E57RefImpl)";
+    homepage = "https://github.com/asmaloney/libE57Format";
+    license = licenses.boost;
+    maintainers = with maintainers; [ chpatrick nh2 ];
+    platforms = platforms.linux; # because of the .so buiding in `postInstall` above
+  };
+}

--- a/pkgs/development/libraries/pdal/default.nix
+++ b/pkgs/development/libraries/pdal/default.nix
@@ -1,0 +1,98 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, pkg-config
+# , openscenegraph
+, curl
+, gdal
+, hdf5-cpp
+, LASzip
+, libe57format
+, libgeotiff
+, libxml2
+, postgresql
+, tiledb
+, xercesc
+, zlib
+, zstd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pdal";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "PDAL";
+    repo = "PDAL";
+    rev = version;
+    sha256 = "0zb3zjqgmjjryb648c1hmwh1nfa7893bjzbqpmr6shjxvzgnj9p6";
+  };
+
+  patches = [
+    # Fix duplicate paths like
+    #     /nix/store/7iafqfmjdlxqim922618wg87cclrpznr-PDAL-2.1.0//nix/store/7iafqfmjdlxqim922618wg87cclrpznr-PDAL-2.1.0/lib
+    # similar to https://github.com/NixOS/nixpkgs/pull/82654.
+    # TODO Remove on release > 2.1.0
+    (fetchpatch {
+      name = "pdal-Fixup-install-config.patch";
+      url = "https://github.com/PDAL/PDAL/commit/2f887ef624db50c6e20f091f34bb5d3e65b5c5c8.patch";
+      sha256 = "0pdw9v5ypq7w9i7qzgal110hjb9nqi386jvy3x2h4vf1dyalzid8";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    # openscenegraph
+    curl
+    gdal
+    hdf5-cpp
+    LASzip
+    libe57format
+    libgeotiff
+    libxml2
+    postgresql
+    tiledb
+    xercesc
+    zlib
+    zstd
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_PLUGIN_E57=ON"
+    "-DBUILD_PLUGIN_HDF=ON"
+    "-DBUILD_PLUGIN_PGPOINTCLOUD=ON"
+    "-DBUILD_PLUGIN_TILEDB=ON"
+
+    # Plugins that can probably be made working relatively easily:
+    # As of writing, seems to be incompatible (build error):
+    #     error: no matching function for call to 'osg::TriangleFunctor<pdal::CollectTriangles>::operator()(const Vec3&, const Vec3&, const Vec3&)'
+    "-DBUILD_PLUGIN_OPENSCENEGRAPH=OFF" # requires OpenGL
+
+    # Plugins can probably not be made work easily:
+    "-DBUILD_PLUGIN_CPD=OFF"
+    "-DBUILD_PLUGIN_FBX=OFF" # Autodesk FBX SDK is gratis+proprietary; not packaged in nixpkgs
+    "-DBUILD_PLUGIN_GEOWAVE=OFF"
+    "-DBUILD_PLUGIN_I3S=OFF"
+    "-DBUILD_PLUGIN_ICEBRIDGE=OFF"
+    "-DBUILD_PLUGIN_MATLAB=OFF"
+    "-DBUILD_PLUGIN_MBIO=OFF"
+    "-DBUILD_PLUGIN_MRSID=OFF"
+    "-DBUILD_PLUGIN_NITF=OFF"
+    "-DBUILD_PLUGIN_OCI=OFF"
+    "-DBUILD_PLUGIN_RDBLIB=OFF" # Riegl rdblib is proprietary; not packaged in nixpkgs
+    "-DBUILD_PLUGIN_RIVLIB=OFF"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "PDAL is Point Data Abstraction Library. GDAL for point cloud data.";
+    homepage = "https://pdal.io";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ nh2 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/meshlabxml/default.nix
+++ b/pkgs/development/python-modules/meshlabxml/default.nix
@@ -1,0 +1,29 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  lib,
+}:
+
+buildPythonPackage rec {
+  pname = "MeshLabXML";
+  version = "2018.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1villmg46hqby5jjkkpxr5bxydr72y5b3cbfngwpyxxdljn091w8";
+  };
+
+  propagatedBuildInputs = [ ];
+
+  doCheck = false; # Upstream not currently have any tests.
+
+  pythonImportsCheck = [ "meshlabxml" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/3DLIRIOUS/MeshLabXML";
+    description = "Create and run MeshLab XML scripts with Python";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ nh2 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12898,6 +12898,8 @@ in
   inherit (callPackage ../development/libraries/libdwarf { })
     libdwarf dwarfdump;
 
+  libe57format = callPackage ../development/libraries/libe57format { };
+
   libeatmydata = callPackage ../development/libraries/libeatmydata { };
 
   libeb = callPackage ../development/libraries/libeb { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12612,6 +12612,7 @@ in
   lasso = callPackage ../development/libraries/lasso { };
 
   LASzip = callPackage ../development/libraries/LASzip { };
+  LASzip2 = callPackage ../development/libraries/LASzip/LASzip2.nix { };
 
   lcms = lcms1;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10249,6 +10249,8 @@ in
 
   cloud-nuke = callPackage ../development/tools/cloud-nuke { };
 
+  cloudcompare = libsForQt5.callPackage ../applications/graphics/cloudcompare {};
+
   cloudfoundry-cli = callPackage ../development/tools/cloudfoundry-cli { };
 
   coan = callPackage ../development/tools/analysis/coan { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14170,6 +14170,8 @@ in
 
   pcre2 = callPackage ../development/libraries/pcre2 { };
 
+  pdal = callPackage ../development/libraries/pdal { } ;
+
   pdf2xml = callPackage ../development/libraries/pdf2xml {} ;
 
   inherit (callPackage ../development/libraries/physfs { })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4587,6 +4587,8 @@ in {
 
   mesonpep517 = callPackage ../development/python-modules/mesonpep517 { };
 
+  meshlabxml = callPackage ../development/python-modules/meshlabxml { };
+
   metaphone = callPackage ../development/python-modules/metaphone { };
 
   mezzanine = callPackage ../development/python-modules/mezzanine { };


### PR DESCRIPTION
###### Motivation for this change

This adds various 3D point cloud processing tools, including [CloudCompare](http://cloudcompare.org), one of the main point cloud GUI softwares.

Required for that:

* Making available both `LASzip 2` and `LASzip 3`, see https://github.com/libLAS/libLAS/issues/144, CC @michelk 
* Adding the [pdal](https://pdal.io) library

Also:

* MeshLabXML, cc @FRidh or @jonringer for some Python packaging style review

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I've tested tested running CloudCompare on Ubuntu with [nixGL](https://github.com/guibou/nixGL), built on a NixOS builder. @chpatrick has run it on NixOS desktop.

MeshLabXML is only packaged, and not significantly tested (but that is fine).