### PR TITLE
hubstaff: 1.5.2-bead991b -> 1.5.12-69dedb26

### DIFF
--- a/pkgs/applications/misc/hubstaff/revision.json
+++ b/pkgs/applications/misc/hubstaff/revision.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://hubstaff-production.s3.amazonaws.com/downloads/HubstaffClient/Builds/Release/1.5.2-bead991b/Hubstaff-1.5.2-bead991b.sh",
-  "version": "1.5.2-bead991b",
-  "sha256": "068b0q94ydldyjmzbka1j94vr1xdxvkxq79pp7ria81hvpp68yxf"
+  "url": "https://hubstaff-production.s3.amazonaws.com/downloads/HubstaffClient/Builds/Release/1.5.12-69dedb26/Hubstaff-1.5.12-69dedb26.sh",
+  "version": "1.5.12-69dedb26",
+  "sha256": "0pp5bz1hi42h98yah7xynmr3i63w03q0cf3nyilq4binblf6yh8x"
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Hubstaff disallows login to 1.5.2. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
