### PR TITLE
bee: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6052,6 +6052,12 @@
     githubId = 673857;
     name = "Pash Shocky";
   };
+  paulperegud = {
+    email = "paulperegud@gmail.com";
+    github = "paulperegud";
+    githubId = 247162;
+    name = "Pawel 'pepesza' Peregud";
+  };
   pashev = {
     email = "pashev.igor@gmail.com";
     github = "ip1981";

--- a/pkgs/applications/networking/bee/default.nix
+++ b/pkgs/applications/networking/bee/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "bee";
+  version = "0.1.0";
+
+  subPackages = [
+    "cmd/bee"
+  ];
+
+  vendorSha256 = "1a9fmf5c3asvylcb0ixlwb6jk2z5hzdaa6yffg1pjvq9rx92jbjy";
+
+  src = fetchFromGitHub {
+    owner = "ethersphere";
+    repo = "bee";
+    rev = "v${version}";
+    sha256 = "1iwwhs2zm8ml484sc0d7smmmp1x893zjafr1mnaswl8pxg0lnm2l";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://swarm-gateways.net/bzz:/docs.swarm.eth/";
+    description = "Ethereum Swarm Bee";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ paulperegud ];
+  };
+}

--- a/pkgs/applications/networking/bee/default.nix
+++ b/pkgs/applications/networking/bee/default.nix
@@ -4,18 +4,16 @@ buildGoModule rec {
   pname = "bee";
   version = "0.1.0";
 
-  subPackages = [
-    "cmd/bee"
-  ];
-
-  vendorSha256 = "1a9fmf5c3asvylcb0ixlwb6jk2z5hzdaa6yffg1pjvq9rx92jbjy";
-
   src = fetchFromGitHub {
     owner = "ethersphere";
     repo = "bee";
     rev = "v${version}";
     sha256 = "1iwwhs2zm8ml484sc0d7smmmp1x893zjafr1mnaswl8pxg0lnm2l";
   };
+
+  vendorSha256 = "1a9fmf5c3asvylcb0ixlwb6jk2z5hzdaa6yffg1pjvq9rx92jbjy";
+
+  subPackages = [ "cmd/bee" ];  
 
   meta = with stdenv.lib; {
     homepage = "https://swarm-gateways.net/bzz:/docs.swarm.eth/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2369,6 +2369,8 @@ in
 
   beanstalkd = callPackage ../servers/beanstalkd { };
 
+  bee = callPackage ../applications/networking/bee { };
+
   beets = callPackage ../tools/audio/beets {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bee is an official implementation of Ethereum's Swarm - distributed storage platform.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
