### PR TITLE
vkBasalt: init at 0.3.2.2

### DIFF
--- a/pkgs/tools/graphics/vkBasalt/default.nix
+++ b/pkgs/tools/graphics/vkBasalt/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, lib, fetchFromGitHub
+, glslang, meson, ninja, pkg-config
+, libX11
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vkBasalt${lib.optionalString stdenv.is32bit "32"}";
+  version = "0.3.2.2";
+
+  src = fetchFromGitHub {
+    owner = "DadSchoorse";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0xh6y831lf2rfwbpq82nh8ra9a745xrqrp7qd7hczw2pgwaqh44v";
+  };
+
+  # Patch layer library_path to use absolute path to libvkbasalt.so
+  # and rename layer in 32bit package so it can be installed alongside
+  # the 64bit package
+  postPatch = ''
+    substituteInPlace config/vkBasalt.json \
+      --replace libvkbasalt.so "$out/lib${lib.optionalString stdenv.is32bit "32"}/libvkbasalt.so"
+  '' + lib.optionalString stdenv.is32bit ''
+    substituteInPlace config/vkBasalt.json \
+      --replace VK_LAYER_VKBASALT_post_processing \
+                VK_LAYER_VKBASALT_post_processing_32
+  '';
+
+  nativeBuildInputs = [ glslang meson ninja pkg-config ];
+  buildInputs = [ libX11 ];
+
+  # Rename files in 32bit package so it can be installed alongside
+  # the 64bit package
+  postInstall = lib.optionalString stdenv.is32bit ''
+    mv "$out/lib" "$out/lib32"
+    mv "$out/share/vulkan/implicit_layer.d/vkBasalt.json" \
+      "$out/share/vulkan/implicit_layer.d/vkBasalt32.json"
+  '';
+
+  meta = with lib; {
+    description = "A Vulkan post processing layer for Linux";
+    homepage = "https://github.com/DadSchoorse/vkBasalt";
+    license = licenses.zlib;
+    maintainers = with maintainers; [ metadark ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7441,6 +7441,8 @@ in
 
   viu = callPackage ../tools/graphics/viu { };
 
+  vkBasalt = callPackage ../tools/graphics/vkBasalt { };
+
   vnc2flv = callPackage ../tools/video/vnc2flv {};
 
   vncrec = callPackage ../tools/video/vncrec { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #84684

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  No binary files, tested through use of Vulkan game
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Rendering The Legend of Zelda: Breath of the Wild through Cemu with [ASCII shader](https://github.com/crosire/reshade-shaders/blob/master/Shaders/ASCII.fx):
![Screenshot from 2020-07-05 23:46:15](https://user-images.githubusercontent.com/382041/86554000-5f785d00-bf1a-11ea-85d6-09a616856aed.png)

