### PR TITLE
Fix licenses

### DIFF
--- a/pkgs/applications/audio/foo-yc20/default.nix
+++ b/pkgs/applications/audio/foo-yc20/default.nix
@@ -18,12 +18,12 @@ stdenv.mkDerivation {
   # remove lv2 until https://github.com/sampov2/foo-yc20/issues/6 is resolved
   postInstallFixup = "rm -rf $out/lib/lv2";
 
-  meta = {
+  meta = with stdenv.lib; {
     broken = true; # see: https://github.com/sampov2/foo-yc20/issues/7
     description = "A Faust implementation of a 1969 designed Yamaha combo organ, the YC-20";
     homepage = "https://github.com/sampov2/foo-yc20";
-    license     = "BSD";
-    maintainers = [ stdenv.lib.maintainers.magnetophon ];
-    platforms = stdenv.lib.platforms.linux;
+    license     = with licenses; [ bsd3 lgpl21 mpl11 ] ;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/audio/wavesurfer/default.nix
+++ b/pkgs/applications/misc/audio/wavesurfer/default.nix
@@ -20,9 +20,9 @@ stdenv.mkDerivation {
                  --prefix PATH : "${stdenv.lib.makeBinPath [ tcl tk ]}"
   '';
 
-  meta = { 
+  meta = {
     description = "Tool for recording, playing, editing, viewing and labeling of audio";
     homepage = "http://www.speech.kth.se/wavesurfer/";
-    license = "BSD";
+    license = stdenv.lib.licenses.bsd0;
   };
 }

--- a/pkgs/applications/misc/gmrun/default.nix
+++ b/pkgs/applications/misc/gmrun/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       ./gmrun-0.9.2-xdg.patch
     ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Gnome Completion-Run Utility";
     longDescription = ''
       A simple program which provides a "run program" window, featuring a bash-like TAB completion.
@@ -35,8 +35,8 @@ stdenv.mkDerivation rec {
       Running commands in a terminal with CTRL-Enter. URL handlers.
     '';
     homepage = "https://sourceforge.net/projects/gmrun/";
-    license = "GPL";
+    license = licenses.gpl2;
     maintainers = [];
-    platforms = stdenv.lib.platforms.all;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/misc/mrxvt/default.nix
+++ b/pkgs/applications/misc/mrxvt/default.nix
@@ -27,14 +27,14 @@ stdenv.mkDerivation {
     sha256 = "1mqhmnlz32lvld9rc6c1hyz7gjw4anwf39yhbsjkikcgj1das0zl";
   };
 
-  meta = { 
+  meta = with stdenv.lib; {
     description = "Lightweight multitabbed feature-rich X11 terminal emulator";
     longDescription = "
-    	Multitabbed lightweight terminal emulator based on rxvt. 
+    	Multitabbed lightweight terminal emulator based on rxvt.
 	Supports transparency, backgroundimages, freetype fonts, ...
     ";
     homepage = "https://sourceforge.net/projects/materm";
-    license = "GPL";
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/sbagen/default.nix
+++ b/pkgs/applications/misc/sbagen/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Binaural sound generator";
     homepage = "http://uazu.net/sbagen";
-    license = "GPL";
+    license = stdenv.lib.licenses.gpl2;
     platforms = [ "i686-linux" ];
   };
 }

--- a/pkgs/applications/misc/thinking-rock/default.nix
+++ b/pkgs/applications/misc/thinking-rock/default.nix
@@ -32,10 +32,10 @@ stdenv.mkDerivation {
 
   installPhase = ":";
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Task management system";
     homepage = "http://www.thinkingrock.com.au/";
-    license = "CDDL"; # Common Development and Distribution License
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.cddl;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/offrss/default.nix
+++ b/pkgs/applications/networking/offrss/default.nix
@@ -26,11 +26,11 @@ stdenv.mkDerivation {
     sha256 = "1akw1x84jj2m9z60cvlvmz21qwlaywmw18pl7lgp3bj5nw6250p6";
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "http://vicerveza.homeunix.net/~viric/cgi-bin/offrss";
     description = "Offline RSS/Atom reader";
-    license="AGPLv3+";
-    maintainers = with stdenv.lib.maintainers; [viric];
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ viric ];
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/science/biology/emboss/default.nix
+++ b/pkgs/applications/science/biology/emboss/default.nix
@@ -21,8 +21,8 @@ stdenv.mkDerivation {
     specially developed for the needs of the molecular biology (e.g. EMBnet)
     user community, including libraries. The software automatically copes with
     data in a variety of formats and even allows transparent retrieval of
-    sequence data from the web.''; 
-    license     = "GPL2";
+    sequence data from the web.'';
+    license     = stdenv.lib.licenses.gpl2;
     homepage    = "http://emboss.sourceforge.net/";
   };
 }

--- a/pkgs/applications/science/biology/mrbayes/default.nix
+++ b/pkgs/applications/science/biology/mrbayes/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   builder = ./builder.sh;
   buildInputs = [readline];
 
-  meta = {
+  meta = with stdenv.lib; {
     description     = "Bayesian Inference of Phylogeny";
     longDescription = ''
       Bayesian inference of phylogeny is based upon a
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
       MrBayes uses a simulation technique called Markov chain Monte Carlo (or
       MCMC) to approximate the posterior probabilities of trees.
     '';
-    license     = "GPL2";
+    license     = licenses.gpl2;
     homepage    = "http://mrbayes.csit.fsu.edu/";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Fix a bunch licenses that were text only form

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
