### PR TITLE
python3Packages.pykwalify: init at 1.7.0

### DIFF
--- a/pkgs/development/python-modules/pykwalify/default.nix
+++ b/pkgs/development/python-modules/pykwalify/default.nix
@@ -1,0 +1,53 @@
+{ lib, buildPythonPackage, fetchPypi
+, dateutil, docopt, pyyaml
+, pytest, testfixtures
+}:
+
+buildPythonPackage rec {
+  version = "1.7.0";
+  pname = "pykwalify";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1cnfzkg1b01f825ikpw2fhjclf9c8akxjfrbd1vc22x1lg2kk2vy";
+  };
+
+  propagatedBuildInputs = [
+    dateutil
+    docopt
+    pyyaml
+  ];
+
+  checkInputs = [
+    pytest
+    testfixtures
+  ];
+
+  checkPhase = ''
+    pytest \
+      -k 'not test_multi_file_support'
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Grokzen/pykwalify";
+    description = "YAML/JSON validation library";
+    longDescription = ''
+      This framework is a port with a lot of added functionality
+      of the Java version of the framework kwalify that can be found at
+      http://www.kuwata-lab.com/kwalify/
+
+      The original source code can be found at
+      http://sourceforge.net/projects/kwalify/files/kwalify-java/0.5.1/
+
+      The source code of the latest release that has been used can be found at
+      https://github.com/sunaku/kwalify.
+      Please note that source code is not the original authors code
+      but a fork/upload of the last release available in Ruby.
+
+      The schema this library is based on and extended from:
+      http://www.kuwata-lab.com/kwalify/ruby/users-guide.01.html#schema
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ siriobalmelli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7539,6 +7539,8 @@ in {
 
   webrtcvad = callPackage ../development/python-modules/webrtcvad { };
 
+  pykwalify = callPackage ../development/python-modules/pykwalify { };
+
   wfuzz = callPackage ../development/python-modules/wfuzz { };
 
   wget = callPackage ../development/python-modules/wget { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Require `pykwalify` package to be able to build `west` on Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
