### PR TITLE
stuffbin: init at 1.1.0

### DIFF
--- a/pkgs/development/tools/stuffbin/default.nix
+++ b/pkgs/development/tools/stuffbin/default.nix
@@ -20,6 +20,5 @@ buildGoModule rec {
     description = "Compress and embed static files and assets into Go binaries and access them with a virtual file system in production";
     maintainers = with maintainers; [ RaghavSood ];
     license = licenses.mit;
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/stuffbin/default.nix
+++ b/pkgs/development/tools/stuffbin/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "stuffbin";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "knadh";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "12nx1ymhbz2vkc8bm4dbl3j0ksgv86rg330grh5l6afv3qvb3g9k";
+  };
+
+  subPackages = [ "stuffbin" ];
+
+  vendorSha256 = "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
+
+  meta = with lib; {
+    homepage = "https://github.com/knadh/stuffbin";
+    description = "Compress and embed static files and assets into Go binaries and access them with a virtual file system in production";
+    maintainers = with maintainers; [ RaghavSood ];
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17550,6 +17550,8 @@ in
 
   iferr = callPackage ../development/tools/iferr { };
 
+  stuffbin = callPackage ../development/tools/stuffbin { };
+
   go-bindata = callPackage ../development/tools/go-bindata { };
 
   go-bindata-assetfs = callPackage ../development/tools/go-bindata-assetfs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`stuffbin` is a binary packer similar to go-bindata.

It is a prerequisite for [listmonk](https://github.com/knadh/listmonk), which I will be adding in a separate PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
