### PR TITLE
_1password: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchzip, autoPatchelfHook, fetchurl, xar, cpio }:
+{ stdenv, fetchzip, fetchurl, autoPatchelfHook, xar, cpio, installShellFiles }:
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "1.1.1";
+  version = "1.2.0";
   src =
     if stdenv.isLinux then fetchzip {
       url = {
@@ -10,14 +10,17 @@ stdenv.mkDerivation rec {
         "x86_64-linux" = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_amd64_v${version}.zip";
       }.${stdenv.hostPlatform.system};
       sha256 = {
-        "i686-linux" = "1andl3ripkcg4jhwdkd4b39c9aaxqpx9wzq21pysn6rlyy4hfcb0";
-        "x86_64-linux" = "0qj5v8psqyp0sra0pvzkwjpm28kx3bgg36y37wklb6zl2ngpxm5g";
+        "i686-linux" = "1fpmglqj7qqaa7k79ngrf16qq6rv4m8b57hzq87fyj22myaxydjy";
+        "x86_64-linux" = "0c0zj3bv0rgdqaanm6gk7fsy5ckj5h8zc5jckrv1nsfqr7lpbydd";
       }.${stdenv.hostPlatform.system};
       stripRoot = false;
     } else fetchurl {
       url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_darwin_amd64_v${version}.pkg";
-      sha256 = "16inwxkrky4xwlr7vara1l8kapdgjg3kfq1l94i5855782hn4ppm";
+      sha256 = "0sc5fi55gcbjmj5cp9clilkdz7c6nzqyyh1fficfafh8il4qvki6";
     };
+
+  nativeBuildInputs = [ installShellFiles ]
+    ++ stdenv.lib.optionals stdenv.isLinux [ autoPatchelfHook ];
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ xar cpio ];
 
@@ -26,13 +29,14 @@ stdenv.mkDerivation rec {
     zcat Payload | cpio -i
   '';
 
-  installPhase = ''
-    install -D op $out/bin/op
-  '';
-
   dontStrip = stdenv.isDarwin;
 
-  nativeBuildInputs = stdenv.lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  installPhase = ''
+    install -D op $out/bin/op
+    $out/bin/op completion bash > op.bash
+    $out/bin/op completion zsh > op.zsh
+    installShellCompletion op.{bash,zsh}
+  '';
 
   doInstallCheck = true;
 
@@ -41,11 +45,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description  = "1Password command-line tool";
-    homepage     = "https://support.1password.com/command-line/";
+    description = "1Password command-line tool";
+    homepage = "https://support.1password.com/command-line/";
     downloadPage = "https://app-updates.agilebits.com/product_history/CLI";
-    maintainers  = with maintainers; [ joelburget marsam ];
-    license      = licenses.unfree;
-    platforms    = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ joelburget marsam ivar ];
+    license = licenses.unfree;
+    platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Another new 1password release. Release notes state that bash and zsh completion is added, though you have to manually enable it as per their help section. (`source <(op completion bash)` for bash, `eval "$(op _completion zsh)"; compdef _op op` for zsh). Not sure if we can automate this.

Added myself as a maintainer as well, as i actively use this application a lot.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
