### PR TITLE
Update Gambit, Gerbil and libraries

### DIFF
--- a/pkgs/development/compilers/gambit/unstable.nix
+++ b/pkgs/development/compilers/gambit/unstable.nix
@@ -1,13 +1,13 @@
 { callPackage, fetchFromGitHub, gambit-support }:
 
 callPackage ./build.nix {
-  version = "unstable-2020-05-15";
-  git-version = "4.9.3-1109-g3c4d40de";
+  version = "unstable-2020-07-29";
+  git-version = "4.9.3-1232-gbba388b8";
   src = fetchFromGitHub {
     owner = "feeley";
     repo = "gambit";
-    rev = "3c4d40de908ae03ca0e3d854edc2234ef401b36c";
-    sha256 = "1c9a6rys2kiiqb79gvw29nv3dwwk6hmi1q4jk1whcx7mds7q5dvr";
+    rev = "bba388b80ca62a77883a8936d64b03316808696a";
+    sha256 = "0iqlp1mvxz8g32kqrqm0phnnp1i5c4jrapqh2wqwa8fh1vgnizg1";
   };
   gambit-params = gambit-support.unstable-params;
 }

--- a/pkgs/development/compilers/gerbil/gerbil-crypto.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-crypto.nix
@@ -1,0 +1,27 @@
+{ pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
+
+gerbil-support.gerbilPackage {
+  pname = "gerbil-crypto";
+  version = "unstable-2020-08-01";
+  git-version = "0.0-6-ga228862";
+  gerbil-package = "clan/crypto";
+  gerbil = gerbil-unstable;
+  gerbilInputs = [gerbil-support.gerbilPackages-unstable.gerbil-utils];
+  buildInputs = [pkgs.secp256k1 pkgs.pkg-config];
+  gambit-params = gambit-support.unstable-params;
+  version-path = "version";
+  softwareName = "Gerbil-crypto";
+  src = fetchFromGitHub {
+    owner = "fare";
+    repo = "gerbil-crypto";
+    rev = "a22886260849ec92c3a34bfeedc1574e41e49e33";
+    sha256 = "0qbanw2vnw2ymmr4pr1jap29cyc3icbhyq0apibpfnj2znns7w47";
+  };
+  meta = {
+    description = "Gerbil Crypto: Extra Cryptographic Primitives for Gerbil";
+    homepage    = "https://github.com/fare/gerbil-crypto";
+    license     = lib.licenses.asl20;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ fare ];
+  };
+}

--- a/pkgs/development/compilers/gerbil/gerbil-ethereum.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-ethereum.nix
@@ -1,0 +1,28 @@
+{ pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
+
+gerbil-support.gerbilPackage {
+  pname = "gerbil-ethereum";
+  version = "unstable-2020-08-02";
+  git-version = "0.0-15-g7cd2dd7";
+  gerbil-package = "mukn/ethereum";
+  gerbil = gerbil-unstable;
+  gerbilInputs = with gerbil-support.gerbilPackages-unstable;
+    [gerbil-utils gerbil-crypto gerbil-poo gerbil-persist];
+  buildInputs = [];
+  gambit-params = gambit-support.unstable-params;
+  version-path = "version";
+  softwareName = "Gerbil-ethereum";
+  src = fetchFromGitHub {
+    owner = "fare";
+    repo = "gerbil-ethereum";
+    rev = "7cd2dd7436b11917d0729dbafe087cfa8ec38f86";
+    sha256 = "0qq3ch2dg735yrj3l2c9pb9qlvz98x3vjfi2xyr4fwr78smpqgb5";
+  };
+  meta = {
+    description = "Gerbil Ethereum: a Scheme alternative to web3.js";
+    homepage    = "https://github.com/fare/gerbil-ethereum";
+    license     = lib.licenses.asl20;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ fare ];
+  };
+}

