### PR TITLE
mycli: 1.20.1 -> 1.21.1

### DIFF
--- a/pkgs/tools/admin/mycli/default.nix
+++ b/pkgs/tools/admin/mycli/default.nix
@@ -7,11 +7,11 @@ with python3.pkgs;
 
 buildPythonApplication rec {
   pname = "mycli";
-  version = "1.20.1";
+  version = "1.21.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0vhwaqkx4njarm0wy8zg2hvzr2yl92y8gnwipcn7p59sazw4whfl";
+    sha256 = "1q9p0yik9cpvpxjs048anvhicfcna84mpl7axv9bwgr48w40lqwg";
   };
 
   propagatedBuildInputs = [
@@ -25,6 +25,12 @@ buildPythonApplication rec {
     export LC_ALL="en_US.UTF-8"
 
     py.test
+  '';
+
+  # TODO: remove with next release
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "prompt_toolkit>=2.0.6,<3.0.0" "prompt_toolkit"
   '';
 
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to latest release (https://github.com/dbcli/mycli/blob/master/changelog.md#1211). 

Currently the `setup.py` restricts `prompt_toolkit to < 3.0`. Upstream has adjusted the supported version range to `>=3.0.0,<4.0.0` a few days after the 1.21.1 release.

I did try the tool with the current prompt_toolkit version in nixpkgs and noticed no obvious problems. The `postPatch` should be removed with the next upstream release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/6xxp4vd31cpsvhkjij7n3knc52xfihd8-mycli-1.20.1	  172056576
/nix/store/nndmxssy3xljzxhfl8cjvqrlc2p4hrcs-mycli-1.21.1	  172307888
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
