### PR TITLE
Fix termdown for 20.03

### DIFF
--- a/pkgs/applications/misc/termdown/default.nix
+++ b/pkgs/applications/misc/termdown/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, buildPythonApplication,
-click, pyfiglet, dateutil}:
+click, pyfiglet, dateutil, setuptools}:
 
 with stdenv.lib;
 
@@ -15,7 +15,7 @@ buildPythonApplication rec {
     owner  = "trehn";
   };
 
-  propagatedBuildInputs = [ dateutil click pyfiglet ];
+  propagatedBuildInputs = [ dateutil click pyfiglet setuptools ];
 
   meta = with stdenv.lib; {
     description     = "Starts a countdown to or from TIMESPEC";

--- a/pkgs/applications/misc/termdown/default.nix
+++ b/pkgs/applications/misc/termdown/default.nix
@@ -17,6 +17,10 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = [ dateutil click pyfiglet setuptools ];
 
+  checkPhase = ''
+    ${placeholder "out"}/bin/termdown --no-figlet 1
+  '';
+
   meta = with stdenv.lib; {
     description     = "Starts a countdown to or from TIMESPEC";
     longDescription = "Countdown timer and stopwatch in your terminal";


### PR DESCRIPTION
###### Motivation for this change

Termdown is currently broken on 20.03 because of a missing dependency on `setuptools`.
This is fixed in master by https://github.com/NixOS/nixpkgs/pull/87535/ which updates it to a newer version and add the missing dependency, but hasn't been backported.

This MR just backports the addition of `setuptools`, and add a quick test ensuring that the executable works fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
