### PR TITLE
home-assistant: fix zha in home-assistant

### DIFF
--- a/pkgs/development/python-modules/bellows/default.nix
+++ b/pkgs/development/python-modules/bellows/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, click, click-log, pure-pcapy3
+, pyserial, pyserial-asyncio, voluptuous, zigpy
+, asynctest, pytest, pytest-asyncio }:
+
+let
+  pname = "bellows";
+  version = "0.17.0";
+
+in buildPythonPackage rec {
+  inherit pname version;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03gckhrxji8lgjsi6xr8yql405kfanii5hjrmakk1328bmq9g5f6";
+  };
+
+  propagatedBuildInputs = [
+    click click-log pure-pcapy3 pyserial pyserial-asyncio voluptuous zigpy
+  ];
+
+  checkInputs = [
+    asynctest pytest pytest-asyncio
+  ];
+
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "click-log==0.2.0" "click-log>=0.2.0"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Python 3 project to implement EZSP for EmberZNet devices";
+    homepage = "https://github.com/zigpy/bellows";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ etu mvnetbiz ];
+  };
+}

--- a/pkgs/development/python-modules/pure-pcapy3/default.nix
+++ b/pkgs/development/python-modules/pure-pcapy3/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pure-pcapy3";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14panfklap6wwi9avw46gvd7wg9mkv9xbixvbvmi1m2adpqlb7mr";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Pure Python reimplementation of pcapy. This package is API compatible and a drop-in replacement.";
+    homepage = "http://bitbucket.org/viraptor/pure-pcapy";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ etu ];
+  };
+}

