### PR TITLE
gperftools: fix build on ARM

### DIFF
--- a/pkgs/development/libraries/gperftools/default.nix
+++ b/pkgs/development/libraries/gperftools/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1jb30zxmw7h9qxa8yi76rfxj4ssk60rv8n9y41m6pzqfk9lwis0y";
   };
 
-  buildInputs = stdenv.lib.optional stdenv.isLinux libunwind;
+  # tcmalloc uses libunwind in a way that works correctly only on non-ARM linux
+  buildInputs = stdenv.lib.optional (stdenv.isLinux && !(stdenv.isAarch64 || stdenv.isAarch32)) libunwind;
 
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace Makefile.am --replace stdc++ c++


### PR DESCRIPTION
###### Motivation for this change

The default use of `libunwind` by `tcmalloc` segfaults on ARM. For example, starting mongodb immediately crashes (I'll include the backtrace below, for future searches).

This fix removes the use of `libunwind` on ARM. I've verified this fixes mongodb on aarch64. Other [descriptions of the issue](https://www.dcddcc.com/blog/2018-06-09-building-mongodb-for-32-bit-ARM-on-debian-ubuntu.html#problem-6-tcmalloc-and-libunwind) say this exact problem also hits aarch32, so the diff covers both architecture variants.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Backtrace

Without this fix, this is my backtrace when mongodb crashes on start, on aarch64:

```
#0  0x0000007faaedf934 in access_mem () from /nix/store/800ilx46h9s56yr24z73y4ppjlgninxb-libunwind-1.4.0/lib/libunwind.so.8
#1  0x0000007faaee022c in _ULaarch64_is_signal_frame () from /nix/store/800ilx46h9s56yr24z73y4ppjlgninxb-libunwind-1.4.0/lib/libunwind.so.8
#2  0x0000007faaee0834 in _ULaarch64_step () from /nix/store/800ilx46h9s56yr24z73y4ppjlgninxb-libunwind-1.4.0/lib/libunwind.so.8
#3  0x0000007fab8f82e8 in GetStackTrace_libunwind(void**, int, int) [clone .part.0] ()
   from /nix/store/z0k99bd8s25qryw29h5kkmljyqdz7lya-gperftools-2.7/lib/libtcmalloc.so.4
#4  0x0000007fab8f86c0 in GetStackTrace(void**, int, int) ()
   from /nix/store/z0k99bd8s25qryw29h5kkmljyqdz7lya-gperftools-2.7/lib/libtcmalloc.so.4
#5  0x0000007fab8e8fd8 in tcmalloc::PageHeap::GrowHeap(unsigned long) ()
   from /nix/store/z0k99bd8s25qryw29h5kkmljyqdz7lya-gperftools-2.7/lib/libtcmalloc.so.4
#6  0x0000007fab8e9264 in tcmalloc::PageHeap::New(unsigned long) ()
   from /nix/store/z0k99bd8s25qryw29h5kkmljyqdz7lya-gperftools-2.7/lib/libtcmalloc.so.4
#7  0x0000007fab8e7450 in tcmalloc::CentralFreeList::Populate() ()
   from /nix/store/z0k99bd8s25qryw29h5kkmljyqdz7lya-gperftools-2.7/lib/libtcmalloc.so.4
#8  0x0000007fab8e7670 in tcmalloc::CentralFreeList::FetchFromOneSpansSafe(int, void**, void**) ()
   from /nix/store/z0k99bd8s25qryw29h5kkmljyqdz7lya-gperftools-2.7/lib/libtcmalloc.so.4
#9  0x0000007fab8e7724 in tcmalloc::CentralFreeList::RemoveRange(void**, void**, int) ()
   from /nix/store/z0k99bd8s25qryw29h5kkmljyqdz7lya-gperftools-2.7/lib/libtcmalloc.so.4
#10 0x0000007fab8eac20 in tcmalloc::ThreadCache::FetchFromCentralCache(unsigned int, int, void* (*)(unsigned long)) ()
   from /nix/store/z0k99bd8s25qryw29h5kkmljyqdz7lya-gperftools-2.7/lib/libtcmalloc.so.4
#11 0x0000007fab8fb5b8 in tcmalloc::allocate_full_malloc_oom(unsigned long) ()
   from /nix/store/z0k99bd8s25qryw29h5kkmljyqdz7lya-gperftools-2.7/lib/libtcmalloc.so.4
#12 0x0000007fab3d9be4 in ?? () from /nix/store/lhm57ki56ndzwnz6qsg9iii5ljzc3350-gcc-9.3.0-lib/lib/libstdc++.so.6
#13 0x0000007fabd47abc in call_init.part () from /nix/store/ajn7yh1fm35f8lv3pfmbf7d1f3c1vwkw-glibc-2.30/lib/ld-linux-aarch64.so.1
#14 0x0000007fabd47bc0 in _dl_init () from /nix/store/ajn7yh1fm35f8lv3pfmbf7d1f3c1vwkw-glibc-2.30/lib/ld-linux-aarch64.so.1
#15 0x0000007fabd3b104 in _dl_start_user () from /nix/store/ajn7yh1fm35f8lv3pfmbf7d1f3c1vwkw-glibc-2.30/lib/ld-linux-aarch64.so.1
```