### PR TITLE
nfs-ganesha: init at 3.3

### DIFF
--- a/pkgs/development/libraries/ntirpc/default.nix
+++ b/pkgs/development/libraries/ntirpc/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, cmake
+, krb5, liburcu , libtirpc
+} :
+
+stdenv.mkDerivation rec {
+  pname = "ntirpc";
+  version = "3.3";
+
+  src = fetchFromGitHub {
+    owner = "nfs-ganesha";
+    repo = "ntirpc";
+    rev = "v${version}";
+    sha256 = "08vc2z9sl1p9mk1mx0zn4xv7dw12gamhciy41fbavm90iavf3vqm";
+  };
+
+  postPatch = ''
+    substituteInPlace ntirpc/netconfig.h --replace "/etc/netconfig" "$out/etc/netconfig"
+  '';
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ krb5 liburcu ];
+
+  postInstall = ''
+    mkdir -p $out/etc
+
+    # Library needs a netconfig to run.
+    # Steal the file from libtirpc
+    cp ${libtirpc}/etc/netconfig $out/etc/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Transport-independent RPC (TI-RPC)";
+    homepage = "https://github.com/nfs-ganesha/ntirpc";
+    maintainers = [ maintainers.markuskowa ];
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/servers/nfs-ganesha/default.nix
+++ b/pkgs/servers/nfs-ganesha/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, cmake, pkg-config
+, krb5, xfsprogs, jemalloc, dbus, libcap
+, ntirpc, liburcu, bison, flex, nfs-utils
+} :
+
+stdenv.mkDerivation rec {
+  pname = "nfs-ganesha";
+  version = "3.3";
+
+  src = fetchFromGitHub {
+    owner = "nfs-ganesha";
+    repo = "nfs-ganesha";
+    rev = "V${version}";
+    sha256 = "1w48rqrbqah0hnirvjdz8lyr9ah8b73j3cgsppb04gnrmpssgmb6";
+  };
+
+  patches = [ ./sysstatedir.patch ];
+
+  preConfigure = "cd src";
+
+  cmakeFlags = [ "-DUSE_SYSTEM_NTIRPC=ON" ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    bison
+    flex
+  ];
+
+  buildInputs = [
+    krb5
+    xfsprogs
+    jemalloc
+    dbus.lib
+    libcap
+    ntirpc
+    liburcu
+    nfs-utils
+  ];
+
+  meta = with stdenv.lib; {
+    description = "NFS server that runs in user space";
+    homepage = "https://github.com/nfs-ganesha/nfs-ganesha/wiki";
+    maintainers = [ maintainers.markuskowa ];
+    platforms = platforms.linux;
+    license = licenses.lgpl3Plus;
+  };
+}

--- a/pkgs/servers/nfs-ganesha/sysstatedir.patch
+++ b/pkgs/servers/nfs-ganesha/sysstatedir.patch
@@ -1,0 +1,15 @@
+diff --git a/src/include/config-h.in.cmake b/src/include/config-h.in.cmake
+index 51697310b..2b5f91075 100644
+--- a/src/include/config-h.in.cmake
++++ b/src/include/config-h.in.cmake
+@@ -72,8 +72,8 @@
+ #define NFS_GANESHA 1
+ 
+ #define GANESHA_CONFIG_PATH "@SYSCONFDIR@/ganesha/ganesha.conf"
+-#define GANESHA_PIDFILE_PATH "@SYSSTATEDIR@/run/ganesha.pid"
+-#define NFS_V4_RECOV_ROOT "@SYSSTATEDIR@/lib/nfs/ganesha"
++#define GANESHA_PIDFILE_PATH "/run/ganesha.pid"
++#define NFS_V4_RECOV_ROOT "/var/lib/nfs/ganesha"
+ /**
+  * @brief Default value for krb5_param.ccache_dir
+  */

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5642,6 +5642,8 @@ in
 
   ntfy = callPackage ../tools/misc/ntfy {};
 
+  ntirpc = callPackage ../development/libraries/ntirpc { };
+
   ntopng = callPackage ../tools/networking/ntopng { };
 
   ntp = callPackage ../tools/networking/ntp {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5540,6 +5540,8 @@ in
 
   ndstool = callPackage ../tools/archivers/ndstool { };
 
+  nfs-ganesha = callPackage ../servers/nfs-ganesha { };
+
   ngrep = callPackage ../tools/networking/ngrep { };
 
   ngrok = ngrok-2;


### PR DESCRIPTION
###### Motivation for this change
NFS daemon that runs in user space. 

###### Things done
* Init `ntirpc` at 3.3, which is a required library.
 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
