### PR TITLE
python3Packages.mt-940: disable tests, no longer present

### DIFF
--- a/pkgs/development/python-modules/mt-940/default.nix
+++ b/pkgs/development/python-modules/mt-940/default.nix
@@ -15,9 +15,13 @@ buildPythonPackage rec {
 
   checkInputs = [ pyyaml pytest ];
 
+  # requires tests files that are not present
+  doCheck = false;
   checkPhase = ''
     py.test
   '';
+
+  pythonImportsCheck = [ "mt940" ];
 
   meta = with lib; {
     description = "A library to parse MT940 files and returns smart Python collections for statistics and manipulation";


### PR DESCRIPTION
###### Motivation for this change
noticed it was failing during a review

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
