### PR TITLE
Fix typos in documentation (#91934)

### DIFF
--- a/doc/using/configuration.xml
+++ b/doc/using/configuration.xml
@@ -85,19 +85,19 @@
   <title>Installing packages on unsupported systems</title>
 
   <para>
-   There are also two ways to try compiling a package which has been marked as unsuported for the given system.
+   There are also two ways to try compiling a package which has been marked as unsupported for the given system.
   </para>
 
   <itemizedlist>
    <listitem>
     <para>
-     For allowing the build of a broken package once, you can use an environment variable for a single invocation of the nix tools:
+     For allowing the build of an unsupported package once, you can use an environment variable for a single invocation of the nix tools:
 <programlisting>$ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1</programlisting>
     </para>
    </listitem>
    <listitem>
     <para>
-     For permanently allowing broken packages to be built, you may add <literal>allowUnsupportedSystem = true;</literal> to your user's configuration file, like this:
+     For permanently allowing unsupported packages to be built, you may add <literal>allowUnsupportedSystem = true;</literal> to your user's configuration file, like this:
 <programlisting>
 {
   allowUnsupportedSystem = true;


### PR DESCRIPTION
Replace "broken" with "unsupported" in documentation when applicable/needed. Fixes #91934