### PR TITLE
firefox: update

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -8,7 +8,7 @@
 , yasm, libGLU, libGL, sqlite, unzip, makeWrapper
 , hunspell, libXdamage, libevent, libstartup_notification
 , libvpx, libvpx_1_8
-, icu, libpng, jemalloc, glib
+, icu, icu67, libpng, jemalloc, glib
 , autoconf213, which, gnused, cargo, rustc, llvmPackages
 , rust-cbindgen, nodejs, nasm, fetchpatch
 , debugBuild ? false
@@ -111,7 +111,7 @@ stdenv.mkDerivation ({
     xorg.libXScrnSaver xorg.xorgproto
     xorg.libXext unzip makeWrapper
     libevent libstartup_notification /* cairo */
-    icu libpng jemalloc glib
+    libpng jemalloc glib
     nasm
     # >= 66 requires nasm for the AV1 lib dav1d
     # yasm can potentially be removed in future versions
@@ -119,8 +119,10 @@ stdenv.mkDerivation ({
     # https://groups.google.com/forum/#!msg/mozilla.dev.platform/o-8levmLU80/SM_zQvfzCQAJ
     nspr nss
   ]
-  ++ lib.optionals  (lib.versionOlder ffversion "75") [ libvpx sqlite ]
+  ++ lib.optionals (lib.versionOlder ffversion "75") [ libvpx sqlite ]
   ++ lib.optional  (lib.versionAtLeast ffversion "75.0") libvpx_1_8
+  ++ lib.optional  (lib.versionOlder ffversion "78") icu
+  ++ lib.optional  (lib.versionAtLeast ffversion "78.0") icu67
   ++ lib.optional  alsaSupport alsaLib
   ++ lib.optional  pulseaudioSupport libpulseaudio # only headers are needed
   ++ lib.optional  gtk3Support gtk3
@@ -200,7 +202,6 @@ stdenv.mkDerivation ({
     "--enable-application=browser"
     "--with-system-jpeg"
     "--with-system-zlib"
-    "--with-system-bz2"
     "--with-system-libevent"
     "--with-system-libvpx"
     "--with-system-png" # needs APNG support
@@ -208,18 +209,20 @@ stdenv.mkDerivation ({
     "--enable-system-ffi"
     "--enable-system-pixman"
     #"--enable-system-cairo"
-    "--enable-startup-notification"
-    #"--enable-content-sandbox" # TODO: probably enable after 54
     "--disable-tests"
     "--disable-necko-wifi" # maybe we want to enable this at some point
     "--disable-updater"
     "--enable-jemalloc"
-    "--disable-gconf"
     "--enable-default-toolkit=${default-toolkit}"
     "--with-libclang-path=${llvmPackages.libclang}/lib"
     "--with-clang-path=${llvmPackages.clang}/bin/clang"
     "--with-system-nspr"
     "--with-system-nss"
+  ]
+  ++ lib.optionals (lib.versionOlder ffversion "78") [
+    "--with-system-bz2"
+    "--enable-startup-notification"
+    "--disable-gconf"
   ]
   ++ lib.optional (lib.versionOlder ffversion "75") "--enable-system-sqlite"
   ++ lib.optional (stdenv.isDarwin) "--disable-xcode-checks"

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,10 +7,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    ffversion = "77.0.1";
+    ffversion = "78.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "ngLihC0YuclLJEV3iPEX+tRzDKIdBe+CCOuFxvWNo7DnX8royOvTj2m4YyWyZoTQ5UCbPTQYmP4otgfovZSe8g==";
+      sha512 = "mdO6masIpiZBvYi6kpYUTSnsOda04CUs2CL1LNf1Yad+rfY4ga4aFuLtfKqfgV5IcIIl86XeiC+0grd4irbCYg==";
     };
 
     patches = [

--- a/pkgs/development/libraries/nspr/default.nix
+++ b/pkgs/development/libraries/nspr/default.nix
@@ -2,7 +2,7 @@
 , CoreServices ? null
 , buildPackages }:
 
-let version = "4.25"; in
+let version = "4.26"; in
 
 stdenv.mkDerivation {
   pname = "nspr";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://mozilla/nspr/releases/v${version}/src/nspr-${version}.tar.gz";
-    sha256 = "0mjjk2b7ika3v4y99cnaqz3z1iq1a50r1psn9i3s87gr46z0khqb";
+    sha256 = "0gbp3g9p4nhf0zrlvqi5883sqb9zdw0wk83lccpgskxphlni97gw";
   };
 
   patches = [

--- a/pkgs/development/libraries/nss/85_security_load.patch
+++ b/pkgs/development/libraries/nss/85_security_load.patch
@@ -1,7 +1,8 @@
-diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/cmd/shlibsign/shlibsign.c nss/cmd/shlibsign/shlibsign.c
---- nss/cmd/shlibsign/shlibsign.c	2017-01-04 15:24:24.000000000 +0100
-+++ nss/cmd/shlibsign/shlibsign.c	2017-01-24 14:43:31.030420852 +0100
-@@ -875,6 +875,8 @@
+diff --git nss/cmd/shlibsign/shlibsign.c nss/cmd/shlibsign/shlibsign.c
+index ad8f3b84e..74676d039 100644
+--- nss/cmd/shlibsign/shlibsign.c
++++ nss/cmd/shlibsign/shlibsign.c
+@@ -875,6 +875,8 @@ main(int argc, char **argv)
          goto cleanup;
      }
      lib = PR_LoadLibrary(libname);
@@ -10,37 +11,31 @@ diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/cmd/shlibsign/shlibsign.c nss/cmd/sh
      assert(lib != NULL);
      if (!lib) {
          PR_fprintf(PR_STDERR, "loading softokn3 failed");
-diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/coreconf/config.mk nss/coreconf/config.mk
---- nss/coreconf/config.mk	2017-01-04 15:24:24.000000000 +0100
-+++ nss/coreconf/config.mk	2017-01-24 14:43:47.989432372 +0100
-@@ -202,3 +202,6 @@
- 
- # Hide old, deprecated, TLS cipher suite names when building NSS
- DEFINES += -DSSL_DISABLE_DEPRECATED_CIPHER_SUITE_NAMES
-+
-+# Nix specific stuff.
-+DEFINES += -DNIX_NSS_LIBDIR=\"$(out)/lib/\"
-diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/lib/pk11wrap/pk11load.c nss/lib/pk11wrap/pk11load.c
---- nss/lib/pk11wrap/pk11load.c	2017-01-04 15:24:24.000000000 +0100
-+++ nss/lib/pk11wrap/pk11load.c	2017-01-24 14:45:06.883485652 +0100
-@@ -440,6 +440,13 @@
+diff --git nss/lib/pk11wrap/pk11load.c nss/lib/pk11wrap/pk11load.c
+index 9e7a0a546..a0a23a1a4 100644
+--- nss/lib/pk11wrap/pk11load.c
++++ nss/lib/pk11wrap/pk11load.c
+@@ -466,6 +466,15 @@ secmod_LoadPKCS11Module(SECMODModule *mod, SECMODModule **oldModule)
           * unload the library if anything goes wrong from here on out...
           */
          library = PR_LoadLibrary(mod->dllName);
++#ifndef NSS_STATIC_SOFTOKEN
 +        if ((library == NULL) &&
 +            !rindex(mod->dllName, PR_GetDirectorySeparator())) {
 +            library = PORT_LoadLibraryFromOrigin(my_shlib_name,
 +                (PRFuncPtr) &softoken_LoadDSO,
 +                mod->dllName);
 +        }
++#endif
 +
          mod->library = (void *)library;
  
          if (library == NULL) {
-diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/lib/util/secload.c nss/lib/util/secload.c
---- nss/lib/util/secload.c	2017-01-04 15:24:24.000000000 +0100
-+++ nss/lib/util/secload.c	2017-01-24 14:43:31.030420852 +0100
-@@ -70,9 +70,14 @@
+diff --git nss/lib/util/secload.c nss/lib/util/secload.c
+index 12efd2f75..8b74478f6 100644
+--- nss/lib/util/secload.c
++++ nss/lib/util/secload.c
+@@ -70,9 +70,14 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
  
      /* Remove the trailing filename from referencePath and add the new one */
      c = strrchr(referencePath, PR_GetDirectorySeparator());
@@ -56,7 +51,7 @@ diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/lib/util/secload.c nss/lib/util/secl
          if (fullName) {
              memcpy(fullName, referencePath, referencePathSize);
              strcpy(fullName + referencePathSize, name);
-@@ -82,6 +87,11 @@
+@@ -82,6 +87,11 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
  #endif
              libSpec.type = PR_LibSpec_Pathname;
              libSpec.value.pathname = fullName;
@@ -68,7 +63,7 @@ diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/lib/util/secload.c nss/lib/util/secl
              dlh = PR_LoadLibraryWithFlags(libSpec, PR_LD_NOW | PR_LD_LOCAL
  #ifdef PR_LD_ALT_SEARCH_PATH
                                                         /* allow library's dependencies to be found in the same directory
-@@ -89,6 +99,10 @@
+@@ -89,6 +99,10 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
                                                         | PR_LD_ALT_SEARCH_PATH
  #endif
                                            );

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, nspr, perl, zlib, sqlite, fixDarwinDylibNames, buildPackages }:
+{ stdenv, fetchurl, nspr, perl, zlib, sqlite, fixDarwinDylibNames, buildPackages, ninja, coreutils }:
 
 let
   nssPEM = fetchurl {
     url = "http://dev.gentoo.org/~polynomial-c/mozilla/nss-3.15.4-pem-support-20140109.patch.xz";
     sha256 = "10ibz6y0hknac15zr6dw4gv9nb5r5z9ym6gq18j3xqx7v7n3vpdw";
   };
-  version = "3.52.1";
+  version = "3.54";
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 
 in stdenv.mkDerivation rec {
@@ -14,12 +14,12 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/${pname}-${version}.tar.gz";
-    sha256 = "0y4jb9095f7bbgw7d7kvzm4c3g4p5i6y68fwhb8wlkpb7b1imj5w";
+    sha256 = "0hvfip056pl07h6w91i6fyji5nczrrsxyr56rls7jd2yryzqpcfs";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ perl ninja (buildPackages.python2.withPackages (ps: with ps; [ gyp ])) ];
 
   buildInputs = [ zlib sqlite ]
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
@@ -29,10 +29,18 @@ in stdenv.mkDerivation rec {
   prePatch = ''
     # strip the trailing whitespace from the patch line and the renamed CKO_NETSCAPE_ enum to CKO_NSS_
     xz -d < ${nssPEM} | sed \
-       -e '/^-DIRS = builtins $/ s/ $//' \
+       -e 's/-DIRS = builtins $/-DIRS = . builtins/g' \
        -e 's/CKO_NETSCAPE_/CKO_NSS_/g' \
        -e 's/CKT_NETSCAPE_/CKT_NSS_/g' \
        | patch -p1
+
+    patchShebangs nss
+
+    for f in nss/coreconf/config.gypi nss/build.sh nss/coreconf/config.gypi; do
+      substituteInPlace "$f" --replace "/usr/bin/env" "${coreutils}/bin/env"
+    done
+
+    substituteInPlace nss/coreconf/config.gypi --replace "/usr/bin/grep" "grep"
   '';
 
   patches =
@@ -52,43 +60,40 @@ in stdenv.mkDerivation rec {
 
   preConfigure = "cd nss";
 
-  makeFlags = let
-    # NSS's build systems expects aarch32 to be called arm; if we pass in armv6l/armv7l, it
-    # fails with a linker error
-    cpu = if stdenv.hostPlatform.isAarch32 then "arm" else stdenv.hostPlatform.parsed.cpu.name;
-  in [
-    "NSPR_INCLUDE_DIR=${nspr.dev}/include"
-    "NSPR_LIB_DIR=${nspr.out}/lib"
-    "NSDISTMODE=copy"
-    "BUILD_OPT=1"
-    "SOURCE_PREFIX=\$(out)"
-    "NSS_ENABLE_ECC=1"
-    "USE_SYSTEM_ZLIB=1"
-    "NSS_USE_SYSTEM_SQLITE=1"
-    "NATIVE_CC=${buildPackages.stdenv.cc}/bin/cc"
-  ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
-    # Pass in CPU even if we're not cross compiling, because otherwise it tries to guess with
-    # uname, which can be wrong if e.g. we're compiling for aarch32 on aarch64
-    "OS_TEST=${cpu}"
-    "CPU_ARCH=${cpu}"
-  ] ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "CROSS_COMPILE=1"
-    "NSS_DISABLE_GTESTS=1" # don't want to build tests when cross-compiling
-  ] ++ stdenv.lib.optional stdenv.is64bit "USE_64=1"
-    ++ stdenv.lib.optional stdenv.isDarwin "CCC=clang++";
+  buildPhase = let
+    getArch = platform: if platform.isx86_64 then "x64"
+          else if platform.isx86_32 then "ia32"
+          else if platform.isAarch32 then "arm"
+          else if platform.isAarch64 then "arm64"
+          else platform.parsed.cpu.name;
+    # yes, this is correct. nixpkgs uses "host" for the platform the binary will run on whereas nss uses "host" for the platform that the build is running on
+    target = getArch stdenv.hostPlatform;
+    host = getArch stdenv.buildPlatform;
+  in ''
+    runHook preBuild
 
-  NIX_CFLAGS_COMPILE = "-Wno-error";
+    sed -i 's|nss_dist_dir="$dist_dir"|nss_dist_dir="'$out'"|;s|nss_dist_obj_dir="$obj_dir"|nss_dist_obj_dir="'$out'"|' build.sh
+    ./build.sh -v --opt \
+      --with-nspr=${nspr.dev}/include:${nspr.out}/lib \
+      --system-sqlite \
+      --enable-legacy-db \
+      --target ${target} \
+      -Dhost_arch=${host} \
+      -Duse_system_zlib=1 \
+      ${stdenv.lib.optionalString stdenv.isDarwin "--clang"} \
+      ${stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "--disable-tests"}
 
-  # TODO(@oxij): investigate this: `make -n check` works but `make
-  # check` fails with "no rule", same for "installcheck".
-  doCheck = false;
-  doInstallCheck = false;
+    runHook postBuild
+  '';
 
-  postInstall = ''
+  NIX_CFLAGS_COMPILE = "-Wno-error -DNIX_NSS_LIBDIR=\"${placeholder "out"}/lib/\"";
+
+  installPhase = ''
+    runHook preInstall
+
     rm -rf $out/private
+    find $out -name "*.TOC" -delete
     mv $out/public $out/include
-    mv $out/*.OBJ/* $out/
-    rmdir $out/*.OBJ
 
     ln -s lib $out/lib64
 
@@ -138,6 +143,8 @@ in stdenv.mkDerivation rec {
     moveToOutput bin/nss-config "$dev"
     moveToOutput lib/libcrmf.a "$dev" # needed by firefox, for example
     rm -f "$out"/lib/*.a
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Upstream releases.

Contains #91746.

`firefox-esr-68` doesn't build. Looks like it's incompatible with the new `nss/nspr`.
The other 3 packages seem to build and work fine.

cc @andir 