### PR TITLE
dotnetCorePackage.{asp,}netcore_3_1: 3.1.2 -> 3.1.5

### DIFF
--- a/pkgs/development/compilers/dotnet/default.nix
+++ b/pkgs/development/compilers/dotnet/default.nix
@@ -77,11 +77,11 @@ rec {
   # v3.1.1 (LTS)
 
   aspnetcore_3_1 = buildAspNetCore {
-    version = "3.1.2";
+    version = "3.1.5";
     sha512 = {
-      x86_64-linux = "27708bk5liz8r39p4dzs41clgq298d49g8ipzdj56pz613vkfyv7bp91666ydz36aazm265j2g9ji3sk1f9kbgv6024zwrly5w9vqrm";
-      aarch64-linux = "2sm5yf376w5dm0za3gbcj251kc909fmlasmlyn70zhqp2jiii075vcqh40racjlwlhsfydx32cw7kgnv238lad5mw5jxy143zql5xl3";
-      x86_64-darwin = "311sihjzg0x5inyrz0px29jikxcibd6l56xfdmxkncgwaikf3663x10dfl246qhz8v0f3lvg2vndgp5icbaqrp8awsnrhsl0vi5d7fh";
+      x86_64-linux = "3ziyvm6llvhnjg8ayr4cfcabwkc46fqscgj12faavib34r5zx4mnv3qccqm3gg2r8jps60h42lvrwj3fliqmr0qqnhsw04819kqwai6";
+      aarch64-linux = "2nbhvh8dpg7dghcs6ysdg7mcc60hbk5d3zab0nnbqkib93fdhbzhzcra9qhh80h8x03zw0jsn3gzqx0d1z2vz5z3lsa14vmb86pzj4a";
+      x86_64-darwin = "1sfnp849vmsv8775fjsf9nzx28cmkvfgk8fa81h2l849z31ssaw9fn89kk0n83l0wrhr24ivmprfr11sp42gnjbncqfsnz4883lfchw";
     };
   };
 

--- a/pkgs/development/compilers/dotnet/default.nix
+++ b/pkgs/development/compilers/dotnet/default.nix
@@ -86,11 +86,11 @@ rec {
   };
 
   netcore_3_1 = buildNetCore {
-    version = "3.1.2";
+    version = "3.1.5";
     sha512 = {
-      x86_64-linux = "3zwg1anrcni9kagmjxn485bpjvb146hkm7irmikq3v879gjhd2fgpscg226ds83l4pxll3r7lwris6ij952xmy8lsqraapd9111ba14";
-      aarch64-linux = "3hf61d5adlfffy51627ypp36qc5r55g9xwgfxqd0c7vj9bqmpiph673bvqqpr189df9shxr21p94cwrc5n36z72a37vw4ic8ks2yayx";
-      x86_64-darwin = "35flr1p5zpcd77mjsl6qy9ipxc5k9j6pk7ca6mnvqqjf0r3agm3qf8cs5fbraprvkwj8fha3giwbp5xir6050fbb374375idn9x12d8";
+      x86_64-linux = "03g6aghbpsxj9csaq9lkc8cad1nk8kvlivkarq6bfqvx992fxw6zryp7kcm5h6a5gkgpimb1nr17vndj1r629hdhpincqj8yw6i33mq";
+      aarch64-linux = "25gwicmpzhzs96w3azypbl32bx967f14xkfdgvl7knw234rcmfv7zr0a7lb3vci68dbx4xywpnwlrvgi54mimzp8nagrgwva8zrrxzb";
+      x86_64-darwin = "2g28jmv1n7pgxfq4wk9x58y5dp835c7rckz6c88ylk7g9w6z75l94pblfl1rc7mr6g3wddiy5cl87a607j9g283hv28a4vcpvll8s7g";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
