### PR TITLE
ddcui: init at 0.1.1

### DIFF
--- a/pkgs/applications/misc/ddcui/default.nix
+++ b/pkgs/applications/misc/ddcui/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, pkg-config
+, qtbase
+, qttools
+, ddcutil
+}:
+
+mkDerivation rec {
+  pname = "ddcui";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "rockowitz";
+    repo = "ddcui";
+    rev = "v${version}";
+    sha256 = "02qr7i3pdq8p6lnhwihfgd9b7y9zwpdk6gwv626rz32ai6mfrfhl";
+  };
+
+  nativeBuildInputs = [
+    # Using cmake instead of the also-supported qmake because ddcui's qmake
+    # file is not currently written to support PREFIX installations.
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    qtbase
+    qttools
+    ddcutil
+  ];
+
+  meta = with lib; {
+    description = "Graphical user interface for ddcutil - control monitor settings";
+    homepage = "https://www.ddcutil.com/ddcui_main/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ nh2 ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2895,6 +2895,8 @@ in
 
   ddccontrol-db = callPackage ../data/misc/ddccontrol-db { };
 
+  ddcui = libsForQt5.callPackage ../applications/misc/ddcui { };
+
   ddcutil = callPackage ../tools/misc/ddcutil { };
 
   ddclient = callPackage ../tools/networking/ddclient { };


### PR DESCRIPTION
##### Motivation for this change

GUI for `ddcutil`, allows adjusting monitor hardware settings:

![image](https://user-images.githubusercontent.com/399535/85886584-a6fa3d00-b7e6-11ea-948a-85a130c7dd57.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested it running on Ubuntu with `sudo ddcui` after building on NixOS.

FYI @rnhmjoj (maintainer of `ddcutil`)