### PR TITLE
ngircd: 25 -> 26

### DIFF
--- a/pkgs/servers/irc/ngircd/default.nix
+++ b/pkgs/servers/irc/ngircd/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, zlib, openssl, pam, libiconv }:
 
 stdenv.mkDerivation rec {
-  name = "ngircd-25";
+  pname = "ngircd";
+  version = "26";
 
   src = fetchurl {
-    url = "https://ngircd.barton.de/pub/ngircd/${name}.tar.xz";
-    sha256 = "0kpf5qi98m9f833r4rx9n6h9p31biwk798jwc1mgzmix7sp7r6f4";
+    url = "https://ngircd.barton.de/pub/ngircd/${pname}-${version}.tar.xz";
+    sha256 = "1ijmv18fa648y7apxb9vp4j9iq6fxq850kz5v36rysaq614cdp2n";
   };
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

Fixes: https://nvd.nist.gov/vuln/detail/CVE-2020-14148
New version: https://github.com/ngircd/ngircd/blob/rel-26/ChangeLog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

nixpkgs-update fails with a funny error:
```
2020-07-05T17:52:23 ngircd 25 -> 26 https://repology.org/metapackage/ngircd/versions
2020-07-05T17:52:36 [version] 
2020-07-05T17:52:37 FAIL stderr did not split as expected full stderr was: 
error: anonymous function at /var/cache/nixpkgs-update/nixpkgs/pkgs/build-support/fetchurl/default.nix:38:1 called with unexpected argument 'sha266', at /var/cache/nixpkgs-update/nixpkgs/pkgs/servers/irc/ngircd/default.nix:6:9
```
