### PR TITLE
doc: adding labels doesn't require commit rights

### DIFF
--- a/doc/contributing/reviewing-contributions.xml
+++ b/doc/contributing/reviewing-contributions.xml
@@ -49,7 +49,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     Add labels to the pull request. (Requires commit rights)
+     Add labels to the pull request. (Requires maintainer rights)
     </para>
     <itemizedlist>
      <listitem>
@@ -188,7 +188,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     Add labels to the pull request. (Requires commit rights)
+     Add labels to the pull request. (Requires maintainer rights)
     </para>
     <itemizedlist>
      <listitem>
@@ -304,7 +304,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     Add labels to the pull request. (Requires commit rights)
+     Add labels to the pull request. (Requires maintainer rights)
     </para>
     <itemizedlist>
      <listitem>
@@ -408,7 +408,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     Add labels to the pull request. (Requires commit rights)
+     Add labels to the pull request. (Requires maintainer rights)
     </para>
     <itemizedlist>
      <listitem>


### PR DESCRIPTION
###### Motivation for this change

As of [RFC 39][1], package maintainers are members of the NixOS github
organization who don't have commit rights.  However, they *do* have what
GitHub calls [Triage rights][2], which means that package maintainers
are able to add labels to PRs.  The documentation should make this
clear.

I don't know the right way to phrase this in the docs, but the current
text of "Requires commit rights" is definitely incorrect.

[1]: https://discourse.nixos.org/t/join-the-package-maintainer-team/3751
[2]: https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#repository-access-for-each-permission-level

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
