### PR TITLE
python3Packages.mac_alias: init at 2.0.7

### DIFF
--- a/pkgs/development/python-modules/mac_alias/default.nix
+++ b/pkgs/development/python-modules/mac_alias/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi
+}:
+
+buildPythonPackage rec {
+  version = "2.0.7";
+  pname = "mac_alias";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08z2i68mk5j0vfy8jqihjm9m6njp1lpjh1m91b60h0k0kpmy71f4";
+  };
+
+  # pypi package does not include tests;
+  # tests anyway require admin privileges to succeed
+  doCheck = false;
+  pythonImportsCheck = [ "mac_alias" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/al45tair/mac_alias";
+    description = "Generate or read binary Alias and Bookmark records from Python code";
+    longDescription = ''
+      mac_alias lets you generate or read binary Alias and Bookmark records from Python code.
+
+      While it is written in pure Python, some OS X specific code is required
+      to generate a proper Alias or Bookmark record for a given file,
+      so this module currently is not portable to other platforms.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ siriobalmelli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -930,6 +930,8 @@ in {
 
   logzero = callPackage ../development/python-modules/logzero { };
 
+  mac_alias = callPackage ../development/python-modules/mac_alias { };
+
   macropy = callPackage ../development/python-modules/macropy { };
 
   mail-parser = callPackage ../development/python-modules/mail-parser { };


### PR DESCRIPTION
Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Requirement for [briefcase](https://beeware.org/project/projects/tools/briefcase/) build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
