### PR TITLE
mpvScripts.sponsorblock: init

### DIFF
--- a/pkgs/applications/video/mpv/scripts/sponsorblock.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchFromGitHub, fetchpatch, python3 }:
+
+# Usage: `pkgs.mpv.override { scripts = [ pkgs.mpvScripts.sponsorblock ]; }`
+stdenv.mkDerivation {
+  pname = "mpv_sponsorblock";
+  version = "unstable-2020-07-05";
+
+  src = fetchFromGitHub {
+    owner = "po5";
+    repo = "mpv_sponsorblock";
+    rev = "f71e49e0531350339134502e095721fdc66eac20";
+    sha256 = "1fr4cagzs26ygxyk8dxqvjw4n85fzv6is6cb1jhr2qnsjg6pa0p8";
+  };
+
+  dontBuild = true;
+
+  patches = [
+    # Use XDG_DATA_HOME and XDG_CACHE_HOME if defined for UID and DB
+    # Necessary to avoid sponsorblock to write in the nix store at runtime.
+    # https://github.com/po5/mpv_sponsorblock/pull/17
+    (fetchpatch {
+      url = "https://github.com/po5/mpv_sponsorblock/pull/17/commits/e65b360a7d03a3430b4829e457a6670b2f617b09.patch";
+      sha256 = "00wv0pvbz0dz2ibka66zhl2jk0pil4pyv6ipjfz37i81q6szyhs5";
+    })
+    (fetchpatch {
+      url = "https://github.com/po5/mpv_sponsorblock/pull/17/commits/3832304d959205e99120a14c0560ed3c37104b08.patch";
+      sha256 = "149ffvn714n2m3mqs8mgrbs24bcr74kqfkx7wyql36ndhm88xd2z";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace sponsorblock.lua \
+      --replace "python3" "${python3}/bin/python3" \
+      --replace 'mp.find_config_file("scripts")' "\"$out/share/mpv/scripts\""
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/mpv/scripts
+    cp -r sponsorblock.lua sponsorblock_shared $out/share/mpv/scripts/
+  '';
+
+  passthru.scriptName = "sponsorblock.lua";
+
+  meta = with stdenv.lib; {
+    description = "mpv script to skip sponsored segments of YouTube videos";
+    homepage = "https://github.com/po5/mpv_sponsorblock";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ pacien ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21474,6 +21474,7 @@ in
     convert = callPackage ../applications/video/mpv/scripts/convert.nix {};
     mpris = callPackage ../applications/video/mpv/scripts/mpris.nix {};
     simple-mpv-webui = callPackage ../applications/video/mpv/scripts/simple-mpv-webui.nix {};
+    sponsorblock = callPackage ../applications/video/mpv/scripts/sponsorblock.nix {};
   };
 
   mrpeach = callPackage ../applications/audio/pd-plugins/mrpeach { };


### PR DESCRIPTION
###### Motivation for this change

This creates a package for the [sponsorblock mpv script].

[sponsorblock mpv script]: https://github.com/po5/mpv_sponsorblock


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
