### PR TITLE
home-assistant: Fix dependency restriction

### DIFF
--- a/pkgs/servers/home-assistant/0001-setup.py-relax-dependencies.patch
+++ b/pkgs/servers/home-assistant/0001-setup.py-relax-dependencies.patch
@@ -20,5 +20,6 @@ index 4e46f63217..b1aafee59d 100755
 +    "requests>=2.23.0",
 +    "ruamel.yaml>=0.15.100",
      "voluptuous==0.11.7",
-     "voluptuous-serialize==2.3.0",
+-    "voluptuous-serialize==2.3.0",
++    "voluptuous-serialize>=2.3.0",
  ]


### PR DESCRIPTION
###### Motivation for this change
Update of the lib broke the build of home-assistant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
