### PR TITLE
ocamlPackages.webmachine: 0.6.1 → 0.6.2

### DIFF
--- a/pkgs/development/ocaml-modules/webmachine/default.nix
+++ b/pkgs/development/ocaml-modules/webmachine/default.nix
@@ -5,7 +5,7 @@
 
 buildDunePackage rec {
   pname = "webmachine";
-  version = "0.6.1";
+  version = "0.6.2";
 
   minimumOCamlVersion = "4.04";
 
@@ -13,7 +13,7 @@ buildDunePackage rec {
     owner = "inhabitedtype";
     repo = "ocaml-webmachine";
     rev = "${version}";
-    sha256 = "0kpbxsvjzylbxmxag77k1c8m8mwn4f4xscqk2i7fc591llgq9fp3";
+    sha256 = "1zi1vsm589y2njwzsqkmdbxvs9s4xlgbd62xqw2scp60mccp09nk";
   };
 
   propagatedBuildInputs = [ cohttp dispatch ptime ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/inhabitedtype/ocaml-webmachine/releases/tag/0.6.2>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
