### PR TITLE
ocamlPackages.angstrom 0.14.1 and update of all affected packages (encore, git)

### DIFF
--- a/pkgs/development/ocaml-modules/angstrom/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom/default.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage rec {
   pname = "angstrom";
-  version = "0.13.0";
+  version = "0.14.1";
 
   minimumOCamlVersion = "4.04";
 
@@ -10,7 +10,7 @@ buildDunePackage rec {
     owner  = "inhabitedtype";
     repo   = pname;
     rev    = version;
-    sha256 = "0vzbwd8j34iv7n6gwqq2mf25q7rqpnpxnifb9ssxhq55p5dd1kp4";
+    sha256 = "1l69y0qspgi7kgrphyh7718hjb2sml1a9lljkp65bkqmmmi6ybly";
   };
 
   checkInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/bigarray-overlap/default.nix
+++ b/pkgs/development/ocaml-modules/bigarray-overlap/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildDunePackage, fetchurl
+, bigarray-compat, alcotest, astring, fpath, bos, findlib, pkg-config
+}:
+
+buildDunePackage rec {
+  pname = "bigarray-overlap";
+  version = "0.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/dinosaure/overlap/releases/download/v${version}/bigarray-overlap-v${version}.tbz";
+    sha256 = "1v86avafsbyxjccy0y9gny31s2jzb0kd42v3mhcalklx5f044lcy";
+  };
+
+  minimumOCamlVersion = "4.07";
+  useDune2 = true;
+
+  propagatedBuildInputs = [ bigarray-compat ];
+
+  checkInputs = [ alcotest astring fpath bos findlib pkg-config ];
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/dinosaure/overlap";
+    description = "A minimal library to know that 2 bigarray share physically the same memory or not";
+    license = licenses.mit;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/encore/default.nix
+++ b/pkgs/development/ocaml-modules/encore/default.nix
@@ -1,15 +1,21 @@
-{ lib, buildDunePackage, fetchurl, ocaml, alcotest, angstrom, ke }:
+{ lib, buildDunePackage, fetchurl, ocaml
+, fmt, bigstringaf, bigarray-compat
+, bigarray-overlap, angstrom, ke, alcotest }:
 
 buildDunePackage rec {
   pname = "encore";
-  version = "0.3";
+  version = "0.5";
+
   src = fetchurl {
     url = "https://github.com/mirage/encore/releases/download/v${version}/encore-v${version}.tbz";
-    sha256 = "05nv6yms5axsmq9cspr7884rz5kirj50izx3vdm89q4yl186qykl";
+    sha256 = "15n0dla149k9h7migs76wap08z5402qcvxyqxzl887ha6isj3p9n";
   };
-  propagatedBuildInputs = [ angstrom ke ];
-  checkInputs = lib.optional doCheck alcotest;
-  doCheck = lib.versions.majorMinor ocaml.version != "4.07";
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [ angstrom ke fmt bigstringaf bigarray-compat bigarray-overlap ];
+  checkInputs = [ alcotest ];
+  doCheck = true;
 
   meta = {
     homepage = "https://github.com/mirage/encore";

--- a/pkgs/development/ocaml-modules/git-http/default.nix
+++ b/pkgs/development/ocaml-modules/git-http/default.nix
@@ -1,12 +1,12 @@
-{ buildDunePackage, git, cohttp-lwt, alcotest, mtime, nocrypto }:
+{ buildDunePackage, git, cohttp, cohttp-lwt }:
 
 buildDunePackage {
 	pname = "git-http";
-	inherit (git) version src;
+	inherit (git) version src minimumOCamlVersion;
 
-	buildInputs = [ alcotest mtime nocrypto ];
-	propagatedBuildInputs = [ git cohttp-lwt ];
-	doCheck = true;
+	useDune2 = true;
+
+	propagatedBuildInputs = [ git cohttp cohttp-lwt ];
 
 	meta = {
 		description = "Client implementation of the “Smart” HTTP Git protocol in pure OCaml";

--- a/pkgs/development/ocaml-modules/git-unix/default.nix
+++ b/pkgs/development/ocaml-modules/git-unix/default.nix
@@ -1,13 +1,17 @@
-{ buildDunePackage, git-http, cohttp-lwt-unix, tls, cmdliner, mtime }:
+{ stdenv, buildDunePackage, git-http, cohttp, cohttp-lwt-unix
+, mmap, cmdliner, mtime, alcotest, mirage-crypto-rng, tls
+, io-page, git-binary
+}:
 
 buildDunePackage {
 	pname = "git-unix";
-	inherit (git-http) version src;
+	inherit (git-http) version src minimumOCamlVersion;
 
 	useDune2 = true;
 
-	buildInputs = [ cmdliner mtime ];
-	propagatedBuildInputs = [ cohttp-lwt-unix git-http tls ];
+	propagatedBuildInputs = [ mmap cmdliner git-http cohttp cohttp-lwt-unix mtime ];
+	checkInputs = [ alcotest mirage-crypto-rng tls io-page git-binary ];
+	doCheck = !stdenv.isAarch64;
 
 	meta = {
 		description = "Unix backend for the Git protocol(s)";

--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -1,23 +1,30 @@
-{ lib, fetchurl, buildDunePackage
-, alcotest, git, mtime, nocrypto
-, angstrom, astring, cstruct, decompress, digestif, encore, duff, fmt
+{ stdenv, fetchurl, buildDunePackage
+, alcotest, mtime, mirage-crypto-rng, tls, git-binary
+, angstrom, astring, cstruct, decompress, digestif, encore, duff, fmt, checkseum
 , fpath, hex, ke, logs, lru, ocaml_lwt, ocamlgraph, ocplib-endian, uri, rresult
+, stdlib-shims
 }:
 
 buildDunePackage rec {
-  pname = "git";
-	version = "2.1.2";
+	pname = "git";
+	version = "2.1.3";
+
+	minimumOCamlVersion = "4.07";
+	useDune2 = true;
 
 	src = fetchurl {
 		url = "https://github.com/mirage/ocaml-git/releases/download/${version}/git-${version}.tbz";
-		sha256 = "0yyclsh255k7pvc2fcsdi8k2fcrr0by2nz6g3sqnwlimjyp7mz5j";
+		sha256 = "1ppllv65vrkfrmx46aiq5879isffcjmg92z9rv2kh92a83h4lqax";
 	};
 
-	propagatedBuildInputs = [ angstrom astring cstruct decompress digestif encore duff fmt fpath hex ke logs lru ocaml_lwt ocamlgraph ocplib-endian uri rresult ];
-	checkInputs = lib.optionals doCheck [ alcotest git mtime nocrypto ];
-	doCheck = true;
+	propagatedBuildInputs = [
+		angstrom astring checkseum cstruct decompress digestif encore duff fmt fpath
+		hex ke logs lru ocaml_lwt ocamlgraph ocplib-endian uri rresult stdlib-shims
+	];
+	checkInputs = [ alcotest mtime mirage-crypto-rng tls git-binary ];
+	doCheck = !stdenv.isAarch64;
 
-	meta = {
+	meta = with stdenv; {
 		description = "Git format and protocol in pure OCaml";
 		license = lib.licenses.isc;
 		maintainers = [ lib.maintainers.vbgl ];

--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -533,6 +533,7 @@ rec {
     pname = "email_message";
     hash = "131jd72k4s8cdbgg6gyg7w5v8mphdlvdx4fgvh8d9a1m7kkvbxfg";
     propagatedBuildInputs = [ async angstrom core_extended cryptokit magic-mime ounit ];
+    patches = [ ./email-message-angstrom-0.14.patch ];
     meta.description = "E-mail message parser";
   };
 

--- a/pkgs/development/ocaml-modules/janestreet/email-message-angstrom-0.14.patch
+++ b/pkgs/development/ocaml-modules/janestreet/email-message-angstrom-0.14.patch
@@ -1,0 +1,22 @@
+diff --git a/email_address/src/email_address.ml b/email_address/src/email_address.ml
+index 7470273..d070465 100644
+--- a/email_address/src/email_address.ml
++++ b/email_address/src/email_address.ml
+@@ -38,7 +38,7 @@ module Stable = struct
+       let of_string ?default_domain input_str =
+         let open Core_kernel in
+         let open! Int.Replace_polymorphic_compare in
+-        match Angstrom.parse_string Email_address_parser_stable_v1.email_only input_str with
++        match Angstrom.parse_string ~consume:Prefix Email_address_parser_stable_v1.email_only input_str with
+         | Error error ->
+           Or_error.error_s [%message
+             "Failed to parse email address"
+@@ -104,7 +104,7 @@ module T = Stable.V1.With_comparator
+ include T
+ 
+ let list_of_string ?default_domain input_str =
+-  match Angstrom.parse_string Email_address_parser_stable_v1.email_list_only input_str with
++  match Angstrom.parse_string ~consume:Prefix Email_address_parser_stable_v1.email_list_only input_str with
+   | Error error ->
+     Or_error.error_s [%message
+       "Failed to parse email address(es)"

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -350,11 +350,15 @@ let
 
     gg = callPackage ../development/ocaml-modules/gg { };
 
-    git = callPackage ../development/ocaml-modules/git { inherit (pkgs) git; };
+    git = callPackage ../development/ocaml-modules/git {
+      git-binary = pkgs.git;
+    };
 
     git-http = callPackage ../development/ocaml-modules/git-http { };
 
-    git-unix = callPackage ../development/ocaml-modules/git-unix { };
+    git-unix = callPackage ../development/ocaml-modules/git-unix {
+      git-binary = pkgs.git;
+    };
 
     gmetadom = callPackage ../development/ocaml-modules/gmetadom { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -52,6 +52,8 @@ let
 
     bigarray-compat = callPackage ../development/ocaml-modules/bigarray-compat { };
 
+    bigarray-overlap = callPackage ../development/ocaml-modules/bigarray-overlap { };
+
     bigstringaf = callPackage ../development/ocaml-modules/bigstringaf { };
 
     bigstring = callPackage ../development/ocaml-modules/bigstring { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

angstrom 0.14 (now bugfixed [0.14.1](https://github.com/inhabitedtype/angstrom/releases/tag/0.14.1)) broke some libraries due to an API change, in nixpkgs `encore` and `git` (and indirectly the irmin libraries). Since [encore 0.5](https://github.com/mirage/encore/releases/tag/v0.5) and [git 2.1.3](https://github.com/mirage/ocaml-git/releases/tag/2.1.3) have been released, we can go to angstrom 0.14.1 in nixpkgs.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

If this is merged, #90630 can be closed
