### PR TITLE
apachePulsar: 2.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4667,6 +4667,12 @@
     githubId = 10626;
     name = "Andreas Wagner";
   };
+  lperkins = {
+    email = "lucperkins@gmail.com";
+    github = "lucperkins";
+    githubId = 1523104;
+    name = "Luc Perkins";
+  };
   lschuermann = {
     email = "leon.git@is.currently.online";
     github = "lschuermann";

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -345,6 +345,7 @@ in
       zoneminder = 314;
       paperless = 315;
       #mailman = 316;  # removed 2019-08-30
+      apache-pulsar = 317;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -645,6 +646,7 @@ in
       zoneminder = 314;
       paperless = 315;
       #mailman = 316;  # removed 2019-08-30
+      apache-pulsar = 317;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/pkgs/servers/apache-pulsar/default.nix
+++ b/pkgs/servers/apache-pulsar/default.nix
@@ -1,0 +1,32 @@
+{ fetchurl, stdenv, version ? "2.6.0" }:
+
+let
+  versionMap = {
+    "2.6.0" = {
+      sha512 = "6c86a31ef6a9ffac2fb6830026d8d522e561a8cfbd5caed463ed78aa4de98829cf6e35ec7e7f65e99a8f3282d7cbf7a2bbc32a81d6d431e02f8bec445aed9552";
+    };
+  };
+
+  sha512 = versionMap.${version}.sha512;
+in
+  stdenv.mkDerivation {
+    name = "apache-pulsar";
+
+    src = fetchurl {
+      url = "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-${version}/apache-pulsar-${version}-bin.tar.gz";
+      sha512 = sha512;
+    };
+
+    installPhase = ''
+      mkdir -p $out
+      cp -R * $out
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = "https://pulsar.apache.org";
+      description = "An open source distributed pub-sub messaging system";
+      license = licenses.asl20;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ lperkins ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10067,6 +10067,9 @@ in
   apacheKafka_2_3 = callPackage ../servers/apache-kafka { majorVersion = "2.3"; };
   apacheKafka_2_4 = callPackage ../servers/apache-kafka { majorVersion = "2.4"; };
 
+  apachePulsar = apachePulsar_2_6;
+  apachePulsar_2_6 = callPackage ../servers/apache-pulsar { version = "2.6.0"; };
+
   kt = callPackage ../tools/misc/kt {};
 
   argbash = callPackage ../development/tools/misc/argbash {};


### PR DESCRIPTION
###### Motivation for this change

This PR adds initial Nix support for [Apache Pulsar](https://pulsar.apache.org), a widely used messaging system akin to Kafka, RabbitMQ, and related systems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).