### PR TITLE
roundcubePlugins.carddav: init at 3.0.3

### DIFF
--- a/pkgs/servers/roundcube/plugins/carddav/default.nix
+++ b/pkgs/servers/roundcube/plugins/carddav/default.nix
@@ -1,0 +1,11 @@
+{ roundcubePlugin, fetchzip }:
+
+roundcubePlugin rec {
+  pname = "carddav";
+  version = "3.0.3";
+
+  src = fetchzip {
+    url = "https://github.com/blind-coder/rcmcarddav/releases/download/v${version}/carddav-${version}.tar.bz2";
+    sha256 = "0scqxqfwv9r4ggaammmjp51mj50qc5p4jmjliwjvcwyjr36wjq3z";
+  };
+}

--- a/pkgs/servers/roundcube/plugins/plugins.nix
+++ b/pkgs/servers/roundcube/plugins/plugins.nix
@@ -5,5 +5,6 @@
 
   roundcubePlugin = callPackage ./roundcube-plugin.nix { };
 
+  carddav = callPackage ./carddav { };
   persistent_login = callPackage ./persistent_login { };
 }


### PR DESCRIPTION
###### Motivation for this change
I'd like to use my carddav contacts in my new roundcube setup, like described [here](https://www.benhup.com/freebsd/carddav-support-in-roundcube-webmail-with-nextcloud-back-end/).

I haven't tested this particular branch but I'm using it successfully like this:

```nix
  services.roundcube.package = pkgs.roundcube.withPlugins (plugins: [
      (pkgs.roundcubePlugins.roundcubePlugin rec {
        pname = "carddav";
        version = "3.0.3";

        src = pkgs.fetchzip {
          url = "https://github.com/blind-coder/rcmcarddav/releases/download/v${version}/carddav-${version}.tar.bz2";
          sha256 = "0scqxqfwv9r4ggaammmjp51mj50qc5p4jmjliwjvcwyjr36wjq3z";
        };
      })
    ]);
```

which is basically the same code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
