### PR TITLE
[20.03] chocolateDoom: 2.3.0 -> 3.0.1 (CVE-2020-14983)

### DIFF
--- a/pkgs/games/chocolate-doom/default.nix
+++ b/pkgs/games/chocolate-doom/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "chocolate-doom";
-  version = "3.0.0";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "chocolate-doom";
     repo = pname;
     rev = "${pname}-${version}";
-    sha256 = "0ajzb767wyj8vzhjpsmgslw42b0155ji4alk26shxl7k5ijbzn0j";
+    sha256 = "1zlcqhd49c5n8vaahgaqrc2y10z86xng51sbd82xm3rk2dly25jp";
   };
 
   postPatch = ''

--- a/pkgs/games/chocolate-doom/default.nix
+++ b/pkgs/games/chocolate-doom/default.nix
@@ -1,17 +1,22 @@
-{ stdenv, autoreconfHook, pkgconfig, SDL, SDL_mixer, SDL_net, fetchurl }:
+{ stdenv, autoreconfHook, pkgconfig, SDL2, SDL2_mixer, SDL2_net, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "chocolate-doom-2.3.0";
-  src = fetchurl {
-    url = "https://github.com/chocolate-doom/chocolate-doom/archive/${name}.tar.gz";
-    sha256 = "0i57smxmbhxj0wgvxq845ba9zsn5nx5wmzkl71rdchyd4q5jmida";
+  pname = "chocolate-doom";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "chocolate-doom";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "0ajzb767wyj8vzhjpsmgslw42b0155ji4alk26shxl7k5ijbzn0j";
   };
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ SDL SDL_mixer SDL_net ];
-  patchPhase = ''
+
+  postPatch = ''
     sed -e 's#/games#/bin#g' -i src{,/setup}/Makefile.am
   '';
 
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ SDL2 SDL2_mixer SDL2_net ];
   enableParallelBuilding = true;
 
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2020-14983:

https://github.com/chocolate-doom/chocolate-doom/blob/539ef367c9982c5945f8608b63d2236eaecc929a/NEWS.md#301-2020-06-24

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
