### PR TITLE
licenses: Make single-version-only GPL explicit

### DIFF
--- a/doc/stdenv/meta.xml
+++ b/doc/stdenv/meta.xml
@@ -155,17 +155,17 @@ hello-2.3  A program that produces a familiar, friendly greeting
       <itemizedlist>
        <listitem>
         <para>
-         Single license referenced by attribute (preferred) <literal>stdenv.lib.licenses.gpl3</literal>.
+         Single license referenced by attribute (preferred) <literal>stdenv.lib.licenses.gpl3Only</literal>.
         </para>
        </listitem>
        <listitem>
         <para>
-         Single license referenced by its attribute shortName (frowned upon) <literal>"gpl3"</literal>.
+         Single license referenced by its attribute shortName (frowned upon) <literal>"gpl3Only"</literal>.
         </para>
        </listitem>
        <listitem>
         <para>
-         Single license referenced by its attribute spdxId (frowned upon) <literal>"GPL-3.0"</literal>.
+         Single license referenced by its attribute spdxId (frowned upon) <literal>"GPL-3.0-only"</literal>.
         </para>
        </listitem>
        <listitem>

--- a/doc/using/configuration.xml
+++ b/doc/using/configuration.xml
@@ -162,10 +162,10 @@
 </programlisting>
     </para>
     <para>
-     The following example configuration blacklists the <literal>gpl3</literal> and <literal>agpl3</literal> licenses:
+     The following example configuration blacklists the <literal>gpl3Only</literal> and <literal>agpl3Only</literal> licenses:
 <programlisting>
 {
-  blacklistedLicenses = with stdenv.lib.licenses; [ agpl3 gpl3 ];
+  blacklistedLicenses = with stdenv.lib.licenses; [ agpl3Only gpl3Only ];
 }
 </programlisting>
     </para>

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -28,7 +28,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "Academic Free License v3.0";
   };
 
-  agpl3 = spdx {
+  agpl3Only = spdx {
     spdxId = "AGPL-3.0-only";
     fullName = "GNU Affero General Public License v3.0 only";
   };
@@ -281,12 +281,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "European Union Public License 1.2";
   };
 
-  fdl11 = spdx {
+  fdl11Only = spdx {
     spdxId = "GFDL-1.1-only";
     fullName = "GNU Free Documentation License v1.1 only";
   };
 
-  fdl12 = spdx {
+  fdl12Only = spdx {
     spdxId = "GFDL-1.2-only";
     fullName = "GNU Free Documentation License v1.2 only";
   };
@@ -296,7 +296,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "GNU Free Documentation License v1.2 or later";
   };
 
-  fdl13 = spdx {
+  fdl13Only = spdx {
     spdxId = "GFDL-1.3-only";
     fullName = "GNU Free Documentation License v1.3 only";
   };
@@ -327,7 +327,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     free = false;
   };
 
-  gpl1 = spdx {
+  gpl1Only = spdx {
     spdxId = "GPL-1.0-only";
     fullName = "GNU General Public License v1.0 only";
   };
@@ -337,7 +337,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "GNU General Public License v1.0 or later";
   };
 
-  gpl2 = spdx {
+  gpl2Only = spdx {
     spdxId = "GPL-2.0-only";
     fullName = "GNU General Public License v2.0 only";
   };
@@ -362,7 +362,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "GNU General Public License v2.0 or later";
   };
 
-  gpl3 = spdx {
+  gpl3Only = spdx {
     spdxId = "GPL-3.0-only";
     fullName = "GNU General Public License v3.0 only";
   };
@@ -437,7 +437,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "JasPer License";
   };
 
-  lgpl2 = spdx {
+  lgpl2Only = spdx {
     spdxId = "LGPL-2.0-only";
     fullName = "GNU Library General Public License v2 only";
   };
@@ -447,7 +447,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "GNU Library General Public License v2 or later";
   };
 
-  lgpl21 = spdx {
+  lgpl21Only = spdx {
     spdxId = "LGPL-2.1-only";
     fullName = "GNU Lesser General Public License v2.1 only";
   };
@@ -457,7 +457,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "GNU Lesser General Public License v2.1 or later";
   };
 
-  lgpl3 = spdx {
+  lgpl3Only = spdx {
     spdxId = "LGPL-3.0-only";
     fullName = "GNU Lesser General Public License v3.0 only";
   };
@@ -782,4 +782,16 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     spdxId = "ZPL-2.1";
     fullName = "Zope Public License 2.1";
   };
+} // {
+  # TODO: remove legacy aliases
+  agpl3 = lib.licenses.agpl3Only;
+  fdl11 = lib.licenses.fdl11Only;
+  fdl12 = lib.licenses.fdl12Only;
+  fdl13 = lib.licenses.fdl13Only;
+  gpl1 = lib.licenses.gpl1Only;
+  gpl2 = lib.licenses.gpl2Only;
+  gpl3 = lib.licenses.gpl3Only;
+  lgpl2 = lib.licenses.lgpl2Only;
+  lgpl21 = lib.licenses.lgpl21Only;
+  lgpl3 = lib.licenses.lgpl3Only;
 }


### PR DESCRIPTION
###### Motivation for this change
I commonly see people use the former when they should use the latter.

Would be also in line with the SPDX change https://gnu.org/licenses/identify-licenses-clearly.html

Still need to rename the licenses at the point of use.