### PR TITLE
python3Packages.mozfile: fix build

### DIFF
--- a/pkgs/development/python-modules/marionette-harness/mozfile.nix
+++ b/pkgs/development/python-modules/marionette-harness/mozfile.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy27
 , six
 }:
 
@@ -14,7 +13,7 @@ buildPythonPackage rec {
     sha256 = "e5dc835582ea150e35ecd57e9d86cb707d3aa3b2505679db7332326dd49fd6b8";
   };
 
-  propagatedBuildInputs = lib.optional isPy27 six;
+  propagatedBuildInputs = [ six ];
 
   # mozhttpd -> moznetwork -> mozinfo -> mozfile
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
```
  ERROR: Could not find a version that satisfies the requirement six>=1.10.0 (from mozfile==2.1.0) (from versions: none)
  ERROR: No matching distribution found for six>=1.10.0 (from mozfile==2.1.0)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/91541
2 packages built:
python37Packages.mozfile python38Packages.mozfile
```