### PR TITLE
kbs2: init at 0.1.1

### DIFF
--- a/pkgs/tools/security/kbs2/default.nix
+++ b/pkgs/tools/security/kbs2/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, rustPlatform, fetchFromGitHub, installShellFiles, python3, libxcb, AppKit }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "kbs2";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "woodruffw";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0761g8cl9v7jj444vp83zq9f1shrddqq20pd41d5mbl6f8qpk4m5";
+  };
+
+  cargoSha256 = "0vzjkw1g6saz4nwy823dpip02jg2f21rsd8kkpra206b8i6q0mfg";
+
+  nativeBuildInputs = [ installShellFiles ]
+    ++ stdenv.lib.optionals stdenv.isLinux [ python3 ];
+
+  buildInputs = [ ]
+    ++ stdenv.lib.optionals stdenv.isLinux [ libxcb ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ AppKit ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkFlagsArray = [ "--skip=kbs2::config::tests::test_find_config_dir" ];
+
+  postInstall = ''
+    for shell in bash fish zsh; do
+      $out/bin/kbs2 --completions $shell > kbs2.$shell
+      installShellCompletion kbs2.$shell
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A secret manager backed by age";
+    homepage = "https://github.com/woodruffw/kbs2";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4537,6 +4537,10 @@ in
 
   kbdd = callPackage ../applications/window-managers/kbdd { };
 
+  kbs2 = callPackage ../tools/security/kbs2 {
+    inherit (darwin.apple_sdk.frameworks) AppKit;
+  };
+
   kdbplus = pkgsi686Linux.callPackage ../applications/misc/kdbplus { };
 
   keepalived = callPackage ../tools/networking/keepalived { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add https://github.com/woodruffw/kbs2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
