### PR TITLE
python3Packages.glasgow: unstable-2020-02-08 -> unstable-2020-06-29

### DIFF
--- a/pkgs/development/python-modules/fx2/default.nix
+++ b/pkgs/development/python-modules/fx2/default.nix
@@ -7,15 +7,15 @@
 , crcmod
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "fx2";
-  version = "unstable-2020-01-25";
+  version = "0.9";
 
   src = fetchFromGitHub {
     owner = "whitequark";
     repo = "libfx2";
-    rev = "d3e37f640d706aac5e69ae4476f6cd1bd0cd6a4e";
-    sha256 = "1dsyknjpgf4wjkfr64lln1lcy7qpxdx5x3qglidrcswzv9b3i4fg";
+    rev = version;
+    sha256 = "sha256-Uk+K7ym92JX4fC3PyTNxd0UvBzoNZmtbscBYjSWChuk=";
   };
 
   nativeBuildInputs = [ sdcc ];

--- a/pkgs/development/python-modules/glasgow/default.nix
+++ b/pkgs/development/python-modules/glasgow/default.nix
@@ -18,15 +18,15 @@
 
 buildPythonPackage rec {
   pname = "glasgow";
-  version = "unstable-2020-02-08";
+  version = "unstable-2020-06-29";
   # python software/setup.py --version
   realVersion = "0.1.dev1352+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "GlasgowEmbedded";
     repo = "glasgow";
-    rev = "2a8bfc981b90ba5d86c310911dbd6ffe71acd498";
-    sha256 = "01v5269bv09ggvmq6lqyhr5am51hzmwya1p5n62h84b7rdwd8q9m";
+    rev = "f885790d7927b893e631c33744622d6ebc18b5e3";
+    sha256 = "sha256-fSorSEa5K09aPEOk4XPWOFRxYl1KGVy29jOBqIvs2hk=";
   };
 
   nativeBuildInputs = [ setuptools_scm sdcc ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update glasgow to an unstable version from 06-29. This adds the analyze applet.

###### Things done
I've tried using this and it has worked as expected.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
