### PR TITLE
php74: 7.4.7 -> 7.4.8

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -284,8 +284,8 @@ let
   });
 
   php74base = callPackage generic (_args // {
-    version = "7.4.7";
-    sha256 = "0ynq4fz54jpzh9nxvbgn3vrdad2clbac0989ai0yrj2ryc0hs3l0";
+    version = "7.4.8";
+    sha256 = "0ql01sfg8l7y2bfwmnjxnfw9irpibnz57ssck24b00y00nkd6j3a";
   });
 
   defaultPhpExtensions = { all, ... }: with all; ([

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -1014,6 +1014,7 @@ in
                +----------------------------------------------------------------------+
                | Copyright (c) The PHP Group                                          |
           '')
+        ] ++ lib.optional (lib.versionOlder php.version "7.4.8") [
           (pkgs.writeText "mysqlnd_fix_compression.patch" ''
             --- a/ext/mysqlnd/mysqlnd.h
             +++ b/ext/mysqlnd/mysqlnd.h


### PR DESCRIPTION
###### Motivation for this change
Changelog: https://www.php.net/ChangeLog-7.php#7.4.8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
