### PR TITLE
pythonPackages.{webcolors,imageio,pydicom}: disable python2, abandoned upstream

### DIFF
--- a/pkgs/development/python-modules/imageio/default.nix
+++ b/pkgs/development/python-modules/imageio/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , buildPythonPackage
+, isPy27
 , pathlib
 , fetchPypi
 , pillow
@@ -16,6 +17,7 @@
 buildPythonPackage rec {
   pname = "imageio";
   version = "2.8.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     sha256 = "fb5fd6d3d17126bbaac9af29fe340e2c97a196eb9416d4f28c0e543744a152cf";
@@ -25,11 +27,7 @@ buildPythonPackage rec {
   checkInputs = [ pytest psutil ] ++ stdenv.lib.optionals isPy3k [
     imageio-ffmpeg ffmpeg_3
     ];
-  propagatedBuildInputs = [ numpy pillow ] ++ stdenv.lib.optionals (!isPy3k) [
-    futures
-    enum34
-    pathlib
-  ];
+  propagatedBuildInputs = [ numpy pillow ];
 
   checkPhase = ''
     export IMAGEIO_USERDIR="$TMP"

--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , pytest
 , pytestrunner
 , numpy
@@ -10,6 +11,7 @@
 buildPythonPackage rec {
   version = "2.0.0";
   pname = "pydicom";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/webcolors/default.nix
+++ b/pkgs/development/python-modules/webcolors/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , python
 , six
 }:
@@ -8,6 +9,7 @@
 buildPythonPackage rec {
   pname = "webcolors";
   version = "1.11.1";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
```
Processing ./webcolors-1.11.1-py2-none-any.whl
ERROR: Package 'webcolors' requires a different Python: 2.7.18 not in '>=3.5,'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
