### PR TITLE
bitcoin-abc: 0.21.5 -> 0.21.10

### DIFF
--- a/pkgs/applications/blockchains/bitcoin-abc.nix
+++ b/pkgs/applications/blockchains/bitcoin-abc.nix
@@ -1,30 +1,36 @@
-{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, autoreconfHook, openssl, db53, boost
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, cmake, openssl, db53, boost
 , zlib, miniupnpc, qtbase ? null , qttools ? null, utillinux, protobuf, qrencode, libevent
-, withGui }:
+, withGui, python3, jemalloc, zeromq4 }:
 
 with stdenv.lib;
 
 mkDerivation rec {
 
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-abc-" + version;
-  version = "0.21.5";
+  version = "0.21.10";
 
   src = fetchFromGitHub {
     owner = "bitcoin-ABC";
     repo = "bitcoin-abc";
     rev = "v${version}";
-    sha256 = "1jx33n8dhn16iaxvmc56cxw0i5qk0ga5nf7qf9frwwq6zkglknga";
+    sha256 = "1m210g6db8f09m66v75ia1fdd1dlvs1srgk2jhd3wqbvnmjqa77f";
   };
 
   patches = [ ./fix-bitcoin-qt-build.patch ];
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook ];
-  buildInputs = [ openssl db53 boost zlib
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ openssl db53 boost zlib python3 jemalloc zeromq4
                   miniupnpc utillinux protobuf libevent ]
                   ++ optionals withGui [ qtbase qttools qrencode ];
 
-  configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
-                     ++ optionals withGui [ "--with-gui=qt5" ];
+  cmakeFlags = optionals (!withGui) [
+    "-DBUILD_BITCOIN_QT=OFF"
+  ];
+
+  # many of the generated scripts lack execute permissions
+  postConfigure = ''
+    find ./. -type f -iname "*.sh" -exec chmod +x {} \;
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date in `r-ryantm` logs

switch from autotools to cmake, as it was deprecated upstream

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
