### PR TITLE
keysmith: 0.1 → 0.2

### DIFF
--- a/pkgs/tools/security/keysmith/default.nix
+++ b/pkgs/tools/security/keysmith/default.nix
@@ -10,30 +10,25 @@
 , qtgraphicaleffects
 , kirigami2
 , oathToolkit
+, ki18n
+, libsodium
 }:
 mkDerivation rec {
 
   pname = "keysmith";
-  version = "0.1";
+  version = "0.2";
 
   src = fetchFromGitHub {
     owner = "KDE";
     repo = "keysmith";
     rev = "v${version}";
-    sha256 = "15fzf0bvarivm32zqa5w71mscpxdac64ykiawc5hx6kplz93bsgx";
+    sha256 = "1gvzw23mly8cp7ag3xpbngpid9gqrfj8cyv9dar6i9j660bh03km";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules makeWrapper ];
 
-  buildInputs = [ oathToolkit kirigami2 qtquickcontrols2 qtbase ];
-
-  postInstall = ''
-    mv $out/bin/org.kde.keysmith $out/bin/.org.kde.keysmith-wrapped
-    makeWrapper $out/bin/.org.kde.keysmith-wrapped $out/bin/org.kde.keysmith \
-      --set QML2_IMPORT_PATH "${lib.getLib kirigami2}/lib/qt-5.12.7/qml:${lib.getBin qtquickcontrols2}/lib/qt-5.12.7/qml:${lib.getBin qtdeclarative}/lib/qt-5.12.7/qml:${qtgraphicaleffects}/lib/qt-5.12.7/qml" \
-      --set QT_PLUGIN_PATH "${lib.getBin qtbase}/lib/qt-5.12.7/plugins"
-    ln -s $out/bin/org.kde.keysmith $out/bin/keysmith
-  '';
+  buildInputs = [ libsodium ki18n oathToolkit kirigami2 qtquickcontrols2 qtbase ];
+  propagatedBuildInput = [ oathToolkit ];
 
   meta = with lib; {
     description = "OTP client for Plasma Mobile and Desktop";


### PR DESCRIPTION
#### Motivation for this change
Keysmith released a new stable tag

###### Things done
Moved from 0.1 to 0.2, this release brings a lot of new good features.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
