### PR TITLE
sqlite: 3.32.2 -> 3.32.3

### DIFF
--- a/pkgs/development/libraries/sqlite/analyzer.nix
+++ b/pkgs/development/libraries/sqlite/analyzer.nix
@@ -6,11 +6,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sqlite-analyzer";
-  version = "3.32.2";
+  version = "3.32.3";
 
   src = assert version == sqlite.version; fetchurl {
     url = "https://sqlite.org/2020/sqlite-src-${archiveVersion version}.zip";
-    sha256 = "1jqhs896cvp9l399mjpbv1x2qbfvq875l1vrgnl3zc4ffdjxs9z0";
+    sha256 = "1fgmslzf013ry3a7g2vms7zyg24gs53gfj308r6ki4inbn3g04lk";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -10,12 +10,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sqlite";
-  version = "3.32.2";
+  version = "3.32.3";
 
   # NB! Make sure to update analyzer.nix src (in the same directory).
   src = fetchurl {
     url = "https://sqlite.org/2020/sqlite-autoconf-${archiveVersion version}.tar.gz";
-    sha256 = "1130bcd70s2vlsq0d638pb5qrw9kwqvjswnp2dfypghx9hjz3gid";
+    sha256 = "0rlbaq177gcgk5dswd3akbhv2nvvzljrbhgy18hklbhw7h90f5d3";
   };
 
   outputs = [ "bin" "dev" "out" ];


### PR DESCRIPTION
###### Motivation for this change

Fixes various CVEs in sqlite:

CVE-2019-19242
CVE-2019-19244
CVE-2019-19317
CVE-2019-19603
CVE-2019-19645
CVE-2019-19646
CVE-2019-19880
CVE-2019-19923
CVE-2019-19924
CVE-2019-19925
CVE-2019-19926
CVE-2019-19959
CVE-2019-20218
CVE-2020-9327
CVE-2020-11655
CVE-2020-11656
CVE-2020-13434
CVE-2020-13435
CVE-2020-13630
CVE-2020-13631
CVE-2020-13632
CVE-2020-13871
CVE-2020-15358

Re #92072, #90989, #88403, #88401, #88400, #77944, #92063, #90990

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
