### PR TITLE
beamerpresenter: init at 0.1.1

### DIFF
--- a/pkgs/applications/office/beamerpresenter/default.nix
+++ b/pkgs/applications/office/beamerpresenter/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, mkDerivation, fetchFromGitHub, makeDesktopItem, installShellFiles,
+  qmake, qtbase, poppler, qtmultimedia }:
+
+mkDerivation rec {
+  pname = "beamerpresenter";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "stiglers-eponym";
+    repo = "BeamerPresenter";
+    rev = "v${version}";
+    sha256 = "0j7wx3qqwhda33ig2464bi0j0a473y5p7ndy5f7f8x9cqdal1d01";
+  };
+
+  nativeBuildInputs = [ qmake installShellFiles ];
+  buildInputs = [ qtbase qtmultimedia poppler ];
+
+  postPatch = ''
+    # Fix location of poppler-*.h
+    shopt -s globstar
+    for f in **/*.{h,cpp}; do
+      substituteInPlace $f --replace '#include <poppler-' '#include <poppler/qt5/poppler-'
+    done
+  '';
+
+  installPhase = ''
+    install -m755 beamerpresenter -Dt $out/bin/
+    install -m644 src/icons/beamerpresenter.svg -Dt $out/share/icons/hicolor/scalable/apps/
+    install -m644 $desktopItem/share/applications/*.desktop -Dt $out/share/applications/
+    installManPage man/*.{1,5}
+  '';
+
+  # TODO: replace with upstream's .desktop file once available.
+  # https://github.com/stiglers-eponym/BeamerPresenter/pull/4
+  desktopItem = makeDesktopItem {
+    name = pname;
+    desktopName = "BeamerPresenter";
+    genericName = "Beamer presentation viewer";
+    comment = "Simple dual screen pdf presentation software";
+    icon = "beamerpresenter";
+    categories = "Office;";
+    exec = "beamerpresenter %F";
+    mimeType = "application/pdf;application/x-pdf;";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Simple dual screen pdf presentation software";
+    homepage = "https://github.com/stiglers-eponym/BeamerPresenter";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ pacien ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2387,6 +2387,8 @@ in
 
   bdsync = callPackage ../tools/backup/bdsync { };
 
+  beamerpresenter = libsForQt5.callPackage ../applications/office/beamerpresenter { };
+
   beanstalkd = callPackage ../servers/beanstalkd { };
 
   beets = callPackage ../tools/audio/beets {


### PR DESCRIPTION
###### Motivation for this change

This creates a package for [BeamerPresenter], a PDF presentation viewer.

[BeamerPresenter]: https://github.com/stiglers-eponym/BeamerPresenter


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] Could load a PDF presentation and its notes
  - [x] Icon and desktop item registration [verified](https://github.com/NixOS/nixpkgs/pull/92480#pullrequestreview-443307337)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC: @minijackson 