### PR TITLE
pidgin: now builds and runs on osx

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -40,9 +40,7 @@ let unwrapped = stdenv.mkDerivation rec {
   ++ (lib.optional (openssl != null) openssl)
   ++ (lib.optional (gnutls != null) gnutls)
   ++ (lib.optional (libgcrypt != null) libgcrypt)
-  ++ (lib.optional (stdenv.isLinux) gtk2)
-  ++ (lib.optional (stdenv.isLinux) gtkspell2)
-  ++ (lib.optional (stdenv.isLinux) farstream)
+  ++ (lib.optionals (stdenv.isLinux) [gtk2 gtkspell2 farstream])
   ++ (lib.optional (stdenv.isDarwin) gtk2-x11);
 
 
@@ -62,11 +60,10 @@ let unwrapped = stdenv.mkDerivation rec {
     "--disable-meanwhile"
     "--disable-nm"
     "--disable-tcl"
-    "--disable-gtkspell"
-    "--disable-vv"
   ]
   ++ (lib.optionals (cyrus_sasl != null) [ "--enable-cyrus-sasl=yes" ])
-  ++ (lib.optionals (gnutls != null) ["--enable-gnutls=yes" "--enable-nss=no"]);
+  ++ (lib.optionals (gnutls != null) ["--enable-gnutls=yes" "--enable-nss=no"])
+  ++ (lib.optionals (stdenv.isDarwin) ["--disable-gtkspell" "--disable-vv"]);
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig, gtk2, gtkspell2, aspell
+{ stdenv, fetchurl, makeWrapper, pkgconfig, gtk2, gtk2-x11
+, gtkspell2, aspell
 , gst_all_1, startupnotification, gettext
 , perlPackages, libxml2, nss, nspr, farstream
 , libXScrnSaver, ncurses, avahi, dbus, dbus-glib, intltool, libidn
@@ -29,19 +30,26 @@ let unwrapped = stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-I${gst_all_1.gst-plugins-base.dev}/include/gstreamer-1.0";
 
   buildInputs = [
-    gtkspell2 aspell startupnotification
+    aspell startupnotification
     gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
-    libxml2 nss nspr farstream
+    libxml2 nss nspr
     libXScrnSaver ncurses python
     avahi dbus dbus-glib intltool libidn
     libICE libXext libSM cyrus_sasl
   ]
   ++ (lib.optional (openssl != null) openssl)
   ++ (lib.optional (gnutls != null) gnutls)
-  ++ (lib.optional (libgcrypt != null) libgcrypt);
+  ++ (lib.optional (libgcrypt != null) libgcrypt)
+  ++ (lib.optional (stdenv.isLinux) gtk2)
+  ++ (lib.optional (stdenv.isLinux) gtkspell2)
+  ++ (lib.optional (stdenv.isLinux) farstream)
+  ++ (lib.optional (stdenv.isDarwin) gtk2-x11);
 
-  propagatedBuildInputs = [ pkgconfig gtk2 gettext ]
-    ++ (with perlPackages; [ perl XMLParser ]);
+
+  propagatedBuildInputs = [ pkgconfig gettext ]
+    ++ (with perlPackages; [ perl XMLParser ])
+    ++ (lib.optional (stdenv.isLinux) gtk2)
+    ++ (lib.optional (stdenv.isDarwin) gtk2-x11);
 
   patches = [ ./pidgin-makefile.patch ./add-search-path.patch ];
 
@@ -54,6 +62,8 @@ let unwrapped = stdenv.mkDerivation rec {
     "--disable-meanwhile"
     "--disable-nm"
     "--disable-tcl"
+    "--disable-gtkspell"
+    "--disable-vv"
   ]
   ++ (lib.optionals (cyrus_sasl != null) [ "--enable-cyrus-sasl=yes" ])
   ++ (lib.optionals (gnutls != null) ["--enable-gnutls=yes" "--enable-nss=no"]);
@@ -69,7 +79,7 @@ let unwrapped = stdenv.mkDerivation rec {
     description = "Multi-protocol instant messaging client";
     homepage = "http://pidgin.im";
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.vcunat ];
   };
 };


### PR DESCRIPTION
Signed-off-by: Frederick F. Kautz IV <fkautz@alumni.cmu.edu>

A quick note: this is my first patch in nixpkgs. I don't know if I have followed best practices. E.g. I read sandboxing is enabled by default but I don't know how to confirm it.

Also, this package does require an X11 server to run. Nix does provide access to the xquartz installer, but it is possible to run pidgin with an already running X11 server.

###### Motivation for this change
Before: No Pidgin on OSX
After: Pidgin on OSX

###### Things done

Changed build to support unix.

* Build: constrain to platforms.unix instead of platforms.linux
* Build: Differences Linux and OSX now parameterized
* Darwin: build against gtk2-x11 instead of gtk
* Darwin: disable gtkspell2 (spellcheck)
* Darwin: disable farstream (voice and video)

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
  - I didn't disable sandbox, I read somewhere in docs that it is enabled by default. Don't know how to confirm.
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - I see that these tests exist, I don't know how to run them yet. Would appreciate assistance here.
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] OSX
  - [ ] Linux (I have a headless NixOS)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
  - No docs found
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
  - I read through and attempted to adapt. Please verify.