### PR TITLE
nixos/test-driver: print a traceback when testScript fails

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import traceback
 import unicodedata
 
 CHAR_TO_KEY = {
@@ -892,7 +893,8 @@ def run_tests() -> None:
             try:
                 exec(tests, globals())
             except Exception as e:
-                eprint("error: {}".format(str(e)))
+                print("error: ")
+                traceback.print_exc()
                 sys.exit(1)
     else:
         ptpython.repl.embed(locals(), globals())

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -893,7 +893,7 @@ def run_tests() -> None:
             try:
                 exec(tests, globals())
             except Exception as e:
-                print("error: ")
+                eprint("error: ")
                 traceback.print_exc()
                 sys.exit(1)
     else:


### PR DESCRIPTION
###### Motivation for this change

Python's assertion statement can be used in two ways:
```python
assert condition, "error message"
# or
assert condition
```
In the second case, the exception raised has an empty `str` representation because there is no second parameter (the error message).

This means that when running a test like this:

```nix
import ./src/nixpkgs/nixos/tests/make-test-python.nix ({ ... }:
  {
    testScript = ''
      assert 1 == 2
    '';
  })

```
it will fail with such output:
```
building '/nix/store/ih10jd03m4qh96dyx1vxx9zzb8ivqh53-vm-test-run-unnamed.drv'...
running the VM test script
error:
cleaning up
(0.00 seconds)
builder for '/nix/store/ih10jd03m4qh96dyx1vxx9zzb8ivqh53-vm-test-run-unnamed.drv' failed with exit code 1
```
Note the empty `error:` line.

`assert` statement is frequently used in nixos module tests (a naive grep yields 269 occurences), yet this empty error without a traceback makes them hard to debug. A quick look at a few of the tests tells me that not every assertion uses an error message.

With this change, here is what you get instead:

```
these derivations will be built:
  /nix/store/q0d5n5vfpgfq0f8myp8snp015bps0w6m-vm-test-run-unnamed.drv
building '/nix/store/q0d5n5vfpgfq0f8myp8snp015bps0w6m-vm-test-run-unnamed.drv'...
running the VM test script
error:
Traceback (most recent call last):
  File "/nix/store/llsl3wbxqfbc04aj4wmx9rkg86hywpjj-nixos-test-driver/bin/.nixos-test-driver-wrapped", line 894, in run_tests
    exec(tests, globals())
  File "<string>", line 1, in <module>
  File "<string>", line 1, in <module>
AssertionError
cleaning up
(0.00 seconds)
builder for '/nix/store/q0d5n5vfpgfq0f8myp8snp015bps0w6m-vm-test-run-unnamed.drv' failed with exit code 1
error: build of '/nix/store/q0d5n5vfpgfq0f8myp8snp015bps0w6m-vm-test-run-unnamed.drv' failed
```

I would also change up the `error:` header into something friendlier, i.e. `An error occured in testScript:`, but went conservative for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
