### PR TITLE
platformio: Add udev rules to package output

### DIFF
--- a/pkgs/development/arduino/platformio/chrootenv.nix
+++ b/pkgs/development/arduino/platformio/chrootenv.nix
@@ -1,4 +1,4 @@
-{ lib, buildFHSUserEnv }:
+{ lib, buildFHSUserEnv, fetchFromGitHub }:
 
 let
   pio-pkgs = pkgs:
@@ -19,6 +19,14 @@ let
       platformio
     ]);
 
+  src = fetchFromGitHub {
+    owner = "platformio";
+    repo = "platformio-core";
+    rev = "v4.3.4";
+    sha256 = "0vf2j79319ypr4yrdmx84853igkb188sjfvlxgw06rlsvsm3kacq";
+  };
+
+
 in buildFHSUserEnv {
   name = "platformio";
 
@@ -34,7 +42,10 @@ in buildFHSUserEnv {
   };
 
   extraInstallCommands = ''
+    mkdir -p $out/lib/udev/rules.d
+
     ln -s $out/bin/platformio $out/bin/pio
+    ln -s ${src}/scripts/99-platformio-udev.rules $out/lib/udev/rules.d/99-platformio-udev.rules
   '';
 
   runScript = "platformio";

--- a/pkgs/development/arduino/platformio/core.nix
+++ b/pkgs/development/arduino/platformio/core.nix
@@ -82,6 +82,7 @@ in buildPythonApplication rec {
   patches = [
     ./fix-searchpath.patch
     ./use-local-spdx-license-list.patch
+    ./missing-udev-rules-nixos.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/arduino/platformio/missing-udev-rules-nixos.patch
+++ b/pkgs/development/arduino/platformio/missing-udev-rules-nixos.patch
@@ -1,0 +1,14 @@
+diff --git a/platformio/exception.py b/platformio/exception.py
+index d291ad7f..4761a35b 100644
+--- a/platformio/exception.py
++++ b/platformio/exception.py
+@@ -195,7 +195,8 @@ class MissedUdevRules(InvalidUdevRules):
+ 
+     MESSAGE = (
+         "Warning! Please install `99-platformio-udev.rules`. \nMode details: "
+-        "https://docs.platformio.org/en/latest/faq.html#platformio-udev-rules"
++        "https://docs.platformio.org/en/latest/faq.html#platformio-udev-rules\n"
++        "On NixOS add the platformio package to services.udev.packages"
+     )
+ 
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The udev rules shipped with platformio are not part of the package output. This is a follow up to #91679 (I'll close the PR when this gets merged)


###### Things done
Put the udev rules into `$out/lib/udev/rules.d/99-platformio-udev.rules`. This also adds a patch to change the default warning when the rules are not found to a more NixOS specific message.

Some things feel weird for me:
1.) Is calling `fetchFromGitHub` in multiple places with the same arguments considered good style? I could not think of a better way to do this.
2.) Is patching a appropriate way to inform about the usage of the udev rules?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
