### PR TITLE
rbw: init at 0.4.4

### DIFF
--- a/pkgs/tools/security/rbw/default.nix
+++ b/pkgs/tools/security/rbw/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, rustPlatform
+, fetchCrate
+, pinentry
+, openssl
+, pkgconfig
+, makeWrapper
+, cargo
+
+# rbw-fzf
+, withFzf ? false, fzf, perl
+
+# rbw-rofi
+, withRofi ? false, rofi, xclip
+
+# pass-import
+, withPass ? false, pass
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rbw";
+  version = "0.4.4";
+
+  src = fetchCrate {
+    inherit version;
+    crateName = "${pname}";
+    sha256 = "01p37zx2h3gpm363xn96w0wlg7kqayjl3an65h9p6md21d41bvyr";
+  };
+
+  cargoSha256 = "1xiw21snsbqxfw624cdc340asp2kmcp8rymfcjj7w2lwcqhadrh9";
+
+  nativeBuildInputs = [
+    pkgconfig
+    makeWrapper
+  ];
+
+  postPatch = ''
+    substituteInPlace src/pinentry.rs \
+        --replace "Command::new(\"pinentry\")" "Command::new(\"${pinentry}/bin/pinentry\")"
+  '' + lib.optionalString withFzf ''
+    patchShebangs bin/rbw-fzf
+    substituteInPlace bin/rbw-fzf \
+        --replace fzf ${fzf}/bin/fzf \
+        --replace perl ${perl}/bin/perl
+  '' + lib.optionalString withRofi ''
+    patchShebangs bin/rbw-rofi
+    substituteInPlace bin/rbw-rofi \
+        --replace rofi ${rofi}/bin/rofi \
+        --replace xclip ${xclip}/bin/xclip
+  '' + lib.optionalString withRofi ''
+    patchShebangs bin/pass-import
+    substituteInPlace bin/pass-import \
+        --replace pass ${pass}/bin/pass
+  '';
+
+  preConfigure = ''
+    export OPENSSL_INCLUDE_DIR="${openssl.dev}/include"
+    export OPENSSL_LIB_DIR="${openssl.out}/lib"
+  '';
+
+  postInstall = lib.optionalString withFzf ''
+    cp bin/rbw-fzf $out/bin
+  '' + lib.optionalString withRofi ''
+    cp bin/rbw-rofi $out/bin
+  '' + lib.optionalString withPass ''
+    cp bin/pass-import $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Unofficial command line client for Bitwarden";
+    homepage = "https://crates.io/crates/rbw";
+    license = licenses.mit;
+    maintainers = with maintainers; [ albakham luc65r ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6220,6 +6220,8 @@ in
 
   pywal = with python3Packages; toPythonApplication pywal;
 
+  rbw = callPackage ../tools/security/rbw { };
+
   remarshal = callPackage ../development/tools/remarshal { };
 
   rig = callPackage ../tools/misc/rig {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The Bitwarden command-line tool is very slow, so I wanted to package `rbw`, which is way faster.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
