### PR TITLE
fslint: init at 2.46

### DIFF
--- a/pkgs/applications/misc/fslint/default.nix
+++ b/pkgs/applications/misc/fslint/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchFromGitHub, python2, makeWrapper }:
+
+let pythonEnv = python2.withPackages(ps: [ ps.pyGtkGlade]);
+in stdenv.mkDerivation rec {
+  pname   = "fslint";
+  version = "2.46";
+
+  src = fetchFromGitHub {
+    owner  = "pixelb";
+    repo   = "fslint";
+    rev    = version;
+    sha256 = "048pc1rsslbsrfchl2wmdd4hpa2gycglib7kdx8vqs947zcm0sfv";
+  };
+
+  buildInputs = [
+    pythonEnv makeWrapper
+  ];
+
+  prePatch = ''
+    substituteInPlace fslint-gui --replace "liblocation=os.path.dirname(os.path.abspath(sys.argv[0]))" "liblocation='$out'"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp * -R $out/
+    cp fslint-gui $out/bin/fslint
+
+    wrapProgram "$out/bin/fslint" \
+      --prefix PYTHONPATH : "${pythonEnv.interpreter}"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A utility to find and clean various forms of lint on a filesystem.";
+    homepage = "https://www.pixelbeat.org/fslint/";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.dasj19 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24276,6 +24276,8 @@ in
     };
   };
 
+  fslint = callPackage ../applications/misc/fslint {};
+
   galaxis = callPackage ../games/galaxis { };
 
   gambatte = callPackage ../games/gambatte { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Packaging fslint as requested here: https://github.com/NixOS/nixpkgs/issues/92768

Right now we have a fslint running.
There is some functionality like "installed packages" which is hardcoded for deb/rpm distros. That obviously does not work on nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
