### PR TITLE
nxpmicro-mfgtools: init at 1.3.191

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1043,6 +1043,12 @@
     githubId = 16330;
     name = "Mathijs Kwik";
   };
+  bmilanov = {
+    name = "Biser Milanov";
+    email = "bmilanov11+nixpkgs@gmail.com";
+    github = "bmilanov";
+    githubId = 30090366;
+  };
   bobakker = {
     email = "bobakk3r@gmail.com";
     github = "bobakker";

--- a/pkgs/development/tools/misc/nxpmicro-mfgtools/default.nix
+++ b/pkgs/development/tools/misc/nxpmicro-mfgtools/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, bzip2
+, libusb1
+, libzip
+, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nxpmicro-mfgtools";
+  version = "1.3.191";
+
+  src = fetchFromGitHub {
+    owner = "NXPmicro";
+    repo = "mfgtools";
+    rev = "uuu_${version}";
+    sha256 = "196blmd7nf5kamvay22rvnkds2v6h7ab8lyl10dknxgy8i8siqq9";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ bzip2 libusb1 libzip openssl ];
+
+  preConfigure = "echo ${version} > .tarball-version";
+
+  meta = with stdenv.lib; {
+    description = "Freescale/NXP I.MX chip image deploy tools";
+    longDescription = ''
+      UUU (Universal Update Utility) is a command line tool, evolved out of
+      MFGTools (aka MFGTools v3).
+
+      One of the main purposes is to upload images to I.MX SoC's using at least
+      their boot ROM.
+
+      With time, the need for an update utility portable to Linux and Windows
+      increased. UUU has the same usage on both Windows and Linux. It means the same
+      script works on both OS.
+    '';
+    homepage = "https://github.com/NXPmicro/mfgtools";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.bmilanov ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5590,6 +5590,8 @@ in
 
   nwdiag = with python3Packages; toPythonApplication nwdiag;
 
+  nxpmicro-mfgtools = callPackage ../development/tools/misc/nxpmicro-mfgtools { };
+
   nyancat = callPackage ../tools/misc/nyancat { };
 
   nylon = callPackage ../tools/networking/nylon { };


### PR DESCRIPTION
Add nxpmicro-mfgtools to nixpkgs

From the project's homepage [1]:

    Freescale/NXP I.MX Chip image deploy tools.

The project's only binary and library at the moment is UUU. NXP
might add more in the future, so making the package name:

    nxpmicro-mfgtools

instead of:

    nxp-uuu

or something similar.

Add a preConfigure step based on bbigras' suggestion.

[1]: https://github.com/NXPmicro/mfgtools

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
