### PR TITLE
ovito: mark broken

### DIFF
--- a/pkgs/development/python-modules/ovito/default.nix
+++ b/pkgs/development/python-modules/ovito/default.nix
@@ -29,5 +29,6 @@ stdenv.mkDerivation {
     # ensures not built on hydra
     # https://github.com/NixOS/nixpkgs/pull/46846#issuecomment-436388048
     hydraPlatforms = [ ];
+    broken = true; # cmake unable to find Qt5Core and other dependencies
   };
 }


### PR DESCRIPTION
###### Motivation for this change
It has likely been broken for over a year since the Qt changes
```
    Add the installation prefix of "Qt5Core" to CMAKE_PREFIX_PATH or set
    "Qt5Core_DIR" to a directory containing one of the above files.  If
    "Qt5Core" provides a separate development package or SDK, be sure it has
    been installed.
```
hydra is specifically not building this package, so there's no hydra build history
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
