### PR TITLE
pythonPackages.webargs: init at 6.1.0

### DIFF
--- a/pkgs/development/python-modules/marshmallow/default.nix
+++ b/pkgs/development/python-modules/marshmallow/default.nix
@@ -36,5 +36,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/marshmallow-code/marshmallow";
     license = licenses.mit;
+    maintainers = with maintainers; [ cript0nauta ];
   };
+
 }

--- a/pkgs/development/python-modules/webargs/default.nix
+++ b/pkgs/development/python-modules/webargs/default.nix
@@ -1,0 +1,41 @@
+{ buildPythonPackage, fetchPypi, lib, isPy27, marshmallow, pytestCheckHook
+, pytest-aiohttp, webtest, webtest-aiohttp, flask, django, bottle, tornado
+, pyramid, falcon, aiohttp }:
+
+buildPythonPackage rec {
+  pname = "webargs";
+  version = "8.0.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xy6na8axc5wnp2wg3kvqbpl2iv0hx0rsnlrmrgkgp88znx6cmjn";
+  };
+
+  pythonImportsCheck = [
+    "webargs"
+  ];
+
+
+  propagatedBuildInputs = [ marshmallow ];
+  checkInputs = [
+    pytestCheckHook
+    pytest-aiohttp
+    webtest
+    webtest-aiohttp
+    flask
+    django
+    bottle
+    tornado
+    pyramid
+    falcon
+    aiohttp
+  ];
+
+  meta = with lib; {
+    description = "Declarative parsing and validation of HTTP request objects, with built-in support for popular web frameworks";
+    homepage = "https://github.com/marshmallow-code/webargs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cript0nauta ];
+  };
+}

--- a/pkgs/development/python-modules/webtest-aiohttp/default.nix
+++ b/pkgs/development/python-modules/webtest-aiohttp/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage, fetchFromGitHub, lib, isPy27, webtest, invoke, flake8
+, aiohttp, pytest-aiohttp, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "webtest-aiohttp";
+  version = "2.0.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "sloria";
+    repo = pname;
+    rev = version;
+    sha256 = "1apr1x0wmnc6l8wv67z4dp00fiiygda6rwpxlspfk7nk9zz37q2j";
+  };
+
+  pythonImportsCheck = [
+    "webtest_aiohttp"
+  ];
+
+  propagatedBuildInputs = [ webtest ];
+  checkInputs = [ invoke flake8 aiohttp pytest-aiohttp pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Provides integration of WebTest with aiohttp.web applications";
+    homepage = "https://github.com/sloria/webtest-aiohttp";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cript0nauta ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8982,6 +8982,8 @@ in {
 
   webhelpers = callPackage ../development/python-modules/webhelpers { };
 
+  webargs = callPackage ../development/python-modules/webargs { };
+
   webob = callPackage ../development/python-modules/webob { };
 
   weboob = callPackage ../development/python-modules/weboob { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8998,6 +8998,8 @@ in {
 
   webtest = callPackage ../development/python-modules/webtest { };
 
+  webtest-aiohttp = callPackage ../development/python-modules/webtest-aiohttp { };
+
   webthing = callPackage ../development/python-modules/webthing { };
 
   werkzeug = callPackage ../development/python-modules/werkzeug {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I added the webargs and webtest-aiohttp Python packages. Also, removed some unused dependencies from marshmallow (otherwise the webargs test would fail).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
