### PR TITLE
openafs: 1.6.23 -> 1.6.24, mark broken due to EOL

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -493,6 +493,46 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
    <listitem>
     <para>
      In the <literal>resilio</literal> module, <xref linkend="opt-services.resilio.httpListenAddr"/> has been changed to listen to <literal>[::1]</literal> instead of <literal>0.0.0.0</literal>.
+     </para>
+   </listitem>
+   <listitem>
+    <para>
+     Users of <link xlink:href="http://openafs.org">OpenAFS 1.6</link> must
+     upgrade their services to OpenAFS 1.8! In this release, the OpenAFS package
+     version 1.6.24 is marked broken but can be used during transition to
+     OpenAFS 1.8.x. Use the options
+     <option>services.openafsClient.packages.module</option>,
+     <option>services.openafsClient.packages.programs</option> and
+     <option>services.openafsServer.package</option> to select a different
+     OpenAFS package. OpenAFS 1.6 will be removed in the next release. The
+     package <literal>openafs</literal> and the service options will then
+     silently point to the OpenAFS 1.8 release.
+    </para>
+    <para>
+     See also the OpenAFS <link
+     xlink:href="http://docs.openafs.org/AdminGuide/index.html">Administrator
+     Guide</link> for instructions. Beware of the following when updating
+     servers:
+     <itemizedlist>
+      <listitem>
+       <para>
+       The storage format of the server key has changed and the key must be converted before running the new release.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+       When updating multiple database servers, turn off the database servers
+       from the highest IP down to the lowest with resting periods in
+       between. Start up in reverse order. Do not concurrently run database
+       servers working with different OpenAFS releases!
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+       Update servers first, then clients.
+       </para>
+      </listitem>
+     </itemizedlist>
     </para>
    </listitem>
   </itemizedlist>

--- a/pkgs/servers/openafs/1.6/default.nix
+++ b/pkgs/servers/openafs/1.6/default.nix
@@ -85,5 +85,7 @@ stdenv.mkDerivation {
     license = licenses.ipl10;
     platforms = platforms.linux;
     maintainers = [ maintainers.maggesi maintainers.spacefrogg ];
+    # Package will be removed in 21.03
+    broken = true;
   };
 }

--- a/pkgs/servers/openafs/1.6/module.nix
+++ b/pkgs/servers/openafs/1.6/module.nix
@@ -70,8 +70,8 @@ in stdenv.mkDerivation {
     license = licenses.ipl10;
     platforms = platforms.linux;
     maintainers = [ maintainers.maggesi maintainers.spacefrogg ];
-    broken = versionOlder kernel.version "3.18" || builtins.compareVersions kernel.version "5.0" >= 0
-             || stdenv.targetPlatform.isAarch64;
+    # Package will be removed in 21.03
+    broken = true;
   };
 
 }

--- a/pkgs/servers/openafs/1.6/srcs.nix
+++ b/pkgs/servers/openafs/1.6/srcs.nix
@@ -1,14 +1,14 @@
 { fetchurl }:
 rec {
-  version = "1.6.23";
+  version = "1.6.24";
   src = fetchurl {
     url = "http://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    sha256 = "1gy7a0jhagxif8av540xb1aa6cl7id08nsgjbgady54bnmb0viga";
+    sha256 = "1dxzc1y5mmx3ap0m94sx80vfs3qxkckid3wc1xm0wr5i6fh7zn1h";
   };
 
   srcs = [ src
     (fetchurl {
       url = "http://www.openafs.org/dl/openafs/${version}/openafs-${version}-doc.tar.bz2";
-      sha256 = "18my71s9mddy0k835852ksjzkza7xs73kyxavmdqflh5vkywb6y0";
+      sha256 = "0aq9ipqpr2ksmk30h2dc4mlrkrqs16xnmspwfb6xj3rgr1pwszlx";
     })];
 }


### PR DESCRIPTION
Last old stable release. Enforce switch to openafs_1_8 by marking broken while
leaving a reasonable short-term alternative.

Ref #90927

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
