### PR TITLE
graphite-web: fix patch

### DIFF
--- a/nixos/tests/graphite.nix
+++ b/nixos/tests/graphite.nix
@@ -16,7 +16,7 @@ import ./make-test-python.nix ({ pkgs, ... } :
           api = {
             enable = true;
             port = 8082;
-            finders = [ pkgs.python3Packages.influxgraph ];
+            finders = [ ];
           };
           carbon.enableCache = true;
           seyren.enable = false;  # Implicitely requires openssl-1.0.2u which is marked insecure
@@ -36,10 +36,14 @@ import ./make-test-python.nix ({ pkgs, ... } :
     # even if they're still in preStart (which takes quite long for graphiteWeb).
     # Wait for ports to open so we're sure the services are up and listening.
     one.wait_for_open_port(8080)
+    one.wait_for_open_port(8082)
     one.wait_for_open_port(2003)
     one.succeed('echo "foo 1 `date +%s`" | nc -N localhost 2003')
     one.wait_until_succeeds(
         "curl 'http://localhost:8080/metrics/find/?query=foo&format=treejson' --silent | grep foo >&2"
+    )
+    one.wait_until_succeeds(
+        "curl 'http://localhost:8082/metrics/find/?query=foo&format=treejson' --silent | grep foo >&2"
     )
   '';
 })

--- a/nixos/tests/graphite.nix
+++ b/nixos/tests/graphite.nix
@@ -1,11 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... } :
 {
   name = "graphite";
-  meta = {
-    # Fails on dependency `python-2.7-Twisted`'s test suite
-    # complaining `ImportError: No module named zope.interface`.
-    broken = true;
-  };
   nodes = {
     one =
       { ... }: {

--- a/pkgs/development/python-modules/graphite-web/update-django-tagging.patch
+++ b/pkgs/development/python-modules/graphite-web/update-django-tagging.patch
@@ -1,12 +1,13 @@
-diff -Nur a/setup.py b/setup.py
---- a/setup.py	2020-03-12 18:45:34.654296302 +0100
-+++ b/setup.py	2020-03-12 18:46:17.476893828 +0100
-@@ -115,7 +115,7 @@
+diff --git a/setup.py b/setup.py
+index a1a21f1..f0d1051 100644
+--- a/setup.py
++++ b/setup.py
+@@ -117,7 +117,7 @@ try:
          ['templates/*', 'local_settings.py.example']},
        scripts=glob('bin/*'),
        data_files=list(webapp_content.items()) + storage_dirs + conf_files + examples,
--      install_requires=['Django>=1.8,<2.3', 'django-tagging==0.4.3', 'pytz', 'pyparsing', 'cairocffi', 'urllib3', 'scandir', 'six'],
-+      install_requires=['Django>=1.8,<2.3', 'django-tagging==0.4.6', 'pytz', 'pyparsing', 'cairocffi', 'urllib3', 'scandir', 'six'],
+-      install_requires=['Django>=1.8,<3.1', 'django-tagging==0.4.3', 'pytz',
++      install_requires=['Django>=1.8,<3.1', 'django-tagging==0.5.0', 'pytz',
+                         'pyparsing', 'cairocffi', 'urllib3', 'scandir', 'six'],
        classifiers=[
            'Intended Audience :: Developers',
-           'Natural Language :: English',


### PR DESCRIPTION
###### Motivation for this change

The update to 1.1.7 reformatted things, so the build broke.

The test has been disabled for a long time: the reason in the comment no longer applies now that graphite things use python3, so it now passes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
