### PR TITLE
evolution: 3.36.3 -> 3.36.4

### DIFF
--- a/pkgs/desktops/gnome-3/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/apps/evolution/default.nix
@@ -43,11 +43,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution";
-  version = "3.36.3";
+  version = "3.36.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "00yann3cibbsap7vh6qq08aklvydynmk6gmljkzd80kc52m6rqal";
+    sha256 = "0vgd3i5zrs4r0i0700hhl89c66j41bgdzg9j8wdf0w8irlqj5xv2";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump for evolution.


```
Evolution 3.36.4 2020-07-03
---------------------------

Bug Fixes:
	I#963 - Composer: New message can incorrectly keep selected default account (Milan Crha)
	I#969 - Workaround freeze on drag of message over composer body (Milan Crha)
	I#979 - Undeletable empty item in folder list (Milan Crha)
	I#982 - 'Message contains'-search broken in 3.36.3 (Milan Crha)
	I#985 - Ensure 16px online/offline icon height in the status bar (Milan Crha)

Translations:
	Matej Urbančič (sl)
	Baurzhan Muftakhidinov (kk)
	Yuri Chornoivan (uk)
	Charles Monzat (fr)

```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
