### PR TITLE
ocamlPackages.lambdasoup: 0.6.3 → 0.7.1

### DIFF
--- a/pkgs/development/ocaml-modules/lambdasoup/default.nix
+++ b/pkgs/development/ocaml-modules/lambdasoup/default.nix
@@ -2,13 +2,13 @@
 
 buildDunePackage rec {
   pname = "lambdasoup";
-  version = "0.6.3"; # NB: double-check the license when updating
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "aantron";
     repo = pname;
     rev = version;
-    sha256 = "1w4zp3vswijzvrx0c3fv269ncqwnvvrzc46629nnwm9shwv07vmv";
+    sha256 = "14lndpsnzjjg58sdwxqpsv7kz77mnwn5658lya9jyaclj8azmaks";
   };
 
   propagatedBuildInputs = [ markup ];
@@ -16,7 +16,7 @@ buildDunePackage rec {
   meta = {
     description = "Functional HTML scraping and rewriting with CSS in OCaml";
     homepage = "https://aantron.github.io/lambdasoup/";
-    license = lib.licenses.bsd2;
+    license = lib.licenses.mit;
     maintainers = [ lib.maintainers.vbgl ];
   };
 


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
