### PR TITLE
python3Packages.pyside2: 5.12.3 -> 5.12.6

### DIFF
--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "pyside2";
-  version = "5.12.3";
+  version = "5.12.6";
 
   src = fetchurl {
     url = "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${version}-src/pyside-setup-everywhere-src-${version}.tar.xz";
-    sha256 = "0hk89jm8pa0q6kifask5rrffa3bvx02dg2f97ibv7wds9dysnyjg";
+    sha256 = "1n45l6xxyxs6cfp2l4rp8qs1c2fyfwyrdxa4qcpwfsqsi51rydsk";
   };
 
   patches = [

--- a/pkgs/development/python-modules/shiboken2/nix_compile_cflags.patch
+++ b/pkgs/development/python-modules/shiboken2/nix_compile_cflags.patch
@@ -1,6 +1,6 @@
---- pyside-setup-everywhere-src-5.12.3/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp~	2019-06-15 10:31:04.712949189 +0200
-+++ pyside-setup-everywhere-src-5.12.3/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp	2019-06-15 11:52:52.894987343 +0200
-@@ -317,15 +317,15 @@
+--- pyside-setup-everywhere-src-5.12.6/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp~	2020-07-08 14:37:13.022476435 -0700
++++ pyside-setup-everywhere-src-5.12.6/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp	2020-07-08 14:37:18.271484269 -0700
+@@ -330,17 +330,15 @@
      }
  #endif // NEED_CLANG_BUILTIN_INCLUDES
  
@@ -9,10 +9,12 @@
 -    // A fix for this has been added to Clang 5.0, so, the code can be removed
 -    // once Clang 5.0 is the minimum version.
 -    if (needsGppInternalHeaders()) {
--        const HeaderPaths gppPaths = gppInternalIncludePaths(QStringLiteral("g++"));
+-        const HeaderPaths gppPaths = gppInternalIncludePaths(compilerFromCMake(QStringLiteral("g++")));
 -        for (const HeaderPath &h : gppPaths) {
--            if (h.path.contains("c++"))
+-            if (h.path.contains("c++")
+-                || h.path.contains("sysroot")) { // centOS
 -                headerPaths.append(h);
+-            }
 +    const HeaderPaths gppPaths = gppInternalIncludePaths(QStringLiteral("g++"));
 +    for (const HeaderPath &h : gppPaths) {
 +        // PySide2 requires that Qt headers are not -isystem
@@ -25,3 +27,4 @@
          }
      }
  #else
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

fixes #91726

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
