### PR TITLE
kustomize: 3.3.1 -> 3.8.0

### DIFF
--- a/pkgs/development/tools/kustomize/default.nix
+++ b/pkgs/development/tools/kustomize/default.nix
@@ -1,29 +1,30 @@
-{ lib, buildGoModule, fetchFromGitHub, tree }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "kustomize";
-  version = "3.3.1";
-  # rev is the 3.3.1 commit, mainly for kustomize version command output
-  rev = "f2ac5a2d0df13c047fb20cbc12ef1a3b41ce2dad";
+  version = "3.8.0";
+  # rev is the 3.8.0 commit, mainly for kustomize version command output
+  rev = "6a50372dd5686df22750b0c729adaf369fbf193c";
 
-  buildFlagsArray = let t = "sigs.k8s.io/kustomize/v3/provenance"; in ''
-    -ldflags=
-      -s -X ${t}.version=${version}
-         -X ${t}.gitCommit=${rev}
-         -X ${t}.buildDate=unknown
-  '';
+  buildFlagsArray = let t = "sigs.k8s.io/kustomize/api/provenance"; in
+    ''
+      -ldflags=
+        -s -X ${t}.version=${version}
+           -X ${t}.gitCommit=${rev}
+    '';
 
   src = fetchFromGitHub {
     owner = "kubernetes-sigs";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0yxxz0b56r18w178y32s619zy8ci6l93c6vlzx11hhxhbw43f6v6";
+    rev = "kustomize/v${version}";
+    sha256 = "1v86gqn16xh28gi2fa6jgbbk0clrcng3sbr1az42iy4mm4nmsriy";
   };
 
   # avoid finding test and development commands
   sourceRoot = "source/kustomize";
 
-  vendorSha256 = "06mf5zvxn10g5rqjpqv3afvhj9xmijbj8ag8pqcg1996s4rp4p7a";
+  deleteVendor = true;
+  vendorSha256 = "03z40gi9nrj120cd57pa3fmi8grldyxa65a1lkvlc2r3z9g29vdw";
 
   meta = with lib; {
     description = "Customization of kubernetes YAML configurations";


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Version update

###### Things done
tree removed, since doesn't look necessary
buildDate flag removed. If unset, the default date is 1/1/1970, which is
common practice when building nix packages

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
