### PR TITLE
 thunderbird, thunderbird-bin: 68.9.0 -> 68.10.0 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,615 +1,615 @@
 {
-  version = "68.9.0";
+  version = "68.10.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ar/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ar/thunderbird-68.10.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "7e0a07631f2130d2876e020f7f28817cbca343e0666abd156d8f5c48a7f4bb0f4775f6366deeffdcd0676172e3b75c48c02635d018a5f1050f635f334834908d";
+      sha512 = "2f49abd71f7542042ef2823cd420e225bb1015684dc258fd7e8eb1104ac9865957b0e6c975043e3611d4d884c085ad670ce21af8c8cab1da80f08aa302078059";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ast/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ast/thunderbird-68.10.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "47ef45548aeb20dc8dbd4f35bf12913b642986cf6071f060611696da99da30a2b10c9c8aaff8974f4fc02403026146b516e84f8f2244932f290202ef2aa59853";
+      sha512 = "91043afae8c2f31f6d2aa5b7f6c7f874150c7f8ef0ef7401132b12822bbdde8c7d7f24022f3f5d0cec262100a2b8791f440a55f0ed00c30acb9429290aa290f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/be/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/be/thunderbird-68.10.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "c704c3e4be866d70c098b07bacdd4a1020ec109e92eb85c9c04d20d90db668a36bfef711acbe8bacb897543e3b8d499d35e54875bbe10fb3fc5436f8759828c3";
+      sha512 = "6167bd7fe2d980af40a0d5594e67dfc262bb7ab5fb76ea07c919136d967505e84b4d27448d883a31323db7aafd33b4222cff63d27d10ec914354ba4264736459";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/bg/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/bg/thunderbird-68.10.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "ac31e7ceb3042c2f2ac4c833687a9a44b6ec593b2d50da2edf9f11fa9bba378dea192cd472470cb7cdb2a0b708b84de688f2988f6161447cf00e5a13fe6cdd9f";
+      sha512 = "885c5ee186933eac265ed530f9b8b3cabc934e1ff4efc50b10381f8e53ddc39fe385e21e22041d93ef987e031ec41c2b98e898bcceacec004542bcaa35d0ccca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/br/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/br/thunderbird-68.10.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "1c3342c2cca3061d07be17f57d967b1e9e478f5ff91cac1df1dbc901e102e2fbeb68375af20ccc0b6922364c62fcc44a6d7715aee43fef0b2165ac091427708c";
+      sha512 = "e5c31ab8b32f9f0bd72a03207d4c9a2ca75d0c5f28e497456850bf92f75020784258725942079e52f6b38c0740e7d2ec80ef24bd88aca9fe35e9386f65cf7c1a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ca/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ca/thunderbird-68.10.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "2a0bca4b9fe58bb7872265384151ae7d2ed87122a9372ffd52752a11bec29b24a8d28f0e3102c0d6f84e545ccc6004fdace3bba7d68de206a3be5c72962c1a9e";
+      sha512 = "2d727f09dd202291cbb908c2e7805ecc7ec29302bb2481b63a5df1f43c29c39d1ae26bcf3b5dea550619391a96982d3d2bb831548a9a2331e986345c64b4b6b4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/cak/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/cak/thunderbird-68.10.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "ef27a17f5a44072596b753cd110ed4d24d7355649ddfae988a2d6622871421088d1502866226fc1f18bf8233478b5c00e98f10cf3f920ad6b4a7bad9c5e9cae2";
+      sha512 = "1e74db72b4bc0ca3db90b9ae678dea551293dd54eb5cc5e5c124c51e61ef0d4cb074769bf807ba2d680db10f6086bb3bbcf5d082e815bff10fb8c6ae14c5a72a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/cs/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/cs/thunderbird-68.10.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "1a68ecf3ae228078c67b296a1642578d8e5a7808707e8a7eab4cbe8191a6b19057fca8e3c4faa660d6a64732ca3a052579fa652bbe5bb30a85d577f7b702e55e";
+      sha512 = "9c89e7328879f82cec0e2c5f7efb2711242cb3f36a4ccf6a014c6ed589f0e02748c997ea98909d546ca33478022bc9143987710945eed1e191517d1348f8a064";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/cy/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/cy/thunderbird-68.10.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "4d3cc4a57f3e210129ba47c2fc0798d852e4369a62dfefaf3b9a8fc77939431a7cc5839c667a062231ccf49e6eeedfc60c5492fdbf5eec080233b851203305f4";
+      sha512 = "46e234560ac4a9e7c5b54816bde0f22f2677b6ea117ce5c528260222e940b5e47b12d8b08b24d2ee9bcfc4dd72168faa036207c88f5bc573051fd7eea2281fd0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/da/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/da/thunderbird-68.10.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "79e655f62bc95b65640e3556d2690725ff012a16b2cbe656223a118294915c5619563fbdef9b88fd5db3f982cea5e8ad85a9bc389776ea95ab155539d6a4c217";
+      sha512 = "8ef4fb0210a21df0be22e1866859ac316890cc90e6b157e0cad2725d59360b06db068aa000627ffa750c05cdc8314cb564c32476dcea3975bb63f66b20873059";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/de/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/de/thunderbird-68.10.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "cad5d0c08e07f6d1247cae9737d0747875b9b35036892093230423d92530fe2de2975174dfd6ec0d2e2d7ddf86027601d37d3fce14343ad4cb89be5d68052785";
+      sha512 = "b3c7673728c8af318c0c8e0c3af8e1b7ba457bfd2c5a67bf3df4df6c3c990970d45e1a0884c03aa0a3d973efb12983afea40de55c8831d2b254acfb742c71478";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/dsb/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/dsb/thunderbird-68.10.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "15ca27de99125e4be3f6cf79ebe5e897efea14ea469040ab39ef2e0ab4a6ce61bb22f9afe95a670fcf9e1cf077512b8214226946e4f4a02e7bb04d136390bf6e";
+      sha512 = "adeba633f288fff864e7247e36b4d7f49046a3901de0e4f93f12ada6fef275578b494441d01e820400045d5f7d64048684554934be678d1b7259910a162a4ed8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/el/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/el/thunderbird-68.10.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "8fdda97681d04d9247d8030535d15888d24f3462ee8d91ac86ae9b0489ca4a2c759bbbcb151548786febed90de2ff4bf6e77fa55b8bc2b1cd4c8faef374fcc45";
+      sha512 = "6ed60a3cb194de3e2bcffbdf1d0c89460b2c2416878f348c913aaaff911f43e9a624a8de87d46df366c8bd608c47f6a6de8b90fec9c0c82e38afe860ca760f65";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/en-GB/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/en-GB/thunderbird-68.10.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "51ccb86fc17862c9264823568fb2453318a8b6625f1d51eecaa150358a9efe4a15126c1a132bc57834645ba3d5799f75dd48e7cacc6305970698bdcad85c0bfd";
+      sha512 = "a09f578de9b8f23c9b24123092abecedc70e5b48c9c15089505ca049258621f14d8a4f02c8154f7d2c729ed002814af17e08bf211708fc59e5345c92cb259fa2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/en-US/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/en-US/thunderbird-68.10.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "ed6caacf356c6487a489e983275a2c3d00eac3b2282445667a1f26ac9ce217afb8261a929ccc9aa2bdf7a89101a86faee2ef87c16f0677ecf5abcc727397275f";
+      sha512 = "3f7d4c844185b0be0ee3354130112ecc034f06cc2335681998e210b79537df7365f251b005387f319b0a2d2dd6a6337fd6287a007fd54ac03c39315c42893dfe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/es-AR/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/es-AR/thunderbird-68.10.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "b8e75f5579740c8d0ae7ef30afb133b827c2e217bf9b0acdc8f117b6ffbd6c2674ff8670db87ede6db3c842af8d6f820bfa4370c0d611b7e74e99e8ad67a31b8";
+      sha512 = "a028429230c625b0dcb9e200b2e21c6d4db8e96a93313881701b5965dc25db31a0992d4d6da6072a6ed73eb5891d15ac71f19f343172796db82d6e98355baa75";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/es-ES/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/es-ES/thunderbird-68.10.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "e51df8034b18c8dc0d7fa024c3e58317a614f4da4d286c837efac3d21c59d1e58a786cc2ae0afae8730f81e96a4f0263e4fa09b552df3b58f915fd0cad133c62";
+      sha512 = "58afe4eb60993bae1271fa03a45ce13611a1d83e4defc1f237ed47b243785881c8309f5fa8a5257fa5b343e2dec7595c8ba6143faa63f49749453ad229ee8102";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/et/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/et/thunderbird-68.10.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "a81e2bf12df9ba23b8d330599eb9d32d25cb862d3cbd109183c0164ccfd2036bd327aaba36248e85f738d02d15d59f9fcaa837101b154834b53b04d2925ad666";
+      sha512 = "402c33c3fd7194a3f5c0d6afb81f639fd4a0cfebdaa61043858938fb5b2690844ec2fabfe9f73d41f45c26d56adcb121234fb1baa76b2455c87863dd79cf065d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/eu/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/eu/thunderbird-68.10.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "98a3b4e765683a9fdb9f1b128354ddc8f81ffb7bcdfb3ecc04431e84862d65184f220cddf86ba2a3442f87c27ea990a2868ebf68dce7328857718f9e02ecd474";
+      sha512 = "ace87496370c17b663971365da8c1f88000b76247aba2a6fd5d29a31b5d4b02bf9b56e101c477d48553ca56416e73209aff7f729ea2b8c044e33b9307009321f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/fi/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/fi/thunderbird-68.10.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "75d0523e83f9f95fdef45fb8b6de632eedb8b274225ac5c6d6d460cc7c129f7e34f735262cbc44e8f99957358e33eb8c8e2ce0cdbbd59d237dde468991139e6f";
+      sha512 = "775c937de9d9ed49ec70850a1d8ccbe22c964e12a932c52d3dc360425643f2be5487857caa811556e341d94bc62ed9b8dba5e94039c2cff6de50bdf16e364c89";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/fr/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/fr/thunderbird-68.10.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "c7b070e1b5dbb682e6dd119436512c5e2200105294f1c4e84c88fc8326f342196da1abaf8b7b4882397cf797070a524c19b640fc41d532885b9ce867de46d055";
+      sha512 = "1ac4d3e23f71bedf77a8d2dd4fe8d02fbd1083977a8892d2c6db394a9d345bcff73a916f34a078ddd0850e8ac1bb0486aec06d6e36875eafcac0dab08bdedde1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/fy-NL/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/fy-NL/thunderbird-68.10.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "bd93c4d482231c0c5444b653c045f4951d73c0c4c1ef9126757c41b30280f0009fddec38d8532af2c2e379a26128fe3b5e8db2857709fd2ed226d2fa73f0d88b";
+      sha512 = "b62676e5302cc265a6ee65de7a31585bade7bfd51395bd56257f733fc9a6f4c391e5318aad3b48441464e5d8bcbe3606cca1edcd6fca6517b205814b9e39b635";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ga-IE/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ga-IE/thunderbird-68.10.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "f6da6b1635d44f217b1ffe9e446d4ce8fbc82ecd5fa8a0421abdf83a0bdaf46db35343a5345b009fdf09a8237475b393d2cf0cd3f52fa16cd2cca63b792a546b";
+      sha512 = "81ba90087282fdfcd15a534e9065fdd94a859dedd6a85dc9da94de4af698eef6b31a19d3a007eaa27e08944682c9f6108a0d0991f1e394451da881018e5cc70c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/gd/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/gd/thunderbird-68.10.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "d6e4c7e51432c4bc81a9470615349624f2d8eea0d6092e53afb833a2cb4a9e770ea4c373fbef424e9139a1668cb695841fe2cf8c752befb650d0e72185693c5c";
+      sha512 = "1db39cc3ea8990ec8d9ff214d554bf95a6f2699e3f1bf625180b7f84ebc3284e1eec8e2cfdcf87b3a31b466ef2f84dd0a56d771078f4cb06962a28531ee085d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/gl/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/gl/thunderbird-68.10.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "763f2dc852ac4ecc4accd7140ea9c1945bc343342a01efe8b09470cc41f76fad4f61ec25c9456b10a16f9db528fc6aed802d949252b12e0d73c89c299ee813be";
+      sha512 = "dbaa3cd2341d8ad4834b9db4982b731fbcb1125398cc4a7ce6a9cbc44db7218a165392781e144b68618781ed8d26216f11e1bf172ce4ba9b18515cce0feb9bf4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/he/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/he/thunderbird-68.10.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "82d66c85f843978d9b2e3e0353e831c7779a16cc3a977f225ef93c92cd8eb8ac98afd255e40b1da0c21a356a7f290027b7f2c1c2ecce656524f21d3f8d962a4d";
+      sha512 = "547795f844b60b347a10abc8e609f7d311b63ae4cf76b2b0cb0b0605f597ec0e1c7ec3347042161a4b15201f816f99c391851004de9a957754aca6f50a055d7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/hr/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hr/thunderbird-68.10.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "7c013aff2eb1d4d2330df3ec81dd4e6bc99f4ec9b620fd13cc487a02825669f7fbab84d8f9a2cb76cc34290dc301522505352b0985f75b7f26133cc0987d30e3";
+      sha512 = "6c72a46406396578c329b1ba1c47a46c124f22fb5c47eb1f16af7672e4269bb84f62ac4c1d9b61a5e8e46eaa4c91e5169b59e9908ad61606b243ed21ce31d859";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/hsb/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hsb/thunderbird-68.10.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "707059d39c02b2c95f18817757a4ab5fcdef4eba63645c93a8e1cdb37dd013633aaa7b67628d357e8c530a7d9394448d61fde9fae32befdb351502c27db3cd93";
+      sha512 = "e06eeaceffa7b39810faf42640f22b8edef8ad501530f1602a7b13265f5a9b34a1d9304a19a514e3beff2b3c7e8ba92c72aaae6b34cede15e6fa59125344c026";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/hu/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hu/thunderbird-68.10.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "238047229050a38375a05d9d16514c88c5312d56857b179d7818be4421e3fb6450558f378c18035707d2abbbbb878656f1aeff461fb9f6b0f7a1b9e7e9863b96";
+      sha512 = "9ab3e1b47a3120b74adb1f0f0ec657443578203f4c7f7e00804ef61bfeb2c7cd36721256943e8c86e0a62f90c1576e16a9051b33dc9a0006cb7fcf55bc90fc0c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/hy-AM/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hy-AM/thunderbird-68.10.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "871c444b878cdc2c63d96d389ff0ece2773862e825bf00bb4534475130f4b0b684dcad1002bc1d183f6c81b730bb3af1098d29b81dd7d07a5321e01fff3c39c6";
+      sha512 = "614da904a59666d5e67852296eb22ea0ee0d137764ba9fc4f60edee2f547b91659147d14849ca83927671e94b32847f748f97df4bcd93569d46f3cfb0f8f372d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/id/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/id/thunderbird-68.10.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "518ce09cb9cedf086549873f6cc868235afa24fd04be3e2af00d92dcce8c1f08c7855c7af9c4cc21d2329187f2a28ddcbcdd46fb5a7f26f2993261e0f2cf7afc";
+      sha512 = "13e01f8fe23f10d24b4399da8540c2afdeb762b1068f10984945c0920882b67bdef48f0f26180786a8d944ca1ea601e3c51bbf6f0cb64697fca0c0b0acb08b84";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/is/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/is/thunderbird-68.10.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "855c8d301067538bdd1494fb9a6b57e0182e94deab34a9aadc65dbe6a5829023145d88d4233f10702947fbbc7361812fea94b6a1352f687bc006988618781816";
+      sha512 = "176492bbf4ac3b2bb4367848f1283c7dbb805b5bfe6c71cab6c8893578f1d0ca1b9edcbc1e736748d04f2d0ca78f4d6edb21671b78379e26d41d9c43e8727075";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/it/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/it/thunderbird-68.10.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "d447dcae327ceab2edc4302235d9055d1b11ff0407dc3a05cb1f16f8a53c6bd71dbaf5c33766f5c343ec357cbf8a8702c637c0748f658aa2083d244de9fff968";
+      sha512 = "41d10acbb84fde6556530253ecb5926ba4b5d81a38349a00281a7273669cf37245640f789dae7363c4e1a0224127885fae3dac701926dab6e4512df723d39548";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ja/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ja/thunderbird-68.10.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "1ad5d5c0c7cb04fe7f471ea85557f8c4aac62eb9b7276b53fcc3111d3e37a7eed56e2e4521c1e978acc32c973618d84c05792b4100fbf9175d2a5db0c74eac1c";
+      sha512 = "8124ccd221818d37d6d22f204baaf34bd87e7907c50ab380a3a1bf252432b41caa71dc3ba2b575903bfd255f16b702cc89d91903f494437547a7b8fa16469cbf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ka/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ka/thunderbird-68.10.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "0d0f376c9a13165978e1b5d77e6b098f17ec552baa9e8e64d32b5d33c5b2d52f78c6e45ff92901f6c94cf9efc1d0349025c3dd7baff9693c9e5ce9f62e0a7c4f";
+      sha512 = "464a9e0aebda0fa6412665e4cf2d6f590d44636bc395f8a03f96ffa7e8f5423e51499bd801f9ffb65c0c931960b761d00df3ac8f391b2157ab411ad49c7054b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/kab/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/kab/thunderbird-68.10.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "76927cd9f2630d8aa4b501a8ff49ebdabeaf75ecf5dc166aaccc254d38493a94df7dc6d432bb68511b78b5e31b483859503bf846b4c2e7fee2ea4d40e4506db9";
+      sha512 = "d99305c424e0475ed2c1890e2c5cc96d1e4925d329948c33ac0183e3affadd960266e76e380c4fbc017e24538428439888d96f49d73468f9f6162dcb51a358f1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/kk/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/kk/thunderbird-68.10.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "1a0d0a328341a7efffb6fa5ebb7bdced15f8202d37520b1e2972a3f82f37053669d52e0a8a815a8a9f2cb439227fba2c6f25a5967f459b1d2d7140e16315cac1";
+      sha512 = "9398172a5d2f902256b2b36df5f936a39e5f2d253ee4ee566109f67a49f2e2bd4239b92802475b459d79acb5af7e4839f6f5f0a5db1c7da10fa35873c470003d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ko/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ko/thunderbird-68.10.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "d4b654cfc6f0f8be641d844a52eb332c2218b419c7a699852ad693b90958d185ef29c2c1bba5b7b9e397e05fe1572b80b0f0df01e83b65edede368e0c6ad9ead";
+      sha512 = "80e7f9929a197ea4b431376f168fcfaf42718b1744bbf0bddf8672346ff08e65c35af5816a21effaac6794d9e55009885037007e87a05571e1d7eaaf7c86f30c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/lt/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/lt/thunderbird-68.10.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "fdedc91f7bffbc4f464682f3a020ab161592015fe5c50180899eecf951e9f775cf5ef3cc6b5baf7faa58221f00e19fe99074f60d292ca258cf44dad2db0d0d69";
+      sha512 = "74ca7346f87b078cb9f598e79278ee39498b09370be5517a3893dc4bc2d5efe81f9b9076b27891be0c8d170802a02ac67dabeffa022fe222e95b73455b40ff34";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ms/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ms/thunderbird-68.10.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "1ecb61c99626dfbc8386364b747e94de7080facd6434813c8afeca60373d3cf07d2259ba90ed6de01c68a65e8b8408e58647d4e72b62f150f82da4a81e78f861";
+      sha512 = "90c71d0b3f598c21026441dd5b34efca7276f34153ffacd327f09d2c78296c9dbc2ae9eb8e1f7635b8e3cafed15f07cc3c19254405de2e6c9e1fd4300b844876";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/nb-NO/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/nb-NO/thunderbird-68.10.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "45ec1f8def3d2b57e29a3fd22bc38f08a9c7b1ebf44e6dfb736ee13d09cb1bcfcd632c2f8594e3c531d35aa7b696d45ffa1bf5c4cad7e1304fa92763f923df43";
+      sha512 = "08da0c8a887c820d246559bb7c1394282a68f2971ba2f2943084ebf3cafdd2580477ef5a9ca06c1e5aac353287276aa88aab8346beb95addfa95d5014cd4974a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/nl/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/nl/thunderbird-68.10.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "20dd4c7e946e0fca871fddc3481f2f44b72939de3a7f5064ab8f062981ea717d47f2a3c09af32c9913556e2f5fc01fe1dd78c2d35b5fd44a7f35cdef1e4252d7";
+      sha512 = "f846e221c2bf3cebd93961e6af10c24215b698cb8318c6446224f5de5b533e887e76818b6b902adc839a3f7c5ec24e9b13aae63b5d601d6716643f64aa29b7da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/nn-NO/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/nn-NO/thunderbird-68.10.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "c366bdbd0cda3143c7684c1cfd948965c2b80bd5076878cf3e98b9b5fb82baa6df419445ab0da134209a969baa0e36d759297bfda701d2ea4cd8c6720b61f123";
+      sha512 = "c33a600e2d64c94cdda74f2a94fc54f05133cc543c795dee70909b00b92eb5a48b183600f328f45fc8c9bdabb59f455a4875e68e6e62ce4f6309cfc0aed24fc0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/pl/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/pl/thunderbird-68.10.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "163130f55ed9e0cbc68b48c41541748aa320d7a8fdb954c38fc25ca7e2dac6fea98b30b2653b6e8b31230ebd8364ca12281551e00375e4dd64b87515f08e6bec";
+      sha512 = "555b0fb0c4117521f020f7d9846b19dd18ccbec585cd89282384e0a311dd5bbedab84101bd55064c7ae20ecd811c70f31948da26befcb12abe0937ed2736b9b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/pt-BR/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/pt-BR/thunderbird-68.10.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "5e362e0c53f898d1d156c53415469fe965162047bf5ab55798ece681a33322d677a874b80f9f934067a847da9f2c45a62d63753b866e368585ac5f0844e410df";
+      sha512 = "a51b74e5d9394ee2ebc26149e1e01766b9c4cde5815fcd915bbc5307095a851e6242fb007c8e93027ea0a77b3074679041c65a1996528435f30f7f17b06959a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/pt-PT/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/pt-PT/thunderbird-68.10.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "b322096fd6fb0778fc26146b69fa9a63f249e927de6d2ae3fd6093e3e24b4825ed29a1d09cb68de274aebeb06effdec78e6445fa5282dd6a733b2181ead21248";
+      sha512 = "4912989c47a3c021a28ed56629e308d2326a07ec99dc00b624889a10013f36445fbfe11a8cdde7ff4f69c965b0d2221c61c246933cc313df9f63ae3ec65db891";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/rm/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/rm/thunderbird-68.10.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "715075dabca54e27001f68b11e6c3c99fc5e20f1fcba637e7613584d84a97520e06fd73761bc6c780ae8abbec3121504fb1b51b615a35c0d8660381d71f94eb0";
+      sha512 = "70298a29589b928748d32adcf83b12c006d23cd3a171af1eb790eaa34eae4b1a8e97056fc71f9a795a9b9e07f5d8e2a9f4ffc475eaa4b06b9390976fd6359668";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ro/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ro/thunderbird-68.10.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "fc279090426b3baef609f23228ac11d4665fd805d6118a4ecc2bfd1dd7b36d37004033db4be1095275c677a092026a083199e699b553c6eb82192db0190d844d";
+      sha512 = "7c36cefeec21820b90a8acc09856aaedf4cf94215cae71daa8142a1d166de79dd0114495b92d954f978d1be88c06ad5fa269fb33ae0b307ca05f3d7ae90844d5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/ru/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ru/thunderbird-68.10.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "8c575c2749cd719878ffba2c8158597222d1d494f2c3749c6b5253a8d75607f42a45799a288f85042d8390225f74ac55d7497abc76a8fc870f89f8f7b7a3c699";
+      sha512 = "b7dbd077b0271818ba33d8651fc60e371f9a89771020113ce2a0785c2d228b90d219fcf944e6ee2645fd683fbc1d597529382c4b808ee4cf81f7123e1de9d583";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/si/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/si/thunderbird-68.10.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "b2edb098eea69332528f24a352e2cd318161ab3383cf13f878c7fdbca14f923f74a769fd494b435d0ef2fd760d4b7cfead063c91112fd44dfd3d4a47d4597549";
+      sha512 = "b9217a815c7f042bb33e0ea2ef9129e8ef1c825af315d0cddb6c0760bc87f1b8932b6f7cca747d50a29a55ac66a21d8113febc360e5f963566399a38e3b5a2a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/sk/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sk/thunderbird-68.10.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "2dde57c16b15b823a698f7c17d98eadd5528ea29cbc50d22a586c3ad7357289f2c4719edf8ba47c59c3419383c64b8ff948582a58356719990340f5db0be84c9";
+      sha512 = "494ffad5906f35f9b3141fb06f6900e0d82553c16c8f3d99b50d6718643cac21fbd6a205af146df54125c009f190285281b09bb42996505a2fc120dd85bde882";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/sl/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sl/thunderbird-68.10.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "0014d8985ee139ec3ffae5ff18bcb8ac6f0921930853bab3ddcdcd6d21b9453aaa0af058068770dacb04bd1521b555945f9bfa7d9f47ba4a2adfd667fb067d78";
+      sha512 = "d34836dbf915e4d5157a1f8760dae8d8659ceda2ceb594d737da7384139f245915f01a0b025585c117762f2d3261dffdf1c7efa5c2e1f920fe5a350d85406015";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/sq/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sq/thunderbird-68.10.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "5aa41dfc73adbad839452077b436ff302d0e611fb342998a7f6bffe98fd634d7995a30f49f8640645052b9f68c149c71a6bcdf0fd2df7e3c67783bca3c4ef511";
+      sha512 = "909aa9e820cb984459deae17b80488db09718eb428e32a35ecb1723fa3c8d7ed974f6cb17a07db8e642cdb51b885291a3fca518542372fe2c2b3360553b3527b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/sr/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sr/thunderbird-68.10.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "266d0030c7d018dd68d5cd8496eeba061453e1d5a37e99c1645aa9c677492d0da397b2a9e70aed5d927c2e955449ff5b75efbad74d60fea4bb4ef90c36d765ec";
+      sha512 = "aa39d12ff81a371722609a4ec401021512f651c4f592159f8ef9bcfcb641b55a8f6ccea970b4d8375cb326e0cfd5fa18097ee3131e7546c53b1e29d14058622f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/sv-SE/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sv-SE/thunderbird-68.10.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "6ce755bf48a29522e1f0805d6fb37bdbf145f75a4b6fa176c06562bd1b6b272d752a3d638ab66bf66dd6dc67fd817d76e70cc31fdf9b201f56c6bacd058e49df";
+      sha512 = "3f373131df39c343579ddd851e8c5eef3147650a5c75a5fc3ce84c2e1a694494cd6e3ab12b3cf86018880384f02ca38a54fcca8cc04f3074699fb89c4ded78e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/tr/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/tr/thunderbird-68.10.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "302b03ab2e23f6c0cac0fff85cfeacfcebabea838fef824b7d1733054fd9a3cb766dcff1dad333b199ea876a16ab7a059fe4e01289aef4ed481126c27011b4c6";
+      sha512 = "2c91ad17ddad9db19ff2eb47ff7a10253febd30faee710301dcb96ed0472f81153de5d7d906b3dc706d39ff058eefcdb9210ac274469fcc02a39cdbb99a126f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/uk/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/uk/thunderbird-68.10.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "b3d59d62dd3d3e6e9ce8be3c4c746c41a0a0962d1327d1187b0b2034d0c1691970d181405cc7ab7e2f1fcafec6caaa26863020f5edae4479e453718619b7d02e";
+      sha512 = "d98a132e14a5921b6a75a8fe7cf3c1aaf22e83c4c8252dcbd5aa0434b98a7d9d88711b68cc470e6007027e6e588cf9ea00dd78a2d97b48b975adef1cd059e79d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/uz/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/uz/thunderbird-68.10.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "73d36534f000d00a52988825c0145288d8d1eb944065d11231501f6e2906e97b0beb89d59b796d3f2828054ed9393e8f65866cfcaed6eb7f939cf657b6f3d740";
+      sha512 = "dac94504203e7862608333f1f84134d7afe0e1f534eec9b91ec48a850e0143b625f4be311c2e6e716a16c941d3c2f5dd2101abfae205c802749ca95428b7e754";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/vi/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/vi/thunderbird-68.10.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "b3ec66f92f5d023933e8dae18f0827f0fc8c5880890f9986b339f06b4e565cbe228bc2b0843924bd2a524a77ded7667e63c2747d2ff6c3789d57c8a68e440714";
+      sha512 = "684626eb432e89e85b9d3270198ee20470e675ea7294222755b5b588db7e318c20fd8d2fc9a0c95374e8ed53e792ab0e24e826709aa619fbab059a77e6341213";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/zh-CN/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/zh-CN/thunderbird-68.10.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "e61e72c3dcd376d74e732d76c5a49203b47e2ea31c86bcdcaad673583795f5c01549fa2c5526205857e565f2a72b8abf8b2aa4e7ede45a94b218428607662a1e";
+      sha512 = "8a25fd27a555b18bc41ae31f024e80adc1b06de064bf2391c1db5510869af8c145780a01a26f6cb465d2c6b53f4ceeb924657eefeb95f7ae2ac584ddfc4a56d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-x86_64/zh-TW/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/zh-TW/thunderbird-68.10.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "f47bfe43ec5b570863ed1fc81828a23beb250db24fb77d2df2dfb5ec60a9c750f188cbda1a0f2927688865219f6a36695d87e4a8eb1fd642c4c9650dcf2e9063";
+      sha512 = "8f202b1a79ae831bf5a28356a06213586bb2c0f4410516a8121c73a8902d0ce7e54f8e6fd7d2c74b300c9692eb3ad4a9b9290cc93ce3205f73842d93a46cb77c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ar/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ar/thunderbird-68.10.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "83a77d9f39196a8a3ec72469c038c835fb6b50872a2dd611519b178f5e46ef40293bfbdd908b3ce236681205b9b3ed133c845e357abb70285f9920401ad90cd2";
+      sha512 = "868f092cc144611611133f50be9317161cb34ba2d0012d238789f2d1124b547c52d2aa02d4daa090322e327a4652808cc882835195f02bbea8e67818d22ca8da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ast/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ast/thunderbird-68.10.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "83084855cf03e66968d20d2caca749a9ff9d47b0cfdecdcedf0320b4bc7e628ff5f3a971ae1f6472c5a44facfcaee419250f55ebb254bff9f344c64772f54791";
+      sha512 = "bb077167ec58446aaaaaa7439e04332946d62cc6a35ff00bdda20a03eccf80b09bce70524c3b3351fe0b821dda0762cd666c66b00314751301a67d635c2d37e5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/be/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/be/thunderbird-68.10.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "722bcaa29137994e36f70a438fddb5be55355cd85d414fcf70cb8bbaf66a9ab0fc21408cf282272dbe977f46b5aa63575c7504bef8292adbd8d4c6e308655411";
+      sha512 = "a8ec19464c57509ccea6f83305d441aa9c61ddf0bfe2af172df24f67d7abaf2e568eeabfdfea9e0a843d42ff9c6d2610b1e1e5c060ccb50bce4045b47586f204";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/bg/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/bg/thunderbird-68.10.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "95464ffd5256fb181599ad795fbfe5d9cfe8ef0c02a7830174ee4732761cd94a2cca75b6a686559e07d996640f5e973a660fc857f0839d6bea5594e61f2f7e4e";
+      sha512 = "9c8ef811f0bf04066f3c55e4b02107450d88a1774417ee503027423917bdf16ab9b102eb0f7f4c777ee60039998f8391164f1719bb8abc4d79774664041fa6c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/br/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/br/thunderbird-68.10.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "fe09bb21248975aa60ffd74a970c9dcfbef578c1188bc1c3704c7411c2e94f88976ac7ac5e52a69ac6235723332f2fc76757ef9118092833fe64bf0a05e3ecf3";
+      sha512 = "e94fa2e49fca5bd6e6f1139adb86604482deeb1160cc8fe348a1cfab2bb19c8ba694ca5743ed6e5da81c9789521e8b6018db4ecc68ec91c8a277916c6a553521";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ca/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ca/thunderbird-68.10.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "01ac3c0090448f1ffc7c97623df8576a7a3c184a2bc1a2761f0e3451a18dee6d4f6bc37b305dcaea89930a1750a9541116bdf03f613b333ddc47d5f257b3bfc0";
+      sha512 = "4dc73850268e885b9791b29573f35704d730e9a9ac833265f47413eadb2e3d359b8b56405ebfa58816b8b2ba390077c14f17a769fec94870652147d2a2915243";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/cak/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/cak/thunderbird-68.10.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "27dad086126a268f2c6700a5f01006c40e911ecbc95dc994da7cd2dadc3f2bd3bc94d5da15a297b2e72e8b20254d40c757456c308b70bae2c1d451ec6ad7d1d8";
+      sha512 = "569d8b373efc412180cf01ad9333a1b2f05687f3b8cfc4286c81c9309681d390d9ccc2767248e36db7931e2b941dce6ca209a00e7ba5dbebea6d40c710dc2cdd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/cs/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/cs/thunderbird-68.10.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "b99dc13bf43a9aebd08f13fb113186e6e4a72c68d609895afc8a52c4909a0506f646ba394c705004272d1b91db4efc81a5518bbd06e359a8a24c85f4fbb30102";
+      sha512 = "e87eebe5c3486b02f46784209019b5f5dbfbeb36be8914604416c194bfebda2827861172019ca33bf754bc86ad91327ce5e29ecabcc77390d84be80c2f682e29";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/cy/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/cy/thunderbird-68.10.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "36c1557a9955e461128929b7be0f679a02592b65e4b401b052ecf1f467a231ba725c92eb96b8118bb75d49ae45f8287bb5fbeb22d94ba11dcf311cdb87170ee0";
+      sha512 = "e97bde29c976e200f418b2ec150969459e4e17872184dfef548b08e16286f948259d2fc84d0d07965a5dedae8d5e3268c3a6ac0794cb0c3a739ffc86b2a6f748";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/da/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/da/thunderbird-68.10.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "e81b41e38b322f2eddfd68c07f326ec9d716bdbdf31c3a02d22d9377002fd21b58a68a8ac952fed2ed164a02f8b20e9f6678c52fbaca741a4bcde1079ecbe38a";
+      sha512 = "7bfbeb6e8bb427e7e3aee31e897d025e338a4c4da59eb2700b52dd08cd53efaf6dfe1d33e456572c0203fe6927bc069ff297288cc47dec2ef9835e047a5d2938";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/de/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/de/thunderbird-68.10.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "da6a44a2a6545b10bbe12644e433932c4410471f5948278b919baca1c6eb0181366114c1a6f611b897c71bf4091a6734393fd36f997c118f49466faa8dd2264d";
+      sha512 = "15da351e919e0b931dfe48f77b9eeeaec40e94c973de507560c62a86e2b106f7d4afa7602186829fad2984f9964ad23792ca88bd5b94976972bc103f0560ee4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/dsb/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/dsb/thunderbird-68.10.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "6d19a0010553d1b08bc47a22c0c7f23bf4c86ca79ef3ca26c970cd502e6db003ccf045488f88d68a5b1b0ece4436de55d65592b314126b9b5792be30c9def553";
+      sha512 = "1b8c1b12b8d7979a0ce45db282bc2a3b933bda3711c07097533a8a04b38edae3f0bd00298cbd485954ab09fa57b10aca5238e8a7bf4e23ea80ebed2dba1d73e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/el/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/el/thunderbird-68.10.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "67e6382474356c4ff25e6f49a7ee3859eba5bb29a4e795668e1ec52131dbaf0d87b9cfb8ffe1fa855bf8f34e841b8fac90c356545f47a711b533e3593219e957";
+      sha512 = "67c5dad2a95ff1b8b3ab2ebcb0c1c4af87c5325e22d43c24f4f1c0df9ac328b43b0b25247408c8c95cb5f98b9396a1714b0cb39cd2e43ecd04b28f8bd1dc43ab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/en-GB/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/en-GB/thunderbird-68.10.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "f4e1d9b10ffc96aa7ef4202e73445d98a06082abcb87fb60d951ce491ead7cee4bad5c1009270004540d03aaf383eb5b8203845f84335b523d92bb586ed5932c";
+      sha512 = "c9feebac54a357470523029377699fc9c0bca08e4705374dd1b8756cc8461237426cded2d9ee994b7ee529c60d50a555e4e1c2d9ec71ceccb7fccc651e35058c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/en-US/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/en-US/thunderbird-68.10.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "a8fcf918c869e8064c2dd39a03bb768616b1a5e4e1c6121aa544d72626bfb790625e2cc48dc973443b947c6e619f9481cb20239d544b10bdf287b7fa4e05128c";
+      sha512 = "9280a58b42f93b38f4c9ab26b8b6c2956ccb135ae959c61799cd3ce3b3419c9642f86418ac53e9c4f69e0430508c0619db4cf856a28d233a8d319e262755f4a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/es-AR/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/es-AR/thunderbird-68.10.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "6b98ed36080e8eba879e305aa34ccc77e1735700d104f592095cf9810545bdf25665dd36a527e19cf12ec4cf782a6387e30f7b4406b76230c08a350f4cfd5fcc";
+      sha512 = "9c17d648a2ed9c2b6dc7d403436dc9aad91e10e63579e26e4dafe3d5b3a15633167c87b67924026882a03f1aab05673566a0c5f0d84efb656b6b3d7d4b812e5e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/es-ES/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/es-ES/thunderbird-68.10.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "0cf479d98ce943e20871e7073188db3c9162dec8cf2b0abaedbaabfac9b29411dad39fdf44c038680956c42f7f7e303d5e2bf8d7ef9225fa093821ce760e9974";
+      sha512 = "d22ba4fbd7e8d22f70950b61354b99ffa6bb1c298504f8f05297cbc20f0c89a9d657c74ab367480906cbc4b699df6c603d6f6b936ccdb4213e178f3eb153a314";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/et/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/et/thunderbird-68.10.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "51584ee5c76710a9b805d4da528d5463f1e51e3efa6ca3b9cf3fc6bb6b953cac6b7919f908975905f619d9be75e4b9ea32980bd5f198f77dae0f75795465fc23";
+      sha512 = "107fa0cd997edeba0a88d365c52fe48ea0d355ca8bf8723f5bf2ad4a930711e8fcdad27b457d309a5d4dfc0f29f6988f2b04f153b83384484ed397261c07db7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/eu/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/eu/thunderbird-68.10.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "bbcbd4a91856ebb9418c00feed41f00c93ffc5eed4af7c1c27585c707aa8dbfe4e48b0204cbb236a8205a219f0044811dc43f4cc94b6610f30d38120e3ab4b21";
+      sha512 = "ba50b4fed2d682f1c46699f72d86b219a1bb398b1b2180cdfd246bf4eaffd61e34e24222bcd82ebcc68b9cfa9f98f56fe859cc6d5bd744a7223e7264d6d4f261";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/fi/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/fi/thunderbird-68.10.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "f03014cd7a28b4d85c2d896e8e2a5a1db959c7290c98cfd0c12839170956e98e0087685ab4304fbbdae42b06a8ff7b5563e70c9bbe0a787d2d9b4103019cf31a";
+      sha512 = "6f4fde19af18845d50f591940786402233bb77f518f1f8f9cda727bd458e21669f692681cc691617a0ce05f8516383ce38b7b51445e3937ff8c1868e84a92ae0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/fr/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/fr/thunderbird-68.10.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "ce7b187a572da6bee677cc7849bd5123545bf437005b16a855d9e4bfcd58a10f3b095a3b0a767d5a67aa113c0a9e0d437827c37fe1c8bf84a3fc8c8d2c702a8d";
+      sha512 = "7e9dc42478dae325a51f44781048a55fea3e2bedcbf663c534510404e59dfa10216dfc0df4efd40e0bf1f4fea3abdc9867b6c6b33f199e406ab07d68b68acfe5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/fy-NL/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/fy-NL/thunderbird-68.10.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "2062090196c7b07ce148a2937027637469e7593ac092db0bf7139286faac51d350c786c0bfed6e32903bcb7f2ddc4e3df6e993f8637fc68c1aae1be89ceddc98";
+      sha512 = "1b665dce92e8c1de000063f1a12192a2fa5aff2c65db9aa6769ca16604e7e97a602baad9761110124c65dc479fdbce7640020701fb280b3c62e5c78368fb496f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ga-IE/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ga-IE/thunderbird-68.10.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "fb11eadd35e46081a16116843a4a134b8197c4e8e1d1a52981a085f02bbda7ca49dbf1d9a88f4a7fe2542a99ff24f6d35fc661414cef1fb50edecb98c6693f4f";
+      sha512 = "42faafcbe85ab995b549bf072942dcc2e87780099b3bcb2974ca3eff6acade40be7bd8ded5cb0db6a02bfdc255c60e252061a767543b2215719a1fc2600fdd81";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/gd/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/gd/thunderbird-68.10.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "e9b985732d6619555c24ababbbe38303998750986395c647aadebb0c209467fcdfe5f9dca99ecef0e0b747aa8598f887ef2218140ad1d97e7e3d73b430dad1d6";
+      sha512 = "e1455ef926d71ecfdad24ebcf4b3de59d04611bf641ba381534bd1b94c2f7b730687cf2e8412e6910d37e402b58f32588482089f4d12308a7b9cf6af82b66e97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/gl/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/gl/thunderbird-68.10.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "3b8eff0004db222eff3b4f42be4eff168310fd0e17e676ae92fddd9c11e3a6d4826c63a35f9de37095a7fa88f7f4931e36bc17ace548e36f91bd8334fa53799f";
+      sha512 = "344d619a5437d0efe2e522680849dd809b07c3aa9cf2831610aaf7ce28e81f16782a4a8174c01cc339914e02a23cb3ce603d04dd0dca8eb4f547e0d0e780d8f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/he/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/he/thunderbird-68.10.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "e3dcd319e08ddb5aef2bc576f136eae7838e3aca3c9160aabdaecc32332f0c250201a80f31724233a77f4dd2857684f2bcd9b194df5ec965d69cc04a9e9b7da9";
+      sha512 = "c081d81f3c1a61d2922bdad144a97c8568326e97fe29909d4319ca9019d9bd466dccabc6f2069eadafaa6bf6bb5bd50e8cf0c070dd992cc095411dd909b43f06";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/hr/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hr/thunderbird-68.10.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "84164d00d087e507ab79aa4db6567311bd0cecbde1cb1be7337f4ffc42abc8c7cd0f4fe9a3aae2e35b01683f96e1bfbc816fa96e6fb872157cb473128679e19f";
+      sha512 = "2c142b9bed17fc1fef3e4339f0477d3f469923083a37ec3b2dc3d4690a44ee34d5a23faa37876cec2f3bcd02c1048ec343f16bd02a1771296e77cf3f63ca787e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/hsb/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hsb/thunderbird-68.10.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "a3fac91f5e2fbf739d2f2c164c6d58ea89026c1e8250a41c51ee11640bd7831c73a4c3148cd80ae2b40a2e1a369d47d3832f96a276dae2c80ba2d90d6990d062";
+      sha512 = "fcbcc78b1d5620c27b7cfb7ee88463dc81664f5eba679a81920ac6923b0e3f05bc70b99ba7268017b59219872921e76860a113fbba757cebf942641ba0591517";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/hu/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hu/thunderbird-68.10.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "002c42f700616d2ddcf1753d37de064959965e4504112e96507a8aaf2398fa25f650e1fcb50189aebf3bc3d0c3de795b496d1f8e1550fc0186d74ef312a11d74";
+      sha512 = "d59024db516156a89cbcc0148a5bf85059ac2393f41709e224f109abca6fea693b822d7c4a3ce5e360435c8700010aaeb4b26ef9e163827bcc8b6cf1761d3781";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/hy-AM/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hy-AM/thunderbird-68.10.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "41fe16657886ccde1c6410e3e62ade72d8890a50e77526994e82cb929c8296110d0aa32d8d02dd7d1482d594322325d28cfa54afe113dc69e2520dcfd56516f1";
+      sha512 = "17876cefb335375b7884080315690fef116983b7559421f86ad0ef787bdfdf5aed283d84114cc1c1d3cb3119d735f50e975f94ead6fcab6046c207d4c1a8fc8b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/id/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/id/thunderbird-68.10.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "8fb8703220a801bb2d29e436d28325a3310b61f6a22d3d8964b98bd9cea9e74f9e53cd41c8c9a501057d1915a6c71f6f5d27fea267b802082488d2690a0ee088";
+      sha512 = "0c74ca260ffee635cd556c0710a13ed091a1f2eb63a1b1ac2a745ea0e86d42b52b08b00f648c406356e1e170c77242d43d9a4d2b2f0bb1fb26d4dc83b4179a8c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/is/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/is/thunderbird-68.10.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "09c59bca1a0282416aff4043b7d64e5f8ce308792efd35e197b2d91125715453769b482e5815c9f33cd0d9d3809bbe898c40e767c13786868673bc7f041f1c17";
+      sha512 = "97fdf5fa7dd6fade8ec7efc179f6a65bda90cfb285341e3e98b9b2ab70ba91ebc8c47bf8948189d4c181566c9ed950fbd0fb6b4d4cd96b2e3329c0085e32771c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/it/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/it/thunderbird-68.10.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "c3f09f2681d0aa197084b0935855dba98517d6f5595595385d93dd7a998ff5b0c98f35141091f41ea8e91ea10b25f6464f242218cd7030351347f77f35396ca2";
+      sha512 = "3d42b5a8c55519accb3246c5a7f50def9d854ccaffa0e34b20e6e2f51cc07a787a9ab0c0b205e28b40d9ec4f55f1176f391ff9156076327f8a4416a9ff6ea8ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ja/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ja/thunderbird-68.10.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "4bdea34b50edfea5b3dd3bb80935e1148b3ad926c95d84a3d265268f783ff3c487527726b0151643c8f3eb5d061d441742da23f6cb03297894a8076a87275574";
+      sha512 = "bf90c9c27abac84ef91a2fe3ceea142ac7041c10d41a0e5a2ee31742f9f64b2b24a331af769e8ae93c7b09bf8645dc4d274524281fbfe69a908fd22aaac7c2d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ka/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ka/thunderbird-68.10.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "ec029d7a58aa502742160e131eab70f50f83851124297fef72214d58f1309f047b9881d824432a8bd3841dd158493ca2b41e41f4f9bf9dc043db9ec4df1a1d24";
+      sha512 = "8e2fb192c6776ad702ea7aaa9bc9dd31b20c1c66e2ce4dd91aa10eda5528172680740e28f8a7bab52a7c6eae92578822669d6ad068bbc85a04d97c91a4b7e08b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/kab/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/kab/thunderbird-68.10.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "cf291b9d2924e72b9871a4eadf10118cd0299e2206151c67bf36fe0c766b75c9e67e9b11e8612ca5d95c50c6cd3d90e95210e9625ed8eb1c14ba5a8d45bb997b";
+      sha512 = "10b9418db83b328353afb73b7630add081309cc0b55fac8aec38f6e09036968082d3d12386efb6b4347b33977998bbd906501adc45a8c8d27dfd0f8d98288bde";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/kk/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/kk/thunderbird-68.10.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "1031db4a9f0716973fb1ddbc8e12b2252bdb8450617a6c642ad4001c119cd3eb3bad999b861e8204a85699b415fdc5d768b6aafa6fee2c5b9efb7e9a3558eda2";
+      sha512 = "7dcfb10ce402c90452815523d5672a1cd60201b33b997c5b769341e904f4840ff57685eab61dc3073f789bf042453f3d144e54bec32afae2dd65367a0f1768a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ko/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ko/thunderbird-68.10.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "bde75ae38856970c4da871cdbd63d96f31021f707869be7517d4c719ecce3f505f886c65e9faad8bcc0ac26885777e070246576fd47f75669b77f0247689954f";
+      sha512 = "fddcd08f00cc4f3de59993c8c917e20e77918d87e2c23e989e8e8aaf78c6130f42e546acc17eb6f8c9a24550c596ad201d63f325e7ba078a6c791fc94589e0a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/lt/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/lt/thunderbird-68.10.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "9459b50e1fd01ce742bfe6f13ac26241958ad5307c08e3980ed5a84023a12be009dc6a83085ad52c68e162e6a45f4f430e79e21e4d19f67e470ab07151c40bc8";
+      sha512 = "ab221093a0df2876f558ff2e0df090b95872281e1cae8ac23c9753dadd6305608c6e7ec5104d491ca3a3f1c1ebd830b8094080ce99bba49b19b46e617238cc87";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ms/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ms/thunderbird-68.10.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "0632af25fd5245ec2a15a09a075db24a64e3020ea6353e88f72fa74f929d8507cb868cc617da8e97f01efff19a9108c9b2b30adc8e58b0e7e6353332219e658d";
+      sha512 = "ce6b0e1ba8a1a1bbfd4d2e265a45430c2d931530d13eff67fea4179c4a8e2a204ff35103c921073bc33c3e2a8f8f3f55fb91b3218cab9718df76da696ed09750";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/nb-NO/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/nb-NO/thunderbird-68.10.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "b16523b5a40dbe496537df487d72f8cb16ccf338c1a96e6ec3dc7e1a5d3073991c12ada23fc6b31f34d2fb712050334eae145a45420994c607a63799ed42d264";
+      sha512 = "07e73fd67e0c1974c5e5b90d74e555b75820b66ae9bca0470b6d291e848e5f28fea680cf09c2167dd56b0765ae0e3682b5f2ab7f33cc5b059e60252236dc24cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/nl/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/nl/thunderbird-68.10.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "82f0ab2e4969323ea8294f732b13144ddd453a613a68b582ff398cb85aee88874a5fb5eb61627f142ce8124b476f49fa6cf68cdaa41fdaf3621519c53c4ac16b";
+      sha512 = "a24ed7d30e53058653c0de6b96867fa9621118fa43e109940502eea798a5c7b8688c65bf08d765f3c6dc6e8ab0dabfef98ae005e00c465f847454b384953276f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/nn-NO/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/nn-NO/thunderbird-68.10.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "815d0010de5f6d9144a182a2170c59a502b167f18eec65d23987e4b73e6d5bae46be18d7f55462a3ec8634466639aceca03ad9b772c7e8b232eb874998e6148c";
+      sha512 = "4bddbdd0a2353f8c43e65cbce5974911809cf28c3d7ce521d662d782f8858b469575857688a5c674f6d028acd55869c062edf9f55dfa3d387fab8fb60f6f2fad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/pl/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/pl/thunderbird-68.10.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "5be434a54c91097d4f6477767af96f8b862828912783eee48577cc450a14eceee2e067e9c10697633a2833f473b9d10bea33b3c6c6377b898a18d3d7c6568f96";
+      sha512 = "953d9e547eb343a0d7f96f501bb87ece71e2f860f8517fb13b76301c7b3e77d7f572a8106fdd43c2b390654457e43703b22566bd3159ace962af2eb1f8bc6ca8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/pt-BR/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/pt-BR/thunderbird-68.10.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "b7b3fd6bb8535f2328ceb9259d7517bfd695cc881130720d3857d5a27197deba4fe683e163f49613054ebec2827e805a31a62c9a9e578f4ffb760f421a4ea506";
+      sha512 = "b3807897100857c33768478c9dec57024f968a83188b51bd2708b7caf7c53edb39b15cc8dfb5f73ca937c298fa83551edf82d7f43c065bc2fc25467a02343d20";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/pt-PT/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/pt-PT/thunderbird-68.10.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "b9561a6f55c25cff2bec9bda78e46204dc85429c52bb42f33b6ae972c0bf16f3a99ccbe3f283ef08cca955d31e5eb6d91ff9d8b50e85bd75443998236d6e08b1";
+      sha512 = "e50bf636697714fc4dfd04e1a8d6d7d87239553f01064bb566e218395a2e5d9b16ef22c01509f18f9f562b75eb19a2616d8c7f8a4d212a9a445b1eece17527f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/rm/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/rm/thunderbird-68.10.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "7ff72dc448c9303a70403558ae46cd720e645c24681dabbf265db783ef872e92216f8ee9169e155904d3fcd3288f2ee0ad11ca22bbf041b380884d57b306876e";
+      sha512 = "1480eb4c77d88fc461000f423179e5bc693b2f25abe5c6384f4c98494f698c620fdd53e65d75ebd17ce9546c5fb00ef8f40bfffd9b31114417cd10262569a54d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ro/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ro/thunderbird-68.10.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "7f585b942076749269ca86161694ef1b9f4e68e75300d60ea4141b2404be0c79761a2658c123787d67e65992e4b3dd5b7406acfee6084846bdefdb0f82d9baea";
+      sha512 = "d9cfc8f03d75f3a58fe103c34eb0fdcb3530f0ebc68c0acae7fe1b783bf11c0585e266556d16fa3db174aaafcc319cef9cfa363361cad7b1053a504101b13880";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/ru/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ru/thunderbird-68.10.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "e4ef9e081cfdb3567f1823866ffd0e3e5fbe8596fd3a7dbb94869a8d1ebd328938c490669c8f46bc6575d6b8c5c351e387faf8dd2a33db263cb2fb5ddb2974f5";
+      sha512 = "d67f550615eb195b80f7338708b7ecf7455203f86aff1682f2e8e654d019fb49c6468eb1c099f7fc78797b97d41c9f42aff5498f27b6cb458f049fd8b6aa3d4e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/si/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/si/thunderbird-68.10.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "42db8e43c4bd722102778d4a9cdfb0ba54b0151882b7963e07c0b8cd653d7303eb22a541a8fc3a5b93c9db09c1a24db8f5c3365b5654e997c17d3b4b2c2a5f38";
+      sha512 = "6dd9d78a9f2ef4ed28a95e83e76e9779d02c950ba906ca14d8fac0bf7300ad2d7d5ad9cfa3973cc8c861011dc8f1c58a6ea5909206443cd2f24bf5bcfe8c5673";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/sk/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sk/thunderbird-68.10.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "fb025203b739cd89169bc25b36e6d541ebaf8726720c0b51e58a33fd0e71c2a4ae46428fe16547ed5e639e81ce35253a5519a28de9a8baa952a1b1af184b77a3";
+      sha512 = "ba40286898a7722533f8a65e1e9bb494bc28212d2fe21c820f64b1a8bcaad6d0ca1d7a870d5289792a79a6c4851931236b13c1ba07b812b591b3d4c6004ff78d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/sl/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sl/thunderbird-68.10.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "ba392d3748b697d323e63c7217ce3c3aa4eaf6b994d798655a1667644733a6f19b23b95df420b2235e9ee000a868485d4f32fbe5d737ef5c7296c085738168bd";
+      sha512 = "bc8e926583e92f4cfe3081a1bb618d7c5fbe9e1f93af378040a72820b820a38915ff1c74deb6069bbaf2957adc536b78faf1df853e8ff6390a9396d909ee040e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/sq/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sq/thunderbird-68.10.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "b795928265f2b50a1032ab8fcce954f6d0d35a6dab2b381f11ca1b6b204aa1ae91b0ceb221da5ccadcca303f20792715d0f770c215dc59654df1b325ccc3e42e";
+      sha512 = "084bce04b0d83ab24682d04f4c788d61a2a6bfe0777f44f4c9a07d8fd7fef4251464e9a0e523f4e111bd5323ceb398fa09ae3391295047beac3157ce9d2e8905";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/sr/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sr/thunderbird-68.10.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "274c3675cd3d5264c2ce74b101b7c87bfd1703645e4341f6499c25b4905781395f514ed8412b22289ad097994e748ee7b527f1d6081022429292a64155d2df74";
+      sha512 = "544ed1f0cb8beeac3ac1b2ed02078c3acc5961d6fe4c3f0722b1a36208740226053236453a215e564371453cc5acb541a6f307d594524081a5f4c96aa077c21f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/sv-SE/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sv-SE/thunderbird-68.10.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "318ccb06cf2c9f5fdbf25fe70a8c5e65c20e5d7ca375f52f64724410d2afa8a852f9e9e77b673c1f59e26bddd6fde74783a96f69f7bd73a1b7042633b624b310";
+      sha512 = "806ea4d93a8cb3e5dba8cbc59dd25adbb19e048306124ffebbf1b2a56d49f236d9a79d0e14b5fc0c15537c266a85408ce1a5568e8e6e4417dd94f1b98d9bf36e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/tr/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/tr/thunderbird-68.10.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "a86a69a8c146a0765e9fb7c835c1cc774a0a7fc309fa7f6627f427bc2cb4bd1b3e18f4aa61288cb68483f267b0be02662250abcdcafcb6619f1b4e3437cbb908";
+      sha512 = "cf30e9ebaf5770437415377c9a13d66b44a7de7c85bec9b980d9e2e059db7f3756f2c3a888ebf9185c59451e2473440fe2c1ff28a979e066225719effecb1c38";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/uk/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/uk/thunderbird-68.10.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "86407123381e64df9f97190b0df253792582b0ba5296d6663bc0d8faf3004e3ec95cbc0140c9292928a7750cece1cc6887086a9e218f3169bee2246232643685";
+      sha512 = "a7f5f6b0f1bc849a3a48a30edc8e408eec0c5e544bb4444a8ade969b1fe7ef1fb9d26a0fea3d4d31bf88eb67570e895fb5d916b9ac88c2a8455abcec60d56ca0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/uz/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/uz/thunderbird-68.10.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "2d31a86952df2f5b339479cc6dabd1cbcc000119514775b07ca086e01e8310fe0d0d2c63cc57cb936588c59a5f72a5d9dae0e0a6e2f9b7cdf6225e400c24bd31";
+      sha512 = "716e1c0a7b9b0ea33d1464930b68f3f817ce3310bee9000199f9e6bdc4d0d68dc6098665423ada94d7ede600cb0c965adcbb413068adf1415cbc048a7f847ebf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/vi/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/vi/thunderbird-68.10.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "3c241242e918bb69d811289879323205c070620829e05488e224450e7edb2be32b0f2c36f3182fcab95a1673fd133635e89801feaf6a34fa1553d8fea3b57641";
+      sha512 = "1667ab35ed705e739c5192246444eda912ec86a153dd1fc3ed83a5ed61d47d5849270492015198cca82827720bc019fa561e710df5fa77a758864e6cfb09d4aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/zh-CN/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/zh-CN/thunderbird-68.10.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "b4932b43158a5f8627ec951a3cb726863575a81b9d7b93ab35a9168224cd91480ecde55a1e7d4c01b9ed74f92440724475980010f1645db9b2ef0b6c42e92d93";
+      sha512 = "4ef6c9933ce8671442aa86f804085b4ce9a73aa4f8cd598b7d41a844be37d54cbd8a2dc39d6ab97f160856435475093f3240f960a206e53d327a4b2e47fac45d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.9.0/linux-i686/zh-TW/thunderbird-68.9.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/zh-TW/thunderbird-68.10.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "018fff050295932a492433992a97fd01acc36685f7d1f96bba2f41972fdd6cd592c117434d2de81d0d018595c8473427aefe5a7b66194bc18d127c2e7eab5a34";
+      sha512 = "ab19d7c1114835a380e035dafc2e30849e8084cdac9175eb5eb3a9fde81d49cb710d9dce21652780a35011d139e070c0f61840275aa8d0e99252bfa5a8aa1735";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -72,13 +72,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "68.9.0";
+  version = "68.10.0";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "3q0dikgkfr72hhz39pxi2f0cljn09lw4940qcn9kzfwfid2h290j7pihx6gs0z6h82fl78f9fl1598d064lwl1i2434dzx6bg4p4549";
+      "24jq4wxhk58403ax8jf6p82fyzf0vszz8am5d8jb6j559da3lp6wv4m5xqavvcf9i57rdivzrmqw9agr8mypfxs8zb908aln5iy7d4d";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Bug fixes

https://www.thunderbird.net/en-US/thunderbird/68.10.0/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
