### PR TITLE
systemd: change fallback dns servers

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -170,8 +170,22 @@ in stdenv.mkDerivation {
     "-Dman=true"
   ];
 
-  preConfigure = ''
+  preConfigure = let
+    defaultDnsServers = [
+      # We use these public name services, ordered by their privacy policy (hopefully):
+      #  * Cloudflare (https://1.1.1.1/)
+      #  * Quad9 without filtering (https://www.quad9.net/)
+      #  * Google (https://developers.google.com/speed/public-dns/)
+      "1.1.1.1"
+      "9.9.9.10"
+      "8.8.8.8"
+      "2606:4700:4700::1111"
+      "2620:fe::10"
+      "2001:4860:4860::8888"
+    ];
+  in ''
     mesonFlagsArray+=(-Dntp-servers="0.nixos.pool.ntp.org 1.nixos.pool.ntp.org 2.nixos.pool.ntp.org 3.nixos.pool.ntp.org")
+    mesonFlagsArray+=("-Ddns-servers=${toString defaultDnsServers}")
     export LC_ALL="en_US.UTF-8";
     # FIXME: patch this in systemd properly (and send upstream).
     # already fixed in f00929ad622c978f8ad83590a15a765b4beecac9: (u)mount


### PR DESCRIPTION
By default systemd fallbacks first to cloudflare and than to google DNS server.
The new default is to first use Cloudflare than Quad9 than google. 
The first two should have have better privacy policies than the google one. 
Note that this is the default value which can be overridden by users as well. 
The default should be a good compromise between global availability, speed and privacy.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
