### PR TITLE
pythonPackages.tinycss2: remove failing lint test

### DIFF
--- a/pkgs/development/python-modules/tinycss2/default.nix
+++ b/pkgs/development/python-modules/tinycss2/default.nix
@@ -35,6 +35,10 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ webencodings ];
 
   checkInputs = [ pytest pytestrunner pytestcov pytest-flake8 pytest-isort ];
+  preCheck = ''
+    # this fails a flake lint-type check, so just remove it
+    rm tinycss2/css-parsing-tests/make_color3_hsl.py
+  '';
 
   meta = with lib; {
     description = "Low-level CSS parser for Python";


### PR DESCRIPTION
###### Motivation for this change

Fix `tinycss2`. Unblocks #84150.

Although I have to say, I'm confused. This caused a fairly large rebuild for something seemingly broken?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
