### PR TITLE
shattered-pixel-dungeon: 0.8.0b -> 0.8.1

### DIFF
--- a/pkgs/games/shattered-pixel-dungeon/default.nix
+++ b/pkgs/games/shattered-pixel-dungeon/default.nix
@@ -9,13 +9,13 @@
 
 let
   pname = "shattered-pixel-dungeon";
-  version = "0.8.0b";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "00-Evan";
     repo = "shattered-pixel-dungeon";
     rev = "v${version}";
-    sha256 = "1qi90qw2xp56wai4gn39rpwh3gs3kx2zcpbni861f7hl9hnf87bf";
+    sha256 = "1n459xdvqf974hs91xfq5fdj29s4w5w83dg3m2vp7gqmrmm2jykf";
   };
 
   postPatch = ''


### PR DESCRIPTION
##### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
