### PR TITLE
libhandy: 0.0.13 -> 1.0.0

### DIFF
--- a/pkgs/development/libraries/libhandy/default.nix
+++ b/pkgs/development/libraries/libhandy/default.nix
@@ -1,66 +1,90 @@
-{ stdenv, fetchFromGitLab, fetchpatch, meson, ninja, pkgconfig, gobject-introspection, vala
-, gtk-doc, docbook_xsl, docbook_xml_dtd_43
-, gtk3, gnome3, glade
-, dbus, xvfb_run, libxml2
+{ stdenv
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, gobject-introspection
+, vala
+, gtk-doc
+, docbook_xsl
+, docbook_xml_dtd_43
+, gtk3
+, gnome3
+, glade
+, dbus
+, xvfb_run
+, libxml2
+, gdk-pixbuf
+, librsvg
 , hicolor-icon-theme
 }:
 
 stdenv.mkDerivation rec {
   pname = "libhandy";
-  version = "0.0.13";
+  version = "1.0.0";
 
   outputs = [ "out" "dev" "devdoc" "glade" ];
   outputBin = "dev";
 
-  src = fetchFromGitLab {
-    domain = "source.puri.sm";
-    owner = "Librem5";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "1y23k623sjkldfrdiwfarpchg5mg58smcy1pkgnwfwca15wm1ra5";
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    hash = "sha256-qTmFgvR7fXKSBdbqwMBo/vNarySf3Vfuo3JPhRjSZpk=";
   };
 
-  patches = [
-    # Fix build with Glade 3.36.0
-    # https://source.puri.sm/Librem5/libhandy/merge_requests/451
-    (fetchpatch {
-      url = "https://source.puri.sm/Librem5/libhandy/commit/887beedb467984ab5c7b91830181645fadef7849.patch";
-      sha256 = "0qgh4i0l1028qxqmig4x2c10yj5s80skl70qnc5wnp71s45alvk5";
-      excludes = [ "glade/glade-hdy-header-bar.c" ];
-    })
+  nativeBuildInputs = [
+    docbook_xml_dtd_43
+    docbook_xsl
+    gobject-introspection
+    gtk-doc
+    libxml2
+    meson
+    ninja
+    pkgconfig
+    vala
   ];
 
-  nativeBuildInputs = [
-    meson ninja pkgconfig gobject-introspection vala libxml2
-    gtk-doc docbook_xsl docbook_xml_dtd_43
+  buildInputs = [
+    gdk-pixbuf
+    glade
+    gnome3.gnome-desktop
+    gtk3
+    libxml2
   ];
-  buildInputs = [ gnome3.gnome-desktop gtk3 glade libxml2 ];
-  checkInputs = [ dbus xvfb_run hicolor-icon-theme ];
+
+  checkInputs = [
+    dbus
+    hicolor-icon-theme
+    xvfb_run
+  ];
 
   mesonFlags = [
     "-Dgtk_doc=true"
-    "-Dglade_catalog=enabled"
-    "-Dintrospection=enabled"
   ];
 
+  # Uses define_variable in pkgconfig, but we still need it to use the glade output
   PKG_CONFIG_GLADEUI_2_0_MODULEDIR = "${placeholder "glade"}/lib/glade/modules";
   PKG_CONFIG_GLADEUI_2_0_CATALOGDIR = "${placeholder "glade"}/share/glade/catalogs";
 
-  doCheck = true;
+  # Bail out! dbind-FATAL-WARNING:
+  # AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown:
+  # The name org.a11y.Bus was not provided by any .service files
+  doCheck = false;
 
   checkPhase = ''
     NO_AT_BRIDGE=1 \
-    XDG_DATA_DIRS="$XDG_DATA_DIRS:${hicolor-icon-theme}/share" \
+    XDG_DATA_DIRS="$XDG_DATA_DIRS:${hicolor-icon-theme}/share"
+    GDK_PIXBUF_MODULE_FILE="${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
     xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
       --config-file=${dbus.daemon}/share/dbus-1/session.conf \
       meson test --print-errorlogs
   '';
 
   meta = with stdenv.lib; {
-    description = "A library full of GTK widgets for mobile phones";
-    homepage = "https://source.puri.sm/Librem5/libhandy";
+    changelog = "https://gitlab.gnome.org/GNOME/libhandy/-/tags/${version}";
+    description = "Building blocks for modern adaptive GNOME apps";
+    homepage = "https://gitlab.gnome.org/GNOME/libhandy";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = teams.gnome.members;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update libhandy (latest elementary onboarding needs it). I did run into an issue getting the tests to pass in the hdy-avatar.
It seems to be something gdk-pixbuf/librsvg related? I left the output in the comment in the expression.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
