### PR TITLE
python-jsonrpc-server: make version overridable

### DIFF
--- a/pkgs/development/python-modules/python-jsonrpc-server/default.nix
+++ b/pkgs/development/python-modules/python-jsonrpc-server/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    sed -i 's/version=versioneer.get_version(),/version="${version}",/g' setup.py
+    sed -i "s/version=versioneer.get_version(),/version=\"$version\",/g" setup.py
     # https://github.com/palantir/python-jsonrpc-server/issues/36
     sed -i -e 's!ujson<=!ujson>=!' setup.py
   '';


### PR DESCRIPTION
###### Motivation for this change
The way the version attribute was inserted into the postPatch script prevented it from being overridden via `overrideAttrs` or `overridePythonAttrs`. It would still use the original definition instead of the overridden one.

###### Things done
replace nix-based string substitution with bash-based string substitution

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
