### PR TITLE
kaggle: init at 1.5.6

### DIFF
--- a/pkgs/development/python-modules/kaggle/default.nix
+++ b/pkgs/development/python-modules/kaggle/default.nix
@@ -1,0 +1,48 @@
+{ buildPythonPackage
+, certifi
+, fetchPypi
+, lib
+, python-dateutil
+, python-slugify
+, six
+, requests
+, tqdm
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "kaggle";
+  version = "1.5.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0f5qrkgklcpgbwncrif7aw4f86dychqplh7k3f4rljwnr9yhjb1w";
+  };
+
+  # The version bounds in the setup.py file are unnecessarily restrictive.
+  patchPhase = ''
+    substituteInPlace setup.py \
+      --replace 'urllib3 >= 1.21.1, < 1.25' 'urllib3'
+  '';
+
+  propagatedBuildInputs = [
+    certifi
+    python-dateutil
+    python-slugify
+    requests
+    six
+    tqdm
+    urllib3
+  ];
+
+  # Tests try to access the network.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Official API for https://www.kaggle.com, accessible using a command line tool implemented in Python 3";
+    homepage = "https://github.com/Kaggle/kaggle-api";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ cdepillabout ];
+  };
+}
+

--- a/pkgs/development/python-modules/kaggle/default.nix
+++ b/pkgs/development/python-modules/kaggle/default.nix
@@ -36,7 +36,13 @@ buildPythonPackage rec {
   ];
 
   # Tests try to access the network.
-  doCheck = false;
+  checkPhase = ''
+    export HOME="$TMP"
+    mkdir -p "$HOME/.kaggle/"
+    echo '{"username":"foobar","key":"00000000000000000000000000000000"}' > "$HOME/.kaggle/kaggle.json"
+    $out/bin/kaggle --help > /dev/null
+  '';
+  pythonImportsCheck = [ "kaggle" ];
 
   meta = with lib; {
     description = "Official API for https://www.kaggle.com, accessible using a command line tool implemented in Python 3";
@@ -45,4 +51,3 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ cdepillabout ];
   };
 }
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2036,6 +2036,8 @@ in
 
   ir-standard-fonts = callPackage ../data/fonts/ir-standard-fonts { };
 
+  kaggle = with python3Packages; toPythonApplication kaggle;
+
   lynis = callPackage ../tools/security/lynis { };
 
   mapproxy = callPackage ../applications/misc/mapproxy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4330,6 +4330,8 @@ in {
 
   jupyterhub-ldapauthenticator = callPackage ../development/python-modules/jupyterhub-ldapauthenticator { };
 
+  kaggle = callPackage ../development/python-modules/kaggle { };
+
   keyring = if isPy3k then
     callPackage ../development/python-modules/keyring { }
   else


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This adds the `kaggle` package, which can be used to interact with the API for https://www.kaggle.com/.

Note that if you try to build and run this, you will be presented with an error message like the following:

```console
$ nix-build -A kaggle
$ ./result/bin/kaggle  --help
Traceback (most recent call last):
  File "/nix/store/5hxdnnyg76klxwwfdvh31n92mlkhkvgb-python3.8-kaggle-1.5.6/bin/.kaggle-wrapped", line 6, in <module>
    from kaggle.cli import main
  File "/nix/store/5hxdnnyg76klxwwfdvh31n92mlkhkvgb-python3.8-kaggle-1.5.6/lib/python3.8/site-packages/kaggle/__init__.py", line 23, in <module>
    api.authenticate()
  File "/nix/store/5hxdnnyg76klxwwfdvh31n92mlkhkvgb-python3.8-kaggle-1.5.6/lib/python3.8/site-packages/kaggle/api/kaggle_api_extended.py", line 147, in authenticate
    raise IOError('Could not find {}. Make sure it\'s located in'
OSError: Could not find kaggle.json. Make sure it's located in /home/user/.kaggle. Or use the environment method.
```

You have to actually create the `~/.kaggle/kaggle.json` file as described in the [README.md](https://github.com/Kaggle/kaggle-api).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
