### PR TITLE
[20.03] openafs_1_8: 1.8.5 -> 1.8.6

### DIFF
--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -18,22 +18,6 @@ in stdenv.mkDerivation {
 
   buildInputs = [ kerberos ];
 
-  patches = [
-    # openafs 5.6 patches, included in the next release
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/34f1689b7288688550119638ee9959e453fde414.patch";
-      sha256 = "0rxjqzr8c5ajlk8wrhgjc1qp1934qiriqdi0qxsnk4gj5ibbk4d5";
-    })
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/355ea43f0d1b7feae1b3af58bc33af12838db7c3.patch";
-      sha256 = "1f9xn8ql6vnxglpj3dvi30sj8vkncazjab2rc13hbw48nvsvcnhm";
-    })
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/17d38e31e6f2e237a7fb4dfb46841060296310b6.patch";
-      sha256 = "14dydxfm0f5fvnj0kmvgm3bgh0ajhh04i3l7l0hr9cpmwl7vrlcg";
-    })
-  ];
-
   hardeningDisable = [ "pic" ];
 
   configureFlags = [

--- a/pkgs/servers/openafs/1.8/srcs.nix
+++ b/pkgs/servers/openafs/1.8/srcs.nix
@@ -1,14 +1,14 @@
 { fetchurl }:
 rec {
-  version = "1.8.5";
+  version = "1.8.6";
   src = fetchurl {
-    url = "http://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    sha256 = "08w5n803xm75j7daa3mr2ncfmcg0wpm7yasj6zyddqlb4f7xdppf";
+    url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
+    sha256 = "0i99klrw00v4bwd942n90xqfn16z6337m89xfm9dgv7ih0qrsklb";
   };
 
   srcs = [ src
     (fetchurl {
-      url = "http://www.openafs.org/dl/openafs/${version}/openafs-${version}-doc.tar.bz2";
-      sha256 = "08mg3n0q2igfas1khj18r9apyrkpbp1jick0ix5nfaal90jbifis";
+      url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-doc.tar.bz2";
+      sha256 = "1s91kmxfimhdqrz7l6jgjz72j9pyalghrvg4h384fsz0ks6s4kz3";
     })];
 }


### PR DESCRIPTION
###### Motivation for this change

Without this update, OpenAFS fails to build with kernel 5.6 and 5.7. Backport of #84968.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
