### PR TITLE
timeular: init at 3.4.1

### DIFF
--- a/pkgs/applications/office/timeular/default.nix
+++ b/pkgs/applications/office/timeular/default.nix
@@ -1,0 +1,45 @@
+{
+  stdenv,
+  fetchurl,
+  appimageTools,
+  libsecret
+}:
+
+let
+  version = "3.4.1";
+  pname = "timeular";
+  name = "${pname}-${version}";
+  src = fetchurl {
+    url = "https://s3.amazonaws.com/timeular-desktop-packages/linux/production/Timeular-${version}.AppImage";
+    sha256 = "1s5jjdl1nzq9yd582lqs904yl10mp0s25897zmifmcbw1vz38bar";
+  };
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+in appimageTools.wrapType2 rec {
+  inherit name src;
+
+  extraPkgs = pkgs: with pkgs; [
+    libsecret
+  ];
+
+  extraInstallCommands = ''
+    mv $out/bin/{${name},${pname}}
+    install -m 444 -D ${appimageContents}/timeular.desktop $out/share/applications/timeular.desktop
+    install -m 444 -D ${appimageContents}/timeular.png $out/share/icons/hicolor/512x512/apps/timeular.png
+    substituteInPlace $out/share/applications/timeular.desktop --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Timetracking by flipping 8-sided dice";
+    longDescription = ''
+      The Timeular Tracker is an 8-sided dice that sits on your desk.
+      Assign an activity to each side and flip to start tracking your time.
+      The desktop app tell you where every minute of your day is spent.
+    '';
+    homepage = https://timeular.com;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ ktor ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26444,6 +26444,8 @@ in
 
   tilt = callPackage ../applications/networking/cluster/tilt {};
 
+  timeular = callPackage ../applications/office/timeular {};
+
   tetex = callPackage ../tools/typesetting/tex/tetex { libpng = libpng12; };
 
   tewi-font = callPackage ../data/fonts/tewi


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I do have the Timeular dice but up until now I've used third party OSS cli software to send my worklogs. Shout out to 
Kris Buist, author of https://github.com/krisbuist/timeular-zei-linux, you've enabled the ZEI dice for me on NixOS for two years already!! 

I've done all post-editing of timetracks on their Android app that's a little laggy.

Since Timeular has released AppImage version of their desktop app recently I've decided to give it a try. It works flawlessy, is snappy, has nice GUI and connects with the dice without a problem on NixOS. The package could be improved. It doesn't generate `.desktop` file and could probably use appImageTool instead of appimage-run but it works and user does not need to prepare it's own appimage-run overlay with libsecret.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
