### PR TITLE
pango: 1.44.7 -> 1.45.3

### DIFF
--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -9,14 +9,25 @@ with stdenv.lib;
 
 let
   pname = "pango";
-  version = "1.44.7";
+  version = "1.45.3";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "07qvxa2sk90chp1l12han6vxvy098mc37sdqcznyywyv2g6bd9b6";
+    sha256 = "0zg6gvzk227q997jf1c9p7j5ra87nm008hlgq6q8na9xmgmw2x8z";
   };
+
+  patches = [
+    # Fix issue with Pango loading unsupported formats that
+    # breaks mixed x11/opentype font packages.
+    # See https://gitlab.gnome.org/GNOME/pango/issues/457
+    # Remove on next release.
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/pango/commit/fe1ee773310bac83d8e5d3c062b13a51fb5fb4ad.patch";
+      sha256 = "1px66g31l2jx4baaqi4md59wlmvw0ywgspn6zr919fxl4h1kkh0h";
+    })
+  ];
 
   # FIXME: docs fail on darwin
   outputs = [ "bin" "dev" "out" ] ++ optional (!stdenv.isDarwin) "devdoc";


### PR DESCRIPTION
###### Motivation for this change
This update is needed to cleanly apply a patch, which fixes the issue that required to split the outputs of type1 bitmap fonts.
See #75160 for why this is needed.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test
- [ ] Tested compilation of all pkgs that depend on this change
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (for harfbuzz, mostly negligible)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

For now I've built a VM with xfce and tested a couple GTK applications.

