### PR TITLE
python3Packages.notifymuch: Init at 0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3018,6 +3018,16 @@
     githubId = 615606;
     name = "Glenn Searby";
   };
+  glittershark = {
+    name = "Griffin Smith";
+    email = "root@gws.fyi";
+    github = "glittershark";
+    githubId = 1481027;
+    keys = [{
+      longkeyid = "rsa2048/0x44EF5B5E861C09A7";
+      fingerprint = "0F11 A989 879E 8BBB FDC1  E236 44EF 5B5E 861C 09A7";
+    }];
+  };
   gloaming = {
     email = "ch9871@gmail.com";
     github = "gloaming";

--- a/pkgs/development/python-modules/notifymuch/default.nix
+++ b/pkgs/development/python-modules/notifymuch/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, buildPythonApplication
+, isPy3k
+, fetchFromGitHub
+, notmuch
+, pygobject3
+, gobject-introspection
+, libnotify
+, wrapGAppsHook
+, gtk3
+}:
+
+buildPythonApplication rec {
+  pname = "notifymuch";
+  version = "0.1";
+  disabled = ! isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "kspi";
+    repo = "notifymuch";
+    rev = "9d4aaf54599282ce80643b38195ff501120807f0";
+    sha256 = "1lssr7iv43mp5v6nzrfbqlfzx8jcc7m636wlfyhhnd8ydd39n6k4";
+  };
+
+  propagatedBuildInputs = [
+    notmuch
+    pygobject3
+    libnotify
+    gtk3
+  ];
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    echo "wrapper args"
+    echo "''${makeWrapperArgs[@]}"
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    echo "wrapper args again"
+    echo "''${makeWrapperArgs[@]}"
+  '';
+
+  strictDeps = false;
+
+  meta = with stdenv.lib; {
+    description = "Display desktop notifications for unread mail in a notmuch database";
+    homepage = "https://github.com/kspi/notifymuch";
+    maintainers = with maintainers; [ glittershark ];
+    license = licenses.gpl3;
+    platforms = with platforms; [ linux ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4898,6 +4898,8 @@ in {
 
   notify2 = callPackage ../development/python-modules/notify2 {};
 
+  notifymuch = callPackage ../development/python-modules/notifymuch {};
+
   notmuch = callPackage ../development/python-modules/notmuch {
     inherit (pkgs) notmuch;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I'd like to use the package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
