### PR TITLE
picmi: init at 19.12.3

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -174,6 +174,7 @@ let
       messagelib = callPackage ./messagelib.nix {};
       minuet = callPackage ./minuet.nix {};
       okular = callPackage ./okular.nix {};
+      picmi = callPackage ./picmi {};
       pimcommon = callPackage ./pimcommon.nix {};
       pim-data-exporter = callPackage ./pim-data-exporter.nix {};
       pim-sieve-editor = callPackage ./pim-sieve-editor.nix {};

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -174,7 +174,7 @@ let
       messagelib = callPackage ./messagelib.nix {};
       minuet = callPackage ./minuet.nix {};
       okular = callPackage ./okular.nix {};
-      picmi = callPackage ./picmi {};
+      picmi = callPackage ./picmi.nix {};
       pimcommon = callPackage ./pimcommon.nix {};
       pim-data-exporter = callPackage ./pim-data-exporter.nix {};
       pim-sieve-editor = callPackage ./pim-sieve-editor.nix {};

--- a/pkgs/applications/kde/picmi.nix
+++ b/pkgs/applications/kde/picmi.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, lib
+, libkdegames, extra-cmake-modules
+, kdeclarative, knewstuff
+}:
+
+mkDerivation {
+  name = "picmi";
+  meta = with lib; { maintainers = with maintainers; [ freezeboy ]; };
+  nativeBuildInputs = [
+    extra-cmake-modules
+  ];
+  buildInputs = [
+    kdeclarative
+    knewstuff
+    libkdegames
+  ];
+}

--- a/pkgs/applications/kde/picmi.nix
+++ b/pkgs/applications/kde/picmi.nix
@@ -5,7 +5,15 @@
 
 mkDerivation {
   name = "picmi";
-  meta = with lib; { maintainers = with maintainers; [ freezeboy ]; };
+  meta = with lib; {
+    description = "Nonogram game";
+    longDescription = ''The goal is to reveal the hidden pattern in the board by coloring or
+      leaving blank the cells in a grid according to numbers given at the side of the grid.
+      '';
+    maintainers = with maintainers; [ freezeboy ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
   nativeBuildInputs = [
     extra-cmake-modules
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20674,7 +20674,7 @@ in
     akonadi akregator ark dolphin dragon elisa ffmpegthumbs filelight gwenview k3b
     kaddressbook kapptemplate kate kcachegrind kcalc kcharselect kcolorchooser kdenlive kdf kdialog
     keditbookmarks kfind kget kgpg khelpcenter kig kleopatra kmail kmix kmplot kolourpaint kompare konsole yakuake
-    kpkpass kitinerary kontact korganizer krdc krfb ksystemlog ktouch kwalletmanager marble minuet okular spectacle;
+    kpkpass kitinerary kontact korganizer krdc krfb ksystemlog ktouch kwalletmanager marble minuet okular picmi spectacle;
 
   okteta = libsForQt5.callPackage ../applications/editors/okteta { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Make picmi app available in kdeApplications

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
