### PR TITLE
libsrt: init at 1.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4713,6 +4713,12 @@
     githubId = 34683288;
     name = "Luke Bentley-Fox";
   };
+  "lukegb" = {
+    email = "nit@lukegb.com";
+    github = "lukegb";
+    githubId = 246745;
+    name = "Luke Granger-Brown";
+  };
   lukego = {
     email = "luke@snabb.co";
     github = "lukego";

--- a/pkgs/development/libraries/libsrt/default.nix
+++ b/pkgs/development/libraries/libsrt/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, cmake, openssl, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "libsrt";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "Haivision";
+    repo = "srt";
+    rev = "v${version}";
+    sha256 = "01xaq44j95kbgqfl41pnybvqy0yq6wd4wdw88ckylzf0nzp977xz";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ openssl ];
+  outputs = [ "out" "dev" ];
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Haivision/srt";
+    description = "Video transport technology that optimizes streaming performance across unpredictable networks, such as the Internet.";
+    platforms = platforms.unix;
+    license = licenses.mpl20;
+    maintainers = [ maintainers.lukegb ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13504,6 +13504,8 @@ in
 
   libspiro = callPackage ../development/libraries/libspiro {};
 
+  libsrt = callPackage ../development/libraries/libsrt { };
+
   libssh = callPackage ../development/libraries/libssh { };
 
   libssh2 = callPackage ../development/libraries/libssh2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I'd like to compile ffmpeg with Secure Reliable Transport (SRT) support (https://github.com/Haivision/srt, https://www.srtalliance.org/).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
