### PR TITLE
jsoncpp: fix generated pkg-config file

### DIFF
--- a/pkgs/development/libraries/jsoncpp/default.nix
+++ b/pkgs/development/libraries/jsoncpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, python, fetchpatch }:
+{ stdenv, fetchFromGitHub, cmake, python, validatePkgConfig, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "jsoncpp";
@@ -28,10 +28,16 @@ stdenv.mkDerivation rec {
     export LD_LIBRARY_PATH="`pwd`/src/lib_json''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
   '';
 
-  nativeBuildInputs = [ cmake python ];
+  nativeBuildInputs = [ cmake python validatePkgConfig ];
 
-  # fix inverted sense in isAnyCharRequiredQuoting on arm. See: https://github.com/open-source-parsers/jsoncpp/pull/1120
-  patches = stdenv.lib.optionals (stdenv.isAarch64 || stdenv.isAarch32) [
+  patches = [
+    # Fix generation of pkg-config file (https://github.com/open-source-parsers/jsoncpp/pull/1199)
+    (fetchpatch {
+      url = "https://github.com/open-source-parsers/jsoncpp/commit/b05a21342a646a986b11c28ba6b19665756d21d2.patch";
+      sha256 = "0dn4cvvkcp9mnxbzyaqb49z6bv5yqsx1wlf1lyki1n2rni2hn63p";
+    })
+  ] ++ stdenv.lib.optionals (stdenv.isAarch64 || stdenv.isAarch32) [
+    # fix inverted sense in isAnyCharRequiredQuoting on arm. See: https://github.com/open-source-parsers/jsoncpp/pull/1120
     (fetchpatch {
       url = "https://github.com/open-source-parsers/jsoncpp/commit/9093358efae9e5981aa60013487fc7215f040a59.patch";
       sha256 = "1wiqp70sck2md14sfc0zdkblqk9750cl55ykf9d6b9vs1ifzzzq5";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Using jsoncpp's imported CMake targets currently results in the following error:
```
CMake Error in src/CMakeLists.txt:
  Imported target "JSONCPP::JSONCPP" includes non-existent path

    "/nix/store/gg18a1zlj0wkdlx3qv5549vwhyqiidzg-jsoncpp-1.9.2//nix/store/gg18a1zlj0wkdlx3qv5549vwhyqiidzg-jsoncpp-1.9.2/include"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```

This happens because jsoncpp uses the `install(EXPORT ...)` CMake function, which does not work with absolute paths in the `CMAKE_INSTALL_INCLUDEDIR` variable. This PR makes the package use a relative path for `CMAKE_INSTALL_INCLUDEDIR`, which is fine in this case because this package does not use split outputs.

cc @ttuegel @cpages @nand0p 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
