### PR TITLE
spaceship-prompt: enable on darwin

### DIFF
--- a/pkgs/shells/zsh/spaceship-prompt/default.nix
+++ b/pkgs/shells/zsh/spaceship-prompt/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "Zsh prompt for Astronauts";
     homepage = "https://github.com/denysdovhan/spaceship-prompt/";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ nyanloutre ];
   };
 }


### PR DESCRIPTION
This commit enable spaceship-prompt to be used on darwin machines.
