### PR TITLE
vulnix: add patch to fix flake8 failure

### DIFF
--- a/pkgs/tools/security/vulnix/default.nix
+++ b/pkgs/tools/security/vulnix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, python3Packages, nix, ronn }:
+{ stdenv, fetchpatch, python3Packages, nix, ronn }:
 
 python3Packages.buildPythonApplication rec {
   pname = "vulnix";
@@ -8,6 +8,14 @@ python3Packages.buildPythonApplication rec {
     inherit pname version;
     sha256 = "06dpdsnz1ih0syas3x25s557qpw0f4kmypvxwaffm734djg8klmi";
   };
+
+  patches = [
+    # https://github.com/flyingcircusio/vulnix/pull/64 -- flake8 fix
+    (fetchpatch {
+      url = "https://github.com/flyingcircusio/vulnix/commit/10c96d48d14d73cc27a22551c684e5bf5bedf884.patch";
+      sha256 = "080dnyq7ab2kg61z3zkf5y8yb1glqj1n6c032n8zw212v5kj4cxg";
+    })
+  ];
 
   outputs = [ "out" "doc" "man" ];
   nativeBuildInputs = [ ronn ];


### PR DESCRIPTION
###### Motivation for this change
https://hydra.nixos.org/build/123238104 (broken at head)

https://github.com/flyingcircusio/vulnix/pull/64 was already merged upstream, cherry-pick the fix.

cc @ckauhaus 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
