### PR TITLE
insomina-designer: init at 2020.2.2

### DIFF
--- a/pkgs/development/web/insomnia/designer.nix
+++ b/pkgs/development/web/insomnia/designer.nix
@@ -1,0 +1,92 @@
+{ stdenv, makeWrapper, fetchurl, dpkg, alsaLib, atk, cairo, cups, dbus, expat
+, fontconfig, freetype, gdk-pixbuf, glib, gnome2, nspr, nss, gtk3, gtk2
+, at-spi2-atk, gsettings-desktop-schemas, gobject-introspection, wrapGAppsHook
+, libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
+, libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb, nghttp2
+, libudev0-shim, glibc, curl, openssl, autoPatchelfHook }:
+
+let
+  runtimeLibs = stdenv.lib.makeLibraryPath [
+    curl
+    glibc
+    libudev0-shim
+    nghttp2
+    openssl
+    stdenv.cc.cc
+  ];
+in stdenv.mkDerivation rec {
+  pname = "insomnia-designer";
+  version = "2020.2.2";
+
+  src = fetchurl {
+    url =
+      "https://github.com/Kong/insomnia/releases/download/designer@${version}/Insomnia.Designer-${version}.deb";
+    sha256 = "0hqhfwsvdz1jcza05prjvr5md5bdd2w0zffg5wh0bsvmsv6p1nq7";
+  };
+
+  nativeBuildInputs =
+    [ autoPatchelfHook dpkg makeWrapper gobject-introspection wrapGAppsHook ];
+
+  buildInputs = [
+    alsaLib
+    at-spi2-atk
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gnome2.GConf
+    gnome2.pango
+    gtk2
+    gtk3
+    gsettings-desktop-schemas
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libxcb
+    nspr
+    nss
+    stdenv.cc.cc
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    mkdir -p $out/share/insomnia $out/lib $out/bin
+
+    mv usr/share/* $out/share/
+    mv opt/Insomnia\ Designer/* $out/share/insomnia
+    mv $out/share/insomnia/*.so $out/lib/
+
+    ln -s $out/share/insomnia/designer $out/bin/designer
+    sed -i 's|\/opt\/Insomnia Designer|'$out'/bin|g' $out/share/applications/designer.desktop
+  '';
+
+  preFixup = ''
+    wrapProgram "$out/bin/designer" --prefix LD_LIBRARY_PATH : ${runtimeLibs}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://insomnia.rest/";
+    description = "The most intuitive cross-platform REST API Client";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ markus1189 babariviere ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10657,6 +10657,8 @@ in
 
   insomnia = callPackage ../development/web/insomnia { };
 
+  insomnia-designer = callPackage ../development/web/insomnia/designer.nix { };
+
   iozone = callPackage ../development/tools/misc/iozone { };
 
   itstool = callPackage ../development/tools/misc/itstool { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add `insomina-designer` package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
