### PR TITLE
 wayland: documentation outputs

### DIFF
--- a/pkgs/development/libraries/gd/default.nix
+++ b/pkgs/development/libraries/gd/default.nix
@@ -1,5 +1,7 @@
-{ stdenv, fetchurl
-, pkgconfig
+{ stdenv, fetchurl, fetchpatch
+, autoconf
+, automake
+, pkg-config
 , zlib
 , libpng
 , libjpeg ? null
@@ -20,11 +22,24 @@ stdenv.mkDerivation rec {
   };
 
   hardeningDisable = [ "format" ];
+  patches = [
+    # Fixes an issue where some other packages would fail to build
+    # their documentation with an error like:
+    # "Error: Problem doing text layout"
+    #
+    # Can be removed if Wayland can still be built successfully with
+    # documentation.
+    (fetchpatch {
+      url = "https://github.com/libgd/libgd/commit/3dd0e308cbd2c24fde2fc9e9b707181252a2de95.patch";
+      excludes = [ "tests/gdimagestringft/.gitignore" ];
+      sha256 = "12iqlanl9czig9d7c3rvizrigw2iacimnmimfcny392dv9iazhl1";
+    })
+  ];
 
   # -pthread gets passed to clang, causing warnings
   configureFlags = stdenv.lib.optional stdenv.isDarwin "--enable-werror=no";
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoconf automake pkg-config ];
 
   buildInputs = [ zlib fontconfig freetype ];
   propagatedBuildInputs = [ libpng libjpeg libwebp libtiff libXpm ];

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -1,7 +1,8 @@
 { lib, stdenv, fetchurl, meson, pkgconfig, ninja
 , libffi, libxml2, wayland
 , expat ? null # Build wayland-scanner (currently cannot be disabled as of 1.7.0)
-, withDocumentation ? false, graphviz-nox, doxygen, libxslt, xmlto, python3
+, withDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform
+, graphviz-nox, doxygen, libxslt, xmlto, python3
 , docbook_xsl, docbook_xml_dtd_45, docbook_xml_dtd_42
 }:
 
@@ -19,6 +20,7 @@ in stdenv.mkDerivation rec {
     sha256 = "0k995rn96xkplrapz5k648j651wc43kq817xk1x8280h16gsfxa6";
   };
 
+  outputs = [ "out" ] ++ lib.optionals withDocumentation [ "doc" "man" ];
   separateDebugInfo = true;
 
   mesonFlags = [ "-Ddocumentation=${lib.boolToString withDocumentation}" ];

--- a/pkgs/development/tools/misc/automake/automake-1.15.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.15.x.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, perl, autoconf }:
 
 stdenv.mkDerivation rec {
-  name = "automake-1.15";
+  name = "automake-1.15.1";
 
   src = fetchurl {
     url = "mirror://gnu/automake/${name}.tar.xz";
-    sha256 = "0dl6vfi2lzz8alnklwxzfz624b95hb1ipjvd3mk177flmddcf24r";
+    sha256 = "1bzd9g32dfm4rsbw93ld9x7b5nc1y6i4m6zp032qf1i28a8s6sxg";
   };
 
   nativeBuildInputs = [ autoconf perl ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11911,6 +11911,7 @@ in
   gf2x = callPackage ../development/libraries/gf2x {};
 
   gd = callPackage ../development/libraries/gd {
+    automake = automake115x;
     libtiff = null;
     libXpm = null;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Build the documentation by default, but install it to seperate outputs
so it doesn't have to be downloaded.  Documentation is still disabled
when cross-compiling, because that is currently broken:
wayland -> graphviz -> libdevil -> openexr -> ilmbase (broken)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
