### PR TITLE
matrix-mirage: init at 0.5.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/mirage/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mirage/default.nix
@@ -1,0 +1,55 @@
+{ mkDerivation
+, lib
+, fetchFromGitHub
+, qmake
+, makeWrapper
+, qtquickcontrols2
+, pyotherside
+, qtgraphicaleffects
+, python3Packages
+}:
+
+mkDerivation rec {
+  pname = "mirage";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "mirukana";
+    repo = "mirage";
+    rev = "v${version}";
+    sha256 = "15kcac92h82vina3rn08m35y71h7h76hkyys42sa95hxbl3gpi21";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ qmake makeWrapper python3Packages.wrapPython ];
+  buildInputs = [
+    qtquickcontrols2
+    pyotherside
+    qtgraphicaleffects
+  ];
+  pythonPath = with python3Packages; [
+    aiofiles
+    filetype
+    matrix-nio
+    appdirs
+    cairosvg
+    pymediainfo
+    setuptools
+    html-sanitizer
+    mistune
+    blist
+  ];
+
+  postInstall = ''
+    buildPythonPath "$pythonPath"
+    wrapProgram $out/bin/mirage --prefix PYTHONPATH : "$program_PYTHONPATH"
+  '';
+
+
+  meta = with lib; {
+    description = "A fancy, customizable, keyboard-operable Matrix chat client for encrypted and decentralized communication.";
+    homepage = "https://github.com/mirukana/mirage";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ atemu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20977,6 +20977,8 @@ in
 
   matrix-recorder = callPackage ../applications/networking/instant-messengers/matrix-recorder {};
 
+  matrix-mirage = qt5.callPackage ../applications/networking/instant-messengers/mirage { };
+
   mblaze = callPackage ../applications/networking/mailreaders/mblaze { };
 
   mcpp = callPackage ../development/compilers/mcpp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/mirukana/mirage

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
