### PR TITLE
pythonPackages.html-sanitizer init at 1.9.1

### DIFF
--- a/pkgs/development/python-modules/html-sanitizer/default.nix
+++ b/pkgs/development/python-modules/html-sanitizer/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchFromGitHub, lxml, beautifulsoup4, pytest, pytestrunner }:
+
+buildPythonPackage rec {
+  pname = "html-sanitizer";
+  version = "1.9.1";
+
+  src = fetchFromGitHub {
+    owner = "matthiask";
+    repo = pname;
+    rev = version;
+    sha256 = "0nnv34924r0yn01rwlk749j5ijy7yxyj302s1i57yjrkqr3zlvas";
+  };
+
+  propagatedBuildInputs = [ lxml beautifulsoup4 ];
+
+  meta = with lib; {
+    description = "An  allowlist-based and very opinionated HTML sanitizer that can be used both for untrusted and trusted sources.";
+    homepage = "https://github.com/matthiask/html-sanitizer";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4153,6 +4153,8 @@ in {
 
   htmllaundry = callPackage ../development/python-modules/htmllaundry { };
 
+  html-sanitizer = callPackage ../development/python-modules/html-sanitizer { };
+
   html5lib = callPackage ../development/python-modules/html5lib { };
 
   httmock = callPackage ../development/python-modules/httmock { };


### PR DESCRIPTION
###### Motivation for this change

Initialize new python package, `html-sanitizer`. Needed for #84150 for Mirage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
