### PR TITLE
PerconaToolkit: use shortenPerlShebang

### DIFF
--- a/pkgs/development/perl-modules/Percona-Toolkit/default.nix
+++ b/pkgs/development/perl-modules/Percona-Toolkit/default.nix
@@ -10,7 +10,8 @@ buildPerlPackage {
     sha256 = "0xk4h4dzl80kf97lbx0nznx9ajrb6kkg7k3iwca3rj6f3rqggv9y";
   };
   outputs = [ "out" ];
-  buildInputs = [ DBDmysql DBI IOSocketSSL TermReadKey shortenPerlShebang ];
+  nativeBuildInputs = [ shortenPerlShebang ];
+  buildInputs = [ DBDmysql DBI IOSocketSSL TermReadKey ];
   postInstall = ''
     shortenPerlShebang $(grep -l "/bin/env perl" $out/bin/*)
   '';

--- a/pkgs/development/perl-modules/Percona-Toolkit/default.nix
+++ b/pkgs/development/perl-modules/Percona-Toolkit/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildPerlPackage, DBDmysql, DBI, IOSocketSSL, TermReadKey }:
+{ lib, fetchFromGitHub, buildPerlPackage, DBDmysql, DBI, IOSocketSSL, TermReadKey, shortenPerlShebang }:
 
 buildPerlPackage {
   pname = "Percona-Toolkit";
@@ -10,7 +10,10 @@ buildPerlPackage {
     sha256 = "0xk4h4dzl80kf97lbx0nznx9ajrb6kkg7k3iwca3rj6f3rqggv9y";
   };
   outputs = [ "out" ];
-  buildInputs = [ DBDmysql DBI IOSocketSSL TermReadKey ];
+  buildInputs = [ DBDmysql DBI IOSocketSSL TermReadKey shortenPerlShebang ];
+  postInstall = ''
+    shortenPerlShebang $(grep -l "/bin/env perl" $out/bin/*)
+  '';
   meta = {
     description = ''Collection of advanced command-line tools to perform a variety of MySQL and system tasks.'';
     homepage = "http://www.percona.com/software/percona-toolkit";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The package is broken because the shebang is not being shortened and all the binaries don't work.
More info here: https://github.com/NixOS/nixpkgs/issues/91419

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
