### PR TITLE
python2Packages: don't recurseIntoAttrs

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9735,7 +9735,7 @@ in
   inherit (pythonInterpreters) python27 python35 python36 python37 python38 python39 python3Minimal pypy27 pypy36;
 
   # Python package sets.
-  python27Packages = lib.hiPrioSet (recurseIntoAttrs python27.pkgs);
+  python27Packages = lib.hiPrioSet python27.pkgs;
   python35Packages = python35.pkgs;
   python36Packages = python36.pkgs;
   python37Packages = recurseIntoAttrs python37.pkgs;


### PR DESCRIPTION
###### Motivation for this change
felt like this is overdue. Python has been EOL for >5 months now, also has active CVEs. This isn't to kill the package set, but rather not have hydra build the packages, and `nixpkgs-review` will no longer test python2 packages for breakages.

https://discourse.nixos.org/t/what-should-i-expect-to-find-in-cache-nixos-org/7935/5

cc @FRidh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
1 package added:
svg2tikz (init at 1.0.0)

2413 packages removed:
addic7ed-cli (†1.4.6) appleseed (†2.0.5-beta) avahi (†0.7) behave (†1.2.6) boost (†1.69.0) codespell (†1.17.1) dtc (†1.6.0) eccodes (†2.12.5) egg-build-hook.sh (†) egg-install-hook.sh (†) egg-unpack-hook.sh (†) fontforge (†20200314) gaia (†2.4.6) galario (†1.2.1) gdal (†3.0.4) gdown (†3.11.1) google-compute-engine (†20190124) gpgme (†1.13.1) gprof2dot (†2019-11-30) grib-api (†1.28.0) gwyddion (†2.55) hepmc3 (†3.2.0) hook (†) hoomd-blue (†2.3.4) jsbeautifier (†1.11.0) libiio (†0.20) libmodulemd (†2.9.2) libnl (†3.5.0) libpam-wrapper (†1.1.3) libplist (†2019-04-04) librepo (†1.11.3) libselinux (†2.9) libtorrent-rasterbar (†1.2.6) libxml2 (†2.9.10) libxslt (†1.1.34) mininet (†2.3.0d6) mypy-protobuf (†1.21) neuron (†7.5) neuron (†7.5) nghttp2 (†1.40.0) nixpart (†0.4.1) nixpart (†1.0.0) opencv (†3.4.8) opencv (†4.3.0) opencv (†4.3.0) or-tools (†7.6) ovito (†3.0.0) pip-build-hook.sh (†) pip-install-hook (†) py3buddy-unstable (†2019-09-29) pyblock (†0.53) pyside2 (†5.12.3) pyside2-tools (†5.12.3) pytest-check-hook (†) python (†2.7.18) python-catch-conflicts-hook (†) python-imports-check-hook.sh (†) python-namespaces-hook.sh (†) python-notify (†0.1.1) python-recompile-bytecode-hook (†) python-recursive-pth-loader (†1.0) python-remove-bin-bytecode-hook (†) python-remove-tests-dir-hook (†) python2.7-aafigure (†0.6) python2.7-absl-py (†0.9.0) python2.7-acme (†1.3.0) python2.7-acme-tiny (†4.1.0) python2.7-adal (†1.2.4) python2.7-adb-homeassistant (†1.3.1) python2.7-aenum (†2.2.3) python2.7-affine (†2.3.0) python2.7-affinity (†0.1.0) python2.7-agate (†1.6.1) python2.7-agate-dbf (†0.2.1) python2.7-agate-excel (†0.2.3) python2.7-agate-sql (†0.5.4) python2.7-aioconsole (†0.1.16) python2.7-aiodns (†2.0.0) python2.7-aioeventlet (†0.5.2) python2.7-ajpy (†0.0.5) python2.7-alabaster (†0.7.12) python2.7-alembic (†1.4.2) python2.7-allpairspy (†2.5.0) python2.7-amazon_kclpy (†1.5.0) python2.7-amqp (†2.6.0) python2.7-amqplib (†1.0.2) python2.7-androguard (†3.3.5) python2.7-aniso8601 (†8.0.0) python2.7-annexremote (†1.3.1) python2.7-annoy (†1.16.3) python2.7-anonip (†1.0.0) python2.7-ansi (†0.1.5) python2.7-ansi2html (†1.5.2) python2.7-ansible (†2.9.10) python2.7-ansicolor (†0.2.6) python2.7-ansicolors (†1.1.8) python2.7-ansiconv (†1.0.0) python2.7-ansiwrap (†0.8.4) python2.7-antlr4-python2-runtime (†4.7.2) python2.7-anyjson (†0.3.3) python2.7-anytree (†2.8.0) python2.7-apache-libcloud (†2.8.2) python2.7-apipkg (†1.5) python2.7-appdirs (†1.4.4) python2.7-applicationinsights (†0.11.9) python2.7-apprise (†0.8.5) python2.7-approvaltests (†0.2.6) python2.7-APScheduler (†3.6.3) python2.7-apsw (†3.32.2-r1) python2.7-area (†1.1.1) python2.7-argcomplete (†1.11.1) python2.7-argh (†0.26.2) python2.7-argon2_cffi (†19.2.0) python2.7-args (†0.1.0) python2.7-Arpeggio (†1.9.2) python2.7-arrow (†0.15.6) python2.7-arxiv2bib (†1.0.8) python2.7-asana (†0.8.2) python2.7-asciimatics (†1.11.0) python2.7-asciitree (†0.3.3) python2.7-ase (†3.17.0) python2.7-asn1ate (†0.6) python2.7-asn1crypto (†1.3.0) python2.7-aspy.yaml (†1.3.0) python2.7-astor (†0.8.1) python2.7-astroid (†1.6.6) python2.7-asttokens (†2.0.4) python2.7-astunparse (†1.6.3) python2.7-atlassian-python-api (†1.15.9) python2.7-atomiclong (†0.1.1) python2.7-atomicwrites (†1.4.0) python2.7-atsim.potentials (†0.2.1) python2.7-attrdict (†2.0.1) python2.7-attrs (†19.3.0) python2.7-audioread (†2.1.8) python2.7-audiotools (†3.1.1) python2.7-augeas (†1.1.0) python2.7-auth0-python (†3.10.0) python2.7-authheaders (†0.13.0) python2.7-authlib (†0.14.3) python2.7-authres (†1.2.0) python2.7-autograd (†1.3) python2.7-Autologging (†1.3.2) python2.7-Automat (†20.2.0) python2.7-autopep8 (†1.5.3) python2.7-avro (†1.9.2) python2.7-awesome-slugify (†1.6.5) python2.7-awkward (†0.12.21) python2.7-aws-lambda-builders (†0.8.0) python2.7-aws-sam-translator (†1.24.0) python2.7-aws-xray-sdk (†2.5.0) python2.7-azure-applicationinsights (†0.1.0) python2.7-azure-batch (†9.0.0) python2.7-azure-common (†1.1.25) python2.7-azure-cosmos (†3.1.2) python2.7-azure-cosmosdb-nspkg (†2.0.2) python2.7-azure-cosmosdb-table (†1.0.6) python2.7-azure-datalake-store (†0.0.48) python2.7-azure-eventgrid (†1.3.0) python2.7-azure-functions-devops-build (†0.0.22) python2.7-azure-graphrbac (†0.61.1) python2.7-azure-keyvault-nspkg (†1.0.0) python2.7-azure-loganalytics (†0.1.0) python2.7-azure-mgmt-advisor (†4.0.0) python2.7-azure-mgmt-applicationinsights (†0.3.0) python2.7-azure-mgmt-authorization (†0.60.0) python2.7-azure-mgmt-batch (†9.0.0) python2.7-azure-mgmt-batchai (†2.0.0) python2.7-azure-mgmt-billing (†0.2.0) python2.7-azure-mgmt-cdn (†4.0.0) python2.7-azure-mgmt-cognitiveservices (†6.2.0) python2.7-azure-mgmt-commerce (†1.0.1) python2.7-azure-mgmt-common (†0.20.0) python2.7-azure-mgmt-compute (†12.0.0) python2.7-azure-mgmt-consumption (†3.0.0) python2.7-azure-mgmt-containerinstance (†1.5.0) python2.7-azure-mgmt-containerservice (†9.0.1) python2.7-azure-mgmt-cosmosdb (†0.14.0) python2.7-azure-mgmt-datafactory (†0.10.0) python2.7-azure-mgmt-datalake-analytics (†0.6.0) python2.7-azure-mgmt-datalake-nspkg (†3.0.1) python2.7-azure-mgmt-datalake-store (†0.5.0) python2.7-azure-mgmt-datamigration (†4.0.0) python2.7-azure-mgmt-devspaces (†0.2.0) python2.7-azure-mgmt-devtestlabs (†4.0.0) python2.7-azure-mgmt-dns (†3.0.0) python2.7-azure-mgmt-eventgrid (†2.2.0) python2.7-azure-mgmt-eventhub (†3.1.0) python2.7-azure-mgmt-hanaonazure (†0.14.0) python2.7-azure-mgmt-iotcentral (†3.0.0) python2.7-azure-mgmt-iothub (†0.12.0) python2.7-azure-mgmt-iothubprovisioningservices (†0.2.0) python2.7-azure-mgmt-keyvault (†2.2.0) python2.7-azure-mgmt-loganalytics (†0.6.0) python2.7-azure-mgmt-logic (†3.0.0) python2.7-azure-mgmt-machinelearningcompute (†0.4.1) python2.7-azure-mgmt-managementgroups (†0.2.0) python2.7-azure-mgmt-managementpartner (†0.1.1) python2.7-azure-mgmt-maps (†0.1.0) python2.7-azure-mgmt-marketplaceordering (†0.2.1) python2.7-azure-mgmt-media (†2.1.0) python2.7-azure-mgmt-monitor (†0.9.0) python2.7-azure-mgmt-msi (†1.0.0) python2.7-azure-mgmt-network (†10.2.0) python2.7-azure-mgmt-notificationhubs (†2.1.0) python2.7-azure-mgmt-nspkg (†3.0.2) python2.7-azure-mgmt-policyinsights (†0.5.0) python2.7-azure-mgmt-powerbiembedded (†2.0.0) python2.7-azure-mgmt-rdbms (†2.2.0) python2.7-azure-mgmt-recoveryservices (†0.5.0) python2.7-azure-mgmt-recoveryservicesbackup (†0.7.0) python2.7-azure-mgmt-redis (†6.0.0) python2.7-azure-mgmt-relay (†0.2.0) python2.7-azure-mgmt-reservations (†0.7.0) python2.7-azure-mgmt-resource (†10.0.0) python2.7-azure-mgmt-scheduler (†2.0.0) python2.7-azure-mgmt-search (†2.1.0) python2.7-azure-mgmt-servicebus (†0.6.0) python2.7-azure-mgmt-servicefabric (†0.4.0) python2.7-azure-mgmt-signalr (†0.4.0) python2.7-azure-mgmt-sql (†0.18.0) python2.7-azure-mgmt-storage (†10.0.0) python2.7-azure-mgmt-subscription (†0.5.0) python2.7-azure-mgmt-trafficmanager (†0.51.0) python2.7-azure-mgmt-web (†0.47.0) python2.7-azure-nspkg (†3.0.2) python2.7-azure-servicebus (†0.50.3) python2.7-azure-servicefabric (†7.1.0.45) python2.7-azure-servicemanagement-legacy (†0.20.7) python2.7-azure-storage (†0.36.0) python2.7-azure-storage-blob (†2.1.0) python2.7-azure-storage-common (†2.1.0) python2.7-azure-storage-file (†2.1.0) python2.7-azure-storage-nspkg (†3.1.0) python2.7-azure-storage-queue (†2.1.0) python2.7-Babel (†2.7.0) python2.7-babelfish (†0.5.5) python2.7-backcall (†0.1.0) python2.7-backports.csv (†1.0.7) python2.7-backports.functools_lru_cache (†1.6.1) python2.7-backports.lzma (†0.0.14) python2.7-backports.os (†0.1.1) python2.7-backports.shutil_get_terminal_size-unstable (†2016-02-21) python2.7-backports.shutil_which (†3.5.2) python2.7-backports.ssl_match_hostname (†3.7.0.1) python2.7-backports.tempfile (†1.0) python2.7-backports.unittest_mock (†1.5) python2.7-backports.weakref (†1.0.post1) python2.7-backports_abc (†0.5) python2.7-bacpypes (†0.18.0) python2.7-bap (†1.3.1) python2.7-bashlex (†0.14) python2.7-batinfo (†0.4.2) python2.7-bayesian-optimization (†1.1.0) python2.7-bcdoc (†0.16.0) python2.7-bcrypt (†3.1.7) python2.7-beanstalkc (†0.5.2) python2.7-beautifulsoup4 (†4.9.1) python2.7-BespON (†0.4.0) python2.7-betamax (†0.8.1) python2.7-betamax-matchers (†0.4.0) python2.7-betamax-serializers (†0.2.1) python2.7-bibtexparser (†1.1.0) python2.7-bids-validator (†1.5.2) python2.7-billiard (†3.6.3.0) python2.7-binaryornot (†0.4.4) python2.7-binwalk (†2.2.0) python2.7-binwalk-full (†2.2.0) python2.7-bitarray (†1.2.2) python2.7-bitbucket-api (†0.5.0) python2.7-bitbucket-cli (†0.5.1) python2.7-bitcoin-price-api (†0.0.4) python2.7-bitmath (†1.3.3.1) python2.7-bitstring (†3.1.5) python2.7-bitstruct (†8.11.0) python2.7-bjoern (†3.1.0) python2.7-bkcharts (†0.2) python2.7-bleach (†3.1.5) python2.7-blessed (†1.15.0) python2.7-blessings (†1.7) python2.7-blinker (†1.4) python2.7-BlinkStick (†1.1.8) python2.7-blis (†0.4.1) python2.7-blist (†1.3.6) python2.7-blivet (†0.67) python2.7-bluepy (†1.3.0) python2.7-boltons (†20.1.0) python2.7-boolean.py (†3.7) python2.7-bootstrapped-pip (†20.1.1) python2.7-boto (†2.49.0) python2.7-boto3 (†1.14.3) python2.7-botocore (†1.17.3) python2.7-bottle (†0.12.18) python2.7-Bottleneck (†1.3.2) python2.7-Box2D (†2.3.2) python2.7-bpython (†0.19) python2.7-braintree (†4.1.0) python2.7-branca (†0.4.1) python2.7-broadlink (†0.14.0) python2.7-brotli (†1.0.7) python2.7-brotlipy (†0.7.0) python2.7-browsermob-proxy (†0.8.0) python2.7-bsddb3 (†6.2.7) python2.7-bt-proximity (†0.0.20180217) python2.7-btchip-python (†0.1.28) python2.7-bugsnag (†3.6.1) python2.7-bugz (†0.9.3-0.13) python2.7-bumps (†0.7.14) python2.7-bunch (†1.0.1) python2.7-bz2file (†0.98) python2.7-CacheControl (†0.12.6) python2.7-cached-property (†1.5.1) python2.7-cachelib (†0.1) python2.7-cachetools (†3.1.1) python2.7-cachy (†0.3.0) python2.7-cairocffi (†0.9.0) python2.7-CairoSVG (†1.0.22) python2.7-caldav (†0.7.0) python2.7-caldavclientlibrary-asynk-asynkdev (†) python2.7-canmatrix (†0.8) python2.7-canonicaljson (†1.1.4) python2.7-canopen (†0.5.1) python2.7-capstone (†4.0.2) python2.7-capturer (†3.0) python2.7-carbon (†1.1.7) python2.7-carrot (†0.10.7) python2.7-case (†1.5.3) python2.7-cassandra-driver (†3.23.0) python2.7-casttube (†0.2.1) python2.7-cbor (†1.0.0) python2.7-cbor2 (†5.1.0) python2.7-cchardet (†2.1.6) python2.7-CDDB (†1.4) python2.7-cdecimal (†2.3) python2.7-Cerberus (†1.3.2) python2.7-certifi (†2020.4.5.1) python2.7-certipy (†0.1.3) python2.7-cffi (†1.14.0) python2.7-cfn-flip (†1.2.2) python2.7-cfn-lint (†0.33.0) python2.7-cgen (†2020.1) python2.7-cgroup-utils (†0.8) python2.7-chai (†1.1.2) python2.7-chainmap (†1.0.3) python2.7-chalice (†1.14.1) python2.7-Chameleon (†3.7.2) python2.7-characteristic (†14.3.0) python2.7-chardet (†3.0.4) python2.7-chart-studio (†1.0.0) python2.7-check-manifest (†0.42) python2.7-cheetah (†2.4.4) python2.7-chevron (†0.13.1) python2.7-ciso8601 (†2.1.3) python2.7-citeproc-py (†0.5.1) python2.7-cld2-cffi (†0.1.4) python2.7-clf (†0.5.7) python2.7-cliapp (†1.20150305) python2.7-click (†7.1.2) python2.7-click-default-group (†1.2.2) python2.7-click-didyoumean (†0.0.3) python2.7-click-log (†0.3.2) python2.7-click-plugins (†1.1.1) python2.7-click-repl (†0.1.6) python2.7-click-threading (†0.4.4) python2.7-clickclick (†1.2.2) python2.7-cligj (†0.5.0) python2.7-clint (†0.5.1) python2.7-clize (†4.1.1) python2.7-cli_helpers (†2.0.1) python2.7-closure-linter (†2.3.19) python2.7-cloudflare (†2.7.1) python2.7-ClusterShell (†1.8.3) python2.7-cma (†2.7.0) python2.7-cmarkgfm (†0.4.2) python2.7-cmdline (†0.2.0) python2.7-cmdtest (†0.32) python2.7-CNTK (†2.7) python2.7-cocotb (†1.3.1) python2.7-codecov (†2.1.4) python2.7-cogapp (†3.0.0) python2.7-coinmarketcap (†5.0.3) python2.7-colander (†1.7.0) python2.7-ColanderAlchemy (†0.3.3) python2.7-colorama (†0.4.3) python2.7-colorclass (†2.2.0) python2.7-colored (†1.4.2) python2.7-coloredlogs (†10.0) python2.7-colorlog (†4.1.0) python2.7-colorlover (†0.3.0) python2.7-colormath (†3.0.0) python2.7-colorspacious (†1.1.2) python2.7-colour (†0.1.5) python2.7-commonmark (†0.9.1) python2.7-compiledb (†0.10.1) python2.7-conda (†4.3.16) python2.7-ConfigArgParse (†1.2.3) python2.7-configobj (†5.0.6) python2.7-configparser (†4.0.2) python2.7-configshell (†1.1.28) python2.7-confluent-kafka (†1.4.2) python2.7-consonance (†0.1.3) python2.7-constantly (†15.1.0) python2.7-construct (†2.9.45) python2.7-contexter (†0.1.4) python2.7-contextlib2 (†0.6.0.post1) python2.7-convertdate (†2.2.1) python2.7-cookiecutter (†1.7.2) python2.7-cookies (†2.2.1) python2.7-coreschema (†0.0.4) python2.7-cov-core (†1.15.0) python2.7-coverage (†5.1) python2.7-cram (†0.7) python2.7-crayons (†0.3.0) python2.7-crc16 (†0.1.1) python2.7-crc32c (†2.0) python2.7-crccheck (†0.6) python2.7-crcmod (†1.7) python2.7-credstash (†1.17.1) python2.7-cryptography (†2.9.2) python2.7-cryptography_vectors (†2.9.2) python2.7-css-parser (†1.0.4) python2.7-csscompressor (†0.9.5) python2.7-cssmin (†0.2.0) python2.7-cssselect (†1.1.0) python2.7-cssutils (†1.0.2) python2.7-cufflinks (†0.17.3) python2.7-cupy (†7.5.0) python2.7-curtsies (†0.3.0) python2.7-curve25519-donna (†1.3) python2.7-cvxopt (†1.2.5) python2.7-cx_Freeze (†6.1) python2.7-cx_Oracle (†7.3.0) python2.7-cycler (†0.10.0) python2.7-cymem (†2.0.3) python2.7-cypari2 (†2.1.1) python2.7-cysignals (†1.10.2) python2.7-Cython (†0.29.19) python2.7-cytoolz (†0.10.1) python2.7-d2to1 (†0.2.12.post1) python2.7-daemonize (†2.5.0) python2.7-darcsver (†1.7.4) python2.7-dash (†1.13.3) python2.7-dash_core_components (†1.10.1) python2.7-dash_html_components (†1.0.3) python2.7-dash_renderer (†1.5.0) python2.7-dash_table (†4.8.1) python2.7-databricks-cli (†0.11.0) python2.7-datadiff (†1.1.6) python2.7-datadog (†0.36.0) python2.7-DataModelDict (†0.9.6) python2.7-datashape (†0.5.4) python2.7-dateparser (†0.7.4) python2.7-datrie (†0.7.1) python2.7-dbf (†0.98.3) python2.7-dbfread (†2.0.7) python2.7-dbus-python (†1.2.12) python2.7-ddt (†1.4.1) python2.7-deap (†1.3.1) python2.7-decorator (†4.4.1) python2.7-deeptoolsintervals (†0.1.9) python2.7-deform (†2.0.8) python2.7-defusedxml (†0.6.0) python2.7-delegator.py (†0.1.1) python2.7-deluge-client (†1.9.0) python2.7-demjson (†2.2.4) python2.7-DendroPy (†4.4.0) python2.7-denonavr (†0.8.1) python2.7-dependency-injector (†3.15.6) python2.7-Deprecated (†1.2.10) python2.7-deprecation (†2.1.0) python2.7-derpconf (†0.8.3) python2.7-descartes (†1.1.0) python2.7-deskcon (†0.3) python2.7-detox (†0.19) python2.7-devpi-common (†3.5.0) python2.7-diceware (†0.9.6) python2.7-dict2xml (†1.7.0) python2.7-dictionaries (†0.0.2) python2.7-dicttoxml (†1.7.4) python2.7-diff-match-patch (†20181111) python2.7-dill (†0.3.1.1) python2.7-discid (†1.2.0) python2.7-discogs-client (†2.3.0) python2.7-dissononce (†0.34.3) python2.7-distlib (†0.3.0) python2.7-distorm3 (†3.3.4) python2.7-distro (†1.5.0) python2.7-distutils-extra (†2.39) python2.7-dj-database-url (†0.5.0) python2.7-dj-email-url (†1.0.1) python2.7-dj-search-url (†0.1) python2.7-Django (†1.11.28) python2.7-django-cache-url (†3.1.2) python2.7-django-gravatar2 (†1.4.4) python2.7-django-paintstore (†0.2) python2.7-django-versatileimagefield (†2.0) python2.7-django-webpack-loader (†0.7.0) python2.7-dkimpy (†1.0.4) python2.7-dlib (†19.20) python2.7-dlx (†1.0.4) python2.7-dmenu-python (†0.2.1) python2.7-dnslib (†0.9.13) python2.7-dnspython (†1.16.0) python2.7-dnspython (†1.16.0) python2.7-doc8 (†0.8.1) python2.7-docker (†4.2.1) python2.7-docker-pycreds (†0.4.0) python2.7-dockerfile-parse (†0.0.18) python2.7-dockerpty (†0.4.1) python2.7-docloud (†1.0.375) python2.7-docopt (†0.6.2) python2.7-docplex (†2.14.186) python2.7-docrep (†0.2.7) python2.7-doctest-ignore-unicode (†0.1.2) python2.7-docutils (†0.16) python2.7-dogpile.cache (†0.9.2) python2.7-dogpile.core (†0.4.1) python2.7-dominate (†2.5.1) python2.7-dopy (†2016-01-04) python2.7-dot2tex (†2.11.3) python2.7-dpkt (†1.9.2) python2.7-drms (†0.5.7) python2.7-dropbox (†10.2.0) python2.7-ds4drv (†0.5.1) python2.7-dtopt (†0.1) python2.7-duckdb (†0.1.7) python2.7-dulwich (†0.19.16) python2.7-dyn (†1.8.1) python2.7-easydict (†1.9) python2.7-easygui (†0.98.1) python2.7-EasyProcess (†0.3) python2.7-easysnmp (†0.2.5) python2.7-easywatch (†0.0.5) python2.7-ecdsa (†0.15) python2.7-ECPy (†1.2.3) python2.7-ed25519 (†1.5) python2.7-editorconfig (†0.12.2) python2.7-elasticsearch (†7.7.1) python2.7-elasticsearch-dsl (†7.2.1) python2.7-elasticsearch-dsl (†7.2.1) python2.7-email_validator (†1.1.1) python2.7-emcee (†3.0.2) python2.7-emoji (†0.5.4) python2.7-entrypoints (†0.3) python2.7-enum (†0.4.7) python2.7-enum-compat (†0.0.3) python2.7-enum34 (†1.1.10) python2.7-envs (†1.3) python2.7-enzyme (†0.4.1) python2.7-epc (†0.0.5) python2.7-ephem (†3.7.7.1) python2.7-eradicate (†1.0) python2.7-escapism (†1.0.1) python2.7-etcd (†2.0.8) python2.7-et_xmlfile (†1.0.1) python2.7-evdev (†1.3.0) python2.7-Eve (†1.1.1) python2.7-eventlet (†0.25.2) python2.7-Events (†0.3) python2.7-evernote (†1.25.3) python2.7-ewmh (†0.1.6) python2.7-exchangelib (†1.12.2) python2.7-execnet (†1.7.1) python2.7-executor (†21.3) python2.7-ExifRead (†2.1.2) python2.7-extras (†1.0.0) python2.7-fabric (†2.5.0) python2.7-face (†20.1.1) python2.7-facebook-sdk (†3.1.0) python2.7-face_recognition (†1.3.0) python2.7-face_recognition_models (†0.3.0) python2.7-factory_boy (†2.12.0) python2.7-fake-factory (†9999.9.9) python2.7-fake-useragent (†0.1.11) python2.7-Faker (†4.1.0) python2.7-falcon (†2.0.0) python2.7-fastcache (†1.1.0) python2.7-fastdtw (†0.3.4) python2.7-fasteners (†0.15) python2.7-fastentrypoints (†0.12) python2.7-fastimport (†0.9.8) python2.7-fastpair (†2016-07-05) python2.7-fastpbkdf2 (†0.2) python2.7-fastrlock (†0.5) python2.7-fasttext (†0.9.2) python2.7-faulthandler (†3.2) python2.7-favicon (†0.7.0) python2.7-fb-re2 (†1.0.7) python2.7-fdint (†2.0.2) python2.7-feedgen (†0.9.0) python2.7-feedgenerator (†1.9.1) python2.7-feedparser (†5.2.1) python2.7-ffmpeg-python (†0.2.0) python2.7-fido2 (†0.8.1) python2.7-file (†5.39) python2.7-filebytes (†0.10.2) python2.7-filelock (†3.0.12) python2.7-filetype (†1.0.7) python2.7-Fiona (†1.8.13.post1) python2.7-fipy (†3.4.1) python2.7-fire (†0.3.1) python2.7-firetv (†1.0.9) python2.7-first (†2.0.2) python2.7-fitbit (†0.3.1) python2.7-fixtures (†3.0.0) python2.7-flake8 (†3.8.3) python2.7-flake8-blind-except (†0.1.1) python2.7-flake8-debugger (†3.2.1) python2.7-flake8-future-import (†0.4.6) python2.7-flake8-import-order (†0.18.1) python2.7-flake8-polyfill (†1.0.2) python2.7-flaky (†3.6.1) python2.7-flammkuchen (†0.9.2) python2.7-Flask (†1.1.2) python2.7-flask-admin (†1.5.6) python2.7-Flask-API (†2.0) python2.7-Flask-Assets (†2.0) python2.7-Flask-AutoIndex (†0.6.6) python2.7-Flask-Babel (†1.0.0) python2.7-Flask-Babel (†1.0.0) python2.7-flask-babelex (†0.9.4) python2.7-flask-bcrypt (†0.7.1) python2.7-Flask-Bootstrap (†3.3.7.1) python2.7-Flask-Compress (†1.5.0) python2.7-Flask-Cors (†3.0.8) python2.7-Flask-Elastic (†0.2) python2.7-Flask-HTTPAuth (†4.1.0) python2.7-Flask-JWT-Extended (†3.24.1) python2.7-flask-ldap-login (†0.3.4) python2.7-Flask-Limiter (†1.3.1) python2.7-Flask-Login (†0.5.0) python2.7-Flask-Mail (†0.9.1) python2.7-Flask-Migrate (†2.5.3) python2.7-flask-mongoengine (†0.9.5) python2.7-flask-paginate (†0.5.4) python2.7-Flask-Principal (†0.4.0) python2.7-flask-pymongo (†2.3.0) python2.7-Flask-RESTful (†0.3.8) python2.7-flask-restplus (†0.13.0) python2.7-Flask-Script (†2.0.6) python2.7-Flask-Silk (†2018-06-28) python2.7-Flask-Sockets (†0.2.1) python2.7-Flask-SQLAlchemy (†2.4.3) python2.7-flask-swagger (†0.2.14) python2.7-flask-swagger-ui (†3.25.0) python2.7-Flask-Testing (†0.8.0) python2.7-Flask-Versioned (†0.9.4-20101221) python2.7-Flask-WTF (†0.14.3) python2.7-flexmock (†0.10.4) python2.7-flickrapi (†2.4.0) python2.7-fluent-logger (†0.9.6) python2.7-flup (†1.0.3) python2.7-fn (†0.4.3) python2.7-foolscap (†20.4.0) python2.7-forbiddenfruit (†0.1.3) python2.7-FormEncode (†1.3.1) python2.7-foundationdb (†5.1.7) python2.7-foundationdb (†5.2.8) python2.7-foundationdb (†6.0.18) python2.7-foundationdb (†6.1.12) python2.7-FoxDot (†0.8.8) python2.7-fpdf (†1.7.2) python2.7-fpylll (†0.5.1dev) python2.7-freezegun (†0.3.15) python2.7-frozendict (†1.2) python2.7-fs (†2.4.11) python2.7-fs-s3fs (†1.1.1) python2.7-ftputil (†3.4) python2.7-fudge (†1.1.1) python2.7-funcparserlib (†0.3.6) python2.7-funcsigs (†1.0.2) python2.7-functools32 (†3.2.3-2) python2.7-funcy (†1.14) python2.7-furl (†2.1.0) python2.7-fuse-python (†1.0.0) python2.7-fusepy (†3.0.1) python2.7-future (†0.18.2) python2.7-future-fstrings (†1.0.0) python2.7-futures (†3.3.0) python2.7-fuzzywuzzy (†0.18.0) python2.7-fx2-unstable (†2020-01-25) python2.7-gast (†0.3.3) python2.7-gateone (†1.2-0d57c3) python2.7-gcovr (†4.2) python2.7-gdata (†2.0.18) python2.7-geeknote (†2015-05-11) python2.7-genpy (†2016.1.3) python2.7-Genshi (†0.7.3) python2.7-gentools (†1.1.0) python2.7-genzshcomp (†0.6.0) python2.7-GeoAlchemy2 (†0.8.3) python2.7-geographiclib (†1.50) python2.7-GeoIP (†1.3.2) python2.7-geoip2 (†3.0.0) python2.7-geojson (†2.5.0) python2.7-geopy (†1.22.0) python2.7-getmac (†0.8.2) python2.7-gevent (†20.5.2) python2.7-gevent-socketio (†0.3.6) python2.7-gevent-websocket (†0.10.1) python2.7-geventhttpclient (†1.4.2) python2.7-ghdiff (†0.4) python2.7-gin-config (†0.3.0) python2.7-gipc (†1.1.0) python2.7-github-webhook (†1.0.4) python2.7-github3.py (†1.3.0) python2.7-glob2 (†0.7) python2.7-globus-sdk (†1.9.0) python2.7-glom (†20.5.0) python2.7-gmpy (†1.17) python2.7-gmpy2 (†2.1a4) python2.7-gmusicapi (†13.0.0) python2.7-gnureadline (†8.0.0) python2.7-google-apputils (†0.4.2) python2.7-google-auth (†1.17.0) python2.7-google-auth-httplib2 (†0.0.3) python2.7-google-auth-oauthlib (†0.4.1) python2.7-google-cloud-testutils-unstable (†36ffa923c7037e8b4fdcaa76272cb6267e908a9d) python2.7-google-i18n-address (†2.3.5) python2.7-google-pasta (†0.2.0) python2.7-google-resumable-media (†0.5.1) python2.7-googleapis-common-protos (†1.52.0) python2.7-googletrans (†2.4.0) python2.7-gorilla (†0.3.0) python2.7-gphoto2 (†2.2.2) python2.7-gpsoauth (†0.4.1) python2.7-gpxpy (†1.3.5) python2.7-GPy (†1.9.9) python2.7-GPyOpt-unstable (†2019-09-25) python2.7-grandalf (†0.6) python2.7-graph-tool (†2.31) python2.7-graphite_beacon (†0.27.0) python2.7-graphviz (†0.10.1) python2.7-grappelli_safe (†0.5.2) python2.7-green (†3.1.4) python2.7-greenlet (†0.4.16) python2.7-grequests (†0.6.0) python2.7-grip (†4.5.2) python2.7-grpc-google-iam-v1 (†0.12.3) python2.7-grpcio (†1.29.0) python2.7-grpcio-gcp (†0.2.2) python2.7-grpcio-tools (†1.29.0) python2.7-gsd (†1.9.3) python2.7-gspread (†3.6.0) python2.7-gssapi (†1.6.2) python2.7-gst-python (†1.16.2) python2.7-gtimelog (†0.9.1) python2.7-gtts-token (†1.1.3) python2.7-guessit (†3.1.1) python2.7-guestfs (†1.40.1) python2.7-gunicorn (†19.10.0) python2.7-gurobipy (†7.5.2) python2.7-guzzle_sphinx_theme (†0.7.11) python2.7-gyp (†2015-06-11) python2.7-h11 (†0.9.0) python2.7-h2 (†3.2.0) python2.7-h3 (†3.6.3) python2.7-h5py (†2.9.0) python2.7-h5py (†2.9.0) python2.7-hawkauthlib (†0.1.1) python2.7-hcloud (†1.7.0) python2.7-hdbscan (†0.8.26) python2.7-hdmedians (†0.13) python2.7-HeapDict (†1.0.1) python2.7-helpdev (†0.7.1) python2.7-helper (†2.4.2) python2.7-hetzner (†0.8.2) python2.7-hg-evolve (†10.0.0) python2.7-hg-git (†0.8.12) python2.7-hgsvn (†0.3.15) python2.7-hidapi (†0.9.0.post2) python2.7-hieroglyph (†1.0.0) python2.7-hiredis (†1.0.1) python2.7-hiro (†0.5.1) python2.7-HiYaPyCo (†0.4.16) python2.7-hkdf (†0.0.3) python2.7-hmmlearn (†0.2.3) python2.7-hocr-tools (†1.3.0) python2.7-holidays (†0.10.2) python2.7-hopcroftkarp (†1.2.5) python2.7-howdoi (†1.2.1) python2.7-hpack (†3.0.0) python2.7-hsaudiotag (†1.1.1) python2.7-html-sanitizer (†1.9.1) python2.7-html2text (†2018.1.9) python2.7-html5-parser (†0.4.9) python2.7-html5lib (†1.0.1) python2.7-htmllaundry (†2.2) python2.7-htmlmin (†0.1.12) python2.7-htmltreediff (†0.1.2) python2.7-HTSeq (†0.12.4) python2.7-httmock (†1.3.0) python2.7-httpauth (†0.3) python2.7-httplib2 (†0.18.1) python2.7-httpretty (†0.9.7) python2.7-httpsig (†1.3.0) python2.7-http_ece (†1.1.0) python2.7-http_signature (†0.1.4) python2.7-huey (†2.2.0) python2.7-humanfriendly (†8.2) python2.7-hupper (†1.10.2) python2.7-hvac (†0.10.3) python2.7-hydra (†0.11.3) python2.7-hypchat (†0.21) python2.7-hyperframe (†5.2.0) python2.7-hyperlink (†19.0.0) python2.7-hypothesis (†4.57.1) python2.7-hypothesis (†4.57.1) python2.7-i3-py (†0.6.4) python2.7-iapws (†1.4.1) python2.7-icalendar (†4.0.6) python2.7-identify (†1.4.19) python2.7-idna (†2.9) python2.7-idna-ssl (†1.1.0) python2.7-ifaddr (†0.1.6) python2.7-ifconfig-parser (†0.0.5) python2.7-ihatemoney (†4.1) python2.7-ijson (†3.0.4) python2.7-imagesize (†1.2.0) python2.7-IMAPClient (†2.1.0) python2.7-imaplib2 (†2.45.0) python2.7-imbalanced-learn (†0.4.3) python2.7-impacket (†0.9.21) python2.7-importlib-metadata (†1.6.0) python2.7-importlib_resources (†1.5.0) python2.7-importmagic (†0.1.7) python2.7-imutils (†0.5.3) python2.7-incremental (†17.5.0) python2.7-influxdb (†5.3.0) python2.7-infoqscraper (†0.1.0) python2.7-inifile (†0.3) python2.7-iniparse (†0.5) python2.7-inotify-simple (†1.2.1) python2.7-inquirer (†2.6.3) python2.7-intelhex (†2.2.1) python2.7-internetarchive (†1.9.4) python2.7-interruptingcow (†0.8) python2.7-intervaltree (†3.0.2) python2.7-intreehooks (†1.0) python2.7-invoke (†1.4.1) python2.7-iocapture (†0.1.2) python2.7-iowait (†0.2) python2.7-ipaddr (†2.2.0) python2.7-ipaddress (†1.0.23) python2.7-ipdb (†0.13.2) python2.7-ipdbplugin (†1.5.0) python2.7-iptools (†0.7.0) python2.7-IPy (†1.00) python2.7-ipykernel (†4.10.1) python2.7-ipympl (†0.5.6) python2.7-ipython (†5.8.0) python2.7-ipython_genutils (†0.2.0) python2.7-ipywidgets (†7.5.1) python2.7-irclib (†0.4.8) python2.7-isbnlib (†3.10.3) python2.7-islpy (†2019.1.2) python2.7-iso (†639-0.4.5) python2.7-iso3166 (†0.8) python2.7-iso8601 (†0.1.12) python2.7-isodate (†0.6.0) python2.7-isort (†4.3.21) python2.7-isoweek (†1.3.3) python2.7-itanium_demangler (†1.0) python2.7-itsdangerous (†1.1.0) python2.7-itypes (†1.2.0) python2.7-j2cli (†0.3.10) python2.7-jabberbot (†0.16) python2.7-jaraco.functools (†2.0) python2.7-jaraco.stream (†2.0) python2.7-jaraco.text (†3.2.0) python2.7-javaobj-py3 (†0.4.1) python2.7-javaproperties (†0.7.0) python2.7-jdatetime (†3.6.2) python2.7-jdcal (†1.4.1) python2.7-jedi (†0.17.0) python2.7-jenkins-job-builder (†3.4.0) python2.7-jenkinsapi (†0.3.11) python2.7-jieba (†0.42.1) python2.7-Jinja2 (†2.11.2) python2.7-jinja2-time (†0.2.0) python2.7-jmespath (†0.10.0) python2.7-joblib (†0.15.1) python2.7-josepy (†1.3.0) python2.7-jpylyzer (†1.18.0) python2.7-jq (†0.1.6) python2.7-jsmin (†2.2.2) python2.7-json-merge-patch (†0.2) python2.7-jsondate (†0.1.3) python2.7-jsondiff (†1.2.0) python2.7-jsonlines (†1.2.0) python2.7-jsonmerge (†1.7.0) python2.7-jsonnet (†0.16.0) python2.7-jsonpatch (†1.25) python2.7-jsonpath (†0.82) python2.7-jsonpath-rw (†1.4.0) python2.7-jsonpickle (†1.4.1) python2.7-jsonpointer (†2.0) python2.7-jsonref (†0.2) python2.7-jsonrpc-base (†1.0.3) python2.7-jsonrpclib (†0.1.7) python2.7-jsonrpclib-pelix (†0.4.1) python2.7-jsonschema (†3.2.0) python2.7-jsonwatch (†0.2.0) python2.7-Jug (†2.0.0) python2.7-junit-xml (†1.9) python2.7-junitparser (†1.4.1) python2.7-junos-eznc (†2.4.1) python2.7-jupyter (†1.0.0) python2.7-jupyter_client (†5.3.4) python2.7-jupyter_console (†5.2.0) python2.7-jupyter_core (†4.6.3) python2.7-jupytext (†1.4.2) python2.7-jwcrypto (†0.7) python2.7-k5test (†0.9.2) python2.7-kaa-base (†0.99.2dev-384-2b73caca) python2.7-kaa-metadata (†0.7.8dev-r4569-20111003) python2.7-kafka-python (†2.0.1) python2.7-kaitaistruct (†0.8) python2.7-Kajiki (†0.8.2) python2.7-kaptan (†0.5.12) python2.7-kazoo (†2.7.0) python2.7-kconfiglib (†14.1.0) python2.7-keepalive (†0.5) python2.7-Keras (†2.3.1) python2.7-Keras_Applications (†1.0.8) python2.7-Keras_Preprocessing (†1.1.2) python2.7-kerberos (†1.3.0) python2.7-keyring (†18.0.1) python2.7-keyutils (†0.6) python2.7-kitchen (†1.2.6) python2.7-kiwisolver (†1.1.0) python2.7-klein (†17.10.0) python2.7-kmapper (†1.2.0) python2.7-kmsxx (†2020-02-14) python2.7-konfig (†1.1) python2.7-kubernetes (†11.0.0) python2.7-labelbox (†2.4) python2.7-langdetect (†1.0.7) python2.7-larch (†1.20131130) python2.7-lark-parser (†0.8.8) python2.7-Lasagne (†0.1) python2.7-latexcodec (†2.0.0) python2.7-lazr.config (†2.2.2) python2.7-lazr.delegates (†2.0.4) python2.7-lazy (†1.4) python2.7-lazy-object-proxy (†1.5.0) python2.7-lazy_import (†0.2.2) python2.7-ldap3 (†2.7) python2.7-ldappool (†2.4.1) python2.7-ldaptor (†19.1.0) python2.7-le (†1.4.29) python2.7-leather (†0.3.3) python2.7-ledgerblue (†0.1.31) python2.7-lektor (†3.1.3) python2.7-leveldb (†0.201) python2.7-libais (†0.17) python2.7-libarchive (†3.1.2-1) python2.7-libarchive (†3.1.2-1) python2.7-libarchive-c (†2.9) python2.7-libasyncns-python (†0.7.1) python2.7-libgpuarray (†0.7.5) python2.7-libkeepass (†0.3.1.post1) python2.7-libmr (†0.1.9) python2.7-libnacl (†1.7.1) python2.7-libsoundtouch (†0.4.0) python2.7-libtmux (†0.8.2) python2.7-libusb1 (†1.8) python2.7-libvirt (†5.9.0) python2.7-license-expression (†1.2) python2.7-lightblue (†0.4) python2.7-lightgbm (†2.3.1) python2.7-lightning-python (†1.2.1) python2.7-limitlessled (†1.1.3) python2.7-limits (†1.5.1) python2.7-linecache2 (†1.0.0) python2.7-line_profiler (†3.0.2) python2.7-linode (†0.4) python2.7-linode-api (†4.1.8b1) python2.7-linuxfd (†1.4.4) python2.7-livestreamer (†1.12.2) python2.7-livestreamer-curses (†1.5.2) python2.7-llfuse (†1.3.6) python2.7-lmdb (†0.98) python2.7-lmtpd (†6.1.0) python2.7-localzone (†0.9.6) python2.7-locket (†0.2.0) python2.7-lockfile (†0.12.2) python2.7-locustio (†0.14.4) python2.7-Logbook (†1.5.3) python2.7-logfury (†0.1.2) python2.7-logster (†1.0.1) python2.7-logutils (†0.3.5) python2.7-logzero (†1.5.0) python2.7-loo-py (†2017.2) python2.7-lsi (†0.4.0) python2.7-lxml (†4.5.0) python2.7-lzstring (†1.0.4) python2.7-M2Crypto (†0.35.2) python2.7-m2r (†0.2.1) python2.7-m3u8 (†0.6.0) python2.7-magic-wormhole-transit-relay (†0.2.1) python2.7-mahotas (†1.4.9) python2.7-mail-parser (†3.12.0) python2.7-mailcap-fix (†1.0.1) python2.7-mailchimp (†2.0.9) python2.7-maildir-deduplicate (†2.1.0) python2.7-Mako (†1.1.3) python2.7-managesieve (†0.6) python2.7-manhole (†1.6.0) python2.7-manifestparser (†1.1) python2.7-mapbox (†0.18.0) python2.7-mapsplotlib (†1.2.0) python2.7-marionette-harness (†5.0.0) python2.7-marionette_driver (†3.0.0) python2.7-marisa (†1.3.40) python2.7-marisa-trie (†0.7.5) python2.7-Markdown (†3.1.1) python2.7-markdown-macros (†0.1.2) python2.7-markdown2 (†2.3.6) python2.7-MarkdownSuperscript (†2.1.1) python2.7-markerlib (†0.6.0) python2.7-Markups (†3.0.0) python2.7-MarkupSafe (†1.1.1) python2.7-matplotlib (†2.2.3) python2.7-matrix_client (†0.3.2) python2.7-maxminddb (†1.5.4) python2.7-mccabe (†0.6.1) python2.7-MDP (†3.6) python2.7-mecab-python3 (†0.996.5) python2.7-MechanicalSoup (†0.12.0) python2.7-mechanize (†0.4.5) python2.7-meinheld (†1.0.2) python2.7-meld3 (†2.0.1) python2.7-meliae (†0.4.0) python2.7-memcached (†1.51-1.51) python2.7-memory_profiler (†0.55.0) python2.7-merkletools (†1.0.3) python2.7-MeshLabXML (†2018.3) python2.7-metaphone (†0.6) python2.7-micawber (†0.5.1) python2.7-MIDIUtil (†1.2.1) python2.7-milksnake (†0.1.5) python2.7-minimock (†1.2.8) python2.7-miniupnpc (†2.0.2) python2.7-misaka (†2.1.1) python2.7-mistune (†0.8.4) python2.7-mkl-service (†2.3.0) python2.7-mmpython (†0.4.10) python2.7-mnemonic (†0.19) python2.7-mnist (†0.2.2) python2.7-mock (†3.0.5) python2.7-mock-open (†1.3.1) python2.7-mockito (†1.2.1) python2.7-modeled (†0.1.8) python2.7-ModestMaps (†1.4.7) python2.7-moinmoin (†1.9.10) python2.7-mongodict (†0.3.1) python2.7-mongoengine (†0.18.2) python2.7-monkeyhex (†1.7.1) python2.7-monotonic (†1.5) python2.7-more-itertools (†5.0.0) python2.7-moretools (†0.1.12) python2.7-morphys (†1.0) python2.7-moto (†1.3.14) python2.7-mox (†0.5.3) python2.7-mox3 (†1.1.0) python2.7-mozcrash (†1.1.0) python2.7-mozdevice (†3.0.7) python2.7-mozfile (†2.1.0) python2.7-mozhttpd (†0.7) python2.7-mozinfo (†1.1.0) python2.7-mozlog (†5.0) python2.7-moznetwork (†1.0.0) python2.7-mozprocess (†1.0.0) python2.7-mozprofile (†2.4.0) python2.7-mozrunner (†7.7.0) python2.7-mozterm (†1.0.0) python2.7-moztest (†0.8) python2.7-mozversion (†2.2.0) python2.7-mpi4py (†3.0.3) python2.7-mplleaflet (†0.0.5) python2.7-mpmath (†1.1.0) python2.7-mpyq (†0.2.5) python2.7-mr-bob (†0.1.2) python2.7-msal (†1.3.0) python2.7-msal-extensions (†0.2.2) python2.7-msgpack (†1.0.0) python2.7-msgpack-numpy (†0.4.6.post0) python2.7-msrest (†0.6.13) python2.7-msrestazure (†0.6.3) python2.7-mt (†940-4.21.0) python2.7-multipledispatch (†0.6.0) python2.7-multiprocess (†0.70.9) python2.7-multiset (†2.1.1) python2.7-multi_key_dict (†2.0.3) python2.7-munch (†2.5.0) python2.7-murmurhash (†1.0.2) python2.7-musicbrainzngs (†0.7.1) python2.7-mutagen (†1.43.0) python2.7-muttils (†1.3) python2.7-mwclient (†0.10.0) python2.7-mwlib (†0.16.1) python2.7-mwlib.ext (†0.13.2) python2.7-mwlib.rl (†0.14.5) python2.7-mwoauth (†0.3.7) python2.7-mwparserfromhell (†0.5.4) python2.7-mxnet (†1.6.0) python2.7-mypgoclient (†1.8) python2.7-mypy-extensions (†0.4.3) python2.7-mysql-connector (†8.0.20) python2.7-mysqlclient (†1.4.6) python2.7-namebench (†1.3.1) python2.7-namedlist (†1.7) python2.7-nameparser (†1.0.6) python2.7-names (†0.3.0) python2.7-nanoleaf (†0.4.1) python2.7-nanomsg-python (†1.0.20190114) python2.7-nanotime (†0.5.2) python2.7-naturalsort (†1.5.1) python2.7-nbconflux (†0.7.0) python2.7-nbconvert (†5.6.1) python2.7-nbformat (†4.4.0) python2.7-nbmerge-unstable (†2017-10-23) python2.7-nbval (†0.9.5) python2.7-nbxmpp (†0.6.10) python2.7-ncclient (†0.6.7) python2.7-ndg-httpsclient (†0.5.1) python2.7-neo (†0.8.0) python2.7-netaddr (†0.7.19) python2.7-netifaces (†0.10.9) python2.7-networkx (†2.2) python2.7-neuronpy (†0.1.6) python2.7-Nevow (†0.14.5) python2.7-nidaqmx (†0.5.7) python2.7-nimfa (†1.4.0) python2.7-nine (†1.1.0) python2.7-nitpick (†1.1) python2.7-nltk (†3.5) python2.7-node-semver (†0.7.0) python2.7-nodeenv (†1.3.3) python2.7-noise (†1.2.2) python2.7-nose (†1.3.7) python2.7-nose-cov (†1.6) python2.7-nose-cover3 (†0.1.0) python2.7-nose-cprof (†0.2.1) python2.7-nose-exclude (†0.5.0) python2.7-nose-focus (†0.1.3) python2.7-nose-of-yeti (†1.8) python2.7-nose-pattern-exclude (†0.1.3) python2.7-nose-progressive (†1.5.2) python2.7-nose-randomly (†1.2.6) python2.7-NoseJS (†0.9.4) python2.7-nosexcover (†1.0.11) python2.7-notebook (†5.7.8) python2.7-notedown (†1.5.1) python2.7-notify2 (†0.3.1) python2.7-notmuch (†0.29.3) python2.7-ntlm-auth (†1.4.0) python2.7-ntplib (†0.3.3) python2.7-Nuitka (†0.6.8.1) python2.7-num2words (†0.5.10) python2.7-numcodecs (†0.6.4) python2.7-numexpr (†2.7.1) python2.7-numpy (†1.16.5) python2.7-numpy-stl (†2.11.2) python2.7-numpydoc (†1.0.0) python2.7-numtraits (†0.2) python2.7-nxt-python-unstable (†20160819) python2.7-oath (†1.4.3) python2.7-oauth (†1.0.1) python2.7-oauth2 (†1.9.0.post1) python2.7-oauth2client (†4.1.3) python2.7-oauthlib (†3.1.0) python2.7-obfsproxy (†0.2.13) python2.7-objgraph (†3.4.1) python2.7-od (†1.0) python2.7-odfpy (†1.4.1) python2.7-offtrac (†0.1.0) python2.7-ofxclient (†2.0.3) python2.7-ofxhome (†0.3.3) python2.7-ofxparse (†0.20) python2.7-olefile (†0.46) python2.7-omegaconf (†1.4.1) python2.7-onkyo-eiscp (†1.2.7) python2.7-openant-unstable (†2017-02-11) python2.7-openapi-spec-validator (†0.2.8) python2.7-openidc-client (†0.6.0) python2.7-openpyxl (†2.6.4) python2.7-opentracing (†2.3.0) python2.7-opt_einsum (†2.3.2) python2.7-ordereddict (†1.1) python2.7-orderedmultidict (†1.0.1) python2.7-orderedset (†2.0.3) python2.7-oscrypto (†1.1.1) python2.7-oset (†0.1.3) python2.7-osqp (†0.6.1) python2.7-ovh (†0.5.0) python2.7-oyaml (†0.9) python2.7-packaging (†20.4) python2.7-packet-python (†1.42.0) python2.7-pafy (†0.5.5) python2.7-pagelabels (†1.2.0) python2.7-pagerduty (†0.2.1) python2.7-paho-mqtt (†1.5.0) python2.7-palettable (†3.3.0) python2.7-pamela (†1.0.0) python2.7-pamqp (†2.3.0) python2.7-pandas (†0.24.2) python2.7-pandoc-attributes (†0.1.7) python2.7-pandocfilters (†1.4.2) python2.7-paperspace (†0.2.0) python2.7-papis-python-rofi (†1.0.2) python2.7-param (†1.9.3) python2.7-parameterized (†0.7.4) python2.7-paramiko (†2.7.1) python2.7-paramz (†0.9.5) python2.7-parse (†1.15.0) python2.7-parsedatetime (†2.6) python2.7-parsel (†1.6.0) python2.7-parse_type (†0.5.2) python2.7-parsimonious (†0.8.1) python2.7-Parsley (†1.3) python2.7-parso (†0.7.0) python2.7-parver (†0.3.0) python2.7-passlib (†1.7.2) python2.7-paste (†3.4.0) python2.7-PasteDeploy (†2.1.0) python2.7-pastel (†0.2.0) python2.7-PasteScript (†3.2.0) python2.7-patch (†1.16) python2.7-patch-ng (†1.17.4) python2.7-path-and-address (†2.0.1) python2.7-path.py (†11.5.2) python2.7-pathlib (†1.0.1) python2.7-pathlib2 (†2.3.5) python2.7-pathos (†0.2.5) python2.7-pathspec (†0.8.0) python2.7-pathtools (†0.1.2) python2.7-patsy (†0.5.1) python2.7-Paver (†1.3.4) python2.7-paypalrestsdk (†1.13.1) python2.7-pbkdf2 (†1.3) python2.7-pbr (†5.4.5) python2.7-pc-ble-driver-py (†0.11.4) python2.7-pcpp (†1.21) python2.7-pdf2image (†1.13.1) python2.7-pdfkit (†0.6.1) python2.7-pdfrw (†0.4) python2.7-pdftools.pdfposter (†0.7.post1) python2.7-pdftotext (†2.1.4) python2.7-peewee (†3.13.3) python2.7-pefile (†2019.4.18) python2.7-pendulum (†2.1.0) python2.7-pep257 (†0.7.0) python2.7-pep8 (†1.7.1) python2.7-pep8-naming (†0.10.0) python2.7-peppercorn (†0.6) python2.7-percol (†0.2.1) python2.7-periodictable (†1.5.2) python2.7-persim (†0.1.2) python2.7-persisting-theory (†0.2.1) python2.7-pex (†2.1.11) python2.7-pexif (†0.15) python2.7-pexpect (†4.8.0) python2.7-pg8000 (†1.12.5) python2.7-pgpdump (†1.5) python2.7-pgpy (†0.5.2) python2.7-pgsanity (†0.2.9) python2.7-pgspecial (†1.11.10) python2.7-phonenumbers (†8.12.5) python2.7-phonopy (†2.4.2) python2.7-phpserialize (†1.3) python2.7-pickleshare (†0.7.5) python2.7-picos (†2.0) python2.7-pid (†3.0.3) python2.7-piep (†0.9.2) python2.7-piexif (†1.1.3) python2.7-pika (†1.1.0) python2.7-pika-pool (†0.1.3) python2.7-pilkit (†2.0) python2.7-Pillow (†6.2.2) python2.7-pillowfight (†0.3) python2.7-pip (†20.1.1) python2.7-pip-tools (†5.2.0) python2.7-pip2nix (†0.7.0) python2.7-pivy (†0.6.5a2) python2.7-pkgconfig (†1.5.1) python2.7-pkginfo (†1.5.0.1) python2.7-plac (†1.2.0) python2.7-plaid-python (†4.0.0) python2.7-plaster (†1.0) python2.7-plaster_pastedeploy (†0.6) python2.7-playsound (†1.2.2) python2.7-PlexAPI (†3.6.0) python2.7-plone.testing (†8.0.0) python2.7-plotly (†4.8.1) python2.7-pluggy (†0.13.1) python2.7-pluginbase (†1.0.0) python2.7-plumbum (†1.6.9) python2.7-ply (†3.11) python2.7-plyfile (†0.7.2) python2.7-PlyPlus (†0.7.5) python2.7-plyvel (†1.2.0) python2.7-Pmw (†2.0.1) python2.7-pocket (†0.3.6) python2.7-podcastparser (†0.6.5) python2.7-podcats (†0.5.0) python2.7-polib (†1.1.0) python2.7-polyline (†1.4.0) python2.7-pomegranate (†0.11.2) python2.7-pony (†0.7.13) python2.7-ponywhoosh (†1.7.8) python2.7-portalocker (†1.7.0) python2.7-portpicker (†1.3.1) python2.7-posix_ipc (†1.0.4) python2.7-power (†1.4) python2.7-pox (†0.2.7) python2.7-poyo (†0.5.0) python2.7-ppft (†1.6.6.1) python2.7-pplpy (†0.8.4) python2.7-pprintpp (†0.4.0) python2.7-prance (†0.18.3) python2.7-praw (†6.3.1) python2.7-prawcore (†1.4.0) python2.7-preggy (†1.4.4) python2.7-premailer (†3.7.0) python2.7-preshed (†3.0.2) python2.7-pretend (†1.0.9) python2.7-prettytable (†0.7.2) python2.7-priority (†1.3.0) python2.7-prison (†0.1.2) python2.7-privacyidea-ldap-proxy (†0.6.1) python2.7-proboscis (†1.2.6.0) python2.7-process-tests (†2.0.2) python2.7-proglog (†0.1.9) python2.7-progress (†1.5) python2.7-progressbar (†2.5) python2.7-progressbar2 (†3.51.4) python2.7-progressbar231 (†2.3.1) python2.7-progressbar33 (†2.4) python2.7-prometheus_client (†0.8.0) python2.7-prompt_toolkit (†1.0.18) python2.7-property-manager (†2.3.1) python2.7-Protego (†0.1.16) python2.7-protobuf (†3.8.0) python2.7-prov (†1.5.3) python2.7-prox-tv (†3.3.0) python2.7-psd-tools (†1.9.13) python2.7-psutil (†5.7.0) python2.7-psycopg2 (†2.8.5) python2.7-ptable-unstable (†2019-06-14) python2.7-ptest (†1.7.4) python2.7-ptyprocess (†0.6.0) python2.7-publicsuffix (†1.1.1) python2.7-publicsuffix2 (†2.20191221) python2.7-pudb (†2019.2) python2.7-PuLP (†2.1) python2.7-pulsectl (†20.5.1) python2.7-pure-python-adb-homeassistant (†0.1.6.dev0) python2.7-purepng (†0.2.0) python2.7-purl (†1.5) python2.7-pushbullet.py (†0.11.0) python2.7-pushover-complete (†1.1.1) python2.7-pwntools (†4.1.1) python2.7-py (†1.8.1) python2.7-py-cpuinfo (†5.0.0) python2.7-py-lru-cache (†0.1.4) python2.7-py-radix (†0.10.0) python2.7-py-vapid (†1.7.0) python2.7-py2bit (†0.3.0) python2.7-py3to2 (†1.1.1) python2.7-py4j (†0.10.9) python2.7-pyacoustid (†1.2.0) python2.7-pyaes (†1.6.1) python2.7-PyAMF (†0.8.0) python2.7-pyamg (†4.0.0) python2.7-pyaml (†20.4.0) python2.7-pyannotate (†1.2.0) python2.7-pyasn1 (†0.4.8) python2.7-pyasn1-modules (†0.2.8) python2.7-pyatmo (†3.3.1) python2.7-PyAudio (†0.2.11) python2.7-pybase64 (†1.0.1) python2.7-pybfd (†-0.1.1.2017-12-31) python2.7-pyBigWig (†0.3.17) python2.7-pybind11 (†2.4.3) python2.7-PyBindGen (†0.21.0) python2.7-pyblake2 (†1.1.2) python2.7-pyblosxom (†1.5.3) python2.7-pybluez-unstable (†20160819) python2.7-pybotvac (†0.0.17) python2.7-PyBrowserID (†0.14.0) python2.7-pybtex (†0.22.2) python2.7-pybtex-docutils (†0.2.2) python2.7-pybullet (†2.8.1) python2.7-pycairo (†1.18.2) python2.7-pycallgraph (†1.0.1) python2.7-pycapnp (†0.6.4) python2.7-pycarddav (†0.7.0) python2.7-pycares (†3.1.1) python2.7-pycassa (†1.11.2) python2.7-pycdio (†2.1.0) python2.7-pychart (†1.39) python2.7-PyChef (†0.3.0) python2.7-pyclipper (†1.1.0.post3) python2.7-pycodestyle (†2.6.0) python2.7-pycoin (†0.90.20200322) python2.7-pycollada (†0.7.1) python2.7-PyContracts (†1.8.14) python2.7-pycosat (†0.6.3) python2.7-pycountry (†19.8.18) python2.7-pycparser (†2.20) python2.7-PyCRC (†1.21) python2.7-pycrypto (†3.9.7) python2.7-pycryptodome (†3.9.7) python2.7-pycryptodomex (†3.9.7) python2.7-pycryptopp (†0.7.1.869544967005693312591928092448767568728501330214) python2.7-pyct (†0.4.6) python2.7-pycuda (†2019.1.2) python2.7-pycups (†1.9.73) python2.7-pycurl (†7.43.0.5) python2.7-pycurl2 (†7.20.0) python2.7-pydbus (†0.6.0) python2.7-pydenticon (†0.3.1) python2.7-pydispatcher (†2.0.5) python2.7-pydns (†2.3.6) python2.7-pydocstyle (†2.1.1) python2.7-pydocumentdb (†2.3.5) python2.7-pydot (†1.4.1) python2.7-pydotplus (†2.0.2) python2.7-pydot_ng (†2.0.0) python2.7-pydub (†0.24.0) python2.7-pydy (†0.5.0) python2.7-pyechonest (†9.0.0) python2.7-pyelftools (†0.26) python2.7-pyemd (†0.5.1) python2.7-pyepsg (†0.4.0) python2.7-pyexcelerator (†0.6.4.1) python2.7-pyexiv2 (†0.3.2) python2.7-pyext (†0.8) python2.7-pyfaidx (†0.5.8) python2.7-pyfakefs (†4.0.2) python2.7-pyfantom-unstable (†2013-12-18) python2.7-pyfcm (†1.4.7) python2.7-pyfiglet (†0.8.post1) python2.7-pyflakes (†2.2.0) python2.7-pyfma (†0.1.1) python2.7-pyfribidi (†0.12.0) python2.7-pyftgl (†0.4b) python2.7-pyftpdlib (†1.5.6) python2.7-pyfttt (†0.3.2) python2.7-PyFxA (†0.7.3) python2.7-pygal (†2.4.0) python2.7-pygame (†1.9.6) python2.7-pygame_sdl2 (†2.1.0-7.2.0) python2.7-pygccxml (†1.9.1) python2.7-pygdbmi (†0.9.0.2) python2.7-pygeoip (†0.3.2) python2.7-pyglet (†1.4.2) python2.7-Pygments (†2.5.2) python2.7-pygments-markdown-lexer (†0.1.0.dev39) python2.7-pygobject (†2.28.7) python2.7-pygobject (†3.36.0) python2.7-pygpgme (†0.3) python2.7-pygraphviz (†1.5) python2.7-pygtail (†0.8.0) python2.7-pygtk (†2.24.0) python2.7-pygtk (†2.24.0) python2.7-pygtksourceview (†2.10.1) python2.7-PyHamcrest (†1.10.1) python2.7-pyhocon (†0.3.53) python2.7-PyICU (†2.3.1) python2.7-pyinotify (†0.9.6) python2.7-pyinputevent (†2016-10-18) python2.7-pyjet (†1.6.0) python2.7-pyjks (†20.0.0) python2.7-pyjson5 (†0.8.5) python2.7-pyjwkest (†1.4.2) python2.7-PyJWT (†1.7.1) python2.7-pykdtree (†1.3.1) python2.7-pykeepass (†3.2.0) python2.7-pykerberos (†1.2.1) python2.7-pykickstart (†1.99.39) python2.7-pykka (†2.0.1) python2.7-pylama (†7.7.1) python2.7-pylatexenc (†2.4) python2.7-pyld (†1.0.5) python2.7-pylev (†1.3.0) python2.7-pylibacl (†0.5.4) python2.7-pylibconfig2 (†0.2.5) python2.7-pylibftdi (†0.18.1) python2.7-pyliblo (†0.10.0) python2.7-pylibmc (†1.6.1) python2.7-pylint (†1.9.5) python2.7-pylru (†1.2.0) python2.7-pyls-isort (†0.1.1) python2.7-PyLTI (†0.7.0) python2.7-pymacaroons (†0.13.0) python2.7-pymaging-png-unstable (†2016-11-16) python2.7-pymaging-unstable (†2016-11-16) python2.7-pymavlink (†2.4.8) python2.7-pymbolic (†2020.1) python2.7-pymediainfo (†4.2.1) python2.7-PyMeeus (†0.3.7) python2.7-pymemoize (†1.0.3) python2.7-pyment (†0.3.3) python2.7-pymongo (†3.10.1) python2.7-Pympler (†0.8) python2.7-PyMsgBox (†1.0.6) python2.7-PyMuPDF (†1.17.0) python2.7-PyMVGLive (†1.1.4) python2.7-PyMySQL (†0.9.3) python2.7-pymysql-sa (†1.0) python2.7-pymystem3 (†0.2.0) python2.7-pynac (†0.2) python2.7-pynacl (†1.3.0) python2.7-PyNamecheap (†0.0.3) python2.7-pynisher (†0.5.0) python2.7-pynmea2 (†1.15.0) python2.7-pynput (†1.6.8) python2.7-pynrrd (†0.4.2) python2.7-pynvim (†0.4.1) python2.7-pynzb (†0.1.0) python2.7-pyodbc (†4.0.30) python2.7-PyOgg (†0.6.9a1) python2.7-pyopencl (†2020.2) python2.7-pyopengl (†3.1.4) python2.7-pyOpenSSL (†19.1.0) python2.7-pyosmium (†2.15.3) python2.7-pyotp (†2.3.0) python2.7-pypandoc (†1.5) python2.7-pyparser (†1.0) python2.7-pyparsing (†2.4.6) python2.7-pyparted (†3.11.4) python2.7-pypcap (†1.2.3) python2.7-pyPdf (†1.13) python2.7-PyPDF2 (†1.26.0) python2.7-pypeg2 (†2.15.2) python2.7-pyperclip (†1.8.0) python2.7-pyperf (†2.0.0) python2.7-Pyphen (†0.9.5) python2.7-PyPlatec (†1.4.0) python2.7-pypoppler (†0.12.2) python2.7-PyPrind (†2.11.2) python2.7-pyprof2calltree (†1.4.5) python2.7-pyptlib (†0.0.6) python2.7-PyQRCode (†1.2.1) python2.7-PyQt-x11-gpl (†4.12) python2.7-PyQt5 (†5.14.2) python2.7-PyQt5 (†5.14.2) python2.7-PyQt5 (†5.14.2) python2.7-pyqtgraph (†0.10.0) python2.7-PyQtWebEngine (†5.14.0) python2.7-pyquery (†1.2.9) python2.7-pyrabbit2 (†1.0.7) python2.7-pyrad (†2.3) python2.7-PyReadability (†0.4.0) python2.7-pyreport (†0.3.4c) python2.7-pyres (†1.5) python2.7-pyRFC3339 (†1.1) python2.7-pyroma (†2.6) python2.7-pyroute2 (†0.5.12) python2.7-pyrr (†0.10.3) python2.7-pyrsistent (†0.16.0) python2.7-PyRSS2Gen (†1.1) python2.7-pyrtlsdr (†0.2.7) python2.7-pysam (†0.15.4) python2.7-pyscard (†1.9.9) python2.7-pyschedule (†0.2.34) python2.7-pyscreenshot (†2.2) python2.7-pyscrypt (†1.6.2) python2.7-pyScss (†1.3.7) python2.7-PySDL2 (†0.9.6) python2.7-pysendfile (†2.0.1) python2.7-pysensors (†2017-07-13) python2.7-pyserial (†3.4) python2.7-pysftp (†0.2.9) python2.7-pysha3 (†1.0.2) python2.7-pyshp (†2.1.0) python2.7-pyside (†1.2.4) python2.7-pyside-shiboken (†1.2.4) python2.7-pyside-tools (†0.2.15) python2.7-pysigset (†0.3.2) python2.7-pyslurm (†19-05-0) python2.7-pysmb (†1.2.1) python2.7-pysmbc (†1.0.21) python2.7-pysmf (†0.1.1) python2.7-pysmi (†0.3.4) python2.7-pysnmp (†4.4.12) python2.7-pysnooper (†0.4.1) python2.7-pysnow (†0.7.16) python2.7-pysocks (†1.7.1) python2.7-pysolr (†3.9.0) python2.7-pyspark (†2.4.6) python2.7-pysparse (†1.3-dev) python2.7-pyspf (†2.0.14) python2.7-pyspinel (†1.0.1) python2.7-pyspotify (†2.1.3) python2.7-pysptk (†0.1.18) python2.7-pysqlite (†2.8.3) python2.7-pysrim (†0.5.10) python2.7-pysrt (†1.1.2) python2.7-pyssim (†0.4) python2.7-pystache (†0.5.4) python2.7-PyStemmer (†2.0.0.1) python2.7-pystray (†0.15.0) python2.7-PyStringTemplate (†3.2b1) python2.7-pysvn (†1.8.0) python2.7-PyTado (†0.2.7) python2.7-pytaglib (†1.4.5) python2.7-pyte (†0.8.0) python2.7-pyTelegramBotAPI (†3.7.1) python2.7-pytesseract (†0.3.4) python2.7-pytest (†4.6.9) python2.7-pytest (†4.6.9) python2.7-pytest-annotate (†1.0.3) python2.7-pytest-ansible (†2.1.1) python2.7-pytest-arraydiff (†0.3) python2.7-pytest-bdd (†3.2.1) python2.7-pytest-benchmark (†3.2.2) python2.7-pytest-cache (†1.0) python2.7-pytest-catchlog (†1.2.2) python2.7-pytest-check (†0.3.9) python2.7-pytest-click (†0.3) python2.7-pytest-cov (†2.9.0) python2.7-pytest-cram (†0.2.0) python2.7-pytest-datadir (†1.3.1) python2.7-pytest-datafiles (†2.0) python2.7-pytest-dependency (†0.5.1) python2.7-pytest-env (†0.6.2) python2.7-pytest-expect (†1.1.0) python2.7-pytest-fixture-config (†1.7.0) python2.7-pytest-flake8 (†1.0.6) python2.7-pytest-flakes (†4.0.0) python2.7-pytest-flask (†1.0.0) python2.7-pytest-forked (†1.1.3) python2.7-pytest-freezegun (†0.4.1) python2.7-pytest-helpers-namespace (†2019.1.8) python2.7-pytest-isort (†1.0.0) python2.7-pytest-lazy-fixture (†0.6.3) python2.7-pytest-localserver (†0.5.0) python2.7-pytest-metadata (†1.9.0) python2.7-pytest-mock (†2.0.0) python2.7-pytest-mpl (†0.11) python2.7-pytest-ordering-unstable (†2019-06-19) python2.7-pytest-pep257 (†0.0.5) python2.7-pytest-pep8 (†1.0.6) python2.7-pytest-qt (†3.3.0) python2.7-pytest-quickcheck (†0.8.4) python2.7-pytest-raisesregexp (†2.1) python2.7-pytest-relaxed (†1.1.5) python2.7-pytest-remotedata (†0.3.2) python2.7-pytest-repeat (†0.8.0) python2.7-pytest-runner (†5.2) python2.7-pytest-server-fixtures (†1.7.0) python2.7-pytest-services (†2.0.1) python2.7-pytest-shutil (†1.7.0) python2.7-pytest-socket (†0.3.3) python2.7-pytest-subtesthack (†0.1.1) python2.7-pytest-sugar (†0.9.3) python2.7-pytest-testmon (†1.0.2) python2.7-pytest-timeout (†1.3.3) python2.7-pytest-tornado (†0.8.0) python2.7-pytest-twisted (†1.12) python2.7-pytest-virtualenv (†1.7.0) python2.7-pytest-warnings (†0.3.0) python2.7-pytest-watch (†4.2.0) python2.7-pytest-xdist (†1.32.0) python2.7-pytest-xprocess (†0.13.1) python2.7-python-application (†2.8.0) python2.7-python-axolotl (†0.2.3) python2.7-python-axolotl-curve25519 (†0.4.1.post2) python2.7-python-baseconv (†1.2.2) python2.7-python-can (†3.3.3) python2.7-python-cjson (†1.2.2) python2.7-python-constraint (†1.4.0) python2.7-python-consul (†1.1.0) python2.7-python-ctags3 (†1.3.0) python2.7-python-dateutil (†2.8.1) python2.7-python-dateutil (†2.8.1) python2.7-python-dbusmock (†0.19) python2.7-python-debian (†0.1.37) python2.7-python-digitalocean (†1.15.0) python2.7-python-docx (†0.8.10) python2.7-python-dotenv (†0.13.0) python2.7-python-editor (†1.0.4) python2.7-python-efl (†1.24.0) python2.7-python-etcd (†0.4.5) python2.7-python-eventlib (†0.2.4) python2.7-python-fedora (†1.0.0) python2.7-Python-fontconfig (†0.5.1) python2.7-python-forecastio (†1.4.0) python2.7-python-gflags (†3.1.2) python2.7-python-gnupg (†0.4.6) python2.7-python-gnutls (†3.1.3) python2.7-python-hglib (†2.6.1) python2.7-python-hosts (†1.0.0) python2.7-python-igraph (†0.8.2) python2.7-python-imread (†0.7.0) python2.7-python-jenkins (†1.7.0) python2.7-python-jose (†3.1.0) python2.7-python-json-logger (†0.1.11) python2.7-python-jsonrpc-server (†0.3.4) python2.7-python-keyczar (†0.716) python2.7-python-language-server (†0.33.1) python2.7-python-ldap (†3.2.0) python2.7-python-ldap-test (†0.3.1) python2.7-python-Levenshtein (†0.12.0) python2.7-python-logstash (†0.4.6) python2.7-python-lpod (†1.1.7) python2.7-python-lxc-unstable (†2016-08-25) python2.7-python-ly (†0.9.6) python2.7-python-lz4 (†2.1.10) python2.7-python-lz4 (†2.1.10) python2.7-python-lzf (†0.2.4) python2.7-python-lzo (†1.12) python2.7-python-magic (†0.4.18) python2.7-python-mapnik-unstable (†2020-02-24) python2.7-python-markdown-math (†0.6) python2.7-python-mimeparse (†1.6.0) python2.7-python-mnist (†0.7) python2.7-python-mpd (†0.3.0) python2.7-python-mpd2 (†1.0.0) python2.7-python-msrplib (†0.19.2) python2.7-python-multipart (†0.0.5) python2.7-python-nomad (†1.2.1) python2.7-python-oauth2 (†1.1.1) python2.7-python-olm (†3.1.5) python2.7-python-otr (†1.2.0) python2.7-python-packer (†0.1.2) python2.7-python-pam (†1.8.4) python2.7-python-pam (†1.8.4) python2.7-python-periphery (†2.1.0) python2.7-python-pipedrive (†0.4.0) python2.7-python-poppler-qt5 (†0.24.2) python2.7-python-potr (†1.0.2) python2.7-python-prctl (†1.7) python2.7-python-ptrace (†0.9.5) python2.7-python-pushover (†0.4) python2.7-python-redis-lock (†3.5.0) python2.7-python-simple-hipchat (†0.4.0) python2.7-python-simple-hipchat (†0.4.0) python2.7-python-slugify (†4.0.0) python2.7-python-snappy (†0.5.4) python2.7-python-sql (†1.1.0) python2.7-python-statsd (†2.1.0) python2.7-python-stdnum (†1.13) python2.7-python-sybase (†0.40pre2) python2.7-python-twitter (†3.5) python2.7-python-u2flib-host (†3.0.3) python2.7-python-uinput (†0.11.2) python2.7-python-unshare-unstable (†2018-05-20) python2.7-python-utils (†2.4.0) python2.7-python-vagrant (†0.5.15) python2.7-python-vipaccess (†0.13) python2.7-python-vlc (†3.0.9113) python2.7-python-vxi11 (†0.9) python2.7-python-wifi (†0.6.1) python2.7-python-xcaplib (†1.2.1) python2.7-python-xmp-toolkit (†2.0.2) python2.7-python2-pythondialog (†3.5.1) python2.7-pythonmagick (†0.9.16) python2.7-pythonnet (†2.4.0) python2.7-pytidylib (†0.3.2) python2.7-pytimeparse (†1.1.8) python2.7-pytmx (†3.21.7) python2.7-pytoml (†0.1.20) python2.7-pytools (†2020.2) python2.7-pytrends (†4.7.3) python2.7-pytricia-unstable (†2019-01-16) python2.7-pytun (†2.2.1) python2.7-pytz (†2020.1) python2.7-pytzdata (†2019.3) python2.7-pyu2f (†0.1.4) python2.7-pyudev (†0.22.0) python2.7-pyunifi (†2.20.1) python2.7-pyusb (†1.0.2) python2.7-pyutil (†3.3.0) python2.7-pyutilib (†5.7.2) python2.7-pyuv (†1.2.0) python2.7-pyvcd (†0.2.1) python2.7-PyVCF (†0.6.8) python2.7-PyVirtualDisplay (†1.3.2) python2.7-pyviz_comms (†0.7.4) python2.7-pyvmomi (†7.0) python2.7-pyvoro (†1.3.2) python2.7-pywatchman (†1.4.1) python2.7-pywbem (†0.17.2) python2.7-PyWebDAV (†0.9.8) python2.7-pywebpush (†1.11.0) python2.7-pywinrm (†0.4.1) python2.7-pyxattr (†0.6.1) python2.7-pyxdg (†0.26) python2.7-PyXML (†0.8.4) python2.7-PyYAML (†5.3.1) python2.7-pyzmq (†19.0.1) python2.7-PyZufall (†0.13.2) python2.7-py_stringmatching (†0.4.1) python2.7-qdarkstyle (†2.8.1) python2.7-qpid-python (†0.32) python2.7-qrcode (†6.1) python2.7-qscintilla (†2.11.2) python2.7-qscintilla (†2.11.2) python2.7-qscintilla (†2.11.2) python2.7-qserve (†0.2.8) python2.7-QtAwesome (†0.7.2) python2.7-qtconsole (†4.7.5) python2.7-QtPy (†1.9.0) python2.7-quantities (†0.12.4) python2.7-queuelib (†1.5.0) python2.7-qutip (†2.2.0) python2.7-r2pipe (†1.4.2) python2.7-rabbitpy (†1.0.0) python2.7-radicale_infcloud (†2017-07-27) python2.7-rainbowstream (†1.5.2) python2.7-ramlfications (†0.1.9) python2.7-random2 (†1.0.1) python2.7-rarfile (†3.0) python2.7-rasterio (†1.1.4) python2.7-ratelimiter (†1.2.0.post0) python2.7-raven (†6.10.0) python2.7-rawkit (†0.6.0) python2.7-rcssmin (†1.0.6) python2.7-rdflib (†5.0.0) python2.7-readchar (†2.0.0) python2.7-readme (†0.7.1) python2.7-readme_renderer (†26.0) python2.7-readthedocs-sphinx-ext (†1.0.4) python2.7-rebulk (†2.0.1) python2.7-recaptcha-client (†1.0.6) python2.7-recommonmark (†0.6.0) python2.7-redis (†3.5.3) python2.7-rednose (†1.3.0) python2.7-regex (†2020.5.14) python2.7-regional (†1.1.2) python2.7-reikna (†0.7.5) python2.7-relatorio (†0.9.1) python2.7-remotecv (†2.2.2) python2.7-rencode-git20150810 (†) python2.7-repeated_test (†1.0.1) python2.7-repocheck (†2015-08-05) python2.7-reportlab (†3.5.42) python2.7-repoze.lru (†0.7) python2.7-repoze.sphinx.autointerface (†0.8) python2.7-repoze.who (†2.4) python2.7-requests (†2.23.0) python2.7-requests-aws4auth (†0.9) python2.7-requests-cache (†0.5.2) python2.7-requests-file (†1.5.1) python2.7-requests-http-signature (†0.1.0) python2.7-requests-kerberos (†0.12.0) python2.7-requests-mock (†1.8.0) python2.7-requests-oauthlib (†1.3.0) python2.7-requests-toolbelt (†0.9.1) python2.7-requests-toolbelt (†0.9.1) python2.7-requests-unixsocket (†0.2.0) python2.7-requestsexceptions (†1.4.0) python2.7-requests_download (†0.1.2) python2.7-requests_ntlm (†1.1.0) python2.7-responses (†0.10.14) python2.7-RestrictedPython (†5.0) python2.7-restructuredtext_lint (†1.3.1) python2.7-restview (†2.9.1) python2.7-rethinkdb (†2.4.7) python2.7-retry (†0.9.2) python2.7-retrying (†1.3.3) python2.7-retry_decorator (†1.1.1) python2.7-rfc3986 (†1.4.0) python2.7-rfc3987 (†1.3.8) python2.7-rfc6555 (†0.0.0) python2.7-rfc7464 (†17.7.0) python2.7-rhpl (†0.218) python2.7-rig (†2.4.1) python2.7-ripser (†0.4.1) python2.7-rjsmin (†1.1.0) python2.7-rnc2rng (†2.6.4) python2.7-RoboMachine (†0.9.0) python2.7-robot-detection (†0.4) python2.7-robotframework (†3.2.1) python2.7-robotframework-databaselibrary (†1.2.4) python2.7-robotframework-requests (†0.7.0) python2.7-robotframework-ride (†1.2.3) python2.7-robotframework-selenium2library (†3.0.0) python2.7-robotframework-seleniumlibrary (†3.3.1) python2.7-robotframework-sshlibrary (†3.4.0) python2.7-robotframework-tools (†0.1rc4) python2.7-robotstatuschecker (†1.3) python2.7-robotsuite (†2.2.1) python2.7-rocket-errbot (†1.2.5) python2.7-roman (†2.0.0) python2.7-rope (†0.17.0) python2.7-ROPGadget (†6.3) python2.7-rotate-backups (†6.0) python2.7-rpdb (†0.1.6) python2.7-rply (†0.7.7) python2.7-rpmfluff (†0.5.7.1) python2.7-rpy2 (†2.8.6) python2.7-rpyc (†4.1.3) python2.7-rq (†1.4.2) python2.7-rsa (†4.0) python2.7-rtmidi-python (†0.2.2) python2.7-Rtree (†0.9.4) python2.7-rtslib (†2.1.72) python2.7-ruamel.base (†1.0.0) python2.7-ruamel.ordereddict (†0.4.14) python2.7-ruamel.yaml (†0.16.10) python2.7-ruamel.yaml.clib (†0.2.0) python2.7-ruffus (†2.8.1) python2.7-runsnakerun (†2.0.5) python2.7-rx (†1.6.1) python2.7-rxv (†0.6.0) python2.7-s2clientprotocol (†3.19.1.58600.0) python2.7-s3transfer (†0.3.3) python2.7-sabyenc (†3.3.6) python2.7-sacremoses (†0.0.35) python2.7-Safe (†0.4) python2.7-sampledata (†0.3.7) python2.7-sandboxlib (†0.31) python2.7-sapi-python-client (†0.1.3) python2.7-sarge (†0.1.5.post0) python2.7-sasmodels (†1.0.1) python2.7-scales (†1.0.9) python2.7-scandir (†1.10.0) python2.7-scapy (†2.4.3) python2.7-schedule (†0.6.0) python2.7-schema (†0.7.2) python2.7-scikit-build (†0.10.0) python2.7-scikit-fmm (†2019.1.30) python2.7-scikit-learn (†0.20.4) python2.7-scikit-optimize (†0.6) python2.7-scikits.odes (†2.6.1) python2.7-scikits.samplerate (†0.3.3) python2.7-scipy (†1.2.2) python2.7-scour (†0.37) python2.7-scp (†0.13.2) python2.7-scripttest (†1.3) python2.7-scrypt (†0.8.15) python2.7-scs (†2.1.1) python2.7-sdnotify (†0.3.2) python2.7-seaborn (†0.9.1) python2.7-seabreeze (†0.6.0) python2.7-secp256k1 (†0.13.2) python2.7-secretstorage (†2.3.1) python2.7-seekpath (†2.0.1) python2.7-selectors2 (†2.0.1) python2.7-selectors34 (†1.2) python2.7-selenium (†3.141.0) python2.7-semantic (†1.0.3) python2.7-semantic_version (†2.8.5) python2.7-semver (†2.10.2) python2.7-Send2Trash (†1.5.0) python2.7-sentencepiece (†0.1.91) python2.7-sentinel (†0.1.2) python2.7-serpent (†1.30.2) python2.7-serpy (†0.3.1) python2.7-serverlessrepo (†0.1.10) python2.7-service_identity (†18.1.0) python2.7-setproctitle (†1.1.10) python2.7-setuptools (†44.0.0) python2.7-setuptools-git (†1.2) python2.7-setuptools-lint (†0.6.0) python2.7-setuptools-scm-git-archive (†1.1) python2.7-setuptools_darcs (†1.2.11) python2.7-setuptools_scm (†4.1.2) python2.7-setuptools_trial (†0.6.0) python2.7-sexpdata (†0.0.3) python2.7-sfepy_2019.4 (†) python2.7-sh (†1.12.14) python2.7-Shapely (†1.7.0) python2.7-sharedmem (†0.3.7) python2.7-shellingham (†1.3.2) python2.7-shippai (†0.3.2) python2.7-shodan (†1.23.0) python2.7-shortuuid (†1.0.1) python2.7-should-dsl (†2.1.2) python2.7-shouldbe (†0.1.2) python2.7-showit (†1.1.4) python2.7-shutilwhich (†1.1.0) python2.7-sievelib (†1.1.1) python2.7-signedjson (†1.1.0) python2.7-sigtools (†2.0.2) python2.7-simanneal (†0.4.2) python2.7-simple-salesforce (†0.74.3) python2.7-simple-websocket-server (†20180414) python2.7-simpleai (†0.8.2) python2.7-simplebayes (†1.5.8) python2.7-simpleeval (†0.9.10) python2.7-simplefix (†1.0.12) python2.7-simplegeneric (†0.8.1) python2.7-simplejson (†3.17.0) python2.7-simplekml (†1.3.5) python2.7-simpleparse (†2.2.0) python2.7-singledispatch (†3.4.0.3) python2.7-sip (†4.19.22) python2.7-sipsimple (†3.4.2) python2.7-six (†1.15.0) python2.7-sklearn-deap (†0.2.3) python2.7-sleekxmpp (†1.3.3) python2.7-slicerator (†1.0.0) python2.7-slimit (†0.8.1) python2.7-slowaes (†0.1a1) python2.7-smartdc (†0.2.0) python2.7-smartypants (†1.8.6) python2.7-smart_open (†2.0.0) python2.7-smmap (†3.0.4) python2.7-smpplib (†2.1.0) python2.7-smugpy (†20131218) python2.7-snakebite (†2.11.0) python2.7-snakeviz (†2.1.0) python2.7-Snapper-GUI (†0.1) python2.7-snowballstemmer (†2.0.0) python2.7-snug (†1.3.4) python2.7-snuggs (†1.4.7) python2.7-sockjs-tornado (†1.0.7) python2.7-SocksiPy-branch (†1.01) python2.7-sorl-thumbnail (†12.6.3) python2.7-sortedcollections (†1.1.2) python2.7-sortedcontainers (†2.1.0) python2.7-sounddevice (†0.3.15) python2.7-soundfile (†0.10.3.post1) python2.7-soundfile (†0.10.3.post1) python2.7-soupsieve (†1.9.6) python2.7-spake2 (†0.8) python2.7-spambayes (†1.1b3) python2.7-spark_parser (†1.8.9) python2.7-SPARQLWrapper (†1.8.5) python2.7-speaklater (†1.3) python2.7-speedtest-cli (†2.1.2) python2.7-spglib (†1.15.1) python2.7-sphfile (†1.0.3) python2.7-sphinx (†1.7.9) python2.7-sphinx (†1.8.5) python2.7-sphinx-argparse (†0.2.5) python2.7-sphinx-jinja (†1.1.1) python2.7-sphinx-navtree (†0.3.0) python2.7-Sphinx-PyPI-upload (†0.2.1) python2.7-sphinx-testing (†1.0.1) python2.7-sphinxcontrib-applehelp (†1.0.2) python2.7-sphinxcontrib-devhelp (†1.0.2) python2.7-sphinxcontrib-htmlhelp (†1.0.3) python2.7-sphinxcontrib-httpdomain (†1.7.0) python2.7-sphinxcontrib-jsmath (†1.0.1) python2.7-sphinxcontrib-newsfeed (†0.1.4) python2.7-sphinxcontrib-openapi (†0.7.0) python2.7-sphinxcontrib-plantuml (†0.18) python2.7-sphinxcontrib-qthelp (†1.0.3) python2.7-sphinxcontrib-serializinghtml (†1.1.4) python2.7-sphinxcontrib-tikz (†0.4.8) python2.7-sphinxcontrib-websupport (†1.1.2) python2.7-sphinx_rtd_theme (†0.4.3) python2.7-splinter (†0.13.0) python2.7-spotipy (†2.12.0) python2.7-SQLAlchemy (†1.3.17) python2.7-sqlalchemy-citext (†1.6.3) python2.7-SQLAlchemy-ImageAttach (†1.0.0) python2.7-sqlalchemy-migrate (†0.12.0) python2.7-sqlalchemy-utils (†0.36.5) python2.7-sqlite3dbm (†0.1.4) python2.7-sqlitedict (†1.6.0) python2.7-sqlmap (†1.4.6) python2.7-SQLObject (†3.8.0) python2.7-sqlparse (†0.3.1) python2.7-sqlsoup (†0.9.1) python2.7-squaremap (†1.0.5) python2.7-srp (†1.0.16) python2.7-srptools (†1.0.0) python2.7-srvlookup (†2.0.0) python2.7-ssdeep (†3.4) python2.7-sseclient (†0.0.26) python2.7-sshpubkeys (†3.1.0) python2.7-sshtunnel (†0.1.5) python2.7-staticjinja (†0.3.5) python2.7-statistics (†1.0.3.5) python2.7-statsd (†3.3.0) python2.7-statsmodels (†0.11.1) python2.7-stem (†1.8.0) python2.7-stevedore (†2.0.0) python2.7-stm32loader (†0.5.1) python2.7-stompclient (†0.3.2) python2.7-strategies (†0.2.3) python2.7-stravalib (†0.10.2) python2.7-strict-rfc3339 (†0.7) python2.7-strictyaml (†1.0.6) python2.7-stringcase (†1.2.0) python2.7-stripe (†2.48.0) python2.7-subdownloader (†2.0.18) python2.7-subliminal (†2.1.0) python2.7-subprocess32 (†3.5.4) python2.7-subunit (†1.4.0) python2.7-suds (†0.4) python2.7-suds-jurko (†0.6) python2.7-supervise_api (†0.6.0) python2.7-supervisor (†4.2.0) python2.7-sure (†1.4.11) python2.7-svg.path (†4.0.2) python2.7-svg2tikz (†1.0.0) python2.7-swagger-spec-validator (†2.5.0) python2.7-swagger-ui-bundle (†0.0.6) python2.7-symengine (†0.4.0) python2.7-sympy (†1.5.1) python2.7-systemd (†234) python2.7-sysv_ipc (†1.0.1) python2.7-tableaudocumentapi (†0.6) python2.7-tables (†3.5.2) python2.7-tabulate (†0.8.7) python2.7-tadasets (†0.0.4) python2.7-tarman (†0.1.3) python2.7-tasklib (†2.1.1) python2.7-taskw (†1.2.0) python2.7-tblib (†1.6.0) python2.7-telegram (†0.0.1) python2.7-tempita (†0.5.3-2016-09-28) python2.7-tenacity (†6.2.0) python2.7-tensorflow (†1.14.0) python2.7-tensorflow (†1.14.0) python2.7-tensorflow (†2.1.0) python2.7-tensorflow-estimator (†1.15.1) python2.7-tensorflow-estimator (†1.15.1) python2.7-tensorflow-estimator (†2.1.0) python2.7-tensorflow-tensorboard (†1.15.0) python2.7-tensorflow-tensorboard (†1.15.0) python2.7-tensorflow-tensorboard (†2.1.0) python2.7-termcolor (†1.1.0) python2.7-terminado (†0.8.3) python2.7-terminaltables (†3.1.0) python2.7-termstyle (†0.1.11) python2.7-tess-unstable (†2019-05-07) python2.7-tesserocr (†2.5.1) python2.7-testfixtures (†6.14.1) python2.7-testpath (†0.4.4) python2.7-testrepository (†0.0.20) python2.7-testresources (†2.0.1) python2.7-testscenarios (†0.5.0) python2.7-testtools (†2.4.0) python2.7-text-unidecode (†1.3) python2.7-texttable (†1.6.2) python2.7-textwrap3 (†0.9.2) python2.7-Theano (†1.0.4) python2.7-Theano (†1.0.4) python2.7-Theano (†1.0.4) python2.7-thespian (†3.10.0) python2.7-threadpool (†1.3.2) python2.7-thrift (†0.13.0) python2.7-thumbor-pexif (†0.14.1) python2.7-tifffile (†2020.6.3) python2.7-tilestache (†1.51.14) python2.7-timelib (†0.2.4) python2.7-timeout-decorator (†0.4.1) python2.7-tinycss (†0.4) python2.7-tinydb-v3.14.1 (†) python2.7-tiros (†1.0.44) python2.7-tissue (†0.9.2) python2.7-titlecase (†0.12.0) python2.7-tkinter (†2.7.18) python2.7-tl-eggdeps (†0.4) python2.7-tld (†0.12.2) python2.7-tldextract (†2.2.2) python2.7-tlsh (†3.4.5) python2.7-tlslite-ng (†0.7.5) python2.7-tmdb3 (†0.7.2) python2.7-todoist-python (†8.1.1) python2.7-tokenlib (†0.3.1) python2.7-toml (†0.10.1) python2.7-tomlkit (†0.6.0) python2.7-toolz (†0.10.0) python2.7-toposort (†1.5) python2.7-tornado (†4.5.3) python2.7-tornado (†5.1.1) python2.7-tox (†3.15.1) python2.7-tqdm (†4.47.0) python2.7-traceback2 (†1.4.0) python2.7-tracing (†0.8) python2.7-trackpy (†0.4.2) python2.7-traitlets (†4.3.3) python2.7-transaction (†3.0.0) python2.7-transformers (†2.2.1) python2.7-transip-api (†2.0.0) python2.7-transitions (†0.8.1) python2.7-translationstring (†1.3) python2.7-transmissionrpc (†0.11) python2.7-treq (†20.4.1) python2.7-trimesh (†3.6.43) python2.7-trollius (†2.2.post1) python2.7-trueskill (†0.4.5) python2.7-trustme (†0.6.0) python2.7-ttystatus (†0.23) python2.7-tunigo (†1.0.0) python2.7-TurboCheetah (†1.0) python2.7-tvdb_api (†3.0.2) python2.7-tvnamer (†2.5) python2.7-tweepy (†3.8.0) python2.7-Twiggy (†0.5.0) python2.7-twilio (†6.39.0) python2.7-twill (†2.0) python2.7-Twisted (†20.3.0) python2.7-twitter (†1.18.0) python2.7-twitter.common.collections (†0.3.11) python2.7-twitter.common.confluence (†0.3.11) python2.7-twitter.common.dirutil (†0.3.11) python2.7-twitter.common.lang (†0.3.11) python2.7-twitter.common.log (†0.3.11) python2.7-twitter.common.options (†0.3.11) python2.7-twofish (†0.3.0) python2.7-txAMQP (†0.8.2) python2.7-txdbus (†1.1.1) python2.7-txgithub (†15.0.0) python2.7-txrequests (†0.9.6) python2.7-txtorcon (†20.0.0) python2.7-typesentry (†0.2.7) python2.7-typing (†3.7.4.1) python2.7-typing_extensions (†3.7.4.2) python2.7-tzlocal (†2.1) python2.7-u-msgpack-python (†2.6.0) python2.7-ua-parser (†0.10.0) python2.7-uamqp (†1.2.8) python2.7-ujson (†3.0.0) python2.7-UkPostcodeParser (†1.1.2) python2.7-umalqurra (†0.2) python2.7-umemcache (†1.6.3) python2.7-uncertainties (†3.1.2) python2.7-unicode-slugify (†0.1.3) python2.7-unicodecsv (†0.14.1) python2.7-unicorn (†1.0.1) python2.7-Unidecode (†1.1.1) python2.7-unidiff (†0.6.0) python2.7-unifi (†1.2.5) python2.7-units (†0.07) python2.7-unittest-data-provider (†1.0.1) python2.7-unittest-xml-reporting (†3.0.2) python2.7-unittest2 (†1.1.0) python2.7-unpaddedbase64 (†1.1.0) python2.7-untangle (†1.1.1) python2.7-upass (†0.1.4) python2.7-update-dotdee (†5.0) python2.7-update_checker (†0.17) python2.7-uproot (†3.11.7) python2.7-uproot-methods (†0.7.4) python2.7-uptime (†3.0.1) python2.7-uritemplate (†3.0.1) python2.7-urlgrabber (†4.1.0) python2.7-urllib3 (†1.25.9) python2.7-urwid (†2.1.0) python2.7-urwidtrees (†1.0.2) python2.7-usbtmc (†0.8) python2.7-user-agents (†2.1.0) python2.7-uuid (†1.30) python2.7-validate-email (†1.3) python2.7-validators (†0.15.0) python2.7-validictory (†1.1.2) python2.7-variants (†0.2.0) python2.7-varint (†1.0.2) python2.7-vcversioner (†2.16.0.0) python2.7-vdf (†3.3) python2.7-vega (†3.4.0) python2.7-vega_datasets (†0.8.0) python2.7-venusian (†3.0.0) python2.7-verboselogs (†1.7) python2.7-versioneer (†0.18) python2.7-versiontools (†1.9.1) python2.7-vertica-python (†0.10.4) python2.7-veryprettytable (†0.8.1) python2.7-vidstab (†1.7.3) python2.7-vine (†1.3.0) python2.7-virtkey (†0.63.0) python2.7-virtualenv (†20.0.21) python2.7-virtualenv-clone (†0.5.4) python2.7-virtualenvwrapper (†4.8.4) python2.7-visitor (†0.1.3) python2.7-vmprof (†0.4.15) python2.7-vobject (†0.9.6.1) python2.7-voluptuous (†0.11.7) python2.7-vowpalwabbit (†8.8.1) python2.7-vsts (†0.1.25) python2.7-vsts-cd-manager (†1.0.2) python2.7-vultr (†0.1.2) python2.7-w3lib (†1.22.0) python2.7-waitress (†1.4.4) python2.7-wakeonlan (†1.1.6) python2.7-Wand (†0.6.1) python2.7-warlock (†1.3.3) python2.7-warrant (†0.6.1) python2.7-wasabi (†0.6.0) python2.7-watchdog (†0.10.2) python2.7-WazeRouteCalculator (†0.12) python2.7-wcwidth (†0.2.3) python2.7-web.py (†0.51) python2.7-webapp2 (†2.5.2) python2.7-webassets (†2.0) python2.7-webencodings (†0.5.1) python2.7-WebOb (†1.8.6) python2.7-webrtcvad (†2.0.10) python2.7-websocket_client (†0.57.0) python2.7-websockify (†0.9.0) python2.7-Werkzeug (†1.0.1) python2.7-wfuzz (†2.4.2) python2.7-wget (†3.2) python2.7-wheel (†0.33.6) python2.7-whichcraft (†0.6.1) python2.7-whisper (†1.1.7) python2.7-Whoosh (†2.7.4) python2.7-widgetsnbextension (†3.5.1) python2.7-willow (†1.3) python2.7-worldengine (†0.19.0) python2.7-wptserve (†3.0) python2.7-wrapt (†1.12.1) python2.7-WSGIProxy (†0.2.2) python2.7-WSGIProxy2 (†0.4.2) python2.7-wsgitools (†0.3.1) python2.7-wsproto (†0.15.0) python2.7-wtf-peewee (†3.0.0) python2.7-WTForms (†2.3.1) python2.7-wurlitzer (†2.0.0) python2.7-wxPython (†3.0.2.0) python2.7-wxPython (†3.0.2.0) python2.7-wxPython (†4.0.7.post2) python2.7-x11_hash (†1.4) python2.7-x256 (†0.0.3) python2.7-xapian (†1.4.15) python2.7-xapp (†2.0.1) python2.7-xattr (†0.9.7) python2.7-xcffib (†0.9.0) python2.7-xhtml2pdf (†0.2.4) python2.7-xkcdpass (†1.17.3) python2.7-xlib (†0.25) python2.7-xlrd (†1.2.0) python2.7-xlsx2csv (†0.7.6) python2.7-XlsxWriter (†1.2.8) python2.7-xlwt (†1.3.0) python2.7-xmltodict (†0.12.0) python2.7-xmodem (†0.4.5) python2.7-xmpp.py (†0.5.0rc1) python2.7-XStatic (†1.0.2) python2.7-XStatic-Bootbox (†4.4.0.1) python2.7-XStatic-Bootstrap (†4.1.3.1) python2.7-XStatic-jQuery (†3.4.1.0) python2.7-XStatic-jQuery-File-Upload (†9.23.0.1) python2.7-XStatic-jquery-ui (†1.12.1.1) python2.7-XStatic-Pygments (†2.2.0.1) python2.7-xvfbwrapper (†0.2.9) python2.7-xxhash (†1.4.3) python2.7-yamllint (†1.23.0) python2.7-yanc (†0.3.3) python2.7-yapf (†0.30.0) python2.7-yappi (†1.2.5) python2.7-Yapsy (†1.12.2) python2.7-yarg (†0.1.9) python2.7-yattag (†1.13.2) python2.7-ydiff (†1.1) python2.7-yenc (†0.4.0) python2.7-youtube-dl (†2020.06.16.1) python2.7-youtube-dl (†2020.06.16.1) python2.7-yt (†3.6.0) python2.7-yubico-client (†1.13.0) python2.7-z3c-checkversions (†1.1) python2.7-zake (†0.2.2) python2.7-zarr (†2.4.0) python2.7-zbase32 (†1.1.5) python2.7-zc.buildout (†2.13.3) python2.7-zc.buildout (†2.13.3) python2.7-zc.buildout (†2.13.3) python2.7-zc.lockfile (†2.0) python2.7-zeep (†3.4.0) python2.7-zeroc-ice (†3.7.4) python2.7-zerorpc (†0.6.3) python2.7-zetup (†0.2.64) python2.7-zfec (†1.5.3) python2.7-zict (†2.0.0) python2.7-zipp (†1.0.0) python2.7-zipstream (†1.1.4) python2.7-zodbpickle (†2.0.0) python2.7-zope-deferredimport (†4.3) python2.7-zope-hookable (†5.0.1) python2.7-zope.broken (†3.6.0) python2.7-zope.component (†4.6.1) python2.7-zope.configuration (†4.4.0) python2.7-zope.contenttype (†4.5.0) python2.7-zope.copy (†4.2) python2.7-zope.deprecation (†4.4.0) python2.7-zope.dottedname (†4.3) python2.7-zope.event (†4.4) python2.7-zope.exceptions (†4.3) python2.7-zope.filerepresentation (†5.0.0) python2.7-zope.i18n (†4.7.0) python2.7-zope.i18nmessageid (†5.0.1) python2.7-zope.interface (†5.1.0) python2.7-zope.lifecycleevent (†4.3) python2.7-zope.location (†4.2) python2.7-zope.proxy (†4.3.5) python2.7-zope.schema (†6.0.0) python2.7-zope.size (†4.3) python2.7-zope.testing (†4.7) python2.7-zope.testrunner (†5.1) python2.7-zstandard (†0.13.0) python2.7-zstd (†1.4.5.1) python2.7-zxcvbn (†4.4.28) pythonocc-core (†0.18.1) pyunbound (†1.9.3) ropper (†1.13.3) screeninfo (†0.6.5) setuptools-check-hook (†) setuptools-setup-hook (†) shiboken2 (†5.12.3) smugline (†20160106) soapysdr (†0.7.2) soapysdr (†0.7.2) sybil (†1.3.0) syncthing-gtk (†0.9.4.4) trytond (†5.6.2) vtk (†7.1.1) wheel-unpack-hook.sh (†) yoda (†1.8.2) z3 (†4.8.7) zeitgeist (†1.0.2)
```