### PR TITLE
ocamlPackages.mirage-crypto: 0.8.0 → 0.8.1, tls: 0.12.2 → 0.12.3

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -1,14 +1,14 @@
-{ lib, fetchurl, buildDunePackage, ounit, cstruct, dune-configurator, pkg-config }:
+{ lib, fetchurl, buildDunePackage, ounit, cstruct, dune-configurator, eqaf, pkg-config }:
 
 buildDunePackage rec {
   minimumOCamlVersion = "4.08";
 
   pname = "mirage-crypto";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-crypto/releases/download/v${version}/mirage-crypto-v${version}.tbz";
-    sha256 = "1wb2923v17z179v866ragil0r601w5b3kvpnbkmkwlijp4i5grih";
+    sha256 = "13qjisijayviw1s77s74f7klkrjj470vhj4b21cpif7jj2i4ljgk";
   };
 
   useDune2 = true;
@@ -17,7 +17,7 @@ buildDunePackage rec {
   checkInputs = [ ounit ];
 
   nativeBuildInputs = [ dune-configurator pkg-config ];
-  propagatedBuildInputs = [ cstruct ];
+  propagatedBuildInputs = [ cstruct eqaf ];
 
   meta = with lib; {
     homepage = "https://github.com/mirage/mirage-crypto";

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -6,12 +6,12 @@
 buildDunePackage rec {
   minimumOCamlVersion = "4.08";
 
-  version = "0.12.2";
+  version = "0.12.3";
   pname = "tls";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-tls/releases/download/v${version}/tls-v${version}.tbz";
-    sha256 = "1wpgs0cd79wl4lnn1i44xjn8prha793nrbyv68zjiqpq3gmpyy3k";
+    sha256 = "1kfkxsy0nkqi0gbsqn1ssh4x0xhy0p07ijclm42806rxlqr3x405";
   };
 
   useDune2 = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New ciphers

* <https://github.com/mirage/mirage-crypto/releases/tag/v0.8.1>
* <https://github.com/mirleft/ocaml-tls/releases/tag/v0.12.3>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
