### PR TITLE
redo-c: Init at 0.2

### DIFF
--- a/pkgs/development/tools/build-managers/redo-c/Makefile
+++ b/pkgs/development/tools/build-managers/redo-c/Makefile
@@ -1,0 +1,10 @@
+CFLAGS=-Os
+
+all: redo links
+
+links:
+	sh links.do
+
+install:
+	mkdir -p "$(out)/bin"
+	cp --no-dereference redo redo-* "$(out)/bin"

--- a/pkgs/development/tools/build-managers/redo-c/default.nix
+++ b/pkgs/development/tools/build-managers/redo-c/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  pname = "redo-c";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "leahneukirchen";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "11wc2sgw1ssdm83cjdc6ndnp1bv5mzhbw7njw47mk7ri1ic1x51b";
+  };
+
+  postPatch = ''
+    cp '${./Makefile}' Makefile
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An implementation of the redo build system in portable C with zero dependencies";
+    homepage = "https://github.com/leahneukirchen/redo-c";
+    license = licenses.cc0;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ck3d ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11020,6 +11020,8 @@ in
 
   redo-apenwarr = callPackage ../development/tools/build-managers/redo-apenwarr { };
 
+  redo-c = callPackage ../development/tools/build-managers/redo-c { };
+
   redo-sh = callPackage ../development/tools/build-managers/redo-sh { };
 
   reno = callPackage ../development/tools/reno { };


### PR DESCRIPTION
Add redo-c-0.2

###### Motivation for this change
An implementation of the redo build system in portable C with zero dependencies

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
