### PR TITLE
python3Packages.msrest{,azure}: bump

### DIFF
--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -18,7 +18,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.6.13";
+  version = "0.6.17";
   pname = "msrest";
 
   # no tests in PyPI tarball
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "Azure";
     repo = "msrest-for-python";
     rev = "v${version}";
-    sha256 = "1s34xp6wgas17mbg6ysciqlgb3qc2p2d5bs9brwr05ys62l6y8cz";
+    sha256 = "1f1cpl5x7q0f9lpwxc1pl9j5x5yrksfizl9k939iqklf95ssymff";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/msrestazure/default.nix
+++ b/pkgs/development/python-modules/msrestazure/default.nix
@@ -12,7 +12,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.6.3";
+  version = "0.6.4";
   pname = "msrestazure";
 
   # Pypi tarball doesnt include tests
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "Azure";
     repo = "msrestazure-for-python";
     rev = "v${version}";
-    sha256 = "0pd3qw96c9fz4qgimnc0qf0pz7m9rr1wzhxj8m792swaf3pb18z8";
+    sha256 = "0ik81f0n6r27f02gblgm0vl5zl3wc6ijsscihgvc1fgm9f5mk5b5";
   };
 
   propagatedBuildInputs = [ adal msrest ];


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

failure broken on master
```
https://github.com/NixOS/nixpkgs/pull/92682
1 package failed to build:
python37Packages.azure-identity

262 packages built:
azure-cli nixops_1_6_1 python27Packages.azure-applicationinsights python27Packages.azure-batch python27Packages.azure-eventgrid python27Packages.azure-functions-devops-build python27Packages.azure-graphrbac python27Packages.azure-loganalytics python27Packages.azure-mgmt-advisor python27Packages.azure-mgmt-applicationinsights python27Packages.azure-mgmt-authorization python27Packages.azure-mgmt-batch python27Packages.azure-mgmt-batchai python27Packages.azure-mgmt-billing python27Packages.azure-mgmt-cdn python27Packages.azure-mgmt-cognitiveservices python27Packages.azure-mgmt-commerce python27Packages.azure-mgmt-common python27Packages.azure-mgmt-compute python27Packages.azure-mgmt-consumption python27Packages.azure-mgmt-containerinstance python27Packages.azure-mgmt-containerservice python27Packages.azure-mgmt-cosmosdb python27Packages.azure-mgmt-datafactory python27Packages.azure-mgmt-datalake-analytics python27Packages.azure-mgmt-datalake-store python27Packages.azure-mgmt-datamigration python27Packages.azure-mgmt-devspaces python27Packages.azure-mgmt-devtestlabs python27Packages.azure-mgmt-dns python27Packages.azure-mgmt-eventgrid python27Packages.azure-mgmt-eventhub python27Packages.azure-mgmt-hanaonazure python27Packages.azure-mgmt-iotcentral python27Packages.azure-mgmt-iothub python27Packages.azure-mgmt-iothubprovisioningservices python27Packages.azure-mgmt-keyvault python27Packages.azure-mgmt-loganalytics python27Packages.azure-mgmt-logic python27Packages.azure-mgmt-machinelearningcompute python27Packages.azure-mgmt-managementgroups python27Packages.azure-mgmt-managementpartner python27Packages.azure-mgmt-maps python27Packages.azure-mgmt-marketplaceordering python27Packages.azure-mgmt-media python27Packages.azure-mgmt-monitor python27Packages.azure-mgmt-msi python27Packages.azure-mgmt-network python27Packages.azure-mgmt-notificationhubs python27Packages.azure-mgmt-policyinsights python27Packages.azure-mgmt-powerbiembedded python27Packages.azure-mgmt-rdbms python27Packages.azure-mgmt-recoveryservices python27Packages.azure-mgmt-recoveryservicesbackup python27Packages.azure-mgmt-redis python27Packages.azure-mgmt-relay python27Packages.azure-mgmt-reservations python27Packages.azure-mgmt-resource python27Packages.azure-mgmt-scheduler python27Packages.azure-mgmt-search python27Packages.azure-mgmt-servicebus python27Packages.azure-mgmt-servicefabric python27Packages.azure-mgmt-signalr python27Packages.azure-mgmt-sql python27Packages.azure-mgmt-storage python27Packages.azure-mgmt-subscription python27Packages.azure-mgmt-trafficmanager python27Packages.azure-mgmt-web python27Packages.azure-servicebus python27Packages.azure-servicefabric python27Packages.msrest python27Packages.msrestazure python27Packages.vsts python27Packages.vsts-cd-manager python37Packages.azure-applicationinsights python37Packages.azure-batch python37Packages.azure-core python37Packages.azure-eventgrid python37Packages.azure-functions-devops-build python37Packages.azure-graphrbac python37Packages.azure-keyvault python37Packages.azure-keyvault-certificates python37Packages.azure-keyvault-keys python37Packages.azure-keyvault-secrets python37Packages.azure-loganalytics python37Packages.azure-mgmt-advisor python37Packages.azure-mgmt-apimanagement python37Packages.azure-mgmt-appconfiguration python37Packages.azure-mgmt-applicationinsights python37Packages.azure-mgmt-authorization python37Packages.azure-mgmt-batch python37Packages.azure-mgmt-batchai python37Packages.azure-mgmt-billing python37Packages.azure-mgmt-botservice python37Packages.azure-mgmt-cdn python37Packages.azure-mgmt-cognitiveservices python37Packages.azure-mgmt-commerce python37Packages.azure-mgmt-common python37Packages.azure-mgmt-compute python37Packages.azure-mgmt-consumption python37Packages.azure-mgmt-containerinstance python37Packages.azure-mgmt-containerregistry python37Packages.azure-mgmt-containerservice python37Packages.azure-mgmt-core python37Packages.azure-mgmt-cosmosdb python37Packages.azure-mgmt-datafactory python37Packages.azure-mgmt-datalake-analytics python37Packages.azure-mgmt-datalake-store python37Packages.azure-mgmt-datamigration python37Packages.azure-mgmt-deploymentmanager python37Packages.azure-mgmt-devspaces python37Packages.azure-mgmt-devtestlabs python37Packages.azure-mgmt-dns python37Packages.azure-mgmt-eventgrid python37Packages.azure-mgmt-eventhub python37Packages.azure-mgmt-hanaonazure python37Packages.azure-mgmt-hdinsight python37Packages.azure-mgmt-imagebuilder python37Packages.azure-mgmt-iotcentral python37Packages.azure-mgmt-iothub python37Packages.azure-mgmt-iothubprovisioningservices python37Packages.azure-mgmt-keyvault python37Packages.azure-mgmt-kusto python37Packages.azure-mgmt-loganalytics python37Packages.azure-mgmt-logic python37Packages.azure-mgmt-machinelearningcompute python37Packages.azure-mgmt-managedservices python37Packages.azure-mgmt-managementgroups python37Packages.azure-mgmt-managementpartner python37Packages.azure-mgmt-maps python37Packages.azure-mgmt-marketplaceordering python37Packages.azure-mgmt-media python37Packages.azure-mgmt-monitor python37Packages.azure-mgmt-msi python37Packages.azure-mgmt-netapp python37Packages.azure-mgmt-network python37Packages.azure-mgmt-notificationhubs python37Packages.azure-mgmt-policyinsights python37Packages.azure-mgmt-powerbiembedded python37Packages.azure-mgmt-privatedns python37Packages.azure-mgmt-rdbms python37Packages.azure-mgmt-recoveryservices python37Packages.azure-mgmt-recoveryservicesbackup python37Packages.azure-mgmt-redhatopenshift python37Packages.azure-mgmt-redis python37Packages.azure-mgmt-relay python37Packages.azure-mgmt-reservations python37Packages.azure-mgmt-resource python37Packages.azure-mgmt-scheduler python37Packages.azure-mgmt-search python37Packages.azure-mgmt-security python37Packages.azure-mgmt-servicebus python37Packages.azure-mgmt-servicefabric python37Packages.azure-mgmt-signalr python37Packages.azure-mgmt-sql python37Packages.azure-mgmt-sqlvirtualmachine python37Packages.azure-mgmt-storage python37Packages.azure-mgmt-subscription python37Packages.azure-mgmt-trafficmanager python37Packages.azure-mgmt-web python37Packages.azure-multiapi-storage python37Packages.azure-servicebus python37Packages.azure-servicefabric python37Packages.azure-storage-file-share python37Packages.msrest python37Packages.msrestazure python37Packages.vsts python37Packages.vsts-cd-manager python38Packages.azure-applicationinsights python38Packages.azure-batch python38Packages.azure-core python38Packages.azure-eventgrid python38Packages.azure-functions-devops-build python38Packages.azure-graphrbac python38Packages.azure-keyvault python38Packages.azure-keyvault-certificates python38Packages.azure-keyvault-keys python38Packages.azure-keyvault-secrets python38Packages.azure-loganalytics python38Packages.azure-mgmt-advisor python38Packages.azure-mgmt-apimanagement python38Packages.azure-mgmt-appconfiguration python38Packages.azure-mgmt-applicationinsights python38Packages.azure-mgmt-authorization python38Packages.azure-mgmt-batch python38Packages.azure-mgmt-batchai python38Packages.azure-mgmt-billing python38Packages.azure-mgmt-botservice python38Packages.azure-mgmt-cdn python38Packages.azure-mgmt-cognitiveservices python38Packages.azure-mgmt-commerce python38Packages.azure-mgmt-common python38Packages.azure-mgmt-compute python38Packages.azure-mgmt-consumption python38Packages.azure-mgmt-containerinstance python38Packages.azure-mgmt-containerregistry python38Packages.azure-mgmt-containerservice python38Packages.azure-mgmt-core python38Packages.azure-mgmt-cosmosdb python38Packages.azure-mgmt-datafactory python38Packages.azure-mgmt-datalake-analytics python38Packages.azure-mgmt-datalake-store python38Packages.azure-mgmt-datamigration python38Packages.azure-mgmt-deploymentmanager python38Packages.azure-mgmt-devspaces python38Packages.azure-mgmt-devtestlabs python38Packages.azure-mgmt-dns python38Packages.azure-mgmt-eventgrid python38Packages.azure-mgmt-eventhub python38Packages.azure-mgmt-hanaonazure python38Packages.azure-mgmt-hdinsight python38Packages.azure-mgmt-imagebuilder python38Packages.azure-mgmt-iotcentral python38Packages.azure-mgmt-iothub python38Packages.azure-mgmt-iothubprovisioningservices python38Packages.azure-mgmt-keyvault python38Packages.azure-mgmt-kusto python38Packages.azure-mgmt-loganalytics python38Packages.azure-mgmt-logic python38Packages.azure-mgmt-machinelearningcompute python38Packages.azure-mgmt-managedservices python38Packages.azure-mgmt-managementgroups python38Packages.azure-mgmt-managementpartner python38Packages.azure-mgmt-maps python38Packages.azure-mgmt-marketplaceordering python38Packages.azure-mgmt-media python38Packages.azure-mgmt-monitor python38Packages.azure-mgmt-msi python38Packages.azure-mgmt-netapp python38Packages.azure-mgmt-network python38Packages.azure-mgmt-notificationhubs python38Packages.azure-mgmt-policyinsights python38Packages.azure-mgmt-powerbiembedded python38Packages.azure-mgmt-privatedns python38Packages.azure-mgmt-rdbms python38Packages.azure-mgmt-recoveryservices python38Packages.azure-mgmt-recoveryservicesbackup python38Packages.azure-mgmt-redhatopenshift python38Packages.azure-mgmt-redis python38Packages.azure-mgmt-relay python38Packages.azure-mgmt-reservations python38Packages.azure-mgmt-resource python38Packages.azure-mgmt-scheduler python38Packages.azure-mgmt-search python38Packages.azure-mgmt-security python38Packages.azure-mgmt-servicebus python38Packages.azure-mgmt-servicefabric python38Packages.azure-mgmt-signalr python38Packages.azure-mgmt-sql python38Packages.azure-mgmt-sqlvirtualmachine python38Packages.azure-mgmt-storage python38Packages.azure-mgmt-subscription python38Packages.azure-mgmt-trafficmanager python38Packages.azure-mgmt-web python38Packages.azure-multiapi-storage python38Packages.azure-servicebus python38Packages.azure-servicefabric python38Packages.azure-storage-file-share python38Packages.msrest python38Packages.msrestazure python38Packages.vsts python38Packages.vsts-cd-manager
```