### PR TITLE
mariadb: 10.4.15 -> 10.5.8

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -258,6 +258,15 @@
    </listitem>
    <listitem>
     <para>
+     MariaDB has been updated to 10.5.
+     Before you upgrade, it would be best to take a backup of your database and read
+     <link xlink:href="https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#incompatible-changes-between-104-and-105">
+     Incompatible Changes Between 10.4 and 10.5</link>.
+     After the upgrade you will need to run <literal>mysql_upgrade</literal>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      The TokuDB storage engine dropped in <package>mariadb</package> 10.5 and removed in <package>mariadb</package> 10.6.
      It is recommended to switch to RocksDB. See also <link xlink:href="https://mariadb.com/kb/en/tokudb/">TokuDB</link> and
      <link xlink:href="https://jira.mariadb.org/browse/MDEV-19780">MDEV-19780: Remove the TokuDB storage engine</link>.

--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -258,6 +258,13 @@
    </listitem>
    <listitem>
     <para>
+     The TokuDB storage engine dropped in <package>mariadb</package> 10.5 and removed in <package>mariadb</package> 10.6.
+     It is recommended to switch to RocksDB. See also <link xlink:href="https://mariadb.com/kb/en/tokudb/">TokuDB</link> and
+     <link xlink:href="https://jira.mariadb.org/browse/MDEV-19780">MDEV-19780: Remove the TokuDB storage engine</link>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
       The <literal>openldap</literal> module now has support for OLC-style
       configuration, users of the <literal>configDir</literal> option may wish
       to migrate. If you continue to use <literal>configDir</literal>, ensure that

--- a/nixos/tests/mysql/mysql.nix
+++ b/nixos/tests/mysql/mysql.nix
@@ -98,7 +98,7 @@ import ./../make-test-python.nix ({ pkgs, ...} : {
         }];
         services.mysql.settings = {
           mysqld = {
-            plugin-load-add = [ "ha_tokudb.so" "ha_rocksdb.so" ];
+            plugin-load-add = [ "ha_rocksdb.so" ];
           };
         };
         services.mysql.package = pkgs.mariadb;
@@ -184,20 +184,6 @@ import ./../make-test-python.nix ({ pkgs, ...} : {
     )
     mariadb.succeed(
         "echo 'use testdb; drop table rocksdb;' | sudo -u testuser mysql -u testuser"
-    )
-  '' + pkgs.lib.optionalString pkgs.stdenv.isx86_64 ''
-    # Check if TokuDB plugin works
-    mariadb.succeed(
-        "echo 'use testdb; create table tokudb (test_id INT, PRIMARY KEY (test_id)) ENGINE = TokuDB;' | sudo -u testuser mysql -u testuser"
-    )
-    mariadb.succeed(
-        "echo 'use testdb; insert into tokudb values (25);' | sudo -u testuser mysql -u testuser"
-    )
-    mariadb.succeed(
-        "echo 'use testdb; select test_id from tokudb;' | sudo -u testuser mysql -u testuser -N | grep 25"
-    )
-    mariadb.succeed(
-        "echo 'use testdb; drop table tokudb;' | sudo -u testuser mysql -u testuser"
     )
   '';
 })

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -183,9 +183,10 @@ server = stdenv.mkDerivation (common // {
     "-DWITH_ROCKSDB_JEMALLOC=ON"
   ] ++ optional (!stdenv.hostPlatform.isDarwin) [
     "-DWITH_JEMALLOC=yes"
-  ] ++ optional stdenv.hostPlatform.isDarwin [
+  ] ++ optionals stdenv.hostPlatform.isDarwin [
     "-DPLUGIN_AUTH_PAM=OFF"
     "-DWITHOUT_OQGRAPH=1"
+    "-DWITHOUT_PLUGIN_S3=1"
   ];
 
   preConfigure = optionalString (!stdenv.hostPlatform.isDarwin) ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17785,9 +17785,6 @@ in
   };
 
   mariadb = callPackage ../servers/sql/mariadb {
-    # As per mariadb's cmake, "static jemalloc_pic.a can only be used up to jemalloc 4".
-    # https://jira.mariadb.org/browse/MDEV-15034
-    jemalloc450 = jemalloc450.override ({ disableInitExecTls = true; });
     inherit (darwin) cctools;
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
Upgrade MariaDB server to 10.5.4

cc @thoughtpolice @flokli @aanderse @dasJ

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
