### PR TITLE
[WIP] lossless-cut: Init at version 3.23.7

### DIFF
--- a/pkgs/applications/video/lossless-cut/default.nix
+++ b/pkgs/applications/video/lossless-cut/default.nix
@@ -1,15 +1,41 @@
-{ stdenv, fetchFromGitHub, mkYarnPackage }:
-
-mkYarnPackage rec {
+{ stdenv
+, fetchFromGitHub
+, mkYarnPackage
+, makeWrapper
+, electron
+}:
+let
   name = "lossless-cut";
   version = "3.23.7";
-
+in
+mkYarnPackage {
+  inherit version;
   src = fetchFromGitHub {
     owner = "mifi";
     repo = name;
     rev = "v${version}";
     sha256 = "14vfmidj0m11vd1asghmcxwj102c468n6wb4swagnjzrxqh22xa3";
   };
+
+  nativeBuildInputs = [ makeWrapper ];
+  runtimeDependencies = [ electron ];
+
+  installPhase = ''
+    # resources
+    electronFileDir=$out/libexec/lossless-cut
+    mkdir -p $electronFileDir
+    mv ./deps/lossless-cut $electronFileDir
+    mv ./node_modules $electronFileDir
+
+    # executable
+    mkdir -p $out/bin
+    makeWrapper "${electron}/bin/electron" "$out/bin/lossless-cut" --add-flags "$electronFileDir"
+  '';
+
+  # Doesn't need to generate the tarball
+  distPhase = ''
+    true
+  '';
 
   meta = with stdenv.lib; {
     description = "The swiss army knife of lossless video/audio editing";

--- a/pkgs/applications/video/lossless-cut/default.nix
+++ b/pkgs/applications/video/lossless-cut/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub, mkYarnPackage }:
+
+mkYarnPackage rec {
+  name = "lossless-cut";
+  version = "3.23.7";
+
+  src = fetchFromGitHub {
+    owner = "mifi";
+    repo = name;
+    rev = "v${version}";
+    sha256 = "14vfmidj0m11vd1asghmcxwj102c468n6wb4swagnjzrxqh22xa3";
+  };
+
+  meta = with stdenv.lib; {
+    description = "The swiss army knife of lossless video/audio editing";
+    license = licenses.mit;
+    homepage = "https://mifi.no/losslesscut";
+    maintainers = with maintainers; [ ShamrockLee ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21107,6 +21107,8 @@ in
 
   looking-glass-client = callPackage ../applications/virtualization/looking-glass-client { };
 
+  lossless-cut = callPackage ../applications/video/lossless-cut { };
+
   ltc-tools = callPackage ../applications/audio/ltc-tools { };
 
   lumail = callPackage ../applications/networking/mailreaders/lumail {


### PR DESCRIPTION
This is a draft to package [lossless-cut](https://github.com/mifi/lossless-cut) .
As a beginner, I may need help from others often.
Any advise, contributions or corrections are more than welcome. If you would like to be added as a maintainer, please go ahead or inform me.
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
LosslessCut is an intuitive GUI application that cuts videos/audios losslessly.
If applied, we will be able to natively install this app.

###### Things done
Create a simple `default.nix` that makes use of `mkYarnPackage`.
Create `yarn.nix` using `yarn2nix`.
Add entry lossless-cut to `all-packages.nix`.

Takes 50 minutes to build on my slow usb-stick-based NixOS system,
and most of the time is spent on the node dependencies.
Closure size: 1,614,691,296 bytes, where
$out/libexec/lossless-cut/node_modules occupies 686,152,094 bytes.

Problem: $out/bin is empty.
TODO: Add something to the `installPhase`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
