### PR TITLE
undervolt: allow strings in options again

### DIFF
--- a/nixos/modules/services/hardware/undervolt.nix
+++ b/nixos/modules/services/hardware/undervolt.nix
@@ -46,7 +46,7 @@ in
     };
 
     coreOffset = mkOption {
-      type = types.nullOr types.int;
+      type = with types; nullOr (oneOf [ int str ]);
       default = null;
       description = ''
         The amount of voltage in mV to offset the CPU cores by.
@@ -54,7 +54,7 @@ in
     };
 
     gpuOffset = mkOption {
-      type = types.nullOr types.int;
+      type = with types; nullOr (oneOf [ int str ]);
       default = null;
       description = ''
         The amount of voltage in mV to offset the GPU by.
@@ -62,7 +62,7 @@ in
     };
 
     uncoreOffset = mkOption {
-      type = types.nullOr types.int;
+      type = with types; nullOr (oneOf [ int str ]);
       default = null;
       description = ''
         The amount of voltage in mV to offset uncore by.
@@ -70,7 +70,7 @@ in
     };
 
     analogioOffset = mkOption {
-      type = types.nullOr types.int;
+      type = with types; nullOr (oneOf [ int str ]);
       default = null;
       description = ''
         The amount of voltage in mV to offset analogio by.
@@ -78,7 +78,7 @@ in
     };
 
     temp = mkOption {
-      type = types.nullOr types.int;
+      type = with types; nullOr (oneOf [ int str ]);
       default = null;
       description = ''
         The temperature target in Celsius degrees.
@@ -86,7 +86,7 @@ in
     };
 
     tempAc = mkOption {
-      type = types.nullOr types.int;
+      type = with types; nullOr (oneOf [ int str ]);
       default = null;
       description = ''
         The temperature target on AC power in Celsius degrees.
@@ -94,7 +94,7 @@ in
     };
 
     tempBat = mkOption {
-      type = types.nullOr types.int;
+      type = with types; nullOr (oneOf [ int str ]);
       default = null;
       description = ''
         The temperature target on battery power in Celsius degrees.


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/90144 changed the undervolt config
options' types to ints which broke backwards compatibility with older configs
where strings were required

This lets you use ints or strings, whichever you prefer

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
