### PR TITLE
searx: 0.16.0 -> 0.17.0

### DIFF
--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -4,39 +4,18 @@ with python3Packages;
 
 buildPythonApplication rec {
   pname = "searx";
-  version = "0.16.0";
+  version = "0.17.0";
 
   # Can not use PyPI because certain test files are missing.
   src = fetchFromGitHub {
     owner = "asciimoo";
     repo = "searx";
     rev = "v${version}";
-    sha256 = "0hfa4nmis98yvghxw866rzjpmhb2ln8l6l8g9yx4m79b2lk76xcs";
+    sha256 = "0pznz3wsaikl8khmzqvj05kzh5y07hjw8gqhy6x0lz1b00cn5af4";
   };
 
-  patches = [(fetchpatch {
-    url = "https://github.com/asciimoo/searx/commit/b8b13372c8fd3bfe978a1c724ab98b05348df054.patch";
-    sha256 = "1zc3dx8pgqfg0bj48ihckjk9xrrm33jlnmj8k02g17gfcmj7566a";
-  })];
-
   postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace 'certifi==2019.3.9' 'certifi' \
-      --replace 'flask==1.0.2' 'flask' \
-      --replace 'flask-babel==0.12.2' 'flask-babel' \
-      --replace 'jinja2==2.10.1' 'jinja2' \
-      --replace 'lxml==4.3.3' 'lxml' \
-      --replace 'idna==2.8' 'idna' \
-      --replace 'pygments==2.1.3' 'pygments>=2.1,<3.0' \
-      --replace 'pyopenssl==19.0.0' 'pyopenssl' \
-      --replace 'python-dateutil==2.8.0' 'python-dateutil==2.8.*' \
-      --replace 'pyyaml==5.1' 'pyyaml' \
-      --replace 'requests[socks]==2.22.0' 'requests[socks]'
-    substituteInPlace requirements-dev.txt \
-      --replace 'plone.testing==5.0.0' 'plone.testing' \
-      --replace 'pep8==1.7.0' 'pep8==1.7.*' \
-      --replace 'splinter==0.11.0' 'splinter' \
-      --replace 'selenium==3.141.0' 'selenium'
+    sed -i 's/==.*$//' requirements.txt
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bump to latest version: https://github.com/asciimoo/searx/releases/tag/v0.17.0

Builds, tests pass, and I've briefly tested this with my own searx instance.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
