### PR TITLE
numpy: fix distutils patch for 1.19.0

### DIFF
--- a/pkgs/development/python-modules/numpy/numpy-distutils-C++.patch
+++ b/pkgs/development/python-modules/numpy/numpy-distutils-C++.patch
@@ -1,8 +1,7 @@
 diff --git a/numpy/distutils/unixccompiler.py b/numpy/distutils/unixccompiler.py
-index 6ed5eec..82a88b5 100644
 --- a/numpy/distutils/unixccompiler.py
 +++ b/numpy/distutils/unixccompiler.py
-@@ -44,8 +44,6 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
+@@ -37,8 +37,6 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
          if opt not in llink_s:
              self.linker_so = llink_s.split() + opt.split()
  
@@ -11,7 +10,7 @@ index 6ed5eec..82a88b5 100644
      # gcc style automatic dependencies, outputs a makefile (-MF) that lists
      # all headers needed by a c file as a side effect of compilation (-MMD)
      if getattr(self, '_auto_depends', False):
-@@ -54,8 +52,15 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
+@@ -47,8 +45,15 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
          deps = []
  
      try:
@@ -26,6 +25,6 @@ index 6ed5eec..82a88b5 100644
 +            self.spawn(self.compiler_so + cc_args + [src, '-o', obj] + deps +
 +                       extra_postargs, display = display)
 +
-     except DistutilsExecError:
-         msg = str(get_exception())
+     except DistutilsExecError as e:
+         msg = str(e)
          raise CompileError(msg)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The `python3Packages.numpy` build is broken on darwin after update to 1.19.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
