### PR TITLE
cloudcompare: Improve Qt wrapping

### DIFF
--- a/pkgs/applications/graphics/cloudcompare/default.nix
+++ b/pkgs/applications/graphics/cloudcompare/default.nix
@@ -1,7 +1,7 @@
-{ stdenv
+{ lib
+, mkDerivation
 , fetchFromGitHub
 , cmake
-, wrapQtAppsHook
 , dxflib
 , eigen
 , flann
@@ -16,7 +16,7 @@
 , xercesc
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "cloudcompare";
   version = "2.11.0";
 
@@ -36,7 +36,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     eigen # header-only
-    wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -73,7 +72,7 @@ stdenv.mkDerivation rec {
     "-DPLUGIN_IO_QRDB=OFF" # Riegl rdblib is proprietary; not packaged in nixpkgs
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "3D point cloud and mesh processing software";
     homepage = "https://cloudcompare.org";
     license = licenses.gpl2Plus;


### PR DESCRIPTION
###### Motivation for this change

As I learned in the review of #91627.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
