### PR TITLE
grub: Fix incorrect upgrade to new `jsonStateLine`

### DIFF
--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -638,8 +638,11 @@ sub readGrubState {
     # guaranteed to be present.
     $jsonStateLine = defined $jsonStateLine ? $jsonStateLine : '{}'; # empty JSON object
     chomp($jsonStateLine);
+    if ($jsonStateLine eq "") {
+        $jsonStateLine = '{}'; # empty JSON object
+    }
     my %jsonState = %{decode_json($jsonStateLine)};
-    my @extraGrubInstallArgs = @{$jsonState{'extraGrubInstallArgs'}};
+    my @extraGrubInstallArgs = exists($jsonState{'extraGrubInstallArgs'}) ? @{$jsonState{'extraGrubInstallArgs'}} : ();
     close FILE;
     my $grubState = GrubState->new(name => $name, version => $version, efi => $efi, devices => $devices, efiMountPoint => $efiMountPoint, extraGrubInstallArgs => \@extraGrubInstallArgs );
     return $grubState


### PR DESCRIPTION
###### Motivation for this change

Fixes error reported in https://github.com/NixOS/nixpkgs/pull/85895#issuecomment-654459724:

    Can't use an undefined value as an ARRAY reference at /nix/store/...-install-grub.pl line 642, <FILE> line 5.

with `/boot/grub/state` being:

```
grub
2.04
no
/dev/sda
/boot

```

I am not sure where the trailing empty line can come from; the script does not seem to write it. In any case, now we handle that situation as well.

Further, ensure that `extraGrubInstallArgs` defaults to the empty array if its key is not present in the `jsonState`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
