### PR TITLE
certbot: add certbot.withPlugins

### DIFF
--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, python, runCommand
 , fetchFromGitHub
 , ConfigArgParse, acme, configobj, cryptography, distro, josepy, parsedatetime, pyRFC3339, pyopenssl, pytz, requests, six, zope_component, zope_interface
 , dialog, mock, gnureadline
@@ -50,6 +51,19 @@ buildPythonPackage rec {
   doCheck = true;
 
   makeWrapperArgs = [ "--prefix PATH : ${dialog}/bin" ];
+
+  # certbot.withPlugins has a similar calling convention as python*.withPackages
+  # it gets invoked with a lambda, and invokes that lambda with the python package set matching certbot's:
+  # certbot.withPlugins (cp: [ cp.certbot-dns-foo ])
+  passthru.withPlugins = f: let
+    pythonEnv = python.withPackages f;
+
+  in runCommand "certbot-with-plugins" {
+  } ''
+    mkdir -p $out/bin
+    cd $out/bin
+    ln -s ${pythonEnv}/bin/certbot
+  '';
 
   meta = with lib; {
     homepage = src.meta.homepage;

--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -1,12 +1,12 @@
 { lib
-, buildPythonApplication
+, buildPythonPackage
 , fetchFromGitHub
 , ConfigArgParse, acme, configobj, cryptography, distro, josepy, parsedatetime, pyRFC3339, pyopenssl, pytz, requests, six, zope_component, zope_interface
 , dialog, mock, gnureadline
-, pytest_xdist, pytest, dateutil
+, pytest_xdist, pytest, pytestCheckHook, dateutil
 }:
 
-buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "certbot";
   version = "1.6.0";
 
@@ -16,6 +16,8 @@ buildPythonApplication rec {
     rev = "v${version}";
     sha256 = "1y0m5qm853i6pcpb2mrf8kjkr9wr80mdrx1qmck38ayvr2v2p5lc";
   };
+
+  sourceRoot = "source/${pname}";
 
   propagatedBuildInputs = [
     ConfigArgParse
@@ -36,20 +38,18 @@ buildPythonApplication rec {
 
   buildInputs = [ dialog mock gnureadline ];
 
-  checkInputs = [ pytest_xdist pytest dateutil ];
+  checkInputs = [
+    dateutil
+    pytest
+    pytestCheckHook
+    pytest_xdist
+  ];
 
-  preBuild = ''
-    cd certbot
-  '';
-
-  postInstall = ''
-    for i in $out/bin/*; do
-      wrapProgram "$i" --prefix PYTHONPATH : "$PYTHONPATH" \
-                       --prefix PATH : "${dialog}/bin:$PATH"
-    done
-  '';
+  pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
 
   doCheck = true;
+
+  makeWrapperArgs = [ "--prefix PATH : ${dialog}/bin" ];
 
   meta = with lib; {
     homepage = src.meta.homepage;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11592,7 +11592,7 @@ in
     ogre = ogre1_10;
   };
 
-  certbot = python3Packages.callPackage ../tools/admin/certbot { };
+  certbot = python3.pkgs.toPythonApplication python3.pkgs.certbot;
 
   caf = callPackage ../development/libraries/caf {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11594,6 +11594,12 @@ in
 
   certbot = python3.pkgs.toPythonApplication python3.pkgs.certbot;
 
+  certbot-full = certbot.withPlugins (cp: with cp; [
+    certbot-dns-cloudflare
+    certbot-dns-rfc2136
+    certbot-dns-route53
+  ]);
+
   caf = callPackage ../development/libraries/caf {};
 
   # CGAL 5 has API changes

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -585,6 +585,8 @@ in {
 
   cdecimal = callPackage ../development/python-modules/cdecimal { };
 
+  certbot = callPackage ../development/python-modules/certbot { };
+
   certbot-dns-cloudflare = callPackage ../development/python-modules/certbot-dns-cloudflare { };
 
   certbot-dns-rfc2136 = callPackage ../development/python-modules/certbot-dns-rfc2136 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1043,7 +1043,7 @@ in {
   nvchecker = callPackage ../development/python-modules/nvchecker { };
 
   numericalunits = callPackage ../development/python-modules/numericalunits { };
-  
+
   nunavut = callPackage ../development/python-modules/nunavut { };
 
   oath = callPackage ../development/python-modules/oath { };
@@ -1677,7 +1677,7 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices CoreServices;
   };
 
-  pyuavcan = callPackage ../development/python-modules/pyuavcan { 
+  pyuavcan = callPackage ../development/python-modules/pyuavcan {
     # this version pinpoint to anold version is necessary due to a regression
     nunavut = self.nunavut.overridePythonAttrs ( old: rec {
       version = "0.2.3";
@@ -4491,7 +4491,7 @@ in {
   }));
 
   libkeepass = callPackage ../development/python-modules/libkeepass { };
-  
+
   libredwg = toPythonModule (pkgs.libredwg.override {
     enablePython = true;
     inherit (self) python libxml2;
@@ -4544,7 +4544,7 @@ in {
 
   locustio = callPackage ../development/python-modules/locustio { };
 
-  llvmlite = callPackage ../development/python-modules/llvmlite { 
+  llvmlite = callPackage ../development/python-modules/llvmlite {
     llvm = pkgs.llvm_9; # llvmlite always requires a specific version of llvm.
   };
 
@@ -6702,7 +6702,7 @@ in {
 
   zipp = if pythonOlder "3.6" then
     callPackage ../development/python-modules/zipp/1.nix { }
-  else 
+  else
     callPackage ../development/python-modules/zipp { };
 
   zope_broken = callPackage ../development/python-modules/zope_broken { };


### PR DESCRIPTION
Simplifies making use of certbot plugins introduced in https://github.com/NixOS/nixpkgs/pull/92696.

This can be used to wrap certbot to include some plugins.

certbot.withPlugins has a similar calling convention as python*.withPackages:

```
certbot.withPlugins (cp: [ cp.certbot-dns-foo ])
```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
