### PR TITLE
searx: allow running on priviledged ports.

### DIFF
--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -47,16 +47,16 @@ in
 
   config = mkIf config.services.searx.enable {
 
-    users.users.searx =
-      { uid = config.ids.uids.searx;
-        description = "Searx user";
-        createHome = true;
-        home = "/var/lib/searx";
-      };
+   users.users.searx = {
+      uid = config.ids.uids.searx;
+      description = "Searx user";
+      createHome = true;
+      home = "/var/lib/searx";
+    };
 
-    users.groups.searx =
-      { gid = config.ids.gids.searx;
-      };
+    users.groups.searx = {
+        gid = config.ids.gids.searx;
+    };
 
     systemd.services.searx =
       {
@@ -66,6 +66,8 @@ in
         serviceConfig = {
           User = "searx";
           ExecStart = "${cfg.package}/bin/searx-run";
+          # Allow running the service on priviledged ports.
+          AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         };
       } // (optionalAttrs (configFile != null) {
         environment.SEARX_SETTINGS_PATH = configFile;

--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -50,8 +50,6 @@ in
    users.users.searx = {
       uid = config.ids.uids.searx;
       description = "Searx user";
-      createHome = true;
-      home = "/var/lib/searx";
     };
 
     users.groups.searx = {
@@ -66,6 +64,7 @@ in
         serviceConfig = {
           User = "searx";
           ExecStart = "${cfg.package}/bin/searx-run";
+          StateDirectory = "searx";
           # Allow running the service on priviledged ports.
           AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         };

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "fastapi";
-  version = "0.54.1";
+  version = "0.55.1";
   format = "flit";
   disabled = !isPy3k;
 
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "tiangolo";
     repo = "fastapi";
     rev = version;
-    sha256 = "0k0lss8x6lzf0szcli48v28r269fsx1jdkr9q78liz47dz5x03d8";
+    sha256 = "1515nhwari48v0angyl5z3cfpvwn4al2nvqh0cjd9xgxzvm310s8";
   };
 
   postPatch = ''

--- a/pkgs/tools/networking/network-manager/dmenu/default.nix
+++ b/pkgs/tools/networking/network-manager/dmenu/default.nix
@@ -4,13 +4,13 @@
 let inherit (python3Packages) python pygobject3;
 in stdenv.mkDerivation rec {
   pname = "networkmanager_dmenu";
-  version = "1.1";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "firecat53";
     repo = "networkmanager-dmenu";
-    rev = "v${version}";
-    sha256 = "1z6151z7c4jv5k2i50zr7ld4k3m07dgpmss9f3hsav95cv55dcnb";
+    rev = "${version}";
+    sha256 = "1msk4zkm4042av61rgbwc62i62vnv9py93fm1bczmw0b1f54qpmk";
   };
 
   buildInputs = [ glib python pygobject3 gobject-introspection networkmanager python3Packages.wrapPython ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Added  `AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];` to allow running the service on priviledged ports. (0-1024)

Thanks @mweinelt for pointing that out. I changed this PR to the new strategy for allowing priviledged ports.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @rnhmjoj