### PR TITLE
zstd: build programs and tests against the shared library

### DIFF
--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -2,7 +2,8 @@
 , fixDarwinDylibNames
 , file
 , legacySupport ? false
-, enableShared ? true }:
+, static ? false
+}:
 
 stdenv.mkDerivation rec {
   pname = "zstd";
@@ -28,9 +29,24 @@ stdenv.mkDerivation rec {
     # work fine, and I'm not sure how to write the condition.
     ++ stdenv.lib.optional stdenv.hostPlatform.isWindows ./mcfgthreads-no-pthread.patch;
 
+  postPatch =
+  # Patch shebangs for playTests
+  ''
+    patchShebangs programs/zstdgrep
+  '' + stdenv.lib.optionalString (!static) ''
+    substituteInPlace build/cmake/CMakeLists.txt \
+      --replace 'message(SEND_ERROR "You need to build static library to build tests")' ""
+    substituteInPlace build/cmake/tests/CMakeLists.txt \
+      --replace 'libzstd_static' 'libzstd_shared'
+    sed -i \
+      "1aexport ${stdenv.lib.optionalString stdenv.isDarwin "DY"}LD_LIBRARY_PATH=$PWD/build_/lib" \
+      tests/playTests.sh
+  '';
+
   cmakeFlags = [
-    "-DZSTD_BUILD_SHARED:BOOL=${if enableShared then "ON" else "OFF"}"
-    # They require STATIC for bin/zstd and tests.
+    "-DZSTD_BUILD_SHARED:BOOL=${if (!static) then "ON" else "OFF"}"
+    "-DZSTD_BUILD_STATIC:BOOL=${if static then "ON" else "OFF"}"
+    "-DZSTD_PROGRAMS_LINK_SHARED:BOOL=${if (!static) then "ON" else "OFF"}"
     "-DZSTD_LEGACY_SUPPORT:BOOL=${if legacySupport then "ON" else "OFF"}"
     "-DZSTD_BUILD_TESTS:BOOL=ON"
   ];
@@ -56,8 +72,6 @@ stdenv.mkDerivation rec {
     substituteInPlace ../programs/zstdless \
       --replace "zstdcat" "$bin/bin/zstdcat"
   '';
-  # Don't duplicate the library code in runtime closures.
-  postInstall = stdenv.lib.optionalString enableShared ''rm "$out"/lib/libzstd.a'';
 
   outputs = [ "bin" "dev" "man" "out" ];
 

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -242,7 +242,7 @@ in {
   };
 
   zstd = super.zstd.override {
-    enableShared = false;
+    static = true;
   };
 
   llvmPackages_8 = super.llvmPackages_8 // {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

7f76daacdb0190ce91c95111cc3eba49cea41fd7 introduces a regression where cmake still exports `zstd_static` library, but the file doesn't exist anymore. In the discussion https://github.com/NixOS/nixpkgs/pull/90218#issuecomment-647020495 it was also pointed out that we are not testing the libraries that we are using.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
