### PR TITLE
the permissions for the datadog-agent need to be modifiable

### DIFF
--- a/nixos/modules/services/monitoring/datadog-agent.nix
+++ b/nixos/modules/services/monitoring/datadog-agent.nix
@@ -201,6 +201,16 @@ in {
           excluded_interfaces = [ "lo" "lo0" ]; } ];
       };
     };
+
+    permissions = mkOption {
+      description = "User and group permissions for datadog-agent";
+      type = types.attrs;
+      default = {
+        User = "datadog";
+        Group = "datadog";
+      };
+    };
+
   };
   config = mkIf cfg.enable {
     environment.systemPackages = [ datadogPkg pkgs.sysstat pkgs.procps pkgs.iproute ];
@@ -220,8 +230,8 @@ in {
         path = [ datadogPkg pkgs.python pkgs.sysstat pkgs.procps pkgs.iproute ];
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
-          User = "datadog";
-          Group = "datadog";
+          User = cfg.permissions.User;
+          Group = cfg.permissions.Group;
           Restart = "always";
           RestartSec = 2;
         };
@@ -231,7 +241,7 @@ in {
       datadog-agent = makeService {
         description = "Datadog agent monitor";
         preStart = ''
-          chown -R datadog: /etc/datadog-agent
+          chown -R ${cfg.permissions.User}: /etc/datadog-agent
           rm -f /etc/datadog-agent/auth_token
         '';
         script = ''

--- a/nixos/modules/services/monitoring/datadog-agent.nix
+++ b/nixos/modules/services/monitoring/datadog-agent.nix
@@ -204,10 +204,19 @@ in {
 
     permissions = mkOption {
       description = "User and group permissions for datadog-agent";
-      type = types.attrs;
-      default = {
-        User = "datadog";
-        Group = "datadog";
+      type = with types; submodule {
+        options = {
+          User = mkOption {
+            description = "User permissions";
+            type = types.str;
+            default = "datadog";
+          };
+          Group = mkOption {
+            description = "Group permissions";
+            type = types.str;
+            default = "datadog";
+          };
+        };
       };
     };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I can't get any disk metrics with the `user-group` datadog. My system runs all daemons through root. Below is my error message that I was able to resolve by creating a permissions option in the datadog-agent module setting my `services.datadog-agent.permissions = { User = "root"; Group = "root"; };`

```
Jun 27 02:14:59 nixos zx0f096xv8lgg1wxgnwhspxq0n4lj96g-unit-script-datadog-agent-start[16394]: 2020-06-27 02:14:59 UTC | CORE | WARN | (pkg/collector/py/datadog_agent.go:148 in LogMessage) | (disk.py:107) | Unable to get disk metrics for /run/user/1000/gvfs: [Errno 13] Permission denied: '/run/user/1000/gvfs'
``` 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
