### PR TITLE
chocolate-doom: fixed CVE-2020-14983

### DIFF
--- a/pkgs/games/chocolate-doom/default.nix
+++ b/pkgs/games/chocolate-doom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, autoreconfHook, pkgconfig, SDL2, SDL2_mixer, SDL2_net, fetchFromGitHub }:
+{ stdenv, autoreconfHook, pkgconfig, SDL2, SDL2_mixer, SDL2_net, fetchFromGitHub, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "chocolate-doom";
@@ -11,12 +11,25 @@ stdenv.mkDerivation rec {
     sha256 = "0ajzb767wyj8vzhjpsmgslw42b0155ji4alk26shxl7k5ijbzn0j";
   };
 
+  patches = [
+    # Fixes CVE-2020-14983
+    ( fetchpatch {
+      url = "https://github.com/chocolate-doom/chocolate-doom/commit/f1a8d991aa8a14afcb605cf2f65cd15fda204c56.diff";
+      sha256 = "1zj8mh25dnln81rnwag7xp3wc10i8qx0pvg9v2li8gqczlkb91bi";
+    } )
+    ( fetchpatch {
+      url = "https://github.com/chocolate-doom/chocolate-doom/commit/54fb12eeaa7d527defbe65e7e00e37d5feb7c597.diff";
+      sha256 = "0hl7qjll2ys53q62pmc6mj7bvyz0qjlyddz2lc8l1sm4rcf7abns";
+    } )
+  ];
+
   postPatch = ''
     sed -e 's#/games#/bin#g' -i src{,/setup}/Makefile.am
   '';
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ SDL2 SDL2_mixer SDL2_net ];
+
   enableParallelBuilding = true;
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Fix [CVE-2020-14983](https://nvd.nist.gov/vuln/detail/CVE-2020-14983)

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
