### PR TITLE
python3Packages.wheel: 0.33.6 -> 0.34.2

### DIFF
--- a/pkgs/development/python-modules/wheel/default.nix
+++ b/pkgs/development/python-modules/wheel/default.nix
@@ -1,41 +1,51 @@
 { lib
-, setuptools
-, pip
 , buildPythonPackage
 , fetchFromGitHub
-, pytest
-, pytestcov
-, coverage
-, jsonschema
 , bootstrapped-pip
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "wheel";
-  version = "0.33.6";
+  version = "0.34.2";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = pname;
     rev = version;
-    sha256 = "1bg4bxazsjxp621ymaykd8l75k7rvcvwawlipmjk7nsrl72l4p0s";
+    sha256 = "1mwh35ycv07ajnpcjc4rjdmndh6nyg03gdgag5m8c2af7z1xlcmj";
     name = "${pname}-${version}-source";
   };
 
-  checkInputs = [ pytest pytestcov coverage ];
-  nativeBuildInputs = [ bootstrapped-pip setuptools ];
+  nativeBuildInputs = [
+    bootstrapped-pip
+    setuptools
+  ];
 
-  catchConflicts = false;
   # No tests in archive
   doCheck = false;
+  pythonImportsCheck = [ "wheel" ];
 
   # We add this flag to ignore the copy installed by bootstrapped-pip
   pipInstallFlags = [ "--ignore-installed" ];
 
-  meta = {
-    description = "A built-package format for Python";
-    license = with lib.licenses; [ mit ];
+  meta = with lib; {
     homepage = "https://bitbucket.org/pypa/wheel/";
+    description = "A built-package format for Python";
+    longDescription = ''
+      This library is the reference implementation of the Python wheel packaging standard,
+      as defined in PEP 427.
+
+      It has two different roles:
+
+      - A setuptools extension for building wheels that provides the bdist_wheel setuptools command
+      - A command line tool for working with wheel files
+
+      It should be noted that wheel is not intended to be used as a library,
+      and as such there is no stable, public API.
+    '';
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ siriobalmelli ];
   };
 }


### PR DESCRIPTION
Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

wheel >0.34 required for [briefcase](https://beeware.org/project/projects/tools/briefcase/) build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
