### PR TITLE
z3: Add Java Bindings

### DIFF
--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -1,4 +1,12 @@
-{ stdenv, fetchFromGitHub, python, fixDarwinDylibNames }:
+{ stdenv, fetchFromGitHub, python, fixDarwinDylibNames
+, javaBindings ? false
+, pythonBindings ? true
+, jdk ? null
+}:
+
+assert javaBindings -> jdk != null;
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "z3";
@@ -11,22 +19,23 @@ stdenv.mkDerivation rec {
     sha256 = "0hprcdwhhyjigmhhk6514m71bnmvqci9r8gglrqilgx424r6ff7q";
   };
 
-  buildInputs = [ python fixDarwinDylibNames ];
+  buildInputs = [ python fixDarwinDylibNames ] ++ optional javaBindings jdk;
   propagatedBuildInputs = [ python.pkgs.setuptools ];
   enableParallelBuilding = true;
 
-  configurePhase = ''
-    ${python.interpreter} scripts/mk_make.py --prefix=$out --python --pypkgdir=$out/${python.sitePackages}
-    cd build
-  '';
+  configurePhase = concatStringsSep " " (
+    [ "${python.interpreter} scripts/mk_make.py --prefix=$out" ]
+    ++ optional javaBindings   "--java"
+    ++ optional pythonBindings "--python --pypkgdir=$out/${python.sitePackages}"
+  ) + "\n" + "cd build";
 
   postInstall = ''
-    mkdir -p $dev $lib $python/lib
-
-    mv $out/lib/python*  $python/lib/
-    mv $out/lib          $lib/lib
-    mv $out/include      $dev/include
-
+    mkdir -p $dev $lib
+    mv $out/lib     $lib/lib
+    mv $out/include $dev/include
+  '' + optionalString pythonBindings ''
+    mkdir -p $python/lib
+    mv $out/lib/python* $python/lib/
     ln -sf $lib/lib/libz3${stdenv.hostPlatform.extensions.sharedLibrary} $python/${python.sitePackages}/z3/lib/libz3${stdenv.hostPlatform.extensions.sharedLibrary}
   '';
 

--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     mv $out/include $dev/include
   '' + optionalString pythonBindings ''
     mkdir -p $python/lib
-    mv $out/lib/python* $python/lib/
+    mv $lib/lib/python* $python/lib/
     ln -sf $lib/lib/libz3${stdenv.hostPlatform.extensions.sharedLibrary} $python/${python.sitePackages}/z3/lib/libz3${stdenv.hostPlatform.extensions.sharedLibrary}
   '';
 


### PR DESCRIPTION
###### Motivation for this change

This is my take on #91939 

###### Things done

Introduce new arguments to build Java Bindings, and to disable building of Python bindings. Default behaviour is preserved.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
