### PR TITLE
mruby: 2.1.0 -> 2.1.1

### DIFF
--- a/pkgs/development/compilers/mruby/bison-36-compat.patch
+++ b/pkgs/development/compilers/mruby/bison-36-compat.patch
@@ -1,0 +1,59 @@
+From acab088fd6af0b2ef2df1396aeb93bfc2e020fa5 Mon Sep 17 00:00:00 2001
+From: "Yukihiro \"Matz\" Matsumoto" <matz@ruby.or.jp>
+Date: Mon, 27 Apr 2020 18:52:43 +0900
+Subject: [PATCH 1/2] Updating `parse.y for recent `bison` (retry).
+
+---
+ mrbgems/mruby-compiler/core/parse.y | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mrbgems/mruby-compiler/core/parse.y b/mrbgems/mruby-compiler/core/parse.y
+index 6a1faf4e..2a4f740e 100644
+--- a/mrbgems/mruby-compiler/core/parse.y
++++ b/mrbgems/mruby-compiler/core/parse.y
+@@ -1323,7 +1323,7 @@ heredoc_end(parser_state *p)
+ 
+ %}
+ 
+-%pure-parser
++%define api.pure
+ %parse-param {parser_state *p}
+ %lex-param {parser_state *p}
+ 
+-- 
+2.27.0
+
+From 3cc682d943b29e84928a847a23f411ddbace74b7 Mon Sep 17 00:00:00 2001
+From: "Yukihiro \"Matz\" Matsumoto" <matz@ruby.or.jp>
+Date: Fri, 15 May 2020 12:30:13 +0900
+Subject: [PATCH 2/2] Remove `YYERROR_VERBOSE` which no longer supported since
+ `bison 3.6`.
+
+Instead we added `%define parse.error verbose`.
+---
+ mrbgems/mruby-compiler/core/parse.y | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mrbgems/mruby-compiler/core/parse.y b/mrbgems/mruby-compiler/core/parse.y
+index 2a4f740e..eee6a5e5 100644
+--- a/mrbgems/mruby-compiler/core/parse.y
++++ b/mrbgems/mruby-compiler/core/parse.y
+@@ -9,7 +9,6 @@
+ #ifdef PARSER_DEBUG
+ # define YYDEBUG 1
+ #endif
+-#define YYERROR_VERBOSE 1
+ #define YYSTACK_USE_ALLOCA 1
+ 
+ #include <ctype.h>
+@@ -1323,6 +1322,7 @@ heredoc_end(parser_state *p)
+ 
+ %}
+ 
++%define parse.error verbose
+ %define api.pure
+ %parse-param {parser_state *p}
+ %lex-param {parser_state *p}
+-- 
+2.27.0
+

--- a/pkgs/development/compilers/mruby/default.nix
+++ b/pkgs/development/compilers/mruby/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, ruby, bison, fetchFromGitHub }:
+{ stdenv, ruby, bison, rake, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "mruby";
-  version = "2.1.0";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner   = "mruby";
     repo    = "mruby";
     rev     = version;
-    sha256  = "1y072c7dh9jf8xwy7kia6cb4dkpspq4zf24ssn7zm5f46p4waxni";
+    sha256  = "gEEb0Vn/G+dNgeY6r0VP8bMSPrEOf5s+0GoOcnIPtEU=";
   };
 
-  nativeBuildInputs = [ ruby bison ];
+  nativeBuildInputs = [ ruby bison rake ];
 
   patches = [ ./bison-36-compat.patch ];
 

--- a/pkgs/development/compilers/mruby/default.nix
+++ b/pkgs/development/compilers/mruby/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ ruby bison ];
 
+  patches = [ ./bison-36-compat.patch ];
+
   # Necessary so it uses `gcc` instead of `ld` for linking.
   # https://github.com/mruby/mruby/blob/35be8b252495d92ca811d76996f03c470ee33380/tasks/toolchains/gcc.rake#L25
   preBuild = if stdenv.isLinux then "unset LD" else null;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Updates `mruby` and closes #90121

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
