### PR TITLE
joplin-desktop: 1.0.216 -> 1.0.233

### DIFF
--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "joplin-desktop";
-  version = "1.0.216";
+  version = "1.0.224";
   desktopItem = makeDesktopItem {
      name = "Joplin";
      exec = "joplin-desktop";
@@ -13,7 +13,7 @@ in appimageTools.wrapType2 rec {
   name = "${pname}-${version}";
   src = fetchurl {
     url = "https://github.com/laurent22/joplin/releases/download/v${version}/Joplin-${version}.AppImage";
-    sha256 = "17rb7h98h9i2p5kw5gznx5swpz6yxqdxwc9x5cgbkc31vk10iszn";
+    sha256 = "098x8dj4zwh0q991v013mjrmcdnzqwgs5xkrqnkk1b7vsqqfklgk";
   };
 
 

--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -2,12 +2,12 @@
 
 let
   pname = "joplin-desktop";
-  version = "1.0.224";
+  version = "1.0.227";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/laurent22/joplin/releases/download/v${version}/Joplin-${version}.AppImage";
-    sha256 = "098x8dj4zwh0q991v013mjrmcdnzqwgs5xkrqnkk1b7vsqqfklgk";
+    sha256 = "1b6sfnb3x9v55imi0105f2ligxrf5sqw2gak3zxwiqy5l4wgyhgz";
   };
 
   appimageContents = appimageTools.extractType2 {

--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -3,19 +3,18 @@
 let
   pname = "joplin-desktop";
   version = "1.0.224";
-  desktopItem = makeDesktopItem {
-     name = "Joplin";
-     exec = "joplin-desktop";
-     type = "Application";
-     desktopName = "Joplin";
-  };
-in appimageTools.wrapType2 rec {
   name = "${pname}-${version}";
+
   src = fetchurl {
     url = "https://github.com/laurent22/joplin/releases/download/v${version}/Joplin-${version}.AppImage";
     sha256 = "098x8dj4zwh0q991v013mjrmcdnzqwgs5xkrqnkk1b7vsqqfklgk";
   };
 
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+in appimageTools.wrapType2 rec {
+  inherit name src;
 
   profile = ''
     export LC_ALL=C.UTF-8
@@ -25,9 +24,12 @@ in appimageTools.wrapType2 rec {
   multiPkgs = null; # no 32bit needed
   extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
   extraInstallCommands = ''
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications
     mv $out/bin/{${name},${pname}}
+    install -m 444 -D ${appimageContents}/joplin.desktop $out/share/applications/joplin.desktop
+    install -m 444 -D ${appimageContents}/joplin.png \
+      $out/share/pixmaps/joplin.png
+    substituteInPlace $out/share/applications/joplin.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
   '';
 
 

--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -2,12 +2,12 @@
 
 let
   pname = "joplin-desktop";
-  version = "1.0.227";
+  version = "1.0.233";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/laurent22/joplin/releases/download/v${version}/Joplin-${version}.AppImage";
-    sha256 = "1b6sfnb3x9v55imi0105f2ligxrf5sqw2gak3zxwiqy5l4wgyhgz";
+    sha256 = "1fmk56b9b70ly1r471mhppr8fz1wm2gpxji1v760ynha8fqy7qg1";
   };
 
   appimageContents = appimageTools.extractType2 {


### PR DESCRIPTION
###### Motivation for this change

1. Joplin Update to 1.0.227. This release includes the new CodeMirror Editor.
2. Security Fix CVE-2020-15844
3. App Icon did not work. Fixed

Since I had no glue how to fix (2), i borrowed the idea from another [nix package](https://github.com/NixOS/nixpkgs/blob/076860e0340a5e4a909b9a710e186508b14d1c90/pkgs/applications/networking/irc/irccloud/default.nix).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).