### PR TITLE
pythonPackages.denonavr: 0.8.1 -> 0.9.3

### DIFF
--- a/pkgs/development/python-modules/denonavr/default.nix
+++ b/pkgs/development/python-modules/denonavr/default.nix
@@ -1,18 +1,18 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy27, requests
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27, requests, netifaces
 , pytest, testtools, requests-mock }:
 
 buildPythonPackage rec {
   pname = "denonavr";
-  version = "0.8.1";
+  version = "0.9.3";
 
   src = fetchFromGitHub {
     owner = "scarface-4711";
     repo = "denonavr";
     rev = version;
-    sha256 = "12g9w5674fmyf3f4plbhvpxpyhzw32pzwl0hvwswzrc2823xl6vx";
+    sha256 = "0s8v918n6xn44r2mrq5hqbf0znpz64clq7a1jakkgz9py8bi6vnn";
   };
 
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [ requests netifaces ];
 
   doCheck = !isPy27;
   checkInputs = [ pytest testtools requests-mock ];


### PR DESCRIPTION
###### Motivation for this change

Update to latest stable, in attempt to fix `denonavr` integration in home-assistant `0.112.x`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
