### PR TITLE
beets: add extrafiles plugin

### DIFF
--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -31,6 +31,7 @@
 , enableAlternatives   ? false
 , enableCheck          ? false, liboggz ? null
 , enableCopyArtifacts  ? false
+, enableExtraFiles     ? false
 
 , bashInteractive, bash-completion
 }:
@@ -100,6 +101,7 @@ let
   externalTestArgs.beets = (beets.override {
     enableAlternatives = false;
     enableCopyArtifacts = false;
+    enableExtraFiles = false;
   }).overrideAttrs (stdenv.lib.const {
     doInstallCheck = false;
   });
@@ -110,6 +112,7 @@ let
     alternatives = callPackage ./alternatives-plugin.nix pluginArgs;
     check = callPackage ./check-plugin.nix pluginArgs;
     copyartifacts = callPackage ./copyartifacts-plugin.nix pluginArgs;
+    extrafiles = callPackage ./extrafiles-plugin.nix pluginArgs;
   };
 
 in pythonPackages.buildPythonApplication rec {
@@ -156,7 +159,9 @@ in pythonPackages.buildPythonApplication rec {
     ++ optional enableThumbnails    pythonPackages.pyxdg
     ++ optional enableWeb           pythonPackages.flask
     ++ optional enableAlternatives  plugins.alternatives
-    ++ optional enableCopyArtifacts plugins.copyartifacts;
+    ++ optional enableCopyArtifacts plugins.copyartifacts
+    ++ optional enableExtraFiles    plugins.extrafiles
+  ;
 
   buildInputs = [
     imagemagick

--- a/pkgs/tools/audio/beets/extrafiles-plugin.nix
+++ b/pkgs/tools/audio/beets/extrafiles-plugin.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, beets, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  pname = "beets-extrafiles";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    repo = "beets-extrafiles";
+    owner = "Holzhaus";
+    rev = "v${version}";
+    sha256 = "0ah7mgax9zrhvvd5scf2z0v0bhd6xmmv5sdb6av840ixpl6vlvm6";
+  };
+
+  postPatch = ''
+    sed -i -e '/install_requires/,/\]/{/beets/d}' setup.py
+    sed -i -e '/namespace_packages/d' setup.py
+  '';
+
+  nativeBuildInputs = [ beets ];
+
+  preCheck = ''
+    HOME=$TEMPDIR
+  '';
+
+  meta = {
+    homepage = "https://github.com/Holzhaus/beets-extrafiles";
+    description = "A plugin for beets that copies additional files and directories during the import process";
+    license = stdenv.lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
#### Motivation for this change

Beets in nixpkgs includes a plugin for [`beets-copyartifacts`](https://github.com/sbarakat/beets-copyartifacts), however that plugin is no longer being maintained and the repo has been archived. They recommend moving to either [`beets-copyartifacts3`](https://github.com/adammillerio/beets-copyartifacts) (which I tried and had issues using, plus that repo has Github issues disabled) or [`beets-extrafiles`](https://github.com/Holzhaus/beets-extrafiles) (which is working for me on another computer with Arch).

Opening this as a draft, though, because I can't get it to actually run successfully after building:
```
./result/bin/beet 
Traceback (most recent call last):
  File "/nix/store/rjiwykpn4k76sw9frv2waslssh7874cn-beets-1.4.9/bin/.beet-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/rjiwykpn4k76sw9frv2waslssh7874cn-beets-1.4.9/lib/python3.8/site-packages/beets/ui/__init__.py", line 1266, in main
    _raw_main(args)
  File "/nix/store/rjiwykpn4k76sw9frv2waslssh7874cn-beets-1.4.9/lib/python3.8/site-packages/beets/ui/__init__.py", line 1249, in _raw_main
    subcommands, plugins, lib = _setup(options, lib)
  File "/nix/store/rjiwykpn4k76sw9frv2waslssh7874cn-beets-1.4.9/lib/python3.8/site-packages/beets/ui/__init__.py", line 1135, in _setup
    plugins = _load_plugins(config)
  File "/nix/store/rjiwykpn4k76sw9frv2waslssh7874cn-beets-1.4.9/lib/python3.8/site-packages/beets/ui/__init__.py", line 1114, in _load_plugins
    beetsplug.__path__ = paths + beetsplug.__path__
TypeError: can only concatenate list (not "_NamespacePath") to list
```

Side note: I can't figure out how to set `enableExtraFiles` to `true` via `nix-build`. I tried `nix-build -A beets --arg enableExtraFiles true` but it doesn't have any effect.

Any advice? @aszlig @domenkozar @pjones

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).