### PR TITLE
picoloop: init at 0.77e

### DIFF
--- a/pkgs/applications/audio/picoloop/default.nix
+++ b/pkgs/applications/audio/picoloop/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, libpulseaudio, SDL2, SDL2_image, SDL2_ttf, alsaLib, libjack2 }:
+
+stdenv.mkDerivation rec {
+  pname = "picoloop";
+  version = "0.77e";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "yoyz";
+    rev = "${pname}-${version}";
+    sha256 = "0i8j8rgyha3ara6d4iis3wcimszf2csxdwrm5yq0wyhg74g7cvjd";
+  };
+
+  buildInputs = [
+    libpulseaudio
+    SDL2
+    SDL2.dev
+    SDL2_image
+    SDL2_ttf
+    alsaLib
+    libjack2 
+  ];
+
+  sourceRoot = "source/picoloop";
+
+  makeFlags = [ "-f Makefile.PatternPlayer_debian_RtAudio_sdl20" ];
+
+  NIX_CFLAGS_COMPILE = [ "-I${SDL2.dev}/include/SDL2" ];
+
+  hardeningDisable = [ "format" ];
+
+  patchPhase = ''
+    substituteInPlace SDL_GUI.cpp \
+    --replace "\"font.ttf\"" "\"$out/share/font.ttf\"" \
+    --replace "\"font.bmp\"" "\"$out/share/font.bmp\""
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,share}
+    cp PatternPlayer_debian_RtAudio_sdl20 $out/bin/picoloop
+    cp font.* $out/share
+  '';
+
+  meta = {
+    description = "Picoloop is a synth and a stepsequencer (a clone of the famous nanoloop).";
+    homepage = "https://github.com/yoyz/picoloop";
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/audio/picoloop/default.nix
+++ b/pkgs/applications/audio/picoloop/default.nix
@@ -38,12 +38,13 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/{bin,share}
     cp PatternPlayer_debian_RtAudio_sdl20 $out/bin/picoloop
-    cp font.* $out/share
+    cp {font.*,LICENSE} $out/share
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Picoloop is a synth and a stepsequencer (a clone of the famous nanoloop).";
     homepage = "https://github.com/yoyz/picoloop";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
+    license = licenses.bsd3;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21686,6 +21686,8 @@ in
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };
 
+  picoloop = callPackage ../applications/audio/picoloop { };
+
   pidgin = callPackage ../applications/networking/instant-messengers/pidgin {
     openssl = if config.pidgin.openssl or true then openssl else null;
     gnutls = if config.pidgin.gnutls or false then gnutls else null;


### PR DESCRIPTION
###### Motivation for this change
Picoloop is not yet in nixpkgs

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
