### PR TITLE
knoxite: init at 2020-06-15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6154,6 +6154,12 @@
     githubId = 8641;
     name = "Pierre Carrier";
   };
+  penguwin = {
+    email = "penguwin@penguwin.eu";
+    github = "penguwin";
+    githubId = 13225611;
+    name = "Nicolas Martin";
+  };
   periklis = {
     email = "theopompos@gmail.com";
     github = "periklis";

--- a/pkgs/tools/backup/knoxite/default.nix
+++ b/pkgs/tools/backup/knoxite/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "knoxite";
+  version = "unstable-2020-06-15";
+
+  src = fetchFromGitHub {
+    owner = "knoxite";
+    repo = pname;
+    rev = "bfdf2fab2325fb2e7521fdf32bbb6edbab4c9896";
+    sha256 = "0fn0rw7xs1q3ybdcbnwwk61wn326n64085gv6qyrn0267vjrnhwj";
+  };
+
+  vendorSha256 = "0cwz0ml384zyq85rln8yi8ymdbc6xb7zy3r2yg135js6r3jjripf";
+
+  meta = with stdenv.lib; {
+    description     = "A secure data storage and backup system";
+    homepage        = "https://www.knoxite.com";
+    license         = licenses.agpl3;
+    maintainers     = [ maintainers.penguwin ];
+    platforms       = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4633,6 +4633,8 @@ in
 
   knockknock = callPackage ../tools/security/knockknock { };
 
+  knoxite = callPackage ../tools/backup/knoxite { };
+
   kore = callPackage ../development/web/kore { };
 
   krakenx = callPackage ../tools/system/krakenx { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

[knoxite](https://www.knoxite.com) is a secure data storage and backup system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
