### PR TITLE
yarn2nix: Don't pass yarnNix to mkDerivation

### DIFF
--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/default.nix
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/default.nix
@@ -284,7 +284,7 @@ in rec {
         '')
         workspaceDependenciesTransitive;
 
-    in stdenv.mkDerivation (builtins.removeAttrs attrs ["pkgConfig" "workspaceDependencies"] // {
+    in stdenv.mkDerivation (builtins.removeAttrs attrs ["yarnNix" "pkgConfig" "workspaceDependencies"] // {
       inherit src pname;
 
       name = baseName;
@@ -389,7 +389,7 @@ in rec {
     # yarn2nix is the only package that requires the yarnNix option.
     # All the other projects can auto-generate that file.
     yarnNix = ./yarn.nix;
-    
+
     # Using the filter above and importing package.json from the filtered
     # source results in an error in restricted mode. To circumvent this,
     # we import package.json from the unfiltered source


### PR DESCRIPTION
###### Motivation for this change
The generated yarnNix file doesn't need to be part of the mkDerivation.
And doing so prevents other platforms from reproducibly instantiating
it. With this change you can e.g. do

```nix
darwinPkgs.yarn2nix.mkYarnPackage {
  # ...
  yarnNix = pkgs.yarn2nix.mkYarnNix {
    yarnLock = ./yarn.lock;
  };
}
```

Which is a darwin derivation, but can still be instantiated reproducibly on Linux.

Ping @zimbatm @moretea @petabyteboy 

I will backport this to stable when merged.

This PR is sponsored by [Niteo](https://niteo.co/) :sparkles:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
