### PR TITLE
nixos/xpadneo: init at 0.8.1

### DIFF
--- a/nixos/modules/hardware/xpadneo.nix
+++ b/nixos/modules/hardware/xpadneo.nix
@@ -1,0 +1,29 @@
+{ config, lib, ... }:
+
+with lib;
+let
+  cfg = config.hardware.xpadneo;
+in
+{
+  options.hardware.xpadneo = {
+    enable = mkEnableOption "the xpadneo driver for Xbox One wireless controllers";
+  };
+
+  config = mkIf cfg.enable {
+    boot = {
+      # Must disable Enhanced Retransmission Mode to support bluetooth pairing
+      # https://wiki.archlinux.org/index.php/Gamepad#Connect_Xbox_Wireless_Controller_with_Bluetooth
+      extraModprobeConfig =
+        mkIf
+          config.hardware.bluetooth.enable
+          "options bluetooth disable_ertm=1";
+
+      extraModulePackages = with config.boot.kernelPackages; [ xpadneo ];
+      kernelModules = [ "hid_xpadneo" ];
+    };
+  };
+
+  meta = {
+    maintainers = with maintainers; [ metadark ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -76,6 +76,7 @@
   ./hardware/video/nvidia.nix
   ./hardware/video/uvcvideo/default.nix
   ./hardware/video/webcam/facetimehd.nix
+  ./hardware/xpadneo.nix
   ./i18n/input-method/default.nix
   ./i18n/input-method/fcitx.nix
   ./i18n/input-method/ibus.nix

--- a/pkgs/os-specific/linux/xpadneo/default.nix
+++ b/pkgs/os-specific/linux/xpadneo/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, kernel, bluez }:
+
+stdenv.mkDerivation rec {
+  pname = "xpadneo";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "atar-axis";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0v688j7jx2b68zlwnrr5y63zxzhldygw1lcp8f3irayhcp8ikzzy";
+  };
+
+  setSourceRoot = ''
+    export sourceRoot=$(pwd)/source/hid-xpadneo/src
+  '';
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+  buildInputs = [ bluez ];
+
+  makeFlags = [
+    "-C"
+    "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "M=$(sourceRoot)"
+  ];
+
+  buildFlags = [ "modules" ];
+  installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
+  installTargets = [ "modules_install" ];
+
+  meta = with stdenv.lib; {
+    description = "Advanced Linux driver for Xbox One wireless controllers";
+    homepage = "https://atar-axis.github.io/xpadneo";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17416,6 +17416,8 @@ in
 
     x86_energy_perf_policy = callPackage ../os-specific/linux/x86_energy_perf_policy { };
 
+    xpadneo = callPackage ../os-specific/linux/xpadneo { };
+
     zenpower = callPackage ../os-specific/linux/zenpower { };
 
     inherit (callPackages ../os-specific/linux/zfs {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I just got an Xbox One controller and I wasn't satisfied with the xpad
driver that ships with the Linux kernel

xpadneo supports more features and fixes problems with
incorrect button mappings

https://atar-axis.github.io/xpadneo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  No binary files, tested through use of Xbox One controller
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
