### PR TITLE
python3Packages.gpxpy: 1.3.5 -> 1.4.2

### DIFF
--- a/pkgs/development/python-modules/gpxpy/default.nix
+++ b/pkgs/development/python-modules/gpxpy/default.nix
@@ -1,14 +1,15 @@
-{ lib, fetchFromGitHub, buildPythonPackage, python, lxml }:
+{ lib, fetchFromGitHub, buildPythonPackage, python, lxml, isPy3k }:
 
 buildPythonPackage rec {
   pname = "gpxpy";
-  version = "1.3.5";
+  version = "1.4.2";
+  disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner = "tkrajina";
     repo = pname;
     rev = "v${version}";
-    sha256 = "18r7pfda7g3l0hv8j9565n52cvvgjxiiqqzagfdfaba1djgl6p8b";
+    sha256 = "1r5gb660nrkrdbw5m5h1n5k10npcfv9bxqv92z55ds8r7rw2saz6";
   };
 
   propagatedBuildInputs = [ lxml ];


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/tkrajina/gpxpy/blob/dev/CHANGELOG.md):
> Removed support for python2.* and python3.5

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
