### PR TITLE
osmium-tools: run tests, install man pages and zsh completions

### DIFF
--- a/pkgs/applications/misc/osmium-tool/default.nix
+++ b/pkgs/applications/misc/osmium-tool/default.nix
@@ -1,4 +1,15 @@
-{ stdenv, fetchFromGitHub, cmake, libosmium, protozero, boost, bzip2, zlib, expat }:
+{ stdenv
+, fetchFromGitHub
+, cmake
+, installShellFiles
+, pandoc
+, boost
+, bzip2
+, expat
+, libosmium
+, protozero
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   pname = "osmium-tool";
@@ -11,8 +22,26 @@ stdenv.mkDerivation rec {
     sha256 = "13142hj8gfgj6w51a62hjzfmzic90xgrnnlnb70hpdqjy86bxv7j";
   };
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ libosmium protozero boost bzip2 zlib expat ];
+  nativeBuildInputs = [
+    cmake
+    installShellFiles
+    pandoc
+  ];
+
+  buildInputs = [
+    boost
+    bzip2
+    expat
+    libosmium
+    protozero
+    zlib
+  ];
+
+  doCheck = true;
+
+  postInstall = ''
+    installShellCompletion --zsh ../zsh_completion/_osmium
+  '';
 
   meta = with stdenv.lib; {
     description = "Multipurpose command line tool for working with OpenStreetMap data based on the Osmium library";

--- a/pkgs/development/libraries/libosmium/default.nix
+++ b/pkgs/development/libraries/libosmium/default.nix
@@ -12,8 +12,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
+
   buildInputs = [ protozero zlib bzip2 expat boost ];
 
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "Fast and flexible C++ library for working with OpenStreetMap data";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

libosmium, osmium-tools: run tests. They are compiled anyway, so let's run them to detect regressions.

osmium-tools: it seems that upstream provides man pages and zsh completions, add them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
