### PR TITLE
bazel: 3.3.0 -> 3.3.1

### DIFF
--- a/pkgs/applications/virtualization/gvisor/default.nix
+++ b/pkgs/applications/virtualization/gvisor/default.nix
@@ -76,7 +76,7 @@ in buildBazelPackage rec {
       rm -f "$bazelOut"/java.log "$bazelOut"/java.log.*
     '';
 
-    sha256 = "0mkgbw08f6kgklvjmlfpyld35q7dvxm9pvrhaf7m7nx69sich6jq";
+    sha256 = "0myffqywbvqhax995z55jymwnwyxmp13r27kpbc7wb5fk9s4skvr";
   };
 
   buildAttrs = {

--- a/pkgs/development/python-modules/dm-sonnet/default.nix
+++ b/pkgs/development/python-modules/dm-sonnet/default.nix
@@ -36,7 +36,7 @@ let
     bazelTarget = ":install";
 
     fetchAttrs = {
-      sha256 = "1gag2xghik68zblhwbdd206hs8nxp2sclw182x2qi78jqgfnq5ci";
+      sha256 = "1dka5nap3d28n18pn3wp5xsi4x3z02h1j8rcjdvi3y6dbqjwdw0v";
     };
 
     bazelFlags = [

--- a/pkgs/development/python-modules/tensorflow-probability/default.nix
+++ b/pkgs/development/python-modules/tensorflow-probability/default.nix
@@ -61,7 +61,7 @@ let
     bazelTarget = ":pip_pkg";
 
     fetchAttrs = {
-      sha256 = "1bh6lsi0732fzhrfs6p33qg2qfvq73r6qmijbpnv592aq8yiy1h5";
+      sha256 = "1qw7vkwnxy45z4vm94isq5m96xiz35sigag7vjg1xb2sklbymxh8";
     };
 
     buildAttrs = {

--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -56,7 +56,7 @@ buildBazelPackage rec {
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
     '';
 
-    sha256 = "17vdqs3dpaqc4llmzh4rd8mkm19q192w5gp90jlry3dpwj6b4kdf";
+    sha256 = "0rfdwss8aahydiybwhi3j0qw12j1l91k9lbn1vaip0bmnq5qfwh9";
   };
 
   buildAttrs = {

--- a/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
@@ -64,7 +64,7 @@ buildBazelPackage rec {
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
     '';
 
-    sha256 = "04wbimzjxxmm8kh57q11zvyardb6ilyffc4nkdp6mb87p1l8fmww";
+    sha256 = "1m7fmb03lirffxx04ck73bn5zwaji7zdwhlqq8s1c6pgp755d3vi";
   };
 
   buildAttrs = {

--- a/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
@@ -25,11 +25,11 @@
 }:
 
 let
-  version = "3.3.0";
+  version = "3.3.1";
 
   src = fetchurl {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    sha256 = "09p8xv8ni4g4wcyaapxsx8gjc3x3l3c6lxn575c7gm89vrh3k805";
+    sha256 = "0ir796kl8r9hpr3li26qsdy1z2lx2bv82zmk4a2s7q64clyg9wg0";
   };
 
   # Update with `eval $(nix-build -A bazel.updater)`,
@@ -53,7 +53,7 @@ let
        else srcs."java_tools_javac11_linux-v8.0.zip")
       srcs."coverage_output_generator-v2.1.zip"
       srcs.build_bazel_rules_nodejs
-      srcs."android_tools_pkg-0.17.0.tar.gz"
+      srcs."android_tools_pkg-0.19.0rc1.tar.gz"
       srcs."bazel-toolchains-3.1.0.tar.gz"
       srcs.rules_pkg
       srcs.rules_cc

--- a/pkgs/development/tools/build-managers/bazel/bazel_3/src-deps.json
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/src-deps.json
@@ -65,14 +65,14 @@
         "patch_cmds_win": [
             "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
         ],
-        "sha256": "8d0bf8ab83c9e38ec6ed5ce7bf425dbdc6469cec9e078559d4e8da42b705410f",
-        "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.17.0.tar.gz"
+        "sha256": "761e997a9055fe5e2b70aba8d64e78d4c2113feafaa8ac81909cb63e403f3087",
+        "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc1.tar.gz"
     },
-    "android_tools_pkg-0.17.0.tar.gz": {
-        "name": "android_tools_pkg-0.17.0.tar.gz",
-        "sha256": "8d0bf8ab83c9e38ec6ed5ce7bf425dbdc6469cec9e078559d4e8da42b705410f",
+    "android_tools_pkg-0.19.0rc1.tar.gz": {
+        "name": "android_tools_pkg-0.19.0rc1.tar.gz",
+        "sha256": "761e997a9055fe5e2b70aba8d64e78d4c2113feafaa8ac81909cb63e403f3087",
         "urls": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.17.0.tar.gz"
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc1.tar.gz"
         ]
     },
     "bazel-toolchains-3.1.0.tar.gz": {


### PR DESCRIPTION
###### Motivation for this change

[bazel 3.3.1](https://github.com/bazelbuild/bazel/releases/tag/3.3.1) is a bugfix release

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
