### PR TITLE
ocamlPackages.ocaml_gettext: 0.4.1 → 0.4.2

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
@@ -1,21 +1,23 @@
-{ lib, fetchurl, buildDunePackage, gettext, fileutils, ounit }:
+{ lib, fetchurl, buildDunePackage, cppo, gettext, fileutils, ounit }:
 
 buildDunePackage rec {
   pname = "gettext";
-  version = "0.4.1";
+  version = "0.4.2";
 
   minimumOCamlVersion = "4.03";
 
   src = fetchurl {
     url = "https://github.com/gildor478/ocaml-gettext/releases/download/v${version}/gettext-v${version}.tbz";
-    sha256 = "0pwy6ym5fd77mdbgyas8x86vbrri9cgk79g8wxdjplhyi7zhh158";
+    sha256 = "19ynsldb21r539fiwz1f43apsdnx7hj2a2d9qr9wg2hva9y2qrwb";
   };
+
+  buildInputs = [ cppo ];
 
   propagatedBuildInputs = [ gettext fileutils ];
 
   doCheck = true;
 
-  checkInputs = lib.optional doCheck ounit;
+  checkInputs = [ ounit ];
 
   dontStrip = true;
 


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
