### PR TITLE
file: backport patch to fix a 5.39 regression

### DIFF
--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
     sha256 = "1lgs2w2sgamzf27kz5h7pajz7v62554q21fbs11n4mfrfrm2hpgh";
   };
 
+  patches = [
+    # https://github.com/file/file/commit/85b7ab83257b3191a1a7ca044589a092bcef2bb3
+    # Without the RCS id change to avoid conflicts. Remove on next bump.
+    ./webassembly-format-fix.patch
+  ];
+
   nativeBuildInputs = stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) file;
   buildInputs = [ zlib ]
               ++ stdenv.lib.optional stdenv.hostPlatform.isWindows libgnurx;

--- a/pkgs/tools/misc/file/webassembly-format-fix.patch
+++ b/pkgs/tools/misc/file/webassembly-format-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/src/funcs.c b/src/funcs.c
+index 299b8f022..ecbfa28c5 100644
+--- a/src/funcs.c
++++ b/src/funcs.c
+@@ -93,7 +93,7 @@ file_checkfmt(char *msg, size_t mlen, const char *fmt)
+ 		if (*++p == '%')
+ 			continue;
+ 		// Skip uninteresting.
+-		while (strchr("0.'+- ", *p) != NULL)
++		while (strchr("#0.'+- ", *p) != NULL)
+ 			p++;
+ 		if (*p == '*') {
+ 			if (msg)


### PR DESCRIPTION
###### Motivation for this change

This bug is causing diffoscope to fail to build with file 5.39.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
