### PR TITLE
libva: 2.7.1 -> 2.8.0

### DIFF
--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -7,28 +7,15 @@
 
 stdenv.mkDerivation rec {
   name = "libva-${lib.optionalString minimal "minimal-"}${version}";
-  version = "2.7.1"; # Also update the hash for libva-utils!
+  version = "2.8.0"; # Also update the hash for libva-utils!
 
   # update libva-utils and vaapiIntel as well
   src = fetchFromGitHub {
     owner  = "intel";
     repo   = "libva";
     rev    = version;
-    sha256 = "0ywasac7z3hwggj8szp83sbxi2naa0a3amblx64y7i1hyyrn0csq";
+    sha256 = "190cq173jzp5rkrczi8gzbwa0y3xk253v4wd205a5ilfngm7srns";
   };
-
-  patches = [
-    (fetchpatch { # meson: Allow for libdir and includedir to be absolute paths
-      url = "https://github.com/intel/libva/commit/de902e2905abff635f3bb151718cc52caa3f669c.patch";
-      sha256 = "1lpc8qzvsxnlsh9g0ab5lja204zxz8rr2p973pfihcw7dcxc3gia";
-    })
-  ];
-
-  postPatch = ''
-    # Remove the execute bit from all source code files
-    # https://github.com/intel/libva/commit/dbd2cd635f33af1422cbc2079af0a7e68671c102
-    chmod -x va/va{,_dec_av1,_trace,_vpp}.h
-  '';
 
   outputs = [ "dev" "out" ];
 

--- a/pkgs/development/libraries/libva/utils.nix
+++ b/pkgs/development/libraries/libva/utils.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner  = "intel";
     repo   = "libva-utils";
     rev    = version;
-    sha256 = "13a0dccphi4cpr2cx45kg4djxsssi3d1fcjrkx27b16xiayp5lx9";
+    sha256 = "081hw2jnj64bpqwh9p41n5caqzm6dnj1ggnvvc5wrf4m2z1h2bjb";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13604,7 +13604,7 @@ in
 
   libva = callPackage ../development/libraries/libva { };
   libva-minimal = libva.override { minimal = true; };
-  libva-utils = callPackage ../development/libraries/libva-utils { };
+  libva-utils = callPackage ../development/libraries/libva/utils.nix { };
 
   libva1 = callPackage ../development/libraries/libva/1.0.0.nix { };
   libva1-minimal = libva1.override { minimal = true; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Via SSH:
```console
$ vainfo
error: can't connect to X server!
libva info: VA-API version 1.8.0
libva info: Trying to open /run/opengl-driver/lib/dri/r600_drv_video.so
libva info: Found init function __vaDriverInit_1_7
libva info: va_openDriver() returns 0
vainfo: VA-API version: 1.8 (libva 2.8.0)
vainfo: Driver version: Mesa Gallium driver 20.0.8 for AMD CAYMAN (DRM 2.50.0 / 5.4.46, LLVM 9.0.1)
vainfo: Supported profile and entrypoints
      VAProfileMPEG2Simple            :	VAEntrypointVLD
      VAProfileMPEG2Main              :	VAEntrypointVLD
      VAProfileVC1Simple              :	VAEntrypointVLD
      VAProfileVC1Main                :	VAEntrypointVLD
      VAProfileVC1Advanced            :	VAEntrypointVLD
      VAProfileH264ConstrainedBaseline:	VAEntrypointVLD
      VAProfileH264Main               :	VAEntrypointVLD
      VAProfileH264High               :	VAEntrypointVLD
      VAProfileNone                   :	VAEntrypointVideoProc
```

Verified via `mpv` (much lower CPU usage with VA-API).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
