### PR TITLE
ocrmypdf: 9.8.2 -> 10.2.0

### DIFF
--- a/pkgs/development/python-modules/coloredlogs/default.nix
+++ b/pkgs/development/python-modules/coloredlogs/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "coloredlogs";
-  version = "10.0";
+  version = "14.0";
 
   src = fetchFromGitHub {
     owner = "xolox";
     repo = "python-coloredlogs";
     rev = version;
-    sha256 = "0rdvp4dfvzhx7z7s2jdl3fv7x1hazgpy5gc7bcf05bnbv2iia54a";
+    sha256 = "0rnmxwrim4razlv4vi3krxk5lc5ksck6h5374j8avqwplika7q2x";
   };
 
   # patch by risicle

--- a/pkgs/tools/text/ocrmypdf/default.nix
+++ b/pkgs/tools/text/ocrmypdf/default.nix
@@ -29,14 +29,14 @@ let
 in
 buildPythonApplication rec {
   pname = "ocrmypdf";
-  version = "9.8.2";
+  version = "10.2.0";
   disabled = ! python3Packages.isPy3k;
 
   src = fetchFromGitHub {
     owner = "jbarlow83";
     repo = "OCRmyPDF";
     rev = "v${version}";
-    sha256 = "0zff9gsbfaf72p8zbjamn6513czpr7papyh1jy0fz1z2a9h7ya0g";
+    sha256 = "1dkxhy3bjl48948jj2k6d684sd76xw1q427qc4hmxncr0wxj0ljp";
   };
 
   nativeBuildInputs = with python3Packages; [
@@ -49,8 +49,10 @@ buildPythonApplication rec {
   propagatedBuildInputs = with python3Packages; [
     cffi
     chardet
+    coloredlogs
     img2pdf
     pdfminer
+    pluggy
     pikepdf
     pillow
     reportlab
@@ -66,7 +68,7 @@ buildPythonApplication rec {
     pytestcov
     pytestrunner
     python-xmp-toolkit
-    setuptools
+    pytestCheckHook
   ] ++ runtimeDeps;
 
   patches = [
@@ -75,25 +77,6 @@ buildPythonApplication rec {
       liblept = "${stdenv.lib.getLib leptonica}/lib/liblept${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];
-
-  # The tests take potentially 20+ minutes, depending on machine
-  doCheck = false;
-
-  # These tests fail and it might be upstream problem... or packaging. :)
-  # development is happening on macos and the pinned test versions are
-  # significantly newer than nixpkgs has. Program still works...
-  # (to the extent I've used it) -- Kiwi
-  checkPhase = ''
-    export HOME=$TMPDIR
-    pytest -k 'not test_force_ocr_on_pdf_with_no_images \
-    and not test_tesseract_crash \
-    and not test_tesseract_crash_autorotate \
-    and not test_ghostscript_pdfa_failure \
-    and not test_gs_render_failure \
-    and not test_gs_raster_failure \
-    and not test_bad_utf8 \
-    and not test_old_unpaper'
-  '';
 
   makeWrapperArgs = [ "--prefix PATH : ${stdenv.lib.makeBinPath [ ghostscript jbig2enc pngquant qpdf tesseract4 unpaper ]}" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to latest version.

`coloredlogs` is required in a newer version, so I updated its too.

###### Things done

@flokli @Mic92 I enabled the tests as discussed in https://github.com/NixOS/nixpkgs/pull/89710

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
