### PR TITLE
Add Apache Pulsar

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -345,6 +345,9 @@ in
       zoneminder = 314;
       paperless = 315;
       #mailman = 316;  # removed 2019-08-30
+      pulsar-zookeeper = 317;
+      pulsar-bookie = 318;
+      pulsar-broker = 319;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -512,6 +512,7 @@
   ./services/misc/xmr-stak.nix
   ./services/misc/zoneminder.nix
   ./services/misc/zookeeper.nix
+  ./services/misc/pulsar.nix
   ./services/monitoring/alerta.nix
   ./services/monitoring/apcupsd.nix
   ./services/monitoring/arbtt.nix

--- a/nixos/modules/services/misc/pulsar.nix
+++ b/nixos/modules/services/misc/pulsar.nix
@@ -1,0 +1,251 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.pulsar;
+
+  zkServersConfText = concatStringsSep "\n" (builtins.genList
+    (idx: let
+      host = builtins.elemAt cfg.zookeeper.servers idx;
+    in "servers.${toString idx}=${host}:2888:3888")
+    (builtins.length cfg.zookeeper.servers)
+  );
+  zkConf = pkgs.writeText "pulsar-zookeeper.cfg" ''
+    clientPort=${toString cfg.zookeeper.clientPort}
+    dataDir=${cfg.zookeeper.dataDir}
+    ${cfg.zookeeper.extraConf}
+    ${zkServersConfText}
+  '';
+
+  zkConnectionString = concatStringsSep "," (map
+    (host: ''${host}:${toString cfg.zookeeper.clientPort}'')
+    cfg.zookeeper.servers
+  );
+
+  bkConf = pkgs.writeText "pulsar-bookie.cfg" ''
+    zkServers=${zkConnectionString}
+    advertisedAddress=${cfg.bookie.advertisedAddress}
+    journalDirectories=${cfg.bookie.dataDir}/journal
+    ledgerDirectories=${cfg.bookie.dataDir}/ledger
+    storage.range.store.dirs=${cfg.bookie.dataDir}/range
+    ${cfg.bookie.extraConf}
+  '';
+
+  brokerConf = pkgs.writeText "pulsar-broker.cfg" ''
+    zookeeperServers=${zkConnectionString}
+    configurationStoreServers=${zkConnectionString}
+    clusterName=pulsar-cluster-1
+    # to not conflict with the bookkeeper admin interface
+    webServicePort=8081
+    ${cfg.broker.extraConf}
+  '';
+
+  loggingConf = pkgs.writeText "log4j.properties" cfg.logging;
+
+  environment = {
+    PULSAR_ZK_CONF = zkConf;
+    PULSAR_BOOKKEEPER_CONF = bkConf;
+    BOOKIE_CONF = bkConf;
+    PULSAR_BROKER_CONF = brokerConf;
+    PULSAR_LOG_CONF = loggingConf;
+    BOOKIE_LOG_CONF = loggingConf;
+    PULSAR_MEM = cfg.jvmMemoryOptions;
+  };
+in {
+  options.services.pulsar = {
+    package = mkOption {
+      description = "The pulsar package to use";
+      default = pkgs.pulsar;
+      defaultText = "pkgs.pulsar";
+      type = types.package;
+    };
+
+    webServiceUrl = mkOption {
+      description = "Web service URL that the cluster will be initalized with";
+      default = "http://127.0.0.1:8080";
+      type = types.str;
+    };
+
+    brokerServiceUrl = mkOption {
+      description = "Broker service URL that the cluster will be initalized with";
+      default = "pulsar://127.0.0.1:6650";
+      type = types.str;
+    };
+
+    logging = mkOption {
+      description = "Log4j logging configuration.";
+      default = ''
+        zookeeper.root.logger=INFO, CONSOLE
+        log4j.rootLogger=INFO, CONSOLE
+        log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+        log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+        log4j.appender.CONSOLE.layout.ConversionPattern=[myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+      '';
+      type = types.lines;
+    };
+
+    jvmMemoryOptions = mkOption {
+      description = "JVM memory options, overriding Pulsar's defaults.";
+      default = "";
+      example = "-Xms64m -Xmx64m";
+      type = types.str;
+    };
+  };
+
+  options.services.pulsar.zookeeper = {
+    enable = mkOption {
+      description = "Whether to run a pulsar Zookeeper.";
+      default = false;
+      type = types.bool;
+    };
+
+    id = mkOption {
+      description = ''
+        This node's Zookeeper id, a 0-index of the current server in
+        services.pulsar.zookeeper.servers list.
+      '';
+      default = 0;
+      type = types.int;
+    };
+
+    servers = mkOption {
+      description = "Hosts of all pulsar Zookeeper Servers.";
+      default = ["127.0.0.1"];
+      type = types.listOf types.str;
+      example = ["host0" "host1" "host2"];
+    };
+
+    dataDir = mkOption {
+      description = "Data directory for Zookeeper.";
+      type = types.path;
+      default = "/var/lib/pulsar-zookeeper";
+    };
+
+    clientPort = mkOption {
+      description = "Port to run the client Zookeeper service for pulsar.";
+      type = types.int;
+      default = 2181;
+    };
+
+    extraConf = mkOption {
+      description = "Extra configuration for pulsar Zookeeper.";
+      type = types.lines;
+      default = ''
+        initLimit=5
+        syncLimit=2
+        tickTime=2000
+        autopurge.purgeInterval=1
+      '';
+    };
+  };
+
+  options.services.pulsar.bookie = {
+    enable = mkOption {
+      description = "Whether to run a Pulsar Bookkeeper.";
+      default = false;
+      type = types.bool;
+    };
+
+    dataDir = mkOption {
+      description = "Data directory for Bookkeeper.";
+      type = types.path;
+      default = "/var/lib/pulsar-bookie";
+    };
+
+    advertisedAddress = mkOption {
+      description = "Advertised IP address for this node";
+      type = types.str;
+      default = "127.0.0.1";
+    };
+
+    extraConf = mkOption {
+      description = "Extra configuration for Bookkeeper.";
+      type = types.lines;
+      default = "";
+    };
+  };
+
+  options.services.pulsar.broker = {
+    enable = mkOption {
+      description = "Whether to run a pulsar Broker.";
+      default = false;
+      type = types.bool;
+    };
+
+    extraConf = mkOption {
+      description = "Extra configuration for the Broker.";
+      type = types.lines;
+      default = "";
+    };
+  };
+
+  config = {
+    users.users.pulsar-zookeeper = mkIf cfg.zookeeper.enable {
+      description = "Pulsar zookeeper daemons user";
+      uid = config.ids.uids.pulsar-zookeeper;
+      home = cfg.zookeeper.dataDir;
+      createHome = true;
+    };
+    systemd.services.pulsar-zookeeper = mkIf cfg.zookeeper.enable {
+      description = "Pulsar's Zookeeper Daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      inherit environment;
+      serviceConfig.User = "pulsar-zookeeper";
+      script = "${cfg.package}/bin/pulsar zookeeper";
+      preStart = ''
+        echo "${toString cfg.zookeeper.id}" > ${cfg.zookeeper.dataDir}/myid
+      '';
+    };
+
+    users.users.pulsar-bookie = mkIf cfg.bookie.enable {
+      description = "Pulsar bookie daemons user";
+      uid = config.ids.uids.pulsar-bookie;
+      home = cfg.bookie.dataDir;
+      createHome = true;
+    };
+    systemd.services.pulsar-bookie = mkIf cfg.bookie.enable {
+      description = "Pulsar's Bookkeeper Daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "network.target"
+        "pulsar-zookeeper.target"
+      ];
+      inherit environment;
+      serviceConfig.User = "pulsar-bookie";
+      script = ''
+        # It is non-destruction to re-run the cluster initialization
+        ${cfg.package}/bin/pulsar initialize-cluster-metadata \
+            --cluster pulsar-cluster-1 \
+            --zookeeper ${zkConnectionString} \
+            --configuration-store ${zkConnectionString} \
+            --web-service-url ${cfg.webServiceUrl} \
+            --broker-service-url ${cfg.brokerServiceUrl}
+        # However we should only format the bookie data once
+        if [ ! -f ${cfg.bookie.dataDir}/has-done-init ]; then
+          ${cfg.package}/bin/bookkeeper shell bookieformat
+          touch ${cfg.bookie.dataDir}/has-done-init
+        fi
+        ${cfg.package}/bin/pulsar bookie
+      '';
+    };
+
+    users.users.pulsar-broker = mkIf cfg.broker.enable {
+      description = "Pulsar broker daemons user";
+      uid = config.ids.uids.pulsar-broker;
+    };
+    systemd.services.pulsar-broker = mkIf cfg.broker.enable {
+      description = "Pulsar's Broker Daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "network.target"
+        "pulsar-zookeeper.target"
+        "pulsar-bookie.target"
+      ];
+      inherit environment;
+      serviceConfig.User = "pulsar-broker";
+      script = "${cfg.package}/bin/pulsar broker";
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -277,6 +277,8 @@ in
   prosody = handleTest ./xmpp/prosody.nix {};
   prosodyMysql = handleTest ./xmpp/prosody-mysql.nix {};
   proxy = handleTest ./proxy.nix {};
+  pulsar-single-node = handleTest ./pulsar/single-node.nix {};
+  pulsar-multi-node = handleTest ./pulsar/multi-node.nix {};
   qboot = handleTestOn ["x86_64-linux" "i686-linux"] ./qboot.nix {};
   quagga = handleTest ./quagga.nix {};
   quorum = handleTest ./quorum.nix {};

--- a/nixos/tests/pulsar/multi-node.nix
+++ b/nixos/tests/pulsar/multi-node.nix
@@ -1,0 +1,72 @@
+import ../make-test-python.nix ({ pkgs, ...} : {
+  name = "pulsar-multi-node";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ samdroid-apps ];
+  };
+
+  nodes = let
+    jvmMemoryOptions = "-Xms64m -Xmx64m";
+
+    bookieNode = { nodes, ... }: {
+    };
+  in {
+    zk1 = { nodes, ... }: {
+      services.pulsar = {
+        inherit jvmMemoryOptions;
+        zookeeper.enable = true;
+        zookeeper.servers = [ nodes.zk1.config.networking.hostName ];
+      };
+      networking.firewall.allowedTCPPorts = [ 2181 ];
+    };
+    bk1 = { nodes, ... }: {
+      services.pulsar = {
+        inherit jvmMemoryOptions;
+        zookeeper.servers = [ nodes.zk1.config.networking.hostName ];
+        bookie = {
+          enable = true;
+          advertisedAddress = nodes.bk1.config.networking.primaryIPAddress;
+        };
+      };
+      networking.firewall.allowedTCPPorts = [ 3181 ];
+    };
+    bk2 = { nodes, ... }: {
+      services.pulsar = {
+        inherit jvmMemoryOptions;
+        zookeeper.servers = [ nodes.zk1.config.networking.hostName ];
+        bookie = {
+          enable = true;
+          advertisedAddress = nodes.bk2.config.networking.primaryIPAddress;
+        };
+      };
+      networking.firewall.allowedTCPPorts = [ 3181 ];
+    };
+    broker = { nodes, ... }: {
+      services.pulsar = {
+        inherit jvmMemoryOptions;
+        zookeeper.servers = [ nodes.zk1.config.networking.hostName ];
+        broker.enable = true;
+      };
+      networking.firewall.allowedTCPPorts = [ 6650 ];
+      virtualisation.memorySize = 1024;
+    };
+  };
+
+  testScript = ''
+    zk1.wait_for_open_port(2181)
+    bk1.wait_for_open_port(3181)
+    bk2.wait_for_open_port(3181)
+    broker.wait_for_open_port(6650)
+
+    # The subscription can only consume messages sent after it is created.
+    # So constantly send a message while we're subscribed.
+    status, out = broker.execute(
+        "( while true; do"
+        "  ${pkgs.pulsar}/bin/pulsar-client produce test-topic -m foo;"
+        "  sleep 1; done ) &"
+        " ${pkgs.pulsar}/bin/pulsar-client consume test-topic"
+        " -s sub1"
+    )
+    assert status == 0
+    assert "foo" in out
+  '';
+})

