### PR TITLE
btlejack: init at 2.0.0

### DIFF
--- a/pkgs/applications/radio/btlejack/default.nix
+++ b/pkgs/applications/radio/btlejack/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonApplication, fetchFromGitHub, pyserial, halo }:
+
+buildPythonApplication rec {
+  pname = "btlejack";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "virtualabs";
+    repo = "btlejack";
+    rev = "v${version}";
+    sha256 = "1r17079kx7dvsrbmw5sgvz3vj5m3pn2543gxj2xmw4s0lcihy378";
+  };
+
+  postPatch = ''
+    sed -i "s|^.*'argparse',$||" setup.py
+  '';
+
+  propagatedBuildInputs = [ pyserial halo ];
+
+  meta = with lib; {
+    homepage = "https://github.com/virtualabs/btlejack";
+    description = "Bluetooth Low Energy Swiss-army knife";
+    license = licenses.mit;
+    maintainers = with maintainers; [ oxzi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1737,6 +1737,8 @@ in
 
   btrfs-progs = callPackage ../tools/filesystems/btrfs-progs { };
 
+  btlejack = python3Packages.callPackage ../applications/radio/btlejack { };
+
   btrbk = callPackage ../tools/backup/btrbk {
     asciidoc = asciidoc-full;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds the [btlejack](https://github.com/virtualabs/btlejack) tool ~~with its dependencies and transitive dependencies:~~

- ~~[halo](https://github.com/manrajgrover/halo)~~
- ~~[cursor](https://github.com/GijsTimmers/cursor)~~
- ~~[spinners](https://github.com/manrajgrover/py-spinners)~~
- ~~[log-symbols](https://github.com/manrajgrover/py-log-symbols)~~

__Edit:__ The dependencies were added in the meantime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
