### PR TITLE
mutter: 3.36.3 -> 3.36.4

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -44,13 +44,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mutter";
-  version = "3.36.3";
+  version = "3.36.4";
 
   outputs = [ "out" "dev" "man" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1lpf7anlm073npmfqc5n005kyj12j0ym8y9dqg9q7448ilp79kka";
+    sha256 = "0p3jglw6f2h67kwk89qz1rz23y25lip8m2mp2xshf2vrg4a930as";
   };
 
   mesonFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump for mutter.

```
3.36.4
======
* Fix crash on area screenshots with fractional scaling [Sebastian; !1320]
* Do not paint textures of fully obscured windows [Robert; !1326]
* Turn off CRTCs as well when enabling DPMS [Michel; !1240]
* Improve selection support
  [Robert, Carlos, Sebastian; !1330, !1193, !1253, !1255, !1293, !1350]
* Use a more appropriate combine function on opaque areas [Daniel; !1331]
* Fix remote desktop being broken without screencast session [Olivier; #1307]
* Fix popovers disappearing on wayland and HiDPI [Robert; #1312]
* Fixed crashes [Jonas Å.; !1317]
* Plugged memory leaks [Jonas Å.; !1283]
* Misc. bug fixes and cleanups
  [Corentin, Sebastian, Jonas Å., Jonas D.; !1314, !1321, !1295, !1333]

Contributors:
  Jonas Dreßler, Michel Dänzer, Olivier Fourdan, Carlos Garnacho,
  Sebastian Keller, Robert Mader, Corentin Noël, Daniel van Vugt, Jonas Ådahl

```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
