### PR TITLE
mongodb: 4.0.12 -> 4.2.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6316,6 +6316,12 @@
     githubId = 119460;
     name = "Perry Barnoy";
   };
+  pjjw = {
+    email = "peter@shortbus.org";
+    github = "pjjw";
+    githubId = 638;
+    name = "Peter Woodman";
+  };
   pjones = {
     email = "pjones@devalot.com";
     github = "pjones";

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -15,7 +15,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
       node.wait_for_open_port(27017)
 
       assert "hello" in node.succeed(
-          "mongo ${testQuery}"
+          "${pkg}/bin/mongo ${testQuery}"
       )
 
       node.execute(
@@ -36,6 +36,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
           mongodb-3_4
           mongodb-3_6
           mongodb-4_0
+          mongodb-4_2
         ];
       };
     };
@@ -46,6 +47,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
       + runMongoDBTest pkgs.mongodb-3_4
       + runMongoDBTest pkgs.mongodb-3_6 
       + runMongoDBTest pkgs.mongodb-4_0
+      + runMongoDBTest pkgs.mongodb-4_2
       + ''
         node.shutdown()
       '';

--- a/pkgs/development/python-modules/cheetah3/default.nix
+++ b/pkgs/development/python-modules/cheetah3/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, stdenv }:
+
+buildPythonPackage rec {
+  pname = "Cheetah3";
+  version = "3.2.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ececc9ca7c58b9a86ce71eb95594c4619949e2a058d2a1af74c7ae8222515eb1";
+  };
+
+  doCheck = false; # Circular dependency
+
+  meta = {
+    homepage = "http://www.cheetahtemplate.org/";
+    description = "A template engine and code generation tool";
+    license = lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ pjjw ];
+  };
+}

--- a/pkgs/servers/nosql/mongodb/asio-no-experimental-string-view-4-2.patch
+++ b/pkgs/servers/nosql/mongodb/asio-no-experimental-string-view-4-2.patch
@@ -1,0 +1,22 @@
+--- a/src/third_party/asio-master/asio/include/asio/detail/config.hpp
++++ b/src/third_party/asio-master/asio/include/asio/detail/config.hpp
+@@ -831,20 +831,8 @@
+ #     endif // (__cplusplus >= 201402)
+ #    endif // (_LIBCPP_VERSION < 7000)
+ #   else // defined(ASIO_HAS_CLANG_LIBCXX)
+-#    if (__cplusplus >= 201402)
+-#     if __has_include(<experimental/string_view>)
+-#      define ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW 1
+-#     endif // __has_include(<experimental/string_view>)
+-#    endif // (__cplusplus >= 201402)
+ #   endif // // defined(ASIO_HAS_CLANG_LIBCXX)
+ #  endif // defined(__clang__)
+-#  if defined(__GNUC__)
+-#   if ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9)) || (__GNUC__ > 4)
+-#    if (__cplusplus >= 201402)
+-#     define ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW 1
+-#    endif // (__cplusplus >= 201402)
+-#   endif // ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9)) || (__GNUC__ > 4)
+-#  endif // defined(__GNUC__)
+ # endif // !defined(ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW)
+ #endif // !defined(ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW)

--- a/pkgs/servers/nosql/mongodb/forget-build-dependencies-4-2.patch
+++ b/pkgs/servers/nosql/mongodb/forget-build-dependencies-4-2.patch
@@ -1,0 +1,36 @@
+# MongoDB keeps track of its build parameters, which tricks nix into
+# keeping dependencies to build inputs in the final output.
+# We remove the build flags from buildInfo data.
+--- a/site_scons/mongo/generators.py
++++ b/site_scons/mongo/generators.py
+@@ -33,30 +33,12 @@ def default_buildinfo_environment_data():
+             True,
+             False,
+         ),
+-        (
+-            'ccflags',
+-            '$CCFLAGS',
+-            True,
+-            False,
+-        ),
+         (
+             'cxx',
+             '$CXX_VERSION',
+             True,
+             False,
+         ),
+-        (
+-            'cxxflags',
+-            '$CXXFLAGS',
+-            True,
+-            False,
+-        ),
+-        (
+-            'linkflags',
+-            '$LINKFLAGS',
+-            True,
+-            False,
+-        ),
+         (
+             'target_arch',
+             '$TARGET_ARCH',

--- a/pkgs/servers/nosql/mongodb/forget-build-dependencies.patch
+++ b/pkgs/servers/nosql/mongodb/forget-build-dependencies.patch
@@ -1,3 +1,6 @@
+# MongoDB keeps track of its build parameters, which tricks nix into
+# keeping dependencies to build inputs in the final output.
+# We remove the build flags from buildInfo data.
 --- a/site_scons/mongo/generators.py
 +++ b/site_scons/mongo/generators.py
 @@ -18,10 +18,7 @@ def default_buildinfo_environment_data():

--- a/pkgs/servers/nosql/mongodb/v4_2.nix
+++ b/pkgs/servers/nosql/mongodb/v4_2.nix
@@ -1,0 +1,17 @@
+{ stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
+
+let
+  buildMongoDB = callPackage ./mongodb.nix {
+    inherit sasl;
+    inherit boost;
+    inherit Security;
+    inherit CoreFoundation;
+    inherit cctools;
+  };
+in buildMongoDB {
+  version = "4.2.8";
+  sha256 = "13yvhi1258skdni00bh6ph609whqsmhiimhyqy1gs2liwdvh5278";
+  patches =
+    [ ./forget-build-dependencies-4-2.patch ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view-4-2.patch ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16257,6 +16257,13 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
+  mongodb-4_2 = callPackage ../servers/nosql/mongodb/v4_2.nix {
+    sasl = cyrus_sasl;
+    boost = boost169;
+    inherit (darwin) cctools;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+
   nginx-sso = callPackage ../servers/nginx-sso { };
 
   percona-server56 = callPackage ../servers/sql/percona/5.6.x.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2301,6 +2301,8 @@ in {
 
   cheetah = callPackage ../development/python-modules/cheetah { };
 
+  cheetah3 = callPackage ../development/python-modules/cheetah3 { };
+
   cherrypy = if isPy3k then
     callPackage ../development/python-modules/cherrypy { }
   else


### PR DESCRIPTION
Not strictly an upgrade, but adds a new mongodb-4_2 target with the
current mongodb from that branch.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Current mongodb isn't packaged, would like it to be.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
