### PR TITLE
cxxtest: package includes and run tests

### DIFF
--- a/pkgs/development/libraries/cxxtest/default.nix
+++ b/pkgs/development/libraries/cxxtest/default.nix
@@ -1,10 +1,8 @@
-{ stdenv, fetchFromGitHub, python2Packages}:
+{ stdenv, buildPythonApplication, fetchFromGitHub }:
 
-let
+buildPythonApplication rec {
   pname = "cxxtest";
   version = "4.4";
-in python2Packages.buildPythonApplication {
-  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "CxxTest";
@@ -13,16 +11,26 @@ in python2Packages.buildPythonApplication {
     sha256 = "19w92kipfhp5wvs47l0qpibn3x49sbmvkk91yxw6nwk6fafcdl17";
   };
 
-  setSourceRoot = ''
-    sourceRoot=$(echo */python)
+  sourceRoot = "source/python";
+
+  postCheck = ''
+    python scripts/cxxtestgen --error-printer -o build/GoodSuite.cpp ../test/GoodSuite.h
+    $CXX -I.. -o build/GoodSuite build/GoodSuite.cpp
+    build/GoodSuite
   '';
+
+  postInstall = ''
+    mkdir -p "$out/include"
+    cp -r ../cxxtest "$out/include"
+  '';
+
+  dontWrapPythonPrograms = true;
 
   meta = with stdenv.lib; {
     homepage = "http://cxxtest.com";
     description = "Unit testing framework for C++";
-    platforms = platforms.unix ;
+    platforms = platforms.unix;
     license = licenses.lgpl3;
     maintainers = [ maintainers.juliendehos ];
   };
 }
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11736,7 +11736,7 @@ in
 
   cxx-prettyprint = callPackage ../development/libraries/cxx-prettyprint { };
 
-  cxxtest = callPackage ../development/libraries/cxxtest { };
+  cxxtest = python2Packages.callPackage ../development/libraries/cxxtest { };
 
   cypress = callPackage ../development/web/cypress { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes running tests in zynaddsubfx, see #91674

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
