### PR TITLE
gimp: Fix plug-in interpreter paths

### DIFF
--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -28,9 +28,10 @@
 , ghostscript
 , aalib
 , shared-mime-info
-, python2Packages
+, python2
 , libexif
 , gettext
+, makeWrapper
 , xorg
 , glib-networking
 , libmypaint
@@ -47,7 +48,7 @@
 }:
 
 let
-  inherit (python2Packages) pygtk wrapPython python;
+  python = python2.withPackages (pp: [ pp.pygtk ]);
 in stdenv.mkDerivation rec {
   pname = "gimp";
   version = "2.10.20";
@@ -63,7 +64,7 @@ in stdenv.mkDerivation rec {
     pkgconfig
     intltool
     gettext
-    wrapPython
+    makeWrapper
   ];
 
   buildInputs = [
@@ -97,7 +98,6 @@ in stdenv.mkDerivation rec {
     libwebp
     libheif
     python
-    pygtk
     libexif
     xorg.libXpm
     glib-networking
@@ -115,8 +115,6 @@ in stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     gegl
   ];
-
-  pythonPath = [ pygtk ];
 
   # Check if librsvg was built with --disable-pixbuf-loader.
   PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_MODULEDIR = "${librsvg}/${gdk-pixbuf.moduleDir}";
@@ -136,9 +134,7 @@ in stdenv.mkDerivation rec {
   ];
 
   postFixup = ''
-    wrapPythonProgramsIn $out/lib/gimp/${passthru.majorVersion}/plug-ins/
     wrapProgram $out/bin/gimp-${lib.versions.majorMinor version} \
-      --prefix PYTHONPATH : "$PYTHONPATH" \
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
   '';
 

--- a/pkgs/applications/graphics/gimp/hardcode-plugin-interpreters.patch
+++ b/pkgs/applications/graphics/gimp/hardcode-plugin-interpreters.patch
@@ -1,0 +1,11 @@
+--- a/plug-ins/pygimp/Makefile.am
++++ b/plug-ins/pygimp/Makefile.am
+@@ -157,7 +157,7 @@ install-interp-file:
+ 	echo 'python=$(PYBIN_PATH)' > '$(DESTDIR)$(pyinterpfile)'
+ 	echo 'python2=$(PYBIN_PATH)' >> '$(DESTDIR)$(pyinterpfile)'
+ 	echo '/usr/bin/python=$(PYBIN_PATH)' >> '$(DESTDIR)$(pyinterpfile)'
+-	echo ":Python:E::py::`basename $(PYTHON)`:" >> '$(DESTDIR)$(pyinterpfile)'
++	echo ":Python:E::py::$(PYTHON):" >> '$(DESTDIR)$(pyinterpfile)'
+ 
+ install-data-local: install-env-file install-interp-file
+ 


### PR DESCRIPTION
###### Motivation for this change
See https://github.com/NixOS/nixpkgs/issues/60937#issuecomment-653652093 and https://github.com/NixOS/nixpkgs/issues/87883

I can confirm that the warnings are no longer shown and _Filter_ → _Enhance_ → _Heal selection_ opens the dialogue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @jluttine, @rkoe, @shirona