### PR TITLE
gnome-shell: 3.36.3 -> 3.36.4

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -17,11 +17,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "gnome-shell";
-  version = "3.36.3";
+  version = "3.36.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1fs51lcaal4lnx6m5a3j8922yjbjk32khznx77cxb2db1zvspn46";
+    sha256 = "1nyibrr98ijn65z9ki0k7xzcwcliwy2jqssz0l0jalpbkhnr751d";
   };
 
   LANG = "en_US.UTF-8";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump for gnome-shell.
```

3.36.4
======
* Hide switch-user button on lock screen if unsupported [Chingkai; #2687]
* Improve world clocks styling [PrOF-kk; #2825]
* Improve calendar-server performance [Florian, Milan; #1875]
* Fix regressions in redesigned modal dialogs [Florian, Jonas; #2491, !1336]
* Better support sandboxed apps with multiple .desktop files [Florian; #219]
* Fix on-screen keyboard size in portrait orientation [Florian; #2349]
* Support scrolling anywhere in slider menu items [Peter; #2795]
* Fixed crash [Marco; #2643]
* Plugged leaks [Sebastian, Florian; !1306, !1341]
* Misc. bug fixes and cleanups [Jonas, Daniel, Florian, Sebastian, MOZGIII,
  Koki; !1119, !1289, !1331, !1192, !1340, !1327, !1279]

Contributors:
  Marco Trevisan (Treviño), Chingkai, Milan Crha, Jonas Dreßler, Koki Fukuda,
  Sebastian Keller, MOZGIII, Robert Mader, Florian Müllner, PrOF-kk,
  Peter Simonyi, Daniel van Vugt

Translators:
  Matej Urbančič [sl], sicklylife [ja], Fabio Tomat [fur],
  Baurzhan Muftakhidinov [kk], Daniel Șerbănescu [ro]
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
