### PR TITLE
mpfshell: 0.8.1 -> unstable-2020-04-11

### DIFF
--- a/pkgs/development/tools/mpfshell/default.nix
+++ b/pkgs/development/tools/mpfshell/default.nix
@@ -1,19 +1,22 @@
 { lib, python3Packages, fetchFromGitHub }:
 
 python3Packages.buildPythonPackage rec {
-  name = "mpfshell-${version}";
-  version = "0.8.1";
+  pname = "mpfshell-unstable";
+  version = "2020-04-11";
 
   src = fetchFromGitHub {
     owner = "wendlers";
     repo = "mpfshell";
-    rev = version;
-    sha256 = "1n4ap4yfii54y125f9n9krc0lc0drwg3hsq4z6g89xbswdx9sygr";
+    rev = "429469fcccbda770fddf7a4277f5db92b1217664";
+    sha256 = "0md6ih9vp65dacqy8gki3b2p4v76xb9ijqmxymk4b4f9z684x2m7";
   };
 
   propagatedBuildInputs = with python3Packages; [
     pyserial colorama websocket_client
   ];
+
+  doCheck = false;
+  pythonImportsCheck = [ "mp.mpfshell" ];
 
   meta = with lib; {
     homepage = "https://github.com/wendlers/mpfshell";


### PR DESCRIPTION
Update to current git master.

###### Motivation for this change

* 0.8.1 is ~3 years old
* master has fix for connecting to esp8266 boards via websockets wendlers/mpfshell#87

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
