### PR TITLE
rumatui: init at 0.1.16

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rumatui/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rumatui/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+, pkgconfig
+, openssl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rumatui";
+  version = "0.1.18";
+
+  src = fetchFromGitHub {
+    owner = "DevinR528";
+    repo = "rumatui";
+    rev = version;
+    sha256 = "1azqqcb1bgaa9gnb8ym7xfghh7i9wrn188bdzwnlfcdaj16i8rf3";
+  };
+
+  cargoSha256 = "08819s3c188wdmd5zwp2ca596abygrs014i0slccipwd2l59ci0m";
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ openssl ];
+
+  meta = with stdenv.lib; {
+    description = "WIP Command line Matrix client using matrix-rust-sdk";
+    homepage = "https://github.com/DevinR528/rumatui";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2302,6 +2302,8 @@ in
     libmaxminddb = null;
   };
 
+  rumatui = callPackage ../applications/networking/instant-messengers/rumatui { };
+
   xmousepasteblock = callPackage ../tools/X11/xmousepasteblock { };
 
   mar1d = callPackage ../games/mar1d { } ;


### PR DESCRIPTION
#### Motivation for this change

This adds `rumatui` another terminal-based Matrix client.

https://github.com/DevinR528/RumaTui

This is currently a draft because the tests for `0.1.16` seem to fail: https://github.com/DevinR528/rumatui/issues/4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
