### PR TITLE
slack-cli: Add missing dependencies

### DIFF
--- a/pkgs/tools/networking/slack-cli/default.nix
+++ b/pkgs/tools/networking/slack-cli/default.nix
@@ -5,7 +5,8 @@
 # for token storage, except that it would make the Nix package inconsistent with
 # upstream and other distributions.
 
-{ stdenv, lib, fetchFromGitHub, curl, jq, runtimeShell }:
+{ stdenv, lib, fetchFromGitHub, curl, jq, coreutils, gnugrep, gnused
+, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "slack-cli";
@@ -33,7 +34,7 @@ stdenv.mkDerivation rec {
 
     MESSAGE
 
-    export PATH=${lib.makeBinPath [ curl jq ]}:"\$PATH"
+    export PATH=${lib.makeBinPath [ curl jq coreutils gnugrep gnused ]}:"\$PATH"
     exec "$out/bin/.slack-wrapped" "\$@"
     WRAPPER
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

It looks like slack-cli depends on a few more packages than `curl` and `jq`. Specifically, it spawns `dirname`, `grep` and `sed`; so it needs `coreutils`, `gnugrep` and `gnused` in `$PATH`.

It usually works on NixOS as-is since the dependencies are likely there; but in my case it was inside a docker container without those executables.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).