--- a/pkgs/development/compilers/gerbil/gerbil-persist.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-persist.nix
@@ -1,0 +1,27 @@
+{ pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
+
+gerbil-support.gerbilPackage {
+  pname = "gerbil-persist";
+  version = "unstable-2020-08-02";
+  git-version = "0.0-4-ga3b2bd1";
+  gerbil-package = "clan/persist";
+  gerbil = gerbil-unstable;
+  gerbilInputs = with gerbil-support.gerbilPackages-unstable; [gerbil-utils gerbil-crypto gerbil-poo];
+  buildInputs = [];
+  gambit-params = gambit-support.unstable-params;
+  version-path = "version";
+  softwareName = "Gerbil-persist";
+  src = fetchFromGitHub {
+    owner = "fare";
+    repo = "gerbil-persist";
+    rev = "a3b2bd104612db0e4492737f09f72adea6684483";
+    sha256 = "0mc01wva26ww1i7n8naa95mfw7i6lj8qg0bwsik7gb3dsj2acjvh";
+  };
+  meta = {
+    description = "Gerbil Persist: Persistent data and activities";
+    homepage    = "https://github.com/fare/gerbil-persist";
+    license     = lib.licenses.asl20;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ fare ];
+  };
+}

--- a/pkgs/development/compilers/gerbil/gerbil-poo.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-poo.nix
@@ -1,0 +1,27 @@
+{ pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
+
+gerbil-support.gerbilPackage {
+  pname = "gerbil-ethereum";
+  version = "unstable-2020-08-02";
+  git-version = "0.0-13-g1014154";
+  gerbil-package = "clan/poo";
+  gerbil = gerbil-unstable;
+  gerbilInputs = with gerbil-support.gerbilPackages-unstable; [gerbil-utils gerbil-crypto];
+  buildInputs = [];
+  gambit-params = gambit-support.unstable-params;
+  version-path = "version";
+  softwareName = "Gerbil-POO";
+  src = fetchFromGitHub {
+    owner = "fare";
+    repo = "gerbil-poo";
+    rev = "1014154fe4943dfbec7524666c831b601ba88559";
+    sha256 = "0g8l5mi007n07qs79m9h3h3am1p7h0kzq7yb49h562b8frh5gp97";
+  };
+  meta = {
+    description = "Gerbil POO: Prototype Object Orientation for Gerbil Scheme";
+    homepage    = "https://github.com/fare/gerbil-poo";
+    license     = lib.licenses.asl20;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ fare ];
+  };
+}

--- a/pkgs/development/compilers/gerbil/gerbil-support.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-support.nix
@@ -6,6 +6,7 @@ rec {
   gerbilPackages-unstable = {
     gerbil-utils = callPackage ./gerbil-utils.nix { };
     gerbil-crypto = callPackage ./gerbil-crypto.nix { };
+    gerbil-poo = callPackage ./gerbil-poo.nix { };
   };
 
   # Use this function in any package that uses Gerbil libraries, to define the GERBIL_LOADPATH.

--- a/pkgs/development/compilers/gerbil/gerbil-support.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-support.nix
@@ -13,21 +13,26 @@ rec {
 
   # Use this function to create a Gerbil library. See gerbil-utils as an example.
   gerbilPackage = {
-    pname, version, src, meta, package,
-    git-version ? "", version-path ? "config/version.ss",
+    pname, version, src, meta, gerbil-package,
+    git-version ? "", version-path ? "",
     gerbil ? pkgs.gerbil-unstable,
     gambit-params ? pkgs.gambit-support.stable-params,
     gerbilInputs ? [],
     buildInputs ? [],
-    softwareName ? "" } :
+    softwareName ? ""} :
     let buildInputs_ = buildInputs; in
     gccStdenv.mkDerivation rec {
       inherit src meta pname version;
+      passthru = { inherit gerbil-package version-path ;};
       buildInputs = [ gerbil ] ++ gerbilInputs ++ buildInputs_;
       postPatch = ''
         set -e ;
-        if [ -n "${version-path}" ] ; then
-          echo '(import :clan/utils/version)\n(register-software "${softwareName}" "${git-version}")\n' > "${version-path}"
+        if [ -n "${version-path}.ss" ] ; then
+          echo -e '(import :clan/versioning${builtins.concatStringsSep ""
+                     (map (x : if x.passthru.version-path != ""
+                               then " :${x.passthru.gerbil-package}/${x.passthru.version-path}" else "")
+                          gerbilInputs)
+                     })\n(register-software "${softwareName}" "v${git-version}")\n' > "${passthru.version-path}.ss"
         fi
         patchShebangs . ;
       '';

