### PR TITLE
swaylock-effects: v1.6-0 -> v1.6-1

### DIFF
--- a/pkgs/applications/window-managers/sway/lock-effects.nix
+++ b/pkgs/applications/window-managers/sway/lock-effects.nix
@@ -6,14 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "swaylock-effects";
-  version = "v1.6-0";
+  version = "v1.6-1";
 
   src = fetchFromGitHub {
     owner = "mortie";
     repo = "swaylock-effects";
     rev = version;
-    sha256 = "15lshqq3qj9m3yfac65hjcciaf9zdfh3ir7hgh0ach7gpi3rbk13";
-
+    sha256 = "044fc4makjx8v29fkx5xlil6vr1v4r0k6c8741pl67gzvlm4cx3i";
   };
 
   postPatch = ''
@@ -30,7 +29,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Screen locker for Wayland";
     longDescription = ''
-      swaylock-effects is a screen locking utility for Wayland compositors.
+      Swaylock, with fancy effects
     '';
     inherit (src.meta) homepage;
     license = licenses.mit;


### PR DESCRIPTION
##### Motivation for this change


###### Things done

Update swaylock

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
