### PR TITLE
bpm-tools: Specify dependencies and wrap executables

### DIFF
--- a/pkgs/tools/audio/bpm-tools/default.nix
+++ b/pkgs/tools/audio/bpm-tools/default.nix
@@ -1,8 +1,17 @@
 {
   stdenv,
   fetchurl,
+  gnuplot,
+  sox,
+  flac,
+  id3v2,
+  vorbis-tools,
+  makeWrapper
 }:
 
+let
+  path = stdenv.lib.makeBinPath [ gnuplot sox flac id3v2 vorbis-tools ];
+in
 stdenv.mkDerivation rec {
   pname = "bpm-tools";
   version = "0.3";
@@ -12,14 +21,16 @@ stdenv.mkDerivation rec {
     sha256 = "151vfbs8h3cibs7kbdps5pqrsxhpjv16y2iyfqbxzsclylgfivrp";
   };
 
-  patchPhase = ''
-    patchShebangs bpm-tag
-    patchShebangs bpm-graph
-  '';
+  nativeBuildInputs = [ makeWrapper ];
 
   installFlags = [
     "PREFIX=${placeholder "out"}"
   ];
+
+  postFixup = ''
+    wrapProgram $out/bin/bpm-tag --prefix PATH : "${path}"
+    wrapProgram $out/bin/bpm-graph --prefix PATH : "${path}"
+  '';
 
   meta = with stdenv.lib; {
     homepage = "http://www.pogo.org.uk/~mark/bpm-tools/";


### PR DESCRIPTION
###### Motivation for this change

The scripts would fail if the required dependencies (gnuplot, flac, id3v2, vorbis-tools, sox) were not (by sheer coincidence) in $PATH.


###### Things done

Add the required packages as input of this derivation and wrap the scripts so the dependencies are in $PATH.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
