### PR TITLE
ceph: 14.2.10 -> 15.2.4

### DIFF
--- a/nixos/tests/ceph-multi-node.nix
+++ b/nixos/tests/ceph-multi-node.nix
@@ -183,15 +183,15 @@ let
     monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
 
     monA.succeed(
-        "ceph osd pool create multi-node-test 128 128",
+        "ceph osd pool create multi-node-test 32 32",
         "ceph osd pool ls | grep 'multi-node-test'",
         "ceph osd pool rename multi-node-test multi-node-other-test",
         "ceph osd pool ls | grep 'multi-node-other-test'",
     )
-    monA.wait_until_succeeds("ceph -s | grep '1 pools, 128 pgs'")
+    monA.wait_until_succeeds("ceph -s | grep '2 pools, 33 pgs'")
     monA.succeed("ceph osd pool set multi-node-other-test size 2")
     monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
-    monA.wait_until_succeeds("ceph -s | grep '128 active+clean'")
+    monA.wait_until_succeeds("ceph -s | grep '33 active+clean'")
     monA.fail(
         "ceph osd pool ls | grep 'multi-node-test'",
         "ceph osd pool delete multi-node-other-test multi-node-other-test --yes-i-really-really-mean-it",

--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -143,12 +143,12 @@ let
     monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
 
     monA.succeed(
-        "ceph osd pool create single-node-test 128 128",
+        "ceph osd pool create single-node-test 32 32",
         "ceph osd pool ls | grep 'single-node-test'",
         "ceph osd pool rename single-node-test single-node-other-test",
         "ceph osd pool ls | grep 'single-node-other-test'",
     )
-    monA.wait_until_succeeds("ceph -s | grep '1 pools, 128 pgs'")
+    monA.wait_until_succeeds("ceph -s | grep '2 pools, 33 pgs'")
     monA.succeed(
         "ceph osd getcrushmap -o crush",
         "crushtool -d crush -o decrushed",
@@ -158,7 +158,7 @@ let
         "ceph osd pool set single-node-other-test size 2",
     )
     monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
-    monA.wait_until_succeeds("ceph -s | grep '128 active+clean'")
+    monA.wait_until_succeeds("ceph -s | grep '33 active+clean'")
     monA.fail(
         "ceph osd pool ls | grep 'multi-node-test'",
         "ceph osd pool delete single-node-other-test single-node-other-test --yes-i-really-really-mean-it",

--- a/pkgs/tools/filesystems/ceph/0000-fix-SPDK-build-env.patch
+++ b/pkgs/tools/filesystems/ceph/0000-fix-SPDK-build-env.patch
@@ -1,11 +1,11 @@
---- a/cmake/modules/BuildSPDK.cmake	2018-08-09 09:22:34.950684960 +0200
-+++ b/cmake/modules/BuildSPDK.cmake	2018-08-09 09:21:59.986964224 +0200
-@@ -16,7 +16,7 @@
+--- a/cmake/modules/BuildSPDK.cmake
++++ b/cmake/modules/BuildSPDK.cmake
+@@ -35,7 +35,7 @@ macro(build_spdk)
      # unset $CFLAGS, otherwise it will interfere with how SPDK sets
      # its include directory.
      # unset $LDFLAGS, otherwise SPDK will fail to mock some functions.
--    BUILD_COMMAND env -i PATH=$ENV{PATH} CC=${CMAKE_C_COMPILER} $(MAKE) EXTRA_CFLAGS="-fPIC"
-+    BUILD_COMMAND env PATH=$ENV{PATH} CC=${CMAKE_C_COMPILER} $(MAKE) EXTRA_CFLAGS="-fPIC" C_OPT="-mssse3"
+-    BUILD_COMMAND env -i PATH=$ENV{PATH} CC=${CMAKE_C_COMPILER} ${make_cmd} EXTRA_CFLAGS="${spdk_CFLAGS}"
++    BUILD_COMMAND env -i PATH=$ENV{PATH} CC=${CMAKE_C_COMPILER} ${make_cmd} EXTRA_CFLAGS="${spdk_CFLAGS}" C_OPT="-mssse3"
      BUILD_IN_SOURCE 1
      INSTALL_COMMAND "true")
-   ExternalProject_Get_Property(spdk-ext source_dir)
+   unset(make_cmd)

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -75,6 +75,26 @@ let
     none = [ ];
   };
 
