### PR TITLE
insync: fix warning due to missing LD_LIBRARY_PATH

### DIFF
--- a/pkgs/applications/networking/insync/default.nix
+++ b/pkgs/applications/networking/insync/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper }:
+{ stdenv, fetchurl, makeWrapper, autoPatchelfHook }:
 
 stdenv.mkDerivation rec {
   pname = "insync";
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
       throw "${pname}-${version} is not supported on ${stdenv.hostPlatform.system}";
 
   buildInputs = [ makeWrapper ];
+
+  nativeBuildInputs = [ autoPatchelfHook ];
 
   postPatch = ''
     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" client/insync-portable


### PR DESCRIPTION
###### Motivation for this change
as reported [here](https://discourse.nixos.org/t/why-need-ld-library-path-for-insync-in-nixpkgs/7996/2), insync have an issue when it can't work without the appropriate LD_LIBRARY_PATH variable.


###### Things done
I just set the LD_LIBRARY_PATH  to the variable. I doesn't display the warning anymore.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
