### PR TITLE
{cc,bintools}-wrapper: Some fixes

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -132,15 +132,15 @@ stdenv.mkDerivation {
       ldPath="${bintools_bin}/bin"
     ''
 
+    # Solaris needs an additional ld wrapper.
     + optionalString (targetPlatform.isSunOS && nativePrefix != "") ''
-      # Solaris needs an additional ld wrapper.
       ldPath="${nativePrefix}/bin"
       exec="$ldPath/${targetPrefix}ld"
       wrap ld-solaris ${./ld-solaris-wrapper.sh}
     '')
 
+    # Create a symlink to as (the assembler).
     + ''
-      # Create a symlink to as (the assembler).
       if [ -e $ldPath/${targetPrefix}as ]; then
         ln -s $ldPath/${targetPrefix}as $out/bin/${targetPrefix}as
       fi
@@ -200,26 +200,28 @@ stdenv.mkDerivation {
   ];
 
   postFixup =
+    ##
+    ## General libc support
+    ##
     optionalString (libc != null) (''
-      ##
-      ## General libc support
-      ##
-
       echo "-L${libc_lib}${libc.libdir or "/lib"}" > $out/nix-support/libc-ldflags
 
       echo "${libc_lib}" > $out/nix-support/orig-libc
       echo "${libc_dev}" > $out/nix-support/orig-libc-dev
+    ''
 
-      ##
-      ## Dynamic linker support
-      ##
-
+    ##
+    ## Dynamic linker support
+    ##
+    + ''
       if [[ -z ''${dynamicLinker+x} ]]; then
         echo "Don't know the name of the dynamic linker for platform '${targetPlatform.config}', so guessing instead." >&2
         local dynamicLinker="${libc_lib}/lib/ld*.so.?"
       fi
+    ''
 
-      # Expand globs to fill array of options
+    # Expand globs to fill array of options
+    + ''
       dynamicLinker=($dynamicLinker)
 
       case ''${#dynamicLinker[@]} in
@@ -241,45 +243,45 @@ stdenv.mkDerivation {
         local ldflagsBefore=(-dynamic-linker "$dynamicLinker")
     '') + ''
       fi
-
-      # The dynamic linker is passed in `ldflagsBefore' to allow
-      # explicit overrides of the dynamic linker by callers to ld
-      # (the *last* value counts, so ours should come first).
+    ''
+    # The dynamic linker is passed in `ldflagsBefore' to allow
+    # explicit overrides of the dynamic linker by callers to ld
+    # (the *last* value counts, so ours should come first).
+    + ''
       printWords "''${ldflagsBefore[@]}" > $out/nix-support/libc-ldflags-before
     '')
 
+    # Ensure consistent LC_VERSION_MIN_MACOSX and remove LC_UUID.
     + optionalString stdenv.targetPlatform.isMacOS ''
-      # Ensure consistent LC_VERSION_MIN_MACOSX and remove LC_UUID.
       echo "-macosx_version_min 10.12 -sdk_version 10.12 -no_uuid" >> $out/nix-support/libc-ldflags-before
     ''
 
-    + optionalString (!nativeTools) ''
-      ##
-      ## User env support
-      ##
+    ##
+    ## User env support
+    ##
 
-      # Propagate the underling unwrapped bintools so that if you
-      # install the wrapper, you get tools like objdump (same for any
-      # binaries of libc).
+    # Propagate the underling unwrapped bintools so that if you
+    # install the wrapper, you get tools like objdump (same for any
+    # binaries of libc).
+    + optionalString (!nativeTools) ''
       printWords ${bintools_bin} ${if libc == null then "" else libc_bin} > $out/nix-support/propagated-user-env-packages
     ''
 
+    ##
+    ## Man page and info support
+    ##
     + optionalString propagateDoc (''
-      ##
-      ## Man page and info support
-      ##
-
       ln -s ${bintools.man} $man
     '' + optionalString (bintools ? info) ''
       ln -s ${bintools.info} $info
     '')
 
-    + ''
-      ##
-      ## Hardening support
-      ##
+    ##
+    ## Hardening support
+    ##
 
-      # some linkers on some platforms don't support specific -z flags
+    # some linkers on some platforms don't support specific -z flags
+    + ''
       export hardening_unsupported_flags=""
       if [[ "$($ldPath/${targetPrefix}ld -z now 2>&1 || true)" =~ un(recognized|known)\ option ]]; then
         hardening_unsupported_flags+=" bindnow"
@@ -307,12 +309,11 @@ stdenv.mkDerivation {
       substituteAll ${./add-flags.sh} $out/nix-support/add-flags.sh
       substituteAll ${./add-hardening.sh} $out/nix-support/add-hardening.sh
       substituteAll ${../wrapper-common/utils.bash} $out/nix-support/utils.bash
-
-      ##
-      ## Extra custom steps
-      ##
     ''
 
+    ##
+    ## Extra custom steps
+    ##
     + extraBuildCommands;
 
   inherit dynamicLinker expand-response-params;


### PR DESCRIPTION
###### Motivation for this change

1. This means we can freely keep the comments up to date without the penalty of a mass rebuild.

2. This will unbreak firefox and a few other packages which try to grab some of the libcxx flags.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built stdenv on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