--- a/pkgs/development/compilers/gerbil/gerbil-support.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-support.nix
@@ -5,6 +5,7 @@ rec {
   # Gerbil libraries
   gerbilPackages-unstable = {
     gerbil-utils = callPackage ./gerbil-utils.nix { };
+    gerbil-crypto = callPackage ./gerbil-crypto.nix { };
   };
 
   # Use this function in any package that uses Gerbil libraries, to define the GERBIL_LOADPATH.

--- a/pkgs/development/compilers/gerbil/gerbil-support.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-support.nix
@@ -8,6 +8,7 @@ rec {
     gerbil-crypto = callPackage ./gerbil-crypto.nix { };
     gerbil-poo = callPackage ./gerbil-poo.nix { };
     gerbil-persist = callPackage ./gerbil-persist.nix { };
+    gerbil-ethereum = callPackage ./gerbil-ethereum.nix { };
   };
 
   # Use this function in any package that uses Gerbil libraries, to define the GERBIL_LOADPATH.

--- a/pkgs/development/compilers/gerbil/gerbil-support.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-support.nix
@@ -7,6 +7,7 @@ rec {
     gerbil-utils = callPackage ./gerbil-utils.nix { };
     gerbil-crypto = callPackage ./gerbil-crypto.nix { };
     gerbil-poo = callPackage ./gerbil-poo.nix { };
+    gerbil-persist = callPackage ./gerbil-persist.nix { };
   };
 
   # Use this function in any package that uses Gerbil libraries, to define the GERBIL_LOADPATH.

--- a/pkgs/development/compilers/gerbil/gerbil-utils.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-utils.nix
@@ -2,17 +2,18 @@
 
 gerbil-support.gerbilPackage {
   pname = "gerbil-utils";
-  version = "unstable-2020-05-17";
-  git-version = "33ef720";
-  package = "clan";
+  version = "unstable-2020-08-02";
+  git-version = "0.2-21-g7e7d053";
+  gerbil-package = "clan";
   gerbil = gerbil-unstable;
   gambit-params = gambit-support.unstable-params;
-  version-path = "";
+  version-path = "version";
+  softwareName = "Gerbil-utils";
   src = fetchFromGitHub {
     owner = "fare";
     repo = "gerbil-utils";
-    rev = "33ef720799ba98dc9eec773c662f070af4bac016";
-    sha256 = "0dsb97magbxzjqqfzwq4qwf7i80llv0s1dsy9nkzkvkq8drxlmqf";
+    rev = "7e7d053ec5e78cc58d38cb03baf554d83b31b0c6";
+    sha256 = "078vqdcddfavqq0d9pw430iz1562cgx1ck3fw6dpwxjkyc6m4bms";
   };
   meta = {
     description = "Gerbil Clan: Community curated Collection of Common Utilities";

--- a/pkgs/development/compilers/gerbil/unstable.nix
+++ b/pkgs/development/compilers/gerbil/unstable.nix
@@ -1,13 +1,13 @@
 { callPackage, fetchFromGitHub, gambit-unstable, gambit-support }:
 
 callPackage ./build.nix rec {
-  version = "unstable-2020-05-17";
-  git-version = "0.16-1-g36a31050";
+  version = "unstable-2020-08-02";
+  git-version = "0.16-120-g3f248e13";
   src = fetchFromGitHub {
     owner = "vyzo";
     repo = "gerbil";
-    rev = "36a31050f6c80e7e1a49dfae96a57b2ad0260698";
-    sha256 = "0k3fypam9qx110sjxgzxa1mdf5b631w16s9p5v37cb8ll26vqfiv";
+    rev = "3f248e139dfa11be74284fc812253fbecafbaf31";
+    sha256 = "18v192cypj0nbmfcyflm8qnwp27qwy65m0a19ggs47wwbzhgvgqh";
   };
   inherit gambit-support;
   gambit = gambit-unstable;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Upstream update to gambit, gerbil, and gerbil-utils, and new libraries: gerbil-crypto, gerbil-poo, gerbil-persist, gerbil-ethereum.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
