### PR TITLE
pythonPackages.tubeup: init at 0.0.19

### DIFF
--- a/pkgs/development/python-modules/tubeup/default.nix
+++ b/pkgs/development/python-modules/tubeup/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, internetarchive
+, fetchPypi
+, youtube-dl
+, docopt
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "tubeup";
+  version = "0.0.19";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6e3ebbf677a43018bfd71070919187bd57120010b0d708c0494c0f17bb72e84e";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "docopt==0.6.2" "docopt"
+  '';
+
+  propagatedBuildInputs = [ internetarchive docopt youtube-dl ];
+
+  pythonImportsCheck = [ "tubeup" ];
+
+  # Tests failing upstream
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Youtube (and other video site) to Internet Archive Uploader";
+    homepage = "https://github.com/bibanon/tubeup";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7206,6 +7206,8 @@ in {
 
   TurboCheetah = callPackage ../development/python-modules/TurboCheetah { };
 
+  tubeup = callPackage ../development/python-modules/tubeup { };
+
   tvdb_api = callPackage ../development/python-modules/tvdb_api { };
 
   tvnamer = callPackage ../development/python-modules/tvnamer { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add https://github.com/bibanon/tubeup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
