### PR TITLE
python3Packages.zope_contenttype: fix build

### DIFF
--- a/pkgs/development/python-modules/zope_contenttype/default.nix
+++ b/pkgs/development/python-modules/zope_contenttype/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, zope_testrunner
 }:
 
 buildPythonPackage rec {
@@ -12,12 +13,12 @@ buildPythonPackage rec {
     sha256 = "c12d929c67ab3eaef9b8a7fba3d19cce8500c8fd25afed8058c8e15f324cbd5b";
   };
 
+  checkInputs = [ zope_testrunner ];
+
   meta = with stdenv.lib; {
     homepage = "https://github.com/zopefoundation/zope.contenttype";
     description = "A utility module for content-type (MIME type) handling";
     license = licenses.zpl20;
     maintainers = with maintainers; [ goibhniu ];
-    broken = true;
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change
saw it was broken during a review

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/92280
3 packages built:
python27Packages.zope_contenttype python37Packages.zope_contenttype python38Packages.zope_contenttype
```