### PR TITLE
purple-matrix: set c compiler to cc, fixes build on osx

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-matrix/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-matrix/default.nix
@@ -4,6 +4,8 @@ stdenv.mkDerivation rec {
   pname = "purple-matrix-unstable";
   version = "2019-06-06";
 
+  buildFlags = [ "CC=cc" ];
+
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "purple-matrix";


### PR DESCRIPTION
Signed-off-by: Frederick F. Kautz IV <fkautz@alumni.cmu.edu>

###### Motivation for this change
Fixing pidgin uncovered a build time issue in purple-matrix when building on OSX.

###### Things done

Set the c compiler to the portable name: "cc"

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
