### PR TITLE
jabcode: init at git-2020-05-13

### DIFF
--- a/pkgs/development/libraries/jabcode/default.nix
+++ b/pkgs/development/libraries/jabcode/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, subproject ? "library" # one of "library", "reader" or  "writer"
+, zlib, libpng, libtiff
+, jabcode 
+}:
+let
+  subdir = lib.getAttr subproject {
+    "library" = "jabcode";
+    "reader" = "jabcodeReader";
+    "writer" = "jabcodeWriter";
+  };
+in stdenv.mkDerivation rec {
+  pname = "jabcode-${subproject}";
+  version = "git-2020-05-13";
+  src = fetchFromGitHub {
+    repo = "jabcode";
+    owner = "jabcode";
+    rev = "a7c25d4f248078f257b014e31c791bfcfcd083e1";
+    sha256 = "1c4cv9b0d7r4bxzkwzdv9h651ziq822iya6fbyizm57n1nzdkk4s";
+  };
+
+  nativeBuildInputs =
+    [ zlib libpng libtiff ]
+    ++ lib.optionals (subproject != "library") [ jabcode ];
+
+  preConfigure = "cd src/${subdir}";
+
+  installPhase = if subproject == "library" then ''
+    mkdir -p $out/lib
+    cp build/* $out/lib
+  '' else ''
+    mkdir -p $out/bin
+    cp -RT bin $out/bin
+  '';
+
+  meta = with lib; {
+    description = "A high-capacity 2D color bar code (${subproject})";
+    longDescription = "JAB Code (Just Another Bar Code) is a high-capacity 2D color bar code, which can encode more data than traditional black/white (QR) codes. This is the ${subproject} part.";
+    homepage = "https://jabcode.org/";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.xaverdh ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20595,6 +20595,16 @@ in
 
   j4-dmenu-desktop = callPackage ../applications/misc/j4-dmenu-desktop { };
 
+  jabcode = callPackage ../development/libraries/jabcode { };
+
+  jabcode-writer = callPackage ../development/libraries/jabcode {
+    subproject = "writer";
+  };
+
+  jabcode-reader = callPackage ../development/libraries/jabcode {
+    subproject = "reader";
+  };
+
   jabref = callPackage ../applications/office/jabref { };
 
   jack_capture = callPackage ../applications/audio/jack-capture { };


### PR DESCRIPTION
###### Motivation for this change
`jabcode` consists of a library and reader/writer executables for the JAB bar code format. It constitutes the reference implementation of what will be an ISO standard (NP23634).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
