### PR TITLE
bitcoinunlimited: 1.7.0.0 -> 1.8.0.0

### DIFF
--- a/pkgs/applications/blockchains/bitcoin-unlimited.nix
+++ b/pkgs/applications/blockchains/bitcoin-unlimited.nix
@@ -7,13 +7,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-unlimited-" + version;
-  version = "1.7.0.0";
+  version = "1.8.0.0";
 
   src = fetchFromGitHub {
     owner = "bitcoinunlimited";
     repo = "bitcoinunlimited";
-    rev = "bucash${version}";
-    sha256 = "0lil6rivrj4cnr8a7n8zn9rp9f4h2nk88jjxc29m6dwqn5gk6f1i";
+    rev = "BCHunlimited${version}";
+    sha256 = "01qi15li5x9fvhsmvx7ai5fz6yzqqd3r9yv7081h75jn0nxai49q";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook python3 ]


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
