### PR TITLE
rocm-opencl-icd: init at 3.5.0

### DIFF
--- a/pkgs/development/compilers/llvm/rocm/clang.nix
+++ b/pkgs/development/compilers/llvm/rocm/clang.nix
@@ -1,0 +1,67 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, python
+, llvm
+, clang-tools-extra_src ? null
+, rocm-runtime
+, lld
+
+, version
+, src
+}:
+
+stdenv.mkDerivation rec {
+  inherit version src;
+
+  pname = "clang";
+
+  nativeBuildInputs = [ cmake python ];
+
+  buildInputs = [ llvm rocm-runtime ];
+
+  hardeningDisable = [ "all" ];
+
+  cmakeFlags = [
+    "-DLLVM_CMAKE_PATH=${llvm}/lib/cmake/llvm"
+    "-DLLVM_MAIN_SRC_DIR=${llvm.src}"
+    "-DCLANG_SOURCE_DIR=${src}"
+    "-DLLVM_ENABLE_RTTI=ON"
+  ];
+
+  VCSVersion = ''
+    #undef LLVM_REVISION
+    #undef LLVM_REPOSITORY
+    #undef CLANG_REVISION
+    #undef CLANG_REPOSITORY
+  '';
+
+  postUnpack = stdenv.lib.optionalString (!(isNull clang-tools-extra_src)) ''
+    ln -s ${clang-tools-extra_src} $sourceRoot/tools/extra
+  '';
+
+  # Rather than let cmake extract version information from LLVM or
+  # clang source control repositories, we generate the wanted
+  # `VCSVersion.inc` file ourselves and remove it from the
+  # depencencies of the `clangBasic` target.
+  preConfigure = ''
+    sed 's/  ''${version_inc}//' -i lib/Basic/CMakeLists.txt
+    sed 's|sys::path::parent_path(BundlerExecutable)|StringRef("${llvm}/bin")|' -i tools/clang-offload-bundler/ClangOffloadBundler.cpp
+    sed 's|\([[:space:]]*std::string Linker = \)getToolChain().GetProgramPath(getShortName())|\1"${lld}/bin/ld.lld"|' -i lib/Driver/ToolChains/AMDGPU.cpp
+    substituteInPlace lib/Driver/ToolChains/AMDGPU.h --replace ld.lld ${lld}/bin/ld.lld
+    sed 's|configure_file(AST/gen_ast_dump_json_test.py ''${LLVM_TOOLS_BINARY_DIR}/gen_ast_dump_json_test.py COPYONLY)||' -i test/CMakeLists.txt
+  '';
+
+  postConfigure = ''
+    mkdir -p lib/Basic
+    echo "$VCSVersion" > lib/Basic/VCSVersion.inc
+  '';
+
+  meta = with stdenv.lib; {
+    description = "ROCm fork of the clang C/C++/Objective-C/Objective-C++ LLVM compiler frontend";
+    homepage = "https://llvm.org/";
+    license = with licenses; [ ncsa ];
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/compilers/llvm/rocm/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, callPackage, wrapCCWith }:
+
+let
+  version = "3.5.1";
+  src = fetchFromGitHub {
+    owner = "RadeonOpenCompute";
+    repo = "llvm-project";
+    rev = "rocm-${version}";
+    sha256 = "03k2xp8wf4awf1zcjc2hb3kf9bqp567c3s569gp1q3q1zjg6r2ib";
+  };
+in rec {
+  clang = wrapCCWith rec {
+    cc = clang-unwrapped;
+    extraBuildCommands = ''
+      clang_version=`${cc}/bin/clang -v 2>&1 | grep "clang version " | grep -E -o "[0-9.-]+"`
+      rsrc="$out/resource-root"
+      mkdir "$rsrc"
+      ln -s "${cc}/lib/clang/$clang_version/include" "$rsrc"
+      echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
+      echo "--gcc-toolchain=${stdenv.cc.cc}" >> $out/nix-support/cc-cflags
+      echo "-Wno-unused-command-line-argument" >> $out/nix-support/cc-cflags
+      rm $out/nix-support/add-hardening.sh
+      touch $out/nix-support/add-hardening.sh
+    '';
+  };
+
+  clang-unwrapped = callPackage ./clang.nix {
+    inherit lld llvm version;
+    src = "${src}/clang";
+  };
+
+  lld = callPackage ./lld.nix {
+    inherit llvm version;
+    src = "${src}/lld";
+  };
+
+  llvm = callPackage ./llvm.nix {
+    inherit version;
+    src = "${src}/llvm";
+  };
+}

--- a/pkgs/development/compilers/llvm/rocm/lld.nix
+++ b/pkgs/development/compilers/llvm/rocm/lld.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, cmake
+, libxml2
+, llvm
+
+, version
+, src
+}:
+
+stdenv.mkDerivation rec {
+  inherit version src;
+
+  pname = "lld";
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ libxml2 llvm ];
+
+  outputs = [ "out" "dev" ];
+
+  postInstall = ''
+    moveToOutput include "$dev"
+    moveToOutput lib "$dev"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "ROCm fork of the LLVM Linker";
+    homepage = "https://github.com/RadeonOpenCompute/llvm-project";
+    license = licenses.ncsa;
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/compilers/llvm/rocm/llvm-outputs.patch
+++ b/pkgs/development/compilers/llvm/rocm/llvm-outputs.patch
@@ -1,0 +1,26 @@
+diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.cpp
+index 94d426b..37f7794 100644
+--- a/tools/llvm-config/llvm-config.cpp
++++ b/tools/llvm-config/llvm-config.cpp
+@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+     ActiveIncludeOption = "-I" + ActiveIncludeDir;
+   }
+ 
++  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  if (!IsInDevelopmentTree) {
++    bool WantShared = true;
++    for (int i = 1; i < argc; ++i) {
++      StringRef Arg = argv[i];
++      if (Arg == "--link-shared")
++        WantShared = true;
++      else if (Arg == "--link-static")
++        WantShared = false; // the last one wins
++    }
++
++    if (WantShared)
++      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++  }
++
+   /// We only use `shared library` mode in cases where the static library form
+   /// of the components provided are not available; note however that this is
+   /// skipped if we're run from within the build dir. However, once installed,

