### PR TITLE
kubespy: init at 0.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1031,6 +1031,12 @@
     githubId = 5718007;
     name = "Bastian Köcher";
   };
+  blaggacao = {
+    name = "David Arnold";
+    email = "dar@xoe.solutions";
+    github = "blaggacao";
+    githubId = 7548295;
+  };
   blanky0230 = {
     email = "blanky0230@gmail.com";
     github = "blanky0230";

--- a/pkgs/applications/networking/cluster/kubespy/default.nix
+++ b/pkgs/applications/networking/cluster/kubespy/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "kubespy";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "pulumi";
+    repo = "kubespy";
+    sha256 = "1p0qmn6458pa9la6zkvyrkgs2rhzfwsk9m3rk5fkmcfbh7b031r8";
+  };
+  
+  vendorSha256 = "0q85is01cbgxflnqdvxc9w5iqdizgvsc44h8z21j712bm2w7blqq";
+  
+  # TODO: enable after https://github.com/pulumi/kubespy/issues/72 is addressed.
+  # postInstall = ''
+  # 	for shell in bash zsh; do
+  # 		$out/bin/kubespy completion $shell > kubespy.$shell
+  # 		installShellCompletion kubespy.$shell
+  # 	done
+  # '';
+
+  meta = with lib; {
+    description = "A tool to observe Kubernetes resources in real time";
+    homepage = "https://github.com/pulumi/kubespy";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ blaggacao ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10714,6 +10714,8 @@ in
   kube-prompt = callPackage ../development/tools/kube-prompt { };
 
   kubeprompt = callPackage ../development/tools/kubeprompt { };
+  
+  kubespy = callPackage ../applications/networking/cluster/kubespy { };
 
   kubicorn = callPackage ../development/tools/kubicorn {  };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

A tool to observe Kubernetes resource in real time
closes #92196


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
