### PR TITLE
adns: 1.5.1 -> 1.6.0

### DIFF
--- a/pkgs/development/libraries/adns/default.nix
+++ b/pkgs/development/libraries/adns/default.nix
@@ -1,11 +1,8 @@
-{ stdenv, fetchurl }:
+{ stdenv, lib, fetchurl, gnum4 }:
 
-let
-  version = "1.5.1";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "adns";
-  inherit version;
+  version = "1.6.0";
 
   src = fetchurl {
     urls = [
@@ -13,25 +10,38 @@ stdenv.mkDerivation {
       "ftp://ftp.chiark.greenend.org.uk/users/ian/adns/adns-${version}.tar.gz"
       "mirror://gnu/adns/adns-${version}.tar.gz"
     ];
-    sha256 = "1ssfh94ck6kn98nf2yy6743srpgqgd167va5ja3bwx42igqjc42v";
+    sha256 = "1pi0xl07pav4zm2jrbrfpv43s1r1q1y12awgak8k7q41m5jp4hpv";
   };
 
+  nativeBuildInputs = [ gnum4 ];
+
   preConfigure =
-    stdenv.lib.optionalString stdenv.isDarwin "sed -i -e 's|-Wl,-soname=$(SHLIBSONAME)||' configure";
+    lib.optionalString stdenv.isDarwin "sed -i -e 's|-Wl,-soname=$(SHLIBSONAME)||' configure";
 
   # https://www.mail-archive.com/nix-dev@cs.uu.nl/msg01347.html for details.
   doCheck = false;
 
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
-    install_name_tool -id $out/lib/libadns.so.1.5 $out/lib/libadns.so.1.5
+  postInstall = let suffix = lib.versions.majorMinor version;
+  in lib.optionalString stdenv.isDarwin ''
+    install_name_tool -id $out/lib/libadns.so.${suffix} $out/lib/libadns.so.${suffix}
   '';
 
-  meta = {
+  # darwin executables fail, but I don't want to fail the 100-500 packages depending on this lib
+  doInstallCheck = !stdenv.isDarwin;
+  installCheckPhase = ''
+    set -eo pipefail
+
+    for prog in $out/bin/*; do
+      $prog --help > /dev/null && echo $(basename $prog) shows usage
+    done
+  '';
+
+  meta = with lib; {
     homepage = "http://www.chiark.greenend.org.uk/~ian/adns/";
     description = "Asynchronous DNS Resolver Library";
-    license = stdenv.lib.licenses.lgpl2;
+    license = licenses.lgpl2;
 
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.peti ];
+    platforms = platforms.unix;
+    maintainers = [ maintainers.peti ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
saw it needed updating in logs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
