### PR TITLE
crispy-doom: fixed CVE-2020-14983

### DIFF
--- a/pkgs/games/crispy-doom/default.nix
+++ b/pkgs/games/crispy-doom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, autoreconfHook, pkgconfig, SDL2, SDL2_mixer, SDL2_net, fetchFromGitHub }:
+{ stdenv, autoreconfHook, pkgconfig, SDL2, SDL2_mixer, SDL2_net, fetchFromGitHub, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "crispy-doom";
@@ -10,6 +10,18 @@ stdenv.mkDerivation rec {
     rev = "${pname}-${version}";
     sha256 = "1b6gn0dysv631jynh769whww9xcss1gms78sz3nrn855q1dsvcb4";
   };
+
+  patches = [
+    # Fixes CVE-2020-14983
+    (fetchpatch {
+      url = "https://github.com/chocolate-doom/chocolate-doom/commit/f1a8d991aa8a14afcb605cf2f65cd15fda204c56.diff";
+      sha256 = "1z6pxg9azcqq7g09hjc09d01knd803nhqilkw2kbx8648hil9mgn";
+    })
+    (fetchpatch {
+      url = "https://github.com/chocolate-doom/chocolate-doom/commit/54fb12eeaa7d527defbe65e7e00e37d5feb7c597.diff";
+      sha256 = "0ww21jn02ld73rkp06f7fqy92jqv8c9q4d1mvsryag1gmvy57znj";
+    })
+  ];
 
   postPatch = ''
     sed -e 's#/games#/bin#g' -i src{,/setup}/Makefile.am


### PR DESCRIPTION

###### Motivation for this change

Fix [CVE-2020-14983](https://nvd.nist.gov/vuln/detail/CVE-2020-14983)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
