### PR TITLE
mixxx: 2.2.3 -> 2.2.4

### DIFF
--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -19,13 +19,13 @@ let
 in
 mkDerivation rec {
   pname = "mixxx";
-  version = "2.2.3";
+  version = "2.2.4";
 
   src = fetchFromGitHub {
     owner = "mixxxdj";
     repo = "mixxx";
     rev = "release-${version}";
-    sha256 = "1h7q25fv62c5m74d4cn1m6mpanmqpbl2wqbch4qvn488jb2jw1dv";
+    sha256 = "1dj9li8av9b2kbm76jvvbdmihy1pyrw0s4xd7dd524wfhwr1llxr";
   };
 
   nativeBuildInputs = [ scons.py2 ];


### PR DESCRIPTION

###### Motivation for this change

https://github.com/mixxxdj/mixxx/releases/tag/release-2.2.4

Update bot skipped it:
```
2020-07-05T15:14:47 mixxx 2.2.3 -> 2.2.4 https://repology.org/metapackage/mixxx/versions
2020-07-05T15:15:00 [version] generic version rewriter does not support multiple hashes
```

@matthiasbeyer can you perhaps check if streaming works for you with the systemwide libshout version? It might, as release notes contain this line:

> Add workaround for broken libshout versions mixxxdj/mixxx#2040 mixxxdj/mixxx#2438

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
