### PR TITLE
ssm-agent: 2.0.633.0 -> 2.3.1319.0

### DIFF
--- a/nixos/modules/services/misc/ssm-agent.nix
+++ b/nixos/modules/services/misc/ssm-agent.nix
@@ -29,13 +29,15 @@ in {
 
   config = mkIf cfg.enable {
     systemd.services.ssm-agent = {
+      users.extraUsers.ssm-user = {};
+
       inherit (cfg.package.meta) description;
       after    = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      path = [ fake-lsb-release ];
+      path = [ fake-lsb-release pkgs.coreutils ];
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/agent";
+        ExecStart = "${cfg.package}/bin/amazon-ssm-agent";
         KillMode = "process";
         Restart = "on-failure";
         RestartSec = "15min";

--- a/pkgs/applications/networking/cluster/ssm-agent/default.nix
+++ b/pkgs/applications/networking/cluster/ssm-agent/default.nix
@@ -1,22 +1,56 @@
-{ stdenv, fetchFromGitHub, buildGoPackage }:
+{ stdenv, fetchFromGitHub, buildGoPackage, bash, makeWrapper }:
 
 buildGoPackage rec {
   pname   = "amazon-ssm-agent";
-  version = "2.0.633.0";
+  version = "2.3.1319.0";
 
   goPackagePath = "github.com/aws/${pname}";
-  subPackages   = [ "agent" ];
+  subPackages   = [
+    "agent"
+    "agent/framework/processor/executer/outofproc/worker"
+    "agent/framework/processor/executer/outofproc/worker"
+    "agent/framework/processor/executer/outofproc/sessionworker"
+    "agent/session/logging"
+    "agent/cli-main"
+  ];
+
+  buildInputs = [ makeWrapper ];
 
   src = fetchFromGitHub {
-    rev    = "v${version}";
+    rev    = version;
     owner  = "aws";
     repo   = pname;
-    sha256 = "10arshfn2k3m3zzgw8b3xc6ywd0ss73746nq5srh2jir7mjzi4xv";
+    sha256 = "1yiyhj7ckqa32b1rnbwn7zx89rsj00m5imn1xlpsw002ywxsxbnv";
   };
 
   preBuild = ''
     mv go/src/${goPackagePath}/vendor strange-vendor
     mv strange-vendor/src go/src/${goPackagePath}/vendor
+
+    cd go/src/${goPackagePath}
+    echo ${version} > VERSION
+
+    substituteInPlace agent/plugins/inventory/gatherers/application/dataProvider.go \
+      --replace '"github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/localpackages"' ""
+
+    go run agent/version/versiongenerator/version-gen.go
+    substituteInPlace agent/appconfig/constants_unix.go \
+      --replace /usr/bin/ssm-document-worker $bin/bin/ssm-document-worker \
+      --replace /usr/bin/ssm-session-worker $bin/bin/ssm-session-worker \
+      --replace /usr/bin/ssm-session-logger $bin/bin/ssm-session-logger
+    cd -
+  '';
+
+  postBuild = ''
+    mv go/bin/agent go/bin/amazon-ssm-agent
+    mv go/bin/worker go/bin/ssm-document-worker
+    mv go/bin/sessionworker go/bin/ssm-session-worker
+    mv go/bin/logging go/bin/ssm-session-logger
+    mv go/bin/cli-main go/bin/ssm-cli
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/amazon-ssm-agent --prefix PATH : ${bash}/bin
   '';
 
   meta = with stdenv.lib; {
@@ -24,7 +58,6 @@ buildGoPackage rec {
     homepage    = "https://github.com/aws/amazon-ssm-agent";
     license     = licenses.asl20;
     platforms   = platforms.unix;
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = with maintainers; [ copumpkin manveru ];
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

The SSM agent doesn't work anymore on EC2.

Bumping version and switching to Amazon's executable names for less conflicts with other `agent` executables.
To bring the ssm-agent up to date and support new features like AWS Session Manager and SSM SSH.

This is basically a newer version of https://github.com/NixOS/nixpkgs/pull/74384 which was never merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
