### PR TITLE
yubikey-agent: init at 0.1.3

### DIFF
--- a/pkgs/tools/misc/yubikey-agent/default.nix
+++ b/pkgs/tools/misc/yubikey-agent/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, buildGoModule, fetchFromGitHub, pcsclite }:
+
+
+buildGoModule rec {
+  pname = "yubikey-agent";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "FiloSottile";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "07gix5wrakn4z846zhvl66lzwx58djrfnn6m8v7vc69l9jr3kihr";
+  };
+
+  vendorSha256 = "1gn0w557w7cb9xd03sla6r389ncd3ik5bqwnrwzyb2imfpqwz58a";
+
+  buildInputs = [ pcsclite ];
+
+  buildFlagsArray = [ "-ldflags=-s -w -X main.version=${version}" ];
+
+  excludedPackages = "test";
+
+  # Permission Denied
+  # postPatch = ''
+  #   substituteInPlace ${stdenv.lib.getDev pcsclite}/include/PCSC/winscard.h \
+  #     --replace "pcsclite.h" "PCSC/pcsclite.h"
+  # '';
+
+  meta = with lib; {
+    description = "yubikey-agent is a seamless ssh-agent for YubiKeys.";
+    license = licenses.bsd3;
+    homepage = "https://github.com/FiloSottile/yubikey-agent";
+    maintainers = with maintainers; [ rawkode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15423,6 +15423,8 @@ in
     inherit (darwin.apple_sdk.frameworks) PCSC;
   };
 
+  yubikey-agent = callPackage ../tools/misc/yubikey-agent { };
+
   yubikey-manager = callPackage ../tools/misc/yubikey-manager { };
 
   yubikey-manager-qt = libsForQt5.callPackage ../tools/misc/yubikey-manager-qt {


### PR DESCRIPTION
This PR is failing, if anyone can help; I'd really appreciate it.

```
# github.com/go-piv/piv-go/piv
In file included from vendor/github.com/go-piv/piv-go/piv/pcsc_unix.go:30:
/nix/store/wdhrxbxf175g3qwv22fcm5zda2734a7y-pcsclite-1.8.26-dev/include/PCSC/winscard.h:41:10: fatal error: pcsclite.h: No such file or directory
   41 | #include <pcsclite.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```

I tried patching, but permissions fail, which I guess it because it's an input.

```
  # Permission Denied
   postPatch = ''
     substituteInPlace ${stdenv.lib.getDev pcsclite}/include/PCSC/winscard.h \
       --replace "pcsclite.h" "PCSC/pcsclite.h"
   '';
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
