### PR TITLE
lutris: fix for us keyboard layouts

### DIFF
--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -37,6 +37,7 @@
 , wine
 , fluidsynth
 , xorgserver
+, xorg
 }:
 
 let
@@ -55,6 +56,7 @@ let
     wine
     fluidsynth
     xorgserver
+    xorg.setxkbmap
   ];
 
   gstDeps = with gst_all_1; [


### PR DESCRIPTION
###### Motivation for this change
may need to call `setxkbmap`

https://github.com/lutris/lutris/blob/bb7565f14f748eea95fc3c3b4efd8e49099a832d/lutris/game.py#L635

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
