### PR TITLE
ansifilter: extend build to include Darwin

### DIFF
--- a/pkgs/tools/text/ansifilter/default.nix
+++ b/pkgs/tools/text/ansifilter/default.nix
@@ -12,6 +12,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ boost lua ];
 
+  postPatch = ''
+    substituteInPlace src/makefile --replace "CC=g++" "CC=c++"
+  '';
+
   makeFlags = [
     "PREFIX=${placeholder "out"}"
     "conf_dir=/etc/ansifilter"
@@ -26,6 +30,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.andre-simon.de/doku/ansifilter/en/ansifilter.php";
     license = licenses.gpl3;
     maintainers = [ maintainers.Adjective-Object ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
All that was required was to use clang++ instead of g++ when compiling for
Darwin.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

It seemed like a small utility that should be buildable for Macs, and it turned out to be possible to support without much of a hack.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
