### PR TITLE
ocamlPackages.lwt: 4.5.0 → 5.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/inotify/default.nix
+++ b/pkgs/development/ocaml-modules/inotify/default.nix
@@ -1,6 +1,5 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild
+{ stdenv, fetchFromGitHub, fetchpatch, ocaml, findlib, ocamlbuild
 , ocaml_lwt # optional lwt support
-, doCheck ? stdenv.lib.versionAtLeast ocaml.version "4.03"
 , ounit, fileutils # only for tests
 }:
 
@@ -15,13 +14,18 @@ stdenv.mkDerivation rec {
 		sha256 = "1s6vmqpx19hxzsi30jvp3h7p56rqnxfhfddpcls4nz8sqca1cz5y";
 	};
 
-	buildInputs = [ ocaml findlib ocamlbuild ocaml_lwt ]
-	++ stdenv.lib.optionals doCheck [ ounit fileutils ];
+	patches = [ (fetchpatch {
+		url = "https://github.com/whitequark/ocaml-inotify/commit/716c8002cc1652f58eb0c400ae92e04003cba8c9.patch";
+		sha256 = "04lfxrrsmk2mc704kaln8jqx93jc4bkxhijmfy2d4cmk1cim7r6k";
+	}) ];
+
+	buildInputs = [ ocaml findlib ocamlbuild ocaml_lwt ];
+	checkInputs = [ ounit fileutils ];
 
 	configureFlags = [ "--enable-lwt"
 	  (stdenv.lib.optionalString doCheck "--enable-tests") ];
 
-	inherit doCheck;
+	doCheck = true;
 	checkTarget = "test";
 
 	createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/inotify/default.nix
+++ b/pkgs/development/ocaml-modules/inotify/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
 	configureFlags = [ "--enable-lwt"
 	  (stdenv.lib.optionalString doCheck "--enable-tests") ];
 
+	postConfigure = stdenv.lib.optionalString doCheck ''
+	  echo '<lib_test/test_inotify_lwt.*>: pkg_threads' | tee -a _tags
+	'';
+
 	doCheck = true;
 	checkTarget = "test";
 

--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -7,11 +7,11 @@ let inherit (lib) optional versionAtLeast; in
 
 buildDunePackage rec {
   pname = "lwt";
-  version = "4.5.0";
+  version = "5.3.0";
 
   src = fetchzip {
     url = "https://github.com/ocsigen/${pname}/archive/${version}.tar.gz";
-    sha256 = "0l836z5zr38969bi77aga7ismj4wb01i3ffxf5v59jsgd3g44r2w";
+    sha256 = "15hgy3220m2b8imipa514n7l65m1h5lc6l1hanqwwvs7ghh2aqp2";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/ocaml-modules/lwt/ppx.nix
+++ b/pkgs/development/ocaml-modules/lwt/ppx.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage {
   pname = "lwt_ppx";
-  version = "1.2.4";
+  version = "2.0.1";
 
   src = fetchzip {
     # `lwt_ppx` has a different release cycle than Lwt, but it's included in
@@ -12,8 +12,8 @@ buildDunePackage {
     #
     # This is particularly useful for overriding Lwt without breaking `lwt_ppx`,
     # as new Lwt releases may contain broken `lwt_ppx` code.
-    url = "https://github.com/ocsigen/lwt/archive/4.4.0.tar.gz";
-    sha256 = "1l97zdcql7y13fhaq0m9n9xvxf712jg0w70r72fvv6j49xm4nlhi";
+    url = "https://github.com/ocsigen/lwt/archive/5.2.0.tar.gz";
+    sha256 = "1znw8ckwdmqsnrcgar4g33zgr659l4l904bllrz69bbwdnfmz2x3";
   };
 
 


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/ocsigen/lwt/releases

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
