### PR TITLE
cm-rgb: init at 0.3.4

### DIFF
--- a/pkgs/tools/system/cm-rgb/default.nix
+++ b/pkgs/tools/system/cm-rgb/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, buildPythonApplication
+, fetchFromGitHub
+, atk
+, gobject-introspection
+, wrapGAppsHook
+, click
+, hidapi
+, psutil
+, pygobject3
+}:
+
+buildPythonApplication rec {
+  pname = "cm-rgb";
+  version = "0.3.4";
+
+  src = fetchFromGitHub {
+    owner = "gfduszynski";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04brldaa2zpvzkcg43i5hpbj03d1nqrgiplm5nh4shn12cif19ag";
+  };
+
+  nativeBuildInputs = [
+    atk
+
+    # Populate GI_TYPELIB_PATH
+    gobject-introspection
+    wrapGAppsHook
+  ];
+
+  propagatedBuildInputs = [
+    click
+    hidapi
+    psutil
+    pygobject3
+  ];
+
+  postInstall = ''
+    # Remove this line when/if this PR gets merged:
+    # https://github.com/gfduszynski/cm-rgb/pull/43 
+    install -m0755 scripts/cm-rgb-gui $out/bin/cm-rgb-gui
+
+    mkdir -p $out/etc/udev/rules.d
+    echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="2516", ATTR{idProduct}=="0051", TAG+="uaccess"' \
+      > $out/etc/udev/rules.d/60-cm-rgb.rules
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Control AMD Wraith Prism RGB LEDs";
+    longDescription = ''
+      cm-rgb controls AMD Wraith Prism RGB LEDS.
+
+      To permit non-root accounts to change use this utility on
+      NixOS, add this package to <literal>services.udev.packages</literal>
+      in <filename>configuration.nix</filename>.
+    '';
+    homepage = "https://github.com/gfduszynski/cm-rgb";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16752,6 +16752,8 @@ in
 
   cifs-utils = callPackage ../os-specific/linux/cifs-utils { };
 
+  cm-rgb = python3Packages.callPackage ../tools/system/cm-rgb { };
+
   cpustat = callPackage ../os-specific/linux/cpustat { };
 
   cockroachdb = callPackage ../servers/sql/cockroachdb { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This is a set of utilities to control AMD Wraith Prism RGB LEDs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
