### PR TITLE
makeModulesClosure: handle builtin modules better

### DIFF
--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -19,36 +19,55 @@ version=$(cd $kernel/lib/modules && ls -d *)
 echo "kernel version is $version"
 
 # Determine the dependencies of each root module.
-closure=
+mkdir -p $out/lib/modules/"$version"
+touch closure
 for module in $rootModules; do
     echo "root module: $module"
-    deps=$(modprobe --config no-config -d $kernel --set-version "$version" --show-depends "$module" \
-        | sed 's/^insmod //') \
-        || if test -z "$allowMissing"; then exit 1; fi
-    if [[ "$deps" != builtin* ]]; then
-        closure="$closure $deps"
+    modprobe --config no-config -d $kernel --set-version "$version" --show-depends "$module" \
+    | while read cmd module args; do
+        case "$cmd" in
+            builtin)
+                touch found
+                echo "$module" >>closure
+                echo "  builtin dependency: $module";;
+            insmod)
+                touch found
+                if ! test -e "$module"; then
+                    echo "  dependency not found: $module"
+                    exit 1
+                fi
+                target=$(echo "$module" | sed "s^$NIX_STORE.*/lib/modules/^$out/lib/modules/^")
+                if test -e "$target"; then
+                    echo "  dependency already copied: $module"
+                    continue
+                fi
+                echo "$module" >>closure
+                echo "  copying dependency: $module"
+                mkdir -p $(dirname $target)
+                cp "$module" "$target"
+                # If the kernel is compiled with coverage instrumentation, it
+                # contains the paths of the *.gcda coverage data output files
+                # (which it doesn't actually use...).  Get rid of them to prevent
+                # the whole kernel from being included in the initrd.
+                nuke-refs "$target"
+                echo "$target" >> $out/insmod-list;;
+             *)
+                echo "  unexpected modprobe output: $cmd $module"
+                exit 1;;
+        esac
+    done || test -n "$allowMissing"
+    if ! test -e found; then
+        echo "  not found"
+        if test -z "$allowMissing"; then
+            exit 1
+        fi
+    else
+        rm found
     fi
 done
 
-echo "closure:"
-mkdir -p $out/lib/modules/"$version"
-for module in $closure; do
-    target=$(echo $module | sed "s^$NIX_STORE.*/lib/modules/^$out/lib/modules/^")
-    if test -e "$target"; then continue; fi
-    if test \! -e "$module"; then continue; fi # XXX: to avoid error with "cp builtin builtin"
-    mkdir -p $(dirname $target)
-    echo $module
-    cp $module $target
-    # If the kernel is compiled with coverage instrumentation, it
-    # contains the paths of the *.gcda coverage data output files
-    # (which it doesn't actually use...).  Get rid of them to prevent
-    # the whole kernel from being included in the initrd.
-    nuke-refs $target
-    echo $target >> $out/insmod-list
-done
-
 mkdir -p $out/lib/firmware
-for module in $closure; do
+for module in $(cat closure); do
     for i in $(modinfo -F firmware $module); do
         mkdir -p "$out/lib/firmware/$(dirname "$i")"
         echo "firmware for $module: $i"


### PR DESCRIPTION
Rewrite the closure computation and copying.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The previous code discarded entire dependency trees if the first entry in the dependency list compiled by `modprobe --show-depends` is a builtin and otherwise handled its output in a rather hackish way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
