### PR TITLE
linux_testing_bcachefs: 5.3 -> 5.7

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -11,7 +11,7 @@ buildLinux (args // {
     sha256 = "1fnyyl41fy96pn9hh65qp53jmdvygbjl2qwcvbslb5565mpm5875";
   };
 
-  extraConfig = "BCACHEFS_FS m";
+  extraConfig = "BCACHEFS_FS y";
 
   extraMeta = {
     branch = "master";

--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -7,8 +7,8 @@ buildLinux (args // {
   src = fetchFromGitHub {
     owner = "koverstreet";
     repo = "bcachefs";
-    rev = "b1708f0191fcad1b7afa47dd6a7c6b1104c4639d";
-    sha256 = "1fnyyl41fy96pn9hh65qp53jmdvygbjl2qwcvbslb5565mpm5875";
+    rev = "9f34144308fcabb5dcf718406a8c90795e6fd481";
+    sha256 = "0z1aqallj3v20w09gjd2c9hf9kin6a8gnnwpkm37abvaddjh3kf6";
   };
 
   extraConfig = "BCACHEFS_FS y";

--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -1,13 +1,14 @@
-{ stdenv, buildPackages, fetchgit, fetchpatch, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, fetchFromGitHub, fetchpatch, perl, buildLinux, ... } @ args:
 
 buildLinux (args // {
-  version = "5.3.2020.04.04";
-  modDirVersion = "5.3.0";
+  version = "5.7.2020.04.04";
+  modDirVersion = "5.7.0";
 
-  src = fetchgit {
-    url = "https://evilpiepirate.org/git/bcachefs.git";
-    rev = "a27d7265e75f6d65c2b972ce4ac27abfc153c230";
-    sha256 = "0wnjl4xs7073d5ipcsplv5qpcxb7zpfqd5gqvh3mhqc5j3qn816x";
+  src = fetchFromGitHub {
+    owner = "koverstreet";
+    repo = "bcachefs";
+    rev = "b1708f0191fcad1b7afa47dd6a7c6b1104c4639d";
+    sha256 = "1fnyyl41fy96pn9hh65qp53jmdvygbjl2qwcvbslb5565mpm5875";
   };
 
   extraConfig = "BCACHEFS_FS m";

--- a/pkgs/tools/filesystems/bcachefs-tools/default.nix
+++ b/pkgs/tools/filesystems/bcachefs-tools/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, fetchgit, pkgconfig, attr, libuuid, libscrypt, libsodium, keyutils
-, liburcu, zlib, libaio, zstd, lz4, valgrind, python3Packages
+{ stdenv, fetchFromGitHub, pkgconfig, attr, libuuid, libscrypt, libsodium, keyutils
+, liburcu, zlib, libaio, libudev, zstd, lz4, valgrind, python3Packages
 , fuseSupport ? false, fuse3 ? null }:
 
 assert fuseSupport -> fuse3 != null;
 
 stdenv.mkDerivation {
   pname = "bcachefs-tools";
-  version = "2020-04-04";
+  version = "2020-05-23";
 
-  src = fetchgit {
-    url = "https://evilpiepirate.org/git/bcachefs-tools.git";
-    rev = "5d6e237b728cfb7c3bf2cb1a613e64bdecbd740d";
-    sha256 = "1syym9k3njb0bk2mg6832cbf6r42z6y8b6hjv7dg4gmv2h7v7l7g";
+  src = fetchFromGitHub {
+    owner = "koverstreet";
+    repo = "bcachefs-tools";
+    rev = "bae7a9ae8da70447bf62b764dfd124bea9161196";
+    sha256 = "02sbbz2k1zfwiaf185z3i3jlxj29dzqinwz2n0ykf6rvr7yd18q1";
   };
+
 
   postPatch = ''
     substituteInPlace Makefile \
@@ -29,7 +31,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     libuuid libscrypt libsodium keyutils liburcu zlib libaio
-    zstd lz4 python3Packages.pytest
+    zstd lz4 python3Packages.pytest libudev
   ] ++ stdenv.lib.optional fuseSupport fuse3;
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change
Update bcachefs kernel to 5.7.0 so bcachefs users aren't stuck on 5.3

NOTE: I'm new to contributing to nixpkgs, so I'm sorry in advanced
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
