### PR TITLE
pythonPackages.django_3_0: init at 3.0.8

### DIFF
--- a/pkgs/development/python-modules/django/3.0-gis-libs.template.patch
+++ b/pkgs/development/python-modules/django/3.0-gis-libs.template.patch
@@ -1,0 +1,24 @@
+diff -Nur a/django/contrib/gis/gdal/libgdal.py b/django/contrib/gis/gdal/libgdal.py
+--- a/django/contrib/gis/gdal/libgdal.py	2020-07-09 22:34:05.330568948 +0100
++++ b/django/contrib/gis/gdal/libgdal.py	2020-07-09 22:35:08.679095615 +0100
+@@ -14,7 +14,7 @@
+     from django.conf import settings
+     lib_path = settings.GDAL_LIBRARY_PATH
+ except (AttributeError, ImportError, ImproperlyConfigured, OSError):
+-    lib_path = None
++    lib_path = "@gdal@/lib/libgdal@extension@"
+ 
+ if lib_path:
+     lib_names = None
+diff -Nur a/django/contrib/gis/geos/libgeos.py b/django/contrib/gis/geos/libgeos.py
+--- a/django/contrib/gis/geos/libgeos.py	2020-07-09 22:34:05.331568941 +0100
++++ b/django/contrib/gis/geos/libgeos.py	2020-07-09 22:36:24.863526276 +0100
+@@ -24,7 +24,7 @@
+         from django.conf import settings
+         lib_path = settings.GEOS_LIBRARY_PATH
+     except (AttributeError, ImportError, ImproperlyConfigured, OSError):
+-        lib_path = None
++        lib_path = "@geos@/lib/libgeos_c@extension@"
+ 
+     # Setting the appropriate names for the GEOS-C library.
+     if lib_path:

--- a/pkgs/development/python-modules/django/3_0.nix
+++ b/pkgs/development/python-modules/django/3_0.nix
@@ -1,0 +1,39 @@
+{ stdenv, buildPythonPackage, fetchPypi, substituteAll,
+  pythonOlder,
+  geos, gdal, pytz, sqlparse,
+  asgiref,
+  withGdal ? false
+}:
+
+buildPythonPackage rec {
+  pname = "Django";
+  version = "3.0.8";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10jm41nlssisny0dwgmi8hnak8020gqb5h4f52gcjwgwlnzgp99i";
+  };
+
+  patches = stdenv.lib.optional withGdal
+    (substituteAll {
+      src = ./3.0-gis-libs.template.patch;
+      geos = geos;
+      gdal = gdal;
+      extension = stdenv.hostPlatform.extensions.sharedLibrary;
+    })
+  ;
+
+  propagatedBuildInputs = [ pytz sqlparse asgiref ];
+
+  # too complicated to setup
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A high-level Python Web framework";
+    homepage = "https://www.djangoproject.com/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ lsix ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3607,6 +3607,8 @@ in {
 
   django_2_2 = callPackage ../development/python-modules/django/2_2.nix { };
 
+  django_3_0 = callPackage ../development/python-modules/django/3_0.nix { };
+
   django-allauth = callPackage ../development/python-modules/django-allauth { };
 
   django-anymail = callPackage ../development/python-modules/django-anymail {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

We will Maintain `django_2_2` as main django package (it is LTS). This commit introduces django_3_0 as it is the most up-to-date release branch for those who wish to migrate to it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