+  getMeta = description: {
+     homepage = "https://ceph.com/";
+     inherit description;
+     license = with licenses; [ lgpl21 gpl2 bsd3 mit publicDomain ];
+     maintainers = with maintainers; [ adev ak johanot krav ];
+     platforms = [ "x86_64-linux" ];
+   };
+
+  ceph-common = python3Packages.buildPythonPackage rec{
+    pname = "ceph-common";
+    inherit src version;
+
+    sourceRoot = "ceph-${version}/src/python-common";
+
+    checkInputs = [ python3Packages.pytest ];
+    propagatedBuildInputs = with python3Packages; [ pyyaml six ];
+
+    meta = getMeta "Ceph common module for code shared by manager modules";
+  };
+
   ceph-python-env = python3Packages.python.withPackages (ps: [
     ps.sphinx
     ps.flask
@@ -83,27 +103,30 @@ let
     ps.virtualenv
     # Libraries needed by the python tools
     ps.Mako
+    ceph-common
     ps.cherrypy
+    ps.dateutil
+    ps.jsonpatch
     ps.pecan
     ps.prettytable
     ps.pyjwt
     ps.webob
     ps.bcrypt
+    ps.scipy
     ps.six
     ps.pyyaml
   ]);
   sitePackages = ceph-python-env.python.sitePackages;
 
-  version = "14.2.10";
+  version = "15.2.4";
+  src = fetchurl {
+    url = "http://download.ceph.com/tarballs/ceph-${version}.tar.gz";
+    sha256 = "0jy5dp4r1bqk1l7nrv8l8zpl984k61p3vkvf73ygcn03bxyjjlax";
+  };
 in rec {
   ceph = stdenv.mkDerivation {
     pname = "ceph";
-    inherit version;
-
-    src = fetchurl {
-      url = "http://download.ceph.com/tarballs/ceph-${version}.tar.gz";
-      sha256 = "0bbs3ag8zav283qpxrrndhvh2z01ykm6126fmwrbc1c5f9jfjq39";
-    };
+    inherit src version;
 
     patches = [
       ./0000-fix-SPDK-build-env.patch
@@ -173,25 +196,13 @@ in rec {
 
     doCheck = false; # uses pip to install things from the internet
 
-    meta = {
-      homepage = "https://ceph.com/";
-      description = "Distributed storage system";
-      license = with licenses; [ lgpl21 gpl2 bsd3 mit publicDomain ];
-      maintainers = with maintainers; [ adev ak krav johanot srhb ];
-      platforms = [ "x86_64-linux" ];
-    };
+    meta = getMeta "Distributed storage system";
 
     passthru.version = version;
   };
 
   ceph-client = runCommand "ceph-client-${version}" {
-     meta = {
-        homepage = "https://ceph.com/";
-        description = "Tools needed to mount Ceph's RADOS Block Devices";
-        license = with licenses; [ lgpl21 gpl2 bsd3 mit publicDomain ];
-        maintainers = with maintainers; [ adev ak johanot krav ];
-        platforms = [ "x86_64-linux" ];
-      };
+      meta = getMeta "Tools needed to mount Ceph's RADOS Block Devices";
     } ''
       mkdir -p $out/{bin,etc,${sitePackages}}
       cp -r ${ceph}/bin/{ceph,.ceph-wrapped,rados,rbd,rbdmap} $out/bin

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -112,7 +112,10 @@ let
     ps.pyjwt
     ps.webob
     ps.bcrypt
-    ps.scipy
+    # scipy > 1.3 breaks diskprediction_local, leading to mgr hang on startup
+    # Bump (and get rid of scipy_1_3) once these issues are resolved:
+    # https://tracker.ceph.com/issues/42764 https://tracker.ceph.com/issues/45147
+    ps.scipy_1_3
     ps.six
     ps.pyyaml
   ]);

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5902,6 +5902,15 @@ in {
     });
   in if pythonOlder "3.5" then scipy_1_2 else scipy_;
 
+  scipy_1_3 = self.scipy.overridePythonAttrs(oldAttrs: rec {
+    version = "1.3.3";
+    src = oldAttrs.src.override {
+      inherit version;
+      sha256 = "02iqb7ws7fw5fd1a83hx705pzrw1imj7z0bphjsl4bfvw254xgv4";
+    };
+    doCheck = false;
+  });
+
   scikitimage = callPackage ../development/python-modules/scikit-image { };
 
   scikitlearn = let


### PR DESCRIPTION

###### Motivation for this change

Bump ceph to newest major release.

Singlenode and Multinode tests pass locally.

I also performed a full upgrade from Nautilus to Octopus on our test cluster.
Everything works as expected.

Regarding the SPDK-build-env patch: I re-aligned the patch, as it didn't apply correctly. However; I hope someone can help me verify at some point whether this patch is even needed anymore? I don't know what it does in detail other than enabling some machine arch specific features.

Regarding scipy: ceph-mgr hangs during startup due to incompatibility with newer scipy versions, thus the version downgrade. Thanks @srhb.

Ceph has changed a lot of config defaults and it is recommended to read the release notes before upgrading: 
https://docs.ceph.com/docs/master/releases/octopus/#v15-2-4-octopus

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
