### PR TITLE
bash_5: 5.0p16 -> 5.0p17

### DIFF
--- a/pkgs/shells/bash/bash-5.0-patches.nix
+++ b/pkgs/shells/bash/bash-5.0-patches.nix
@@ -17,4 +17,5 @@ patch: [
 (patch "014" "12gm5bvv2pd3m72z2ilj26pa08c61az253dsgfl24vpf2ijywvjx")
 (patch "015" "0pm0px758w4i23s55wajcv6lqfiym7zgxvq0pxf6vclkv8nxy5x5")
 (patch "016" "0vdha332km2iwx8g2ld15jy7d24cbplzgr1531dpzylr9ajxglgz")
+(patch "017" "0cfw5lz3fcvq9h1fxihxvw940fjk68015jazvl8x8rlazgxbkwsc")
 ]


### PR DESCRIPTION
###### Motivation for this change

https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-017

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).