### PR TITLE
gst-plugins-base: mark as broken

### DIFF
--- a/pkgs/development/libraries/gstreamer/legacy/gst-plugins-base/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-plugins-base/default.nix
@@ -56,5 +56,7 @@ stdenv.mkDerivation rec {
     license     = licenses.lgpl2Plus;
     maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.unix;
+    # https://github.com/NixOS/nixpkgs/pull/91090#issuecomment-653753497
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -3,8 +3,9 @@
 , libXfixes, libXrandr, libSM, freetype, fontconfig, zlib, libjpeg, libpng
 , libmng, which, libGLU, openssl, dbus, cups, pkgconfig
 , libtiff, glib, icu, libmysqlclient, postgresql, sqlite, perl, coreutils, libXi
-, buildMultimedia ? stdenv.isLinux, alsaLib, gstreamer, gst-plugins-base
-, buildWebkit ? (stdenv.isLinux || stdenv.isDarwin)
+, buildMultimedia ? false # ancient gstreamer is broken
+, alsaLib, gstreamer, gst-plugins-base
+, buildWebkit ? false
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
 , flashplayerFix ? false, gdk-pixbuf
 , gtkStyle ? stdenv.hostPlatform == stdenv.buildPlatform, gtk2

--- a/pkgs/development/libraries/wxwidgets/3.0/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchurl, pkgconfig
 , libXinerama, libSM, libXxf86vm
 , gtk2, GConf ? null, gtk3
-, xorgproto, gstreamer, gst-plugins-base, setfile
+, xorgproto, gst_all_1, setfile
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
 , withMesa ? libGLSupported
 , libGLU ? null, libGL ? null
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    libXinerama libSM libXxf86vm xorgproto gstreamer gst-plugins-base
+    libXinerama libSM libXxf86vm xorgproto gst_all_1.gstreamer gst_all_1.gst-plugins-base
   ] ++ optionals withGtk2 [ gtk2 GConf ]
     ++ optional (!withGtk2) gtk3
     ++ optional withMesa libGLU

--- a/pkgs/development/libraries/wxwidgets/3.1/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.1/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchurl, pkgconfig
 , libXinerama, libSM, libXxf86vm
 , gtk2, GConf ? null, gtk3
-, xorgproto, gstreamer, gst-plugins-base, setfile
+, xorgproto, gst_all_1, setfile
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
 , withMesa ? libGLSupported, libGLU ? null, libGL ? null
 , compat28 ? false, compat30 ? true, unicode ? true
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    libXinerama libSM libXxf86vm xorgproto gstreamer gst-plugins-base
+    libXinerama libSM libXxf86vm xorgproto gst_all_1.gstreamer gst_all_1.gst-plugins-base
   ] ++ optionals withGtk2 [ gtk2 GConf ]
     ++ optional (!withGtk2) gtk3
     ++ optional withMesa libGLU


### PR DESCRIPTION
This will disable many reverse dependencies. If you need your program to work
you will need to migrate it to the newer gstreamer package.
https://github.com/NixOS/nixpkgs/issues/39975

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
