### PR TITLE
haskellPackages.ghcWithPackages: fix for GHC 8.10

### DIFF
--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -127,7 +127,18 @@ symlinkJoin {
       rm $f-tmp
     done
   '') + ''
-    ${lib.optionalString hasLibraries "$out/bin/${ghcCommand}-pkg recache"}
+    ${lib.optionalString hasLibraries ''
+     # GHC 8.10 changes.
+     # Instead of replacing package.cache[.lock] with the new file,
+     # ghc-pkg is now trying to open the file.  These file are symlink
+     # to another nix derivation, so they are not writable.  Removing
+     # them allow the correct behavior of ghc-pkg recache
+     # See: https://github.com/NixOS/nixpkgs/issues/79441
+     rm $out/lib/${ghc.name}/package.conf.d/package.cache.lock
+     rm $out/lib/${ghc.name}/package.conf.d/package.cache
+
+     $out/bin/${ghcCommand}-pkg recache
+     ''}
     ${# ghcjs will read the ghc_libdir file when resolving plugins.
       lib.optionalString (isGhcjs && ghcLibdir != null) ''
       mkdir -p "${libDir}"


### PR DESCRIPTION
This closes #79441.

ghcWithPackages is using `ghc-pkg recache` to build its package
database. By doing so, it overrides the `package.cache[.lock]` files.

Details are unclear, but GHC 8.10 changed a bit the behavior.
Previously, it was unconditionally replacing the files by new ones. Now
it tries to open (for modification) the files. These files are symlinks
to another nix derivation, which is hence read-only.

This commit removes the files before running `ghc-pkg recache`, hence it
will just write the new files.

Tested with `haskellPackages.ghcWithPackages` (i.e. GHC 8.8) and
`haskell.packages.ghc8101.ghcWithPackages` (i.e GHC 8.10) with the
following nix file, at the root of the nixpkgs repository:

```
with import ./. {
  overlays = [
    (
      self: super: {
        haskellPackages = super.haskell.packages.ghc8101.override {
          overrides = selfh: superh: {
             th-lift-instances = super.haskell.lib.doJailbreak superh.th-lift-instances;
             th-expand-syns    = super.haskell.lib.doJailbreak superh.th-expand-syns;
             th-reify-many     = super.haskell.lib.doJailbreak superh.th-reify-many;
             th-orphans        = super.haskell.lib.doJailbreak superh.th-orphans;
             haskell-src-meta  = super.haskell.lib.doJailbreak superh.haskell-src-meta;
          };
        };
      }
  )
  ];
};
haskellPackages.ghcWithPackages(p:[p.PyF])
```

This will test with GHC 8.10. Comment out the `overlays` to test with
GHC 8.8.