### PR TITLE
check-wmiplus: 1.64 -> 1.65

### DIFF
--- a/pkgs/servers/monitoring/plugins/wmiplus/default.nix
+++ b/pkgs/servers/monitoring/plugins/wmiplus/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   pname = "check-wmiplus";
-  version = "1.64";
+  version = "1.65";
 
   # We fetch from github.com instead of the proper upstream as nix-build errors
   # out with 406 when trying to fetch the sources
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "speartail";
     repo = "checkwmiplus";
     rev = "v${version}";
-    sha256 = "1m36rd2wnc5dk4mm9q4ch67w19144dl112p9s6lhc1sh6h25ln6r";
+    sha256 = "1as0iyhy4flpm37mb7lvah7rnd6ax88appjm1icwhy7iq03wi8pl";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
