### PR TITLE
Bump Roon-Server to latest version and fix bug

### DIFF
--- a/pkgs/servers/roon-server/default.nix
+++ b/pkgs/servers/roon-server/default.nix
@@ -1,13 +1,13 @@
-{ alsaLib, alsaUtils, cifs-utils, fetchurl, ffmpeg_3, libav, mono, stdenv }:
+{ alsaLib, alsaUtils, cifs-utils, fetchurl, ffmpeg_3, libav, zlib, stdenv }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "roon-server";
-  version = "100600401";
+  version = "100700571";
 
   src = fetchurl {
     url = "http://download.roonlabs.com/updates/stable/RoonServer_linuxx64_${version}.tar.bz2";
-    sha256 = "121mmdh35q4bpgsqhcps6a6q1f4ld9v4hq9gp181bf2n779pk8sh";
+    sha256 = "191vlzf10ypkk1prp6x2rszlmsihdwpd3wvgf2jg6ckwyxy2hc6k";
   };
 
   installPhase = ''
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
     sed -i '/ln -sf/ d' Server/RoonServer
     mkdir -p $out/opt
     mv * $out/opt
+    ln -s ${zlib}/lib/libz.so.1 $out/opt/RoonMono/lib/libz.so.1
     ln -sf $out/opt/RoonMono/bin/mono-sgen $out/opt/RoonMono/bin/RoonServer
     ln -sf $out/opt/RoonMono/bin/mono-sgen $out/opt/RoonMono/bin/RoonAppliance
     ln -sf $out/opt/RoonMono/bin/mono-sgen $out/opt/RoonMono/bin/RAATServer


### PR DESCRIPTION
###### Motivation for this change
Update to the newest Roon version and fix bug with ZLib.

The newest version of Roon [won't work without zlib](https://community.roonlabs.com/t/roon-core-build-571-wont-boot-on-nixos-vm-linux/111217). It took me a while to figure this out and truth being told I'm not fully sure this is the best way of going about it.

I run this at home and it works fine, but I'd prefer adding the appropriate zlib into a PATH somehow, instead of making symbolic links. Will this even survive garbage collection?

Can Mono's [DLL mapping](https://www.mono-project.com/docs/advanced/pinvoke/dllmap/) be used somehow?

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
