### PR TITLE
firefox: support for PKCS#11 modules in wrapper

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -27,6 +27,7 @@ let
     , nameSuffix ? ""
     , icon ? browserName
     , extraNativeMessagingHosts ? []
+    , pkcs11Modules ? []
     , forceWayland ? false
     , useGlvnd ? true
     , cfg ? config.${browserName} or {}
@@ -74,7 +75,8 @@ let
             ++ lib.optionals (cfg.enableQuakeLive or false)
             (with xorg; [ stdenv.cc libX11 libXxf86dga libXxf86vm libXext libXt alsaLib zlib ])
             ++ lib.optional (enableAdobeFlash && (cfg.enableAdobeFlashDRM or false)) hal-flash
-            ++ lib.optional (config.pulseaudio or true) libpulseaudio;
+            ++ lib.optional (config.pulseaudio or true) libpulseaudio
+            ++ pkcs11Modules;
       gtk_modules = [ libcanberra-gtk2 ];
 
     in stdenv.mkDerivation {
@@ -152,6 +154,11 @@ let
         mkdir -p $out/lib/mozilla/native-messaging-hosts
         for ext in ${toString nativeMessagingHosts}; do
             ln -sLt $out/lib/mozilla/native-messaging-hosts $ext/lib/mozilla/native-messaging-hosts/*
+        done
+
+        mkdir -p $out/lib/mozilla/pkcs11-modules
+        for ext in ${toString pkcs11Modules}; do
+            ln -sLt $out/lib/mozilla/pkcs11-modules $ext/lib/mozilla/pkcs11-modules/*
         done
 
         # For manpages, in case the program supplies them

--- a/pkgs/tools/security/eid-mw/default.nix
+++ b/pkgs/tools/security/eid-mw/default.nix
@@ -66,13 +66,6 @@ stdenv.mkDerivation rec {
 
       eid-viewer is also installed.
 
-      **TO FIX:** 
-      The procedure below did not work for me, I had to install the .so directly in firefox as instructed at
-      https://eid.belgium.be/en/log-eid#7507
-      and specify
-      /run/current-system/sw/lib/libbeidpkcs11.so
-      as the path to the module.
-
       This package only installs the libraries. To use eIDs in Firefox or
       Chromium, the eID Belgium add-on must be installed.
       This package only installs the libraries. To use eIDs in NSS-compatible
@@ -83,6 +76,11 @@ stdenv.mkDerivation rec {
       Before uninstalling this package, it is a very good idea to run
         ~$ eid-nssdb [--system] remove
       and remove all ~/.pki and/or /etc/pki directories no longer needed.
+
+      The above procedure doesn't seem to work in Firefox. You can override the
+      firefox wrapper to add this derivation to the PKCS#11 modules, like so:
+
+          firefox.override { pkcs11Modules = [ pkgs.eid-mw ]; }
     '';
     platforms = platforms.linux;
     maintainers = with maintainers; [ bfortz ];


### PR DESCRIPTION
###### Motivation for this change

Configuring the middleware for the Belgian eID in firefox required some manual work, that still left the PKCS#11 in a weird state since (at least on my machines) the firefox extension sends a notification warning about the PKCS#11 module being missing (even though the functionality worked). This adds an extra option similar to `extraNativeMessagingHosts` (added in #31572) that allows configuring PKCS#11 modules in the firefox wrapper. This fixed all papercuts related to the eID middleware (manually adding it is no longer required and there is no longer a notification on startup).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
