### PR TITLE
finalfrontier: init at 0.9.3

### DIFF
--- a/pkgs/applications/science/machine-learning/finalfrontier/default.nix
+++ b/pkgs/applications/science/machine-learning/finalfrontier/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, installShellFiles
+, pkg-config
+, libiconv
+, openssl
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "finalfrontier";
+  version = "0.9.3";
+
+  src = fetchFromGitHub {
+    owner = "finalfusion";
+    repo = pname;
+    rev = version;
+    sha256 = "1mb8m1iabaikjc1kn8n6z3zlp50gxm5dgpfvhh9pc4ys63ymcy09";
+  };
+
+  cargoSha256 = "138dlqjza98x1m6igi4xkyypl0mfplvzkqk63bbna0vkma8y66gw";
+
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+  ];
+
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [
+    libiconv
+    Security
+  ];
+
+  postInstall = ''
+    installManPage man/*.1
+
+    # Install shell completions
+    for shell in bash fish zsh; do
+      $out/bin/finalfrontier completions $shell > finalfrontier.$shell
+    done
+    installShellCompletion finalfrontier.{bash,fish,zsh}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Utility for training word and subword embeddings";
+    homepage = "https://github.com/finalfusion/finalfrontier/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19616,6 +19616,10 @@ in
 
   FIL-plugins = callPackage ../applications/audio/FIL-plugins { };
 
+  finalfrontier = callPackage ../applications/science/machine-learning/finalfrontier {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   flacon = libsForQt5.callPackage ../applications/audio/flacon { };
 
   flexget = callPackage ../applications/networking/flexget { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I was a bit hesitant to submit this, because I am one of the main contributors to this project besides @sebpuetz . But I think this is genuinely useful, since finalfrontier can train many more types of embeddings than fastText or word2vec. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
