### PR TITLE
roundcube: Added new option `maxAttachmentSize` to configure max attachment size

### DIFF
--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -95,6 +95,16 @@ in
       '';
     };
 
+    maxAttachmentSize = mkOption {
+      type = types.int;
+      default = 18;
+      description = ''
+        The maximum attachment size in MB. Note: Since roundcube only uses 70% of max upload values configured in php
+        30% is added to <xref linkend="maxAttachmentSize"/>.
+      '';
+      apply = configuredMaxAttachmentSize: "${toString (configuredMaxAttachmentSize * 1.3)}M";
+    };
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";
@@ -115,7 +125,7 @@ in
       $config = array();
       $config['db_dsnw'] = 'pgsql://${cfg.database.username}${lib.optionalString (!localDB) ":' . $password . '"}@${if localDB then "unix(/run/postgresql)" else cfg.database.host}/${cfg.database.dbname}';
       $config['log_driver'] = 'syslog';
-      $config['max_message_size'] = '25M';
+      $config['max_message_size'] =  '${cfg.maxAttachmentSize}';
       $config['plugins'] = [${concatMapStringsSep "," (p: "'${p}'") cfg.plugins}];
       $config['des_key'] = file_get_contents('/var/lib/roundcube/des_key');
       $config['mime_types'] = '${pkgs.nginx}/conf/mime.types';
@@ -172,8 +182,8 @@ in
       phpOptions = ''
         error_log = 'stderr'
         log_errors = on
-        post_max_size = 25M
-        upload_max_filesize = 25M
+        post_max_size = ${cfg.maxAttachmentSize}
+        upload_max_filesize = ${cfg.maxAttachmentSize}
       '';
       settings = mapAttrs (name: mkDefault) {
         "listen.owner" = "nginx";

--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -99,8 +99,10 @@ in
       type = types.int;
       default = 18;
       description = ''
-        The maximum attachment size in MB. Note: Since roundcube only uses 70% of max upload values configured in php
-        30% is added to <xref linkend="maxAttachmentSize"/>.
+        The maximum attachment size in MB.
+
+        Note: Since roundcube only uses 70% of max upload values configured in php
+        30% is added automatically to <xref linkend="opt-services.roundcube.maxAttachmentSize"/>.
       '';
       apply = configuredMaxAttachmentSize: "${toString (configuredMaxAttachmentSize * 1.3)}M";
     };


### PR DESCRIPTION
###### Motivation for this change
Previously the attachment size was fixed to 18MB.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 899, done.
remote: Counting objects: 100% (504/504), done.
remote: Compressing objects: 100% (113/113), done.
remote: Total 261 (delta 187), reused 192 (delta 133), pack-reused 0
Receiving objects: 100% (261/261), 46.02 KiB | 184.00 KiB/s, done.
Resolving deltas: 100% (187/187), completed with 95 local objects.
From https://github.com/NixOS/nixpkgs
   cda41cf743f..e0f07f9b8d7  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-a7fd1e090903ae4ebac97d5f9dd7e3d01467bffb-dirty/nixpkgs e0f07f9b8d737eff6d7f90847f8360afc79fb90a
Preparing worktree (detached HEAD e0f07f9b8d7)
Updating files: 100% (22040/22040), done.
HEAD is now at e0f07f9b8d7 Merge pull request #63165 from CRTified/module/initrd-ovpn
$ nix-env -f /home/asbachb/.cache/nixpkgs-review/rev-a7fd1e090903ae4ebac97d5f9dd7e3d01467bffb-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
