### PR TITLE
mk-python-derivation.nix: fix indentation

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -105,81 +105,81 @@ let
     "disabled" "checkPhase" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts" "format"
   ]) // {
 
-  name = namePrefix + name;
+    name = namePrefix + name;
 
-  nativeBuildInputs = [
-    python
-    wrapPython
-    ensureNewerSourcesForZipFilesHook  # move to wheel installer (pip) or builder (setuptools, flit, ...)?
-    pythonRecompileBytecodeHook  # Remove when solved https://github.com/NixOS/nixpkgs/issues/81441
-    pythonRemoveTestsDirHook
-  ] ++ lib.optionals catchConflicts [
-    setuptools pythonCatchConflictsHook
-  ] ++ lib.optionals removeBinBytecode [
-    pythonRemoveBinBytecodeHook
-  ] ++ lib.optionals (lib.hasSuffix "zip" (attrs.src.name or "")) [
-    unzip
-  ] ++ lib.optionals (format == "setuptools") [
-    setuptoolsBuildHook
-  ] ++ lib.optionals (format == "flit") [
-    flitBuildHook
-  ] ++ lib.optionals (format == "pyproject") [
-    pipBuildHook
-  ] ++ lib.optionals (format == "wheel") [
-    wheelUnpackHook
-  ] ++ lib.optionals (format == "egg") [
-    eggUnpackHook eggBuildHook eggInstallHook
-  ] ++ lib.optionals (!(format == "other") || dontUsePipInstall) [
-    pipInstallHook
-  ] ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
-    # This is a test, however, it should be ran independent of the checkPhase and checkInputs
-    pythonImportsCheckHook
-  ] ++ lib.optionals (python.pythonAtLeast "3.3") [
-    # Optionally enforce PEP420 for python3
-    pythonNamespacesHook
-  ] ++ nativeBuildInputs;
+    nativeBuildInputs = [
+      python
+      wrapPython
+      ensureNewerSourcesForZipFilesHook  # move to wheel installer (pip) or builder (setuptools, flit, ...)?
+      pythonRecompileBytecodeHook  # Remove when solved https://github.com/NixOS/nixpkgs/issues/81441
+      pythonRemoveTestsDirHook
+    ] ++ lib.optionals catchConflicts [
+      setuptools pythonCatchConflictsHook
+    ] ++ lib.optionals removeBinBytecode [
+      pythonRemoveBinBytecodeHook
+    ] ++ lib.optionals (lib.hasSuffix "zip" (attrs.src.name or "")) [
+      unzip
+    ] ++ lib.optionals (format == "setuptools") [
+      setuptoolsBuildHook
+    ] ++ lib.optionals (format == "flit") [
+      flitBuildHook
+    ] ++ lib.optionals (format == "pyproject") [
+      pipBuildHook
+    ] ++ lib.optionals (format == "wheel") [
+      wheelUnpackHook
+    ] ++ lib.optionals (format == "egg") [
+      eggUnpackHook eggBuildHook eggInstallHook
+    ] ++ lib.optionals (!(format == "other") || dontUsePipInstall) [
+      pipInstallHook
+    ] ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
+      # This is a test, however, it should be ran independent of the checkPhase and checkInputs
+      pythonImportsCheckHook
+    ] ++ lib.optionals (python.pythonAtLeast "3.3") [
+      # Optionally enforce PEP420 for python3
+      pythonNamespacesHook
+    ] ++ nativeBuildInputs;
 
-  buildInputs = buildInputs ++ pythonPath;
+    buildInputs = buildInputs ++ pythonPath;
 
-  propagatedBuildInputs = propagatedBuildInputs ++ [ python ];
+    propagatedBuildInputs = propagatedBuildInputs ++ [ python ];
 
-  inherit strictDeps;
+    inherit strictDeps;
 
-  LANG = "${if python.stdenv.isDarwin then "en_US" else "C"}.UTF-8";
+    LANG = "${if python.stdenv.isDarwin then "en_US" else "C"}.UTF-8";
 
-  # Python packages don't have a checkPhase, only an installCheckPhase
-  doCheck = false;
-  doInstallCheck = attrs.doCheck or true;
-  installCheckInputs = [
-  ] ++ lib.optionals (format == "setuptools") [
-    # Longer-term we should get rid of this and require
-    # users of this function to set the `installCheckPhase` or
-    # pass in a hook that sets it.
-    setuptoolsCheckHook
-  ] ++ checkInputs;
+    # Python packages don't have a checkPhase, only an installCheckPhase
+    doCheck = false;
+    doInstallCheck = attrs.doCheck or true;
+    installCheckInputs = [
+    ] ++ lib.optionals (format == "setuptools") [
+      # Longer-term we should get rid of this and require
+      # users of this function to set the `installCheckPhase` or
+      # pass in a hook that sets it.
+      setuptoolsCheckHook
+    ] ++ checkInputs;
 
-  postFixup = lib.optionalString (!dontWrapPythonPrograms) ''
-    wrapPythonPrograms
-  '' + attrs.postFixup or '''';
+    postFixup = lib.optionalString (!dontWrapPythonPrograms) ''
+      wrapPythonPrograms
+    '' + attrs.postFixup or '''';
 
-  # Python packages built through cross-compilation are always for the host platform.
-  disallowedReferences = lib.optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [ python.pythonForBuild ];
+    # Python packages built through cross-compilation are always for the host platform.
+    disallowedReferences = lib.optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [ python.pythonForBuild ];
 
-  # For now, revert recompilation of bytecode.
-  dontUsePythonRecompileBytecode = true;
+    # For now, revert recompilation of bytecode.
+    dontUsePythonRecompileBytecode = true;
 
-  meta = {
-    # default to python's platforms
-    platforms = python.meta.platforms;
-    isBuildPythonPackage = python.meta.platforms;
-  } // meta;
-} // lib.optionalAttrs (attrs?checkPhase) {
-  # If given use the specified checkPhase, otherwise use the setup hook.
-  # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
-  installCheckPhase = attrs.checkPhase;
-}));
+    meta = {
+      # default to python's platforms
+      platforms = python.meta.platforms;
+      isBuildPythonPackage = python.meta.platforms;
+    } // meta;
+  } // lib.optionalAttrs (attrs?checkPhase) {
+    # If given use the specified checkPhase, otherwise use the setup hook.
+    # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
+    installCheckPhase = attrs.checkPhase;
+  }));
 
-passthru.updateScript = let
-    filename = builtins.head (lib.splitString ":" self.meta.position);
-  in attrs.passthru.updateScript or [ update-python-libraries filename ];
+  passthru.updateScript = let
+      filename = builtins.head (lib.splitString ":" self.meta.position);
+    in attrs.passthru.updateScript or [ update-python-libraries filename ];
 in lib.extendDerivation true passthru self


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I got confused while reading through `mk-python-derivation.nix`. I think the current indentation is misleading.
The indented opening brace in line 106 belongs to the closing brace in line 176 which had no indentation.
###### Things done
Fixed the indentation. (No functional change)

