### PR TITLE
assh: 2.7.0 -> 2.10.0, use buildGoModule

### DIFF
--- a/pkgs/tools/networking/assh/default.nix
+++ b/pkgs/tools/networking/assh/default.nix
@@ -1,11 +1,17 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, openssh, makeWrapper }:
+{ stdenv, buildGoModule, fetchFromGitHub, openssh, makeWrapper }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "assh";
-  version = "2.7.0";
+  version = "2.10.0";
 
-  goPackagePath = "github.com/moul/advanced-ssh-config";
-  subPackages = [ "cmd/assh" ];
+  src = fetchFromGitHub {
+    repo = "advanced-ssh-config";
+    owner = "moul";
+    rev = "v${version}";
+    sha256 = "0qsb5p52v961akshgs1yla2d7lhcbwixv2skqaappdmhj18a23q2";
+  };
+
+  vendorSha256 = "03ycjhal4g7bs9fhzrq01ijj48czvs272qcqkd9farsha5gf0q0b";
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -14,16 +20,15 @@ buildGoPackage rec {
       --prefix PATH : ${openssh}/bin
   '';
 
-  src = fetchFromGitHub {
-    repo = "advanced-ssh-config";
-    owner = "moul";
-    rev = "v${version}";
-    sha256 = "0jfpcr8990lb7kacadbishdkz5l8spw24ksdlb79x34sdbbp3fm6";
-  };
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/assh --help > /dev/null
+  '';
 
   meta = with stdenv.lib; {
     description = "Advanced SSH config - Regex, aliases, gateways, includes and dynamic hosts";
-    homepage = "https://github.com/moul/advanced-ssh-config";
+    homepage = "https://github.com/moul/assh";
+    changelog = "https://github.com/moul/assh/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ zzamboni ];
     platforms = with platforms; linux ++ darwin;


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date in logs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
