### PR TITLE
libvirt: use /run for runstatedir

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -65,6 +65,7 @@ in stdenv.mkDerivation rec {
   dontAddDisableDepTrack = true;
 
   configureFlags = [
+    "--with-runstatedir=/run" # TODO: remove when autoconf 1.70 is released
     "--localstatedir=/var"
     "--sysconfdir=/var/lib"
     "--with-libpcap"
@@ -97,6 +98,7 @@ in stdenv.mkDerivation rec {
   ];
 
   installFlags = [
+    "runstatedir=${placeholder "out"}/run"
     "localstatedir=$(TMPDIR)/var"
     "sysconfdir=$(out)/var/lib"
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
libvirt: use /run for runstatedir

systemd complains:

        Jul 08 12:43:59 kaiser systemd[1]: /nix/store/bvfikb8v9m646m23fqm0rfnnsj6plc2k-libvirt-6.2.0/lib/systemd/system/libvirtd-admin.socket:11: ListenStream= references a path below legacy directory /var/run/, updating /var/run/libvirt/libvirt-admin-sock → /run/libvirt/libvirt-admin-sock; please update the unit file accordingly.
        Jul 08 12:43:59 kaiser systemd[1]: /nix/store/bvfikb8v9m646m23fqm0rfnnsj6plc2k-libvirt-6.2.0/lib/systemd/system/libvirtd-ro.socket:11: ListenStream= references a path below legacy directory /var/run/, updating /var/run/libvirt/libvirt-sock-ro → /run/libvirt/libvirt-sock-ro; please update the unit file accordingly.
        Jul 08 12:43:59 kaiser systemd[1]: /nix/store/bvfikb8v9m646m23fqm0rfnnsj6plc2k-libvirt-6.2.0/lib/systemd/system/libvirtd.socket:9: ListenStream= references a path below legacy directory /var/run/, updating /var/run/libvirt/libvirt-sock → /run/libvirt/libvirt-sock; please update the unit file accordingly.

Let's just set it correctly manually, that is what Red Hat does:

https://gitlab.com/libvirt/libvirt/-/commit/ba7592f6c17d50435582e597727fbfc51322d606

See also:

https://gitlab.com/libvirt/libvirt/-/commit/390997925a3aca1b57969526c3e083761fafe7c3


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
