### PR TITLE
 haskellPackages.gcodehs,  haskellPackages.update-nix-fetchgit unbreak & maintain

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2685,7 +2685,7 @@ package-maintainers:
   sorki:
     - cayene-lpp
     - data-stm32
-    # - gcodehs
+    - gcodehs
     - nix-derivation
     - nix-narinfo
     - ttn
@@ -5171,7 +5171,6 @@ broken-packages:
   - gas
   - gbu
   - gc-monitoring-wai
-  - gcodehs
   - gconf
   - gdax
   - gdiff-ig

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2690,6 +2690,7 @@ package-maintainers:
     - nix-narinfo
     - ttn
     # - ttn-client
+    - update-nix-fetchgit
     - zre
 
 unsupported-platforms:
@@ -10563,7 +10564,6 @@ broken-packages:
   - unused
   - uom-plugin
   - up
-  - update-nix-fetchgit
   - Updater
   - uploadcare
   - upskirt


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Breakage removal and maintenance.

`update-nix-fetchgit` release landed just yesterday, seems to be picked by `hackage2nix` for me, feel free to drop the commit if it causes trouble.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
