### PR TITLE
Revert "bashCompletion: speed-up test execution by using xdist"

### DIFF
--- a/pkgs/shells/bash/bash-completion/default.nix
+++ b/pkgs/shells/bash/bash-completion/default.nix
@@ -30,10 +30,6 @@ stdenv.mkDerivation rec {
     python3Packages.pexpect
     python3Packages.pytest
     bashInteractive
-
-    # use xdist to speed up the test run, just like upstream:
-    # https://github.com/scop/bash-completion/blob/009bf2228c68894629eb6fd17b3dc0f1f6d67615/test/requirements.txt#L4
-    python3Packages.pytest_xdist
   ];
 
   # - ignore test_gcc on ARM because it assumes -march=native
@@ -44,7 +40,7 @@ stdenv.mkDerivation rec {
   # - ignore test_ls because impure logic
   # - ignore test_screen because it assumes vt terminals exist
   checkPhase = ''
-    pytest -n $NIX_BUILD_CORES . \
+    pytest . \
       ${stdenv.lib.optionalString (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isAarch32) "--ignore=test/t/test_gcc.py"} \
       --ignore=test/t/test_chsh.py \
       --ignore=test/t/test_ether_wake.py \


### PR DESCRIPTION
This reverts commit a85b07cbcb7a034bc07dda3642bc68fe621a63ec as
executing the tests in parallel makes them flaky. This can be seen very
easily on armv7l machines (and probably other machines that are slower
than common x86_64 machines as well), but is also reproducible on
x86_64.

This fixes #91706.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

These tests break very easily on armv7l and sometimes break on x86_64 as well if ran in parallel. I've not managed to get a single run to fail where the tests were executed serially.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
