### PR TITLE
nixos/g810-led: init

### DIFF
--- a/nixos/modules/hardware/g810-led.nix
+++ b/nixos/modules/hardware/g810-led.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.g810-led;
+in
+{
+  options.hardware.g810-led = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to apply a g810-led profile when a compatible keyboard
+        is connected.
+      '';
+    };
+
+    profile = mkOption {
+      type = types.path;
+      description = ''
+        The profile file to be applied, samples can be found at:
+        https://github.com/MatMoul/g810-led/tree/master/sample_profiles
+      '';
+    };
+
+    enableFlashingWorkaround = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to turn off all LEDs on shutdown and reboot.
+        Enable this if your keyboard flashes 3 times on boot.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    services.udev.packages = [
+      (pkgs.g810-led.override { profile = cfg.profile; })
+    ];
+
+    # Workaround mentioned here:
+    # https://github.com/MatMoul/g810-led/blob/14e331ad2ab7c5ffb546e0c14dd6164b517ff9ca/PROFILES.md
+    systemd.services.g810-led-workaround = mkIf cfg.enableFlashingWorkaround {
+      description = "Turn off all g810-led keys";
+      script = "${pkgs.g810-led}/bin/g810-led -a 000000";
+
+      serviceConfig.Type = "oneshot";
+      unitConfig.DefaultDependencies = false;
+
+      wantedBy = [ "shutdown.target" ];
+      before = [ "shutdown.target" "reboot.target" "halt.target" ];
+    };
+  };
+
+  meta.maintainers = [ maintainers.samuelgrf ];
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -47,6 +47,7 @@
   ./hardware/cpu/intel-microcode.nix
   ./hardware/digitalbitbox.nix
   ./hardware/device-tree.nix
+  ./hardware/g810-led.nix
   ./hardware/sensor/iio.nix
   ./hardware/ksm.nix
   ./hardware/ledger.nix


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add g810-led module. This module allows for setting a custom color profile via nixos configuration.

g810-led is an LED controller for Logitech keyboards and can be used to set custom colors for any keys and also supports multiple animated effects.

###### Things done
Built and tested with Logitech G910.

Depends on #92119 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
