### PR TITLE
nixos/manual: Fix invalid link reference in release notes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -684,7 +684,7 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
    </listitem>
    <listitem>
     <para>
-     The <link linkend="opt-nix.buildMachine">nix.buildMachine</link> option is now type-checked.
+     The <link linkend="opt-nix.buildMachines">nix.buildMachines</link> option is now type-checked.
      There are no functional changes, however this may require updating some configurations to use correct types for all attributes.
     </para>
    </listitem>


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix NixOS manual build failure introduced by #83104.

<details>
  <summary>vp2rmnc0cagd9g8yz9hw30m78g3q35fb-nixos-manual-combined.drv</summary>

```log
manual-combined.xml:82287: element link: validity error : IDREF attribute linkend references an unknown ID "opt-nix.buildMachine"
 82283       </para>
 82284     </listitem>
 82285     <listitem>
 82286      <para>
 82287       The <link linkend="opt-nix.buildMachine">nix.buildMachine</link> option is now type-checked.
 82288       There are no functional changes, however this may require updating some configurations to use correct types for all attributes.
 82289      </para>

manual-combined.xml fails to validate
```  
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested with nix build -f ./nixos --arg configuration '{ config = { fileSystems."/".fsType = "tmpfs"; boot.loader.systemd-boot.enable = true; };}' system`
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @Valodim @Ericson2314