### PR TITLE
enlightenment: setuid missing path

### DIFF
--- a/pkgs/desktops/enlightenment/0003-setuid-missing-path.patch
+++ b/pkgs/desktops/enlightenment/0003-setuid-missing-path.patch
@@ -1,0 +1,25 @@
+From b7ef2a0d3f31db55a12b2b8c2e1c60ba62b971c8 Mon Sep 17 00:00:00 2001
+From: Matt Bagnara <mbagnara@fastmail.com>
+Date: Wed, 1 Jul 2020 15:30:40 -0500
+Subject: [PATCH] add nixos path
+
+---
+ src/bin/e_util_suid.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/bin/e_util_suid.h b/src/bin/e_util_suid.h
+index b01ff792b..88c2a0f17 100644
+--- a/src/bin/e_util_suid.h
++++ b/src/bin/e_util_suid.h
+@@ -246,7 +246,7 @@ e_setuid_setup(uid_t *caller_uid, gid_t *caller_gid, char **caller_user, char **
+ # endif
+ #endif
+    // pass 3 - set path and ifs to minimal defaults
+-   putenv("PATH=/bin:/usr/bin:/sbin:/usr/sbin");
++   putenv("PATH=/bin:/usr/bin:/sbin:/usr/sbin:/run/current-system/sw/bin");
+    putenv("IFS= \t\n");
+    return 0;
+ }
+-- 
+2.27.0
+

--- a/pkgs/desktops/enlightenment/enlightenment.nix
+++ b/pkgs/desktops/enlightenment/enlightenment.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation rec {
     # wrapped in the enlightenment service module, and the wrapped
     # executables should be used instead.
     ./0001-wrapped-setuid-executables.patch
+    ./0003-setuid-missing-path.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
e_util_setuid has the path hardcoded for which applications it allows to execute using setuid bit.
This patch fixes `Trying to rfkill unblock the bluetooth adapter failed` dialogs that occur whenever ACPI awakes occur.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
