### PR TITLE
dockerTools: Support files directly under /nix/store

### DIFF
--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -179,10 +179,11 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         docker.succeed("docker run --rm no-store-paths ls /")
         docker.fail("docker run --rm no-store-paths ls /nix/store")
 
-    with subtest("Ensure buildLayeredImage supports files directly under /nix/store"):
+    with subtest("Ensure buildLayeredImage does not change store path contents."):
         docker.succeed(
             "docker load --input='${pkgs.dockerTools.examples.filesInStore}'",
-            "docker run file-in-store |& grep 'some data'",
+            "docker run --rm file-in-store nix-store --verify --check-contents",
+            "docker run --rm file-in-store |& grep 'some data'",
         )
   '';
 })

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -178,5 +178,11 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         # This check may be loosened to allow an *empty* store rather than *no* store.
         docker.succeed("docker run --rm no-store-paths ls /")
         docker.fail("docker run --rm no-store-paths ls /nix/store")
+
+    with subtest("Ensure buildLayeredImage supports files directly under /nix/store"):
+        docker.succeed(
+            "docker load --input='${pkgs.dockerTools.examples.filesInStore}'",
+            "docker run file-in-store |& grep 'some data'",
+        )
   '';
 })

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -337,12 +337,21 @@ rec {
 
   # 19. Support files in the store on buildLayeredImage
   # See: https://github.com/NixOS/nixpkgs/pull/91084#issuecomment-653496223
-  filesInStore = pkgs.dockerTools.buildLayeredImage {
+  filesInStore = pkgs.dockerTools.buildLayeredImageWithNixDb {
     name = "file-in-store";
     tag = "latest";
-    config.Cmd = [
-      "${pkgs.coreutils}/bin/cat"
-      (pkgs.writeText "somefile" "some data")
+    contents = [
+      pkgs.coreutils
+      pkgs.nix
+      (pkgs.writeScriptBin "myscript" ''
+        #!${pkgs.runtimeShell}
+        cat ${pkgs.writeText "somefile" "some data"}
+      '')
     ];
+    config = {
+      Cmd = [ "myscript" ];
+      # For some reason 'nix-store --verify' requires this environment variable
+      Env = [ "USER=root" ];
+    };
   };
 }

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -335,4 +335,14 @@ rec {
     };
   };
 
+  # 19. Support files in the store on buildLayeredImage
+  # See: https://github.com/NixOS/nixpkgs/pull/91084#issuecomment-653496223
+  filesInStore = pkgs.dockerTools.buildLayeredImage {
+    name = "file-in-store";
+    tag = "latest";
+    config.Cmd = [
+      "${pkgs.coreutils}/bin/cat"
+      (pkgs.writeText "somefile" "some data")
+    ];
+  };
 }

--- a/pkgs/build-support/docker/stream_layered_image.py
+++ b/pkgs/build-support/docker/stream_layered_image.py
@@ -39,6 +39,7 @@ import json
 import hashlib
 import pathlib
 import tarfile
+import itertools
 import threading
 from datetime import datetime
 from collections import namedtuple
@@ -87,10 +88,9 @@ def archive_paths_to(obj, paths, mtime, add_nix, filter=None):
             tar.addfile(apply_filters(dir("/nix/store")))
 
         for path in paths:
-            ti = tar.gettarinfo(os.path.join("/", path))
-            tar.addfile(apply_filters(append_root(ti)))
-
-            for filename in pathlib.Path(path).rglob("*"):
+            path = pathlib.Path(path)
+            files = itertools.chain([path], path.rglob("*"))
+            for filename in sorted(files):
                 ti = append_root(tar.gettarinfo(filename))
 
                 # copy hardlinks as regular files

--- a/pkgs/build-support/docker/stream_layered_image.py
+++ b/pkgs/build-support/docker/stream_layered_image.py
@@ -97,6 +97,7 @@ def archive_paths_to(obj, paths, mtime, add_nix, filter=None):
                 if ti.islnk():
                     ti.type = tarfile.REGTYPE
                     ti.linkname = ""
+                    ti.size = filename.stat().st_size
 
                 ti = apply_filters(ti)
                 if ti.isfile():


### PR DESCRIPTION
###### Motivation for this change

See: https://github.com/NixOS/nixpkgs/pull/91084#issuecomment-653496223

Previosly, stream_layered_iamge.py was assuming that all the paths under
/nix/store were directories, which is clearly wrong. This PR adds a test
for that and fixes the issue.

Also makes sure that the files inside a layer added in a sorted order
to make the results more deterministic.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).