### PR TITLE
labelImg: 1.8.1 -> 1.8.3

### DIFF
--- a/pkgs/applications/science/machine-learning/labelimg/default.nix
+++ b/pkgs/applications/science/machine-learning/labelimg/default.nix
@@ -1,20 +1,31 @@
-{ stdenv, python2Packages, fetchurl }:
-  python2Packages.buildPythonApplication rec {
+{ stdenv, python3Packages, fetchFromGitHub, qt5 }:
+  python3Packages.buildPythonApplication rec {
     pname = "labelImg";
-    version = "1.8.1";
-    src = fetchurl {
-      url = "https://github.com/tzutalin/labelImg/archive/v${version}.tar.gz";
-      sha256 = "1banpkpbrny1jx3zsgs544xai62z5yvislbq782a5r47gv2f2k4a";
+    version = "1.8.3";
+    src = fetchFromGitHub {
+      owner = "tzutalin";
+      repo = "labelImg";
+      rev = "v${version}";
+      sha256 = "07v106fzlmxrbag4xm06m4mx9m0gckb27vpwsn7sap1bbgc1pap5";
     };
-    nativeBuildInputs = with python2Packages; [
-      pyqt4
+    nativeBuildInputs = with python3Packages; [
+      pyqt5
+      qt5.wrapQtAppsHook
     ];
-    propagatedBuildInputs = with python2Packages; [
-      pyqt4
+    propagatedBuildInputs = with python3Packages; [
+      pyqt5
       lxml
+      sip
     ];
     preBuild = ''
-      make qt4py2
+      make qt5py3
+    '';
+    postInstall = ''
+      cp libs/resources.py $out/${python3Packages.python.sitePackages}/libs
+    '';
+    dontWrapQtApps = true;
+    preFixup = ''
+      makeWrapperArgs+=("''${qtWrapperArgs[@]}")
     '';
     meta = with stdenv.lib; {
       description = "LabelImg is a graphical image annotation tool and label object bounding boxes in images";


### PR DESCRIPTION
Switch to python3 and qt5 libraries also

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update package to latest release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
