### PR TITLE
Bloop: 1.3.4 -> 1.4.3

### DIFF
--- a/pkgs/development/tools/build-managers/bloop/default.nix
+++ b/pkgs/development/tools/build-managers/bloop/default.nix
@@ -1,81 +1,79 @@
-{ stdenv, fetchurl, coursier,
- autoPatchelfHook, 
- lib, zlib }:
+{ stdenv
+, fetchurl
+, coursier
+, autoPatchelfHook
+, lib
+, zlib
+}:
 
-let
-  baseName = "bloop";
+stdenv.mkDerivation rec {
+  pname = "bloop";
   version = "1.4.1";
 
-  client = stdenv.mkDerivation {
-    name = "${baseName}-client-${version}";
-
-    nativeBuildInputs = [ autoPatchelfHook ] ;
-    phases = [ "installPhase" "fixupPhase" ];
-    buildInputs = [ stdenv.cc.cc.lib zlib] ;
-
-    installPhase = ''
-      mkdir -p $out/bin
- 
-      export COURSIER_CACHE=$(pwd)
-      ${coursier}/bin/coursier install bloop:${version} \
-                               --repository "bintray:scalameta/maven" \
-                               --repository "bintray:scalacenter/releases" \
-                               --repository "https://oss.sonatype.org/content/repositories/staging" \
-                               --force \
-                               --install-dir $out
-    '';
-    
-    outputHashMode = "recursive";
-    outputHashAlgo = "sha256";
-    outputHash     = "01hgv0j0a4v8iqi638rcqdirpa30jwfp7gh7dvsk32apx003ylvb";
+  bloop-coursier-channel = fetchurl {
+    url = "https://github.com/scalacenter/bloop/releases/download/v${version}/bloop-coursier.json";
+    sha256 = "2e6a873183e5e22712913bfdab1331d0a7792167c369fee5be0c83e27572fe12";
   };
 
-  server = stdenv.mkDerivation {
-    name = "${baseName}-server-${version}";
-    buildCommand = ''
-      mkdir -p $out/bin
-
-      export COURSIER_CACHE=$(pwd)
-      ${coursier}/bin/coursier bootstrap ch.epfl.scala:bloop-frontend_2.12:${version} \
-                               --repository "bintray:scalameta/maven" \
-                               --repository "bintray:scalacenter/releases" \
-                               --repository "https://oss.sonatype.org/content/repositories/staging" \
-                               --deterministic \
-                               --force \
-                               --main bloop.Server \
-                               --output $out/blp-server
-    '';
-    outputHashMode = "recursive";
-    outputHashAlgo = "sha256";
-    outputHash     = "01kyzb374kyicm1nmx6vzz42gj8cd9m6bd5dgrajkcr6q09jfgbg";
+  bloop-bash = fetchurl {
+    url = "https://github.com/scalacenter/bloop/releases/download/v${version}/bash-completions";
+    sha256 = "da6b7ecd4109bd0ff98b1c452d9dd9d26eee0d28ff604f6c83fb8d3236a6bdd1";
   };
 
-  zsh = stdenv.mkDerivation {
-    name = "${baseName}-zshcompletion-${version}";
+  bloop-fish = fetchurl {
+    url = "https://github.com/scalacenter/bloop/releases/download/v${version}/fish-completions";
+    sha256 = "1pa8h81l2498q8dbd83fzipr99myjwxpy8xdgzhvqzdmfv6aa4m0";
+  };
 
-    src = fetchurl {
-      url = "https://raw.githubusercontent.com/scalacenter/bloop/v${version}/etc/zsh/_bloop";
-      sha256 = "1xzg0qfkjdmzm3mvg82mc4iia8cl7b6vbl8ng4ir2xsz00zjrlsq";
-    };
+  bloop-zsh = fetchurl {
+    url = "https://github.com/scalacenter/bloop/releases/download/v${version}/zsh-completions";
+    sha256 = "1xzg0qfkjdmzm3mvg82mc4iia8cl7b6vbl8ng4ir2xsz00zjrlsq";
+  };
+
+  bloop-coursier = stdenv.mkDerivation {
+    name = "${pname}-coursier-${version}";
 
     phases = [ "installPhase" ];
+    installPhase = ''
+      export COURSIER_CACHE=$(pwd)
+      export COURSIER_JVM_CACHE=$(pwd)
 
-    installPhase = ''cp $src $out'';
+      mkdir channel
+      ln -s ${bloop-coursier-channel} channel/bloop.json
+      ${coursier}/bin/coursier install --install-dir $out --default-channels=false --channel channel --only-prebuilt=true bloop
+
+      # Remove binary part of the coursier launcher script to make derivation output hash stable
+      sed -i '5,$ d' $out/bloop
+   '';
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash     = "17jskljn0aspvl7s2hadzjmp05blnsrxi8db8pn3lfw40da4yn79";
   };
-in
-stdenv.mkDerivation {
-  name = "${baseName}-${version}";
 
-  phases = [ "installPhase" ];
+  nativeBuildInputs = [ autoPatchelfHook ] ;
+  phases = [ "installPhase" "fixupPhase" ];
+  buildInputs = [ stdenv.cc.cc.lib zlib ] ;
 
   installPhase = ''
+    export COURSIER_CACHE=$(pwd)
+    export COURSIER_JVM_CACHE=$(pwd)
+
     mkdir -p $out/bin
+    cp ${bloop-coursier}/bloop $out/bloop
+    cp ${bloop-coursier}/.bloop.aux $out/.bloop.aux
+    ln -s $out/bloop $out/bin/bloop
+
+    # patch the bloop launcher so that it works when symlinked
+    sed "s|\$(dirname \"\$0\")|$out|" -i $out/bloop
+
+    #Install completions
+    mkdir -p $out/etc/bash_completion.d
+    ln -s ${bloop-bash} $out/etc/bash_completion.d/bloop
     mkdir -p $out/share/zsh/site-functions
-
-    ln -s ${server}/blp-server $out/bin/blp-server
-
-    ln -s ${zsh} $out/share/zsh/site-functions/_bloop
-    ln -s ${client}/.bloop.aux $out/bin/bloop
+    ln -s ${bloop-zsh} $out/share/zsh/site-functions/_bloop
+    mkdir -p $out/usr/share/fish/vendor_completions.d/
+    ln -s ${bloop-fish} $out/usr/share/fish/vendor_completions.d/bloop.fish
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/build-managers/bloop/default.nix
+++ b/pkgs/development/tools/build-managers/bloop/default.nix
@@ -8,16 +8,16 @@
 
 stdenv.mkDerivation rec {
   pname = "bloop";
-  version = "1.4.1";
+  version = "1.4.3";
 
   bloop-coursier-channel = fetchurl {
     url = "https://github.com/scalacenter/bloop/releases/download/v${version}/bloop-coursier.json";
-    sha256 = "2e6a873183e5e22712913bfdab1331d0a7792167c369fee5be0c83e27572fe12";
+    sha256 = "0abl91l2sb08pwr98mw910zibzwk6lss9r62h2s3g7qnnxp3z59r";
   };
 
   bloop-bash = fetchurl {
     url = "https://github.com/scalacenter/bloop/releases/download/v${version}/bash-completions";
-    sha256 = "da6b7ecd4109bd0ff98b1c452d9dd9d26eee0d28ff604f6c83fb8d3236a6bdd1";
+    sha256 = "1ldxlqv353gvhdn4yq7z506ywvnjv6fjsi8wigwhzg89876pwsys";
   };
 
   bloop-fish = fetchurl {
@@ -42,13 +42,14 @@ stdenv.mkDerivation rec {
       ln -s ${bloop-coursier-channel} channel/bloop.json
       ${coursier}/bin/coursier install --install-dir $out --default-channels=false --channel channel --only-prebuilt=true bloop
 
+
       # Remove binary part of the coursier launcher script to make derivation output hash stable
       sed -i '5,$ d' $out/bloop
    '';
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash     = "17jskljn0aspvl7s2hadzjmp05blnsrxi8db8pn3lfw40da4yn79";
+    outputHash     = "1ncl34f39mvk0zb5jl1l77cwjdg3xfnhjxbzz11pdfqw0d7wqywj";
   };
 
   nativeBuildInputs = [ autoPatchelfHook ] ;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Updates bloop from 1.3.4 to 1.4.2.

During the 1.4.+ upgrade, bloop has changed the way it is packaged. While the previous way of packaging it still works, bloop now uses graalvm native images in other distributions. This PR updates the derivation in order to be as close as possible to the way bloop is packaged in the [archlinux user repository](https://github.com/scalacenter/bloop/blob/fa89510f50545e331318950e4555033174c090c5/project/ReleaseUtils.scala#L298)

This PR should supersedes #89359, commits and attributions have been kept.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
