### PR TITLE
slurm: minor bugfixes

### DIFF
--- a/pkgs/servers/computing/slurm/common-env-echo.patch
+++ b/pkgs/servers/computing/slurm/common-env-echo.patch
@@ -1,0 +1,13 @@
+diff --git a/src/common/env.c b/src/common/env.c
+index 987846d..73d3b3b 100644
+--- a/src/common/env.c
++++ b/src/common/env.c
+@@ -1941,7 +1941,7 @@ char **env_array_user_default(const char *username, int timeout, int mode,
+ 	char **env = NULL;
+ 	char *starttoken = "XXXXSLURMSTARTPARSINGHEREXXXX";
+ 	char *stoptoken  = "XXXXSLURMSTOPPARSINGHEREXXXXX";
+-	char cmdstr[256], *env_loc = NULL;
++	char cmdstr[MAXPATHLEN], *env_loc = NULL;
+ 	char *stepd_path = NULL;
+ 	int fd1, fd2, fildes[2], found, fval, len, rc, timeleft;
+ 	int buf_read, buf_rem, config_timeout;

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pkgconfig, libtool, curl
-, python, munge, perl, pam, openssl, zlib, shadow, coreutils
+, python, munge, perl, pam, zlib, shadow, coreutils
 , ncurses, libmysqlclient, gtk2, lua, hwloc, numactl
-, readline, freeipmi, libssh2, xorg, lz4, rdma-core, nixosTests
+, readline, freeipmi, xorg, lz4, rdma-core, nixosTests
 # enable internal X11 support via libssh2
 , enableX11 ? true
 }:
@@ -37,22 +37,20 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig libtool ];
   buildInputs = [
-    curl python munge perl pam openssl zlib
+    curl python munge perl pam zlib
       libmysqlclient ncurses gtk2 lz4 rdma-core
       lua hwloc numactl readline freeipmi shadow.su
-  ] ++ stdenv.lib.optionals enableX11 [ libssh2 xorg.xauth ];
+  ] ++ stdenv.lib.optionals enableX11 [ xorg.xauth ];
 
   configureFlags = with stdenv.lib;
     [ "--with-freeipmi=${freeipmi}"
       "--with-hwloc=${hwloc.dev}"
       "--with-lz4=${lz4.dev}"
       "--with-munge=${munge}"
-      "--with-ssl=${openssl.dev}"
       "--with-zlib=${zlib}"
       "--with-ofed=${rdma-core}"
       "--sysconfdir=/etc/slurm"
     ] ++ (optional (gtk2 == null)  "--disable-gtktest")
-      ++ (optional enableX11 "--with-libssh2=${libssh2.dev}")
       ++ (optional (!enableX11) "--disable-x11");
 
 

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -22,6 +22,12 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
+  patches = [
+    # increase string length to allow for full
+    # path of 'echo' in nix store
+    ./common-env-echo.patch
+  ];
+
   prePatch = ''
     substituteInPlace src/common/env.c \
         --replace "/bin/echo" "${coreutils}/bin/echo"


### PR DESCRIPTION
###### Motivation for this change
* Fix fallout from https://github.com/NixOS/nixpkgs/pull/90041 and 5d8f61f3bfb8f93751c1e455f51393f10d507e0f, which fixed
the crash of `slurmd` but `sbatch --get-user-env`did not work properly due to a string length limitation.
* Remove dependencies that became obsolete in 19.05


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
