### PR TITLE
g810-led: init at 0.4.2

### DIFF
--- a/pkgs/misc/g810-led/default.nix
+++ b/pkgs/misc/g810-led/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, hidapi
+, profile ? "/etc/g810-led/profile"
+}:
+
+stdenv.mkDerivation rec {
+  pname = "g810-led";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "MatMoul";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1ymkp7i7nc1ig2r19wz0pcxfnpawkjkgq7vrz6801xz428cqwmhl";
+  };
+
+  buildInputs = [ hidapi ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D bin/g810-led $out/bin/g810-led
+    ln -s \./g810-led $out/bin/g213-led
+    ln -s \./g810-led $out/bin/g410-led
+    ln -s \./g810-led $out/bin/g413-led
+    ln -s \./g810-led $out/bin/g512-led
+    ln -s \./g810-led $out/bin/g513-led
+    ln -s \./g810-led $out/bin/g610-led
+    ln -s \./g810-led $out/bin/g815-led
+    ln -s \./g810-led $out/bin/g910-led
+    ln -s \./g810-led $out/bin/gpro-led
+
+    substituteInPlace udev/g810-led.rules \
+      --replace "/usr" $out \
+      --replace "/etc/g810-led/profile" "${profile}"
+    install -D udev/g810-led.rules $out/etc/udev/rules.d/90-g810-led.rules
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Linux LED controller for Logitech G213, G410, G413, G512, G513, G610, G810, G815, G910 and GPRO Keyboards";
+    inherit (src.meta) homepage;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ samuelgrf ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26035,6 +26035,8 @@ in
 
   fuse-emulator = callPackage ../misc/emulators/fuse-emulator {};
 
+  g810-led = callPackage ../misc/g810-led { };
+
   gajim = callPackage ../applications/networking/instant-messengers/gajim {
     inherit (gst_all_1) gstreamer gst-plugins-base gst-libav gst-plugins-ugly;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add g810-led package. It is an LED controller for Logitech keyboards and can be used to set custom colors for any keys and also supports multiple animated effects.

###### Things done
Built and tested with Logitech G910.
I also created a module for g810-led, which allows for setting a color profile via nixos configuration: #92124 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
