### PR TITLE
file-rename: Fix an incorrect test that misidentifies Darwin as Windows

### DIFF
--- a/pkgs/tools/filesystems/file-rename/default.nix
+++ b/pkgs/tools/filesystems/file-rename/default.nix
@@ -11,6 +11,12 @@ perlPackages.buildPerlPackage {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  # Fix an incorrect platform test that misidentifies Darwin as Windows
+  postPatch = ''
+    substituteInPlace Makefile.PL \
+      --replace '/win/i' '/MSWin32/'
+  '';
+
   postInstall = ''
     wrapProgram $out/bin/rename \
       --prefix PERL5LIB : $out/${perlPackages.perl.libPrefix}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`file-rename` fails to build on Darwin due to an incorrect platform-detection test that misidentifies Darwin as Windows.

This causes the script to be installed as `file-rename` instead of `rename` like it is on other Unix systems. This in turn causes `wrapProgram` to fail when building because it expects the wrapped program to be called `rename`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/91699)
<!-- Reviewable:end -->
