### PR TITLE
python-jsonrpc-server: remove ujson version contraint

### DIFF
--- a/pkgs/development/python-modules/python-jsonrpc-server/default.nix
+++ b/pkgs/development/python-modules/python-jsonrpc-server/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   postPatch = ''
     sed -i 's/version=versioneer.get_version(),/version="${version}",/g' setup.py
     # https://github.com/palantir/python-jsonrpc-server/issues/36
-    sed -i -e 's!ujson<=!ujson>=!' setup.py
+    sed -iEe "s!'ujson.*\$!'ujson',!" setup.py
   '';
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change
Since https://github.com/NixOS/nixpkgs/commit/141a029ad733a539f20b34c1ff14f5511f55a05b the version constraint of the ujson dependency is changed via `sed` from "ujson<=1.35" to "ujson>=1.35" to allow for for a newer ujson version.
This is bad for adaptability. If one decides to actually include a correct version of ujson (by using mach-nix for example), then the installation fails despite all dependencies are correct.

I think a better way to bypass upstream version containts is to just remove them.
@Mic92 

###### Things done
Modify the sed command to replace `'ujson<=XXX'` with `'ujson'`

`ujson` builds were failing when using nixpkgs-review, but I guess this has other reasons !?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
