### PR TITLE
zynaddsubfx: use zyn-fusion as default gui module

### DIFF
--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -1,30 +1,117 @@
-{ stdenv, fetchurl, alsaLib, cairo, cmake, libjack2, fftw, fltk13, lash,  libjpeg
-, libXpm, minixml, ntk, pkgconfig, zlib, liblo
+{ lib
+, stdenv
+, fetchFromGitHub
+, callPackage
+
+  # Required build tools
+, cmake
+, makeWrapper
+, pkg-config
+
+  # Required dependencies
+, fftw
+, liblo
+, minixml
+, zlib
+
+  # Optional dependencies
+, alsaSupport ? true
+, alsaLib
+, dssiSupport ? false
+, dssi
+, ladspaH
+, jackSupport ? true
+, libjack2
+, lashSupport ? false
+, lash
+, ossSupport ? true
+, portaudioSupport ? true
+, portaudio
+
+  # Optional GUI dependencies
+, guiModule ? "off"
+, cairo
+, fltk13
+, libGL
+, libjpeg
+, libX11
+, libXpm
+, ntk
+
+  # Test dependencies
+, cxxtest
 }:
 
-stdenv.mkDerivation  rec {
+assert builtins.any (g: guiModule == g) [ "fltk" "ntk" "zest" "off" ];
+
+let
+  guiName = {
+    "fltk" = "FLTK";
+    "ntk" = "NTK";
+    "zest" = "Zyn-Fusion";
+  }.${guiModule};
+  mruby-zest = callPackage ./mruby-zest { };
+in stdenv.mkDerivation rec {
   pname = "zynaddsubfx";
   version = "3.0.5";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/zynaddsubfx/zynaddsubfx-${version}.tar.bz2";
-    sha256 = "0qwzg14h043rmyf9jqdylxhyfy4sl0vsr0gjql51wjhid0i34ivl";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "1vh1gszgjxwn8m32rk5222z1j2cnjax0bqpag7b47v6i36p2q4x8";
+    fetchSubmodules = true;
   };
 
-  buildInputs = [ alsaLib cairo libjack2 fftw fltk13 lash libjpeg libXpm minixml ntk zlib liblo ];
-  nativeBuildInputs = [ cmake pkgconfig ];
-
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace src/Misc/Config.cpp --replace /usr $out
   '';
 
-  hardeningDisable = [ "format" ];
+  nativeBuildInputs = [ cmake makeWrapper pkg-config ];
 
-  meta = with stdenv.lib; {
-    description = "High quality software synthesizer";
-    homepage = "http://zynaddsubfx.sourceforge.net";
+  buildInputs = [ fftw liblo minixml zlib ]
+    ++ lib.optionals alsaSupport [ alsaLib ]
+    ++ lib.optionals dssiSupport [ dssi ladspaH ]
+    ++ lib.optionals jackSupport [ libjack2 ]
+    ++ lib.optionals lashSupport [ lash ]
+    ++ lib.optionals portaudioSupport [ portaudio ]
+    ++ lib.optionals (guiModule == "fltk") [ fltk13 libjpeg libXpm ]
+    ++ lib.optionals (guiModule == "ntk") [ ntk cairo libXpm ]
+    ++ lib.optionals (guiModule == "zest") [ libGL libX11 ];
+
+  cmakeFlags = [ "-DGuiModule=${guiModule}" ]
+    # OSS library is included in glibc.
+    # Must explicitly disable if support is not wanted.
+    ++ lib.optional (!ossSupport) "-DOssEnable=OFF"
+    # Find FLTK without requiring an OpenGL library in buildInputs
+    ++ lib.optional (guiModule == "fltk") "-DFLTK_SKIP_OPENGL=ON";
+
+  doCheck = true;
+  checkInputs = [ cxxtest ];
+
+  # When building with zest GUI, patch plugins
+  # and standalone executable to properly locate zest
+  postFixup = lib.optional (guiModule == "zest") ''
+    patchelf --set-rpath "${mruby-zest}:$(patchelf --print-rpath "$out/lib/lv2/ZynAddSubFX.lv2/ZynAddSubFX_ui.so")" \
+      "$out/lib/lv2/ZynAddSubFX.lv2/ZynAddSubFX_ui.so"
+
+    patchelf --set-rpath "${mruby-zest}:$(patchelf --print-rpath "$out/lib/vst/ZynAddSubFX.so")" \
+      "$out/lib/vst/ZynAddSubFX.so"
+
+    wrapProgram "$out/bin/zynaddsubfx" \
+      --prefix PATH : ${mruby-zest} \
+      --prefix LD_LIBRARY_PATH : ${mruby-zest}
+  '';
+
+  meta = with lib; {
+    description = "High quality software synthesizer (${guiName} GUI)";
+    homepage =
+      if guiModule == "zest"
+      then "https://zynaddsubfx.sourceforge.io/zyn-fusion.html"
+      else "https://zynaddsubfx.sourceforge.io";
+
     license = licenses.gpl2;
+    maintainers = with maintainers; [ goibhniu metadark ];
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu maintainers.nico202 ];
   };
 }

--- a/pkgs/applications/audio/zynaddsubfx/mruby-zest/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/mruby-zest/default.nix
@@ -1,0 +1,109 @@
+{ stdenv
+, fetchFromGitHub
+, bison
+, git
+, python2
+, rake
+, ruby
+, libGL
+, libuv
+, libX11
+}:
+
+let
+  mgem-list = fetchFromGitHub {
+    owner = "mruby";
+    repo = "mgem-list";
+    rev = "2033837203c8a141b1f9d23bb781fe0cbaefbd24";
+    sha256 = "0igf2nsx5i6g0yf7sjxxkngyriv213d0sjs3yidrflrabiywpxmm";
+  };
+
+  mruby-dir = fetchFromGitHub {
+    owner = "iij";
+    repo = "mruby-dir";
+    rev = "89dceefa1250fb1ae868d4cb52498e9e24293cd1";
+    sha256 = "0zrhiy9wmwmc9ls62iyb2z86j2ijqfn7rn4xfmrbrfxygczarsm9";
+  };
+
+  mruby-errno = fetchFromGitHub {
+    owner = "iij";
+    repo = "mruby-errno";
+    rev = "b4415207ff6ea62360619c89a1cff83259dc4db0";
+    sha256 = "12djcwjjw0fygai5kssxbfs3pzh3cpnq07h9m2h5b51jziw380xj";
+  };
+
+  mruby-file-stat = fetchFromGitHub {
+    owner = "ksss";
+    repo = "mruby-file-stat";
+    rev = "aa474589f065c71d9e39ab8ba976f3bea6f9aac2";
+    sha256 = "1clarmr67z133ivkbwla1a42wcjgj638j9w0mlv5n21mhim9rid5";
+  };
+
+  mruby-process = fetchFromGitHub {
+    owner = "iij";
+    repo = "mruby-process";
+    rev = "fe171fbe2a6cc3c2cf7d713641bddde71024f7c8";
+    sha256 = "00yrzc371f90gl5m1gbkw0qq8c394bpifssjr8p1wh5fmzhxqyml";
+  };
+
+  mruby-pack = fetchFromGitHub {
+    owner = "iij";
+    repo = "mruby-pack";
+    rev = "383a9c79e191d524a9a2b4107cc5043ecbf6190b";
+    sha256 = "003glxgxifk4ixl12sy4gn9bhwvgb79b4wga549ic79isgv81w2d";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "mruby-zest";
+  version = "3.0.5";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = "${pname}-build";
+    rev = version;
+    sha256 = "0fxljrgamgz2rm85mclixs00b0f2yf109jc369039n1vf0l5m57d";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ bison git python2 rake ruby ];
+  buildInputs = [ libGL libuv libX11 ];
+
+  patches = [
+    ./force-gcc-as-linker.patch
+    ./system-libuv.patch
+  ];
+
+  # Add missing dependencies of deps/mruby-dir-glob/mrbgem.rake
+  # Should be fixed in next release, see bcadb0a5490bd6d599f1a0e66ce09b46363c9dae
+  postPatch = ''
+    mkdir -p mruby/build/mrbgems
+    ln -s ${mgem-list} mruby/build/mrbgems/mgem-list
+    ln -s ${mruby-dir} mruby/build/mrbgems/mruby-dir
+    ln -s ${mruby-errno} mruby/build/mrbgems/mruby-errno
+    ln -s ${mruby-file-stat} mruby/build/mrbgems/mruby-file-stat
+    ln -s ${mruby-process} mruby/build/mrbgems/mruby-process
+    ln -s ${mruby-pack} mruby/build/mrbgems/mruby-pack
+  '';
+
+  installTargets = [ "pack" ];
+
+  postInstall = ''
+    ln -s "$out/zest" "$out/zyn-fusion"
+    cp -a package/{font,libzest.so,schema,zest} "$out"
+
+    # mruby-widget-lib/src/api.c requires MainWindow.qml as part of a
+    # sanity check, even though qml files are compiled into the binary
+    # https://github.com/mruby-zest/mruby-zest-build/tree/3.0.5/src/mruby-widget-lib/src/api.c#L99-L116
+    # https://github.com/mruby-zest/mruby-zest-build/tree/3.0.5/linux-pack.sh#L17-L18
+    mkdir -p "$out/qml"
+    touch "$out/qml/MainWindow.qml"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The Zest Framework used in ZynAddSubFX's UI";
+    homepage = "https://github.com/mruby-zest";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ metadark ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/audio/zynaddsubfx/mruby-zest/force-gcc-as-linker.patch
+++ b/pkgs/applications/audio/zynaddsubfx/mruby-zest/force-gcc-as-linker.patch
@@ -1,0 +1,13 @@
+diff --git a/mruby/tasks/toolchains/gcc.rake b/mruby/tasks/toolchains/gcc.rake
+index f370c0ab..e5ab9f60 100644
+--- a/mruby/tasks/toolchains/gcc.rake
++++ b/mruby/tasks/toolchains/gcc.rake
+@@ -22,7 +22,7 @@ MRuby::Toolchain.new(:gcc) do |conf, _params|
+   end
+ 
+   conf.linker do |linker|
+-    linker.command = ENV['LD'] || 'gcc'
++    linker.command = 'gcc'
+     linker.flags = [ENV['LDFLAGS'] || %w()]
+     linker.libraries = %w(m)
+     linker.library_paths = []

--- a/pkgs/applications/audio/zynaddsubfx/mruby-zest/system-libuv.patch
+++ b/pkgs/applications/audio/zynaddsubfx/mruby-zest/system-libuv.patch
@@ -1,0 +1,113 @@
+diff --git a/Makefile b/Makefile
+index f3e3be2..2398852 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,8 +1,3 @@
+-UV_DIR    = libuv-v1.9.1
+-UV_FILE   = $(UV_DIR).tar.gz
+-UV_URL    = http://dist.libuv.org/dist/v1.9.1/$(UV_FILE)
+-	 
+-
+ all:
+ 	ruby ./rebuild-fcache.rb
+ 	cd deps/nanovg/src   && $(CC) nanovg.c -c -fPIC
+@@ -10,12 +5,12 @@ all:
+ #	cd deps/pugl         && python2 ./waf configure --no-cairo --static
+ 	cd deps/pugl         && python2 ./waf configure --no-cairo --static --debug
+ 	cd deps/pugl         && python2 ./waf
+-	cd src/osc-bridge    && CFLAGS="-I ../../deps/$(UV_DIR)/include " make lib
++	cd src/osc-bridge    && make lib
+ 	cd mruby             && MRUBY_CONFIG=../build_config.rb rake
+ 	$(CC) -shared -o libzest.so `find mruby/build/host -type f | grep -e "\.o$$" | grep -v bin` ./deps/libnanovg.a \
+ 		./deps/libnanovg.a \
+ 		src/osc-bridge/libosc-bridge.a \
+-		./deps/$(UV_DIR)/.libs/libuv.a  -lm -lX11 -lGL -lpthread
++		-luv -lm -lX11 -lGL -lpthread
+ 	$(CC) test-libversion.c deps/pugl/build/libpugl-0.a -ldl -o zest -lX11 -lGL -lpthread -I deps/pugl -std=gnu99
+ 
+ osx:
+@@ -25,12 +20,12 @@ osx:
+ 	cd deps/pugl         && python2 ./waf configure --no-cairo --static
+ #	cd deps/pugl         && python2 ./waf configure --no-cairo --static --debug
+ 	cd deps/pugl         && python2 ./waf
+-	cd src/osc-bridge    && CFLAGS="-I ../../deps/$(UV_DIR)/include " make lib
++	cd src/osc-bridge    && make lib
+ 	cd mruby             && MRUBY_CONFIG=../build_config.rb rake
+ 	$(CC) -shared -o libzest.so `find mruby/build/host -type f | grep -e "\.o$$" | grep -v bin` ./deps/libnanovg.a \
+ 		./deps/libnanovg.a \
+ 		src/osc-bridge/libosc-bridge.a \
+-		./deps/$(UV_DIR)/.libs/libuv.a  -lm -framework OpenGL -lpthread
++		-luv -lm -framework OpenGL -lpthread
+ 	$(CC) test-libversion.c deps/pugl/build/libpugl-0.a -ldl -o zest -framework OpenGL -framework AppKit -lpthread -I deps/pugl -std=gnu99
+ 
+ windows:
+@@ -38,38 +33,14 @@ windows:
+ 	$(AR) rc deps/libnanovg.a deps/nanovg/src/*.o
+ 	cd deps/pugl         && CFLAGS="-mstackrealign" python2 ./waf configure --no-cairo --static --target=win32
+ 	cd deps/pugl         && python2 ./waf
+-	cd src/osc-bridge    && CFLAGS="-mstackrealign -I ../../deps/$(UV_DIR)/include " make lib
++	cd src/osc-bridge    && CFLAGS="-mstackrealign" make lib
+ 	cd mruby             && WINDOWS=1 MRUBY_CONFIG=../build_config.rb rake
+ 	$(CC) -mstackrealign -shared -o libzest.dll -static-libgcc `find mruby/build/w64 -type f | grep -e "\.o$$" | grep -v bin` \
+         ./deps/libnanovg.a \
+         src/osc-bridge/libosc-bridge.a \
+-        ./deps/libuv-win.a \
+-        -lm -lpthread -lws2_32 -lkernel32 -lpsapi -luserenv -liphlpapi -lglu32 -lgdi32 -lopengl32
++        -luv -lm -lpthread -lws2_32 -lkernel32 -lpsapi -luserenv -liphlpapi -lglu32 -lgdi32 -lopengl32
+ 	$(CC) -mstackrealign -DWIN32 test-libversion.c deps/pugl/build/libpugl-0.a -o zest.exe -lpthread -I deps/pugl -std=c99 -lws2_32 -lkernel32 -lpsapi -luserenv -liphlpapi -lglu32 -lgdi32 -lopengl32
+ 
+-
+-builddep: deps/libuv.a
+-deps/libuv.a:
+-	cd deps/$(UV_DIR)    && ./autogen.sh
+-	cd deps/$(UV_DIR)    && CFLAGS=-fPIC ./configure
+-	cd deps/$(UV_DIR)    && CFLAGS=-fPIC make
+-	cp deps/$(UV_DIR)/.libs/libuv.a deps/
+-
+-builddepwin: deps/libuv-win.a
+-deps/libuv-win.a:
+-	cd deps/$(UV_DIR)   && ./autogen.sh
+-	cd deps/$(UV_DIR)   && CFLAGS="-mstackrealign" ./configure  --host=x86_64-w64-mingw32
+-	cd deps/$(UV_DIR)   && LD=x86_64-w64-mingw32-gcc make
+-	cp deps/$(UV_DIR)/.libs/libuv.a deps/libuv-win.a
+-
+-deps/$(UV_DIR):
+-	cd deps              && wget -4 $(UV_URL) && tar xvf $(UV_FILE)
+-setup: deps/$(UV_DIR)
+-
+-setupwin:
+-	cd deps              && wget -4 $(UV_URL)
+-	cd deps              && tar xvf $(UV_FILE)
+-
+ push:
+ 	cd src/osc-bridge      && git push
+ 	cd src/mruby-qml-parse  && git push
+diff --git a/build_config.rb b/build_config.rb
+index 00f1f69..11ac15b 100644
+--- a/build_config.rb
++++ b/build_config.rb
+@@ -96,7 +96,6 @@ build_type.new(build_name) do |conf|
+   conf.cc do |cc|
+       cc.include_paths << "#{`pwd`.strip}/../deps/nanovg/src"
+       cc.include_paths << "#{`pwd`.strip}/../deps/pugl/"
+-      cc.include_paths << "#{`pwd`.strip}/../deps/libuv-v1.9.1/include/"
+       cc.include_paths << "/usr/share/mingw-w64/include/" if windows
+       cc.include_paths << "/usr/x86_64-w64-mingw32/include/" if windows
+       cc.flags << "-DLDBL_EPSILON=1e-6" if windows
+@@ -117,14 +116,14 @@ build_type.new(build_name) do |conf|
+       linker.flags_after_libraries  << "#{`pwd`.strip}/../deps/pugl/build/libpugl-0.a"
+       linker.flags_after_libraries  << "#{`pwd`.strip}/../deps/libnanovg.a"
+       if(!windows)
+-        linker.flags_after_libraries  << "#{`pwd`.strip}/../deps/libuv.a"
++        linker.flags_after_libraries  << "-luv"
+         if(ENV['OS'] != "Mac")
+           linker.libraries << 'GL'
+           linker.libraries << 'X11'
+         end
+         linker.flags_after_libraries  << "-lpthread -ldl -lm"
+       else
+-        linker.flags_after_libraries  << "#{`pwd`.strip}/../deps/libuv-win.a"
++        linker.flags_after_libraries  << "-luv"
+         linker.flags_after_libraries  << "-lws2_32 -lkernel32 -lpsapi -luserenv -liphlpapi"
+         linker.flags_after_libraries  << "-lglu32 -lgdi32 -lopengl32"
+       end

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24920,7 +24920,19 @@ in
 
   zscroll = callPackage ../applications/misc/zscroll {};
 
-  zynaddsubfx = callPackage ../applications/audio/zynaddsubfx { };
+  zynaddsubfx = zyn-fusion;
+
+  zynaddsubfx-fltk = callPackage ../applications/audio/zynaddsubfx {
+    guiModule = "fltk";
+  };
+
+  zynaddsubfx-ntk = callPackage ../applications/audio/zynaddsubfx {
+    guiModule = "ntk";
+  };
+
+  zyn-fusion = callPackage ../applications/audio/zynaddsubfx {
+    guiModule = "zest";
+  };
 
   ### BLOCKCHAINS / CRYPTOCURRENCIES / WALLETS
 


### PR DESCRIPTION
- Added `guiModule` option that accepts "fltk", "ntk", "zest", or "off"

- Split FLTK dependencies from NTK dependencies

- Added support for building the FLTK gui

- Added support for building the Zyn-Fusion (zest) gui

- Added new derivation for the Zest UI framework (local to zynaddsubfx)
  It's not yet designed to be used outside of zynaddsubfx, but it
  may be in the future

- Added flags for all optional features

- Added & disabled `dssiSupport` by default

- Disabled `lashSupport` by default
  Slows down startup looking for LASH server if not running

- Added & enabled `portaudioSupport` by default
  Cross platform audio library that uses ALSA/JACK on Linux.
  Supports multiple audio streams without needing JACK.

- Enabled tests

- Removes nico202 as maintainer, as requested in code review

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #90698

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  222.5M -> 223.1M
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
