### PR TITLE
firefox{,-bin}: add 'mesa', for wayland/drm

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -47,6 +47,7 @@
 , gnupg
 , ffmpeg_3
 , runtimeShell
+, mesa # firefox wants gbm for drm+dmabuf
 , systemLocale ? config.i18n.defaultLocale or "en-US"
 }:
 
@@ -106,6 +107,7 @@ stdenv.mkDerivation {
       gtk2
       gtk3
       kerberos
+      mesa
       libX11
       libXScrnSaver
       libXcomposite

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -10,6 +10,7 @@
 , udev
 , kerberos
 , libva
+, mesa # firefox wants gbm for drm+dmabuf
 }:
 
 ## configurability of the wrapper itself
@@ -65,7 +66,7 @@ let
           ++ lib.optional (cfg.enableFXCastBridge or false) fx_cast_bridge
           ++ extraNativeMessagingHosts
         );
-      libs =   lib.optionals stdenv.isLinux [ udev libva ]
+      libs =   lib.optionals stdenv.isLinux [ udev libva mesa ]
             ++ lib.optional ffmpegSupport ffmpeg
             ++ lib.optional gssSupport kerberos
             ++ lib.optional gdkWayland libglvnd


### PR DESCRIPTION
###### Motivation for this change

Woot! This puts to bed the mystery of why our Firefox builds (firefox, firefox-bin, latest.firefox-nightly-bin, etc) all report `wayland` instead of `wayland/drm` under `about:support`.

From the source here https://searchfox.org/mozilla-central/source/widget/gtk/DMABufLibWrapper.cpp#157 I enabled logging, ran Firefox and determined it was lacking `libgbm` which I know comes from mesa.

My understanding is that this should provide significant benefits, and maybe have implications for enabling some perf gains that were meant to be enabled with the previous vaapi-enablement.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
