### PR TITLE
cc-tool: Init at unstable-2020-05-19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1652,6 +1652,16 @@
     githubId = 1222362;
     name = "Matías Lang";
   };
+  CRTified = {
+    email = "carl.schneider+nixos@rub.de";
+    github = "CRTified";
+    githubId = 2440581;
+    name = "Carl Richard Theodor Schneider";
+    keys = [{
+      longkeyid = "rsa4096/0x45BCC1E2709B1788";
+      fingerprint = "2017 E152 BB81 5C16 955C  E612 45BC C1E2 709B 1788";
+    }];
+  };
   cryptix = {
     email = "cryptix@riseup.net";
     github = "cryptix";

--- a/pkgs/development/tools/misc/cc-tool/default.nix
+++ b/pkgs/development/tools/misc/cc-tool/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, boost
+, libusb1
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cc-tool";
+  version = "unstable-2020-05-19";
+
+  src = fetchFromGitHub {
+    owner = "dashesy";
+    repo = pname;
+    rev = "19e707eafaaddee8b996ad27a9f3e1aafcb900d2";
+    hash = "sha256:1f78j498fdd36xbci57jkgh25gq14g3b6xmp76imdpar0jkpyljv";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ boost libusb1 ];
+
+  postPatch = ''
+    substituteInPlace udev/90-cc-debugger.rules \
+      --replace 'MODE="0666"' 'MODE="0660", GROUP="plugdev", TAG+="uaccess"'
+  '';
+
+  postInstall = ''
+    install -D udev/90-cc-debugger.rules $out/lib/udev/rules.d/90-cc-debugger.rules
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Command line tool for the Texas Instruments CC Debugger";
+    longDescription = ''
+      cc-tool provides support for Texas Instruments CC Debugger
+    '';
+    homepage = "https://github.com/dashesy/cc-tool";
+    license = licenses.gpl2;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = [ maintainers.CRTified ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10217,6 +10217,8 @@ in
 
   cbrowser = callPackage ../development/tools/misc/cbrowser { };
 
+  cc-tool = callPackage ../development/tools/misc/cc-tool { };
+
   ccache = callPackage ../development/tools/misc/ccache { };
 
   # Wrapper that works as gcc or g++


### PR DESCRIPTION
#### Motivation for this change

cc-tool is a CLI tool to interface with Texas Instruments debugger, to e.g. flash a firmware onto Zigbee devices [like the CC2531](https://www.zigbee2mqtt.io/getting_started/flashing_the_cc2531.html), which is needed to prepare such a device for the usage with zigbee2mqtt (related PR: #72320).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
