### PR TITLE
nixos/tests/initrd-network-ssh: fix with real initrd secrets implementation

### DIFF
--- a/nixos/modules/system/boot/initrd-ssh.nix
+++ b/nixos/modules/system/boot/initrd-ssh.nix
@@ -103,11 +103,10 @@ in
   config = let
     # Nix complains if you include a store hash in initrd path names, so
     # as an awful hack we drop the first character of the hash.
-    initrdKeyPath = path: if isString path
-      then path
+    initrdKeyPath = path: builtins.unsafeDiscardStringContext (
+      if isString path then path
       else let name = builtins.baseNameOf path; in
-        builtins.unsafeDiscardStringContext ("/etc/ssh/" +
-          substring 1 (stringLength name) name);
+        "/etc/ssh/" + substring 1 (stringLength name) name);
 
     sshdCfg = config.services.openssh;
 

--- a/nixos/tests/initrd-network-ssh/default.nix
+++ b/nixos/tests/initrd-network-ssh/default.nix
@@ -19,7 +19,10 @@ import ../make-test-python.nix ({ lib, ... }:
             enable = true;
             authorizedKeys = [ (readFile ./id_ed25519.pub) ];
             port = 22;
-            hostKeys = [ ./ssh_host_ed25519_key ];
+            # Key must be copied to the store for this test so that it is
+            # available when the bootloader is installed. DO NOT do this in a
+            # real config, as it will leak the key into the store.
+            hostKeys = [ "${./ssh_host_ed25519_key}" ];
           };
         };
         boot.initrd.preLVMCommands = ''
@@ -30,6 +33,7 @@ import ../make-test-python.nix ({ lib, ... }:
             sleep 1
           done
         '';
+        virtualisation.useBootLoader = true;
       };
 
     client =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes the `initrd-network-ssh` test, which was broken by the use of a real initrd secrets implementation. This was fixed by enabling the bootloader in the VM, which also exposed a few other bugs along the way.

The `-serial pty` QEMU option specified in the boot disk image builder prevented errors from being shown, and `-nographics` is redundant.

For the secret to be accessible to the VM disk builder, it needed to be added to the store, which broke some assumptions in the initrd-ssh module. I removed some hacks there that do not seem to be necessary, though I may be missing some problem with this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @emilazy @CRTified 
