### PR TITLE
gtkcord: Init at 0.0.4

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gtkcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gtkcord/default.nix
@@ -1,0 +1,42 @@
+{ makeDesktopItem, lib, buildGoModule, fetchFromGitHub, pkg-config, glib, go, gtk3, libhandy }:
+
+buildGoModule rec {
+  pname = "gtkcord";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "diamondburned";
+    repo = "gtkcord3";
+    rev = "v${version}";
+    sha256 = "0n9600s50zpx8kv89icrlxarm3633gnizg1sq1zpask8bbv2xnfd";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ glib gtk3 libhandy ];
+
+  # No upstream desktop file yet: https://github.com/diamondburned/gtkcord3/issues/77
+  desktopFile = makeDesktopItem {
+    name = pname;
+    desktopName = "gtkcord";
+    exec = "gtkcord3";
+    icon = "gtkcord3";
+    categories = "GTK;GNOME;Chat;";
+  };
+
+  postInstall = ''
+    install -Dt $out/share/applications/ "${desktopFile}"/share/applications/*
+    install -D "$src/logo.png" $out/share/icons/hicolor/256x256/apps/gtkcord3.png
+  '';
+
+  vendorSha256 = "0kzq8x0qcjr443ydj05s2f8ybszc2jzqa2annadp3hry8x2va2in";
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Lightweight Discord client which uses GTK3 for the user interface";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ skykanin ];
+    homepage = "https://github.com/diamondburned/gtkcord3";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4056,6 +4056,8 @@ in
 
   gbenchmark = callPackage ../development/libraries/gbenchmark {};
 
+  gtkcord = callPackage ../applications/networking/instant-messengers/gtkcord { };
+
   gtkdatabox = callPackage ../development/libraries/gtkdatabox {};
 
   gtklick = callPackage ../applications/audio/gtklick {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add the gtkcord discord client

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
