### PR TITLE
conan: 1.25.0 -> 1.27.0 & unbreak with six upgrade

### DIFF
--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -91,7 +91,8 @@ in newPython.pkgs.buildPythonApplication rec {
   postPatch = ''
     substituteInPlace conans/requirements.txt \
       --replace "PyYAML>=3.11, <3.14.0" "PyYAML" \
-      --replace "deprecation>=2.0, <2.1" "deprecation"
+      --replace "deprecation>=2.0, <2.1" "deprecation" \
+      --replace "six>=1.10.0,<=1.14.0" "six"
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3, git, pkgconfig }:
+{ lib, python3, fetchFromGitHub, git, pkgconfig }:
 
 # Note:
 # Conan has specific dependency demands; check
@@ -39,12 +39,14 @@ let newPython = python3.override {
 };
 
 in newPython.pkgs.buildPythonApplication rec {
-  version = "1.25.0";
+  version = "1.27.0";
   pname = "conan";
 
-  src = newPython.pkgs.fetchPypi {
-    inherit pname version;
-    sha256 = "1wgmx6s4h5m6zixb3wlaicy56rsqcy2srzmvii80xdx9g5wvi9pv";
+  src = fetchFromGitHub {
+    owner = "conan-io";
+    repo = "conan";
+    rev = version;
+    sha256 = "0ncqs1p4g23fmzgdmwppgxr8w275h38hgjdzs456cgivz8xs9rjl";
   };
 
   propagatedBuildInputs = with newPython.pkgs; [
@@ -75,17 +77,13 @@ in newPython.pkgs.buildPythonApplication rec {
   ] ++ (with newPython.pkgs; [
     codecov
     mock
-    pytest
-    node-semver
     nose
     parameterized
     webtest
   ]);
 
-  # Conan 1.14.0 has removed all tests from the Pypi source dist:
-  #     https://github.com/conan-io/conan/pull/4713
-  # We have recommended they be added back:
-  #     https://github.com/conan-io/conan/issues/4563#issuecomment-602225083
+  # TODO: reenable tests now that we fetch tests w/ the source from GitHub.
+  # Not enabled right now due to time constraints/failing tests that I didn't have time to track down
   doCheck = false;
 
   postPatch = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix #91959

* [x] updated conan to latest version
* [x] switched conan to fetch GitHub vs PyPi source
* [x] removed unused (``pytest``) & redundant (``node-semver``) python dependency packages
* [x] unpinned ``pythonPackages.six`` to fix #91959 (the only update is a faster ``six.ensure_str()`` method).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
