### PR TITLE
netdata: facilitate building netdata with cloud support

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -64,7 +64,6 @@ in stdenv.mkDerivation rec {
   preConfigure = optionalString withCloud ''
     mkdir -p externaldeps
     cp -r "${mosquitto}/lib" externaldeps/mosquitto
-    cp -r "${libwebsockets_3_2}/lib" externaldeps/libwebsockets
   '' + optionalString (!stdenv.isDarwin) ''
     substituteInPlace collectors/python.d.plugin/python_modules/third_party/lm_sensors.py \
       --replace 'ctypes.util.find_library("sensors")' '"${lm_sensors.out}/lib/libsensors${stdenv.hostPlatform.extensions.sharedLibrary}"'

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -70,8 +70,10 @@ in stdenv.mkDerivation rec {
       --replace 'ctypes.util.find_library("sensors")' '"${lm_sensors.out}/lib/libsensors${stdenv.hostPlatform.extensions.sharedLibrary}"'
   '';
 
-  configureFlags = [ "--localstatedir=/var" "--sysconfdir=/etc" ]
-    ++ optional withCloud "--enable-cloud";
+  configureFlags = [
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+  ] ++ optional withCloud "--enable-cloud";
 
   postFixup = ''
     wrapProgram $out/bin/netdata-claim.sh --prefix PATH : ${openssl}/bin

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -63,8 +63,8 @@ in stdenv.mkDerivation rec {
 
   preConfigure = optionalString withCloud ''
     mkdir -p externaldeps
-    cp -r "${mosquitto}/lib" externaldeps/mosquitto;
-    cp -r "${libwebsockets_3_2}/lib" externaldeps/libwebsockets;
+    cp -r "${mosquitto}/lib" externaldeps/mosquitto
+    cp -r "${libwebsockets_3_2}/lib" externaldeps/libwebsockets
   '' + optionalString (!stdenv.isDarwin) ''
     substituteInPlace collectors/python.d.plugin/python_modules/third_party/lm_sensors.py \
       --replace 'ctypes.util.find_library("sensors")' '"${lm_sensors.out}/lib/libsensors${stdenv.hostPlatform.extensions.sharedLibrary}"'

--- a/pkgs/tools/system/netdata/mosquitto.nix
+++ b/pkgs/tools/system/netdata/mosquitto.nix
@@ -27,10 +27,9 @@ stdenv.mkDerivation rec {
     "-DWITH_DOCS=NO"
   ];
 
-  buildPhase = ''
-    cd lib
-    make install
-  '';
+  makeFlags = [
+    "-Clib"
+  ];
 
   postInstall = ''
     cp $out/lib/libmosquitto_static.a $out/lib/libmosquitto.a

--- a/pkgs/tools/system/netdata/mosquitto.nix
+++ b/pkgs/tools/system/netdata/mosquitto.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mosquitto";
-  version = "1.6.8_Netdata-4";
+  version = "1.6.8_Netdata-5";
 
   src = fetchFromGitHub {
     owner = "netdata";
     repo = "mosquitto";
     rev = "v.${version}";
-    sha256 = "06vb9pndw3zwfnh4a8rwafdkrz00kq01vngl0zq32y74h16pp2zb";
+    sha256 = "0ayxnf0wa1nq52ana7san62zzkcm08ss8pmpx8hzp9yi0zl5mpal";
   };
 
   buildInputs = [ c-ares libwebsockets_3_2 openssl ];

--- a/pkgs/tools/system/netdata/mosquitto.nix
+++ b/pkgs/tools/system/netdata/mosquitto.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, c-ares, cmake, libwebsockets_3_2, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "mosquitto";
+  version = "1.6.8_Netdata-4";
+
+  src = fetchFromGitHub {
+    owner = "netdata";
+    repo = "mosquitto";
+    rev = "v.${version}";
+    sha256 = "06vb9pndw3zwfnh4a8rwafdkrz00kq01vngl0zq32y74h16pp2zb";
+  };
+
+  buildInputs = [ c-ares libwebsockets_3_2 openssl ];
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DWITH_THREADING=YES"
+    "-DWITH_WEBSOCKETS=YES"
+    "-DWITH_STATIC_LIBRARIES=YES"
+    "-DWITH_DOCS=NO"
+  ];
+
+  buildPhase = ''
+    cd lib
+    make install
+  '';
+
+  postInstall = ''
+    cp $out/lib/libmosquitto_static.a $out/lib/libmosquitto.a
+    cp $out/include/mosquitto.h $out/lib/mosquitto.h
+  '';
+}

--- a/pkgs/tools/system/netdata/mosquitto.nix
+++ b/pkgs/tools/system/netdata/mosquitto.nix
@@ -1,3 +1,9 @@
+# The Netdata project uses a custom fork of Mosquitto that
+# incorporates support for some callback functionality they
+# require.
+#
+# Also see https://github.com/netdata/netdata/issues/8961
+
 { stdenv, fetchFromGitHub, c-ares, cmake, libwebsockets_3_2, openssl }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/system/netdata/mosquitto.nix
+++ b/pkgs/tools/system/netdata/mosquitto.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = ''
-    cp $out/lib/libmosquitto_static.a $out/lib/libmosquitto.a
-    cp $out/include/mosquitto.h $out/lib/mosquitto.h
+    ln $out/lib/libmosquitto_static.a $out/lib/libmosquitto.a
+    ln $out/include/mosquitto.h $out/lib/mosquitto.h
   '';
 }


### PR DESCRIPTION
This PR adds a `withCloud` option to the netdata package. When enabled it allows the netdata agent to communicate with the netdata cloud.

Other than that, we unconditionally wrap the `netdata-claim.sh` script with a path to openssl and no longer remove the `sbin` output as it is required by the script.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The current netdata package does not support connecting to the netdata cloud.
There has been a packaging request for netdata with cloud support in #91549. 
#92291 was merged in preparation to this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
