### PR TITLE
easypdkprog: init at 1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1782,6 +1782,12 @@
     email = "christoph.senjak@googlemail.com";
     name = "Christoph-Simon Senjak";
   };
+  david-sawatzke = {
+    email = "d-nix@sawatzke.dev";
+    github = "david-sawatzke";
+    githubId = 11035569;
+    name = "David Sawatzke";
+  };
   david50407 = {
     email = "me@davy.tw";
     github = "david50407";

--- a/pkgs/development/tools/misc/easypdkprog/default.nix
+++ b/pkgs/development/tools/misc/easypdkprog/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "easypdkprog";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "free-pdk";
+    repo = "easy-pdk-programmer-software";
+    rev = version;
+    sha256 = "06bn86rd57ff567l0ipx38raih0zll3y16lg5fpn7c601a9jldps";
+  };
+
+  installPhase = ''
+    install -Dm755 -t $out/bin easypdkprog
+  '' + lib.optionalString stdenv.isLinux ''
+    install -Dm644 -t $out/etc/udev/rules.d Linux_udevrules/70-stm32vcp.rules
+  '';
+
+  meta = with lib; {
+    description = "Read, write and execute programs on PADAUK microcontroller";
+    homepage = "https://github.com/free-pdk/easy-pdk-programmer-software";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ david-sawatzke ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10433,6 +10433,8 @@ in
 
   drush = callPackage ../development/tools/misc/drush { };
 
+  easypdkprog = callPackage ../development/tools/misc/easypdkprog { };
+
   editorconfig-checker = callPackage ../development/tools/misc/editorconfig-checker { };
 
   editorconfig-core-c = callPackage ../development/tools/misc/editorconfig-core-c { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The udev rules stuff is taken from the openocd package, but I'm not sure if it works