### PR TITLE
hdl-dump: init at unstable-2020-02-05

### DIFF
--- a/pkgs/tools/filesystems/hdl-dump/default.nix
+++ b/pkgs/tools/filesystems/hdl-dump/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  version = "unstable-2020-02-05";
+  pname = "hdl-dump";
+
+  src = fetchFromGitHub {
+    owner = "AKuHAK";
+    repo  = "hdl-dump";
+    rev = "b0d74679eaeb404cdfd5c43ec8fd18d9e2bbb038";
+    sha256 = "1k6m4px14cr0i8f4fpk4f1wp0sk4isbnbhib1vl7r4yg7564y1j1";
+  };
+
+  makeFlags = [ "DEBUG=no" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp hdl_dump $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A tool to install Playstation 2 games";
+    homepage = "https://github.com/AKuHAK/hdl-dump";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.nilp0inter ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4175,6 +4175,8 @@ in
     javac = jdk;
   };
 
+  hdl-dump = callPackage ../tools/filesystems/hdl-dump { };
+
   hecate = callPackage ../applications/editors/hecate { };
 
   heaptrack = libsForQt5.callPackage ../development/tools/profiling/heaptrack {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I'd like to use the hdl_dump command to manage my PS2 game backup library from my NixOS box.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
