### PR TITLE
pythonPackages.selectors2: fix build by disabling failing test_above_fd_setsize

### DIFF
--- a/pkgs/development/python-modules/selectors2/default.nix
+++ b/pkgs/development/python-modules/selectors2/default.nix
@@ -17,7 +17,8 @@ buildPythonPackage rec {
     # Trick to disable certain tests that depend on timing which
     # will always fail on hydra
     export TRAVIS=""
-    nosetests tests/test_selectors2.py
+    nosetests tests/test_selectors2.py \
+      --exclude=test_above_fd_setsize
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This fixes the following error in the `selectors2` test suite:

```
======================================================================
ERROR: test_above_fd_setsize (tests.test_selectors2.PollSelectorTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/private/var/folders/5h/b11m6fxj2tqgbxwz5bgjy42c0000gn/T/nix-build-python3.8-selectors2-2.0.1.drv-0/selectors2-2.0.1/tests/test_selectors2.py", line 530, in test_above_fd_setsize
    self.assertEqual(limit_nofile // 2, len(s.select()))
  File "/private/var/folders/5h/b11m6fxj2tqgbxwz5bgjy42c0000gn/T/nix-build-python3.8-selectors2-2.0.1.drv-0/selectors2-2.0.1/selectors2.py", line 402, in select
    fd_events = _syscall_wrapper(self._wrap_poll, True, timeout=timeout)
  File "/private/var/folders/5h/b11m6fxj2tqgbxwz5bgjy42c0000gn/T/nix-build-python3.8-selectors2-2.0.1.drv-0/selectors2-2.0.1/selectors2.py", line 662, in _syscall_wrapper
    return func(*args, **kwargs)
  File "/private/var/folders/5h/b11m6fxj2tqgbxwz5bgjy42c0000gn/T/nix-build-python3.8-selectors2-2.0.1.drv-0/selectors2-2.0.1/selectors2.py", line 397, in _wrap_poll
    result = self._poll.poll(timeout)
OSError: [Errno 22] Invalid argument

----------------------------------------------------------------------
```

###### Things done

Disable the specific `test_above_fd_setsize` test.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
