### PR TITLE
haskellPackages: doHaddockInterfaces

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -53,7 +53,7 @@ in
 , maintainers ? []
 , doCoverage ? false
 , doHaddock ? !(ghc.isHaLVM or false)
-, doHaddockInterfaces ? true
+, doHaddockInterfaces ? stdenv.lib.versionAtLeast ghc.version "8.12"
 , passthru ? {}
 , pkgconfigDepends ? [], libraryPkgconfigDepends ? [], executablePkgconfigDepends ? [], testPkgconfigDepends ? [], benchmarkPkgconfigDepends ? []
 , testDepends ? [], testHaskellDepends ? [], testSystemDepends ? [], testFrameworkDepends ? []

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -53,7 +53,7 @@ in
 , maintainers ? []
 , doCoverage ? false
 , doHaddock ? !(ghc.isHaLVM or false)
-, doHaddockInterfaces ? stdenv.lib.versionAtLeast ghc.version "8.12"
+, doHaddockInterfaces ? false
 , passthru ? {}
 , pkgconfigDepends ? [], libraryPkgconfigDepends ? [], executablePkgconfigDepends ? [], testPkgconfigDepends ? [], benchmarkPkgconfigDepends ? []
 , testDepends ? [], testHaskellDepends ? [], testSystemDepends ? [], testFrameworkDepends ? []


### PR DESCRIPTION
###### Motivation for this change

Adds a new builder option `doHaddockInterfaces` to enable the `-haddock` flag in GHC,
which results in Haddock comments parsed at compile-time and embedded in
interface files. These are used by the `:doc` command in GHCi, as well as by IDE
tools like ghcide and hls to display docs on hover.

The `-haddock` flag has been around since at least 8.2, even though it does not
get a mention in the GHC Users guide.

There are two downsides to turning on this flag:

1. Increased compile times, since Haddocks must be parsed and then encoded
2. Haddock parse errors now become [compile errors](https://gitlab.haskell.org/ghc/ghc/-/issues/8944)

Item 2 in particular can be quite problematic for benchmarks and test suites,
where Haddock parse errors would not be a consideration.
This explains the default setting for `doHaddockInterfaces` being `doHaddock && !doCheck `.
Once the problem is fixed in
GHC, the `doHaddockInterfaces` default value can be updated to be always on in
certain GHC versions.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
