### PR TITLE
polar: init at unstable-2021-01-12

### DIFF
--- a/pkgs/tools/misc/polar/Gemfile
+++ b/pkgs/tools/misc/polar/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'google-protobuf'
+gem 'libusb'
+gem 'rubyserial'
+gem 'nokogiri'
+

--- a/pkgs/tools/misc/polar/Gemfile.lock
+++ b/pkgs/tools/misc/polar/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ffi (1.15.0)
+    google-protobuf (3.15.6)
+    libusb (0.6.4)
+      ffi (~> 1.0)
+      mini_portile2 (~> 2.1)
+    mini_portile2 (2.5.0)
+    nokogiri (1.11.2)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    racc (1.5.2)
+    rubyserial (0.6.0)
+      ffi (~> 1.9, >= 1.9.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-protobuf
+  libusb
+  nokogiri
+  rubyserial
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/tools/misc/polar/default.nix
+++ b/pkgs/tools/misc/polar/default.nix
@@ -1,0 +1,73 @@
+{ lib, stdenv, fetchFromGitHub, ruby, bundlerEnv }:
+let
+
+  # To create Gemfile.lock and gemset.nix
+  # > nix-shell -p bundix bundler zlib
+  # > bundle install
+  # > bundix
+  gems = bundlerEnv {
+    name = "polar-env";
+    inherit ruby;
+    gemdir = ./.;
+  };
+
+in
+stdenv.mkDerivation rec {
+
+  pname = "polar";
+  # The package has no releases so let's use the latest commit
+  version = "unstable-2021-01-12";
+
+  src = fetchFromGitHub {
+    owner = "cmaion";
+    repo = pname;
+    rev = "be15f5f897f8a919dd639009873147dca2a9cea0";
+    sha256 = "0gqkqfrqnrsy6avg372xwqj22yz8g6r2hnzbw6197b1rf7zr1il7";
+  };
+
+  prePatch = ''
+    for script in polar_*
+    do
+      substituteInPlace $script --replace "#{File.dirname(__FILE__)}/lib" "$out/lib/polar"
+    done
+  '';
+  buildInputs = [ gems ruby ];
+
+  # See: https://nixos.wiki/wiki/Packaging/Ruby
+  #
+  # Put library content under lib/polar and the raw scripts under share/polar.
+  # Then, wrap the scripts so that they use the correct ruby environment and put
+  # these wrapped executables under bin.
+  installPhase = ''
+    install -Dm644 -t $out/etc/udev/rules.d ./pkg/99-polar.rules
+    mkdir -p $out/{bin,lib/polar,share/polar}
+    cp -r lib/* $out/lib/polar/
+    for script in ./polar_*
+    do
+      raw="$out/share/polar/$script"
+      bin="$out/bin/$script"
+      cp "$script" "$raw"
+      cat > $bin <<EOF
+#!/bin/sh -e
+exec ${gems}/bin/bundle exec ${ruby}/bin/ruby "$raw" "\$@"
+EOF
+      chmod +x $bin
+    done
+  '';
+
+  meta = with lib; {
+    description = "Command-line tools to interact with Polar watches";
+    longDescription = ''
+      A set of command line tools written in Ruby to interact with Polar watches
+      and decode raw data files.
+
+      Udev rules can be added as:
+
+        services.udev.packages = [ pkgs.polar ]
+    '';
+    homepage = "https://github.com/cmaion/polar";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ jluttine ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/polar/gemset.nix
+++ b/pkgs/tools/misc/polar/gemset.nix
@@ -1,0 +1,75 @@
+{
+  ffi = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nq1fb3vbfylccwba64zblxy96qznxbys5900wd7gm9bpplmf432";
+      type = "gem";
+    };
+    version = "1.15.0";
+  };
+  google-protobuf = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1ak5yqqhr04b4x0axzvpw1xzwmxmfcw0gf4r1ijixv15kidhsj3z";
+      type = "gem";
+    };
+    version = "3.15.6";
+  };
+  libusb = {
+    dependencies = ["ffi" "mini_portile2"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "005q4f3bi68yapza1vxamgwz2gpix2akci52s4yvr03hsxi137a6";
+      type = "gem";
+    };
+    version = "0.6.4";
+  };
+  mini_portile2 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hdbpmamx8js53yk3h8cqy12kgv6ca06k0c9n3pxh6b6cjfs19x7";
+      type = "gem";
+    };
+    version = "2.5.0";
+  };
+  nokogiri = {
+    dependencies = ["mini_portile2" "racc"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0b51df8fwadak075cvi17w0nch6qz1r66564qp29qwfj67j9qp0p";
+      type = "gem";
+    };
+    version = "1.11.2";
+  };
+  racc = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "178k7r0xn689spviqzhvazzvxfq6fyjldxb3ywjbgipbfi4s8j1g";
+      type = "gem";
+    };
+    version = "1.5.2";
+  };
+  rubyserial = {
+    dependencies = ["ffi"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vj5yan6srbvkf5vfp9d9b9z8wyygd0zxcy54c35yhkjl6kwd22q";
+      type = "gem";
+    };
+    version = "0.6.0";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12852,6 +12852,8 @@ in
     };
   }));
 
+  polar = callPackage ../tools/misc/polar { };
+
   inherit (nodePackages) postcss-cli;
 
   postiats-utilities = callPackage ../development/tools/postiats-utilities {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add `polar` package for reading Polar watch data. Also, add NixOS program module for defining the required udev rules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
