### PR TITLE
[20.03] samba: 4.11.9 -> 4.11.11

### DIFF
--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -20,11 +20,11 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "samba";
-  version = "4.11.9";
+  version = "4.11.11";
 
   src = fetchurl {
     url = "mirror://samba/pub/samba/stable/${pname}-${version}.tar.gz";
-    sha256 = "1k4dxjspl0xgabdl3nb3wyz714l3df89dj04bf1siwzk9hsyz35d";
+    sha256 = "0q7z0ykzrqk4pwjvg3cgx7qna09583wcz5abg2f2cd35jni0hzs5";
   };
 
   outputs = [ "out" "dev" "man" ];


### PR DESCRIPTION
Changes:
* https://www.samba.org/samba/history/samba-4.11.10.html
* https://www.samba.org/samba/history/samba-4.11.11.html

Unstable update (has 4.12 branch): #92570
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes bunch of DoS:
* https://nvd.nist.gov/vuln/detail/CVE-2020-10730
* https://nvd.nist.gov/vuln/detail/CVE-2020-10745
* https://nvd.nist.gov/vuln/detail/CVE-2020-10760
* https://nvd.nist.gov/vuln/detail/CVE-2020-14303

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
