### PR TITLE
parsedmarc: init at 6.10.0

### DIFF
--- a/pkgs/development/python-modules/collective_checkdocs/default.nix
+++ b/pkgs/development/python-modules/collective_checkdocs/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi, docutils }:
+
+buildPythonPackage rec {
+  pname = "collective.checkdocs";
+  version = "0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0vp4amk5cj1x244mxfhxphvb6zqdj61c281qfmrbq92jghjjhlrs";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ docutils ];
+
+  meta = with stdenv.lib; {
+    description = "Distutils command to view and validate restructured text in package's long_description";
+    homepage = "https://github.com/collective/collective.checkdocs";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ fadenb ];
+  };
+}

--- a/pkgs/development/python-modules/expiringdict/default.nix
+++ b/pkgs/development/python-modules/expiringdict/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, python, nose, mock, coveralls, dill }:
+
+buildPythonPackage rec {
+  pname = "expiringdict";
+  version = "1.2.1";
+  disabled = !python.isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "mailgun";
+    repo = "expiringdict";
+    rev = "v${version}";
+    sha256 = "07g1vxznmim78bankfl9brr01s31sksdcpwynq1yryh6xw9ri5xs";
+  };
+
+  checkInputs = [ coveralls dill mock nose ];
+  checkPhase = ''
+    nosetests -v
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Dictionary with auto-expiring values for caching purposes";
+    homepage = "https://github.com/mailgun/expiringdict";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fadenb ];
+  };
+}

--- a/pkgs/development/python-modules/mailsuite/default.nix
+++ b/pkgs/development/python-modules/mailsuite/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchPypi, python, IMAPClient, html2text, dnspython, mail-parser, six }:
+
+buildPythonPackage rec {
+  pname = "mailsuite";
+  version = "1.6.0";
+  disabled = !python.isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12r2bh9rgivlmk2z2n7rzrx0323ccyn3kgylm17jjrnx670qpmcd";
+  };
+
+  propagatedBuildInputs = [ dnspython IMAPClient html2text mail-parser six ];
+
+  patchPhase = ''
+    substituteInPlace setup.py \
+      --replace "six==1.13.0" "six>=1.13.0" \
+      --replace "mail-parser==3.11.0" "mail-parser>=3.11.0"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Python package to simplify receiving, parsing, and sending email";
+    homepage = "https://seanthegeek.github.io/mailsuite/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fadenb ];
+  };
+}

--- a/pkgs/development/python-modules/rstcheck/default.nix
+++ b/pkgs/development/python-modules/rstcheck/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, docutils }:
+
+buildPythonPackage rec {
+  pname = "rstcheck";
+  version = "3.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "07vl2p16fw0jayfcn424ixfc3cyhj8pnm89b83h70hm5as9ggi4j";
+  };
+
+  propagatedBuildInputs = [ docutils ];
+
+  meta = with stdenv.lib; {
+    description = "Checks syntax of reStructuredText and code blocks nested within it";
+    homepage = "https://github.com/myint/rstcheck";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fadenb ];
+  };
+}

--- a/pkgs/tools/misc/parsedmarc/default.nix
+++ b/pkgs/tools/misc/parsedmarc/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildPythonApplication, fetchPypi, mail-parser, expiringdict, xmltodict
+, lxml, mailsuite, dateparser, geoip2, publicsuffix2, elasticsearch-dsl
+, kafka-python, tqdm }:
+
+buildPythonApplication rec {
+  pname = "parsedmarc";
+  version = "6.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "150drmxxn5m1flb7hqyf9rwrssw28bp2kak0ap8rmpjs8cy47lyl";
+  };
+
+  propagatedBuildInputs = [
+    mail-parser
+    expiringdict
+    xmltodict
+    lxml
+    mailsuite
+    dateparser
+    geoip2
+    publicsuffix2
+    elasticsearch-dsl
+    kafka-python
+    tqdm
+  ];
+
+  meta = {
+    description =
+      "A Python package and CLI for parsing aggregate and forensic DMARC reports";
+    homepage = "https://domainaware.github.io/parsedmarc/";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ fadenb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11057,6 +11057,8 @@ in
 
   parinfer-rust = callPackage ../development/tools/parinfer-rust {};
 
+  parsedmarc = python3Packages.callPackage ../tools/misc/parsedmarc { };
+
   parse-cli-bin = callPackage ../development/tools/parse-cli-bin { };
 
   patchelf = callPackage ../development/tools/misc/patchelf { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7154,6 +7154,8 @@ in {
 
   maildir-deduplicate = callPackage ../development/python-modules/maildir-deduplicate { };
 
+  mailsuite = callPackage ../development/python-modules/mailsuite { };
+
   d2to1 = callPackage ../development/python-modules/d2to1 { };
 
   ovh = callPackage ../development/python-modules/ovh { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6475,6 +6475,8 @@ in {
   else
     callPackage ../development/python-modules/rsa/4_0.nix { };
 
+  rstcheck = callPackage ../development/python-modules/rstcheck { };
+
   squaremap = callPackage ../development/python-modules/squaremap { };
 
   ruamel_base = callPackage ../development/python-modules/ruamel_base { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -701,6 +701,8 @@ in {
 
   exchangelib = callPackage ../development/python-modules/exchangelib { };
 
+  expiringdict = callPackage ../development/python-modules/expiringdict { };
+
   dcmstack = callPackage ../development/python-modules/dcmstack { };
 
   dbus-python = callPackage ../development/python-modules/dbus {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2128,6 +2128,8 @@ in {
 
   citeproc-py = callPackage ../development/python-modules/citeproc-py { };
 
+  collective_checkdocs = callPackage ../development/python-modules/collective_checkdocs { };
+
   colorcet = callPackage ../development/python-modules/colorcet { };
 
   coloredlogs = callPackage ../development/python-modules/coloredlogs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Parsedmarc is not yet available in nixpkgs.
I plan to provide a service module soon.


###### Things done
* Added missing python dependencies
* Added parsedmarc

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