--- a/nixos/tests/pulsar/single-node.nix
+++ b/nixos/tests/pulsar/single-node.nix
@@ -1,0 +1,46 @@
+import ../make-test-python.nix ({ pkgs, ...} : {
+  name = "pulsar-single-node";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ samdroid-apps ];
+  };
+
+  nodes = {
+    server = { ... }: {
+      services.pulsar = {
+        zookeeper.enable = true;
+        bookie.enable = true;
+        broker.enable = true;
+        broker.extraConf = ''
+          # we only have 1 bookie node
+          managedLedgerDefaultEnsembleSize=1
+          managedLedgerDefaultWriteQuorum=1
+          managedLedgerDefaultAckQuorum=1
+        '';
+        # By default pulsar allocates 2GB for all services
+        jvmMemoryOptions = "-Xms64m -Xmx64m";
+      };
+      # 3 JVM services won't fit in the default ~300mb memory
+      virtualisation.memorySize = 1024;
+      networking.firewall.allowedTCPPorts = [ 6650 ];
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    server.wait_for_unit("network.target")
+    server.wait_for_open_port(6650)
+
+    # The subscription can only consume messages sent after it is created.
+    # So constantly send a message while we're subscribed.
+    status, out = server.execute(
+        "( while true; do"
+        "  ${pkgs.pulsar}/bin/pulsar-client produce test-topic -m foo;"
+        "  sleep 1; done ) &"
+        " ${pkgs.pulsar}/bin/pulsar-client consume test-topic"
+        " -s sub1"
+    )
+    assert status == 0
+    assert "foo" in out
+  '';
+})

