### PR TITLE
blockdiag: fix missing dependency

### DIFF
--- a/pkgs/development/python-modules/blockdiag/default.nix
+++ b/pkgs/development/python-modules/blockdiag/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   buildInputs = [ pep8 nose unittest2 docutils ];
 
-  propagatedBuildInputs = [ pillow webcolors funcparserlib ];
+  propagatedBuildInputs = [ setuptools pillow webcolors funcparserlib ];
 
   # One test fails:
   #   ...


### PR DESCRIPTION
Otherwise it yields „ModuleNotFoundError: No module named 'pkg_resources'“