### PR TITLE
libosmium: 2.15.5 -> 2.15.6

### DIFF
--- a/pkgs/applications/misc/osmium-tool/default.nix
+++ b/pkgs/applications/misc/osmium-tool/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "osmium-tool";
-  version = "1.12.0";
+  version = "1.12.1";
 
   src = fetchFromGitHub {
     owner = "osmcode";
     repo = "osmium-tool";
     rev = "v${version}";
-    sha256 = "18afn5qzdjpip176kk5pr04mj0p7dv70dbz1n36qmqnq3gyms10q";
+    sha256 = "13142hj8gfgj6w51a62hjzfmzic90xgrnnlnb70hpdqjy86bxv7j";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/libosmium/default.nix
+++ b/pkgs/development/libraries/libosmium/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libosmium";
-  version = "2.15.5";
+  version = "2.15.6";
 
   src = fetchFromGitHub {
     owner = "osmcode";
     repo = "libosmium";
     rev = "v${version}";
-    sha256 = "1f21dzzkxzi74hv17fs9kb2w6indqvvm4lkxclz4j4x98k8q3n59";
+    sha256 = "0rqy18bbakp41f44y5id9ixh0ar2dby46z17p4115z8k1vv9znq2";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change

Upstream bugfix release.

Releases on GitHub:
- [libosmium 2.15.6](https://github.com/osmcode/libosmium/releases/tag/v2.15.6)
- [osmium-tool 1.12.1](https://github.com/osmcode/osmium-tool/releases/tag/v1.12.1) (included in this PR, because [the only change](https://github.com/osmcode/osmium-tool/compare/v1.12.0...v1.12.1) since 1.12.0 is to require the new libosmium version)

Upstream code changes:
- [libosmium `v2.15.5..v2.15.6`](https://github.com/osmcode/libosmium/compare/v2.15.5...v2.15.6)
- [osmium-tool `v1.12.0..v1.12.1`](https://github.com/osmcode/osmium-tool/compare/v1.12.0...v1.12.1)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
