### PR TITLE
vim_configurable: Only run patchelf on gvim if gvim was built

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -1,5 +1,3 @@
-# TODO tidy up eg The patchelf code is patching gvim even if you don't build it..
-# but I have gvim with python support now :) - Marc
 { source ? "default", callPackage, stdenv, ncurses, pkgconfig, gettext
 , writeText, config, glib, gtk2-x11, gtk3-x11, lua, python, perl, tcl, ruby
 , libX11, libXext, libSM, libXpm, libXt, libXaw, libXau, libXmu
@@ -156,7 +154,12 @@ in stdenv.mkDerivation rec {
   '' + stdenv.lib.optionalString stdenv.isLinux ''
     patchelf --set-rpath \
       "$(patchelf --print-rpath $out/bin/vim):${stdenv.lib.makeLibraryPath buildInputs}" \
-      "$out"/bin/{vim,gvim}
+      "$out"/bin/vim
+    if [[ -e "$out"/bin/gvim ]]; then
+      patchelf --set-rpath \
+        "$(patchelf --print-rpath $out/bin/vim):${stdenv.lib.makeLibraryPath buildInputs}" \
+        "$out"/bin/gvim
+    fi
 
     ln -sfn '${nixosRuntimepath}' "$out"/share/vim/vimrc
   '' + stdenv.lib.optionalString wrapPythonDrv ''


### PR DESCRIPTION
###### Motivation for this change

Previously, the vim_configurable derivation ran `patchelf` unconditionally on `$out/bin/vim` and `$out/bin/gvim`. At some point recently, this started to fail when Vim was being built without GUI support (in which case `$out/bin/gvim` does not exist). This PR adds a check so that `patchelf` is not run on `gvim` unless the file actually exists.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
