### PR TITLE
gradle: 5.6.4 -> 6.5.1

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -51,14 +51,24 @@ rec {
     };
   };
 
-  gradle_latest = gradle_5_6;
+  gradle_latest = gradle_6_5;
+
+  gradle_6_5 = gradleGen rec {
+    name = "gradle-6.5.1";
+    nativeVersion = "0.22-milestone-3";
+
+    src = fetchurl {
+      url = "https://services.gradle.org/distributions/${name}-bin.zip";
+      sha256 = "0jmmipjh4fbsn92zpifa5cqg5ws2a4ha0s4jzqhrg4zs542x79sh";
+    };
+  };
 
   gradle_5_6 = gradleGen rec {
     name = "gradle-5.6.4";
     nativeVersion = "0.18";
 
     src = fetchurl {
-      url = "http://services.gradle.org/distributions/${name}-bin.zip";
+      url = "https://services.gradle.org/distributions/${name}-bin.zip";
       sha256 = "1f3067073041bc44554d0efe5d402a33bc3d3c93cc39ab684f308586d732a80d";
     };
   };
@@ -68,7 +78,7 @@ rec {
     nativeVersion = "0.14";
 
     src = fetchurl {
-      url = "http://services.gradle.org/distributions/${name}-bin.zip";
+      url = "https://services.gradle.org/distributions/${name}-bin.zip";
       sha256 = "0vhqxnk0yj3q9jam5w4kpia70i4h0q4pjxxqwynh3qml0vrcn9l6";
     };
   };

--- a/pkgs/tools/security/jd-gui/default.nix
+++ b/pkgs/tools/security/jd-gui/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jre, jdk, gradle, makeDesktopItem, perl, writeText, runtimeShell }:
+{ stdenv, fetchFromGitHub, jre, jdk, gradle_5, makeDesktopItem, perl, writeText, runtimeShell }:
 
 let
   pname = "jd-gui";
@@ -15,7 +15,7 @@ let
     name = "${pname}-deps";
     inherit src;
 
-    nativeBuildInputs = [ jdk perl gradle ];
+    nativeBuildInputs = [ jdk perl gradle_5 ];
 
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d);
@@ -71,7 +71,7 @@ in stdenv.mkDerivation rec {
   inherit pname version src;
   name = "${pname}-${version}";
 
-  nativeBuildInputs = [ jdk gradle ];
+  nativeBuildInputs = [ jdk gradle_5 ];
 
   buildPhase = ''
     export GRADLE_USER_HOME=$(mktemp -d)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10592,6 +10592,7 @@ in
   gradle_4_10 = res.gradleGen.gradle_4_10;
   gradle_4 = gradle_4_10;
   gradle_5 = res.gradleGen.gradle_5_6;
+  gradle_6 = res.gradleGen.gradle_6_5;
 
   gperf = callPackage ../development/tools/misc/gperf { };
   # 3.1 changed some parameters from int to size_t, leading to mismatches.


### PR DESCRIPTION

###### Motivation for this change

Upgrade Gradle to latest version 6.5.1
Add gradle_6 to the top level packages.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
