### PR TITLE
python3Packages.west: init at 0.7.2

### DIFF
--- a/pkgs/development/python-modules/west/default.nix
+++ b/pkgs/development/python-modules/west/default.nix
@@ -1,0 +1,53 @@
+{ lib, fetchPypi, buildPythonPackage, isPy3k
+, colorama, configobj, packaging, pyyaml, pykwalify
+}:
+
+buildPythonPackage rec {
+  version = "0.7.2";
+  pname = "west";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "11dbzlcg48fymddqjrrs60pr7y33qjjv0y5zrfjc56gkc190gmz6";
+  };
+
+  propagatedBuildInputs = [
+    colorama
+    configobj
+    packaging
+    pyyaml
+    pykwalify
+  ];
+
+  # pypi package does not include tests (and for good reason):
+  # tests run under 'tox' and have west try to git clone repos (not sandboxable)
+  doCheck = false;
+  pythonImportsCheck = [
+    "west"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/zephyrproject-rtos/west";
+    description = "Zephyr RTOS meta tool";
+    longDescription = ''
+      West lets you manage multiple Git repositories under a single directory using a single file,
+      called the west manifest file, or manifest for short.
+
+      The manifest file is named west.yml.
+      You use west init to set up this directory,
+      then west update to fetch and/or update the repositories
+      named in the manifest.
+
+      By default, west uses upstream Zephyr’s manifest file
+      (https://github.com/zephyrproject-rtos/zephyr/blob/master/west.yml),
+      but west doesn’t care if the manifest repository is a Zephyr tree or not.
+
+      For more details, see Multiple Repository Management in the west documentation
+      (https://docs.zephyrproject.org/latest/guides/west/repo-tool.html).
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ siriobalmelli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7673,6 +7673,8 @@ in {
 
   pykwalify = callPackage ../development/python-modules/pykwalify { };
 
+  west = callPackage ../development/python-modules/west { };
+
   wfuzz = callPackage ../development/python-modules/wfuzz { };
 
   wget = callPackage ../development/python-modules/wget { };


### PR DESCRIPTION
Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Require `west` for an embedded toolchain using Zephyr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
