### PR TITLE
google-music-scripts: fix build

### DIFF
--- a/pkgs/tools/audio/google-music-scripts/default.nix
+++ b/pkgs/tools/audio/google-music-scripts/default.nix
@@ -1,19 +1,36 @@
 { lib, python3 }:
 
-with python3.pkgs;
+let
+  py = python3.override {
+    packageOverrides = self: super: {
+      loguru = super.loguru.overridePythonAttrs (oldAttrs: rec {
+        version = "0.4.0";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "0j47cg3gi8in4z6z4w3by6x02mpkkfl78gr85xjn5rg0nxiz7pfm";
+        };
+      });
+    };
+  };
+
+in
+
+with py.pkgs;
 
 buildPythonApplication rec {
   pname = "google-music-scripts";
-  version = "4.3.0";
+  version = "4.5.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0dykjhqklbpqr1lvls0bgf6xkwvslj37lx4q8522hjbs150pwjmq";
+    sha256 = "0apwgj86whrc077dfymvyb4qwj19bawyrx49g4kg364895v0rbbq";
   };
 
+  # pendulum pinning was to prevent PEP517 from trying to build from source
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "audio-metadata>=0.8,<0.9" "audio-metadata"
+      --replace "tomlkit>=0.5,<0.6" "tomlkit" \
+      --replace "pendulum>=2.0,<=3.0,!=2.0.5,!=2.1.0" "pendulum"
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
noticed it failing when reviewing #91488

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
