### PR TITLE
age: unstable-2020-03-25 -> v1.0.0-beta4

### DIFF
--- a/pkgs/tools/security/age/default.nix
+++ b/pkgs/tools/security/age/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "age";
-  version = "unstable-2020-03-25";
+  version = "1.0.0-beta4";
   goPackagePath = "github.com/FiloSottile/age";
   vendorSha256 = "0km7a2826j3fk2nrkmgc990chrkcfz006wfw14yilsa4p2hmfl7m";
 
@@ -14,8 +14,8 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "FiloSottile";
     repo = "age";
-    rev = "f0f8092d60bb96737fa096c29ec6d8adb5810390";
-    sha256 = "079kfc8d1pr39hr4qnx48kviyzwg4p8m4pz0bdkypns4aq8ppbfk";
+    rev = "v${version}";
+    sha256 = "0pp6zn4rdypyxn1md9ppisiwiapkfkbh08rzfl3qwn0998wx6gnb";
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Bumping to upstream release from 2020-06-28. This skips 1.0.0-beta3,
which was released on the same day and contained a bug.

Upstream changelog:

```
189041b6 (tag: v1.0.0-beta4) age: move package from filippo.io/age/age to filippo.io/age 🤦♂
e6093596 (tag: v1.0.0-beta3) age,agessh,armor: unleash public API 💥🦑
33355dcc internal/age: unexport NewX25519Recipient and NewX25519Identity
9a08b7e6 internal/age,internal/armor: add examples
9b83d948 internal/age: surface format.Recipient as type Stanza
c9a35c07 internal/agessh: move EncryptedSSHIdentity out of cmd/age
7d608d12 .github/workflows: add rage interop tests trigger (#125)
6782356e internal/age: add some docs and polish API
08546656 internal/format: fix a nasty bufio.Reader nesting bug
292c3aae internal/agessh: new package
b32ea4c1 cmd/age: add a TODO about not dumping decrypted binary to the terminal
c7c7f187 internal/armor: new package
a7c4274d internal/age: remove EncryptWithArmor and armor support in Decrypt
7088a732 internal/age: unexport SSHFingerprint
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
