### PR TITLE
rofi-blocks: init at 2020-07-09

### DIFF
--- a/pkgs/applications/misc/rofi-blocks/0001-Patch-plugindir-to-output.patch
+++ b/pkgs/applications/misc/rofi-blocks/0001-Patch-plugindir-to-output.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 1ca2cc6..078001b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -57,7 +57,7 @@ PKG_CHECK_MODULES([glib],     [glib-2.0 >= 2.40 gio-unix-2.0 gmodule-2.0 json-gl
+ PKG_CHECK_MODULES([cairo],    [cairo])
+ PKG_CHECK_MODULES([rofi],     [rofi])
+ 
+-[rofi_PLUGIN_INSTALL_DIR]="`$PKG_CONFIG --variable=pluginsdir rofi`"
++[rofi_PLUGIN_INSTALL_DIR]="`echo $out/lib/rofi`"
+ AC_SUBST([rofi_PLUGIN_INSTALL_DIR])
+ 
+ LT_INIT([disable-static])

--- a/pkgs/applications/misc/rofi-blocks/default.nix
+++ b/pkgs/applications/misc/rofi-blocks/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, rofi-unwrapped, pkg-config, autoreconfHook, json-glib, cairo }:
+
+stdenv.mkDerivation rec {
+  pname = "rofi-blocks";
+  version = "2020-07-09";
+
+  src = fetchFromGitHub {
+    owner = "OmarCastro";
+    repo = pname;
+    rev = "f219ceedd1c7baab6de92a69e94ee68bcad8f2bc";
+    sha256 = "1mn2dq30zm7ilsyjcxbbr3l999zisdyfg5z6k7j5z9wa8zbcss0l";
+  };
+
+  nativeBuildInputs = [ pkg-config autoreconfHook json-glib cairo ];
+
+  buildInputs = [ rofi-unwrapped ];
+
+  enableParallelBuilding = true;
+
+  patches = [
+    ./0001-Patch-plugindir-to-output.patch
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Rofi modi that allows controlling rofi content throug communication with an external program.";
+    homepage = "https://github.com/OmarCastro/rofi-blocks";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ oro ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22138,6 +22138,8 @@ in
 
   rofi-systemd = callPackage ../tools/system/rofi-systemd { };
 
+  rofi-blocks = callPackage ../applications/misc/rofi-blocks { };
+
   rootlesskit = callPackage ../tools/virtualization/rootlesskit {};
 
   rpcs3 = libsForQt5.callPackage ../misc/emulators/rpcs3 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adding new plugin for rofi, took inspiration from both `rofi-emoji` and `rofi-calc`.

Tested it with homemanager ala
```nix
  programs.rofi.package = pkgs.rofi.override { plugins = [ pkgs.rofi-blocks ]; };
```

and one example script from upstream, [top_basic.sh](https://github.com/OmarCastro/rofi-blocks/blob/master/examples/top_basic.sh) (with corrected shebang)
``` bash
#!/usr/bin/env bash

toLinesJson(){
	echo "$1" | sed -e 's/\\/\\\\/g' -e 's/\"/\\"/g' -e 's/.*/"&"/' | paste -sd "," -
}

toStringJson(){
	echo "$1" | sed -e 's/\\/\\\\/g' -e 's/\"/\\"/g' -e '$!s/.*/&\\n/' | paste -sd "" -
}

execTop(){
	echo '{"prompt": "search"}'; 
	top -c -b | while IFS= read -r line; do
		TOP="$line"
		while true; do
			IFS= read -t 0.01 -r line;
			VAR=$?
			if ((VAR == 0)); then # read another line successfully
				TOP="$TOP"$'\n'"$line"
			elif (( VAR > 128 )); then # timeout happened
				break;
			else # any other reason
				exit
			fi
		done
		TOP="$(sed '/./,$!d' <<< "$TOP")"
		TOP_INFO="$(sed -n '1,/^\s*PID/p' <<< "$TOP")"
		TOP_PIDLIST="$(sed '1,/^\s*PID/d' <<< "$TOP")"
		JSON_LINES="$(toLinesJson "$TOP_PIDLIST")"
		JSON_MESSAGE="$(toStringJson "$TOP_INFO")"
		printf '{"message": "%s","lines":[%s]}\n' "$JSON_MESSAGE" "$JSON_LINES"
	done
}

execTop | rofi -modi blocks -show blocks "$@"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
