### PR TITLE
[20.03] mattermost-desktop: 4.3.1 -> 4.5.0 (Multiple CVEs)

### DIFF
--- a/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
@@ -43,18 +43,18 @@ let
 in
   stdenv.mkDerivation rec {
     pname = "mattermost-desktop";
-    version = "4.3.1";
+    version = "4.5.0";
 
     src =
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-x64.tar.gz";
-          sha256 = "076nv5h6xscbw1987az00x493qhqgrli87gnn57zbvz0acgvlhfv";
+          sha256 = "1p44vxs7i9f15h4xjyr99g8x73qygv909a32lfkqip1fh8lk7sf4";
         }
       else if stdenv.hostPlatform.system == "i686-linux" then
         fetchurl {
           url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-ia32.tar.gz";
-          sha256 = "19ps9g8j6kp4haj6r3yfy4ma2wm6isq5fa8zlcz6g042ajkqq0ij";
+          sha256 = "03pn853z2famqxcsrwayqb94pzghlpfb0qs2nfi8mc5zzsgcic7z";
         }
       else
         throw "Mattermost-Desktop is not currently supported on ${stdenv.hostPlatform.system}";


### PR DESCRIPTION
###### Motivation for this change

(cherry picked from commit a2cdd1464b72082c45277c9d9f502c684668f510)

I have checked only the 64-bit version here, too, it appeared to be working properly.

Closes #92023.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
