### PR TITLE
zfs: patch client path used in smb share

### DIFF
--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -74,10 +74,15 @@ let
             "udevadm settle",
             "zpool create rpool /dev/vdb1",
             "zfs create -o mountpoint=legacy rpool/root",
+            # shared datasets cannot have legacy mountpoint
+            "zfs create rpool/shared_smb",
             "mount -t zfs rpool/root /tmp/mnt",
             "udevadm settle",
-            "zfs set sharesmb=on rpool/root",
-            "smbclient -NL localhost",
+            # wait for samba services
+            "systemctl is-system-running --wait",
+            "zfs set sharesmb=on rpool/shared_smb",
+            "zfs share rpool/shared_smb",
+            "smbclient -gNL localhost | grep rpool_shared_smb",
             "umount /tmp/mnt",
             "zpool destroy rpool",
             "udevadm settle",

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -6,7 +6,7 @@
 # Userspace dependencies
 , zlib, libuuid, python3, attr, openssl
 , libtirpc
-, nfs-utils
+, nfs-utils, samba
 , gawk, gnugrep, gnused, systemd
 , smartmontools, enableMail ? false
 , sysstat, pkg-config
@@ -55,6 +55,7 @@ let
           # And if it's enabled by default, only change that if we explicitly disable python to remove python from the closure
           nfs-utils.override (old: { enablePython = old.enablePython or true && enablePython; })
         }/bin/exportfs"
+        substituteInPlace ./lib/libshare/smb.h        --replace "/usr/bin/net"            "${samba}/bin/net"
         substituteInPlace ./config/user-systemd.m4    --replace "/usr/lib/modules-load.d" "$out/etc/modules-load.d"
         substituteInPlace ./config/zfs-build.m4       --replace "\$sysconfdir/init.d"     "$out/etc/init.d" \
                                                       --replace "/etc/default"            "$out/etc/default"


### PR DESCRIPTION
fix zfs smb share integration

```
# zfs-sharesmb.nix

{ pkgs, ... }:

let usersharePath = "/var/lib/samba/usershares";
in {
  services = {
    samba = {
      enable = true;
      extraConfig = ''
        registry shares = yes        
        usershare path = ${usersharePath}
        usershare max shares = 100
        usershare allow guests = yes
        usershare owner only = no
      '';
    };
  };

  systemd.services.samba-smbd.serviceConfig.ExecStartPre =
    "${pkgs.coreutils}/bin/mkdir -m +t -p ${usersharePath}";
}
```

```
# zfs set sharesmb=on tank/smb_share
# smbclient -NL localhost
# net usershare info
```

before:
```
# zfs share tank/smb_share
cannot share tank/smb_share: smb add share failed
```
now works as intended.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
