### PR TITLE
webkitgtk: 2.28.2 -> 2.29.3

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -51,6 +51,7 @@
 , xdg-dbus-proxy
 , substituteAll
 , glib
+, systemd
 }:
 
 assert enableGeoLocation -> geoclue2 != null;
@@ -61,13 +62,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "webkitgtk";
-  version = "2.28.2";
+  version = "2.29.3";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://webkitgtk.org/releases/${pname}-${version}.tar.xz";
-    sha256 = "1g9hik3bprki5s9d7y5288q5irwckbzajr6rnlvjrlnqrwjkblmr";
+    sha256 = "164k7fj1rlsnvljv0nrx3sb6mzmmz1257yaaax7ggvky24haq8da";
   };
 
   patches = optionals stdenv.isLinux [
@@ -147,6 +148,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     gtk3
     libsoup
+    systemd
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Major version bump. (Added systemd as a dependency as it requires libsystemd as per the latest version.)

```
What's new in the WebKitGTK 2.29.3 release?
===========================================

  - Add webkit_authentication_request_get_security_origin.
  - Change the cookies accept policy to always when no-third-party is set and ITP is enabled.
  - Fix web process hangs on large GitHub pages.
  - Bubblewrap sandbox should not attempt to bind empty paths.
  - Add support for sndio to bubblewrap sandbox.
  - Also handle dark themes when the name ends with -Dark.
  - Fix a race condition causing a crash in media player.
  - Fix several crashes and rendering issues.

What's new in the WebKitGTK 2.29.2 release?
===========================================

  - Add Intelligent Tracking Prevention (ITP) support.
  - Add support for video formats in img elements.
  - Add API to handle video autoplay policy that now defaults to disallow autoplay videos with audio.
  - Add API to mute a web view.
  - Add API to allow applications to handle the HTTP authentication credential storage.
  - Add a WebKitSetting to set the media content types requiring hardware support.
  - Fix a crash during drag an drop due to a bug introduced in 2.29.1.
  - Do not start page load during animation in back/forward gesture.
  - Fix several crashes and rendering issues.
  - Translation updates: Ukrainian.

What's new in the WebKitGTK 2.29.1 release?
===========================================

  - Stop using GTK theming to render form controls.
  - Add API to disable GTK theming for scrollbars too.
  - Fix several race conditions and threading issues in the media player.
  - Add USER_AGENT_BRANDING build option.
  - Add paste as plain text option to the context menu for rich editable content.
  - Fix several crashes and rendering issues.

```





###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
