### PR TITLE
jetbrains.*: 2020.1.1/2/3 -> 2020.1.2/3/5

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -268,12 +268,12 @@ in
 
   clion = buildClion rec {
     name = "clion-${version}";
-    version = "2020.1.1"; /* updated by script */
+    version = "2020.1.2"; /* updated by script */
     description  = "C/C++ IDE. New. Intelligent. Cross-platform";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/cpp/CLion-${version}.tar.gz";
-      sha256 = "0136hmknkxrsgbygxqzrq1836kg02p14hmv5mzbpp79yglhv2xml"; /* updated by script */
+      sha256 = "0q5bnb0rmsgks7brrdpgah83s2ixa4pyhw8jvg9p2g48b582rmf7"; /* updated by script */
     };
     wmClass = "jetbrains-clion";
     update-channel = "CLion RELEASE"; # channel's id as in http://www.jetbrains.com/updates/updates.xml
@@ -281,12 +281,12 @@ in
 
   datagrip = buildDataGrip rec {
     name = "datagrip-${version}";
-    version = "2020.1.3"; /* updated by script */
+    version = "2020.1.5"; /* updated by script */
     description = "Your Swiss Army Knife for Databases and SQL";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/datagrip/${name}.tar.gz";
-      sha256 = "0ivnicpn67mfyhmiwbx80pq5l2xa4g1cpp79mh7rgm2c5klmf201"; /* updated by script */
+      sha256 = "0605d772156lzlz5904px2spdijc92yz6rjvmpyg6vk5zv5k2wm9"; /* updated by script */
     };
     wmClass = "jetbrains-datagrip";
     update-channel = "DataGrip RELEASE";
@@ -294,12 +294,12 @@ in
 
   goland = buildGoland rec {
     name = "goland-${version}";
-    version = "2020.1.2"; /* updated by script */
+    version = "2020.1.3"; /* updated by script */
     description = "Up and Coming Go IDE";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/go/${name}.tar.gz";
-      sha256 = "0v6vi6m94fwzsg5s357ymh8604zkv6q0zhyqfh9sj4ynzi7l4fyv"; /* updated by script */
+      sha256 = "0pqwj4gc23gf10xqciwndimb4ml7djmx8m5rh52c07m77y4aniyn"; /* updated by script */
     };
     wmClass = "jetbrains-goland";
     update-channel = "GoLand RELEASE";
@@ -307,12 +307,12 @@ in
 
   idea-community = buildIdea rec {
     name = "idea-community-${version}";
-    version = "2020.1.1"; /* updated by script */
+    version = "2020.1.2"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "0q848swfg9mjiini5bbjdj1f0qpd1n4glxdpncjj7mbpvp7s2h5k"; /* updated by script */
+      sha256 = "07gfqyp6blbf7v8p106ngpq7c5p0llcjahi205yg2jgzkhshn7ld"; /* updated by script */
     };
     wmClass = "jetbrains-idea-ce";
     update-channel = "IntelliJ IDEA RELEASE";
@@ -320,12 +320,12 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2020.1.1"; /* updated by script */
+    version = "2020.1.2"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIU-${version}-no-jbr.tar.gz";
-      sha256 = "13khjc7fp28mpcdn74msdw57nzhicg32xrrvj7s7na2qd9gqz0hf"; /* updated by script */
+      sha256 = "13qj8n5daz0z0pjizyfsvbbr1gxp5479ar3a68ygi0vrpmbdbssd"; /* updated by script */
     };
     wmClass = "jetbrains-idea";
     update-channel = "IntelliJ IDEA RELEASE";
@@ -346,12 +346,12 @@ in
 
   phpstorm = buildPhpStorm rec {
     name = "phpstorm-${version}";
-    version = "2020.1.1"; /* updated by script */
+    version = "2020.1.2"; /* updated by script */
     description = "Professional IDE for Web and PHP developers";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webide/PhpStorm-${version}.tar.gz";
-      sha256 = "16gclbczd9czqhply0xb2ykv0bw4bgv85fihy1n2szc4rp643qdw"; /* updated by script */
+      sha256 = "00c8vlp125j56v9g9d4rc5g4dhgvl1bhi6qrzvpaf6x77jbq4fv4"; /* updated by script */
     };
     wmClass = "jetbrains-phpstorm";
     update-channel = "PhpStorm RELEASE";
