### PR TITLE
u-boot: v2020.04 -> v2020.07

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -18,10 +18,10 @@
 }:
 
 let
-  defaultVersion = "2020.04";
+  defaultVersion = "2020.07";
   defaultSrc = fetchurl {
     url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${defaultVersion}.tar.bz2";
-    sha256 = "0wjkasnz87q86hx93inspdjfjsinmxi87bcvj30c773x0fpjlwzy";
+    sha256 = "0sjzy262x93aaqd6z24ziaq19xjjjk5f577ivf768vmvwsgbzxf1";
   };
   buildUBoot = {
     version ? null


### PR DESCRIPTION
I'm a bit sad that they stopped doing changelogs.

 * https://lists.denx.de/pipermail/u-boot/2020-July/418797.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note that I have *only* tested it on the Pinebook Pro as of the moment the PR has been opened, but it was built for all the aarch64 boards locally.

```
nix-build --no-out-link -A pkgsCross.aarch64-multiplatform.ubootBananaPim64 -A pkgsCross.aarch64-multiplatform.ubootOdroidC2 -A pkgsCross.aarch64-multiplatform.ubootOrangePiZeroPlus2H5 -A pkgsCross.aarch64-multiplatform.ubootPine64 -A pkgsCross.aarch64-multiplatform.ubootPine64LTS -A pkgsCross.aarch64-multiplatform.ubootPinebook -A pkgsCross.aarch64-multiplatform.ubootQemuAarch64 -A pkgsCross.aarch64-multiplatform.ubootROCPCRK3399 -A pkgsCross.aarch64-multiplatform.ubootRaspberryPi3_64bit -A pkgsCross.aarch64-multiplatform.ubootRock64 -A pkgsCross.aarch64-multiplatform.ubootRockPro64 -A pkgsCross.aarch64-multiplatform.ubootSopine
```

Any regression is assumed to be an upstream regression here anyway, as we're pretty much only building the defconfig as they are.