### PR TITLE
gSpeech: 0.9.2 -> 0.10.1

### DIFF
--- a/pkgs/applications/audio/gspeech/default.nix
+++ b/pkgs/applications/audio/gspeech/default.nix
@@ -20,13 +20,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gSpeech";
-  version = "0.9.2";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "mothsart";
     repo = pname;
     rev = version;
-    sha256 = "11pvdpb9jjssp8nmlj21gs7ncgfm89kw26mfc8c2x8w2q4h92ja3";
+    sha256 = "1i0jwgxcn94nsi7c0ad0w77y04g04ka2szijzfqzqfnacdmdyrfc";
   };
 
   nativeBuildInputs = [
@@ -56,8 +56,8 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   postFixup = ''
-    wrapProgram $out/bin/gspeech --prefix PATH : ${lib.makeBinPath [ picotts ]}
-    wrapProgram $out/bin/gspeech-cli --prefix PATH : ${lib.makeBinPath [ picotts ]}
+    wrapProgram $out/bin/gspeech --prefix PATH : ${lib.makeBinPath [ picotts sox ]}
+    wrapProgram $out/bin/gspeech-cli --prefix PATH : ${lib.makeBinPath [ picotts sox ]}
   '';
 
   strictDeps = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

gSpeech 0.10 bring 2 big features : 

- control the reading speed
- reading text bigger than 30000 characters

###### Things done

For reading text  bigger than 30000 characters, gSpeech need sox dependance.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
