### PR TITLE
tint2: fix doc directory

### DIFF
--- a/pkgs/applications/misc/tint2/default.nix
+++ b/pkgs/applications/misc/tint2/default.nix
@@ -1,7 +1,25 @@
-{ stdenv, fetchFromGitLab, pkgconfig, cmake, gettext, cairo, pango, pcre
-, glib, imlib2, gtk2, libXinerama, libXrender, libXcomposite, libXdamage
-, libX11, libXrandr, librsvg, libpthreadstubs, libXdmcp
-, libstartup_notification, wrapGAppsHook
+{ stdenv
+, fetchFromGitLab
+, pkg-config
+, cmake
+, gettext
+, cairo
+, pango
+, pcre
+, glib
+, imlib2
+, gtk2
+, libXinerama
+, libXrender
+, libXcomposite
+, libXdamage
+, libX11
+, libXrandr
+, librsvg
+, libpthreadstubs
+, libXdmcp
+, libstartup_notification
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -15,13 +33,31 @@ stdenv.mkDerivation rec {
     sha256 = "1937z0kixb6r82izj12jy4x8z4n96dfq1hx05vcsvsg1sx3wxgb0";
   };
 
-  enableParallelBuilding = true;
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    gettext
+    wrapGAppsHook
+  ];
 
-  nativeBuildInputs = [ pkgconfig cmake gettext wrapGAppsHook ];
-
-  buildInputs = [ cairo pango pcre glib imlib2 gtk2 libXinerama libXrender
-    libXcomposite libXdamage libX11 libXrandr librsvg libpthreadstubs
-    libXdmcp libstartup_notification ];
+  buildInputs = [
+    cairo
+    pango
+    pcre
+    glib
+    imlib2
+    gtk2
+    libXinerama
+    libXrender
+    libXcomposite
+    libXdamage
+    libX11
+    libXrandr
+    librsvg
+    libpthreadstubs
+    libXdmcp
+    libstartup_notification
+  ];
 
   postPatch = ''
     for f in ./src/launcher/apps-common.c \

--- a/pkgs/applications/misc/tint2/default.nix
+++ b/pkgs/applications/misc/tint2/default.nix
@@ -59,6 +59,10 @@ stdenv.mkDerivation rec {
     libstartup_notification
   ];
 
+  cmakeFlags = [
+    "-Ddocdir=share/doc/${pname}"
+  ];
+
   postPatch = ''
     for f in ./src/launcher/apps-common.c \
              ./src/launcher/icon-theme-common.c


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Format with `nixpkgs-fmt`.
- Use `pkg-config` instead of `pkgconfig`
- Do not explicitly enable parallel building, as it is automatically enabled for `cmake` projects
- Fix doc directory. Documentation files should not be installed directly at `$out/share/doc` because they may collide with files from other packages when paths are linked in the system environment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
