### PR TITLE
displaylink: 5.2.14 -> 5.3.1

### DIFF
--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -67,7 +67,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "DisplayLink DL-5xxx, DL-41xx and DL-3x00 Driver for Linux";
-    maintainers = with maintainers; [ nshalman abbradar peterhoeg ];
+    maintainers = with maintainers; [ nshalman abbradar peterhoeg eyjhb ];
     platforms = [ "x86_64-linux" "i686-linux" ];
     license = licenses.unfree;
     homepage = "https://www.displaylink.com/";

--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -11,17 +11,17 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "displaylink";
-  version = "5.2.14";
+  version = "5.3.1.34";
 
   src = requireFile rec {
     name = "displaylink.zip";
-    sha256 = "03b176y95f04rg3lcnjps9llsjbvd8yksh1fpvjwaciz48mnxh2i";
+    sha256 = "1c1kbjgpb71f73qnyl44rvwi6l4ivddq789rwvvh0ahw2jm324hy";
     message = ''
       In order to install the DisplayLink drivers, you must first
       comply with DisplayLink's EULA and download the binaries and
       sources from here:
 
-      http://www.displaylink.com/downloads/file?id=1369
+      https://www.displaylink.com/downloads/file?id=1576
 
       Once you have downloaded the file, please use the following
       commands and re-run the installation:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update version, needs to be merged with https://github.com/NixOS/nixpkgs/pull/92917 - tested to work together.
There is a dub of this PR, that I did not notice till now - https://github.com/NixOS/nixpkgs/pull/91129

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
