### PR TITLE
gnomeExtensions.system-monitor: unbreak with newer GNOME Shell

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -1,6 +1,7 @@
 { fetchurl
 , fetchpatch
 , substituteAll
+, runCommand
 , stdenv
 , pkgconfig
 , gnome3
@@ -42,7 +43,7 @@
 , wayland-protocols
 }:
 
-stdenv.mkDerivation rec {
+let self = stdenv.mkDerivation rec {
   pname = "mutter";
   version = "3.36.3";
 
@@ -132,6 +133,18 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
+    libdir = "${self}/lib/mutter-6";
+
+    tests = {
+      libdirExists = runCommand "mutter-libdir-exists" {} ''
+        if [[ ! -d ${self.libdir} ]]; then
+          echo "passthru.libdir should contain a directory, “${self.libdir}” is not one."
+          exit 1
+        fi
+        touch $out
+      '';
+    };
+
     updateScript = gnome3.updateScript {
       packageName = pname;
       attrPath = "gnome3.${pname}";
@@ -145,4 +158,5 @@ stdenv.mkDerivation rec {
     maintainers = teams.gnome.members;
     platforms = platforms.linux;
   };
-}
+};
+in self

--- a/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, substituteAll, fetchFromGitHub, glib, glib-networking, libgtop, gnome3 }:
+{ stdenv, substituteAll, fetchpatch, fetchFromGitHub, glib, glib-networking, libgtop, gnome3 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-system-monitor";
-  version = "38";
+  version = "2020-04-27-unstable";
 
   src = fetchFromGitHub {
     owner = "paradoxxxzero";
     repo = "gnome-shell-system-monitor-applet";
-    rev = "v${version}";
-    sha256 = "1sdj2kxb418mgq44a6lf6jic33wlfbnn3ja61igmx0jj1530iknv";
+    rev = "7f8f0a7b255473941f14d1dcaa35ebf39d3bccd0";
+    sha256 = "tUUvBY0UEUE+T79zVZEAICpKoriFZuuZzi9ArdHdXks=";
   };
 
   buildInputs = [
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./paths_and_nonexisting_dirs.patch;
+      clutter_path = gnome3.mutter.libdir; # this should not be used in settings but 🤷‍♀️
       gtop_path = "${libgtop}/lib/girepository-1.0";
       glib_net_path = "${glib-networking}/lib/girepository-1.0";
     })
@@ -41,8 +42,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ tiramiseb ];
     homepage = "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet";
-    # 3.36 support not yet ready
-    # https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/pull/564
-    broken = stdenv.lib.versionAtLeast gnome3.gnome-shell.version "3.34";
   };
 }

--- a/pkgs/desktops/gnome-3/extensions/system-monitor/paths_and_nonexisting_dirs.patch
+++ b/pkgs/desktops/gnome-3/extensions/system-monitor/paths_and_nonexisting_dirs.patch
@@ -1,5 +1,5 @@
 diff --git a/system-monitor@paradoxxx.zero.gmail.com/extension.js b/system-monitor@paradoxxx.zero.gmail.com/extension.js
-index b4b7f15..d139135 100644
+index de5e3d7..2d7824d 100644
 --- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
 +++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
 @@ -18,6 +18,9 @@
@@ -11,13 +11,23 @@ index b4b7f15..d139135 100644
 +
  /* Ugly. This is here so that we don't crash old libnm-glib based shells unnecessarily
   * by loading the new libnm.so. Should go away eventually */
- const libnm_glib = imports.gi.GIRepository.Repository.get_default().is_registered("NMClient", "1.0");
-@@ -386,7 +389,7 @@ const smMountsMonitor = new Lang.Class({
-     connected: false,
-     _init: function () {
+ 
+@@ -407,7 +410,7 @@ const smMountsMonitor = class SystemMonitor_smMountsMonitor {
+         this.connected = false;
+ 
          this._volumeMonitor = Gio.VolumeMonitor.get();
 -        let sys_mounts = ['/home', '/tmp', '/boot', '/usr', '/usr/local'];
 +        let sys_mounts = ['/home', '/tmp', '/boot'];
          this.base_mounts = ['/'];
-         sys_mounts.forEach(Lang.bind(this, function (sMount) {
+         sys_mounts.forEach((sMount) => {
              if (this.is_sys_mount(sMount + '/')) {
+diff --git a/system-monitor@paradoxxx.zero.gmail.com/prefs.js b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+index 81d667c..0da4809 100644
+--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
++++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+@@ -1,3 +1,5 @@
++imports.gi.GIRepository.Repository.prepend_search_path('@clutter_path@');
++
+ const Gtk = imports.gi.Gtk;
+ const Gio = imports.gi.Gio;
+ const Gdk = imports.gi.Gdk;


### PR DESCRIPTION
###### Motivation for this change
https://discourse.nixos.org/t/installing-gnome-system-monitor/8057

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested running GNOME Shell 3.36 with the extension (the applet appears in the panel)
- [x] Opened the extension's preferences and tweaked some settings successfully
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
