### PR TITLE
telepathy-qt: 0.9.7 -> 0.9.8

### DIFF
--- a/pkgs/development/libraries/telepathy/qt/default.nix
+++ b/pkgs/development/libraries/telepathy/qt/default.nix
@@ -1,28 +1,20 @@
-{ stdenv, fetchurl, cmake, qtbase, pkgconfig, python2Packages, dbus-glib, dbus
+{ stdenv, fetchurl, cmake, qtbase, pkgconfig, python3Packages, dbus-glib, dbus
 , telepathy-farstream, telepathy-glib, fetchpatch }:
 
 let
-  inherit (python2Packages) python dbus-python;
+  inherit (python3Packages) python dbus-python;
 in stdenv.mkDerivation rec {
-  name = "telepathy-qt-0.9.7";
+  name = "telepathy-qt-0.9.8";
 
   src = fetchurl {
     url = "https://telepathy.freedesktop.org/releases/telepathy-qt/${name}.tar.gz";
-    sha256 = "0krxd4hhfx6r0ja19wh3848j7gn1rv8jrnakgmkbmi7bww5x7fi1";
+    sha256 = "bf8e2a09060addb80475a4938105b9b41d9e6837999b7a00e5351783857e18ad";
   };
 
   nativeBuildInputs = [ cmake pkgconfig python ];
   propagatedBuildInputs = [ qtbase telepathy-farstream telepathy-glib ];
   buildInputs = [ dbus-glib ];
   checkInputs = [ dbus.daemon dbus-python ];
-
-  patches = [
-    # https://github.com/TelepathyIM/telepathy-qt/issues/25
-    (fetchpatch {
-      url = "https://github.com/TelepathyIM/telepathy-qt/commit/d654dc70dbec7097e96e6d96ca74ab1b5b00ef8c.patch";
-      sha256 = "1jzd9b9rqh3c8xlq8dr7c0r8aabzf5ywv2gpkk6phh3xwngzrfbh";
-    })
-  ];
 
   # No point in building tests if they are not run
   # On 0.9.7, they do not even build with QT4

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -566,6 +566,7 @@ mapAliases ({
   telepathy_idle = telepathy-idle; # added 2018-02-25
   telepathy_logger = telepathy-logger; # added 2018-02-25
   telepathy_mission_control = telepathy-mission-control; # added 2018-02-25
+  telepathy-qt = throw "telepathy-qt no longer supports Qt 4. Please use libsForQt5.telepathy instead."; # added 2020-07-02
   telepathy_qt = telepathy-qt; # added 2018-02-25
   telepathy_qt5 = libsForQt5.telepathy;  # added 2015-12-19
   telepathy_salut = telepathy-salut; # added 2018-02-25

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14985,8 +14985,6 @@ in
 
   telepathy-farstream = callPackage ../development/libraries/telepathy/farstream {};
 
-  telepathy-qt = callPackage ../development/libraries/telepathy/qt { qtbase = qt4; };
-
   termbox = callPackage ../development/libraries/termbox { };
 
   tevent = callPackage ../development/libraries/tevent { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Telepathy 0.9.8 has been out for quite some while.
* telepathy 0.9.8 no longer supports Qt 4, so telepathy-qt and telepathy_qt now throw an error suggesting to use the Qt 5 packages instead.
* telepathy 0.9.8 uses Python 3 instead of Python 2, so that has been corrected in the package.
* telepathy 0.9.8 includes the patch that was previously manually added, so therefore it has been removed from the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
 ```
4 packages updated:
telepathy-qt (0.9.7 → 0.9.8) telepathy_qt (0.9.7 → 0.9.8) telepathy_qt5 (0.9.7 → 0.9.8) libsForQt5.telepathy (0.9.7 → 0.9.8)
```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
