### PR TITLE
mdcat: 0.19.0 -> 0.20.0

### DIFF
--- a/pkgs/tools/text/mdcat/default.nix
+++ b/pkgs/tools/text/mdcat/default.nix
@@ -2,30 +2,31 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mdcat";
-  version = "0.19.0";
+  version = "0.20.0";
 
   src = fetchFromGitHub {
     owner = "lunaryorn";
     repo = pname;
     rev = "mdcat-${version}";
-    hash = "sha256-/ZhhDiiUc+swXr3IuuQD4YqIIdgh8PeRWm/ko9Lc0rM=";
+    hash = "sha256-1qxz6p7VaJ9eMcLQaTW/M4+Xo0WLihzyEAycbkjjPyA=";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ] ++ stdenv.lib.optional stdenv.isDarwin Security;
 
-  cargoSha256 = "sha256-SGX94XY7e38xySvTO+CDTUBDTfYybPy12iWFoFc2Nto=";
+  cargoSha256 = "sha256-/mAwlxed1MOFUA1jDSrgPzJuURbKzwucBWORVVHlrt8=";
 
   checkInputs = [ ansi2html ];
   checkPhase = ''
     # Skip tests that use the network and that include files.
-    cargo test -- --skip terminal::iterm2 \
-      --skip magic::tests::detect_mimetype_of_svg_image \
-      --skip magic::tests::detect_mimetype_of_png_image \
+    cargo test -- \
       --skip magic::tests::detect_mimetype_of_larger_than_magic_param_bytes_max_length \
       --skip magic::tests::detect_mimetype_of_magic_param_bytes_max_length \
+      --skip magic::tests::detect_mimetype_of_png_image \
+      --skip magic::tests::detect_mimetype_of_svg_image \
       --skip resources::tests::read_url_with_http_url_fails_when_status_404 \
-      --skip resources::tests::read_url_with_http_url_returns_content_when_status_200
+      --skip resources::tests::read_url_with_http_url_returns_content_when_status_200 \
+      --skip iterm2_tests_render_md_samples_images_md
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade to latest version of mdcat.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
