### PR TITLE
pylint: fix 1.9

### DIFF
--- a/pkgs/development/python-modules/pylint/1.9.nix
+++ b/pkgs/development/python-modules/pylint/1.9.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, buildPythonPackage, fetchPypi, astroid, six, isort,
   mccabe, configparser, backports_functools_lru_cache, singledispatch,
-  pytest, pytestrunner, pyenchant, setuptools }:
+  pytest, pytestrunner, setuptools }:
 
 buildPythonPackage rec {
   pname = "pylint";
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     sha256 = "004kfapkqxqy2s85pmddqv0fabxdxywxrlbi549p0v237pr2v94p";
   };
 
-  checkInputs = [ pytest pytestrunner pyenchant ];
+  checkInputs = [ pytest pytestrunner ];
 
   propagatedBuildInputs = [ astroid six isort mccabe configparser backports_functools_lru_cache singledispatch setuptools ];
 


### PR DESCRIPTION
It depends on pyenchant, which is disabled on python2. This results
in:
```
nix-env -iA unstable.python27Packages.pylint
replacing old 'python2.7-pylint-1.9.5'
installing 'python2.7-pylint-1.9.5'
error: pyenchant-3.1.1 not supported for interpreter python2.7
```

Remove it, à la
https://github.com/NixOS/nixpkgs/commit/eb0d5fc3f076ad8fbac43158e77277066bbe28b9
and now it builds again.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
