### PR TITLE
powerdevil: fix build with new ddcutil [blocks nixos-unstable]

### DIFF
--- a/pkgs/desktops/plasma-5/powerdevil.nix
+++ b/pkgs/desktops/plasma-5/powerdevil.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation,
+  mkDerivation, fetchpatch,
   extra-cmake-modules, kdoctools,
   bluez-qt, kactivities, kauth, kconfig, kdbusaddons, kdelibs4support,
   kglobalaccel, ki18n, kidletime, kio, knotifyconfig, kwayland, libkscreen,
@@ -17,5 +17,15 @@ mkDerivation {
   ];
   cmakeFlags = [
     "-DHAVE_DDCUTIL=On"
+  ];
+  patches = [
+    # This fixes an issue where 'DDCA_Feature_List*' cannot be converted to
+    # 'DDCA_Feature_List'.
+    # This can be dropped with the next release.
+    # https://bugs.kde.org/show_bug.cgi?id=423605
+    (fetchpatch {
+      url = "https://invent.kde.org/plasma/powerdevil/-/commit/fcb26be2fb279e6ad3b7b814d26a5921d16201eb.patch";
+      sha256 = "0gdyaa0nd1c1d6x2h0m933lascm8zm5sikd99wxmkf7hhaby6k2s";
+    })
   ];
 }


### PR DESCRIPTION
https://hydra.nixos.org/build/123207159

The KDE ISO depends on this package, which blocks nixos-unstable.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
