### PR TITLE
telepresence: fix build

### DIFF
--- a/pkgs/tools/networking/telepresence/default.nix
+++ b/pkgs/tools/networking/telepresence/default.nix
@@ -1,20 +1,29 @@
-{ lib, pythonPackages, fetchgit, fetchFromGitHub, makeWrapper, git
+{ lib, pythonPackages, fetchFromGitHub, makeWrapper, git
 , sshfs-fuse, torsocks, sshuttle, conntrack-tools , openssh, coreutils
 , iptables, bash }:
 
 let
-  sshuttle-telepresence = lib.overrideDerivation sshuttle (p: {
-    src = fetchgit {
-      url = "https://github.com/datawire/sshuttle.git";
-      rev = "32226ff14d98d58ccad2a699e10cdfa5d86d6269";
-      sha256 = "1q20lnljndwcpgqv2qrf1k0lbvxppxf98a4g5r9zd566znhcdhx3";
-    };
+  sshuttle-telepresence = 
+    let
+      sshuttleTelepresenceRev = "32226ff14d98d58ccad2a699e10cdfa5d86d6269";
+    in
+      lib.overrideDerivation sshuttle (p: {
+        src = fetchFromGitHub {
+          owner = "datawire";
+          repo = "sshuttle";
+          rev = sshuttleTelepresenceRev;
+          sha256 = "1lp5b0h9v59igf8wybjn42w6ajw08blhiqmjwp4r7qnvmvmyaxhh";
+        };
 
-    nativeBuildInputs = p.nativeBuildInputs ++ [ git ];
+        nativeBuildInputs = p.nativeBuildInputs ++ [ git ];
 
-    postPatch = "rm sshuttle/tests/client/test_methods_nat.py";
-    postInstall = "mv $out/bin/sshuttle $out/bin/sshuttle-telepresence";
-  });
+        preBuild = ''
+          export SETUPTOOLS_SCM_PRETEND_VERSION="${sshuttleTelepresenceRev}"
+        '';
+
+        postPatch = "rm sshuttle/tests/client/test_methods_nat.py";
+        postInstall = "mv $out/bin/sshuttle $out/bin/sshuttle-telepresence";
+      });
 in pythonPackages.buildPythonPackage rec {
   pname = "telepresence";
   version = "0.105";

--- a/pkgs/tools/networking/telepresence/default.nix
+++ b/pkgs/tools/networking/telepresence/default.nix
@@ -17,10 +17,10 @@ let
   });
 in pythonPackages.buildPythonPackage rec {
   pname = "telepresence";
-  version = "0.104";
+  version = "0.105";
 
   src = fetchFromGitHub {
-    owner = "datawire";
+    owner = "telepresenceio";
     repo = "telepresence";
     rev = version;
     sha256 = "0fccbd54ryd9rcbhfh5lx8qcc3kx3k9jads918rwnzwllqzjf7sg";

--- a/pkgs/tools/networking/telepresence/default.nix
+++ b/pkgs/tools/networking/telepresence/default.nix
@@ -15,8 +15,6 @@ let
           sha256 = "1lp5b0h9v59igf8wybjn42w6ajw08blhiqmjwp4r7qnvmvmyaxhh";
         };
 
-        nativeBuildInputs = p.nativeBuildInputs ++ [ git ];
-
         preBuild = ''
           export SETUPTOOLS_SCM_PRETEND_VERSION="${sshuttleTelepresenceRev}"
         '';

--- a/pkgs/tools/networking/telepresence/default.nix
+++ b/pkgs/tools/networking/telepresence/default.nix
@@ -15,9 +15,7 @@ let
           sha256 = "1lp5b0h9v59igf8wybjn42w6ajw08blhiqmjwp4r7qnvmvmyaxhh";
         };
 
-        preBuild = ''
-          export SETUPTOOLS_SCM_PRETEND_VERSION="${sshuttleTelepresenceRev}"
-        '';
+        SETUPTOOLS_SCM_PRETEND_VERSION="${sshuttleTelepresenceRev}";
 
         postPatch = "rm sshuttle/tests/client/test_methods_nat.py";
         postInstall = "mv $out/bin/sshuttle $out/bin/sshuttle-telepresence";


### PR DESCRIPTION
setuptools-scm needs a full git repo in it's source to fetch the
version from the git tag

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

