### PR TITLE
pmix: init at 3.1.5, add support to slurm, openmpi

### DIFF
--- a/pkgs/development/libraries/pmix/default.nix
+++ b/pkgs/development/libraries/pmix/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, perl, autoconf, automake
+, libtool, flex, libevent, hwloc, munge, zlib
+} :
+
+let
+  version = "3.1.5";
+
+in stdenv.mkDerivation {
+  pname = "pmix";
+  inherit version;
+
+  src = fetchFromGitHub {
+    repo = "openpmix";
+    owner = "openpmix";
+    rev = "v${version}";
+    sha256 = "0fvfsig20amcigyn4v3gcdxc0jif44vqg37b8zzh0s8jqqj7jz5w";
+  };
+
+  postPatch = ''
+    patchShebangs ./autogen.pl
+    patchShebangs ./config
+  '';
+
+  nativeBuildInputs = [ perl autoconf automake libtool flex ];
+
+  buildInputs = [ libevent hwloc munge zlib ];
+
+  configureFlags = [
+    "--with-libevent=${libevent.dev}"
+    "--with-munge=${munge}"
+    "--with-hwloc=${hwloc.dev}"
+  ];
+
+  preConfigure = ''
+    ./autogen.pl
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Process Management Interface for HPC environments";
+    homepage = "https://openpmix.github.io/";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.markuskowa ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -2,6 +2,7 @@
 , python, munge, perl, pam, zlib, shadow, coreutils
 , ncurses, libmysqlclient, gtk2, lua, hwloc, numactl
 , readline, freeipmi, xorg, lz4, rdma-core, nixosTests
+, pmix
 # enable internal X11 support via libssh2
 , enableX11 ? true
 }:
@@ -26,6 +27,8 @@ stdenv.mkDerivation rec {
     # increase string length to allow for full
     # path of 'echo' in nix store
     ./common-env-echo.patch
+    # Required for configure to pick up the right dlopen path
+    ./pmix-configure.patch
   ];
 
   prePatch = ''
@@ -46,6 +49,7 @@ stdenv.mkDerivation rec {
     curl python munge perl pam zlib
       libmysqlclient ncurses gtk2 lz4 rdma-core
       lua hwloc numactl readline freeipmi shadow.su
+      pmix
   ] ++ stdenv.lib.optionals enableX11 [ xorg.xauth ];
 
   configureFlags = with stdenv.lib;
@@ -56,6 +60,7 @@ stdenv.mkDerivation rec {
       "--with-zlib=${zlib}"
       "--with-ofed=${rdma-core}"
       "--sysconfdir=/etc/slurm"
+      "--with-pmix=${pmix}"
     ] ++ (optional (gtk2 == null)  "--disable-gtktest")
       ++ (optional (!enableX11) "--disable-x11");
 

--- a/pkgs/servers/computing/slurm/pmix-configure.patch
+++ b/pkgs/servers/computing/slurm/pmix-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 1cf53bc..ab68441 100755
+--- a/configure
++++ b/configure
+@@ -21207,7 +21207,7 @@ rm -f conftest.err conftest.i conftest.$ac_ext
+                 as_fn_error $? "error processing $x_ac_cv_pmix_libdir: PMIx v3.x was already found in one of the previous paths" "$LINENO" 5
+               fi
+               _x_ac_pmix_v3_found="1"
+-              PMIX_V3_CPPFLAGS="-I$x_ac_cv_pmix_dir/include"
++              PMIX_V3_CPPFLAGS="-I$x_ac_cv_pmix_dir/include -DPMIXP_V3_LIBPATH=\\\"$x_ac_cv_pmix_libdir\\\""
+               if test "$ac_with_rpath" = "yes"; then
+                 PMIX_V3_LDFLAGS="-Wl,-rpath -Wl,$x_ac_cv_pmix_libdir -L$x_ac_cv_pmix_libdir"
+               else

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6138,6 +6138,8 @@ in
 
   pmacct = callPackage ../tools/networking/pmacct { };
 
+  pmix = callPackage ../development/libraries/pmix { };
+
   polygraph = callPackage ../tools/networking/polygraph { };
 
   progress = callPackage ../tools/misc/progress { };


### PR DESCRIPTION
###### Motivation for this change
Unlock the full potential of Slurm. By adding PMIx, Slurm now fully supports running MPI binaries with `srun` instead of `mpirun`.

Addresses also ideas from https://github.com/NixOS/nixpkgs/pull/79771

###### Things done
* init pmix
* build slurm with PMIx support
* build openmpi against PMIx support
* add a PMIx test case to `nixos/tests/slurm.nix`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
