### PR TITLE
libinput: Fix commands

### DIFF
--- a/pkgs/development/libraries/libevdev/default.nix
+++ b/pkgs/development/libraries/libevdev/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python3 }:
+{ stdenv, fetchurl, fetchpatch, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "libevdev";
@@ -8,6 +8,15 @@ stdenv.mkDerivation rec {
     url = "https://www.freedesktop.org/software/${pname}/${pname}-${version}.tar.xz";
     sha256 = "17pb5375njb1r05xmk0r57a2j986ihglh2n5nqcylbag4rj8mqg7";
   };
+
+  patches = [
+    # Fix libevdev-python tests on aarch64
+    # https://gitlab.freedesktop.org/libevdev/libevdev/merge_requests/63
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/libevdev/libevdev/commit/66113fe84f62bab3a672a336eb10b255d2aa5ce7.patch";
+      sha256 = "gZKr/P+/OqU69IGslP8CQlcGuyzA/ulcm+nGwHdis58=";
+    })
+  ];
 
   nativeBuildInputs = [ python3 ];
 

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -47,10 +47,23 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig meson ninja ]
     ++ optionals documentationSupport [ doxygen graphviz sphinx-build ];
 
-  buildInputs = [ libevdev mtdev libwacom ]
+  buildInputs = [
+    libevdev
+    mtdev
+    libwacom
+    (python3.withPackages (pp: with pp; [
+      pp.libevdev # already in scope
+      pyudev
+      pyyaml
+      setuptools
+    ]))
+  ]
     ++ optionals eventGUISupport [ cairo glib gtk3 ];
 
-  checkInputs = [ (python3.withPackages (pkgs: with pkgs; [ evdev ])) check valgrind ];
+  checkInputs = [
+    check
+    valgrind
+  ];
 
   propagatedBuildInputs = [ udev ];
 
@@ -60,6 +73,7 @@ stdenv.mkDerivation rec {
     patchShebangs tools/helper-copy-and-exec-from-tmp.sh
     patchShebangs test/symbols-leak-test
     patchShebangs test/check-leftover-udev-rules.sh
+    patchShebangs test/helper-copy-and-exec-from-tmp.sh
   '';
 
   doCheck = testsSupport && stdenv.hostPlatform == stdenv.buildPlatform;

--- a/pkgs/development/python-modules/libevdev/default.nix
+++ b/pkgs/development/python-modules/libevdev/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, buildPythonPackage, isPy27, fetchPypi }:
+{ stdenv
+, buildPythonPackage
+, isPy27
+, fetchPypi
+, substituteAll
+, pkgs
+}:
 
 buildPythonPackage rec {
   pname = "libevdev";
@@ -9,6 +15,13 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "17agnigmzscmdjqmrylg1lza03hwjhgxbpf4l705s6i7p7ndaqrs";
   };
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      libevdev = stdenv.lib.getLib pkgs.libevdev;
+    })
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/libevdev/default.nix
+++ b/pkgs/development/python-modules/libevdev/default.nix
@@ -4,6 +4,7 @@
 , fetchPypi
 , substituteAll
 , pkgs
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -23,7 +24,7 @@ buildPythonPackage rec {
     })
   ];
 
-  doCheck = false;
+  checkInputs = [ pytestCheckHook ];
 
   meta = with stdenv.lib; {
     description = "Python wrapper around the libevdev C library";

--- a/pkgs/development/python-modules/libevdev/fix-paths.patch
+++ b/pkgs/development/python-modules/libevdev/fix-paths.patch
@@ -1,0 +1,22 @@
+diff --git a/libevdev/_clib.py b/libevdev/_clib.py
+index 6e4ab2c..9db54d1 100644
+--- a/libevdev/_clib.py
++++ b/libevdev/_clib.py
+@@ -120,7 +120,7 @@ class Libevdev(_LibraryWrapper):
+ 
+     @staticmethod
+     def _cdll():
+-        return ctypes.CDLL("libevdev.so.2", use_errno=True)
++        return ctypes.CDLL("@libevdev@/lib/libevdev.so.2", use_errno=True)
+ 
+     _api_prototypes = {
+         # const char *libevdev_event_type_get_name(unsigned int type);
+@@ -910,7 +910,7 @@ class UinputDevice(_LibraryWrapper):
+ 
+     @staticmethod
+     def _cdll():
+-        return ctypes.CDLL("libevdev.so.2", use_errno=True)
++        return ctypes.CDLL("@libevdev@/lib/libevdev.so.2", use_errno=True)
+ 
+     _api_prototypes = {
+         # int libevdev_uinput_create_from_device(const struct libevdev *, int, struct libevdev_uinput **)

--- a/pkgs/development/python-modules/pyudev/default.nix
+++ b/pkgs/development/python-modules/pyudev/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     '';
 
   checkInputs = [ pytest mock hypothesis docutils ];
-  propagatedBuildInputs = [ systemd six ];
+  propagatedBuildInputs = [ six ];
 
   checkPhase = ''
     py.test


### PR DESCRIPTION
###### Motivation for this change

Running subcommands like `libinput measure` requires python and some python modules. 

I previously added the dependencies in <https://github.com/NixOS/nixpkgs/pull/51304> but <https://github.com/NixOS/nixpkgs/commit/de14f0c6e1247aa48b0d77c4a3390a61e020bebf> accidentally moved them to checkInputs so they are not available at runtime by patchShebangs (especially since tests are disabled).

Additionally, the tools were ported from evdev python module to python-libevdev in libinput 1.14, which was [missed][3] during upgrade.

Finally, other python modules are needed so let's add them as well.

[3]: https://github.com/NixOS/nixpkgs/commit/b291f2a9953d48d6edc5c73776db9ba289ccf213


###### Closure size
```
before:
/nix/store/q1fzqnxjfiklxxw0w43amavbg9171vs0-libinput-1.15.5    	  52.4M
/nix/store/43nkzxizpfaq9ljhjhfwk146p8jf9pa5-libinput-1.15.5-bin	  53.0M
/nix/store/04r1xdb26swsf7rykdmpf5llsh918nsy-libinput-1.15.5-dev	 152.4M

after:
/nix/store/7yxwhlrr7n0i53jd352mg4slrfihqd31-libinput-1.15.5    	  52.4M
/nix/store/lh3q2fvd4jf0j0q1x39by770l3mkaymp-libinput-1.15.5-bin	 220.6M
/nix/store/lk4qiabwznc8hpava8wiwf2xsgbgbdzx-libinput-1.15.5-dev	 220.8M

original before regressions:
/nix/store/55xasqvnqw88cficppnkmvs6y3dqq213-libinput-1.15.5    	  52.4M
/nix/store/qbhb51ad9anvp36pdgkrc4h13r26x203-libinput-1.15.5-bin	 126.5M
/nix/store/cd25ap98596ws5wrjcib3hsv8dk65grm-libinput-1.15.5-dev	 217.2M

after, simplified with pyudev not propagating systemd:
/nix/store/4xzs08bm15p55x2b6wlw99nn9xr2z2ka-libinput-1.15.5    	  52.4M
/nix/store/qhpd9c5q9lymz9pd87bqgfakk2n39234-libinput-1.15.5-bin	 130.1M
/nix/store/fllaxc6hi1rppfvw9nss14rbh949nqw3-libinput-1.15.5-dev	 220.8M
```

Packages typically depend on the `out` output, so their runtime closure should not be affected by the increase in `bin`.

Fixes: https://github.com/NixOS/nixpkgs/issues/48252

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
