### PR TITLE
starship: 0.43.0 -> 0.44.0

### DIFF
--- a/pkgs/tools/misc/starship/default.nix
+++ b/pkgs/tools/misc/starship/default.nix
@@ -3,13 +3,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "starship";
-  version = "0.43.0";
+  version = "0.44.0";
 
   src = fetchFromGitHub {
     owner = "starship";
     repo = pname;
     rev = "v${version}";
-    sha256 = "16ch3dhwgwmdalif3cyi3x4vrpww546wspcwc4xi0k7lp2zppbwf";
+    sha256 = "1pxrg5sfqqkvqww3fabq64j1fg03v5fj5yvm2xg2qa5n2f2qwnhi";
   };
 
   nativeBuildInputs = [ installShellFiles ] ++ stdenv.lib.optionals stdenv.isLinux [ pkg-config ];
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
     done
   '';
 
-  cargoSha256 = "09lq9ngnwg5z2l2y2ah8ng4cl8afb4gy4djwiq9yv61sjlqbr1y2";
+  cargoSha256 = "1b5gsw7jpiqjc7kbwf2kp6h6ks7jcgygrwzvn2akz86z40sskyg3";
 
   preCheck = ''
     substituteInPlace tests/testsuite/common.rs \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/nix/store/hzdc2bj588x60v11c80fbiapyka7rs5k-starship-0.43.0	  40.2M
/nix/store/xqr4azrk0ir7kvir3pzhzpzsg9xd4d9y-starship-0.44.0	  40.2M