### PR TITLE
powerline: 2.7 -> 2.8.1

### DIFF
--- a/pkgs/development/python-modules/powerline/default.nix
+++ b/pkgs/development/python-modules/powerline/default.nix
@@ -1,26 +1,38 @@
 { lib
-, fetchurl
+, fetchFromGitHub
+, python
 , buildPythonPackage
+, socat
 , psutil
+, hglib
 , pygit2
+, pyuv
+, i3ipc
 }:
 
-# The source of this package needs to be patched to include the full path to
-# the executables of git, mercurial and bazaar.
+# TODO: bzr support is missing because nixpkgs switched to `breezy`
 
 buildPythonPackage rec {
-  version  = "2.7";
+  version  = "2.8.1";
   pname = "powerline";
 
-  src = fetchurl {
-    url    = "https://github.com/powerline/powerline/archive/${version}.tar.gz";
-    name   = "${pname}-${version}.tar.gz";
-    sha256 = "1h1j2rfphvfdq6mmfyn5bql45hzrwxkhpc2jcwf0vrl3slzkl5s5";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "0xscckcbw75pbcl4546ndrjs4682pn2sqqrd6qvqm0s6zswg7a0y";
   };
 
-  propagatedBuildInputs = [ psutil pygit2];
+  propagatedBuildInputs = [
+    socat
+    psutil
+    hglib
+    pygit2
+    pyuv
+    i3ipc
+  ];
 
-# error: This is still beta and some tests still fail
+  # tests are travis-specific
   doCheck = false;
 
   postInstall = ''
@@ -29,19 +41,9 @@ buildPythonPackage rec {
     install -m644 "font/PowerlineSymbols.otf" "$out/share/fonts/OTF/PowerlineSymbols.otf"
     install -m644 "font/10-powerline-symbols.conf" "$out/etc/fonts/conf.d/10-powerline-symbols.conf"
 
-    install -dm755 "$out/share/vim/vimfiles/plugin"
-    install -m644 "powerline/bindings/vim/plugin/powerline.vim" "$out/share/vim/vimfiles/plugin/powerline.vim"
-
-    install -dm755 "$out/share/zsh/site-contrib"
-    install -m644 "powerline/bindings/zsh/powerline.zsh" "$out/share/zsh/site-contrib/powerline.zsh"
-
-    install -dm755 "$out/share/tmux"
-    install -m644 "powerline/bindings/tmux/powerline.conf" "$out/share/tmux/powerline.conf"
-    
-    install -dm755 "$out/share/fish/vendor_functions.d"
-    install -m644 "powerline/bindings/fish/powerline-setup.fish" "$out/share/fish/vendor_functions.d/powerline-setup.fish"
-
-    '';
+    cp -ra powerline/bindings/{bash,fish,shell,tcsh,tmux,vim,zsh} $out/share/
+    rm $out/share/*/*.py
+  '';
 
   meta = {
     homepage    = "https://github.com/powerline/powerline";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8072,6 +8072,7 @@ in
 
   grml-zsh-config = callPackage ../shells/zsh/grml-zsh-config { };
 
+  powerline = with python3Packages; toPythonApplication powerline;
 
   ### DEVELOPMENT / COMPILERS
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream version.  I've also added all optional dependencies, except for `bzr`, which we no longer have in nixpkgs.  The replacement, `breezy`, does not seem to be supported by `powerline`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
