### PR TITLE
python3Packages.pypubsub: init at 4.0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9043,4 +9043,10 @@
     github = "saulecabrera";
     githubId = 1423601;
   };
+  tfmoraes = {
+    name = "Thiago Franco de Moraes";
+    email = "351108+tfmoraes@users.noreply.github.com";
+    github = "tfmoraes";
+    githubId = 351108;
+  };
 }

--- a/pkgs/development/python-modules/pypubsub/default.nix
+++ b/pkgs/development/python-modules/pypubsub/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27, pytest }:
+
+buildPythonPackage rec {
+  pname = "pypubsub";
+  version = "4.0.3";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "schollii";
+    repo = "pypubsub";
+    rev = "v4.0.3";
+    sha256 = "02j74w28wzmdvxkk8i561ywjgizjifq3hgcl080yj0rvkd3wivlb";
+  };
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    cd tests/suite
+    py.test
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/schollii/pypubsub";
+    description = "Python 3 publish-subcribe library";
+    longDescription = ''
+     Provides a publish-subscribe API to facilitate event-based or
+     message-based  architecture in a single-process application. It is pure
+     Python  and works on Python 3.3+. It is centered on the notion of a topic;
+     senders publish messages of a given topic, and listeners subscribe to
+     messages of a given topic, all inside the same process. The package also
+     supports a variety of advanced features that facilitate debugging and
+     maintaining topics and messages in larger desktop- or server-based
+     applications.
+    '';
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ tfmoraes ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5205,6 +5205,8 @@ in {
 
   pymetar = callPackage ../development/python-modules/pymetar { };
 
+  pypubsub = callPackage ../development/python-modules/pypubsub { };
+
   pysftp = callPackage ../development/python-modules/pysftp { };
 
   soundfile = callPackage ../development/python-modules/soundfile { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add PyPubSub to NixOS. It'll necessary when packagin wxPython 4.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
