### PR TITLE
dpic: cleanup derivation, install man pages

### DIFF
--- a/pkgs/tools/graphics/dpic/default.nix
+++ b/pkgs/tools/graphics/dpic/default.nix
@@ -9,21 +9,15 @@ stdenv.mkDerivation rec {
     sha256 = "1gbkpbjwjaaifxff8amm9b47dynq4l4698snjdgnn4flndw62q88";
   };
 
-  phases = [ "unpackPhase" "buildPhase" "installPhase" ];
+  # The prefix passed to configure is not used.
+  makeFlags = [ "DESTDIR=$(out)" ];
 
-  makeFlags = [ "CC=${stdenv.cc.outPath}/bin/cc" ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp -fv dpic $out/bin
-  '';
-
-  meta = {
-    homepage = "https://ece.uwaterloo.ca/~aplevich/dpic/";
+  meta = with stdenv.lib; {
     description = "An implementation of the pic little language for creating drawings";
-    license = stdenv.lib.licenses.bsd2;
-    maintainers = [ stdenv.lib.maintainers.aespinosa ];
-    platforms = stdenv.lib.platforms.all;
+    homepage = "https://ece.uwaterloo.ca/~aplevich/dpic/";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ aespinosa ];
+    platforms = platforms.all;
   };
 }
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Use configure, since upstream provides it.
- Rely on `make install` to install dpic.
- This also installs the man pages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
