### PR TITLE
Update looking-glass-client to B2-rc2

### DIFF
--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -1,18 +1,19 @@
 { stdenv, fetchFromGitHub, fetchpatch
 , cmake, pkgconfig, SDL2, SDL, SDL2_ttf, openssl, spice-protocol, fontconfig
 , libX11, freefont_ttf, nettle, libconfig, wayland, libpthreadstubs, libXdmcp
-, libXfixes, libbfd
+, libXfixes, libbfd, libXi
 }:
 
 stdenv.mkDerivation rec {
   pname = "looking-glass-client";
-  version = "B1";
+  version = "B2-rc2";
 
   src = fetchFromGitHub {
     owner = "gnif";
     repo = "LookingGlass";
     rev = version;
-    sha256 = "0vykv7yjz4fima9d82m83acd8ab72nq4wyzyfs1c499i27wz91ia";
+    sha256 = "0xcnvn7b621sxzld53csrm257agz5bizxl4bnjqwx8djpj0yhv6x";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -20,7 +21,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     SDL SDL2 SDL2_ttf openssl spice-protocol fontconfig
     libX11 freefont_ttf nettle libconfig wayland libpthreadstubs
-    libXdmcp libXfixes libbfd cmake
+    libXdmcp libXfixes libbfd cmake libXi
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION


###### Motivation for this change

Update Looking Glass to B2-rc2 to take advantage of approximately a year worth of performance and feature improvements.

###### Things done

* Set looking-glass-client version to B2-rc2.
* Add libXi dependency to address compilation exception
* Update fetchFromGitHub to fetch submodules introduced in recent versions.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
