### PR TITLE
nss: 3.52.1 -> 3.54

### DIFF
--- a/pkgs/development/libraries/nspr/default.nix
+++ b/pkgs/development/libraries/nspr/default.nix
@@ -2,7 +2,7 @@
 , CoreServices ? null
 , buildPackages }:
 
-let version = "4.25"; in
+let version = "4.26"; in
 
 stdenv.mkDerivation {
   pname = "nspr";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://mozilla/nspr/releases/v${version}/src/nspr-${version}.tar.gz";
-    sha256 = "0mjjk2b7ika3v4y99cnaqz3z1iq1a50r1psn9i3s87gr46z0khqb";
+    sha256 = "0gbp3g9p4nhf0zrlvqi5883sqb9zdw0wk83lccpgskxphlni97gw";
   };
 
   patches = [

--- a/pkgs/development/libraries/nss/85_security_load.patch
+++ b/pkgs/development/libraries/nss/85_security_load.patch
@@ -1,7 +1,8 @@
-diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/cmd/shlibsign/shlibsign.c nss/cmd/shlibsign/shlibsign.c
---- nss/cmd/shlibsign/shlibsign.c	2017-01-04 15:24:24.000000000 +0100
-+++ nss/cmd/shlibsign/shlibsign.c	2017-01-24 14:43:31.030420852 +0100
-@@ -875,6 +875,8 @@
+diff --git nss/cmd/shlibsign/shlibsign.c nss/cmd/shlibsign/shlibsign.c
+index ad8f3b84e..74676d039 100644
+--- nss/cmd/shlibsign/shlibsign.c
++++ nss/cmd/shlibsign/shlibsign.c
+@@ -875,6 +875,8 @@ main(int argc, char **argv)
          goto cleanup;
      }
      lib = PR_LoadLibrary(libname);
