### PR TITLE
chore: modernize PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,17 @@
 <!--
 To help with the large amounts of pull requests, we would appreciate your
-reviews of other pull requests, especially simple package updates. Just leave a
-comment describing what you have tested in the relevant package/service.
-Reviewing helps to reduce the average time-to-merge for everyone.
-Thanks a lot if you do!
+reviews of other pull requests, especially simple package updates.
+
+You can start by reviewing packages on your platform to complement the
+author's platform (see steps below).
+
+In any case, just leave a comment describing what you have tested in the
+relevant package/service.
+
 List of open PRs: https://github.com/NixOS/nixpkgs/pulls
+Marvin needs_reviewer: https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+is%3Aopen+label%3Aneeds_reviewer+
+Marvin needs_merger: https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+is%3Aopen+label%3Aneeds_merger+
+
 Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
 -->
 
@@ -13,16 +20,28 @@ Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/do
 
 ###### Things done
 
-<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
+<!-- 
+Requirements: 
+- install `nixpkgs-review` for good with `nix-env -f '<nixpkgs>' -iA nixpkgs-review`
+- consult usage documentation: https://github.com/Mic92/nixpkgs-review#usage
+- setup github api token: https://github.com/Mic92/nixpkgs-review#github-api-token
+-->
 
-- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
-- Built on platform(s)
+- [ ] Tested sucessful built of final PR `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr <pr-number>`.
+      If suceeded, within the resulting `nix-shell`:
+   - [ ] Manually tested execution of all binary files (usually in `./result/bin/`)
+   - [ ] If ok, posted the results: `nix-shell> nixpkgs-review post-result`
+
+- Tick the the platform(s) at hand that you did built on (more is better, reviewers are encouraged to complement):
    - [ ] NixOS
    - [ ] macOS
