### PR TITLE
osm2pgsql: use libs from NixPkgs instead of vendored ones

### DIFF
--- a/pkgs/tools/misc/osm2pgsql/default.nix
+++ b/pkgs/tools/misc/osm2pgsql/default.nix
@@ -1,5 +1,16 @@
-{ stdenv, fetchFromGitHub, cmake, expat, proj, bzip2, zlib, boost, postgresql
-, withLuaJIT ? false, lua, luajit }:
+{ stdenv
+, fetchFromGitHub
+, cmake
+, expat
+, proj
+, bzip2
+, zlib
+, boost
+, postgresql
+, withLuaJIT ? false
+, lua
+, luajit
+}:
 
 stdenv.mkDerivation rec {
   pname = "osm2pgsql";

--- a/pkgs/tools/misc/osm2pgsql/default.nix
+++ b/pkgs/tools/misc/osm2pgsql/default.nix
@@ -10,6 +10,7 @@
 , withLuaJIT ? false
 , lua
 , luajit
+, libosmium
 }:
 
 stdenv.mkDerivation rec {
@@ -25,11 +26,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ expat proj bzip2 zlib boost postgresql ]
+  buildInputs = [ expat proj bzip2 zlib boost postgresql libosmium ]
     ++ stdenv.lib.optional withLuaJIT luajit
     ++ stdenv.lib.optional (!withLuaJIT) lua;
 
-  cmakeFlags = stdenv.lib.optional withLuaJIT "-DWITH_LUAJIT:BOOL=ON";
+  cmakeFlags = [ "-DEXTERNAL_LIBOSMIUM=ON" ]
+    ++ stdenv.lib.optional withLuaJIT "-DWITH_LUAJIT:BOOL=ON";
 
   NIX_CFLAGS_COMPILE = "-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H";
 

--- a/pkgs/tools/misc/osm2pgsql/default.nix
+++ b/pkgs/tools/misc/osm2pgsql/default.nix
@@ -11,6 +11,7 @@
 , lua
 , luajit
 , libosmium
+, protozero
 }:
 
 stdenv.mkDerivation rec {
@@ -26,11 +27,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ expat proj bzip2 zlib boost postgresql libosmium ]
+  buildInputs = [ expat proj bzip2 zlib boost postgresql libosmium protozero ]
     ++ stdenv.lib.optional withLuaJIT luajit
     ++ stdenv.lib.optional (!withLuaJIT) lua;
 
-  cmakeFlags = [ "-DEXTERNAL_LIBOSMIUM=ON" ]
+  cmakeFlags = [ "-DEXTERNAL_LIBOSMIUM=ON" "-DEXTERNAL_PROTOZERO=ON" ]
     ++ stdenv.lib.optional withLuaJIT "-DWITH_LUAJIT:BOOL=ON";
 
   NIX_CFLAGS_COMPILE = "-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H";

--- a/pkgs/tools/misc/osm2pgsql/default.nix
+++ b/pkgs/tools/misc/osm2pgsql/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/openstreetmap/osm2pgsql";
     license = licenses.gpl2;
     platforms = with platforms; linux ++ darwin;
-    maintainers = with maintainers; [ jglukasik ];
+    maintainers = with maintainers; [ jglukasik das-g ];
   };
 }


### PR DESCRIPTION
osm2pgsql "vendors" (i.e. contains in its own repo the source of) two libraries we have in NixPkgs and would build against and use these bundled versions by default:

- libosmium
- protozero

These changes makes osm2pgsql compile against and use the respective libraries from NixPkgs instead. Further, I'm adding myself as an additional maintainer.

###### Motivation for this change

This avoids having to build libosmium and protozero as part of osm2pgsql when already-built store paths can be used instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
---
Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
<br>- osm2pgsql
</details>