### PR TITLE
pythonPackages.rednose: fix build on macOS

### DIFF
--- a/pkgs/development/python-modules/rednose/default.nix
+++ b/pkgs/development/python-modules/rednose/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy27, nose, six, colorama, termstyle }:
+{ stdenv, buildPythonPackage, fetchPypi, isPy27, pythonAtLeast
+, nose, six, colorama, termstyle }:
 
 buildPythonPackage rec {
   pname = "rednose";
@@ -15,7 +16,8 @@ buildPythonPackage rec {
 
   # Do not test on Python 2 because the tests suite gets stuck
   # https://github.com/NixOS/nixpkgs/issues/60786
-  doCheck = !(isPy27);
+  # Also macOS tests are broken on python38
+  doCheck = !(isPy27 || (stdenv.isDarwin && pythonAtLeast "3.8"));
 
   checkInputs = [ six ];
   propagatedBuildInputs = [ nose colorama termstyle ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://hydra.nixos.org/build/123143226

Fixes https://github.com/NixOS/nixpkgs/issues/92956

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
