### PR TITLE
ssh-ident: switch to python3 interpreter

### DIFF
--- a/pkgs/tools/networking/ssh-ident/default.nix
+++ b/pkgs/tools/networking/ssh-ident/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper, python }:
+{ stdenv, lib, fetchFromGitHub, python3, makeWrapper, openssh }:
 
 stdenv.mkDerivation {
   pname = "ssh-ident";
@@ -10,12 +10,12 @@ stdenv.mkDerivation {
     sha256 = "1jf19lz1gwn7cyp57j8d4zs5bq13iw3kw31m8nvr8h6sib2pf815";
   };
 
-  buildInputs = [ makeWrapper ];
+  buildInputs = [ python3 makeWrapper ];
   installPhase = ''
     mkdir -p $out/bin
     install -m 755 ssh-ident $out/bin/ssh-ident
     wrapProgram $out/bin/ssh-ident \
-      --prefix PATH : "${python}/bin/python"
+      --prefix PATH : ${lib.makeBinPath [ openssh  ]}
   '';
 
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Python2 is obsolete, so why still depend on it for ssh-ident.
even though the code is pretty old it is working painlessly with python3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
