### PR TITLE
platformio-udev-rules: init at 4.3.4

### DIFF
--- a/pkgs/os-specific/linux/platformio-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/platformio-udev-rules/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub }:
+
+let
+  pname = "platformio-udev-rules";
+  version = "4.3.4";
+in stdenv.mkDerivation {
+  inherit version pname;
+
+  src = fetchFromGitHub {
+    owner = "platformio";
+    repo = "platformio-core";
+    rev = "v${version}";
+    sha256 = "0vf2j79319ypr4yrdmx84853igkb188sjfvlxgw06rlsvsm3kacq";
+  };
+
+  installPhase = ''
+    mkdir -p $out/lib/udev/rules.d
+    install -D scripts/99-platformio-udev.rules $out/lib/udev/rules.d/99-platformio.rules
+  '';
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/platformio/platformio-core";
+    description = "Udev rules for PlatformIO";
+    platforms = platforms.linux;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ f4814n ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6019,6 +6019,8 @@ in
   platformioPackages = dontRecurseIntoAttrs (callPackage ../development/arduino/platformio { });
   platformio = platformioPackages.platformio-chrootenv;
 
+  platformio-udev-rules = callPackage ../os-specific/linux/platformio-udev-rules { };
+
   platinum-searcher = callPackage ../tools/text/platinum-searcher { };
 
   playbar2 = libsForQt5.callPackage ../applications/audio/playbar2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The platformio UDEV rules are not shipped with the platformio package.

Tagging @mogorman @makefu (the maintainers of the platformio package)

###### Things done

Add a platformio-udev-rules package containing the udev rules provided by the project. I am not sure if creating
a new package is the correct thing to do. If patching the platformio package to contain the udev rules is the better way, then tell me, please.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
