### PR TITLE
oneshot: init at 1.0.1

### DIFF
--- a/pkgs/tools/networking/oneshot/default.nix
+++ b/pkgs/tools/networking/oneshot/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "oneshot";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "raphaelreyna";
+    repo = "oneshot";
+    rev = "v${version}";
+    sha256 = "1gcxwamchznkzg3m0gfig7733z2w035lxxj6h18gc6zzcnf6p57w";
+  };
+
+  goPackagePath = "github.com/raphaelreyna/oneshot";
+  vendorSha256 = "0v53dsj0w959pmvk6v1i7rwlfd2y0vrghxlwkgidw0sf775qpgvy";
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "A first-come-first-serve single-fire HTTP server";
+    homepage = "https://github.com/raphaelreyna/oneshot";
+    license = licenses.mit;
+    maintainers = with maintainers; [ edibopp ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2157,6 +2157,8 @@ in
 
   onboard = callPackage ../applications/misc/onboard { };
 
+  oneshot = callPackage ../tools/networking/oneshot { };
+
   onnxruntime = callPackage ../development/libraries/onnxruntime { };
 
   xkbd = callPackage ../applications/misc/xkbd { };


### PR DESCRIPTION
###### Motivation for this change

I use the package and want to make it easily available to other nixpkgs users.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).