### PR TITLE
nixos/keycloak: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -847,6 +847,7 @@
   ./services/web-apps/icingaweb2/module-monitoring.nix
   ./services/web-apps/ihatemoney
   ./services/web-apps/jirafeau.nix
+  ./services/web-apps/keycloak.nix
   ./services/web-apps/limesurvey.nix
   ./services/web-apps/mattermost.nix
   ./services/web-apps/mediawiki.nix

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -1,0 +1,72 @@
+{ pkgs, lib, config, ... }:
+
+with lib;
+let
+  cfg = config.services.keycloak;
+in
+{
+  options = {
+    services.keycloak = {
+      enable = mkEnableOption "Keycloak identity and access server";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.keycloak;
+        defaultText = "pkgs.keycloak";
+        example = literalExample "pkgs.keycloak";
+        description = "Package that should be used for keycloak";
+      };
+
+      jbossBaseDir = mkOption {
+        type = types.str;
+        default = "/var/lib/keycloak";
+        description = ''
+          The location keycloak (and underlying JBoss/Wildfly) information
+          (configuration, logs, data) is stored.
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        description = "The user to run keycloak as.";
+        default = "keycloak";
+      };
+
+      group = mkOption {
+        type = types.str;
+        description = "The group to run keycloak as.";
+        default = "keycloak";
+      };
+
+      extraFlags = mkOption {
+        description = "Extra flags to pass to the keycloak (standalone.sh) command.";
+        default = [];
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.keycloak-server = {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      description = "Keycloak Open Source Identity and Access Management Server";
+
+      environment = {
+        JBOSS_BASE_DIR = jbossBaseDir;
+      };
+
+      serviceConfig = {
+        User = "${cfg.user}";
+        Group = "${cfg.group}";
+        TimeoutStartSec = 60;
+        TimeoutStopSec = 60;
+        Restart = "always";
+        ExecStart = concatStringsSep " \\\n " (
+          [
+            "${cfg.package}/bin/standalone.sh"
+          ] ++ cfg.extraFlags
+        );
+      };
+    };
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Request to add a module for keycloak: https://github.com/NixOS/nixpkgs/issues/87673

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
