### PR TITLE
ZODB: 3.5.1 -> 3.6.0

### DIFF
--- a/pkgs/development/python-modules/zodb/default.nix
+++ b/pkgs/development/python-modules/zodb/default.nix
@@ -1,8 +1,8 @@
 { stdenv
 , fetchPypi
-, fetchpatch
 , buildPythonPackage
 , python
+, pythonAtLeast
 , zope_testrunner
 , transaction
 , six
@@ -17,25 +17,20 @@
 
 buildPythonPackage rec {
     pname = "ZODB";
-    version = "5.5.1";
+    version = "5.6.0";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "20155942fa326e89ad8544225bafd74237af332ce9d7c7105a22318fe8269666";
+      sha256 = "1zh7rd182l15swkbkm3ib0wgyn16xasdz2mzry8k4lwk6dagnm26";
     };
-
-    patches = [
-      # Compatibility with transaction v3.0
-      (fetchpatch {
-        url = "https://github.com/zopefoundation/ZODB/commit/0adcc6877f690186c97cc5da7e13788946d5e0df.patch";
-        sha256 = "1zmbgm7r36nj5w7icpinp61fm81svh2wk213pzr3l0jxzr9i5qi4";
-      })
-    ];
 
     # remove broken test
     postPatch = ''
       rm -vf src/ZODB/tests/testdocumentation.py
     '';
+
+    # ZConfig 3.5.0 is not compatible with Python 3.8
+    disabled = pythonAtLeast "3.8";
 
     propagatedBuildInputs = [
       transaction


### PR DESCRIPTION
###### Motivation for this change

Updates python3Packages.zodb to the current version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
