### PR TITLE
python2Packages.prawcore: disable on python2

### DIFF
--- a/pkgs/development/python-modules/prawcore/default.nix
+++ b/pkgs/development/python-modules/prawcore/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, isPy27
 , requests
 , testfixtures, mock, requests_toolbelt
 , betamax, betamax-serializers, betamax-matchers, pytest
@@ -7,6 +7,7 @@
 buildPythonPackage rec {
   pname = "prawcore";
   version = "1.4.0";
+  disabled = isPy27; # see https://github.com/praw-dev/prawcore/pull/101
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change
no longer compatible with python2's urllib

```
  prawcore/exceptions.py:2: in <module>
      from urllib.parse import urlparse
  E   ImportError: No module named parse
  builder for '/nix/store/3l1rqygq58hbwyzn6fqx8x4djbmzgggh-python2.7-prawcore-1.4.0.drv' failed with exit code
```

upstream PR: https://github.com/praw-dev/prawcore/pull/101
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
$ nix-env -f /home/jon/.cache/nixpkgs-review/pr-92279/nixpkgs -qaP --xml --out-path --show-trace --meta
nix-b	2 packages removed:
python2.7-praw (†6.3.1) python2.7-prawcore (†1.4.0)

Nothing changed
https://github.com/NixOS/nixpkgs/pull/92279
$ nix-shell /home/jon/.cache/nixpkgs-review/pr-92279/shell.nix
```