### PR TITLE
paraview: Fix dataset filtering

### DIFF
--- a/pkgs/applications/graphics/paraview/default.nix
+++ b/pkgs/applications/graphics/paraview/default.nix
@@ -66,7 +66,6 @@ mkDerivation rec {
     libGLU libGL
     libXt
     openmpi
-    (python3.withPackages (ps: with ps; [ numpy matplotlib mpi4py ]))
     tbb
     boost
     ffmpeg
@@ -76,6 +75,10 @@ mkDerivation rec {
     qttools
     qtxmlpatterns
     qtsvg
+  ];
+
+  propagatedBuildInputs = [
+    (python3.withPackages (ps: with ps; [ numpy matplotlib mpi4py ]))
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Paraview requires python and numpy to be available at runtime not just
build time.  Filtering a csv dataset uses numpy and throws an error
without python and numpy being available in the propagatedBuildInputs.

###### Motivation for this change

Paraview requires python and numpy to be available at runtime not just
build time.  Filtering a csv dataset uses numpy and throws an error
without python and numpy being available in the propagatedBuildInputs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
