### PR TITLE
eclipse-mat: init at 1.10.0.20200225

### DIFF
--- a/pkgs/development/tools/eclipse-mat/default.nix
+++ b/pkgs/development/tools/eclipse-mat/default.nix
@@ -1,0 +1,86 @@
+{ buildEnv, fetchurl, fontconfig, freetype, glib, gsettings-desktop-schemas, gtk3, jdk11, lib, libX11, libXrender, libXtst, makeDesktopItem, makeWrapper, shared-mime-info, stdenv, unzip, webkitgtk, zlib, }:
+
+with lib;
+
+let
+  pVersion = "1.10.0.20200225";
+  pVersionTriple = splitVersion pVersion;
+  majorVersion = elemAt pVersionTriple 0;
+  minorVersion = elemAt pVersionTriple 1;
+  patchVersion = elemAt pVersionTriple 2;
+  baseVersion = "${majorVersion}.${minorVersion}.${patchVersion}";
+  jdk = jdk11;
+in
+
+stdenv.mkDerivation rec {
+  pname = "eclipse-mat";
+  version = "${pVersion}";
+
+  src = fetchurl {
+    url = "http://ftp.halifax.rwth-aachen.de/eclipse//mat/${baseVersion}/rcp/MemoryAnalyzer-${version}-linux.gtk.x86_64.zip";
+    sha256 = "11cg01gjjvlm6lr6z6rwqs1r31xx5pxddnz55ca0s33lrnywf9fx";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "eclipse-mat";
+    exec = "eclipse-mat";
+    icon = "eclipse";
+    comment = "Eclipse Memory Analyzer";
+    desktopName = "Eclipse MAT";
+    genericName = "Java Memory Analyzer";
+    categories = "Development;";
+  };
+
+  unpackPhase = ''
+    unzip $src
+  '';
+
+  buildCommand = ''
+    mkdir -p $out
+    unzip $src
+    mv mat $out
+
+    # Patch binaries.
+    interpreter=$(echo ${stdenv.glibc.out}/lib/ld-linux*.so.2)
+    libCairo=$out/eclipse/libcairo-swt.so
+    patchelf --set-interpreter $interpreter $out/mat/MemoryAnalyzer
+    [ -f $libCairo ] && patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ freetype fontconfig libX11 libXrender zlib ]} $libCairo
+
+    # Create wrapper script.  Pass -configuration to store settings in ~/.eclipse-mat/<version>
+    makeWrapper $out/mat/MemoryAnalyzer $out/bin/eclipse-mat \
+      --prefix PATH : ${jdk}/bin \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath ([ glib gtk3 libXtst webkitgtk ])} \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
+      --add-flags "-configuration \$HOME/.eclipse-mat/''${version}/configuration"
+
+    # Create desktop item.
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/* $out/share/applications
+    mkdir -p $out/share/pixmaps
+    find $out/mat/plugins -name 'eclipse*.png' -type f -exec cp {} $out/share/pixmaps \;
+    mv $out/share/pixmaps/eclipse64.png $out/share/pixmaps/eclipse.png
+  '';
+  
+  buildInputs = [
+    fontconfig freetype glib gsettings-desktop-schemas gtk3 jdk libX11
+    libXrender libXtst makeWrapper zlib unzip shared-mime-info webkitgtk
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  meta = with stdenv.lib; {
+    description = "Fast and feature-rich Java heap analyzer";
+    longDescription = ''
+        The Eclipse Memory Analyzer is a tool that helps you find memory leaks and reduce memory consumption.
+        Use the Memory Analyzer to analyze productive heap dumps with hundreds of millions of objects, quickly
+        calculate the retained sizes of objects, see who is preventing the Garbage Collector from collecting objects,
+        run a report to automatically extract leak suspects.
+    '';
+    homepage = "https://www.eclipse.org/mat";
+    license = licenses.epl20;
+    maintainers = [ maintainers.ktor ];
+    platforms = [ "x86_64-linux" ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -183,6 +183,8 @@ in
 
   deadcode = callPackage ../development/tools/deadcode { };
 
+  eclipse-mat = callPackage ../development/tools/eclipse-mat { };
+
   glade = callPackage ../development/tools/glade { };
 
   hobbes = callPackage ../development/tools/hobbes { };


### PR DESCRIPTION
Closes #43611

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
To add best, free, java memory analyzer to NixOS package collection.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
