### PR TITLE
python2Packages.statsmodels: disable py2, abandonded

### DIFF
--- a/pkgs/development/python-modules/statsmodels/default.nix
+++ b/pkgs/development/python-modules/statsmodels/default.nix
@@ -1,7 +1,7 @@
 { lib
-, self
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , nose
 , numpy
 , scipy
@@ -20,11 +20,13 @@ buildPythonPackage rec {
     sha256 = "5bde3fa0a35a91b45dba7cbc28270b5b649ff1d721c89290883f6e831672d5f0";
   };
 
-  checkInputs = with self; [ nose ];
-  propagatedBuildInputs = with self; [numpy scipy pandas patsy cython matplotlib];
+  nativeBuildInputs = [ cython ];
+  checkInputs = [ nose ];
+  propagatedBuildInputs = [ numpy scipy pandas patsy matplotlib ];
 
   # Huge test suites with several test failures
   doCheck = false;
+  pythonImportsCheck = [ "statsmodels" ];
 
   meta = {
     description = "Statistical computations and models for use with SciPy";


### PR DESCRIPTION
###### Motivation for this change
```
  Processing ./statsmodels-0.11.1-cp27-cp27mu-linux_x86_64.whl
  ERROR: Package 'statsmodels' requires a different Python: 2.7.18 not in '>=3.5'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
