### PR TITLE
teams: 1.3.00.5152 -> 1.3.00.16851

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation rec {
   pname = "teams";
-  version = "1.3.00.5153";
+  version = "1.3.00.16851";
 
   src = fetchurl {
     url = "https://packages.microsoft.com/repos/ms-teams/pool/main/t/teams/teams_${version}_amd64.deb";
-    sha256 = "13c7fmij0gcg6mrjjj2mhs21q7fzdssscwhihzyrmbmj64cd0a69";
+    sha256 = "1mp4xq224nwv2ckb5zd7iv3yvkg3gv6mk9dvx3f60jgain7qr0r3";
   };
 
   nativeBuildInputs = [ dpkg autoPatchelfHook wrapGAppsHook ];
@@ -56,9 +56,9 @@ stdenv.mkDerivation rec {
 
   # Includes runtimeDependencies in the RPATH of the included Node modules
   # so that dynamic loading works. We cannot use directly runtimeDependencies
-  # here, since the libraries from runtimeDependencies are not propagated 
+  # here, since the libraries from runtimeDependencies are not propagated
   # to the dynamically loadable node modules because of a condition in
-  # autoPatchElfHook since *.node modules have Type: DYN (Shared object file) 
+  # autoPatchElfHook since *.node modules have Type: DYN (Shared object file)
   # instead of EXEC or INTERP it expects.
   # Fixes: https://github.com/NixOS/nixpkgs/issues/85449
   postFixup = ''


### PR DESCRIPTION
Microsoft finally released a new version for Linux.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
