### PR TITLE
go-jsonnet: add jsonnetfmt binary

### DIFF
--- a/pkgs/development/compilers/go-jsonnet/default.nix
+++ b/pkgs/development/compilers/go-jsonnet/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   vendorSha256 = "0nsm4gsbbn8myz4yfi6m7qc3iizhdambsr18iks0clkdn3mi2jn1";
 
-  subPackages = [ "cmd/jsonnet", "cmd/jsonnetfmt" ];
+  subPackages = [ "cmd/jsonnet" "cmd/jsonnetfmt" ];
 
   meta = with lib; {
     description = "An implementation of Jsonnet in pure Go";

--- a/pkgs/development/compilers/go-jsonnet/default.nix
+++ b/pkgs/development/compilers/go-jsonnet/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   vendorSha256 = "0nsm4gsbbn8myz4yfi6m7qc3iizhdambsr18iks0clkdn3mi2jn1";
 
-  subPackages = [ "cmd/jsonnet" ];
+  subPackages = [ "cmd/jsonnet", "cmd/jsonnetfmt" ];
 
   meta = with lib; {
     description = "An implementation of Jsonnet in pure Go";


### PR DESCRIPTION
###### Motivation for this change

go-jsonnet added a jsonnetfmt implementation in [0.16.0](https://github.com/google/jsonnet/releases/tag/v0.16.0)
As nix includes the C++ jsonnetfmt implementation in the main jsonnet package, it makes sense to mirror that pattern in the go package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
