### PR TITLE
esphome: 1.14.4 -> 1.14.5

### DIFF
--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -23,7 +23,7 @@ in python.pkgs.buildPythonApplication rec {
   propagatedBuildInputs = with python.pkgs; [
     voluptuous pyyaml paho-mqtt colorlog
     tornado protobuf tzlocal pyserial ifaddr
-    protobuf
+    protobuf click
   ];
 
   # remove all version pinning (E.g tornado==5.1.1 -> tornado)

--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -18,11 +18,11 @@ let
 
 in python.pkgs.buildPythonApplication rec {
   pname = "esphome";
-  version = "1.14.4";
+  version = "1.14.5";
 
   src = python.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "10krdmpbafvii0qlg5w94vdv573f3zdqm78ck79d6q0frdd9q9yn";
+    sha256 = "176mi361677d5cqbi0hn52kky845byjs6gdad8pdhihyjgv7a9y9";
   };
 
   ESPHOME_USE_SUBPROCESS = "";

--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -1,18 +1,11 @@
-{ lib, python3, platformio, esptool, git, protobuf3_10, fetchpatch }:
+{ lib, python3, platformio, esptool, git, protobuf3_11, fetchpatch }:
 
 let
   python = python3.override {
     packageOverrides = self: super: {
       protobuf = super.protobuf.override {
-        protobuf = protobuf3_10;
+        protobuf = protobuf3_11;
       };
-      pyyaml = super.pyyaml.overridePythonAttrs (oldAttrs: rec {
-        version = "5.1.2";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "1r5faspz73477hlbjgilw05xsms0glmsa371yqdd26znqsvg1b81";
-        };
-      });
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

> esphome: Fix ESP32 interrupt enable/disable switched (cherry-picked)

https://github.com/esphome/esphome/releases/tag/v1.14.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