--- a/pkgs/servers/pulsar/default.nix
+++ b/pkgs/servers/pulsar/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, jre, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "pulsar";
+  version = "2.6.0";
+
+  src = fetchurl {
+    url = "mirror://apache/pulsar/${pname}-${version}/apache-${pname}-${version}-bin.tar.gz";
+    sha256 = "0979nvv018brgyc3mn71sbm7yxxbid112lv85y5b8xh58vj96psv";
+  };
+
+  buildInputs = [ makeWrapper jre ];
+
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R bin instances lib conf $out
+    patchShebangs $out/bin
+    for i in $out/bin/*; do
+      if [ -f $i ]; then
+        wrapProgram $i --set JAVA_HOME "${jre}"
+      fi
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://pulsar.apache.org";
+    description = "An open-source distributed pub-sub messaging system, part of the Apache Software Foundation";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ samdroid-apps ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16498,6 +16498,8 @@ in
 
   zookeeper_mt = callPackage ../development/libraries/zookeeper_mt { };
 
+  pulsar = callPackage ../servers/pulsar { };
+
   xqilla = callPackage ../development/tools/xqilla { };
 
   xquartz = callPackage ../servers/x11/xquartz { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds support for the Apache Pulsar message bus in NixOS.  Running Pulsar involves 3 components - the Zookeeper, the Bookkeeper Bookie and the Pulsar Broker.  All component are distributed by Apache Pulsar together.

This PR:

* Adding the `pulsar` package (containing the official distribution of zookeeper, bookie and broker)
* Adds the `services.pulsar` module, made up of a zookeeper, bookie and broker systemd service
* Adds 2 nixos tests for common configurations:
  * A single-node setup, where zookeeper, bookie and broker run on the same machine
  * A more complex multi-node setup, with two bookkeepers (for data integrity) and all services on components machines


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
