### PR TITLE
hepmc3: 3.2.0 -> 3.2.2

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, cmake, gl2ps, gsl, libX11, libXpm, libXft
+{ stdenv, lib, fetchurl, makeWrapper, cmake, gl2ps, gsl, libX11, libXpm, libXft
 , libXext, libGLU, libGL, libxml2, lz4, lzma, pcre, pkgconfig, python, xxHash
 , zlib
 , Cocoa, OpenGL, noSplash ? false }:
@@ -13,11 +13,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper cmake pkgconfig ];
-  buildInputs = [ gl2ps pcre python zlib libxml2 lz4 lzma gsl xxHash ]
-    ++ stdenv.lib.optionals (!stdenv.isDarwin) [ libX11 libXpm libXft libXext libGLU libGL ]
-    ++ stdenv.lib.optionals (stdenv.isDarwin) [ Cocoa OpenGL ]
+  buildInputs = [ gl2ps pcre zlib libxml2 lz4 lzma gsl xxHash python.pkgs.numpy ]
+    ++ lib.optionals (!stdenv.isDarwin) [ libX11 libXpm libXft libXext libGLU libGL ]
+    ++ lib.optionals (stdenv.isDarwin) [ Cocoa OpenGL ]
     ;
-  propagatedBuildInputs = [ python.pkgs.numpy ];
 
   patches = [
     ./sw_vers.patch


### PR DESCRIPTION
###### Motivation for this change
noticed it was failing on #91886

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/92078
7 packages built:
fastnlo hepmc3 python27Packages.hepmc3 python37Packages.hepmc3 python38Packages.hepmc3 root yoda-with-root
```
