### PR TITLE
jellyfin-mpv-shim: 1.4.2 -> 1.5.11

### DIFF
--- a/pkgs/applications/video/jellyfin-mpv-shim/default.nix
+++ b/pkgs/applications/video/jellyfin-mpv-shim/default.nix
@@ -4,13 +4,13 @@
 
 buildPythonApplication rec {
   pname = "jellyfin-mpv-shim";
-  version = "1.4.2";
+  version = "1.5.11";
 
   src = fetchFromGitHub {
     owner = "iwalton3";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1cnii5wj0pgqg3dqk5cm6slpbs3730x8ippps4cjbsxcsrmqjpx6";
+    sha256 = "14hm8yccdp7w1vdnvdzafk1byhaq1qsr33i4962s1nvm9lafxkr7";
     fetchSubmodules = true; # needed for display_mirror css file
   };
 
@@ -23,6 +23,12 @@ buildPythonApplication rec {
     export HOME=$TMPDIR
 
     rm jellyfin_mpv_shim/win_utils.py
+  '';
+
+  # disable the desktop client for now
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'jellyfin-mpv-desktop=jellyfin_mpv_shim.mpv_shim:main_desktop'," ""
   '';
 
   propagatedBuildInputs = [
@@ -42,7 +48,7 @@ buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/iwalton3/jellyfin-mpv-shim";
-    description = "Allows casting of videos to MPV via the jellyfin mobile and web app.";
+    description = "Allows casting of videos to MPV via the jellyfin mobile and web app";
     license = licenses.gpl3;
     maintainers = with maintainers; [ jojosch ];
   };

--- a/pkgs/development/python-modules/jellyfin-apiclient-python/default.nix
+++ b/pkgs/development/python-modules/jellyfin-apiclient-python/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "jellyfin-apiclient-python";
-  version = "1.4.0";
+  version = "1.5.1";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "iwalton3";
     repo = "jellyfin-apiclient-python";
     rev = "v${version}";
-    sha256 = "0b4ij19xjwn0wm5076fx8n4phjbsfx84x9qdrwm8c2r3ld8w7hk4";
+    sha256 = "1mzs4i9c4cf7pmymsyzs8x17hvjs8g9wr046l4f85rkzmz23v1rp";
   };
 
   propagatedBuildInputs = [ requests websocket_client ];

--- a/pkgs/development/python-modules/python-mpv-jsonipc/default.nix
+++ b/pkgs/development/python-modules/python-mpv-jsonipc/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "python-mpv-jsonipc";
-  version = "1.1.8";
+  version = "1.1.11";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "iwalton3";
     repo = "python-mpv-jsonipc";
     rev = "v${version}";
-    sha256 = "0f4nfzfka5n76n6dxmgcz0rkaws7a3jrgyh00va6lnfi7h6dsmx4";
+    sha256 = "034vc2j54dciiq80k7jn6kx4g7i58sjk0ykma039k5rihj2rblpk";
   };
 
   # 'mpv-jsonipc' does not have any tests


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to lastest release. Upstream does provide a "desktop" client which needs additional packages which i am currently not able to package - so i just updated the basic mpv-shim.

Also updated the `python-mpv-jsonipc` and `jellyfin-apiclient-python` to the latest version (at least 1.1.9 / 1.5.1 required by mpv-shim).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
6 packages updated:
jellyfin-mpv-shim (1.4.2 → 1.5.11) plex-mpv-shim python37Packages.jellyfin-apiclient-python (1.4.0 → 1.5.1) python37Packages.python-mpv-jsonipc (1.1.8 → 1.1.11) python38Packages.jellyfin-apiclient-python (1.4.0 → 1.5.1) python38Packages.python-mpv-jsonipc (1.1.8 → 1.1.11)

6 packages built:
jellyfin-mpv-shim plex-mpv-shim python37Packages.jellyfin-apiclient-python python37Packages.python-mpv-jsonipc python38Packages.jellyfin-apiclient-python python38Packages.python-mpv-jsonipc
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/087c4jsh4gxn006qj1f0f2nhiygf3w92-python3.8-python-mpv-jsonipc-1.1.8	  119876632
/nix/store/sqj9rqag2lvqx4wjl81svyyf0sjzyb60-python3.8-jellyfin-apiclient-python-1.4.0	  119620968
/nix/store/3w4kif2r8fflj2jn1znrpihannp6mfiz-jellyfin-mpv-shim-1.4.2	  365533408

/nix/store/sv60yr02phy4wdvm2sjlcn97cy7nw8dg-python3.8-python-mpv-jsonipc-1.1.11	  119854704
/nix/store/5s6qd6fg0zrdq3cx4vhxcwb294kz97cg-python3.8-jellyfin-apiclient-python-1.5.1	  119620960
/nix/store/rnp107rfcs3rqvxfi06qf0xfbrdx0mky-jellyfin-mpv-shim-1.5.11	  365598440
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
