### PR TITLE
littlegptracker: init at unstable-2019-04-14

### DIFF
--- a/pkgs/applications/audio/littlegptracker/0001-Remove-coherency-checks.patch
+++ b/pkgs/applications/audio/littlegptracker/0001-Remove-coherency-checks.patch
@@ -1,0 +1,52 @@
+From 2e1e9b3ffce9d1069fca0b27b8011f85c7547c3b Mon Sep 17 00:00:00 2001
+From: Francesco Gazzetta <fgaz@fgaz.me>
+Date: Wed, 19 Aug 2020 15:06:19 +0200
+Subject: [PATCH 1/2] Remove coherency checks >:)
+
+As far as I can see, they are just to make sure that the types can fit
+in the word length, but this check was written when 64 bits weren't a
+possibility and didn't take that into account,
+so although the types do fit, the checks fail.
+Indeed, the program seems to work well on 64 bits.
+More info here:
+https://github.com/Mdashdotdashn/LittleGPTracker/issues/4
+---
+ sources/Externals/Soundfont/DATATYPE.H | 22 ----------------------
+ 1 file changed, 22 deletions(-)
+
+diff --git a/sources/Externals/Soundfont/DATATYPE.H b/sources/Externals/Soundfont/DATATYPE.H
+index 762a724..f6b031f 100644
+--- a/sources/Externals/Soundfont/DATATYPE.H
++++ b/sources/Externals/Soundfont/DATATYPE.H
+@@ -123,28 +123,6 @@ typedef short               SHORT;     /* 16 bit signed value was: INT */
+ ********************************************************************/
+ typedef unsigned short        EMUSTAT;
+ 
+-/********************************************************************
+-* Compare <limits.h> values with SoundFont Enabler limits.  Fail compile
+-* if discrepency. If compile fails due to one of these errors, then
+-* the SoundFont enabler will not work with your system or the state of your
+-* development environment.
+-********************************************************************/
+-#if (SCHAR_MAX != CHAR_MAXVAL) || (UCHAR_MAX != BYTE_MAXVAL)
+-  #error <datatype.h>: char is out of range!
+-#endif
+-
+-#if (SHRT_MAX != SHRT_MAXVAL)
+-  #error <datatype.h>: short is out of range!
+-#endif
+-
+-#if (LONG_MAX != LONG_MAXVAL)
+-  #error <datatype.h>: long is out of range!
+-#endif
+-
+-#if (ULONG_MAX != DWORD_MAXVAL)
+-  #error <datatype.h>: unsigned long is out of range!
+-#endif
+-
+ #ifdef __BYTE_COHERENT
+ 
+ /********************************************************************
+-- 
+2.25.4
+

--- a/pkgs/applications/audio/littlegptracker/0002-Set-the-initial-directory-to-the-current-directory.patch
+++ b/pkgs/applications/audio/littlegptracker/0002-Set-the-initial-directory-to-the-current-directory.patch
@@ -1,0 +1,27 @@
+From c3865405ca707e3284a81709577d85ce2b3db72c Mon Sep 17 00:00:00 2001
+From: Francesco Gazzetta <fgaz@fgaz.me>
+Date: Wed, 19 Aug 2020 15:06:58 +0200
+Subject: [PATCH 2/2] Set the initial directory to the current directory
+
+otherwise the user has to navigate from the nix store, which makes the program
+crash due to its size
+---
+ sources/Adapters/DEB/System/DEBSystem.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sources/Adapters/DEB/System/DEBSystem.cpp b/sources/Adapters/DEB/System/DEBSystem.cpp
+index 6e86693..65d2cdd 100644
+--- a/sources/Adapters/DEB/System/DEBSystem.cpp
++++ b/sources/Adapters/DEB/System/DEBSystem.cpp
+@@ -54,7 +54,7 @@ void DEBSystem::Boot(int argc,char **argv) {
+ 	}
+ 	Path::SetAlias("bin",dirname(buff)) ;
+ 
+-	Path::SetAlias("root","bin:..") ;
++	Path::SetAlias("root",".") ;
+ 
+ #ifdef _DEBUG
+   Trace::GetInstance()->SetLogger(*(new StdOutLogger()));
+-- 
+2.25.4
+

--- a/pkgs/applications/audio/littlegptracker/default.nix
+++ b/pkgs/applications/audio/littlegptracker/default.nix
@@ -1,0 +1,72 @@
+{ stdenv
+, fetchFromGitHub
+, SDL
+, jack2
+, Foundation
+}:
+
+stdenv.mkDerivation rec {
+  pname = "littlegptracker";
+  version = "unstable-2019-04-14";
+
+  src = fetchFromGitHub {
+    owner = "Mdashdotdashn";
+    repo = "littlegptracker";
+    rev = "0ed729b46739e3df5e111c6fa4d548fde2d3b891";
+    sha256 = "1pc6lg2qp6xh7ahs5d5pb63ms4h2dz7ryp3c7mci4g37gbwbsj5b";
+  };
+
+  buildInputs = [
+    SDL
+  ]
+  ++ stdenv.lib.optional stdenv.isDarwin Foundation
+  ++ stdenv.lib.optional stdenv.isLinux jack2;
+
+  patches = [
+    # Remove outdated (pre-64bit) checks that would fail on modern platforms
+    # (see description in patch file)
+    ./0001-Remove-coherency-checks.patch
+    # Set starting directory to cwd, default is in /nix/store and causes a crash
+    # (see description in patch file)
+    ./0002-Set-the-initial-directory-to-the-current-directory.patch
+  ];
+
+  preBuild = "cd projects";
+
+  makeFlags = [ "CXX=${stdenv.cc.targetPrefix}c++" ]
+    ++ stdenv.lib.optionals stdenv.isLinux  [ "PLATFORM=DEB" ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ "PLATFORM=OSX" ];
+
+  NIX_CFLAGS_COMPILE = [ "-fpermissive" ] ++
+    stdenv.lib.optional stdenv.hostPlatform.isAarch64 "-Wno-error=narrowing";
+
+  NIX_LDFLAGS = stdenv.lib.optional stdenv.isDarwin "-framework Foundation";
+
+  installPhase = let extension = if stdenv.isDarwin then "app" else "deb-exe";
+    in "install -Dm555 lgpt.${extension} $out/bin/lgpt";
+
+  meta = with stdenv.lib; {
+    description = "A music tracker similar to lsdj optimised to run on portable game consoles";
+    longDescription = ''
+      LittleGPTracker (a.k.a 'The piggy', 'lgpt') is a music tracker optimised
+      to run on portable game consoles. It is currently running on Game Park's
+      GP2x & Caanoo, PSP, Dingoo, Windows, Mac OSX (intel/ppc) & Linux (Debian).
+
+      It implements the user interface of littlesounddj, a very famous tracker
+      for the Gameboy platform that has been tried and tested by many users over
+      the years, leading to a little complex but yet extremely efficent way of
+      working.
+
+      Piggy currently supports 8 monophonic 16Bit/44.1Khz stereo sample playback
+      channels. Additionally, the program can drive MIDI instruments (with the
+      gp32 and gp2x a custom MIDI interface is required).
+    '';
+    homepage = "http://www.littlegptracker.com/";
+    downloadPage = "http://www.littlegptracker.com/download.php";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+    # https://github.com/NixOS/nixpkgs/pull/91766#issuecomment-688751821
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21142,6 +21142,10 @@ in
 
   linuxband = callPackage ../applications/audio/linuxband { };
 
+  littlegptracker = callPackage ../applications/audio/littlegptracker {
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  };
+
   ledger = callPackage ../applications/office/ledger { };
 
   ledger-autosync = callPackage  ../applications/office/ledger-autosync { };


### PR DESCRIPTION
##### Motivation for this change

#81815

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/marvin opt-in
/marvin needs_review