### PR TITLE
dockerTools.buildLayeredImage: fix created=now

### DIFF
--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -90,10 +90,19 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
     with subtest("Ensure Docker images can use an unstable date"):
         docker.succeed(
-            "docker load --input='${examples.bash}'"
+            "docker load --input='${examples.unstableDate}'"
         )
         assert unix_time_second1 not in docker.succeed(
             "docker inspect ${examples.unstableDate.imageName} "
+            + "| ${pkgs.jq}/bin/jq -r .[].Created"
+        )
+
+    with subtest("Ensure Layered Docker images can use an unstable date"):
+        docker.succeed(
+            "docker load --input='${examples.unstableDateLayered}'"
+        )
+        assert unix_time_second1 not in docker.succeed(
+            "docker inspect ${examples.unstableDateLayered.imageName} "
             + "| ${pkgs.jq}/bin/jq -r .[].Created"
         )
 

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -354,4 +354,14 @@ rec {
       Env = [ "USER=root" ];
     };
   };
+
+  # 20. Ensure that setting created to now results in a date which
+  # isn't the epoch + 1 for layered images.
+  unstableDateLayered = pkgs.dockerTools.buildLayeredImage {
+    name = "unstable-date-layered";
+    tag = "latest";
+    contents = [ pkgs.coreutils ];
+    created = "now";
+  };
+
 }

--- a/pkgs/build-support/docker/stream_layered_image.py
+++ b/pkgs/build-support/docker/stream_layered_image.py
@@ -41,7 +41,7 @@ import pathlib
 import tarfile
 import itertools
 import threading
-from datetime import datetime
+from datetime import datetime, timezone
 from collections import namedtuple
 
 
@@ -242,7 +242,7 @@ def main():
         conf = json.load(f)
 
     created = (
-      datetime.now(tz=datetime.timezone.utc)
+      datetime.now(tz=timezone.utc)
       if conf["created"] == "now"
       else datetime.fromisoformat(conf["created"])
     )
@@ -280,7 +280,7 @@ def main():
             },
             "history": [
                 {
-                  "created": conf["created"],
+                  "created": datetime.isoformat(created),
                   "comment": f"store paths: {layer.paths}"
                 }
                 for layer in layers


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Building a layered docker image with `created = "now";` like so:

```nix
with import <nixpkgs> {};

pkgs.dockerTools.buildLayeredImage {
  name = "k8s-deployer";
  tag = "latest";
  created = "now";
  # ...
}
```

Fails with error:

```
these derivations will be built:
  /nix/store/w9bis8iriida0vj9ybfnlwd5yskzwj6k-k8s-deployer.tar.gz.drv
building '/nix/store/w9bis8iriida0vj9ybfnlwd5yskzwj6k-k8s-deployer.tar.gz.drv'...
Traceback (most recent call last):
  File "/nix/store/n59sj4r1rr1f6411wbsr1nx6zz33pq47-stream", line 309, in <module>
    main()
  File "/nix/store/n59sj4r1rr1f6411wbsr1nx6zz33pq47-stream", line 245, in main
    datetime.now(tz=datetime.timezone.utc)
AttributeError: type object 'datetime.datetime' has no attribute 'timezone'
builder for '/nix/store/w9bis8iriida0vj9ybfnlwd5yskzwj6k-k8s-deployer.tar.gz.drv' failed with exit code 1
```

`timezone` should be imported from `datetime`, not from `datetime.datetime`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
