### PR TITLE
snes9x-gtk: fix GSettings crash when opening file picker

### DIFF
--- a/pkgs/misc/emulators/snes9x-gtk/default.nix
+++ b/pkgs/misc/emulators/snes9x-gtk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig
+{ stdenv, fetchFromGitHub, wrapGAppsHook, meson, ninja, pkgconfig
 , SDL2, zlib, gtk3, libxml2, libXv, epoxy, minizip, pulseaudio, portaudio }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   enableParallelBuilding = true;
-  nativeBuildInputs = [ meson ninja pkgconfig ];
+  nativeBuildInputs = [ meson ninja pkgconfig wrapGAppsHook ];
   buildInputs = [ SDL2 zlib gtk3 libxml2 libXv epoxy minizip pulseaudio portaudio ];
 
   preConfigure = "cd gtk";


### PR DESCRIPTION

###### Motivation for this change
Without this, when pressing the "Open ROM Image" button, the application crashes:
```
(snes9x-gtk:30675): GLib-GIO-ERROR **: 21:05:41.941: No GSettings schemas are installed on the system
zsh: trace trap (core dumped)  snes9x-gtk
```
Issue seems to have gotten introduced with [this commit](https://github.com/NixOS/nixpkgs/commit/d13a19cfbaf43b1ad2fcf835b1a05410c2f98bcb).

This makes it impossible to pick a ROM, so the application is essentially useless. When adding `wrapGAppsHook` back as a `nativeBuildInput`, the issue doesn't seem to occur anymore. Not sure why this was removed in the first place.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
