### PR TITLE
python3Packages.pipdate: fix dependency management

### DIFF
--- a/pkgs/development/python-modules/pipdate/default.nix
+++ b/pkgs/development/python-modules/pipdate/default.nix
@@ -1,8 +1,10 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , isPy27
 , appdirs
+, importlib-metadata
 , requests
 , pytest
 }:
@@ -20,7 +22,15 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     appdirs
     requests
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
   ];
+
+  # can be removed when https://github.com/nschloe/pipdate/pull/41 gets merged
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "importlib_metadata" "importlib_metadata; python_version < \"3.8\""
+  '';
 
   checkInputs = [
     pytest


### PR DESCRIPTION
###### Motivation for this change
fix usage of "importlib_metadata"

upstream PR: https://github.com/nschloe/pipdate/pull/41

used `substituteInPlace` to prevent breakign the build when it does get updated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