@@ -10,37 +11,31 @@ diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/cmd/shlibsign/shlibsign.c nss/cmd/sh
      assert(lib != NULL);
      if (!lib) {
          PR_fprintf(PR_STDERR, "loading softokn3 failed");
-diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/coreconf/config.mk nss/coreconf/config.mk
---- nss/coreconf/config.mk	2017-01-04 15:24:24.000000000 +0100
-+++ nss/coreconf/config.mk	2017-01-24 14:43:47.989432372 +0100
-@@ -202,3 +202,6 @@
- 
- # Hide old, deprecated, TLS cipher suite names when building NSS
- DEFINES += -DSSL_DISABLE_DEPRECATED_CIPHER_SUITE_NAMES
-+
-+# Nix specific stuff.
-+DEFINES += -DNIX_NSS_LIBDIR=\"$(out)/lib/\"
-diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/lib/pk11wrap/pk11load.c nss/lib/pk11wrap/pk11load.c
---- nss/lib/pk11wrap/pk11load.c	2017-01-04 15:24:24.000000000 +0100
-+++ nss/lib/pk11wrap/pk11load.c	2017-01-24 14:45:06.883485652 +0100
-@@ -440,6 +440,13 @@
+diff --git nss/lib/pk11wrap/pk11load.c nss/lib/pk11wrap/pk11load.c
+index 9e7a0a546..a0a23a1a4 100644
+--- nss/lib/pk11wrap/pk11load.c
++++ nss/lib/pk11wrap/pk11load.c
+@@ -466,6 +466,15 @@ secmod_LoadPKCS11Module(SECMODModule *mod, SECMODModule **oldModule)
           * unload the library if anything goes wrong from here on out...
           */
          library = PR_LoadLibrary(mod->dllName);
++#ifndef NSS_STATIC_SOFTOKEN
 +        if ((library == NULL) &&
 +            !rindex(mod->dllName, PR_GetDirectorySeparator())) {
 +            library = PORT_LoadLibraryFromOrigin(my_shlib_name,
 +                (PRFuncPtr) &softoken_LoadDSO,
 +                mod->dllName);
 +        }
++#endif
 +
          mod->library = (void *)library;
  
          if (library == NULL) {
-diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/lib/util/secload.c nss/lib/util/secload.c
---- nss/lib/util/secload.c	2017-01-04 15:24:24.000000000 +0100
-+++ nss/lib/util/secload.c	2017-01-24 14:43:31.030420852 +0100
-@@ -70,9 +70,14 @@
+diff --git nss/lib/util/secload.c nss/lib/util/secload.c
+index 12efd2f75..8b74478f6 100644
+--- nss/lib/util/secload.c
++++ nss/lib/util/secload.c
+@@ -70,9 +70,14 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
  
      /* Remove the trailing filename from referencePath and add the new one */
      c = strrchr(referencePath, PR_GetDirectorySeparator());
@@ -56,7 +51,7 @@ diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/lib/util/secload.c nss/lib/util/secl
          if (fullName) {
              memcpy(fullName, referencePath, referencePathSize);
              strcpy(fullName + referencePathSize, name);
-@@ -82,6 +87,11 @@
+@@ -82,6 +87,11 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
  #endif
              libSpec.type = PR_LibSpec_Pathname;
              libSpec.value.pathname = fullName;
@@ -68,7 +63,7 @@ diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/lib/util/secload.c nss/lib/util/secl
              dlh = PR_LoadLibraryWithFlags(libSpec, PR_LD_NOW | PR_LD_LOCAL
  #ifdef PR_LD_ALT_SEARCH_PATH
                                                         /* allow library's dependencies to be found in the same directory
-@@ -89,6 +99,10 @@
+@@ -89,6 +99,10 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
                                                         | PR_LD_ALT_SEARCH_PATH
  #endif
                                            );

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, nspr, perl, zlib, sqlite, fixDarwinDylibNames, buildPackages }:
+{ stdenv, fetchurl, nspr, perl, zlib, sqlite, fixDarwinDylibNames, buildPackages, ninja }:
 
 let
   nssPEM = fetchurl {
     url = "http://dev.gentoo.org/~polynomial-c/mozilla/nss-3.15.4-pem-support-20140109.patch.xz";
     sha256 = "10ibz6y0hknac15zr6dw4gv9nb5r5z9ym6gq18j3xqx7v7n3vpdw";
   };
-  version = "3.52.1";
+  version = "3.54";
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 
 in stdenv.mkDerivation rec {
@@ -14,12 +14,12 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/${pname}-${version}.tar.gz";
-    sha256 = "0y4jb9095f7bbgw7d7kvzm4c3g4p5i6y68fwhb8wlkpb7b1imj5w";
+    sha256 = "0hvfip056pl07h6w91i6fyji5nczrrsxyr56rls7jd2yryzqpcfs";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ perl ninja (buildPackages.python2.withPackages (ps: with ps; [ gyp ])) ];
 
   buildInputs = [ zlib sqlite ]
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
@@ -29,10 +29,18 @@ in stdenv.mkDerivation rec {
   prePatch = ''
     # strip the trailing whitespace from the patch line and the renamed CKO_NETSCAPE_ enum to CKO_NSS_
     xz -d < ${nssPEM} | sed \
-       -e '/^-DIRS = builtins $/ s/ $//' \
+       -e 's/-DIRS = builtins $/-DIRS = . builtins/g' \
        -e 's/CKO_NETSCAPE_/CKO_NSS_/g' \
        -e 's/CKT_NETSCAPE_/CKT_NSS_/g' \
        | patch -p1
+
+    patchShebangs nss
+
+    for f in nss/coreconf/config.gypi nss/build.sh nss/coreconf/config.gypi; do
+      substituteInPlace "$f" --replace "/usr/bin/env" "${buildPackages.coreutils}/bin/env"
+    done
+
+    substituteInPlace nss/coreconf/config.gypi --replace "/usr/bin/grep" "${buildPackages.coreutils}/bin/env grep"
   '';
 
   patches =
@@ -40,6 +48,7 @@ in stdenv.mkDerivation rec {
       # Based on http://patch-tracker.debian.org/patch/series/dl/nss/2:3.15.4-1/85_security_load.patch
       ./85_security_load.patch
       ./ckpem.patch
+      ./fix-cross-compilation.patch
     ];
 
   patchFlags = [ "-p0" ];
@@ -52,43 +61,40 @@ in stdenv.mkDerivation rec {
 
   preConfigure = "cd nss";
 
-  makeFlags = let
-    # NSS's build systems expects aarch32 to be called arm; if we pass in armv6l/armv7l, it
-    # fails with a linker error
-    cpu = if stdenv.hostPlatform.isAarch32 then "arm" else stdenv.hostPlatform.parsed.cpu.name;
-  in [
-    "NSPR_INCLUDE_DIR=${nspr.dev}/include"
-    "NSPR_LIB_DIR=${nspr.out}/lib"
-    "NSDISTMODE=copy"
-    "BUILD_OPT=1"
-    "SOURCE_PREFIX=\$(out)"
-    "NSS_ENABLE_ECC=1"
-    "USE_SYSTEM_ZLIB=1"
-    "NSS_USE_SYSTEM_SQLITE=1"
-    "NATIVE_CC=${buildPackages.stdenv.cc}/bin/cc"
-  ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
-    # Pass in CPU even if we're not cross compiling, because otherwise it tries to guess with
-    # uname, which can be wrong if e.g. we're compiling for aarch32 on aarch64
-    "OS_TEST=${cpu}"
-    "CPU_ARCH=${cpu}"
-  ] ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "CROSS_COMPILE=1"
-    "NSS_DISABLE_GTESTS=1" # don't want to build tests when cross-compiling
-  ] ++ stdenv.lib.optional stdenv.is64bit "USE_64=1"
-    ++ stdenv.lib.optional stdenv.isDarwin "CCC=clang++";
+  buildPhase = let
+    getArch = platform: if platform.isx86_64 then "x64"
+          else if platform.isx86_32 then "ia32"
+          else if platform.isAarch32 then "arm"
+          else if platform.isAarch64 then "arm64"
+          else platform.parsed.cpu.name;
+    # yes, this is correct. nixpkgs uses "host" for the platform the binary will run on whereas nss uses "host" for the platform that the build is running on
+    target = getArch stdenv.hostPlatform;
+    host = getArch stdenv.buildPlatform;
+  in ''
+    runHook preBuild
 
-  NIX_CFLAGS_COMPILE = "-Wno-error";
+    sed -i 's|nss_dist_dir="$dist_dir"|nss_dist_dir="'$out'"|;s|nss_dist_obj_dir="$obj_dir"|nss_dist_obj_dir="'$out'"|' build.sh
+    ./build.sh -v --opt \
+      --with-nspr=${nspr.dev}/include:${nspr.out}/lib \
+      --system-sqlite \
+      --enable-legacy-db \
+      --target ${target} \
+      -Dhost_arch=${host} \
+      -Duse_system_zlib=1 \
+      ${stdenv.lib.optionalString stdenv.isDarwin "--clang"} \
+      ${stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "--disable-tests"}
 
-  # TODO(@oxij): investigate this: `make -n check` works but `make
-  # check` fails with "no rule", same for "installcheck".
-  doCheck = false;
-  doInstallCheck = false;
+    runHook postBuild
+  '';
 
-  postInstall = ''
+  NIX_CFLAGS_COMPILE = "-Wno-error -DNIX_NSS_LIBDIR=\"${placeholder "out"}/lib/\"";
+
+  installPhase = ''
+    runHook preInstall
+
     rm -rf $out/private
+    find $out -name "*.TOC" -delete
     mv $out/public $out/include
-    mv $out/*.OBJ/* $out/
-    rmdir $out/*.OBJ
 
     ln -s lib $out/lib64
 
@@ -138,6 +144,8 @@ in stdenv.mkDerivation rec {
     moveToOutput bin/nss-config "$dev"
     moveToOutput lib/libcrmf.a "$dev" # needed by firefox, for example
     rm -f "$out"/lib/*.a
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/nss/fix-cross-compilation.patch
+++ b/pkgs/development/libraries/nss/fix-cross-compilation.patch
@@ -1,0 +1,11 @@
+--- nss/nss.gyp
++++ nss/nss.gyp
+@@ -280,7 +280,7 @@
+                   'outputs/': [['exclude', 'nssdbm3']]
+                 }],
+               ],
+-              'action': ['<(python)', '<(DEPTH)/coreconf/shlibsign.py', '<@(_inputs)']
++              'action': ['true']
+             }
+           ],
+         },


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This has been out for a bit and the FireFox release due tomorrow requires 3.53+
As noted in #89438, there are some issues with this update. They were most likely introduced in https://github.com/nss-dev/nss/commit/eee8f82abbffbbd07691e5581c4c990d0a1bd317.

Looking at how we're building this, I noticed that we're using the legacy build system.
The new one depends on gyp, which depends on python2. That's not great, but at least it works.

~The patches are commented out, because with them it fails~

cc @andir @vcunat 

###### TODO
- [x] test if anything besides compiling works
- [x] fix patches
- [x] test cross compiling
- [ ] test darwin