### PR TITLE
wrapQtAppsHook: wrap binaries in all outputs

### DIFF
--- a/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
@@ -16,6 +16,21 @@ qtUnseenHostPath() {
     return 0
 }
 
+qtFixupPrefixSeen=()
+
+qtUnseenFixupPrefix() {
+    for prefix in "${qtFixupPrefixSeen[@]}"
+    do
+        if [ "${prefix:?}" == "$1" ]
+        then
+            return 1
+        fi
+    done
+
+    qtFixupPrefixSeen+=("$1")
+    return 0
+}
+
 qtHostPathHook() {
     qtUnseenHostPath "$1" || return 0
 
@@ -70,8 +85,7 @@ wrapQtAppsHook() {
     [ -z "${dontWrapQtApps-}" ] || return 0
 
     # guard against running multiple times (e.g. due to propagation)
-    [ -z "$wrapQtAppsHookHasRun" ] || return 0
-    wrapQtAppsHookHasRun=1
+    qtUnseenFixupPrefix "$prefix" || return 0
 
     local targetDirs=( "$prefix/bin" "$prefix/sbin" "$prefix/libexec"  )
     echo "wrapping Qt applications in ${targetDirs[@]}"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`wrapQtAppsHook` currently only wraps the binaries from the first output. All other outputs are skipped.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of some binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
