### PR TITLE
whirlpool-gui: init at 0.10.1

### DIFF
--- a/pkgs/applications/blockchains/whirlpool-gui/default.nix
+++ b/pkgs/applications/blockchains/whirlpool-gui/default.nix
@@ -1,0 +1,103 @@
+{ stdenv, fetchFromGitHub, callPackage, makeWrapper, makeDesktopItem
+, nodejs, yarn, electron_7, jre8, tor }:
+
+let
+  system = stdenv.hostPlatform.system;
+
+in stdenv.mkDerivation rec {
+  pname = "whirlpool-gui";
+  version = "0.10.1";
+
+  src = fetchFromGitHub {
+    owner = "Samourai-Wallet";
+    repo = pname;
+    rev = version;
+    sha256 = "ru6WJQRulhnQCPY2E0x9M6xXtFdj/pg2fu4HpQxhImU=";
+  };
+
+  yarnCache = stdenv.mkDerivation {
+    name = "${pname}-${version}-${system}-yarn-cache";
+    inherit src;
+    phases = [ "unpackPhase" "buildPhase" ];
+    nativeBuildInputs = [ yarn ];
+    buildPhase = ''
+      export HOME=$NIX_BUILD_ROOT
+
+      yarn config set yarn-offline-mirror $out
+      yarn --frozen-lockfile --ignore-scripts --ignore-platform \
+        --ignore-engines --no-progress --non-interactive
+    '';
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = {
+      x86_64-linux = "6fl4cSwHXWgQcYlqxCae0p1Ppcb9fI5fFrxm7y6wxTo=";
+    }.${system} or (throw "Unsupported platform ${system}");
+  };
+
+  nativeBuildInputs = [ makeWrapper nodejs yarn ];
+
+  configurePhase = ''
+    # Yarn and bundler wants a real home directory to write cache, config, etc to
+    export HOME=$NIX_BUILD_ROOT
+
+    # Make yarn install packages from our offline cache, not the registry
+    yarn config --offline set yarn-offline-mirror ${yarnCache}
+  '';
+
+  buildPhase = ''
+    yarn install --offline --ignore-scripts --frozen-lockfile --no-progress --non-interactive
+
+    patchShebangs node_modules/
+
+    yarn build
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,share,libexec/whirlpool-gui/app}
+
+    # install production dependencies
+    yarn install \
+      --offline --frozen-lockfile --ignore-scripts \
+      --no-progress --non-interactive \
+      --production --no-bin-links \
+      --modules-folder $out/libexec/whirlpool-gui/node_modules
+
+    # copy application
+    cp -r app/{dist,app.html,main.prod.js,main.prod.js.map,img} $out/libexec/whirlpool-gui/app
+    cp -r package.json resources $out/libexec/whirlpool-gui
+
+    # make desktop item
+    ln -s "${desktopItem}/share/applications" "$out/share/applications"
+
+    # wrap electron
+    makeWrapper '${electron_7}/bin/electron' "$out/bin/whirlpool-gui" \
+      --add-flags "$out/libexec/whirlpool-gui" \
+      --prefix PATH : "${jre8}/bin:${tor}/bin"
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = "whirlpool-gui";
+    exec = "whirlpool-gui";
+    icon = "whirlpool-gui";
+    desktopName = "Whirlpool";
+    genericName = "Whirlpool";
+    comment = meta.description;
+    categories = "Network;";
+    extraEntries = ''
+      StartupWMClass=whrilpool-gui
+    '';
+  };
+
+  passthru.prefetchYarnCache = stdenv.lib.overrideDerivation yarnCache (d: {
+    outputHash = stdenv.lib.fakeSha256;
+  });
+
+  meta = with stdenv.lib; {
+    description = "Desktop GUI for Whirlpool by Samourai-Wallet";
+    homepage = https://www.samouraiwallet.com/whirlpool;
+    license = licenses.unlicense;
+    maintainers = [ maintainers.offline ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23624,6 +23624,8 @@ in
 
   quorum = callPackage ../applications/blockchains/quorum.nix { };
 
+  whirlpool-gui = callPackage ../applications/blockchains/whirlpool-gui { };
+
   ### GAMES
 
   _2048-in-terminal = callPackage ../games/2048-in-terminal { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add `whrilpool-gui` app.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
