### PR TITLE
portfolio: 0.46.3 -> 0.46.6

### DIFF
--- a/pkgs/applications/office/portfolio/default.nix
+++ b/pkgs/applications/office/portfolio/default.nix
@@ -24,11 +24,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "PortfolioPerformance";
-  version = "0.46.3";
+  version = "0.46.6";
 
   src = fetchurl {
     url = "https://github.com/buchen/portfolio/releases/download/${version}/PortfolioPerformance-${version}-linux.gtk.x86_64.tar.gz";
-    sha256 = "0263v0ymqmf7kcwys4smwx1p1gh8d20dh10canjfqgl4c5lfx966";
+    sha256 = "0df5fhyr4di3c5fvbkli8ff7ylji6wvjghj82zfp0hr02f7cnr6b";
   };
 
   nativeBuildInputs = [
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     description = "A simple tool to calculate the overall performance of an investment portfolio.";
     homepage = "https://www.portfolio-performance.info/";
     license = licenses.epl10;
-    maintainers = with maintainers; [ elohmeier ];
+    maintainers = with maintainers; [ elohmeier oyren ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update of portfolio performance to 0.46.6

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
