### PR TITLE
luaPackages.readline: init at 2.6-0

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -74,6 +74,7 @@ moonscript,,,,,arobyn
 nvim-client,,,,,
 penlight,,,,,
 rapidjson,,,,,
+readline,,,,,
 say,,,,,
 std__debug,std._debug,,,,
 std_normalize,std.normalize,,,,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1407,6 +1407,23 @@ rapidjson = buildLuarocksPackage {
     license.fullName = "MIT";
   };
 };
+readline = buildLuarocksPackage {
+  pname = "readline";
+  version = "2.6-0";
+
+  src = fetchurl {
+    url    = mirror://luarocks/readline-2.6-0.src.rock;
+    sha256 = "1fvz7nqvkdazp30wn5n62n8i97qrfgznbykdpf8cnflqfpd1shms";
+  };
+  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  propagatedBuildInputs = [ lua luaposix ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.pjb.com.au/comp/lua/readline.html";
+    description = "Interface to the readline library";
+    license.fullName = "MIT/X11";
+  };
+};
 say = buildLuarocksPackage {
   pname = "say";
   version = "1.3-1";

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -328,6 +328,23 @@ with super;
     '';
   });
 
+  readline = (super.readline.override ({
+    unpackCmd = ''
+      unzip "$curSrc"
+      tar xf *.tar.gz
+    '';
+    propagatedBuildInputs = super.readline.propagatedBuildInputs ++ [ pkgs.readline ];
+    extraVariables = rec {
+      READLINE_INCDIR = "${pkgs.readline.dev}/include";
+      HISTORY_INCDIR = READLINE_INCDIR;
+    };
+  })).overrideAttrs (old: {
+    # Without this, source root is wrongly set to ./readline-2.6/doc
+    setSourceRoot = ''
+      sourceRoot=./readline-2.6
+    '';
+  });
+
   pulseaudio = super.pulseaudio.override({
     buildInputs = [
       pkgs.libpulseaudio


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Let's support useful readline in Nixpkgs Lua ecosystem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
