### PR TITLE
fix pkgsCross.*.texinfoInteractive

### DIFF
--- a/pkgs/development/tools/misc/texinfo/cross-tools-flags.patch
+++ b/pkgs/development/tools/misc/texinfo/cross-tools-flags.patch
@@ -6,7 +6,7 @@ diff -ur texinfo-6.5/configure texinfo-6.5-patched/configure
    # consequently, we have to re-initialize $PATH.
 -  env -i CC="$BUILD_CC" AR="$BUILD_AR" RANLIB="$BUILD_RANLIB" \
 -      PATH="$PATH" \
-+   env -i CC="$CC_FOR_BUILD" AR="$AR_FOR_BUILD" RANLIB="$RANLIB_FOR_BUILD" \
++  env -i CC="$CC_FOR_BUILD" AR="$AR_FOR_BUILD" RANLIB="$RANLIB_FOR_BUILD" \
 +      PATH="$PATH" CFLAGS="$NATIVE_TOOLS_CFLAGS" LDFLAGS="$NATIVE_TOOLS_LDFLAGS" \
        tools_only=1 \
      ${confdir}/configure --build=${build} --host=${build} \

--- a/pkgs/development/tools/misc/texinfo/cross-tools-flags.patch
+++ b/pkgs/development/tools/misc/texinfo/cross-tools-flags.patch
@@ -4,8 +4,9 @@ diff -ur texinfo-6.5/configure texinfo-6.5-patched/configure
 @@ -23281,7 +23281,7 @@
    # env -i gives this build host configure a clean environment;
    # consequently, we have to re-initialize $PATH.
-   env -i CC="$CC_FOR_BUILD" AR="$AR_FOR_BUILD" RANLIB="$RANLIB_FOR_BUILD" \
+-  env -i CC="$BUILD_CC" AR="$BUILD_AR" RANLIB="$BUILD_RANLIB" \
 -      PATH="$PATH" \
++   env -i CC="$CC_FOR_BUILD" AR="$AR_FOR_BUILD" RANLIB="$RANLIB_FOR_BUILD" \
 +      PATH="$PATH" CFLAGS="$NATIVE_TOOLS_CFLAGS" LDFLAGS="$NATIVE_TOOLS_LDFLAGS" \
        tools_only=1 \
      ${confdir}/configure --build=${build} --host=${build} \


### PR DESCRIPTION
This fixes #86166 to build cross compilied texinfoInteractive.
BUILD_CC has been renamed to CC_FOR_BUILD so the patch needs to applied
this renaming.

tested on: pkgsCross.armv7l-hf-multiplatform.texinfoInteractive

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