```
nix-env -f . -iA telepresence    
installing 'python3.8-telepresence-0.105'
these derivations will be built:
  /nix/store/hw8zqlgg65h2qcwa3i1wd568g395w2k3-sshuttle-0.78.5.drv
  /nix/store/l63g1kar8dp8xrqdkf0rw4lrf54w0q1c-python3.8-telepresence-0.105.drv
building '/nix/store/hw8zqlgg65h2qcwa3i1wd568g395w2k3-sshuttle-0.78.5.drv'...
Sourcing python-recompile-bytecode-hook.sh
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing setuptools-build-hook
Using setuptoolsBuildPhase
Using setuptoolsShellHook
Sourcing pip-install-hook
Using pipInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing setuptools-check-hook
Using setuptoolsCheckPhase
unpacking sources
unpacking source archive /nix/store/nb7kh6cl09hcvpsijlb2dlaymwslkfa7-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file source/tox.ini
patching sources
applying patch /nix/store/zhv3gyxd78kyfh6iyr2v408wbafp7d36-sudo.patch
patching file sshuttle/client.py
Hunk #1 succeeded at 185 with fuzz 1 (offset -7 lines).
configuring
no configure script, doing nothing
building
Executing setuptoolsBuildPhase
Traceback (most recent call last):
  File "nix_run_setup", line 8, in <module>
    exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
  File "setup.py", line 29, in <module>
    setup(
  File "/nix/store/ld0khsbfx69hrvp4qfv3ijw0iczrkiyv-python3.8-setuptools-46.1.3/lib/python3.8/site-packages/setuptools/__init__.py", line 144, in setup
    return distutils.core.setup(**attrs)
  File "/nix/store/f87w21b91cws0wbsvyfn5vnlyv491czi-python3-3.8.3/lib/python3.8/distutils/core.py", line 108, in setup
    _setup_distribution = dist = klass(attrs)
  File "/nix/store/ld0khsbfx69hrvp4qfv3ijw0iczrkiyv-python3.8-setuptools-46.1.3/lib/python3.8/site-packages/setuptools/dist.py", line 425, in __init__
    _Distribution.__init__(self, {
  File "/nix/store/f87w21b91cws0wbsvyfn5vnlyv491czi-python3-3.8.3/lib/python3.8/distutils/dist.py", line 292, in __init__
    self.finalize_options()
  File "/nix/store/ld0khsbfx69hrvp4qfv3ijw0iczrkiyv-python3.8-setuptools-46.1.3/lib/python3.8/site-packages/setuptools/dist.py", line 717, in finalize_options
    ep(self)
  File "/nix/store/ld0khsbfx69hrvp4qfv3ijw0iczrkiyv-python3.8-setuptools-46.1.3/lib/python3.8/site-packages/setuptools/dist.py", line 724, in _finalize_setup_keywords
    ep.load()(self, ep.name, value)
  File "/nix/store/0p46jr9krabb9znd3zdwz3ia7639z22x-python3.8-setuptools_scm-4.1.2/lib/python3.8/site-packages/setuptools_scm/integration.py", line 17, in version_keyword
    dist.metadata.version = _get_version(config)
  File "/nix/store/0p46jr9krabb9znd3zdwz3ia7639z22x-python3.8-setuptools_scm-4.1.2/lib/python3.8/site-packages/setuptools_scm/__init__.py", line 148, in _get_version
    parsed_version = _do_parse(config)
  File "/nix/store/0p46jr9krabb9znd3zdwz3ia7639z22x-python3.8-setuptools_scm-4.1.2/lib/python3.8/site-packages/setuptools_scm/__init__.py", line 110, in _do_parse
    raise LookupError(
LookupError: setuptools-scm was unable to detect version for '/build/source'.

Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.

For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj
builder for '/nix/store/hw8zqlgg65h2qcwa3i1wd568g395w2k3-sshuttle-0.78.5.drv' failed with exit code 1
cannot build derivation '/nix/store/l63g1kar8dp8xrqdkf0rw4lrf54w0q1c-python3.8-telepresence-0.105.drv': 1 dependencies couldn't be built
error: build of '/nix/store/l63g1kar8dp8xrqdkf0rw4lrf54w0q1c-python3.8-telepresence-0.105.drv' failed
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
