### PR TITLE
jailbreak rebase on ghc 8.6

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -64,6 +64,7 @@ self: super: {
   monad-par = dontCheck super.monad-par;  # https://github.com/simonmar/monad-par/issues/66
   github = dontCheck super.github; # hspec upper bound exceeded; https://github.com/phadej/github/pull/341
   binary-orphans = dontCheck super.binary-orphans; # tasty upper bound exceeded; https://github.com/phadej/binary-orphans/commit/8ce857226595dd520236ff4c51fa1a45d8387b33
+  rebase = doJailbreak super.rebase; # time ==1.9.* is too low
 
   # https://github.com/jgm/skylighting/issues/55
   skylighting-core = dontCheck super.skylighting-core;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -72,7 +72,7 @@ default-package-overrides:
   # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
   # not yet available in Nixpkgs
   - gi-gdkx11 < 4
-  # LTS Haskell 16.3
+  # LTS Haskell 16.4
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
   - AC-Angle ==1.0
@@ -279,7 +279,7 @@ default-package-overrides:
   - base32-lens ==0.1.0.0
   - base32string ==0.9.1
   - base58string ==0.10.0
-  - base64 ==0.4.2.1
+  - base64 ==0.4.2.2
   - base64-bytestring ==1.0.0.3
   - base64-bytestring-type ==1.0.1
   - base64-lens ==0.3.0
@@ -334,7 +334,7 @@ default-package-overrides:
   - blaze-bootstrap ==0.1.0.1
   - blaze-builder ==0.4.1.0
   - blaze-html ==0.9.1.2
-  - blaze-markup ==0.8.2.5
+  - blaze-markup ==0.8.2.7
   - blaze-svg ==0.3.6.1
   - blaze-textual ==0.2.1.0
   - bmp ==1.2.6.3
@@ -383,7 +383,7 @@ default-package-overrides:
   - bzlib-conduit ==0.3.0.2
   - c2hs ==0.28.6
   - cabal-appimage ==0.3.0.0
-  - cabal-debian ==5.0.2
+  - cabal-debian ==5.0.3
   - cabal-doctest ==1.0.8
   - cabal-rpm ==2.0.6
   - cache ==0.1.3.0
@@ -749,7 +749,7 @@ default-package-overrides:
   - exception-hierarchy ==0.1.0.3
   - exception-mtl ==0.4.0.1
   - exceptions ==0.10.4
-  - exception-transformers ==0.4.0.8
+  - exception-transformers ==0.4.0.9
   - executable-path ==0.0.3.1
   - exit-codes ==1.0.0
   - exomizer ==1.0.0
@@ -781,7 +781,7 @@ default-package-overrides:
   - filecache ==0.4.1
   - file-embed ==0.0.11.2
   - file-embed-lzma ==0
-  - filelock ==0.1.1.4
+  - filelock ==0.1.1.5
   - filemanip ==0.3.6.3
   - file-modules ==0.1.2.4
   - file-path-th ==0.1.0.0
@@ -904,7 +904,7 @@ default-package-overrides:
   - ghcjs-codemirror ==0.0.0.2
   - ghc-lib ==8.10.1.20200523
   - ghc-lib-parser ==8.10.1.20200523
-  - ghc-lib-parser-ex ==8.10.0.14
+  - ghc-lib-parser-ex ==8.10.0.15
   - ghc-parser ==0.2.2.0
   - ghc-paths ==0.1.0.12
   - ghc-prof ==1.4.1.7
@@ -974,7 +974,7 @@ default-package-overrides:
   - haddock-library ==1.8.0
   - hadolint ==1.18.0
   - hadoop-streaming ==0.2.0.3
-  - hakyll ==4.13.3.0
+  - hakyll ==4.13.4.0
   - half ==0.3
   - hamtsolo ==1.0.3
   - HandsomeSoup ==0.4.2
@@ -1021,7 +1021,7 @@ default-package-overrides:
   - heap ==1.0.4
   - heaps ==0.3.6.1
   - hebrew-time ==0.1.2
-  - hedgehog ==1.0.2
+  - hedgehog ==1.0.3
   - hedgehog-corpus ==0.2.0
   - hedgehog-fakedata ==0.0.1.3
   - hedgehog-fn ==1.0
@@ -1102,7 +1102,7 @@ default-package-overrides:
   - hspec-expectations ==0.8.2
   - hspec-expectations-lifted ==0.10.0
   - hspec-expectations-pretty-diff ==0.7.2.5
-  - hspec-golden ==0.1.0.1
+  - hspec-golden ==0.1.0.2
   - hspec-golden-aeson ==0.7.0.0
   - hspec-hedgehog ==0.0.1.2
   - hspec-leancheck ==0.0.4
@@ -1128,7 +1128,7 @@ default-package-overrides:
   - html-entities ==1.1.4.3
   - html-entity-map ==0.1.0.0
   - htoml ==1.0.0.3
-  - http2 ==2.0.4
+  - http2 ==2.0.5
   - HTTP ==4000.3.14
   - http-api-data ==0.4.1.1
   - http-client ==0.6.4.1
@@ -1149,7 +1149,7 @@ default-package-overrides:
   - human-readable-duration ==0.2.1.4
   - HUnit ==1.6.0.0
   - HUnit-approx ==1.1.1.1
-  - hunit-dejafu ==2.0.0.3
+  - hunit-dejafu ==2.0.0.4
   - hvect ==0.4.0.0
   - hvega ==0.9.1.0
   - hw-balancedparens ==0.4.1.0
@@ -1228,7 +1228,7 @@ default-package-overrides:
   - intro ==0.7.0.0
   - intset-imperative ==0.1.0.0
   - invariant ==0.5.3
-  - invertible ==0.2.0.5
+  - invertible ==0.2.0.6
   - invertible-grammar ==0.1.2
   - io-machine ==0.2.0.0
   - io-manager ==0.1.0.2
@@ -1287,7 +1287,7 @@ default-package-overrides:
   - kind-generics-th ==0.2.2.0
   - kmeans ==0.1.3
   - koofr-client ==1.0.0.3
-  - krank ==0.2.1
+  - krank ==0.2.2
   - kubernetes-webhook-haskell ==0.2.0.2
   - l10n ==0.1.0.1
   - labels ==0.3.3
@@ -1338,7 +1338,7 @@ default-package-overrides:
   - libyaml ==0.1.2
   - LibZip ==1.0.1
   - life-sync ==1.1.1.0
-  - lifted-async ==0.10.0.6
+  - lifted-async ==0.10.1.1
   - lifted-base ==0.2.3.12
   - lift-generics ==0.1.3
   - line ==4.0.1
@@ -1347,7 +1347,7 @@ default-package-overrides:
   - linux-file-extents ==0.2.0.0
   - linux-namespaces ==0.1.3.0
   - List ==0.6.2
-  - ListLike ==4.7
+  - ListLike ==4.7.1
   - list-predicate ==0.1.0.1
   - listsafe ==0.1.0.1
   - list-singleton ==1.0.0.4
@@ -1464,7 +1464,7 @@ default-package-overrides:
   - monad-extras ==0.6.0
   - monadic-arrays ==0.2.2
   - monad-journal ==0.8.1
-  - monad-logger ==0.3.32
+  - monad-logger ==0.3.33
   - monad-logger-json ==0.1.0.0
   - monad-logger-prefix ==0.1.11
   - monad-loops ==0.4.3
@@ -1495,7 +1495,7 @@ default-package-overrides:
   - morpheus-graphql ==0.12.0
   - morpheus-graphql-core ==0.12.0
   - mountpoints ==1.0.2
-  - mpi-hs ==0.7.1.2
+  - mpi-hs ==0.7.2.0
   - mpi-hs-binary ==0.1.1.0
   - mpi-hs-cereal ==0.1.0.0
   - mtl-compat ==0.2.2
@@ -1857,7 +1857,7 @@ default-package-overrides:
   - regex-posix ==0.96.0.0
   - regex-tdfa ==1.3.1.0
   - regex-with-pcre ==1.1.0.0
-  - registry ==0.1.9.0
+  - registry ==0.1.9.1
   - reinterpret-cast ==0.1.0
   - relapse ==1.0.0.0
   - relational-query ==0.12.2.3
@@ -1894,7 +1894,7 @@ default-package-overrides:
   - rope-utf16-splay ==0.3.1.0
   - rosezipper ==0.2
   - rot13 ==0.2.0.1
-  - rpmbuild-order ==0.3
+  - rpmbuild-order ==0.3.1
   - RSA ==2.4.1
   - runmemo ==1.0.0.1
   - safe ==0.3.19
@@ -1967,7 +1967,7 @@ default-package-overrides:
   - servant-elm ==0.7.2
   - servant-errors ==0.1.6.0
   - servant-foreign ==0.15
-  - servant-js ==0.9.4.1
+  - servant-js ==0.9.4.2
   - servant-JuicyPixels ==0.3.0.5
   - servant-lucid ==0.9
   - servant-machines ==0.15
@@ -1993,7 +1993,7 @@ default-package-overrides:
   - setlocale ==1.0.0.9
   - sexp-grammar ==2.1.0
   - SHA ==1.6.4.4
-  - shake-plus ==0.1.7.0
+  - shake-plus ==0.1.10.0
   - shakespeare ==2.0.24.1
   - shared-memory ==0.2.0.0
   - shell-conduit ==4.7.0
@@ -2158,7 +2158,7 @@ default-package-overrides:
   - tardis ==0.4.1.0
   - tasty ==1.2.3
   - tasty-ant-xml ==1.1.6
-  - tasty-dejafu ==2.0.0.5
+  - tasty-dejafu ==2.0.0.6
   - tasty-discover ==4.2.1
   - tasty-expected-failure ==0.11.1.2
   - tasty-golden ==2.3.3.2
@@ -2501,7 +2501,7 @@ default-package-overrides:
   - yesod-auth ==1.6.10
   - yesod-auth-fb ==1.10.1
   - yesod-auth-hashdb ==1.7.1.2
-  - yesod-bin ==1.6.0.4
+  - yesod-bin ==1.6.0.5
   - yesod-core ==1.6.18
   - yesod-fb ==0.6.1
   - yesod-form ==1.6.7


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Rebase depends on time 1.9.*, which apparently isn't the version in nixpkgs master.
This change allows rebase and all packages that depend on it to compile.
This surfaced while building haskell-language-server for ghc 8.6.5 (see [this thread](https://github.com/NixOS/nixpkgs/pull/91279#issuecomment-655708168))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
