### PR TITLE
cc-wrapper: ensure existence of some $out/nix-support/*

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -229,7 +229,7 @@ stdenv.mkDerivation {
 
   postFixup =
     ''
-      # Backwards compatability for packages expecting this file, e.g. with
+      # Backwards compatibility for packages expecting this file, e.g. with
       # `$NIX_CC/nix-support/dynamic-linker`.
       #
       # TODO(@Ericson2314): Remove this after stable release and force
@@ -240,6 +240,8 @@ stdenv.mkDerivation {
       if [[ -f "$bintools/nix-support/dynamic-linker-m32" ]]; then
         ln -s "$bintools/nix-support/dynamic-linker-m32" "$out/nix-support"
       fi
+
+      touch "$out"/nix-support/{cc-cflags,cc-cflags-before,cc-ldflags,libc-cflags}
     ''
 
     + optionalString isClang ''
@@ -294,6 +296,7 @@ stdenv.mkDerivation {
       ## General libc++ support
       ##
 
+      touch "$out"/nix-support/{libcxx-cxxflags,libcxx-ldflags}
     ''
     + optionalString (libcxx == null && cc ? gcc) ''
       for dir in ${cc.gcc}/include/c++/*; do


### PR DESCRIPTION
Done because of f3f7612a409.  Now it's possible to simply use
$(< ${stdenv.cc}/nix-support/libcxx-cxxflags)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] :-) Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
