### PR TITLE
pytest-sugar: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/development/python-modules/amqp/default.nix
+++ b/pkgs/development/python-modules/amqp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest, case, vine, pytest-sugar }:
+{ stdenv, buildPythonPackage, fetchPypi, pytestCheckHook, case, vine }:
 
 buildPythonPackage rec {
   pname = "amqp";
@@ -9,11 +9,12 @@ buildPythonPackage rec {
     sha256 = "24dbaff8ce4f30566bb88976b398e8c4e77637171af3af6f1b9650f48890e60b";
   };
 
-  checkInputs = [ pytest case pytest-sugar ];
   propagatedBuildInputs = [ vine ];
 
-  # Disable because pytest-sugar requires an old version of pytest
-  doCheck = false;
+  checkInputs = [ pytestCheckHook case ];
+  disabledTests = [
+    "test_rmq.py" # requires network access
+  ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/celery/py-amqp";

--- a/pkgs/development/python-modules/ics/default.nix
+++ b/pkgs/development/python-modules/ics/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPythonPackage, fetchFromGitHub, pythonOlder
 , tatsu, arrow
-, pytest-sugar, pytestpep8, pytest-flakes, pytestcov
+, pytestCheckHook, pytestpep8, pytest-flakes
 }:
 
 buildPythonPackage rec {
@@ -22,10 +22,7 @@ buildPythonPackage rec {
       --replace "arrow>=0.11,<0.15" "arrow"
   '';
 
-  checkInputs = [ pytest-sugar pytestpep8 pytest-flakes pytestcov ];
-  checkPhase = ''
-    pytest
-  '';
+  checkInputs = [ pytestCheckHook pytestpep8 pytest-flakes ];
 
   meta = with stdenv.lib; {
     description = "Pythonic and easy iCalendar library (RFC 5545)";

--- a/pkgs/development/python-modules/junit-xml/default.nix
+++ b/pkgs/development/python-modules/junit-xml/default.nix
@@ -2,8 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , six
-, pytest
-, pytest-sugar
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -21,11 +20,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ six ];
 
-  checkInputs = [ pytest pytest-sugar ];
-
-  checkPhase = ''
-    pytest
-  '';
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "Creates JUnit XML test result documents that can be read by tools such as Jenkins";

--- a/pkgs/development/python-modules/pytest-sugar/default.nix
+++ b/pkgs/development/python-modules/pytest-sugar/default.nix
@@ -4,6 +4,7 @@
 , termcolor
 , pytest
 , packaging
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -19,6 +20,10 @@ buildPythonPackage rec {
     termcolor
     pytest
     packaging
+  ];
+
+  checkInputs = [
+    pytestCheckHook
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pytest-sugar/default.nix
+++ b/pkgs/development/python-modules/pytest-sugar/default.nix
@@ -9,11 +9,11 @@
 
 buildPythonPackage rec {
   pname = "pytest-sugar";
-  version = "0.9.3";
+  version = "0.9.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1630b5b7ea3624919b73fde37cffb87965c5087a4afab8a43074ff44e0d810c4";
+    sha256 = "b1b2186b0a72aada6859bea2a5764145e3aaa2c1cfbb23c3a19b5f7b697563d3";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -9,11 +9,9 @@
 , ujson
 , pytest
 , gunicorn
-, pytestcov
 , aiohttp
 , beautifulsoup4
 , pytest-sanic
-, pytest-sugar
 , pytest-benchmark
 
 # required just httpcore / requests-async
@@ -100,11 +98,9 @@ buildPythonPackage rec {
   checkInputs = [
     pytest
     gunicorn
-    pytestcov
     aiohttp
     beautifulsoup4
     pytest-sanic
-    pytest-sugar
     pytest-benchmark
     uvicorn
   ];

--- a/pkgs/development/python-modules/wordcloud/default.nix
+++ b/pkgs/development/python-modules/wordcloud/default.nix
@@ -1,18 +1,12 @@
 { stdenv, buildPythonPackage, fetchFromGitHub
-, codecov, coverage
-, flake8
 , matplotlib
 , mock
 , numpy
 , pillow
 , pytest
 , pytestcov
-, pytest-sugar
-, setuptools
-, twine
-, wheel
 }:
-  
+
 buildPythonPackage rec {
   pname = "word_cloud";
   version = "1.6.0";
@@ -28,12 +22,12 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ matplotlib numpy pillow ];
 
   # Tests require extra dependencies
-  checkInputs = [ codecov coverage flake8 mock pytest pytestcov pytest-sugar setuptools twine wheel ];
+  checkInputs = [ mock pytest pytestcov ];
   # skip tests which make assumptions about installation
   checkPhase = ''
     pytest -k 'not cli_as_executable'
   '';
-  
+
   meta = with stdenv.lib; {
     description = "A little word cloud generator in Python";
     homepage = "https://github.com/amueller/word_cloud";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update package and remove some useless checkInputs.

@FRidh I wasn't able to get `pytestCheckHook` running for wordcloud.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
