### PR TITLE
sponsorblock-mpv-script: init at 2020-06-21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6984,6 +6984,16 @@
     githubId = 132835;
     name = "Samuel Dionne-Riel";
   };
+  samuelgrf = {
+    name = "Samuel Gräfenstein";
+    email = "git@samuelgrf.com";
+    github = "samuelgrf";
+    githubId = 67663538;
+    keys = [{
+      longkeyid = "rsa4096/0xEF76A063F15C63C8";
+      fingerprint = "FF24 5832 8FAF 4660 18C6  186E EF76 A063 F15C 63C8";
+    }];
+  };
   samuelrivas = {
     email = "samuelrivas@gmail.com";
     github = "samuelrivas";

--- a/pkgs/applications/video/mpv/scripts/sponsorblock.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchgit, python3 }:
+
+stdenv.mkDerivation {
+  pname = "sponsorblock-mpv-script";
+  version = "2020-06-21";
+
+  src = fetchgit {
+    url = "https://github.com/po5/mpv_sponsorblock";
+    rev = "2548e6c5f503f6d5ed38bb27923696abde601d6d";
+    sha256 = "1iiqaka8wabham3aramiriviiisxyvd8raf7lhs84ni8wccccjj9";
+  };
+
+  dontBuild = true;
+
+  buildInputs = [ python3 ];
+
+  # The sponsorblock Python script tries to download the sponsor database into
+  # '~/.local/share/sponsorblock' (set in postPatch), this patch makes it create
+  # the directory before downloading.
+  patches = [ ./sponsorblock.patch ];
+
+  # Load python script from Nix store instead of the home directory.
+  # Save database and user ID in "~/.local/share/sponsorblock".
+  postPatch = ''
+    substituteInPlace sponsorblock.lua \
+      --replace 'scripts_dir, "sponsorblock_shared/sponsorblock.py"' \
+        "\"$out/share/mpv/scripts\", \"sponsorblock_shared/sponsorblock.py\"" \
+      --replace 'scripts_dir, "sponsorblock_shared/sponsorblock.txt"' \
+        'os.getenv("HOME"), ".local/share/sponsorblock/sponsorblock.txt"' \
+      --replace 'scripts_dir, "sponsorblock_shared/sponsorblock.db"' \
+        'os.getenv("HOME"), ".local/share/sponsorblock/sponsorblock.db"'
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/mpv/scripts
+    cp -r . $out/share/mpv/scripts
+    rm -f $out/share/mpv/scripts/README.md
+  '';
+
+  # Needed by mpv wrapper
+  passthru.scriptName = "sponsorblock.lua";
+
+  meta = with stdenv.lib; {
+    description = "A fully-featured port of SponsorBlock for mpv";
+    homepage = "https://github.com/po5/mpv_sponsorblock";
+    platforms = platforms.darwin ++ platforms.linux;
+    maintainers = with maintainers; [ samuelgrf ];
+  };
+}

--- a/pkgs/applications/video/mpv/scripts/sponsorblock.patch
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock.patch
@@ -1,0 +1,20 @@
+diff --git a/sponsorblock_shared/sponsorblock.py b/sponsorblock_shared/sponsorblock.py
+index 94de853..0ab27f6 100644
+--- a/sponsorblock_shared/sponsorblock.py
++++ b/sponsorblock_shared/sponsorblock.py
+@@ -6,6 +6,7 @@ import string
+ import json
+ import sys
+ import os
++from pathlib import Path
+ 
+ if sys.argv[1] in ["submit", "stats", "username"]:
+     if not sys.argv[8]:
+@@ -72,6 +73,7 @@ elif sys.argv[1] == "ranges":
+     print(":".join(times))
+ elif sys.argv[1] == "update":
+     try:
++        Path(str(Path.home()) + "/.local/share/sponsorblock").mkdir(parents=True, exist_ok=True)
+         urllib.request.urlretrieve(sys.argv[3] + "/database.db", sys.argv[2] + ".tmp")
+         os.replace(sys.argv[2] + ".tmp", sys.argv[2])
+     except PermissionError:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21185,6 +21185,7 @@ in
     convert = callPackage ../applications/video/mpv/scripts/convert.nix {};
     mpris = callPackage ../applications/video/mpv/scripts/mpris.nix {};
     simple-mpv-webui = callPackage ../applications/video/mpv/scripts/simple-mpv-webui.nix {};
+    sponsorblock = callPackage ../applications/video/mpv/scripts/sponsorblock.nix {};
   };
 
   mrpeach = callPackage ../applications/audio/pd-plugins/mrpeach { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
mpv_sponsorblock is an (or a?) mpv script that automatically skips sponsors on YouTube videos.

###### Things done
Successfully tested that mpv skips sponsors with the script installed.
Rewrote the NixOS wiki entry to use overlays, since packageOverrides are deprecated.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