@@ -359,12 +359,12 @@ in
 
   pycharm-community = buildPycharm rec {
     name = "pycharm-community-${version}";
-    version = "2020.1.1"; /* updated by script */
+    version = "2020.1.2"; /* updated by script */
     description = "PyCharm Community Edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "0p2q01yragab7c15aicpmaby075y7mpf6iavdfipi033q4gnlnki"; /* updated by script */
+      sha256 = "1s04b9w7sydix1sjqzmby63nwcvzs6iw28wz7441kxgryl9qg0qw"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm-ce";
     update-channel = "PyCharm RELEASE";
@@ -372,12 +372,12 @@ in
 
   pycharm-professional = buildPycharm rec {
     name = "pycharm-professional-${version}";
-    version = "2020.1.1"; /* updated by script */
+    version = "2020.1.2"; /* updated by script */
     description = "PyCharm Professional Edition";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "1lq97aqnibvg483ww7wi8slh302gydd2kdkw6p2516rjcmm6n324"; /* updated by script */
+      sha256 = "1ysj00qbn5ik6i5953b9mln4g456fmn3phdln9m5jmcb0126y235"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm";
     update-channel = "PyCharm RELEASE";
@@ -385,12 +385,12 @@ in
 
   rider = buildRider rec {
     name = "rider-${version}";
-    version = "2020.1.2"; /* updated by script */
+    version = "2020.1.3"; /* updated by script */
     description = "A cross-platform .NET IDE based on the IntelliJ platform and ReSharper";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/rider/JetBrains.Rider-${version}.tar.gz";
-      sha256 = "0flwq61p7827f8nmldqgfpxbfl422imclksw6w97mgzqqhcbgksd"; /* updated by script */
+      sha256 = "1zzkd3b5j3q6jqrvibxz33a4fcm7pgqfx91bqjs615v3499ncng7"; /* updated by script */
     };
     wmClass = "jetbrains-rider";
     update-channel = "Rider RELEASE";
@@ -398,12 +398,12 @@ in
 
   ruby-mine = buildRubyMine rec {
     name = "ruby-mine-${version}";
-    version = "2020.1.1"; /* updated by script */
+    version = "2020.1.2"; /* updated by script */
     description = "The Most Intelligent Ruby and Rails IDE";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/ruby/RubyMine-${version}.tar.gz";
-      sha256 = "0xhx3n2xdk0k0qx7hdiyfga16hjf2j95k219wh7mh0cys20hkrg8"; /* updated by script */
+      sha256 = "1ycwml7fyhjajjfy1fhggmx0mcdcjidkxll7357rv2z51r0yhc9h"; /* updated by script */
     };
     wmClass = "jetbrains-rubymine";
     update-channel = "RubyMine RELEASE";
@@ -411,12 +411,12 @@ in
 
   webstorm = buildWebStorm rec {
     name = "webstorm-${version}";
-    version = "2020.1.1"; /* updated by script */
+    version = "2020.1.2"; /* updated by script */
     description = "Professional IDE for Web and JavaScript development";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webstorm/WebStorm-${version}.tar.gz";
-      sha256 = "0d543g06bxpw4q2p19vmvrxpbhqsvspjbs3sqnw6hxni7wcflhkg"; /* updated by script */
+      sha256 = "1szgiccimfk99z9x1k99lgic6ix81fdahf1k3a88rddl8hhncjwv"; /* updated by script */
     };
     wmClass = "jetbrains-webstorm";
     update-channel = "WebStorm RELEASE";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
To get the latest JetBrains patches. Tested jetbrains.idea-ultimate. I was unable to update MPS version with update.pl script as sha256 key delivered by JetBrains was broken so I left it as it was before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
