### PR TITLE
neomutt: enable on darwin

### DIFF
--- a/pkgs/applications/networking/browsers/elinks/default.nix
+++ b/pkgs/applications/networking/browsers/elinks/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses, xlibsWrapper, bzip2, zlib, openssl
+{ stdenv, fetchurl, fetchpatch, ncurses, xlibsWrapper, bzip2, zlib, openssl
 , gpm
 , # Incompatible licenses, LGPLv3 - GPLv2
   enableGuile        ? false,                                         guile ? null
@@ -10,11 +10,12 @@
 assert enableGuile -> guile != null;
 assert enablePython -> python != null;
 
-stdenv.mkDerivation {
-  name = "elinks-0.12pre6";
+stdenv.mkDerivation rec {
+  pname = "elinks";
+  version = "0.12pre6";
 
   src = fetchurl {
-    url = "http://elinks.or.cz/download/elinks-0.12pre6.tar.bz2";
+    url = "http://elinks.or.cz/download/${pname}-${version}.tar.bz2";
     sha256 = "1nnakbi01g7yd3zqwprchh5yp45br8086b0kbbpmnclabcvlcdiq";
   };
 
@@ -23,7 +24,15 @@ stdenv.mkDerivation {
     ./openssl-1.1.patch
   ];
 
-  buildInputs = [ ncurses xlibsWrapper bzip2 zlib openssl spidermonkey gpm ]
+  postPatch = (stdenv.lib.optional stdenv.isDarwin) ''
+    patch -p0 < ${fetchpatch {
+      url = "https://raw.githubusercontent.com/macports/macports-ports/72bed7749e76b9092ddd8d9fe2d8449c5afb1d71/www/elinks/files/patch-perl.diff";
+      sha256 = "14q9hk3kg2n2r5b062hvrladp7b4yzysvhq07903w9kpg4zdbyqh";
+    }}
+  '';
+
+  buildInputs = [ ncurses xlibsWrapper bzip2 zlib openssl spidermonkey ]
+    ++ stdenv.lib.optional stdenv.isLinux gpm
     ++ stdenv.lib.optional enableGuile guile
     ++ stdenv.lib.optional enablePython python
     ++ stdenv.lib.optional enablePerl perl
@@ -44,10 +53,10 @@ stdenv.mkDerivation {
     ++ stdenv.lib.optional enableSpidermonkey "--with-spidermonkey=${spidermonkey}"
     ;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Full-featured text-mode web browser";
     homepage = "http://elinks.or.cz";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2;
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
* [Changelog](https://github.com/neomutt/neomutt/releases/tag/20200626)
* enable on darwin (via enabling **elinks** on darwin)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
