### PR TITLE
python3Packages.cnvkit: fix build

### DIFF
--- a/pkgs/development/python-modules/cnvkit/default.nix
+++ b/pkgs/development/python-modules/cnvkit/default.nix
@@ -6,6 +6,7 @@
 , biopython
 , numpy
 , scipy
+, scikitlearn
 , pandas
 , matplotlib
 , reportlab
@@ -29,6 +30,7 @@ buildPythonPackage rec {
     biopython
     numpy
     scipy
+    scikitlearn
     pandas
     matplotlib
     reportlab
@@ -43,6 +45,8 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace "pandas >= 0.20.1, < 0.25.0" "pandas"
   '';
+
+  pythonImportsCheck = [ "cnvlib" ];
 
   meta = with lib; {
     homepage = "https://cnvkit.readthedocs.io";


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing #92493

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
