### PR TITLE
ocaml-lsp: init at 2020-07-07

### DIFF
--- a/pkgs/development/tools/ocaml/ocaml-lsp/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-lsp/default.nix
@@ -1,0 +1,33 @@
+{ lib, fetchFromGitHub, ocamlPackages }:
+
+with ocamlPackages; buildDunePackage rec {
+  pname = "lsp-unstable";
+  version = "2020-07-08";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "ocaml";
+    repo = "ocaml-lsp";
+    rev = "61686edf88b8f893862f9aa152be64e17c92295f";
+    sha256 = "0qgrsrydf6wimy9hrw7b54zwwrg92fr60r6yf3z4ilbrj4nl5xq4";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ cppo yojson ppx_yojson_conv_lib stdlib-shims menhir dune-build-info ];
+
+  buildPhase = ''
+    dune build @install
+  '';
+
+  installPhase = ''
+    dune install --prefix=$out --sections bin
+  '';
+
+  meta = with lib; {
+    description = "OCaml Language Server Protocol implementation";
+    homepage = "https://github.com/ocaml/ocaml-lsp";
+    license = licenses.isc;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9210,6 +9210,8 @@ in
 
   ocaml-crunch = ocamlPackages.crunch.bin;
 
+  ocaml-lsp = callPackage ../development/tools/ocaml/ocaml-lsp { };
+
   ocamlformat = callPackage ../development/tools/ocaml/ocamlformat { };
 
   orc = callPackage ../development/compilers/orc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add https://github.com/ocaml/ocaml-lsp

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
