### PR TITLE
python3Packages.{confuse,mediafile}: init

### DIFF
--- a/pkgs/development/python-modules/confuse/default.nix
+++ b/pkgs/development/python-modules/confuse/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonPackage
+, enum34
+, fetchPypi
+, isPy27
+, lib
+, pathlib
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "confuse";
+  version = "1.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-kvwEUcbiwnMqw2PQ9Z1+pgir3b7QYt2o6Y6ajJhs5GQ=";
+  };
+
+  propagatedBuildInputs = [ pyyaml ] ++ lib.optionals isPy27 [ enum34 pathlib ] ;
+
+  meta = with lib; {
+    description = "Confuse is a configuration library for Python that uses YAML.";
+    homepage = "https://github.com/beetbox/confuse";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lovesegfault ];
+  };
+}

--- a/pkgs/development/python-modules/mediafile/default.nix
+++ b/pkgs/development/python-modules/mediafile/default.nix
@@ -1,0 +1,44 @@
+{ buildPythonPackage
+, enum34
+, fetchpatch
+, fetchPypi
+, isPy27
+, lib
+, mutagen
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "mediafile";
+  version = "0.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-o/tSAHu8FTr6LZoMHvegr9uCZovNLHS9KkP2U9y4uko=";
+  };
+
+  propagatedBuildInputs = [ mutagen six ] ++ lib.optional isPy27 enum34;
+
+  # NB: Remove in the next release
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/beetbox/mediafile/commit/0ff753d493a1a7f406cb3378545ffe2c85a9afa3.patch";
+      sha256 = "sha256-AQ7YedoYPmLqt4a/odgghIKOY61i9YfA0To0RVFqlk8=";
+    })
+    (fetchpatch {
+      url = "https://github.com/beetbox/mediafile/commit/f0fb4e5111d9dfaa3b38d196ec41fcd237d97953.patch";
+      sha256 = "sha256-5O6RiAqkQEz3Bvqjwwv/LOS33nSIBnT2H/vasGGVrpI=";
+    })
+    (fetchpatch {
+      url = "https://github.com/beetbox/mediafile/commit/d2fc3b59f77c515b02dfe7ad936f89264375d2b4.patch";
+      sha256 = "sha256-SMH0XhCaKLDNB4M8VmZWfGuuelfY5xladZyQYtXtP18=";
+    })
+  ];
+
+  meta = with lib; {
+    description = "MediaFile is a simple interface to the metadata tags for many audio file formats.";
+    homepage = "https://github.com/beetbox/mediafile";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lovesegfault ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3810,6 +3810,8 @@ in {
 
   mechanize = callPackage ../development/python-modules/mechanize { };
 
+  mediafile = callPackage ../development/python-modules/mediafile { };
+
   meinheld = callPackage ../development/python-modules/meinheld { };
 
   meld3 = callPackage ../development/python-modules/meld3 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1332,6 +1332,8 @@ in {
 
   confluent-kafka = callPackage ../development/python-modules/confluent-kafka { };
 
+  confuse = callPackage ../development/python-modules/confuse { };
+
   connexion = callPackage ../development/python-modules/connexion { };
 
   consonance = callPackage ../development/python-modules/consonance { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
These will soon be needed for a new release of beets

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
