### PR TITLE
ocamlPackages.ppx_tools: 6.1 → 6.2

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -1,6 +1,11 @@
 { stdenv, fetchFromGitHub, buildDunePackage, ocaml, findlib }:
 
-let param = {
+let param =
+  let v6_2 = {
+    version = "6.2";
+    sha256 = "0qf4fwnn4hhk52kjw9frv21v23azqnn4mjvwf1hs0nxf7q4kacb5";
+  }; in
+{
   "4.02" = {
     version = "5.0+4.02.0";
     sha256 = "16drjk0qafjls8blng69qiv35a84wlafpk16grrg2i3x19p8dlj8"; };
@@ -20,15 +25,10 @@ let param = {
   "4.07" = {
     version = "5.1+4.06.0";
     sha256 = "1ww4cspdpgjjsgiv71s0im5yjkr3544x96wsq1vpdacq7dr7zwiw"; };
-  "4.08" = {
-    version = "5.3+4.08.0";
-    sha256 = "0vdmhs3hpmh5iclx4lzgdpf362m4l35zprxs73r84z1yhr4jcr4m"; };
-  "4.09" = {
-    version = "6.0+4.08.0";
-    sha256 = "056cmdajap8mbb8k0raj0cq0y4jf7pf5x0hlivm92w2v7xxf59ns"; };
-  "4.10" = {
-    version = "6.1+4.10.0";
-    sha256 = "0ccx2g4zpwnv52bbzhgxji1nvzmn80jwiqalwwc4s60i9qg51llw"; };
+  "4.08" = v6_2;
+  "4.09" = v6_2;
+  "4.10" = v6_2;
+  "4.11" = v6_2;
 }.${ocaml.meta.branch};
 in
 


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
