### PR TITLE
ocamlPackages.tsort: init at 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/tsort/default.nix
+++ b/pkgs/development/ocaml-modules/tsort/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildDunePackage, fetchFromGitHub, containers }:
+
+buildDunePackage rec {
+  pname = "tsort";
+  version = "2.0.0";
+  src = fetchFromGitHub {
+    owner = "dmbaturin";
+    repo = "ocaml-tsort";
+    rev = version;
+    sha256 = "0i67ys5p5i8q9p0nhkq4pjg9jav8dy0fiy975a365j7m6bhrwgc1";
+  };
+
+  propagatedBuildInputs = [ containers ];
+
+  meta = {
+    description = "Easy to use and user-friendly topological sort";
+    inherit (src.meta) homepage;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -758,6 +758,8 @@ let
 
     sqlexpr = callPackage ../development/ocaml-modules/sqlexpr { };
 
+    tsort = callPackage ../development/ocaml-modules/tsort { };
+
     tuntap = callPackage ../development/ocaml-modules/tuntap { };
 
     tyxml = callPackage ../development/ocaml-modules/tyxml { };


### PR DESCRIPTION
###### Motivation for this change

New package for the `tsort` library: “Easy to use and user-friendly topological sort module for OCaml ”.
https://github.com/dmbaturin/ocaml-tsort/

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
