### PR TITLE
homeassistant: 0.111.4 -> 0.112.3

### DIFF
--- a/pkgs/development/python-modules/graphql-core/default.nix
+++ b/pkgs/development/python-modules/graphql-core/default.nix
@@ -13,13 +13,13 @@
 
 buildPythonPackage rec {
   pname = "graphql-core";
-  version = "2.3.1";
+  version = "3.1.2";
 
   src = fetchFromGitHub {
     owner = "graphql-python";
     repo = pname;
     rev = "v${version}";
-    sha256 = "029jnwy6zbj4x7f3ffpn1gyx0w9ala9cj2g115g6aa7im3xd2jma";
+    sha256 = "0kvbj9dwpx8mjfj86kqx54dbz9k72ki147ssyj0ca2syvb8jm3wb";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/graphql-server-core/default.nix
+++ b/pkgs/development/python-modules/graphql-server-core/default.nix
@@ -1,22 +1,32 @@
 { buildPythonPackage
 , fetchFromGitHub
 , lib
-
 , black
 , graphql-core
 , promise
+, fetchpatch
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "graphql-server-core";
-  version = "1.2.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "graphql-python";
     repo = pname;
     rev = "v${version}";
-    sha256 = "123q3xziv0s22h10v3f5slirf4b6nxj0hnmarwx9vws6x21bgrgh";
+    sha256 = "1w3biv2za2m1brwjy0z049c2m94gm1zfwxzgc6lwrsci724jv9fr";
   };
+
+  disable = pythonOlder "3.6";
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/graphql-python/graphql-server-core/commit/865ee9d5602f352c958f6f7e15adbe9abe216784.patch";
+      sha256 = "03p44p4j8rys7mgamh2h9ibbnac2cqwvp5f5hrl2avj2hh0l6j46";
+    })
+  ];
 
   propagatedBuildInputs = [
     graphql-core

--- a/pkgs/development/python-modules/influxdb-client/default.nix
+++ b/pkgs/development/python-modules/influxdb-client/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, rx
+, certifi
+, six
+, python-dateutil
+, setuptools
+, urllib3
+, ciso8601
+, pytz
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "influxdb-client";
+  version = "1.8.0";
+
+  disabled = pythonOlder "3.6"; # requires python version >=3.6
+
+  src = fetchFromGitHub {
+    owner = "influxdata";
+    repo = "influxdb-client-python";
+    rev = "v${version}";
+    sha256 = "0gf0fjkd10yn1bb86rfapnd5diraivshn9mhzqxaxwlfah45q187";
+  };
+
+  # makes test not reproducible
+  postPatch = ''
+    sed -i -e '/randomize/d' test-requirements.txt
+  '';
+
+  propagatedBuildInputs = [
+    rx
+    certifi
+    six
+    python-dateutil
+    setuptools
+    urllib3
+    ciso8601
+    pytz
+  ];
+
+  # requires influxdb server
+  doCheck = false;
+
+  meta = with lib; {
+    description = "InfluxDB 2.0 Python client library";
+    homepage = "https://github.com/influxdata/influxdb-client-python";
+    license = licenses.mit;
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/development/python-modules/rx/default.nix
+++ b/pkgs/development/python-modules/rx/default.nix
@@ -1,15 +1,16 @@
-{ lib, fetchFromGitHub, buildPythonPackage, nose }:
+{ lib, fetchFromGitHub, buildPythonPackage, pythonOlder, nose }:
 
 buildPythonPackage rec {
   pname = "rx";
-  version = "1.6.1";
+  version = "3.1.0";
+  disabled = pythonOlder "3.6";
 
   # There are no tests on the pypi source
   src = fetchFromGitHub {
     owner = "ReactiveX";
     repo = "rxpy";
-    rev = version;
-    sha256 = "14bca67a26clzcf2abz2yb8g9lfxffjs2l236dp966sp0lfbpsn5";
+    rev = "v${version}";
+    sha256 = "0rcwa8001il9p7s096b9gc5yld8cyxvrsmwh1gpc9b87j172z6ax";
   };
 
   checkInputs = [ nose ];

--- a/pkgs/servers/home-assistant/0001-setup.py-relax-dependencies.patch
+++ b/pkgs/servers/home-assistant/0001-setup.py-relax-dependencies.patch
@@ -1,17 +1,8 @@
-From 9d730514540929dc95a7313bdb385bab95d9a28c Mon Sep 17 00:00:00 2001
-From: Martin Weinelt <hexa@darmstadt.ccc.de>
-Date: Wed, 20 May 2020 23:23:23 +0200
-Subject: [PATCH] setup.py: relax dependencies
-
----
- setup.py | 14 +++++++-------
- 1 file changed, 7 insertions(+), 7 deletions(-)
-
 diff --git a/setup.py b/setup.py
-index 1473fd1f5f..149af58b3a 100755
+index 4e46f63217..b1aafee59d 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -32,24 +32,24 @@ PROJECT_URLS = {
+@@ -32,7 +32,7 @@ PROJECT_URLS = {
  PACKAGES = find_packages(exclude=["tests", "tests.*"])
  
  REQUIRES = [
@@ -20,29 +11,14 @@ index 1473fd1f5f..149af58b3a 100755
      "astral==1.10.1",
      "async_timeout==3.0.1",
      "attrs==19.3.0",
-     "bcrypt==3.1.7",
-     "certifi>=2020.4.5.1",
-     "ciso8601==2.1.3",
--    "importlib-metadata==1.6.0",
-+    "importlib-metadata>=1.5.0",
-     "jinja2>=2.11.1",
-     "PyJWT==1.7.1",
-     # PyJWT has loose dependency. We want the latest one.
--    "cryptography==2.9.2",
-+    "cryptography>=2.9",
-     "pip>=8.0.3",
+@@ -48,8 +48,8 @@ REQUIRES = [
      "python-slugify==4.0.0",
--    "pytz>=2020.1",
--    "pyyaml==5.3.1",
--    "requests==2.23.0",
+     "pytz>=2020.1",
+     "pyyaml==5.3.1",
+-    "requests==2.24.0",
 -    "ruamel.yaml==0.15.100",
-+    "pytz>=2019.03",
-+    "pyyaml>=5.2",
-+    "requests>=2.22",
++    "requests>=2.23.0",
 +    "ruamel.yaml>=0.15.100",
      "voluptuous==0.11.7",
      "voluptuous-serialize==2.3.0",
  ]
--- 
-2.26.2
-

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.111.4";
+  version = "0.112.0";
   components = {
     "abode" = ps: with ps; [ ]; # missing inputs: abodepy
     "acer_projector" = ps: with ps; [ pyserial];
@@ -17,9 +17,9 @@
     "airvisual" = ps: with ps; [ pyairvisual];
     "aladdin_connect" = ps: with ps; [ ]; # missing inputs: aladdin_connect
     "alarm_control_panel" = ps: with ps; [ ];
-    "alarmdecoder" = ps: with ps; [ alarmdecoder];
+    "alarmdecoder" = ps: with ps; [ ]; # missing inputs: adext
     "alert" = ps: with ps; [ ];
-    "alexa" = ps: with ps; [ aiohttp-cors sqlalchemy]; # missing inputs: home-assistant-frontend
+    "alexa" = ps: with ps; [ aiohttp-cors];
     "almond" = ps: with ps; [ aiohttp-cors]; # missing inputs: pyalmond
     "alpha_vantage" = ps: with ps; [ ]; # missing inputs: alpha_vantage
     "amazon_polly" = ps: with ps; [ boto3];
@@ -46,7 +46,7 @@
     "arlo" = ps: with ps; [ ha-ffmpeg]; # missing inputs: pyarlo
     "arris_tg2492lg" = ps: with ps; [ ]; # missing inputs: arris-tg2492lg
     "aruba" = ps: with ps; [ pexpect];
-    "arwn" = ps: with ps; [ aiohttp-cors hbmqtt paho-mqtt];
+    "arwn" = ps: with ps; [ aiohttp-cors paho-mqtt];
     "asterisk_cdr" = ps: with ps; [ ]; # missing inputs: asterisk_mbox
     "asterisk_mbox" = ps: with ps; [ ]; # missing inputs: asterisk_mbox
     "asuswrt" = ps: with ps; [ ]; # missing inputs: aioasuswrt
@@ -57,13 +57,13 @@
     "aurora" = ps: with ps; [ ];
     "aurora_abb_powerone" = ps: with ps; [ ]; # missing inputs: aurorapy
     "auth" = ps: with ps; [ aiohttp-cors];
-    "automation" = ps: with ps; [ aiohttp-cors sqlalchemy]; # missing inputs: home-assistant-frontend
+    "automation" = ps: with ps; [ aiohttp-cors];
     "avea" = ps: with ps; [ ]; # missing inputs: avea
     "avion" = ps: with ps; [ ]; # missing inputs: avion
-    "avri" = ps: with ps; [ ]; # missing inputs: avri-api
+    "avri" = ps: with ps; [ pycountry]; # missing inputs: avri-api
     "awair" = ps: with ps; [ ]; # missing inputs: python_awair
     "aws" = ps: with ps; [ ]; # missing inputs: aiobotocore
-    "axis" = ps: with ps; [ aiohttp-cors hbmqtt paho-mqtt]; # missing inputs: axis
+    "axis" = ps: with ps; [ aiohttp-cors paho-mqtt]; # missing inputs: axis
     "azure_event_hub" = ps: with ps; [ ]; # missing inputs: azure-eventhub
     "azure_service_bus" = ps: with ps; [ azure-servicebus];
     "baidu" = ps: with ps; [ ]; # missing inputs: baidu-aip
@@ -104,7 +104,7 @@
     "calendar" = ps: with ps; [ aiohttp-cors];
     "camera" = ps: with ps; [ aiohttp-cors];
     "canary" = ps: with ps; [ ha-ffmpeg]; # missing inputs: py-canary
-    "cast" = ps: with ps; [ aiohttp-cors hass-nabucasa PyChromecast sqlalchemy zeroconf]; # missing inputs: home-assistant-frontend
+    "cast" = ps: with ps; [ aiohttp-cors hass-nabucasa PyChromecast zeroconf];
     "cert_expiry" = ps: with ps; [ ];
     "channels" = ps: with ps; [ ]; # missing inputs: pychannels
     "circuit" = ps: with ps; [ ]; # missing inputs: circuit-webhook
@@ -117,7 +117,7 @@
     "clicksend" = ps: with ps; [ ];
     "clicksend_tts" = ps: with ps; [ ];
     "climate" = ps: with ps; [ ];
-    "cloud" = ps: with ps; [ aiohttp-cors hass-nabucasa sqlalchemy]; # missing inputs: home-assistant-frontend
+    "cloud" = ps: with ps; [ aiohttp-cors hass-nabucasa];
     "cloudflare" = ps: with ps; [ ]; # missing inputs: pycfdns
     "cmus" = ps: with ps; [ ]; # missing inputs: pycmus
     "co2signal" = ps: with ps; [ ]; # missing inputs: co2signal
@@ -144,18 +144,19 @@
     "darksky" = ps: with ps; [ python-forecastio];
     "datadog" = ps: with ps; [ datadog];
     "ddwrt" = ps: with ps; [ ];
+    "debugpy" = ps: with ps; [ ]; # missing inputs: debugpy
     "deconz" = ps: with ps; [ ]; # missing inputs: pydeconz
     "decora" = ps: with ps; [ bluepy]; # missing inputs: decora
     "decora_wifi" = ps: with ps; [ ]; # missing inputs: decora_wifi
-    "default_config" = ps: with ps; [ pynacl aiohttp-cors defusedxml distro hass-nabucasa netdisco sqlalchemy zeroconf]; # missing inputs: home-assistant-frontend
+    "default_config" = ps: with ps; [ pynacl aiohttp-cors defusedxml distro emoji hass-nabucasa netdisco sqlalchemy zeroconf]; # missing inputs: home-assistant-frontend
     "delijn" = ps: with ps; [ ]; # missing inputs: pydelijn
     "deluge" = ps: with ps; [ deluge-client];
     "demo" = ps: with ps; [ aiohttp-cors];
     "denon" = ps: with ps; [ ];
-    "denonavr" = ps: with ps; [ denonavr];
+    "denonavr" = ps: with ps; [ denonavr getmac];
     "derivative" = ps: with ps; [ ];
     "deutsche_bahn" = ps: with ps; [ ]; # missing inputs: schiene
-    "device_automation" = ps: with ps; [ aiohttp-cors];
+    "device_automation" = ps: with ps; [ ];
     "device_sun_light_trigger" = ps: with ps; [ ];
     "device_tracker" = ps: with ps; [ ];
     "devolo_home_control" = ps: with ps; [ ]; # missing inputs: devolo-home-control-api
@@ -178,7 +179,7 @@
     "dovado" = ps: with ps; [ ]; # missing inputs: dovado
     "downloader" = ps: with ps; [ ];
     "dsmr" = ps: with ps; [ ]; # missing inputs: dsmr_parser
-    "dsmr_reader" = ps: with ps; [ aiohttp-cors hbmqtt paho-mqtt];
+    "dsmr_reader" = ps: with ps; [ aiohttp-cors paho-mqtt];
     "dte_energy_bridge" = ps: with ps; [ ];
     "dublin_bus_transport" = ps: with ps; [ ];
     "duckdns" = ps: with ps; [ ];
@@ -258,7 +259,6 @@
     "folder_watcher" = ps: with ps; [ watchdog];
     "foobot" = ps: with ps; [ ]; # missing inputs: foobot_async
     "forked_daapd" = ps: with ps; [ ]; # missing inputs: pyforked-daapd pylibrespot-java
-    "fortigate" = ps: with ps; [ ]; # missing inputs: pyfgt
     "fortios" = ps: with ps; [ ]; # missing inputs: fortiosapi
     "foscam" = ps: with ps; [ ]; # missing inputs: libpyfoscam
     "foursquare" = ps: with ps; [ aiohttp-cors];
@@ -270,7 +270,7 @@
     "fritzbox_callmonitor" = ps: with ps; [ fritzconnection];
     "fritzbox_netmonitor" = ps: with ps; [ fritzconnection];
     "fronius" = ps: with ps; [ ]; # missing inputs: pyfronius
-    "frontend" = ps: with ps; [ aiohttp-cors sqlalchemy]; # missing inputs: home-assistant-frontend
+    "frontend" = ps: with ps; [ aiohttp-cors]; # missing inputs: home-assistant-frontend
     "frontier_silicon" = ps: with ps; [ ]; # missing inputs: afsapi
     "futurenow" = ps: with ps; [ ]; # missing inputs: pyfnip
     "garadget" = ps: with ps; [ ];
@@ -320,7 +320,7 @@
     "hangouts" = ps: with ps; [ ]; # missing inputs: hangups
     "harman_kardon_avr" = ps: with ps; [ ]; # missing inputs: hkavr
     "harmony" = ps: with ps; [ aioharmony];
-    "hassio" = ps: with ps; [ aiohttp-cors sqlalchemy]; # missing inputs: home-assistant-frontend
+    "hassio" = ps: with ps; [ aiohttp-cors]; # missing inputs: home-assistant-frontend
     "haveibeenpwned" = ps: with ps; [ ];
     "hddtemp" = ps: with ps; [ ];
     "hdmi_cec" = ps: with ps; [ ]; # missing inputs: pyCEC
@@ -337,7 +337,7 @@
     "hlk_sw16" = ps: with ps; [ ]; # missing inputs: hlk-sw16
     "home_connect" = ps: with ps; [ aiohttp-cors]; # missing inputs: homeconnect
     "homeassistant" = ps: with ps; [ ];
-    "homekit" = ps: with ps; [ HAP-python pyqrcode aiohttp-cors ha-ffmpeg sqlalchemy zeroconf]; # missing inputs: PyTurboJPEG base36 fnvhash home-assistant-frontend
+    "homekit" = ps: with ps; [ HAP-python pyqrcode aiohttp-cors ha-ffmpeg zeroconf]; # missing inputs: PyTurboJPEG base36 fnvhash
     "homekit_controller" = ps: with ps; [ ]; # missing inputs: aiohomekit[IP]
     "homematic" = ps: with ps; [ pyhomematic];
     "homematicip_cloud" = ps: with ps; [ ]; # missing inputs: homematicip
@@ -351,7 +351,9 @@
     "huawei_lte" = ps: with ps; [ getmac stringcase]; # missing inputs: huawei-lte-api url-normalize
     "huawei_router" = ps: with ps; [ ];
     "hue" = ps: with ps; [ aiohue];
+    "humidifier" = ps: with ps; [ ];
     "hunterdouglas_powerview" = ps: with ps; [ ]; # missing inputs: aiopvapi
+    "hvv_departures" = ps: with ps; [ ]; # missing inputs: pygti
     "hydrawise" = ps: with ps; [ ]; # missing inputs: hydrawiser
     "hyperion" = ps: with ps; [ ];
     "ialarm" = ps: with ps; [ ]; # missing inputs: pyialarm
@@ -367,7 +369,7 @@
     "imap" = ps: with ps; [ ]; # missing inputs: aioimaplib
     "imap_email_content" = ps: with ps; [ ];
     "incomfort" = ps: with ps; [ ]; # missing inputs: incomfort-client
-    "influxdb" = ps: with ps; [ influxdb];
+    "influxdb" = ps: with ps; [ influxdb]; # missing inputs: influxdb-client
     "input_boolean" = ps: with ps; [ ];
     "input_datetime" = ps: with ps; [ ];
     "input_number" = ps: with ps; [ ];
@@ -433,7 +435,6 @@
     "local_ip" = ps: with ps; [ ];
     "locative" = ps: with ps; [ aiohttp-cors];
     "lock" = ps: with ps; [ ];
-    "lockitron" = ps: with ps; [ ];
     "logbook" = ps: with ps; [ aiohttp-cors sqlalchemy]; # missing inputs: home-assistant-frontend
     "logentries" = ps: with ps; [ ];
     "logger" = ps: with ps; [ ];
@@ -453,8 +454,8 @@
     "mailbox" = ps: with ps; [ aiohttp-cors];
     "mailgun" = ps: with ps; [ aiohttp-cors]; # missing inputs: pymailgunner
     "manual" = ps: with ps; [ ];
-    "manual_mqtt" = ps: with ps; [ aiohttp-cors hbmqtt paho-mqtt];
-    "map" = ps: with ps; [ aiohttp-cors sqlalchemy]; # missing inputs: home-assistant-frontend
+    "manual_mqtt" = ps: with ps; [ aiohttp-cors paho-mqtt];
+    "map" = ps: with ps; [ aiohttp-cors]; # missing inputs: home-assistant-frontend
     "marytts" = ps: with ps; [ ]; # missing inputs: speak2mary
     "mastodon" = ps: with ps; [ ]; # missing inputs: Mastodon.py
     "matrix" = ps: with ps; [ matrix-client];
@@ -485,7 +486,7 @@
     "minio" = ps: with ps; [ minio];
     "mitemp_bt" = ps: with ps; [ ]; # missing inputs: mitemp_bt
     "mjpeg" = ps: with ps; [ ];
-    "mobile_app" = ps: with ps; [ pynacl aiohttp-cors hass-nabucasa sqlalchemy]; # missing inputs: home-assistant-frontend
+    "mobile_app" = ps: with ps; [ pynacl aiohttp-cors emoji hass-nabucasa];
     "mochad" = ps: with ps; [ ]; # missing inputs: pymochad
     "modbus" = ps: with ps; [ ]; # missing inputs: pymodbus
     "modem_callerid" = ps: with ps; [ ]; # missing inputs: basicmodem
@@ -494,17 +495,17 @@
     "moon" = ps: with ps; [ ];
     "mpchc" = ps: with ps; [ ];
     "mpd" = ps: with ps; [ mpd2];
-    "mqtt" = ps: with ps; [ aiohttp-cors hbmqtt paho-mqtt];
-    "mqtt_eventstream" = ps: with ps; [ aiohttp-cors hbmqtt paho-mqtt];
-    "mqtt_json" = ps: with ps; [ aiohttp-cors hbmqtt paho-mqtt];
-    "mqtt_room" = ps: with ps; [ aiohttp-cors hbmqtt paho-mqtt];
-    "mqtt_statestream" = ps: with ps; [ aiohttp-cors hbmqtt paho-mqtt];
+    "mqtt" = ps: with ps; [ aiohttp-cors paho-mqtt];
+    "mqtt_eventstream" = ps: with ps; [ aiohttp-cors paho-mqtt];
+    "mqtt_json" = ps: with ps; [ aiohttp-cors paho-mqtt];
+    "mqtt_room" = ps: with ps; [ aiohttp-cors paho-mqtt];
+    "mqtt_statestream" = ps: with ps; [ aiohttp-cors paho-mqtt];
     "msteams" = ps: with ps; [ ]; # missing inputs: pymsteams
     "mvglive" = ps: with ps; [ PyMVGLive];
     "mychevy" = ps: with ps; [ ]; # missing inputs: mychevy
     "mycroft" = ps: with ps; [ ]; # missing inputs: mycroftapi
     "myq" = ps: with ps; [ ]; # missing inputs: pymyq
-    "mysensors" = ps: with ps; [ aiohttp-cors hbmqtt paho-mqtt]; # missing inputs: pymysensors
+    "mysensors" = ps: with ps; [ aiohttp-cors paho-mqtt]; # missing inputs: pymysensors
     "mystrom" = ps: with ps; [ aiohttp-cors]; # missing inputs: python-mystrom
     "mythicbeastsdns" = ps: with ps; [ ]; # missing inputs: mbddns
     "n26" = ps: with ps; [ ]; # missing inputs: n26
@@ -516,7 +517,7 @@
     "nello" = ps: with ps; [ ]; # missing inputs: pynello
     "ness_alarm" = ps: with ps; [ ]; # missing inputs: nessclient
     "nest" = ps: with ps; [ ]; # missing inputs: python-nest
-    "netatmo" = ps: with ps; [ aiohttp-cors hass-nabucasa pyatmo sqlalchemy]; # missing inputs: home-assistant-frontend
+    "netatmo" = ps: with ps; [ aiohttp-cors hass-nabucasa pyatmo];
     "netdata" = ps: with ps; [ ]; # missing inputs: netdata
     "netgear" = ps: with ps; [ ]; # missing inputs: pynetgear
     "netgear_lte" = ps: with ps; [ ]; # missing inputs: eternalegypt
@@ -535,6 +536,7 @@
     "noaa_tides" = ps: with ps; [ ]; # missing inputs: py_noaa
     "norway_air" = ps: with ps; [ pymetno];
     "notify" = ps: with ps; [ ];
+    "notify_events" = ps: with ps; [ ]; # missing inputs: notify-events
     "notion" = ps: with ps; [ ]; # missing inputs: aionotion
     "nsw_fuel_station" = ps: with ps; [ ]; # missing inputs: nsw-fuel-api-client
     "nsw_rural_fire_service_feed" = ps: with ps; [ ]; # missing inputs: aio_geojson_nsw_rfs_incidents
@@ -577,13 +579,13 @@
     "orvibo" = ps: with ps; [ ]; # missing inputs: orvibo
     "osramlightify" = ps: with ps; [ ]; # missing inputs: lightify
     "otp" = ps: with ps; [ pyotp];
-    "owntracks" = ps: with ps; [ pynacl aiohttp-cors hass-nabucasa hbmqtt paho-mqtt sqlalchemy]; # missing inputs: home-assistant-frontend
-    "ozw" = ps: with ps; [ aiohttp-cors hbmqtt paho-mqtt]; # missing inputs: python-openzwave-mqtt
+    "owntracks" = ps: with ps; [ pynacl aiohttp-cors hass-nabucasa paho-mqtt];
+    "ozw" = ps: with ps; [ aiohttp-cors paho-mqtt]; # missing inputs: python-openzwave-mqtt
     "panasonic_bluray" = ps: with ps; [ ]; # missing inputs: panacotta
     "panasonic_viera" = ps: with ps; [ ]; # missing inputs: panasonic_viera
     "pandora" = ps: with ps; [ pexpect];
-    "panel_custom" = ps: with ps; [ aiohttp-cors sqlalchemy]; # missing inputs: home-assistant-frontend
-    "panel_iframe" = ps: with ps; [ aiohttp-cors sqlalchemy]; # missing inputs: home-assistant-frontend
+    "panel_custom" = ps: with ps; [ aiohttp-cors]; # missing inputs: home-assistant-frontend
+    "panel_iframe" = ps: with ps; [ aiohttp-cors]; # missing inputs: home-assistant-frontend
     "pcal9535a" = ps: with ps; [ ]; # missing inputs: pcal9535a
     "pencom" = ps: with ps; [ ]; # missing inputs: pencompy
     "persistent_notification" = ps: with ps; [ ];
@@ -630,7 +632,7 @@
     "quantum_gateway" = ps: with ps; [ ]; # missing inputs: quantum-gateway
     "qvr_pro" = ps: with ps; [ ]; # missing inputs: pyqvrpro
     "qwikswitch" = ps: with ps; [ ]; # missing inputs: pyqwikswitch
-    "rachio" = ps: with ps; [ aiohttp-cors hass-nabucasa sqlalchemy]; # missing inputs: home-assistant-frontend rachiopy
+    "rachio" = ps: with ps; [ aiohttp-cors hass-nabucasa]; # missing inputs: rachiopy
     "radarr" = ps: with ps; [ ];
     "radiotherm" = ps: with ps; [ ]; # missing inputs: radiotherm
     "rainbird" = ps: with ps; [ ]; # missing inputs: pyrainbird
@@ -671,7 +673,7 @@
     "russound_rio" = ps: with ps; [ ]; # missing inputs: russound_rio
     "russound_rnet" = ps: with ps; [ ]; # missing inputs: russound
     "sabnzbd" = ps: with ps; [ aiohttp-cors netdisco zeroconf]; # missing inputs: pysabnzbd
-    "safe_mode" = ps: with ps; [ aiohttp-cors hass-nabucasa sqlalchemy]; # missing inputs: home-assistant-frontend
+    "safe_mode" = ps: with ps; [ aiohttp-cors hass-nabucasa]; # missing inputs: home-assistant-frontend
     "saj" = ps: with ps; [ ]; # missing inputs: pysaj
     "salt" = ps: with ps; [ ]; # missing inputs: saltbox
     "samsungtv" = ps: with ps; [ ]; # missing inputs: samsungctl[websocket] samsungtvws[websocket]
@@ -681,7 +683,7 @@
     "scrape" = ps: with ps; [ beautifulsoup4 jsonpath xmltodict];
     "script" = ps: with ps; [ ];
     "scsgate" = ps: with ps; [ ]; # missing inputs: scsgate
-    "search" = ps: with ps; [ aiohttp-cors sqlalchemy]; # missing inputs: home-assistant-frontend
+    "search" = ps: with ps; [ aiohttp-cors];
     "season" = ps: with ps; [ ephem];
     "sendgrid" = ps: with ps; [ ]; # missing inputs: sendgrid
     "sense" = ps: with ps; [ ]; # missing inputs: sense_energy
@@ -714,15 +716,15 @@
     "sleepiq" = ps: with ps; [ ]; # missing inputs: sleepyq
     "slide" = ps: with ps; [ ]; # missing inputs: goslide-api
     "sma" = ps: with ps; [ ]; # missing inputs: pysma
-    "smappee" = ps: with ps; [ ]; # missing inputs: smappy
+    "smappee" = ps: with ps; [ aiohttp-cors]; # missing inputs: pysmappee
     "smarthab" = ps: with ps; [ ]; # missing inputs: smarthab
-    "smartthings" = ps: with ps; [ aiohttp-cors hass-nabucasa sqlalchemy]; # missing inputs: home-assistant-frontend pysmartapp pysmartthings
+    "smartthings" = ps: with ps; [ aiohttp-cors hass-nabucasa]; # missing inputs: pysmartapp pysmartthings
     "smarty" = ps: with ps; [ ]; # missing inputs: pysmarty
     "smhi" = ps: with ps; [ ]; # missing inputs: smhi-pkg
     "sms" = ps: with ps; [ ]; # missing inputs: python-gammu
     "smtp" = ps: with ps; [ ];
     "snapcast" = ps: with ps; [ snapcast];
-    "snips" = ps: with ps; [ aiohttp-cors hbmqtt paho-mqtt];
+    "snips" = ps: with ps; [ aiohttp-cors paho-mqtt];
     "snmp" = ps: with ps; [ pysnmp];
     "sochain" = ps: with ps; [ ]; # missing inputs: python-sochain-api
     "socialblade" = ps: with ps; [ ]; # missing inputs: socialbladeclient
@@ -815,7 +817,7 @@
     "todoist" = ps: with ps; [ todoist];
     "tof" = ps: with ps; [ ]; # missing inputs: RPi.GPIO VL53L1X2
     "tomato" = ps: with ps; [ ];
-    "toon" = ps: with ps; [ ]; # missing inputs: toonapilib
+    "toon" = ps: with ps; [ aiohttp-cors hass-nabucasa]; # missing inputs: toonapi
     "torque" = ps: with ps; [ aiohttp-cors];
     "totalconnect" = ps: with ps; [ ]; # missing inputs: total_connect_client
     "touchline" = ps: with ps; [ ]; # missing inputs: pytouchline

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.112.0";
+  version = "0.112.2";
   components = {
     "abode" = ps: with ps; [ ]; # missing inputs: abodepy
     "acer_projector" = ps: with ps; [ pyserial];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.112.2";
+  version = "0.112.3";
   components = {
     "abode" = ps: with ps; [ ]; # missing inputs: abodepy
     "acer_projector" = ps: with ps; [ pyserial];
@@ -144,7 +144,7 @@
     "darksky" = ps: with ps; [ python-forecastio];
     "datadog" = ps: with ps; [ datadog];
     "ddwrt" = ps: with ps; [ ];
-    "debugpy" = ps: with ps; [ ]; # missing inputs: debugpy
+    "debugpy" = ps: with ps; [ debugpy];
     "deconz" = ps: with ps; [ ]; # missing inputs: pydeconz
     "decora" = ps: with ps; [ bluepy]; # missing inputs: decora
     "decora_wifi" = ps: with ps; [ ]; # missing inputs: decora_wifi

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -369,7 +369,7 @@
     "imap" = ps: with ps; [ ]; # missing inputs: aioimaplib
     "imap_email_content" = ps: with ps; [ ];
     "incomfort" = ps: with ps; [ ]; # missing inputs: incomfort-client
-    "influxdb" = ps: with ps; [ influxdb]; # missing inputs: influxdb-client
+    "influxdb" = ps: with ps; [ influxdb-client influxdb];
     "input_boolean" = ps: with ps; [ ];
     "input_datetime" = ps: with ps; [ ];
     "input_number" = ps: with ps; [ ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -72,7 +72,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.112.0";
+  hassVersion = "0.112.2";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -91,7 +91,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "0ydbk478wjgplzjsy4v6yqc18isvykkvg1lnsh4mhhc7yy3w0c9a";
+    sha256 = "0pz1q5gaj6zm71ws63zpidhacbq8xyyvhzxj55i6bmb1r2nhxxpa";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -72,7 +72,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.112.2";
+  hassVersion = "0.112.3";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -91,7 +91,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "0pz1q5gaj6zm71ws63zpidhacbq8xyyvhzxj55i6bmb1r2nhxxpa";
+    sha256 = "1azfbjnyaamdnl2f3cllh6pd3kinl1wjqb4hlb569gb8zqs5bsx2";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -72,7 +72,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.111.4";
+  hassVersion = "0.112.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -91,7 +91,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "08dkqczpmdaz8k9fsshgvgma7i7sffzgmhsi49qki7vwn20hl2hf";
+    sha256 = "0ydbk478wjgplzjsy4v6yqc18isvykkvg1lnsh4mhhc7yy3w0c9a";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20200603.3";
+  version = "20200701.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "12bbvqckry6yr7409dir49pjcaa31z74fy6vb0mgr9xzvri5c2s8";
+    sha256 = "16a67fh6hx1jg12qgja9xnzyprv1h3s9w6nwwq4a4rjmvpgnlhxs";
   };
 
   # no Python tests implemented

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20200701.0";
+  version = "20200702.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "16a67fh6hx1jg12qgja9xnzyprv1h3s9w6nwwq4a4rjmvpgnlhxs";
+    sha256 = "1shdz9b0raspwwnkfzxmyn8mrfgc5prl79g7yn0m4z8m1k7pnd36";
   };
 
   # no Python tests implemented

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20200702.0";
+  version = "20200702.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1shdz9b0raspwwnkfzxmyn8mrfgc5prl79g7yn0m4z8m1k7pnd36";
+    sha256 = "0ikzqwwm4m15x2m5byy7r005cfdxk7ajfyz9ljv4nsa3y3g2riw4";
   };
 
   # no Python tests implemented

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -695,6 +695,9 @@ in {
 
   parver = callPackage ../development/python-modules/parver { };
   arpeggio = callPackage ../development/python-modules/arpeggio { };
+
+  influxdb-client = callPackage ../development/python-modules/influxdb-client { };
+
   invoke = callPackage ../development/python-modules/invoke { };
 
   distorm3 = callPackage ../development/python-modules/distorm3 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->
Using the glorious `./update.sh` tooling. Thanks @Mic92!

###### Motivation for this change

New upstream release. 
https://www.home-assistant.io/blog/2020/07/01/release-112/

Logbook and History are now *fast*, expect db migrations on startup.

The tests needed a fixup, because the embedded MQTT broker was removed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@Mic92 @dotlambda 