### PR TITLE
pythonPackages.pywebview: 3.2 -> 3.3.1

### DIFF
--- a/pkgs/development/python-modules/pywebview/default.nix
+++ b/pkgs/development/python-modules/pywebview/default.nix
@@ -1,23 +1,32 @@
-{ lib, buildPythonPackage, fetchFromGitHub }:
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+, importlib-resources, pytest, xvfb_run }:
 
 buildPythonPackage rec {
   pname = "pywebview";
-  version = "3.2";
+  version = "3.3.1";
+  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "r0x0r";
     repo = "pywebview";
     rev = version;
-    sha256 = "0anwm6s0pp7xmgylr4m52v7lw825sdby7fajcl929l099n757gq7";
+    sha256 = "015z7n0hdgkzn0p7aw1xsv6lwc260p8q67jx0zyd1zghnwyj8k79";
   };
 
-  # disabled due to error in loading unittest
-  # don't know how to make test from: None
-  doCheck = false;
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.7") [ importlib-resources ];
+
+  checkInputs = [ pytest xvfb_run ];
+
+  checkPhase = ''
+    pushd tests
+    patchShebangs run.sh
+    xvfb-run -s '-screen 0 800x600x24' ./run.sh
+    popd
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/r0x0r/pywebview";
-    description = "Lightweight cross-platform wrapper around a webview.";
+    description = "Lightweight cross-platform wrapper around a webview";
     license = licenses.bsd3;
     maintainers = with maintainers; [ jojosch ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New release. 

In `nixpkgs-review wip` the new package failed to build with `python 2.7`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
3 packages updated:
jellyfin-mpv-shim python37Packages.pywebview (3.2 → 3.3.1) python38Packages.pywebview (3.2 → 3.3.1)

1 package removed:
python2.7-pywebview (†3.2)
```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
