### PR TITLE
update.nix: Allow passing overlays

### DIFF
--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -9,7 +9,13 @@
 # TODO: add assert statements
 
 let
-  pkgs = import ./../../default.nix (if include-overlays then { } else { overlays = []; });
+  pkgs = import ./../../default.nix (
+    if include-overlays == false then
+      { overlays = []; }
+    else if include-overlays == true then
+      { } # Let Nixpkgs include overlays impurely.
+    else { overlays = include-overlays; }
+  );
 
   inherit (pkgs) lib;
 


### PR DESCRIPTION
[Previously](https://github.com/NixOS/nixpkgs/commit/bacb0969f215faf1ef51ee68bad35b273bc0b418), we relied on `NIX_PATH` for passing overlays but with flakes, we should pass them explicitly.