### PR TITLE
cloud-utils: 0.30 -> 0.31

### DIFF
--- a/pkgs/tools/misc/cloud-utils/default.nix
+++ b/pkgs/tools/misc/cloud-utils/default.nix
@@ -8,10 +8,10 @@ stdenv.mkDerivation rec {
   # $ nix-build nixos/release-combined.nix -A nixos.tests.ec2-nixops
   # growpart is needed in initrd in nixos/system/boot/grow-partition.nix
   pname = "cloud-utils";
-  version = "0.30";
+  version = "0.31";
   src = fetchurl {
-    url = "https://launchpad.net/cloud-utils/trunk/0.3/+download/cloud-utils-${version}.tar.gz";
-    sha256 = "19ca9ckwwsvlqrjz19bc93rq4gv3y4ak7551li2qk95caqyxsq3k";
+    url = "https://launchpad.net/cloud-utils/trunk/${version}/+download/cloud-utils-${version}.tar.gz";
+    sha256 = "07fl3dlqwdzw4xx7mcxhpkks6dnmaxha80zgs9f6wmibgzni8z0r";
   };
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ python3 ];


### PR DESCRIPTION
###### Motivation for this change

upgrade!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).