### PR TITLE
batsignal: Init at 1.0.0

### DIFF
--- a/pkgs/applications/misc/batsignal/default.nix
+++ b/pkgs/applications/misc/batsignal/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, libnotify, pkg-config, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "batsignal";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "electrickite";
+    repo = "batsignal";
+    rev = "${version}";
+    sha256 = "wy7YhgKfz07u0bp7rWpze+KmSdooOkmU7giaBX3wWkY=";
+  };
+
+  buildInputs = [ libnotify glib ];
+  nativeBuildInputs = [ pkg-config ];
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/electrickite/batsignal";
+    description = "Lightweight battery daemon written in C";
+    license = licenses.isc;
+    maintainers = with maintainers; [ SlothOfAnarchy ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18944,6 +18944,8 @@ in
 
   batik = callPackage ../applications/graphics/batik { };
 
+  batsignal = callPackage ../applications/misc/batsignal { };
+
   baudline = callPackage ../applications/audio/baudline { };
 
   bb =  callPackage ../applications/misc/bb { };


### PR DESCRIPTION
###### Motivation for this change

Init batsignal

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
