### PR TITLE
python3Packages.canmatrix: 0.8.0 -> 0.9.1

### DIFF
--- a/pkgs/development/python-modules/canmatrix/default.nix
+++ b/pkgs/development/python-modules/canmatrix/default.nix
@@ -4,6 +4,7 @@
 , pythonOlder
 , attrs
 , bitstruct
+, click
 , future
 , pathlib2
 , typing
@@ -17,20 +18,21 @@
 
 buildPythonPackage rec {
   pname = "canmatrix";
-  version = "0.8";
+  version = "0.9.1";
 
   # uses fetchFromGitHub as PyPi release misses test/ dir
   src = fetchFromGitHub {
     owner = "ebroecker";
     repo = pname;
     rev = version;
-    sha256 = "1wzflapyj2j4xsi7d7gfmznmxbgr658n092xyq9nac46rbhpcphg";
+    sha256 = "129lcchq45h8wqjvvn0rwpbmih4m0igass2cx7a21z94li97hcia";
   };
 
   propagatedBuildInputs = [
     # required
     attrs
     bitstruct
+    click
     future
     pathlib2
     # optional
@@ -41,12 +43,18 @@ buildPythonPackage rec {
     pyyaml
   ] ++ lib.optional (pythonOlder "3.5") typing;
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "version = versioneer.get_version()" "version = \"${version}\""
+  '';
+
   checkInputs = [
     pytest
   ];
 
+  # long_envvar_name_imports requires stable key value pair ordering
   checkPhase = ''
-    pytest -s src/canmatrix
+    pytest -s src/canmatrix -k 'not long_envvar_name_imports'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
noticed a python38 build failures when reviewing: #90588

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