--- a/pkgs/development/compilers/llvm/rocm/llvm.nix
+++ b/pkgs/development/compilers/llvm/rocm/llvm.nix
@@ -1,0 +1,97 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, python3
+, libxml2
+, libffi
+, libbfd
+, ncurses
+, zlib
+, debugVersion ? false
+, enableManpages ? false
+, enableSharedLibraries ? true
+
+, version
+, src
+}:
+
+let
+  llvmNativeTarget =
+    if stdenv.isx86_64 then "X86"
+    else if stdenv.isAarch64 then "AArch64"
+    else throw "Unsupported ROCm LLVM platform";
+in stdenv.mkDerivation rec {
+  inherit src version;
+
+  pname = "rocm-llvm";
+
+  outputs = [ "out" "python" ]
+    ++ stdenv.lib.optional enableSharedLibraries "lib";
+
+  nativeBuildInputs = [ cmake python3 ];
+
+  buildInputs = [ libxml2 libffi ];
+
+  propagatedBuildInputs = [ ncurses zlib ];
+
+  cmakeFlags = with stdenv; [
+    "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
+    "-DLLVM_INSTALL_UTILS=ON" # Needed by rustc
+    "-DLLVM_BUILD_TESTS=OFF"
+    "-DLLVM_ENABLE_FFI=ON"
+    "-DLLVM_ENABLE_RTTI=ON"
+    "-DLLVM_ENABLE_DUMP=ON"
+    "-DLLVM_TARGETS_TO_BUILD=AMDGPU;${llvmNativeTarget}"
+  ]
+  ++
+  stdenv.lib.optional
+    enableSharedLibraries
+    "-DLLVM_LINK_LLVM_DYLIB=ON"
+  ++ stdenv.lib.optionals enableManpages [
+    "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
+    "-DLLVM_BUILD_DOCS=ON"
+    "-DLLVM_ENABLE_SPHINX=ON"
+    "-DSPHINX_OUTPUT_MAN=ON"
+    "-DSPHINX_OUTPUT_HTML=OFF"
+    "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
+  ];
+
+  postPatch = ''
+    substitute '${./llvm-outputs.patch}' ./llvm-outputs.patch --subst-var lib
+    patch -p1 < ./llvm-outputs.patch
+  '';
+
+  # hacky fix: created binaries need to be run before installation
+  preBuild = ''
+    mkdir -p $out/
+    ln -sv $PWD/lib $out
+  '';
+
+  postBuild = ''
+    rm -fR $out
+  '';
+
+  preCheck = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
+  '';
+
+  postInstall = ''
+    moveToOutput share/opt-viewer "$python"
+  ''
+  + stdenv.lib.optionalString enableSharedLibraries ''
+    moveToOutput "lib/libLLVM-*" "$lib"
+    moveToOutput "lib/libLLVM${stdenv.hostPlatform.extensions.sharedLibrary}" "$lib"
+    substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \
+      --replace "\''${_IMPORT_PREFIX}/lib/libLLVM-" "$lib/lib/libLLVM-"
+  '';
+
+  passthru.src = src;
+
+  meta = with stdenv.lib; {
+    description = "ROCm fork of the LLVM compiler infrastructure";
+    homepage = "https://github.com/RadeonOpenCompute/llvm-project";
+    license = with licenses; [ ncsa ];
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/rocclr/default.nix
+++ b/pkgs/development/libraries/rocclr/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, rocm-cmake
+, clang
+, rocm-comgr
+, rocm-opencl-runtime
+, rocm-runtime
+, rocm-thunk
+, libelf
+, libglvnd
+, libX11
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rocclr";
+  version = "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = "ROCm-Developer-Tools";
+    repo = "ROCclr";
+    rev = "roc-${version}";
+    sha256 = "0j70lxpwrdrb1v4lbcyzk7kilw62ip4py9fj149d8k3x5x6wkji1";
+  };
+
+  nativeBuildInputs = [ cmake rocm-cmake ];
+
+  buildInputs = [ clang rocm-comgr rocm-runtime rocm-thunk clang ];
+
+  propagatedBuildInputs = [ libelf libglvnd libX11 ];
+
+  prePatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace 'set(ROCCLR_EXPORTS_FILE "''${CMAKE_CURRENT_BINARY_DIR}/amdrocclr_staticTargets.cmake")' \
+        'set(ROCCLR_EXPORTS_FILE "''${CMAKE_INSTALL_LIBDIR}/cmake/amdrocclr_staticTargets.cmake")' \
+      --replace 'set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ''${CMAKE_CURRENT_BINARY_DIR}/lib)' \
+        'set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ''${CMAKE_INSTALL_LIBDIR})'
+    substituteInPlace device/comgrctx.cpp \
+      --replace "libamd_comgr.so" "${rocm-comgr}/lib/libamd_comgr.so"
+  '';
+
+  cmakeFlags = [
+    "-DOPENCL_DIR=${rocm-opencl-runtime.src}"
+  ];
+
+  preFixup = ''
+    mv $out/include/include/* $out/include
+    ln -s $out/include/compiler/lib/include/* $out/include/include
+    ln -s $out/include/compiler/lib/include/* $out/include
+    sed "s|^\([[:space:]]*IMPORTED_LOCATION_RELEASE \).*|\1 \"$out/lib/libamdrocclr_static.a\"|" -i $out/lib/cmake/amdrocclr_staticTargets.cmake
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Radeon Open Compute common language runtime";
+    homepage = "https://github.com/ROCm-Developer-Tools/ROCclr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danieldk ];
+    # rocclr seems to have some AArch64 ifdefs, but does not seem
+    # to be supported yet by the build infrastructure. Recheck in
+    # the future.
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/libraries/rocm-comgr/default.nix
+++ b/pkgs/development/libraries/rocm-comgr/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, cmake, clang, device-libs, lld, llvm }:
+
+stdenv.mkDerivation rec {
+  pname = "rocm-comgr";
+  version = "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = "RadeonOpenCompute";
+    repo = "ROCm-CompilerSupport";
+    rev = "rocm-${version}";
+    sha256 = "0h9bxz98sskgzc3xpnp469iq1wi59nbijbqprlylha91y10hqb88";
+  };
+
+  sourceRoot = "source/lib/comgr";
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ clang device-libs lld llvm ];
+
+  cmakeFlags = [
+    "-DCLANG=${clang}/bin/clang"
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_C_COMPILER=${clang}/bin/clang"
+    "-DCMAKE_CXX_COMPILER=${clang}/bin/clang++"
+    "-DCMAKE_PREFIX_PATH=${llvm}/lib/cmake/llvm"
+    "-DLLD_INCLUDE_DIRS=${lld.src}/include"
+    "-DLLVM_TARGETS_TO_BUILD=\"AMDGPU;X86\""
+  ];
+
+  # The comgr build tends to link against the static LLVM libraries
+  # *and* the dynamic library. Linking against both causes errors
+  # about command line options being registered twice. This patch
+  # removes the static library linking.
+  patchPhase = ''
+    sed -e '/^llvm_map_components_to_libnames/,/[[:space:]]*Symbolize)/d' \
+        -i CMakeLists.txt
+  '';
+
+  meta = with stdenv.lib; {
+    description = "APIs for compiling and inspecting AMDGPU code objects";
+    homepage = "https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/tree/amd-stg-open/lib/comgr";
+    license = licenses.ncsa;
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/rocm-device-libs/default.nix
+++ b/pkgs/development/libraries/rocm-device-libs/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, clang
+, clang-unwrapped
+, lld
+, llvm
+, rocm-runtime
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rocm-device-libs";
+  version = "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = "RadeonOpenCompute";
+    repo = "ROCm-Device-Libs";
+    rev = "rocm-${version}";
+    sha256 = "0n160jwbh7jnqckz5bn979ll8afh2a97lf962xh9xv3cx025vnrn";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ clang lld llvm rocm-runtime ];
+
+  cmakeBuildType = "Release";
+
+  cmakeFlags = [
+    "-DCMAKE_PREFIX_PATH=${llvm}/lib/cmake/llvm;${clang-unwrapped}/lib/cmake/clang"
+    "-DLLVM_TARGETS_TO_BUILD='AMDGPU;X86'"
+    "-DCLANG=${clang}/bin/clang"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Set of AMD-specific device-side language runtime libraries";
+    homepage = "https://github.com/RadeonOpenCompute/ROCm-Device-Libs";
+    license = licenses.ncsa;
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/rocm-opencl-icd/default.nix
+++ b/pkgs/development/libraries/rocm-opencl-icd/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, rocm-opencl-runtime }:
+
+stdenv.mkDerivation rec {
+  pname = "rocm-opencl-icd";
+  version = "3.5.0";
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out/etc/OpenCL/vendors
+    echo "${rocm-opencl-runtime}/lib/libamdocl64.so" > $out/etc/OpenCL/vendors/amdocl64.icd
+  '';
+
+  meta = with stdenv.lib; {
+    description = "OpenCL ICD definition for AMD GPUs using the ROCm stack";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/rocm-opencl-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-opencl-runtime/default.nix
@@ -1,0 +1,84 @@
+{ stdenv
+, fetchFromGitHub
+, addOpenGLRunpath
+, cmake
+, rocm-cmake
+, clang
+, clang-unwrapped
+, libGLU
+, libX11
+, lld
+, llvm
+, mesa
+, python2
+, rocclr
+, rocm-comgr
+, rocm-device-libs
+, rocm-runtime
+, rocm-thunk
+}:
+
+let
+  version = "3.5.0";
+  tag = "roc-${version}";
+in stdenv.mkDerivation rec {
+  inherit version;
+
+  pname = "rocm-opencl-runtime";
+
+  src = fetchFromGitHub {
+    owner = "RadeonOpenCompute";
+    repo = "ROCm-OpenCL-Runtime";
+    rev = tag;
+    sha256 = "1wrr6mmn4gf6i0vxp4yqk0ny2wglvj1jfj50il8czjwy0cwmhykk";
+    name = "ROCm-OpenCL-Runtime-${tag}-src";
+  };
+
+  nativeBuildInputs = [ cmake rocm-cmake ];
+
+  buildInputs = [
+    clang
+    clang-unwrapped
+    libGLU
+    libX11
+    lld
+    llvm
+    mesa
+    python2
+    rocclr
+    rocm-comgr
+    rocm-device-libs
+    rocm-runtime
+    rocm-thunk
+  ];
+
+  cmakeFlags = [
+    "-DAMDGPU_TARGET_TRIPLE='amdgcn-amd-amdhsa'"
+    "-DCLANG_OPTIONS_APPEND=-Wno-bitwise-conditional-parentheses"
+    "-DClang_DIR=${clang-unwrapped}/lib/cmake/clang"
+    "-DLIBROCclr_STATIC_DIR=${rocclr}/lib/cmake"
+    "-DLLVM_DIR=${llvm.out}/lib/cmake/llvm"
+    "-DUSE_COMGR_LIBRARY='yes'"
+  ];
+
+  dontStrip = true;
+
+  # Fix the ICD installation path for NixOS
+  postPatch = ''
+    substituteInPlace khronos/icd/loader/linux/icd_linux.c \
+      --replace 'ICD_VENDOR_PATH' '"${addOpenGLRunpath.driverLink}/etc/OpenCL/vendors/"'
+    echo 'add_dependencies(amdocl64 OpenCL)' >> amdocl/CMakeLists.txt
+  '';
+
+  preFixup = ''
+    patchelf --set-rpath "$out/lib" $out/bin/clinfo
+  '';
+
+  meta = with stdenv.lib; {
+    description = "OpenCL runtime for AMD GPUs, part of the ROCm stack";
+    homepage = "https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime";
+    license = with licenses; [ asl20 mit ];
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/rocm-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-runtime/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, cmake, elfutils, rocm-thunk }:
+
+stdenv.mkDerivation rec {
+  pname = "rocm-runtime";
+  version = "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = "RadeonOpenCompute";
+    repo = "ROCR-Runtime";
+    rev = "rocm-${version}";
+    sha256 = "028x1f0if6lw41cpfpysp82ikp6c3fdxxd2a6ixs0vpm4424svb1";
+  };
+
+  sourceRoot = "source/src";
+
+  buildInputs = [ cmake elfutils ];
+
+  cmakeFlags = [ "-DCMAKE_PREFIX_PATH=${rocm-thunk}" ];
+
+  # Use the ROCR_EXT_DIR environment variable to try to find
+  # binary-only extension libraries. This environment variable is set
+  # by the `rocr-ext` derivation. If that derivation is not in scope,
+  # then the extension libraries are not loaded. Without this edit, we
+  # would have to rely on LD_LIBRARY_PATH to let the HSA runtime
+  # discover the shared libraries.
+  patchPhase = ''
+    sed 's/\(k\(Image\|Finalizer\)Lib\[os_index(os::current_os)\]\)/os::GetEnvVar("ROCR_EXT_DIR") + "\/" + \1/g' -i core/runtime/runtime.cpp
+  '';
+
+  fixupPhase = ''
+    rm -r $out/lib $out/include
+    mv $out/hsa/lib $out/hsa/include $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Platform runtime for ROCm";
+    homepage = "https://github.com/RadeonOpenCompute/ROCR-Runtime";
+    license = with licenses; [ ncsa ];
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/development/libraries/rocm-thunk/default.nix
+++ b/pkgs/development/libraries/rocm-thunk/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, numactl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rocm-thunk";
+  version = "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = "RadeonOpenCompute";
+    repo = "ROCT-Thunk-Interface";
+    rev = "rocm-${version}";
+    sha256 = "0xn1z0xc3phjc9vabwxgph5any4ffhc8wgs5yb15m5wpg87l8x1z";
+  };
+
+  preConfigure = ''
+    export cmakeFlags="$cmakeFlags "
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ numactl ];
+
+  postInstall = ''
+    cp -r $src/include $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Radeon open compute thunk interface";
+    homepage = "https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface";
+    license = with licenses; [ bsd2 mit ];
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/development/tools/build-managers/rocm-cmake/default.nix
+++ b/pkgs/development/tools/build-managers/rocm-cmake/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "rocm-cmake";
+  version = "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = "RadeonOpenCompute";
+    repo = "rocm-cmake";
+    rev = "rocm-${version}";
+    sha256 = "1x1mj1acarhin319zycms8sqm9ylw2mcdbkpqjlb8yfsgiaa99ja";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "CMake modules for common build tasks for the ROCm stack";
+    homepage = "https://github.com/RadeonOpenCompute/rocm-cmake";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9233,6 +9233,8 @@ in
 
   rgbds = callPackage ../development/compilers/rgbds { };
 
+  rocm-thunk = callPackage ../development/libraries/rocm-thunk { };
+
   rtags = callPackage ../development/tools/rtags {
     inherit (darwin) apple_sdk;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9233,6 +9233,8 @@ in
 
   rgbds = callPackage ../development/compilers/rgbds { };
 
+  rocm-runtime = callPackage ../development/libraries/rocm-runtime { };
+
   rocm-thunk = callPackage ../development/libraries/rocm-thunk { };
 
   rtags = callPackage ../development/tools/rtags {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9250,6 +9250,8 @@ in
     inherit (llvmPackages_rocm) clang clang-unwrapped lld llvm;
   };
 
+  rocm-opencl-icd = callPackage ../development/libraries/rocm-opencl-icd { };
+
   rocm-opencl-runtime = callPackage ../development/libraries/rocm-opencl-runtime {
     stdenv = overrideCC stdenv llvmPackages_rocm.clang;
     inherit (llvmPackages_rocm) clang clang-unwrapped lld llvm;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9250,6 +9250,11 @@ in
     inherit (llvmPackages_rocm) clang clang-unwrapped lld llvm;
   };
 
+  rocm-opencl-runtime = callPackage ../development/libraries/rocm-opencl-runtime {
+    stdenv = overrideCC stdenv llvmPackages_rocm.clang;
+    inherit (llvmPackages_rocm) clang clang-unwrapped lld llvm;
+  };
+
   rocm-runtime = callPackage ../development/libraries/rocm-runtime { };
 
   rocm-thunk = callPackage ../development/libraries/rocm-thunk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9235,6 +9235,10 @@ in
 
   rgbds = callPackage ../development/compilers/rgbds { };
 
+  rocclr = callPackage ../development/libraries/rocclr {
+    inherit (llvmPackages_rocm) clang;
+  };
+
   rocm-cmake = callPackage ../development/tools/build-managers/rocm-cmake { };
 
   rocm-comgr = callPackage ../development/libraries/rocm-comgr {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9101,6 +9101,8 @@ in
 
   llvmPackages_latest = llvmPackages_10;
 
+  llvmPackages_rocm = callPackage ../development/compilers/llvm/rocm { };
+
   lorri = callPackage ../tools/misc/lorri {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9235,6 +9235,11 @@ in
 
   rgbds = callPackage ../development/compilers/rgbds { };
 
+  rocm-comgr = callPackage ../development/libraries/rocm-comgr {
+    inherit (llvmPackages_rocm) clang lld llvm;
+    device-libs = rocm-device-libs;
+  };
+
   rocm-device-libs = callPackage ../development/libraries/rocm-device-libs {
     inherit (llvmPackages_rocm) clang clang-unwrapped lld llvm;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9235,6 +9235,10 @@ in
 
   rgbds = callPackage ../development/compilers/rgbds { };
 
+  rocm-device-libs = callPackage ../development/libraries/rocm-device-libs {
+    inherit (llvmPackages_rocm) clang clang-unwrapped lld llvm;
+  };
+
   rocm-runtime = callPackage ../development/libraries/rocm-runtime { };
 
   rocm-thunk = callPackage ../development/libraries/rocm-thunk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9235,6 +9235,8 @@ in
 
   rgbds = callPackage ../development/compilers/rgbds { };
 
+  rocm-cmake = callPackage ../development/tools/build-managers/rocm-cmake { };
+
   rocm-comgr = callPackage ../development/libraries/rocm-comgr {
     inherit (llvmPackages_rocm) clang lld llvm;
     device-libs = rocm-device-libs;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds the open source AMD ROCm packages for OpenCL support. All the heavy lifting was done by @acowley in the [nixos-rocm](https://github.com/nixos-rocm/nixos-rocm) project. All credit for this work should go to Anthony. I only cleaned up the derivations a little to conform more to nixpkgs guidelines.

I did some very preliminary testing by trying Blender's OpenCL support. Blender seems to pick it up fine.

@acowley I had some questions:

* Should I add you as maintainer of these packages?
* Is `patchelf` in rocm-opencl-runtime still necessary? `clinfo` seems to work fine without? I guess we could also consider removing the `clinfo` binary, since it is already provided by the `clinfo` package in `nixpkgs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
