### PR TITLE
syslinux: make reproducible

### DIFF
--- a/pkgs/os-specific/linux/syslinux/default.nix
+++ b/pkgs/os-specific/linux/syslinux/default.nix
@@ -22,9 +22,15 @@ stdenv.mkDerivation {
       url = mkURL "fa1349f1" "0002-gfxboot-menu-label.patch";
       sha256 = "06ifgzbpjj4picpj17zgprsfi501zf4pp85qjjgn29i5rs291zni";
     })
-    (fetchpatch {
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/0005-gnu-efi-version-compatibility.patch?h=packages/syslinux";
-      sha256 = "0fbqz56hj8az8ws26m39hyp3l5fvcbzvzdddqz3x6n56hzdpz1p6";
+    (fetchurl {
+      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/0005-gnu-efi-version-compatibility.patch?id=821c3da473d1399d930d5b4a086e46a4179eaa45";
+      name = "0005-gnu-efi-version-compatibility.patch";
+      sha256 = "1mz2idg8cwn0mvd3jixxynhkn7rhmi5fp8cc8zznh5f0ysfra446";
+    })
+    (fetchurl {
+      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/0025-reproducible-build.patch?id=821c3da473d1399d930d5b4a086e46a4179eaa45";
+      name = "0025-reproducible-build.patch";
+      sha256 = "0qk6wc6z3648828y3961pn4pi7xhd20a6fqn6z1mnj22bbvzcxls";
     })
     (fetchurl {
       # mbr.bin: too big (452 > 440)
@@ -70,6 +76,7 @@ stdenv.mkDerivation {
     "DATADIR=$(out)/share"
     "MANDIR=$(out)/share/man"
     "PERL=perl"
+    "HEXDATE=0x00000000"
   ]
     ++ stdenv.lib.optionals stdenv.hostPlatform.isi686 [ "bios" "efi32" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I saw it on https://r13y.com/ and I changed stuff in syslinux recently.
This time I tested if it still builds on i686.

~~The reason why I needed to import the patch is that it was missing `memdisk/Makefile` and it tried to use git to determine a date.~~

Both patches are fetched and `HEXDATE` is set through `makeFlags`.

I also changed the url of the patch I introduced in #85094 to one that should be more stable.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @grahamc @samueldr 