### PR TITLE
make-desktopitem: refactoring, documentation and improvement

### DIFF
--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -1,50 +1,58 @@
 { lib, runCommandLocal, desktop-file-utils }:
 
-{ name
+# See https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
+{ name # The name of the desktop file
 , type ? "Application"
 , exec
 , icon ? null
 , comment ? null
 , terminal ? "false"
-, desktopName
+, desktopName # The name of the application
 , genericName ? null
 , mimeType ? null
 , categories ? null
 , startupNotify ? null
-, extraEntries ? null
+, extraDesktopEntries ? {} # Extra key-value pairs to add to the [Desktop Entry] section. This may override other values
+, extraEntries ? "" # Extra configuration. Will be appended to the end of the file and may thus contain extra sections
 , fileValidation ? true # whether to validate resulting desktop file.
 }:
 
 let
-  optionalEntriesList = [{k="Icon";          v=icon;}
-                         {k="Comment";       v=comment;}
-                         {k="GenericName";   v=genericName;}
-                         {k="MimeType";      v=mimeType;}
-                         {k="Categories";    v=categories;}
-                         {k="StartupNotify"; v=startupNotify;}];
+  # like builtins.toString, but null -> null instead of null -> ""
+  nullableToString = value: if value == null then null else builtins.toString value;
 
-  valueNotNull = {k, v}: v != null;
-  entriesToKeep = builtins.filter valueNotNull optionalEntriesList;
+  # The [Desktop entry] section of the desktop file, as attribute set.
+  mainSection = {
+    "Type" = toString type;
+    "Exec" = (nullableToString exec);
+    "Icon" = (nullableToString icon);
+    "Comment" = (nullableToString comment);
+    "Terminal" = (nullableToString terminal);
+    "Name" = toString name;
+    "GenericName" = (nullableToString genericName);
+    "MimeType" = (nullableToString mimeType);
+    "Categories" = (nullableToString categories);
+    "StartupNotify" = (nullableToString startupNotify);
+  } // extraDesktopEntries;
 
-  mkEntry = {k, v}:  k + "=" + v;
-  optionalEntriesString  = lib.concatMapStringsSep "\n" mkEntry entriesToKeep;
+  # Map all entries to a list of lines
+  desktopFileStrings =
+    ["[Desktop Entry]"]
+    ++ builtins.filter
+      (v: v != null)
+      (lib.mapAttrsToList
+        (name: value: if value != null then "${name}=${value}" else null)
+        mainSection
+      )
+    ++ (if extraEntries == "" then [] else ["${extraEntries}"]);
 in
 runCommandLocal "${name}.desktop" {}
-  ''
+  (''
     mkdir -p "$out/share/applications"
     cat > "$out/share/applications/${name}.desktop" <<EOF
-    [Desktop Entry]
-    Type=${type}
-    Exec=${exec}
-    Terminal=${terminal}
-    Name=${desktopName}
-    ${optionalEntriesString}
-    ${if extraEntries == null then ''EOF'' else ''
-    ${extraEntries}
-    EOF''}
-
-    ${lib.optionalString fileValidation ''
-      echo "Running desktop-file validation"
-      ${desktop-file-utils}/bin/desktop-file-validate "$out/share/applications/${name}.desktop"
-    ''}
-  ''
+    ${builtins.concatStringsSep "\n" desktopFileStrings}
+    EOF
+  '' + lib.optionalString fileValidation ''
+    echo "Running desktop-file validation"
+    ${desktop-file-utils}/bin/desktop-file-validate "$out/share/applications/${name}.desktop"
+  '')

--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -6,7 +6,7 @@
 , exec
 , icon ? null
 , comment ? null
-, terminal ? "false"
+, terminal ? false
 , desktopName # The name of the application
 , genericName ? null
 , mimeType ? null
@@ -19,20 +19,22 @@
 
 let
   # like builtins.toString, but null -> null instead of null -> ""
-  nullableToString = value: if value == null then null else builtins.toString value;
+  nullableToString = value: if value == null then null
+        else if builtins.isBool value then lib.boolToString value
+        else builtins.toString value;
 
   # The [Desktop entry] section of the desktop file, as attribute set.
   mainSection = {
     "Type" = toString type;
-    "Exec" = (nullableToString exec);
-    "Icon" = (nullableToString icon);
-    "Comment" = (nullableToString comment);
-    "Terminal" = (nullableToString terminal);
+    "Exec" = nullableToString exec;
+    "Icon" = nullableToString icon;
+    "Comment" = nullableToString comment;
+    "Terminal" = nullableToString terminal;
     "Name" = toString name;
-    "GenericName" = (nullableToString genericName);
-    "MimeType" = (nullableToString mimeType);
-    "Categories" = (nullableToString categories);
-    "StartupNotify" = (nullableToString startupNotify);
+    "GenericName" = nullableToString genericName;
+    "MimeType" = nullableToString mimeType;
+    "Categories" = nullableToString categories;
+    "StartupNotify" = nullableToString startupNotify;
   } // extraDesktopEntries;
 
   # Map all entries to a list of lines


### PR DESCRIPTION
###### Motivation for this change

- New parameter `extraDesktopEntries` to easily add some less usual entries to the desktop file
- Rewrite of the core logic. Instead of a key-value-list, use an attribute set with nullable values to make it overridable
- Added some comments
- Some cosmetic/readability code refactors
	- I didn't like the doubly nested strings around the `fileValidation`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
