### PR TITLE
bs1770gain: use latest ffmpeg

### DIFF
--- a/pkgs/applications/audio/bs1770gain/default.nix
+++ b/pkgs/applications/audio/bs1770gain/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ffmpeg_3, sox }:
+{ stdenv, fetchurl, ffmpeg, sox }:
 
 stdenv.mkDerivation rec {
   pname = "bs1770gain";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1p6yz5q7czyf9ard65sp4kawdlkg40cfscr3b24znymmhs3p7rbk";
   };
 
-  buildInputs = [ ffmpeg_3 sox ];
+  buildInputs = [ ffmpeg sox ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).