### PR TITLE
python35Packages.vega: disable python{2,35}, abandonded

### DIFF
--- a/pkgs/development/python-modules/vega/default.nix
+++ b/pkgs/development/python-modules/vega/default.nix
@@ -1,9 +1,10 @@
-{ stdenv, buildPythonPackage , fetchPypi
+{ stdenv, buildPythonPackage , fetchPypi, pythonOlder
 , pytest, jupyter_core, pandas, ipywidgets }:
 
 buildPythonPackage rec {
   pname = "vega";
   version = "3.4.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION

###### Motivation for this change

```
  Processing ./vega-3.4.0-py2-none-any.whl
  ERROR: Package 'vega' requires a different Python: 2.7.18 not in '>=3.6.1'
  builder for '/nix/store/l6f04q9sk1a3n8rl4rscaz2w8xinygfr-python2.7-vega-3.4.0.drv' failed with exit code 1
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
