### PR TITLE
ocamlPackages.index: 1.2.0 → 1.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/index/default.nix
+++ b/pkgs/development/ocaml-modules/index/default.nix
@@ -1,18 +1,18 @@
-{ lib, fetchurl, buildDunePackage, fmt, logs, stdlib-shims }:
+{ lib, fetchurl, buildDunePackage, fmt, logs, mtime, stdlib-shims }:
 
 buildDunePackage rec {
   pname = "index";
-  version = "1.2.0";
+  version = "1.2.1";
 
   minimumOCamlVersion = "4.07";
 
   src = fetchurl {
     url = "https://github.com/mirage/index/releases/download/${version}/index-${version}.tbz";
-    sha256 = "0d44s1d2mpxvpg0zh57c928wf1w1wd33l1fw5r62al5zmi710ff6";
+    sha256 = "1a9b6rsazrjy07syxl9ix5002i95mlvx5vk7nl2x9cs6s0zw906d";
   };
 
   buildInputs = [ stdlib-shims ];
-  propagatedBuildInputs = [ fmt logs ];
+  propagatedBuildInputs = [ fmt logs mtime ];
 
   meta = {
     homepage = "https://github.com/mirage/index";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/mirage/index/releases/tag/1.2.1>, necessary for latest irmin release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
