### PR TITLE
python3Packages.pytorch: create separate lib output

### DIFF
--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -110,7 +110,8 @@ in buildPythonPackage rec {
 
   outputs = [
     "out"   # output standard python package
-    "dev"   # output libtorch only
+    "dev"   # output libtorch headers
+    "lib"   # output libtorch libraries
   ];
 
   src = fetchFromGitHub {
@@ -239,9 +240,11 @@ in buildPythonPackage rec {
   ];
   postInstall = ''
     mkdir $dev
-    cp -r $out/${python.sitePackages}/torch/lib     $dev/lib
     cp -r $out/${python.sitePackages}/torch/include $dev/include
     cp -r $out/${python.sitePackages}/torch/share   $dev/share
+
+    mkdir $lib
+    cp -r $out/${python.sitePackages}/torch/lib     $lib/lib
   '';
 
   postFixup = stdenv.lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

At some point pytorch.dev was added to expose the libtorch headers and
libraries to non-Python users of libtorch. However, this output
currently has two disadvantages:

1. An application that compiles against the dev output will also have
   the libtorch header files in its closure. This is not so nice when
   e.g. building Docker images of applications that use libtorch.
2. The dev output has a large transitive closure with many dependencies
   that are not necessary when compiling against libtorch.

This change adds the `lib` output so that applications that only link
against libtorch libraries have a small closure.

Tested CUDA build :heavy_check_mark: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