-   - [ ] other Linux distributions
-- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
-- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
-- [ ] Tested execution of all binary files (usually in `./result/bin/`)
-- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
-- [ ] Ensured that relevant documentation is up to date
+   - [ ] other Linux (Ubuntu, Archlinux, Alpine, etc.). Please specify: ...
+
+- [ ] If available*: tested via one or more NixOS test(s) `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr -p nixosTests.<test> <package> <pr-number>` (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
+
+- [ ] No documentation affected by this change
+- [ ] Or: Ensured that relevant documentation is up to date
+
 - [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
+
+\* Note, that only few tests are available, if you'd want to write your own have a look at: https://github.com/NixOS/nixpkgs/issues/34987 and other tests throughout the source.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ Requirements:
 - setup github api token: https://github.com/Mic92/nixpkgs-review#github-api-token
 -->
 
-- [ ] Tested sucessful built of final PR `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr <pr-number>`.
+- [ ] Tested sucessful build of final PR `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr <pr-number>`.
       If suceeded, within the resulting `nix-shell`:
    - [ ] Manually tested execution of all binary files (in `./results/bin/`)
    - [ ] Included manual checks and validations at the end of `editor ./report.md`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,7 +37,7 @@ Requirements:
    - [ ] other Linux (Ubuntu, Archlinux, Alpine, etc.).
 
 - [ ] If available: tested via one or more NixOS test(s) `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr -p nixosTests.<test> <package> <pr-number>` (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
-<!-- Note, that only few tests are available, if you'd want to write your own have a look at: https://github.com/NixOS/nixpkgs/issues/34987 and other tests throughout the source. >
+<!-- Note, that only few tests are available, if you'd want to write your own have a look at: https://github.com/NixOS/nixpkgs/issues/34987 and other tests throughout the source. -->
 
 - [ ] No documentation affected by this change
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,11 +37,12 @@ Requirements:
    - [ ] macOS
    - [ ] other Linux (Ubuntu, Archlinux, Alpine, etc.). Please specify: ...
 
-- [ ] If available*: tested via one or more NixOS test(s) `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr -p nixosTests.<test> <package> <pr-number>` (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
+- [ ] If available: tested via one or more NixOS test(s) `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr -p nixosTests.<test> <package> <pr-number>` (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
+<!-- Note, that only few tests are available, if you'd want to write your own have a look at: https://github.com/NixOS/nixpkgs/issues/34987 and other tests throughout the source. >
 
 - [ ] No documentation affected by this change
+
 - [ ] Or: Ensured that relevant documentation is up to date
 
 - [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
 
-\* Note, that only few tests are available, if you'd want to write your own have a look at: https://github.com/NixOS/nixpkgs/issues/34987 and other tests throughout the source.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,7 +36,7 @@ It is strongly suggested to use `nipkgs-review`:
    - [ ] other Linux distributions (Ubuntu, Arch Linux, Alpine, etc.).
 
 - [ ] If available: tested via one or more NixOS test(s) `nixpkgs-review pr -p nixosTests.<test> <package> <pr-number>` (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
-<!-- Note, that only few tests are available, if you'd want to write your own have a look at: https://github.com/NixOS/nixpkgs/issues/34987 and furthermore read through https://nixos.org/nixos/manual/index.html#sec-nixos-tests. Looking through the source code should be helpful, as well. -->
+<!-- Note, that only few tests are available, if you'd want to write your own have a look at: https://github.com/NixOS/nixpkgs/issues/34987 and furthermore read through https://nixos.org/nixos/manual/index.html#sec-nixos-tests. Looking through the source code should be helpful as well. -->
 
 - [ ] Ensured that relevant documentation is up to date
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,10 +21,9 @@ Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/do
 Requirements: 
 - install `nixpkgs-review` for good with `nix-env -f '<nixpkgs>' -iA nixpkgs-review`
 - consult usage documentation: https://github.com/Mic92/nixpkgs-review#usage
-- setup github api token: https://github.com/Mic92/nixpkgs-review#github-api-token
 -->
 
-- [ ] Tested sucessful build of final PR `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr <pr-number>`.
+- [ ] Tested sucessful build of final PR `nixpkgs-review pr <pr-number>`.
       If suceeded, within the resulting `nix-shell`:
    - [ ] Manually tested execution of all binary files (in `./results/bin/`)
    - [ ] Mentioned the manual checks and validations at the end of generated `./report.md`
@@ -36,7 +35,7 @@ Requirements:
    - [ ] macOS
    - [ ] other Linux distributions (Ubuntu, Arch Linux, Alpine, etc.).
 
-- [ ] If available: tested via one or more NixOS test(s) `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr -p nixosTests.<test> <package> <pr-number>` (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
+- [ ] If available: tested via one or more NixOS test(s) `nixpkgs-review pr -p nixosTests.<test> <package> <pr-number>` (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
 <!-- Note, that only few tests are available, if you'd want to write your own have a look at: https://github.com/NixOS/nixpkgs/issues/34987 and furthermore read through https://nixos.org/nixos/manual/index.html#sec-nixos-tests. Looking through the source code should be helpful, as well. -->
 
 - [ ] Ensured that relevant documentation is up to date

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/do
 ###### Things done
 
 <!-- 
-Requirements: 
+It is strongly suggested to use `nipkgs-review`:
 - install `nixpkgs-review` for good with `nix-env -f '<nixpkgs>' -iA nixpkgs-review`
 - consult usage documentation: https://github.com/Mic92/nixpkgs-review#usage
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,7 +37,7 @@ Requirements:
    - [ ] other Linux distributions (Ubuntu, Arch Linux, Alpine, etc.).
 
 - [ ] If available: tested via one or more NixOS test(s) `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr -p nixosTests.<test> <package> <pr-number>` (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
-<!-- Note, that only few tests are available, if you'd want to write your own have a look at: https://github.com/NixOS/nixpkgs/issues/34987 and other tests throughout the source. -->
+<!-- Note, that only few tests are available, if you'd want to write your own have a look at: https://github.com/NixOS/nixpkgs/issues/34987 and furthermore read through https://nixos.org/nixos/manual/index.html#sec-nixos-tests. Looking through the source code should be helpful, as well. -->
 
 - [ ] Ensured that relevant documentation is up to date
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@ Requirements:
 - [ ] Tested sucessful built of final PR `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr <pr-number>`.
       If suceeded, within the resulting `nix-shell`:
    - [ ] Manually tested execution of all binary files (in `./results/bin/`)
-   - [ ] Include the manual checks and validations you did at the end in `editor ./report.md`
+   - [ ] Included manual checks and validations at the end of `editor ./report.md`
    - [ ] If ok, posted the results: `nix-shell> nixpkgs-review post-result`
 
 - Platform(s), I built on (reviewers, please complement!):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,6 +30,7 @@ Requirements:
 - [ ] Tested sucessful built of final PR `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr <pr-number>`.
       If suceeded, within the resulting `nix-shell`:
    - [ ] Manually tested execution of all binary files (in `./results/bin/`)
+   - [ ] Include the manual checks and validations you did at the end in `editor ./report.md`
    - [ ] If ok, posted the results: `nix-shell> nixpkgs-review post-result`
 
 - Platform(s), I built on (reviewers, please complement!):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,7 @@ Requirements:
 - [ ] Tested sucessful build of final PR `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr <pr-number>`.
       If suceeded, within the resulting `nix-shell`:
    - [ ] Manually tested execution of all binary files (in `./results/bin/`)
-   - [ ] Included manual checks and validations at the end of `editor ./report.md`
+   - [ ] Mentioned the manual checks and validations at the end of generated `./report.md`
    - [ ] If ok, posted the results: `nix-shell> nixpkgs-review post-result`
 
 - Platform(s), I built on (reviewers, please complement!):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,9 +5,6 @@ reviews of other pull requests, especially simple package updates.
 You can start by reviewing packages on your platform to complement the
 author's platform (see steps below).
 
-In any case, just leave a comment describing what you have tested in the
-relevant package/service.
-
 List of open PRs: https://github.com/NixOS/nixpkgs/pulls
 Marvin needs_reviewer: https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+is%3Aopen+label%3Aneeds_reviewer+
 Marvin needs_merger: https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+is%3Aopen+label%3Aneeds_merger+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,8 @@ Requirements:
    - [ ] Manually tested execution of all binary files (usually in `./result/bin/`)
    - [ ] If ok, posted the results: `nix-shell> nixpkgs-review post-result`
 
-- Tick the the platform(s) at hand that you did built on (more is better, reviewers are encouraged to complement):
+- Platform(s), I built on (reviewers, please complement!):
+<!-- more is better, reviewers might complement -->
    - [ ] NixOS
    - [ ] macOS
    - [ ] other Linux (Ubuntu, Archlinux, Alpine, etc.). Please specify: ...
@@ -42,7 +43,7 @@ Requirements:
 
 - [ ] No documentation affected by this change
 
-- [ ] Or: Ensured that relevant documentation is up to date
+- [ ] Or: ensured that relevant documentation is up to date
 
 - [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@ Requirements:
 <!-- more is better, reviewers might complement -->
    - [ ] NixOS
    - [ ] macOS
-   - [ ] other Linux (Ubuntu, Archlinux, Alpine, etc.).
+   - [ ] other Linux distributions (Ubuntu, Arch Linux, Alpine, etc.).
 
 - [ ] If available: tested via one or more NixOS test(s) `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr -p nixosTests.<test> <package> <pr-number>` (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
 <!-- Note, that only few tests are available, if you'd want to write your own have a look at: https://github.com/NixOS/nixpkgs/issues/34987 and other tests throughout the source. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@ Requirements:
 <!-- more is better, reviewers might complement -->
    - [ ] NixOS
    - [ ] macOS
-   - [ ] other Linux (Ubuntu, Archlinux, Alpine, etc.). Please specify: ...
+   - [ ] other Linux (Ubuntu, Archlinux, Alpine, etc.).
 
 - [ ] If available: tested via one or more NixOS test(s) `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr -p nixosTests.<test> <package> <pr-number>` (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
 <!-- Note, that only few tests are available, if you'd want to write your own have a look at: https://github.com/NixOS/nixpkgs/issues/34987 and other tests throughout the source. >
@@ -44,4 +44,3 @@ Requirements:
 - [ ] Or: ensured that relevant documentation is up to date
 
 - [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,8 +39,6 @@ Requirements:
 - [ ] If available: tested via one or more NixOS test(s) `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr -p nixosTests.<test> <package> <pr-number>` (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
 <!-- Note, that only few tests are available, if you'd want to write your own have a look at: https://github.com/NixOS/nixpkgs/issues/34987 and other tests throughout the source. -->
 
-- [ ] No documentation affected by this change
-
-- [ ] Or: ensured that relevant documentation is up to date
+- [ ] Ensured that relevant documentation is up to date
 
 - [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,7 +29,7 @@ Requirements:
 
 - [ ] Tested sucessful built of final PR `GITHUB_TOKEN=<YOUR_TOKEN> nixpkgs-review pr <pr-number>`.
       If suceeded, within the resulting `nix-shell`:
-   - [ ] Manually tested execution of all binary files (usually in `./result/bin/`)
+   - [ ] Manually tested execution of all binary files (in `./results/bin/`)
    - [ ] If ok, posted the results: `nix-shell> nixpkgs-review post-result`
 
 - Platform(s), I built on (reviewers, please complement!):


### PR DESCRIPTION
Also add links to <experimental> marvin labels.
@Mic92 This is an _intention-aware_ refactoring/strip down according to your `nix-review` package.

I also referenced @timokau 's marvin labels. They are unstable, so we should remember I put them here.

Follow up of #92244