### PR TITLE
ocaml-ng.ocamlPackages_4_11.ocaml: 4.11.0+α3 → 4.11.0+β1

### DIFF
--- a/pkgs/development/compilers/ocaml/4.11.nix
+++ b/pkgs/development/compilers/ocaml/4.11.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "11";
-  patch_version = "0+alpha3";
-  sha256 = "0c2g8ncq15nx9pdl14hnsc9342j80s7i1bsyiw98cvgic5miyw9b";
+  patch_version = "0+beta1";
+  sha256 = "1xhkwprbnd3wp6bi3k74f42l1mff1ngn7gl4rgad9dk4ly0yzfdr";
 }


### PR DESCRIPTION
###### Motivation for this change

Announcement: https://inbox.ocaml.org/caml-list/c3b58aec-fc46-4e32-5a67-8daf66dfc2e5@inria.fr/T/#u

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
