### PR TITLE
ocamlPackages.irmin*: 2.1.0 → 2.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/irmin/default.nix
+++ b/pkgs/development/ocaml-modules/irmin/default.nix
@@ -1,31 +1,22 @@
 { lib, fetchurl, buildDunePackage
 , astring, base64, digestif, fmt, jsonm, logs, ocaml_lwt, ocamlgraph, uri
-, alcotest, hex
+, alcotest, hex, ppx_irmin
 }:
 
-buildDunePackage rec {
-
+buildDunePackage {
   pname = "irmin";
-  version = "2.1.0";
 
+  inherit (ppx_irmin) src version;
+
+  useDune2 = true;
   minimumOCamlVersion = "4.07";
-
-  src = fetchurl {
-    url = "https://github.com/mirage/irmin/releases/download/${version}/irmin-${version}.tbz";
-    sha256 = "1ji8r7zbdmhbk8r8w2hskd9z7pnvirzbhincfxndxgdaxbfkff5g";
-  };
 
   propagatedBuildInputs = [ astring base64 digestif fmt jsonm logs ocaml_lwt ocamlgraph uri ];
 
-  checkInputs = lib.optionals doCheck [ alcotest hex ];
-
+  checkInputs = [ alcotest hex ppx_irmin ];
   doCheck = true;
 
-  meta = {
-    homepage = "https://irmin.org/";
+  meta = ppx_irmin.meta // {
     description = "A distributed database built on the same principles as Git";
-    license = lib.licenses.isc;
-    maintainers = [ lib.maintainers.vbgl ];
   };
-
 }

--- a/pkgs/development/ocaml-modules/irmin/fs.nix
+++ b/pkgs/development/ocaml-modules/irmin/fs.nix
@@ -8,6 +8,8 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ irmin ];
 
+  useDune2 = true;
+
   checkInputs = lib.optional doCheck irmin-test;
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/irmin/graphql.nix
+++ b/pkgs/development/ocaml-modules/irmin/graphql.nix
@@ -10,7 +10,8 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ cohttp-lwt graphql-cohttp graphql-lwt irmin ];
 
-  doCheck = true;
+  # test requires network
+  doCheck = false;
 
   meta = irmin.meta // {
     description = "GraphQL server for Irmin";

--- a/pkgs/development/ocaml-modules/irmin/mem.nix
+++ b/pkgs/development/ocaml-modules/irmin/mem.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
 
   inherit (irmin) version src;
 
+  useDune2 = true;
+
   propagatedBuildInputs = [ irmin ];
 
   checkInputs = lib.optional doCheck irmin-test;

--- a/pkgs/development/ocaml-modules/irmin/pack.nix
+++ b/pkgs/development/ocaml-modules/irmin/pack.nix
@@ -7,6 +7,8 @@ buildDunePackage rec {
 
   inherit (irmin) version src;
 
+  useDune2 = true;
+
   propagatedBuildInputs = [ index irmin ocaml_lwt ];
 
   checkInputs = lib.optionals doCheck [ alcotest-lwt irmin-test ];

--- a/pkgs/development/ocaml-modules/irmin/ppx.nix
+++ b/pkgs/development/ocaml-modules/irmin/ppx.nix
@@ -1,16 +1,29 @@
-{ lib, buildDunePackage, ppxlib, ocaml-syntax-shims, irmin }:
+{ lib, fetchurl, buildDunePackage, ppxlib, ocaml-syntax-shims }:
 
-buildDunePackage {
+buildDunePackage rec {
   pname = "ppx_irmin";
+  version = "2.2.0";
 
-  inherit (irmin) version src minimumOCamlVersion;
+  src = fetchurl {
+    url = "https://github.com/mirage/irmin/releases/download/${version}/irmin-${version}.tbz";
+    sha256 = "0gzw918b661qkvd140hilww9jsc49rxsxz1k4iihyvikjn202km4";
+  };
+
+  minimumOCamlVersion = "4.06";
 
   useDune2 = true;
 
   buildInputs = [ ocaml-syntax-shims ];
   propagatedBuildInputs = [ ppxlib ];
 
-  meta = irmin.meta // {
+  # tests depend on irmin, would create mutual dependency
+  # opt to test irmin instead of ppx_irmin
+  doCheck = false;
+
+  meta = {
+    homepage = "https://irmin.org/";
     description = "PPX deriver for Irmin generics";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/irmin/test.nix
+++ b/pkgs/development/ocaml-modules/irmin/test.nix
@@ -6,6 +6,8 @@ buildDunePackage {
 
   inherit (irmin) version src;
 
+  useDune2 = true;
+
   propagatedBuildInputs = [ alcotest cmdliner irmin metrics-unix mtime ];
 
   meta = irmin.meta // {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

new major release <https://github.com/mirage/irmin/releases/tag/2.2.0>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
