### PR TITLE
pythonPackages.maxminddb: fix build on macOS

### DIFF
--- a/pkgs/development/python-modules/maxminddb/default.nix
+++ b/pkgs/development/python-modules/maxminddb/default.nix
@@ -1,4 +1,6 @@
-{ buildPythonPackage, lib, fetchPypi
+{ stdenv, lib, buildPythonPackage, pythonAtLeast
+, fetchPypi
+, libmaxminddb
 , ipaddress
 , mock
 , nose
@@ -13,9 +15,14 @@ buildPythonPackage rec {
     sha256 = "f4d28823d9ca23323d113dc7af8db2087aa4f657fafc64ff8f7a8afda871425b";
   };
 
+  buildInputs = [ libmaxminddb ];
+
   propagatedBuildInputs = [ ipaddress ];
 
   checkInputs = [ nose mock ];
+
+  # Tests are broken for macOS on python38
+  doCheck = !(stdenv.isDarwin && pythonAtLeast "3.8");
 
   meta = with lib; {
     description = "Reader for the MaxMind DB format";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Build C extension and fix build on [macOS](https://hydra.nixos.org/build/123119894).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
