### PR TITLE
Compton: Init at 0.1_beta2

### DIFF
--- a/pkgs/tools/X11/compton/default.nix
+++ b/pkgs/tools/X11/compton/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gnumake
+, dbus
+, pkg-config
+, libconfig
+, pcre
+, libdrm
+, xorg
+, libglvnd
+, linuxHeaders
+}:
+stdenv.mkDerivation rec {
+
+  pname = "Compton";
+  version = "0.1_beta2";
+
+  src = fetchFromGitHub {
+    owner = "tryone144";
+    repo = "compton";
+    rev = "v${version}";
+    sha256 = "0v65viilhnd2xgvmdpzc1srxszcg8kj1vhi5gy9292j48w0s2fx1";
+  };
+
+  patches = [ ./dont-build-doc.patch ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "PREFIX ?= /usr" "PREFIX ?= $out"
+    rm -rf man
+  '';
+
+  nativeBuildInputs = [ gnumake pkg-config ];
+  buildInputs = with xorg; map lib.getDev [ libX11 libXcomposite libXdamage libXrender libXext libXrandr libXinerama libconfig dbus libglvnd libdrm pcre ];
+
+  meta = with lib; {
+    description = "Compositor for X11";
+    license = licenses.mit;
+    homepage = "https://github.com/tryone144/compton";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/X11/compton/dont-build-doc.patch
+++ b/pkgs/tools/X11/compton/dont-build-doc.patch
@@ -1,0 +1,62 @@
+diff -ur a/Makefile b/Makefile
+--- a/Makefile	2013-10-21 16:17:01.000000000 +0200
++++ b/Makefile	2020-07-03 21:01:26.684818543 +0200
+@@ -5,7 +5,6 @@
+ 
+ PREFIX ?= /usr
+ BINDIR ?= $(PREFIX)/bin
+-MANDIR ?= $(PREFIX)/share/man/man1
+ APPDIR ?= $(PREFIX)/share/applications
+ 
+ PACKAGES = x11 xcomposite xfixes xdamage xrender xext xrandr
+@@ -102,8 +101,6 @@
+ CFLAGS += -Wall
+ 
+ BINS = compton bin/compton-trans
+-MANPAGES = man/compton.1 man/compton-trans.1
+-MANPAGES_HTML = $(addsuffix .html,$(MANPAGES))
+ 
+ # === Recipes ===
+ .DEFAULT_GOAL := compton
+@@ -117,37 +114,19 @@
+ compton: $(OBJS)
+ 	$(CC) $(CFG) $(CPPFLAGS) $(LDFLAGS) $(CFLAGS) -o $@ $(OBJS) $(LIBS)
+ 
+-man/%.1: man/%.1.asciidoc
+-	a2x --format manpage $<
+-
+-man/%.1.html: man/%.1.asciidoc
+-	asciidoc $<
+-
+-docs: $(MANPAGES) $(MANPAGES_HTML)
+-
+-install: $(BINS) docs
+-	@install -d "$(DESTDIR)$(BINDIR)" "$(DESTDIR)$(MANDIR)" "$(DESTDIR)$(APPDIR)"
++install: $(BINS)
++	@install -d "$(DESTDIR)$(BINDIR)" "$(DESTDIR)$(APPDIR)"
+ 	@install -m755 $(BINS) "$(DESTDIR)$(BINDIR)"/ 
+-	@install -m644 $(MANPAGES) "$(DESTDIR)$(MANDIR)"/
+ 	@install -m644 compton.desktop "$(DESTDIR)$(APPDIR)"/
+-ifneq "$(DOCDIR)" ""
+-	@install -d "$(DESTDIR)$(DOCDIR)"
+-	@install -m644 README.md compton.sample.conf "$(DESTDIR)$(DOCDIR)"/
+-	@install -m755 dbus-examples/cdbus-driver.sh "$(DESTDIR)$(DOCDIR)"/
+-endif
+ 
+ uninstall:
+ 	@rm -f "$(DESTDIR)$(BINDIR)/compton" "$(DESTDIR)$(BINDIR)/compton-trans"
+-	@rm -f $(addprefix "$(DESTDIR)$(MANDIR)"/, compton.1 compton-trans.1)
+ 	@rm -f "$(DESTDIR)$(APPDIR)/compton.desktop"
+-ifneq "$(DOCDIR)" ""
+-	@rm -f $(addprefix "$(DESTDIR)$(DOCDIR)"/, README.md compton.sample.conf cdbus-driver.sh)
+-endif
+ 
+ clean:
+-	@rm -f $(OBJS) compton $(MANPAGES) $(MANPAGES_HTML) .clang_complete
++	@rm -f $(OBJS) compton .clang_complete
+ 
+ version:
+ 	@echo "$(COMPTON_VERSION)"
+ 
+-.PHONY: uninstall clean docs version
++.PHONY: uninstall clean version

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2770,6 +2770,8 @@ in
 
   compass = callPackage ../development/tools/compass { };
 
+  compton = callPackage ../tools/X11/compton { };
+
   conda = callPackage ../tools/package-management/conda { };
 
   convmv = callPackage ../tools/misc/convmv { };


### PR DESCRIPTION
###### Motivation for this change
Needed Compton for a rice.

###### Things done
Packaged Compton 0.1_beta2, couldn't build the doc.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
