### PR TITLE
python3Packages.biplist: init at 1.0.3

### DIFF
--- a/pkgs/development/python-modules/biplist/default.nix
+++ b/pkgs/development/python-modules/biplist/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildPythonPackage, fetchPypi
+, pytest
+}:
+
+buildPythonPackage rec {
+  version = "1.0.3";
+  pname = "biplist";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1im45a9z7ryrfyp1v6i39qia5qagw6i1mhif0hl0praz9iv4j1ac";
+  };
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    homepage = "https://bitbucket.org/wooster/biplist/src/master/";
+    description = "Binary plist parser/generator for Python";
+    longDescription = ''
+      Binary Property List (plist) files provide a faster and smaller
+      serialization format for property lists on OS X.
+
+      This is a library for generating binary plists which can be read
+      by OS X, iOS, or other clients.
+    '';
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ siriobalmelli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -519,6 +519,8 @@ in {
 
   beancount_docverif = callPackage ../development/python-modules/beancount_docverif { };
 
+  biplist = callPackage ../development/python-modules/biplist { };
+
   bitarray = callPackage ../development/python-modules/bitarray { };
 
   bitcoinlib = callPackage ../development/python-modules/bitcoinlib { };


### PR DESCRIPTION
Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Requirement for [briefcase](https://beeware.org/project/projects/tools/briefcase/) build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
