### PR TITLE
python38Packages.zconfig: fix build

### DIFF
--- a/pkgs/development/python-modules/zconfig/default.nix
+++ b/pkgs/development/python-modules/zconfig/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchPypi
+, fetchpatch
 , buildPythonPackage
 , zope_testrunner
 , manuel
@@ -16,12 +17,16 @@ buildPythonPackage rec {
     sha256 = "0s7aycxna07a04b4rswbkj4y5qh3gxy2mcsqb9dmy0iimj9f9550";
   };
 
-  patches = stdenv.lib.optional stdenv.hostPlatform.isMusl ./remove-setlocale-test.patch;
+  patches = [
+    # fixes 3.8+ logger validation issues, has been merged into master, remove next bump
+    (fetchpatch {
+      url = "https://github.com/zopefoundation/ZConfig/commit/f0c2990d35ac3c924ecc8be4a5c71c8e4abbd0e5.patch";
+      sha256 = "1bjg3wrvii0rwzf3s0vlpzgg2ckj0h2zxkyxwjcr64s4k2vaq9ij";
+    })
+  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./remove-setlocale-test.patch;
 
   buildInputs = [ manuel docutils ];
   propagatedBuildInputs = [ zope_testrunner ];
-
-  disabled = pythonAtLeast "3.8"; # 3.6.0 introduces compatibility for 3.8 and 3.9
 
   meta = with stdenv.lib; {
     description = "Structured Configuration Library";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`

  vulnix doesn't build, but that seems separate.

- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
