### PR TITLE
ferdi: init at 5.5.0; franz: 5.4.1 -> 5.5.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/ferdi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ferdi/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, mkFranzDerivation, fetchurl }:
+
+mkFranzDerivation rec {
+  pname = "ferdi";
+  name = "Ferdi";
+  version = "5.5.0";
+  src = fetchurl {
+    url = "https://github.com/getferdi/ferdi/releases/download/v${version}/ferdi_${version}_amd64.deb";
+    sha256 = "0i24vcnq4iz5amqmn2fgk92ff9x9y7fg8jhc3g6ksvmcfly7af3k";
+  };
+  meta = with stdenv.lib; {
+    description = "Ferdi allows you to combine your favorite messaging services into one application";
+    homepage = "https://getferdi.com/";
+    license = licenses.free;
+    maintainers = [ maintainers.davidtwco ];
+    platforms = [ "x86_64-linux" ];
+    hydraPlatforms = [ ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/franz/default.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/default.nix
@@ -1,57 +1,19 @@
-{ stdenv, fetchurl, makeWrapper, wrapGAppsHook, autoPatchelfHook, dpkg
-, xorg, atk, glib, pango, gdk-pixbuf, cairo, freetype, fontconfig, gtk3
-, gnome2, dbus, nss, nspr, alsaLib, cups, expat, udev, libnotify, xdg_utils }:
+{ stdenv, mkFranzDerivation, fetchurl }:
 
-let
-  version = "5.4.1";
-in stdenv.mkDerivation {
+mkFranzDerivation rec {
   pname = "franz";
-  inherit version;
+  name = "Franz";
+  version = "5.4.1";
   src = fetchurl {
     url = "https://github.com/meetfranz/franz/releases/download/v${version}/franz_${version}_amd64.deb";
     sha256 = "1g1z5zjm9l081hpqslfc4h7pqh4k76ccmlz71r21204wy630mw6h";
   };
-
-  # don't remove runtime deps
-  dontPatchELF = true;
-
-  nativeBuildInputs = [ autoPatchelfHook makeWrapper wrapGAppsHook dpkg ];
-  buildInputs = (with xorg; [
-    libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes
-    libXrender libX11 libXtst libXScrnSaver
-  ]) ++ [
-    gtk3 atk glib pango gdk-pixbuf cairo freetype fontconfig dbus
-    gnome2.GConf nss nspr alsaLib cups expat stdenv.cc.cc
-  ];
-  runtimeDependencies = [ udev.lib libnotify ];
-
-  unpackPhase = "dpkg-deb -x $src .";
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp -r opt $out
-    ln -s $out/opt/Franz/franz $out/bin
-
-    # provide desktop item and icon
-    cp -r usr/share $out
-    substituteInPlace $out/share/applications/franz.desktop \
-      --replace /opt/Franz/franz franz
-  '';
-
-  dontWrapGApps = true;
-
-  postFixup = ''
-    wrapProgram $out/opt/Franz/franz \
-      --prefix PATH : ${xdg_utils}/bin \
-      "''${gappsWrapperArgs[@]}"
-  '';
-
   meta = with stdenv.lib; {
     description = "A free messaging app that combines chat & messaging services into one application";
     homepage = "https://meetfranz.com";
     license = licenses.free;
     maintainers = [ maintainers.davidtwco ];
-    platforms = ["x86_64-linux"];
-    hydraPlatforms = [];
+    platforms = [ "x86_64-linux" ];
+    hydraPlatforms = [ ];
   };
 }

--- a/pkgs/applications/networking/instant-messengers/franz/default.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/default.nix
@@ -3,10 +3,10 @@
 mkFranzDerivation rec {
   pname = "franz";
   name = "Franz";
-  version = "5.4.1";
+  version = "5.5.0";
   src = fetchurl {
     url = "https://github.com/meetfranz/franz/releases/download/v${version}/franz_${version}_amd64.deb";
-    sha256 = "1g1z5zjm9l081hpqslfc4h7pqh4k76ccmlz71r21204wy630mw6h";
+    sha256 = "0kgfjai0pz0gpbxsmn3hbha7zr2kax0s1j3ygcsy4kzghla990wm";
   };
   meta = with stdenv.lib; {
     description = "A free messaging app that combines chat & messaging services into one application";

--- a/pkgs/applications/networking/instant-messengers/franz/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/generic.nix
@@ -1,0 +1,89 @@
+{ stdenv
+, makeWrapper
+, wrapGAppsHook
+, autoPatchelfHook
+, dpkg
+, xorg
+, atk
+, glib
+, pango
+, gdk-pixbuf
+, cairo
+, freetype
+, fontconfig
+, gtk3
+, gnome2
+, dbus
+, nss
+, nspr
+, alsaLib
+, cups
+, expat
+, udev
+, libnotify
+, xdg_utils
+}:
+
+# Helper function for building a derivation for Franz and forks.
+
+{ pname, name, version, src, meta }:
+stdenv.mkDerivation {
+  inherit pname version src meta;
+
+  # Don't remove runtime deps.
+  dontPatchELF = true;
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper wrapGAppsHook dpkg ];
+  buildInputs = (with xorg; [
+    libXi
+    libXcursor
+    libXdamage
+    libXrandr
+    libXcomposite
+    libXext
+    libXfixes
+    libXrender
+    libX11
+    libXtst
+    libXScrnSaver
+  ]) ++ [
+    gtk3
+    atk
+    glib
+    pango
+    gdk-pixbuf
+    cairo
+    freetype
+    fontconfig
+    dbus
+    gnome2.GConf
+    nss
+    nspr
+    alsaLib
+    cups
+    expat
+    stdenv.cc.cc
+  ];
+  runtimeDependencies = [ udev.lib libnotify ];
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r opt $out
+    ln -s $out/opt/${name}/${pname} $out/bin
+
+    # Provide desktop item and icon.
+    cp -r usr/share $out
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace /opt/${name}/${pname} ${pname}
+  '';
+
+  dontWrapGApps = true;
+
+  postFixup = ''
+    wrapProgram $out/opt/${name}/${pname} \
+      --prefix PATH : ${xdg_utils}/bin \
+      "''${gappsWrapperArgs[@]}"
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3601,7 +3601,13 @@ in
 
   fprintd = callPackage ../tools/security/fprintd { };
 
-  franz = callPackage ../applications/networking/instant-messengers/franz { };
+  ferdi = callPackage ../applications/networking/instant-messengers/ferdi {
+    mkFranzDerivation = callPackage ../applications/networking/instant-messengers/franz/generic.nix { };
+  };
+
+  franz = callPackage ../applications/networking/instant-messengers/franz {
+    mkFranzDerivation = callPackage ../applications/networking/instant-messengers/franz/generic.nix { };
+  };
 
   freedroidrpg = callPackage ../games/freedroidrpg { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add a package for [Ferdi](https://github.com/getferdi/ferdi/), a fork of [Franz](https://github.com/meetfranz/franz) which is already packaged. In addition, this updates Franz to the most recent release, 5.5.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
