### PR TITLE
nixos: added navidrome module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -472,6 +472,7 @@
   ./services/misc/mesos-slave.nix
   ./services/misc/metabase.nix
   ./services/misc/mwlib.nix
+  ./services/misc/navidrome.nix
   ./services/misc/nix-daemon.nix
   ./services/misc/nix-gc.nix
   ./services/misc/nix-optimise.nix

--- a/nixos/modules/services/misc/navidrome.nix
+++ b/nixos/modules/services/misc/navidrome.nix
@@ -1,0 +1,101 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.navidrome;
+  configFile = "/etc/navidrome/settings.json";
+  dataFolder = "/var/lib/navidrome";
+in {
+  options = {
+
+    services.navidrome = {
+      enable = mkEnableOption "Navidrome music server and streamer";
+
+      settings = lib.mkOption {
+        type = with types; attrsOf (oneOf [ int str ]);
+        default = {};
+        example = literalExample ''
+          {
+            LogLevel = "INFO";
+            BaseURL = "/music";
+            ScanInterval = "10s";
+            TranscodingCacheSize = "15MB";
+            MusicFolder = "/Media/Music";
+          };
+        '';
+        description = ''
+          Configuration for Navidrome, see <link xlink:href="https://www.navidrome.org/docs/usage/configuration-options/"/> for supported values.
+      '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "navidrome";
+        description = "User account under which Navidrome runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "navidrome";
+        description = "Group account under which Navidrome runs.";
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.etc."navidrome/settings.json".text = builtins.toJSON cfg.settings;
+
+    services.navidrome.settings = {
+      DataFolder = dataFolder;
+      ConfigFile = configFile;
+    };
+    
+    systemd.services.navidrome = {
+      description = "Navidrome Music Server and Streamer compatible with Subsonic/Airsonic";
+      after = [ "remote-fs.target" "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = {
+        ND_CONFIGFILE = configFile;
+      };
+      serviceConfig = {
+        ExecStart = "${pkgs.navidrome}/bin/navidrome";
+        WorkingDirectory = dataFolder;
+        TimeoutStopSec = "20";
+        KillMode = "process";
+        Restart = "on-failure";
+        User = cfg.user;
+        Group = cfg.group;
+        DevicePolicy = "closed";
+        NoNewPrivileges= " yes";
+        PrivateTmp = "yes";
+        PrivateUsers = "yes";
+        ProtectControlGroups = "yes";
+        ProtectKernelModules = "yes";
+        ProtectKernelTunables = "yes";
+        RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
+        RestrictNamespaces = "yes";
+        RestrictRealtime = "yes";
+        SystemCallFilter = "~@clock @debug @module @mount @obsolete @privileged @reboot @setuid @swap";
+        ReadWritePaths = dataFolder;
+        StateDirectory = baseNameOf dataFolder;
+      };
+    };
+
+    users.users = optionalAttrs (cfg.user == "navidrome") ({
+      navidrome = {
+        description = "Navidrome service user";
+        name = cfg.user;
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    });
+
+    users.groups = optionalAttrs (cfg.group == "navidrome") ({
+      navidrome = {};
+    });
+    
+  };
+}

--- a/nixos/tests/navidrome.nix
+++ b/nixos/tests/navidrome.nix
@@ -1,0 +1,16 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "navidrome";
+
+  machine = { ... }: {
+    services.navidrome.enable = true;
+    services.navidrome.settings = {
+      MusicFolder = "/var/music";
+      Port = 4535;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("navidrome")
+    machine.wait_for_open_port("4535")
+  '';
+})


### PR DESCRIPTION
I had to recreate this pull request since I deleted my fork, this was the old one: #91366
I'll continue the discussion here.

> I hate to make suggestions and not follow through.

@aanderse don't worry, at the end with I solved generating a json instead of the a toml:

> Navidrome also supports JSON and YML config files, if it makes it easier for you

@deluan thank you, now it writes a `settings.json` file in `/etc/navidrome/settings.json`

In conclusion the module options are:
* `navidrome.enable`
* `navidrome.user` and `navidrome.group` (defaults are `navidrome` both for user and group)
* `navidrome.musicFolderPermissions` (default is `755`)
* `navidrome.settings` that is if type `type.attrs` and reflects the official navidrome settings. I chose to always overwrite with defaults value for `DataFolder` and `ConfigFile`.

I point out as it's impossible to build the derivation without `navidrome.settings.MusicFolder` and a error is thrown. I think this is ok as it wouldn't make any sense to execute `navidrome` without a music folder.

In my opinion it should me mergeable now, I hope the commit comment is ok, I don't want to try a new rebase...