### PR TITLE
umoci: 0.4.5 -> 0.4.6

### DIFF
--- a/pkgs/applications/virtualization/umoci/default.nix
+++ b/pkgs/applications/virtualization/umoci/default.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "umoci";
-  version = "0.4.5";
+  version = "0.4.6";
 
   src = fetchFromGitHub {
-    owner = "openSUSE";
+    owner = "opencontainers";
     repo = "umoci";
     rev = "v${version}";
-    sha256 = "1gzj4nnys73wajdwjn5jsskvnhzh8s2vmyl76ax8drpvw19bd5g3";
+    sha256 = "0jaar26l940yh77cs31c3zndiycp85m3fz4zivcibzi68g6n6yzg";
   };
 
   vendorSha256 = null;
@@ -24,7 +24,7 @@ buildGoModule rec {
 
   postInstall = ''
     sed -i '/SHELL =/d' Makefile
-    make local-doc
+    make docs
     installManPage doc/man/*.[1-9]
   '';
 
@@ -33,6 +33,6 @@ buildGoModule rec {
     homepage = "https://umo.ci";
     license = licenses.asl20;
     maintainers = with maintainers; [ zokrezyl ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
https://github.com/opencontainers/umoci/releases/tag/v0.4.6

> umoci has been adopted by the Open Container Initative as a reference
implementation of the OCI Image Specification.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
