### PR TITLE
onedrive: 2.4.2 -> 2.4.3

### DIFF
--- a/pkgs/applications/networking/sync/onedrive/default.nix
+++ b/pkgs/applications/networking/sync/onedrive/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "onedrive";
-  version = "2.4.2";
+  version = "2.4.3";
 
   src = fetchFromGitHub {
     owner = "abraunegg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "10s33p1xzq9c5n1bxv9n7n31afxgx9i6c17w0xgxdrma75micm3a";
+    sha256 = "1z5a9rz4g67cb60lvl0iq00s3wh522r74cy35ysz14x47929ziby";
   };
 
   nativeBuildInputs = [ autoreconfHook ldc installShellFiles pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Update


###### Things done

- [x] **Tested using sandboxing** ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] **NixOS**
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested **execution** of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant **documentation** is up to date
- [x] **Fits** [**CONTRIBUTING.md**](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).