### PR TITLE
docs: Explain how to set password-less logins.

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -27,6 +27,15 @@ let
   hashedPasswordDescription = ''
     To generate hashed password install <literal>mkpasswd</literal>
     package and run <literal>mkpasswd -m sha-512</literal>.
+
+    For password-less logins without password prompt, use
+    the empty string <literal>""</literal>.
+
+    For logins with a fixed password (including the empty-string password with
+    prompt), use one of the un-hashed password options instead, such as
+    <option>users.users.<name?>.password</option>.
+
+    Such unprotected logins should only be used for e.g. bootable live systems.
   '';
 
   userOpts = { name, config, ... }: {


### PR DESCRIPTION
##### Motivation for this change

This explains the

    # Allow the user to log in as root without a password.
    users.users.root.initialHashedPassword = "";

that the NixOS installer live systems use in `profiles/installation-device.nix`.

###### Things done

- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
