### PR TITLE
sile: 0.10.4 -> 0.10.9

### DIFF
--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -3,8 +3,6 @@
 , fetchurl
 , makeWrapper
 , pkgconfig
-, autoconf
-, automake
 , harfbuzz
 , icu
 , poppler_utils
@@ -37,7 +35,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.10.8";
+  version = "0.10.9";
 
   src = fetchurl {
     url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.xz";

--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -37,15 +37,16 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.10.5";
+  version = "0.10.8";
 
   src = fetchurl {
-    url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.bz2";
-    sha256 = "16sb9dy0a3mq80qm9b4hjf0d2q5z1aqli439xlx75fj2y8xf4kx1";
+    url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.xz";
+    sha256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
   };
 
   configureFlags = [
     "--with-system-luarocks"
+    "--with-manual"
   ];
 
   nativeBuildInputs = [
@@ -91,10 +92,6 @@ stdenv.mkDerivation rec {
   '';
 
   checkTarget = "check";
-
-  postInstall = ''
-    install -D -t $doc/share/doc/sile documentation/sile.pdf
-  '';
 
   # Hack to avoid TMPDIR in RPATHs.
   preFixup = ''

--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -116,6 +116,7 @@ stdenv.mkDerivation rec {
       such as InDesign.
     '';
     homepage = "https://sile-typesetter.org/";
+    maintainers = with maintainers; [ alerque ];
     platforms = platforms.unix;
     license = licenses.mit;
   };


### PR DESCRIPTION
###### Motivation for this change

[Upstream release](https://github.com/sile-typesetter/sile/releases/tag/v0.10.5)

Note that I am not running Nix, this is in the blind. Prior to this release `make test` was a heavyweight test suite that downloaded a bunch of required fonts for regression testing. As of this release there is now a lightweight `make check` that just makes sure we can generate a valid PDF file, no fonts are downloaded. It does require *poppler* (for `pdfinfo`) to run, so that may need to be added somewhere as a make dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
