### PR TITLE
prometheus-kea-exporter: init at 0.4.1

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -34,6 +34,7 @@ let
     "fritzbox"
     "json"
     "jitsi"
+    "kea"
     "keylight"
     "knot"
     "lnd"

--- a/nixos/modules/services/monitoring/prometheus/exporters/kea.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/kea.nix
@@ -1,0 +1,38 @@
+{ config
+, lib
+, pkgs
+, options
+}:
+
+with lib;
+
+let
+  cfg = config.services.prometheus.exporters.kea;
+in {
+  port = 9547;
+  extraOpts = {
+    controlSocketPaths = mkOption {
+      type = types.listOf types.str;
+      example = literalExample ''
+        [
+          "/run/kea/kea-dhcp4.socket"
+          "/run/kea/kea-dhcp6.socket"
+        ]
+      '';
+      description = ''
+        Paths to kea control sockets
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.prometheus-kea-exporter}/bin/kea-exporter \
+          --address ${cfg.listenAddress} \
+          --port ${toString cfg.port} \
+          ${concatStringsSep " \\n" cfg.controlSocketPaths}
+      '';
+      SupplementaryGroups = [ "kea" ];
+    };
+  };
+}

--- a/pkgs/servers/monitoring/prometheus/kea-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/kea-exporter.nix
@@ -1,0 +1,29 @@
+{ lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "kea-exporter";
+  version = "0.4.2";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "0dpzicv0ksyda2lprldkj452c23qycl5c9avca6x7f7rbqry9pnd";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    click
+    prometheus_client
+  ];
+
+  checkPhase = ''
+    $out/bin/kea-exporter --help > /dev/null
+    $out/bin/kea-exporter --version | grep -q ${version}
+  '';
+
+  meta = with lib; {
+    description = "Export Kea Metrics in the Prometheus Exposition Format";
+    homepage = "https://github.com/mweinelt/kea-exporter";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}
+

--- a/pkgs/servers/monitoring/prometheus/kea-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/kea-exporter.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages }:
+{ lib, python3Packages, nixosTests }:
 
 python3Packages.buildPythonApplication rec {
   pname = "kea-exporter";
@@ -18,6 +18,10 @@ python3Packages.buildPythonApplication rec {
     $out/bin/kea-exporter --help > /dev/null
     $out/bin/kea-exporter --version | grep -q ${version}
   '';
+
+  passthru.tests = {
+    inherit (nixosTests.prometheus-exporters) kea;
+  };
 
   meta = with lib; {
     description = "Export Kea Metrics in the Prometheus Exposition Format";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19323,6 +19323,7 @@ in
   prometheus-haproxy-exporter = callPackage ../servers/monitoring/prometheus/haproxy-exporter.nix { };
   prometheus-jitsi-exporter = callPackage ../servers/monitoring/prometheus/jitsi-exporter.nix { };
   prometheus-json-exporter = callPackage ../servers/monitoring/prometheus/json-exporter.nix { };
+  prometheus-kea-exporter = callPackage ../servers/monitoring/prometheus/kea-exporter.nix { };
   prometheus-keylight-exporter = callPackage ../servers/monitoring/prometheus/keylight-exporter.nix { };
   prometheus-knot-exporter = callPackage ../servers/monitoring/prometheus/knot-exporter.nix { };
   prometheus-lnd-exporter = callPackage ../servers/monitoring/prometheus/lnd-exporter.nix { };


### PR DESCRIPTION
##### Motivation for this change

This is the Prometheus exporter for the ISC Kea DHCP daemon, I want to monitor DHCP metrics with it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
