### PR TITLE
python3Packages.aiorun: fix build

### DIFF
--- a/pkgs/development/python-modules/aiorun/default.nix
+++ b/pkgs/development/python-modules/aiorun/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , isPy27
+, pygments
 , pytest
 , pytestcov
 , uvloop
@@ -20,6 +21,10 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "0wcj8prkijb889ic8n6varms7xkwy028hhw0imgkd1i0p64lm3m4";
   };
+
+  propagatedBuildInputs = [
+    pygments
+  ];
 
   checkInputs = [
     pytest


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken when reviewing #91488

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/92273
2 packages built:
python37Packages.aiorun python38Packages.aiorun
```