### PR TITLE
maintainers: fix previously uncaught name issues

### DIFF
--- a/nixos/tests/dokuwiki.nix
+++ b/nixos/tests/dokuwiki.nix
@@ -32,8 +32,9 @@ let
 
 in {
   name = "dokuwiki";
-  meta.maintainers = with pkgs.lib.maintainers; [ "1000101" ];
-
+  meta = with pkgs.stdenv.lib; {
+    maintainers = with maintainers; [ maintainers."1000101" ];
+  };
   machine = { ... }: {
     services.dokuwiki."site1.local" = {
       aclUse = false;

--- a/nixos/tests/trezord.nix
+++ b/nixos/tests/trezord.nix
@@ -1,9 +1,8 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "trezord";
-  meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ mmahut "1000101" ];
+  meta = with pkgs.stdenv.lib; {
+    maintainers = with maintainers; [ mmahut maintainers."1000101" ];
   };
-
   nodes = {
     machine = { ... }: {
       services.trezord.enable = true;

--- a/nixos/tests/trickster.nix
+++ b/nixos/tests/trickster.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "trickster";
-  meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ "1000101" ];
+  meta = with pkgs.stdenv.lib; {
+    maintainers = with maintainers; [ maintainers."1000101" ];
   };
 
   nodes = {

--- a/pkgs/development/python-modules/shamir-mnemonic/default.nix
+++ b/pkgs/development/python-modules/shamir-mnemonic/default.nix
@@ -17,6 +17,6 @@ buildPythonPackage rec {
     description = "Reference implementation of SLIP-0039";
     homepage = "https://github.com/trezor/python-shamir-mnemonic";
     license = licenses.mit;
-    maintainers = [ maintainers."1000101" ];
+    maintainers = with maintainers; [ maintainers."1000101" ];
   };
 }

--- a/pkgs/servers/web-apps/dokuwiki/default.nix
+++ b/pkgs/servers/web-apps/dokuwiki/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     homepage = "https://www.dokuwiki.org";
     platforms = platforms.all;
-    maintainers = [ maintainers."1000101" ];
+    maintainers = with maintainers; [ maintainers."1000101" ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix my mistakes from the past, when eval was not picking it up and passed although it shouldn't have.

Fixes (hopefully) https://github.com/NixOS/nixpkgs/pull/90029

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
