### PR TITLE
Update percona tools

### DIFF
--- a/pkgs/development/perl-modules/Percona-Toolkit/default.nix
+++ b/pkgs/development/perl-modules/Percona-Toolkit/default.nix
@@ -1,24 +1,32 @@
-{ lib, fetchFromGitHub, buildPerlPackage, DBDmysql, DBI, IOSocketSSL, TermReadKey, shortenPerlShebang }:
+{ stdenv, fetchFromGitHub, buildPerlPackage, shortenPerlShebang
+, DBDmysql, DBI, IOSocketSSL, TermReadKey
+}:
 
-buildPerlPackage {
+buildPerlPackage rec {
   pname = "Percona-Toolkit";
-  version = "3.0.12";
+  version = "3.2.0";
+
   src = fetchFromGitHub {
     owner = "percona";
     repo = "percona-toolkit";
-    rev = "3.0.12";
-    sha256 = "0xk4h4dzl80kf97lbx0nznx9ajrb6kkg7k3iwca3rj6f3rqggv9y";
+    rev = "v${version}";
+    sha256 = "084ldpskvlfm32lfss5qqzm5y9b8hf029aa4i5pcnzgb53xaxkqx";
   };
+
   outputs = [ "out" ];
+
   nativeBuildInputs = [ shortenPerlShebang ];
+
   buildInputs = [ DBDmysql DBI IOSocketSSL TermReadKey ];
+
   postInstall = ''
     shortenPerlShebang $(grep -l "/bin/env perl" $out/bin/*)
   '';
-  meta = {
+
+  meta = with stdenv.lib; {
     description = ''Collection of advanced command-line tools to perform a variety of MySQL and system tasks.'';
-    homepage = "http://www.percona.com/software/percona-toolkit";
-    license = with lib.licenses; [ gpl2 ];
-    maintainers = with lib.maintainers; [ izorkin ];
+    homepage = "https://www.percona.com/software/database-tools/percona-toolkit";
+    license = with licenses; [ gpl2 ];
+    maintainers = with maintainers; [ izorkin ];
   };
 }

--- a/pkgs/tools/backup/percona-xtrabackup/2_4.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/2_4.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... } @ args:
+
+callPackage ./generic.nix (args // {
+  version = "2.4.20";
+  sha256 = "0awdpkcgvx2aq7pwxy8jyzkin6cyrrh3d576x9ldm851kis9n5ii";
+})

--- a/pkgs/tools/backup/percona-xtrabackup/8_0.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/8_0.nix
@@ -1,0 +1,14 @@
+{ callPackage, ... } @ args:
+
+callPackage ./generic.nix (args // {
+  version = "8.0.13";
+  sha256 = "0cj0fnjimv22ykfl0yk6w29wcjvqp8y8j2g1c6gcml65qazrswyr";
+
+  extraPatches = [
+    ./../../../servers/sql/mysql/abi-check.patch
+  ];
+
+  extraPostInstall = ''
+    rm -r "$out"/docs
+  '';
+})

--- a/pkgs/tools/backup/percona-xtrabackup/generic.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/generic.nix
@@ -2,17 +2,18 @@
 , curl, cyrus_sasl, libaio, libedit, libev, libevent, libgcrypt, libgpgerror, lz4
 , ncurses, numactl, openssl, protobuf, valgrind, xxd, zlib
 , perlPackages
+, version, sha256, extraPatches ? [], extraPostInstall ? "", ...
 }:
 
 stdenv.mkDerivation rec {
   pname = "percona-xtrabackup";
-  version = "2.4.20";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "percona";
     repo = "percona-xtrabackup";
     rev = "${pname}-${version}";
-    sha256 = "0awdpkcgvx2aq7pwxy8jyzkin6cyrrh3d576x9ldm851kis9n5ii";
+    inherit sha256;
   };
 
   nativeBuildInputs = [ bison boost cmake makeWrapper pkgconfig ];
@@ -21,6 +22,8 @@ stdenv.mkDerivation rec {
     curl cyrus_sasl libaio libedit libev libevent libgcrypt libgpgerror lz4
     ncurses numactl openssl protobuf valgrind xxd zlib
   ] ++ (with perlPackages; [ perl DBI DBDmysql ]);
+
+  patches = extraPatches;
 
   cmakeFlags = [
     "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
@@ -43,7 +46,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram "$out"/bin/xtrabackup --prefix PERL5LIB : $PERL5LIB
     rm -r "$out"/lib/plugin/debug
-  '';
+  '' + extraPostInstall;
 
   meta = with stdenv.lib; {
     description = "Non-blocking backup tool for MySQL";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5902,8 +5902,12 @@ in
 
   perceptualdiff = callPackage ../tools/graphics/perceptualdiff { };
 
-  percona-xtrabackup = callPackage ../tools/backup/percona-xtrabackup {
+  percona-xtrabackup = percona-xtrabackup_8_0;
+  percona-xtrabackup_2_4 = callPackage ../tools/backup/percona-xtrabackup/2_4.nix {
     boost = boost159;
+  };
+  percona-xtrabackup_8_0 = callPackage ../tools/backup/percona-xtrabackup/8_0.nix {
+    boost = boost170;
   };
 
   pick = callPackage ../tools/misc/pick { };


### PR DESCRIPTION
###### Motivation for this change
Update percona tools:
- percona toolkit update to 3.2.0
- percona-xtrabackup to 2.4.20
- add percona-xtrabackup 8.0.13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
