### PR TITLE
libwebsockets: Change default CMake flags for package

### DIFF
--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -16,7 +16,12 @@ let
 
     nativeBuildInputs = [ cmake ];
 
-    cmakeFlags = [ "-DLWS_WITH_PLUGINS=ON" ];
+    cmakeFlags = [
+      "-DLWS_WITH_PLUGINS=ON"
+      "-DLWS_WITH_IPV6=ON"
+      "-DLWS_WITH_SOCKS5=ON"
+    ];
+
     NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isGNU "-Wno-error=unused-but-set-variable";
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

This PR adds some configuration options to the libwebsockets package.

* `withPlugins` :: Plugin support, this was already present but used to be non-configurable
* `withIPv6` :: IPv6 support
* `withSocks5` :: Socks5 support

Libwebsockets has numerous other configuration options which can be found [here](https://github.com/warmcat/libwebsockets/blob/master/CMakeLists.txt#L83).
I'm not quite sure if it makes sense to support all of them in nixpkgs, but I would of course be willing to add them.

###### Motivation for this change

This is a prerequisite to #91549, as cloud support for netdata requires a libwebsockets build with non-default options.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
