### PR TITLE
demoit: unstable-2019-05-10 -> unstable-2020-06-11

### DIFF
--- a/pkgs/servers/demoit/default.nix
+++ b/pkgs/servers/demoit/default.nix
@@ -1,19 +1,21 @@
 { stdenv
-, buildGoPackage
+, buildGoModule
 , fetchFromGitHub
 }:
 
-buildGoPackage {
+buildGoModule {
   pname = "demoit";
-  version = "unstable-2019-05-10";
+  version = "unstable-2020-06-11";
   goPackagePath = "github.com/dgageot/demoit";
 
   src = fetchFromGitHub {
     owner = "dgageot";
     repo = "demoit";
-    rev = "c1d4780620ebf083cb4a81b83c80e7547ff7bc23";
-    sha256 = "0l0pw0kzgnrk6a6f4ls3s82icjp7q9djbaxwfpjswbcfdzrsk4p2";
+    rev = "5762b169e7f2fc18913874bf52323ffbb906ce84";
+    sha256 = "1jcjqr758d29h3y9ajvzhy1xmxfix5mwhylz6jwhy5nmk28bjzx9";
   };
+  vendorSha256 = null;
+  subPackages = [ "." ];
 
   meta = with stdenv.lib; {
     description = "Live coding demos without Context Switching";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update demoit package to a more recent snapshot

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
