### PR TITLE
qgroundcontrol: 4.0.8 -> 4.0.9

### DIFF
--- a/pkgs/applications/science/robotics/qgroundcontrol/default.nix
+++ b/pkgs/applications/science/robotics/qgroundcontrol/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchgit, SDL2
+{ lib, mkDerivation, fetchFromGitHub, SDL2
 , qtbase, qtcharts, qtlocation, qtserialport, qtsvg, qtquickcontrols2
 , qtgraphicaleffects, qtspeech, qtx11extras, qmake, qttools
 , gst_all_1, wayland, pkgconfig
@@ -6,7 +6,7 @@
 
 mkDerivation rec {
   pname = "qgroundcontrol";
-  version = "4.0.8";
+  version = "4.0.9";
 
   qtInputs = [
     qtbase qtcharts qtlocation qtserialport qtsvg qtquickcontrols2
@@ -58,10 +58,11 @@ mkDerivation rec {
   '';
 
   # TODO: package mavlink so we can build from a normal source tarball
-  src = fetchgit {
-    url = "https://github.com/mavlink/qgroundcontrol.git";
+  src = fetchFromGitHub {
+    owner = "mavlink";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0jr9jpjqdwizsvh9zm0fdp8k2r4536m40dxrn30fbr3ba8vnzkgq";
+    sha256 = "0fwibgb9wmxk2zili5vsibi2q6pk1gna21870y5abx4scbvhgq68";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Updates QGroundControl to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @knedlsepp @globin @adisbladis 