### PR TITLE
gcc: Fix manpage symlinks when architecture tuples are prefixed to the file name

### DIFF
--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -277,7 +277,12 @@ postInstall() {
     done
 
     # Two identical man pages are shipped (moving and compressing is done later)
-    ln -sf gcc.1 "$out"/share/man/man1/g++.1
+    for i in "$out"/share/man/man1/*g++.1; do
+        if test -e "$i"; then
+            man_prefix=`echo "$i" | sed "s,.*/\(.*\)g++.1,\1,"`
+            ln -sf "$man_prefix"gcc.1 "$i"
+        fi
+    done
 }
 
 genericBuild


### PR DESCRIPTION
###### Motivation for this change

In some cases, building `gcc` generates the binaries and manpages prefixed with their architecture tuples, such as `armv6l-unknown-linux-gnueabihf-gcc` and `armv6l-unknown-linux-gnueabihf-g++.1`. One of these cases is building cross compilers like in the following:

```
let
  pkgs = import <nixpkgs> {
    crossSystem = (import <nixpkgs/lib>).systems.examples.raspberryPi;
  };
in
  pkgs.stdenv.cc.man
```

Currently, the `gcc` builder creates a `g++.1 -> gcc.1` symlink to save space, since `g++.1` and `gcc.1` have the same contents, but in such cases where the architecture tuple is included in the manpage name, this creates a broken symlink (which, coincidentally, leads to file collisions when attempting to add a cross-compiler and native `gcc` to a `home-manager` profile or similar). In such cases, `.../share/man/man1` ends up containing a broken symlink like this:

```
total 720
-r--r--r-- 25 root root  13604 Dec 31  1969 armv6l-unknown-linux-gnueabihf-cpp.1.gz
-r--r--r-- 28 root root 335497 Dec 31  1969 armv6l-unknown-linux-gnueabihf-g++.1.gz
-r--r--r-- 28 root root 335497 Dec 31  1969 armv6l-unknown-linux-gnueabihf-gcc.1.gz
-r--r--r-- 25 root root  11318 Dec 31  1969 armv6l-unknown-linux-gnueabihf-gcov.1.gz
-r--r--r-- 25 root root   2517 Dec 31  1969 armv6l-unknown-linux-gnueabihf-gcov-dump.1.gz
-r--r--r-- 25 root root   4056 Dec 31  1969 armv6l-unknown-linux-gnueabihf-gcov-tool.1.gz
lrwxrwxrwx  4 root root      5 Dec 31  1969 g++.1 -> gcc.1
```

This pull request should fix the way the symlink is created to handle the normal situation without any arch tuples prefixing the file, with arch prefixes, and, since I wasn't sure about any other corner cases, it also handles if there are both a prefixed and non-prefixed manpage or if there aren't any manpages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
