### PR TITLE
python2Packages.unittest-sml-reporting: disable py2

### DIFF
--- a/pkgs/development/python-modules/unittest-xml-reporting/default.nix
+++ b/pkgs/development/python-modules/unittest-xml-reporting/default.nix
@@ -1,8 +1,9 @@
-{lib, fetchPypi, buildPythonPackage, six}:
+{lib, fetchPypi, buildPythonPackage, isPy27, six}:
 
 buildPythonPackage rec {
   pname = "unittest-xml-reporting";
   version = "3.0.2";
+  disabled = isPy27;
 
   propagatedBuildInputs = [six];
 


### PR DESCRIPTION
###### Motivation for this change
```
builder for '/nix/store/5hqb6vylvzjj92db46wrzd3mp56vv1ms-python2.7-unittest-xml-reporting-3.0.2.drv' failed with exit code 1; last 10 log lines:
  no configure script, doing nothing
  building
  Executing setuptoolsBuildPhase
  Traceback (most recent call last):
    File "nix_run_setup", line 8, in <module>
      exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
    File "setup.py", line 21, in <module>
      raise RuntimeError('This version requires Python 3.5+')  # pragma: no cover
  RuntimeError: This version requires Python 3.5+
  builder for '/nix/store/5hqb6vylvzjj92db46wrzd3mp56vv1ms-python2.7-unittest-xml-reporting-3.0.2.drv' failed with exi
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
