### PR TITLE
python3Packages.bidict: fix build

### DIFF
--- a/pkgs/development/python-modules/audio-metadata/default.nix
+++ b/pkgs/development/python-modules/audio-metadata/default.nix
@@ -19,7 +19,8 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace setup.py \
       --replace "bidict>=0.17,<0.18" "bidict" \
-      --replace "more-itertools>=4.0,<8.0" "more-itertools"
+      --replace "more-itertools>=4.0,<8.0" "more-itertools" \
+      --replace "pendulum>=2.0,<=3.0,!=2.0.5,!=2.1.0" "pendulum>=2.0,<=3.0"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/bidict/default.nix
+++ b/pkgs/development/python-modules/bidict/default.nix
@@ -23,6 +23,12 @@ buildPythonPackage rec {
   nativeBuildInputs = [ setuptools_scm ];
   propagatedBuildInputs = [ sphinx ];
 
+  # this can be removed >0.19.0
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "setuptools_scm < 4" "setuptools_scm"
+  '';
+
   checkInputs = [
     hypothesis
     py

--- a/pkgs/development/python-modules/google-music-proto/default.nix
+++ b/pkgs/development/python-modules/google-music-proto/default.nix
@@ -19,6 +19,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     sed -i -e "/audio-metadata/c\'audio-metadata'," -e "/marshmallow/c\'marshmallow'," setup.py
+    substituteInPlace setup.py \
+      --replace "pendulum>=2.0,<=3.0,!=2.0.5,!=2.1.0" "pendulum>=2.0,<=3.0"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/tbm-utils/default.nix
+++ b/pkgs/development/python-modules/tbm-utils/default.nix
@@ -20,6 +20,13 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ attrs pendulum pprintpp wrapt ];
 
+  # this versioning was done to prevent normal pip users from encountering
+  # issues with package failing to build from source, but nixpkgs is better
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pendulum>=2.0,<=3.0,!=2.0.5,!=2.1.0" "pendulum>=2.0,<=3.0"
+  '';
+
   # No tests in archive.
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