--- a/pkgs/development/python-modules/zigpy-cc/default.nix
+++ b/pkgs/development/python-modules/zigpy-cc/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pyserial, pyserial-asyncio, zigpy
+, asynctest, pytest, pytest-asyncio }:
+
+buildPythonPackage rec {
+  pname = "zigpy-cc";
+  version = "0.4.4";
+
+  propagatedBuildInputs = [ pyserial pyserial-asyncio zigpy ];
+  checkInputs = [ asynctest pytest pytest-asyncio ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "117a9xak4y5nksfk9rgvzd6l7hscvzspl1wf3gydyq2lc7b3ggnl";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A library which communicates with Texas Instruments CC2531 radios for zigpy";
+    homepage = "http://github.com/sanyatuning/zigpy-cc";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ etu mvnetbiz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/zigpy-deconz/default.nix
+++ b/pkgs/development/python-modules/zigpy-deconz/default.nix
@@ -1,14 +1,13 @@
 { stdenv, buildPythonPackage, fetchPypi
-, aiohttp, crccheck, pyserial, pyserial-asyncio, pycryptodome, zigpy
-, pytest }:
+, pyserial, pyserial-asyncio, zigpy
+, pytest, pytest-asyncio, asynctest }:
 
 buildPythonPackage rec {
   pname = "zigpy-deconz";
   version = "0.9.2";
 
-  nativeBuildInputs = [ pytest ];
-  buildInputs = [ aiohttp crccheck pycryptodome ];
   propagatedBuildInputs = [ pyserial pyserial-asyncio zigpy ];
+  checkInputs = [ pytest pytest-asyncio asynctest ];
 
   src = fetchPypi {
     inherit pname version;
@@ -19,7 +18,7 @@ buildPythonPackage rec {
     description = "Library which communicates with Deconz radios for zigpy";
     homepage = "https://github.com/zigpy/zigpy-deconz";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ etu ];
+    maintainers = with maintainers; [ etu mvnetbiz ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/zigpy-xbee/default.nix
+++ b/pkgs/development/python-modules/zigpy-xbee/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pyserial, pyserial-asyncio, zigpy
+, pytest }:
+
+buildPythonPackage rec {
+  pname = "zigpy-xbee";
+  version = "0.12.1";
+
+  buildInputs = [ pyserial pyserial-asyncio zigpy ];
+  checkInputs = [ pytest ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "09488hl27qjv8shw38iiyzvzwcjkc0k4n00l2bfn1ac443xzw0vh";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A library which communicates with XBee radios for zigpy";
+    homepage = "http://github.com/zigpy/zigpy-xbee";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ etu mvnetbiz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/zigpy-zigate/default.nix
+++ b/pkgs/development/python-modules/zigpy-zigate/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pyserial, pyserial-asyncio, zigpy
+, pytest }:
+
+buildPythonPackage rec {
+  pname = "zigpy-zigate";
+  version = "0.6.1";
+
+  buildInputs = [ pyserial pyserial-asyncio zigpy ];
+  checkInputs = [ pytest ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xxqv65drrr96b9ncwsx9ayd369lpwimj1jjb0d7j6l9lil0wmf5";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A library which communicates with ZiGate radios for zigpy";
+    homepage = "http://github.com/doudz/zigpy-zigate";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ etu mvnetbiz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -1,25 +1,24 @@
 { stdenv, buildPythonPackage, fetchPypi
-, aiohttp, crccheck, pycryptodome, pycrypto
+, aiohttp, crccheck, pycryptodome, pycrypto, voluptuous
 , pytest, pytest-asyncio, asynctest }:
 
 buildPythonPackage rec {
-  pname = "zigpy-homeassistant";
-  version = "0.19.0";
+  pname = "zigpy";
+  version = "0.22.0";
 
-  nativeBuildInputs = [ pytest pytest-asyncio asynctest ];
-  buildInputs = [ aiohttp pycryptodome ];
-  propagatedBuildInputs = [ crccheck pycrypto ];
+  propagatedBuildInputs = [ aiohttp crccheck pycrypto pycryptodome voluptuous ];
+  checkInputs = [ pytest pytest-asyncio asynctest ];
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "779cff7affb86b7141aa641c188342b22be0ec766adee0d180c93e74e2b10adc";
+    sha256 = "1y8n96g5g6qsx8s2z028f1cyp2w8y7kksi8k2yyzpqvmanbxyjhc";
   };
 
   meta = with stdenv.lib; {
     description = "Library implementing a ZigBee stack";
     homepage = "https://github.com/zigpy/zigpy";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ etu ];
+    maintainers = with maintainers; [ etu mvnetbiz ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -934,7 +934,7 @@
     "zeroconf" = ps: with ps; [ aiohttp-cors zeroconf];
     "zerproc" = ps: with ps; [ ]; # missing inputs: pyzerproc
     "zestimate" = ps: with ps; [ xmltodict];
-    "zha" = ps: with ps; [ pyserial zha-quirks zigpy-deconz]; # missing inputs: bellows zigpy-cc zigpy-xbee zigpy-zigate zigpy
+    "zha" = ps: with ps; [ bellows pyserial zha-quirks zigpy-cc zigpy-deconz zigpy-xbee zigpy-zigate zigpy];
     "zhong_hong" = ps: with ps; [ ]; # missing inputs: zhong_hong_hvac
     "ziggo_mediabox_xl" = ps: with ps; [ ]; # missing inputs: ziggo-mediabox-xl
     "zone" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2695,6 +2695,8 @@ in {
 
   zigpy-xbee = callPackage ../development/python-modules/zigpy-xbee { };
 
+  zigpy-zigate = callPackage ../development/python-modules/zigpy-zigate { };
+
   digital-ocean = callPackage ../development/python-modules/digitalocean { };
 
   digi-xbee = callPackage ../development/python-modules/digi-xbee { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7450,6 +7450,8 @@ in {
 
   behave = callPackage ../development/python-modules/behave { };
 
+  bellows = callPackage ../development/python-modules/bellows { };
+
   pyhamcrest = if isPy3k then
     callPackage ../development/python-modules/pyhamcrest { }
   else

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7446,6 +7446,8 @@ in {
 
   pulp  = callPackage ../development/python-modules/pulp { };
 
+  pure-pcapy3 = callPackage ../development/python-modules/pure-pcapy3 { };
+
   behave = callPackage ../development/python-modules/behave { };
 
   pyhamcrest = if isPy3k then

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2689,6 +2689,8 @@ in {
 
   zigpy = callPackage ../development/python-modules/zigpy { };
 
+  zigpy-cc = callPackage ../development/python-modules/zigpy-cc { };
+
   zigpy-deconz = callPackage ../development/python-modules/zigpy-deconz { };
 
   digital-ocean = callPackage ../development/python-modules/digitalocean { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2693,6 +2693,8 @@ in {
 
   zigpy-deconz = callPackage ../development/python-modules/zigpy-deconz { };
 
+  zigpy-xbee = callPackage ../development/python-modules/zigpy-xbee { };
+
   digital-ocean = callPackage ../development/python-modules/digitalocean { };
 
   digi-xbee = callPackage ../development/python-modules/digi-xbee { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I would like to move my home-assistant onto NixOS
Basing off of #88715


###### Things done
Updated versions, fixed dependencies, and enabled the tests.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
