### PR TITLE
feeds: init at 0.16.1

### DIFF
--- a/pkgs/applications/networking/feedreaders/feeds/default.nix
+++ b/pkgs/applications/networking/feedreaders/feeds/default.nix
@@ -1,0 +1,88 @@
+{ lib
+, callPackage
+, stdenv
+, fetchFromGitLab
+
+, appstream
+, gobject-introspection
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook
+
+, glib
+, gtk3
+, libhandy
+, listparser ? callPackage ./listparser.nix { }
+, webkitgtk
+, python3
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "feeds";
+  version = "0.16.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World";
+    repo = "gfeeds";
+    rev = version;
+    sha256 = "10hq06nx7lcm3dqq34qkxc6k6383mvjs7pxii9y9995d9kk5a49k";
+  };
+
+  format = "other";
+
+  nativeBuildInputs = [
+    appstream
+    glib # for glib-compile-schemas
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libhandy
+    webkitgtk
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    beautifulsoup4
+    dateutil
+    feedparser
+    html5lib
+    listparser
+    lxml
+    pillow
+    pygments
+    pygobject3
+    pyreadability
+    pytz
+    requests
+  ];
+
+  # https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  passthru = {
+    inherit listparser;
+  };
+
+  meta = with lib; {
+    description = "An RSS/Atom feed reader for GNOME";
+    homepage = "https://gitlab.gnome.org/World/gfeeds";
+    license = licenses.gpl3Plus;
+    maintainers = [
+      maintainers.pbogdan
+    ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/feedreaders/feeds/listparser.nix
+++ b/pkgs/applications/networking/feedreaders/feeds/listparser.nix
@@ -1,0 +1,31 @@
+{ lib
+, python3
+}:
+python3.pkgs.buildPythonPackage rec {
+  pname = "listparser";
+  version = "0.18";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "0hdqs1mmayw1r8yla43hgb4d9y3zqs5483vgf8j9ygczkd2wrq2b";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    requests
+    six
+  ];
+
+  checkPhase = ''
+    ${python3.interpreter} lptest.py
+  '';
+
+  meta = with lib; {
+    description = "A parser for subscription lists";
+    homepage = "https://github.com/kurtmckee/listparser";
+    license = licenses.lgpl3Plus;
+    maintainers = [
+      maintainers.pbogdan
+    ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3857,6 +3857,8 @@ in
 
   feedreader = callPackage ../applications/networking/feedreaders/feedreader {};
 
+  feeds = callPackage ../applications/networking/feedreaders/feeds {};
+
   fend = callPackage ../tools/misc/fend { };
 
   ferm = callPackage ../tools/networking/ferm { };


### PR DESCRIPTION
###### Motivation for this change

Add (g)feeds - an RSS/Atom feed reader for GNOME. Closes #91370.

###### Things done

I'm not familiar with Python / meson packaging so any feedback would be appreciated. The expression is largely based on the lollypop package.

Also one thing to note - I'm not sure what the package should be called gfeeds or just feeds. The executable is named gfeeds so is the upstream repo while the included desktop file names it as feeds and the package seems to be in a transition period.

I also picked a commit that was most recent version of master at the time I wrote the expression. The most recent tagged release had trouble parsing some of my feeds which was fixed on master so I used that instead try to hunt down the relevant patches to apply on top of a tagged release.

/cc @MetaDark who expressed interest in the package
/cc @jtojnar @worldofpeace as resident GNOME experts

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
