### PR TITLE
python3Packages.tinycss2, python3Packages.cssselect2: cleanup tests

### DIFF
--- a/pkgs/development/python-modules/cssselect2/default.nix
+++ b/pkgs/development/python-modules/cssselect2/default.nix
@@ -5,6 +5,9 @@
 , tinycss2
 , pytest
 , pytestrunner
+, pytestcov
+, pytest-flake8
+, pytest-isort
 }:
 
 buildPythonPackage rec {
@@ -17,19 +20,9 @@ buildPythonPackage rec {
     sha256 = "5c2716f06b5de93f701d5755a9666f2ee22cbcd8b4da8adddfc30095ffea3abc";
   };
 
-  # We're not interested in code quality tests
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "pytest-cov" "" \
-      --replace "pytest-flake8" "" \
-      --replace "pytest-isort" "" \
-      --replace "--flake8" "" \
-      --replace "--isort" ""
-  '';
-
   propagatedBuildInputs = [ tinycss2 ];
 
-  checkInputs = [ pytest pytestrunner ];
+  checkInputs = [ pytest pytestrunner pytestcov pytest-flake8 pytest-isort ];
 
   meta = with lib; {
     description = "CSS selectors for Python ElementTree";

--- a/pkgs/development/python-modules/tinycss2/default.nix
+++ b/pkgs/development/python-modules/tinycss2/default.nix
@@ -35,10 +35,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ webencodings ];
 
   checkInputs = [ pytest pytestrunner pytestcov pytest-flake8 pytest-isort ];
-  preCheck = ''
-    # this fails a flake lint-type check, so just remove it
-    rm tinycss2/css-parsing-tests/make_color3_hsl.py
-  '';
 
   meta = with lib; {
     description = "Low-level CSS parser for Python";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I noticed that #91967 and #91941 both fixed tinycss2's tests in different ways, but did not cause a conflict because they touched different parts of the file. I kept the upstream patch, as it seems like the better solution.

I also noticed that #91364 had, in my opinion, a better fix for cssselect2's tests, but appears to have been superseded by #91941, so I included that patch in this PR as well.

cc @colemickens @misuzu @drewrisinger
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
