### PR TITLE
coqPackages.tlc: 20181116 → 20200328

### DIFF
--- a/pkgs/development/coq-modules/tlc/default.nix
+++ b/pkgs/development/coq-modules/tlc/default.nix
@@ -1,13 +1,27 @@
-{ stdenv, fetchurl, coq }:
+{ stdenv, fetchurl, fetchFromGitHub, coq }:
 
-stdenv.mkDerivation rec {
-  version = "20181116";
-  name = "coq${coq.coq-version}-tlc-${version}";
+let params =
+  if stdenv.lib.versionAtLeast coq.coq-version "8.10"
+  then rec {
+    version = "20200328";
+    src = fetchFromGitHub {
+      owner = "charguer";
+      repo = "tlc";
+      rev = version;
+      sha256 = "16vzild9gni8zhgb3qhmka47f8zagdh03k6nssif7drpim8233lx";
+    };
+  } else rec {
+    version = "20181116";
+    src = fetchurl {
+      url = "http://tlc.gforge.inria.fr/releases/tlc-${version}.tar.gz";
+      sha256 = "0iv6f6zmrv2lhq3xq57ipmw856ahsql754776ymv5wjm88ld63nm";
+    };
+  }
+; in
 
-  src = fetchurl {
-    url = "http://tlc.gforge.inria.fr/releases/tlc-${version}.tar.gz";
-    sha256 = "0iv6f6zmrv2lhq3xq57ipmw856ahsql754776ymv5wjm88ld63nm";
-  };
+stdenv.mkDerivation {
+  inherit (params) version src;
+  pname = "coq${coq.coq-version}-tlc";
 
   buildInputs = [ coq ];
 
@@ -22,6 +36,6 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
-    compatibleCoqVersions = stdenv.lib.flip builtins.elem [ "8.6" "8.7" "8.8" "8.9" "8.10" ];
+    compatibleCoqVersions = stdenv.lib.flip builtins.elem [ "8.6" "8.7" "8.8" "8.9" "8.10" "8.11" "8.12" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Compatibility with Coq ≥ 8.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
