### PR TITLE
python2Packages.numpy: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/numpy/1.16.nix
+++ b/pkgs/development/python-modules/numpy/1.16.nix
@@ -1,0 +1,94 @@
+{ lib
+, fetchPypi
+, python
+, buildPythonPackage
+, gfortran
+, pytest
+, blas
+, lapack
+, writeTextFile
+, isPyPy
+, cython
+, setuptoolsBuildHook
+ }:
+
+assert (!blas.isILP64) && (!lapack.isILP64);
+
+let
+  cfg = writeTextFile {
+    name = "site.cfg";
+    text = (lib.generators.toINI {} {
+      ${blas.implementation} = {
+        include_dirs = "${lib.getDev blas}/include:${lib.getDev lapack}/include";
+        library_dirs = "${blas}/lib:${lapack}/lib";
+        libraries = "lapack,lapacke,blas,cblas";
+      };
+      lapack = {
+        include_dirs = "${lib.getDev lapack}/include";
+        library_dirs = "${lapack}/lib";
+      };
+      blas = {
+        include_dirs = "${lib.getDev blas}/include";
+        library_dirs = "${blas}/lib";
+      };
+    });
+  };
+in buildPythonPackage rec {
+  pname = "numpy";
+  version = "1.16.5";
+  format = "pyproject.toml";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "8bb452d94e964b312205b0de1238dd7209da452343653ab214b5d681780e7a0c";
+  };
+
+  nativeBuildInputs = [ gfortran pytest cython setuptoolsBuildHook ];
+  buildInputs = [ blas lapack ];
+
+  patches = lib.optionals python.hasDistutilsCxxPatch [
+    # We patch cpython/distutils to fix https://bugs.python.org/issue1222585
+    # Patching of numpy.distutils is needed to prevent it from undoing the
+    # patch to distutils.
+    ./numpy-distutils-C++_1.16.patch
+  ];
+
+  preConfigure = ''
+    sed -i 's/-faltivec//' numpy/distutils/system_info.py
+    export NPY_NUM_BUILD_JOBS=$NIX_BUILD_CORES
+  '';
+
+  preBuild = ''
+    ln -s ${cfg} site.cfg
+  '';
+
+  enableParallelBuilding = true;
+
+  doCheck = !isPyPy; # numpy 1.16+ hits a bug in pypy's ctypes, using either numpy or pypy HEAD fixes this (https://github.com/numpy/numpy/issues/13807)
+
+  checkPhase = ''
+    runHook preCheck
+    pushd dist
+    ${python.interpreter} -c 'import numpy; numpy.test("fast", verbose=10)'
+    popd
+    runHook postCheck
+  '';
+
+  passthru = {
+    # just for backwards compatibility
+    blas = blas.provider;
+    blasImplementation = blas.implementation;
+    inherit cfg;
+  };
+
+  # Disable test
+  # - test_large_file_support: takes a long time and can cause the machine to run out of disk space
+  NOSE_EXCLUDE="test_large_file_support";
+
+  meta = {
+    description = "Scientific tools for Python";
+    homepage = "https://numpy.org/";
+    maintainers = with lib.maintainers; [ fridh ];
+  };
+}

--- a/pkgs/development/python-modules/numpy/numpy-distutils-C++_1.16.patch
+++ b/pkgs/development/python-modules/numpy/numpy-distutils-C++_1.16.patch
@@ -1,0 +1,30 @@
+diff --git a/numpy/distutils/unixccompiler.py b/numpy/distutils/unixccompiler.py
+--- a/numpy/distutils/unixccompiler.py
++++ b/numpy/distutils/unixccompiler.py
+@@ -44,8 +44,6 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
+         if opt not in llink_s:
+             self.linker_so = llink_s.split() + opt.split()
+ 
+-    display = '%s: %s' % (os.path.basename(self.compiler_so[0]), src)
+-
+     # gcc style automatic dependencies, outputs a makefile (-MF) that lists
+     # all headers needed by a c file as a side effect of compilation (-MMD)
+     if getattr(self, '_auto_depends', False):
+@@ -54,8 +52,15 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
+         deps = []
+ 
+     try:
+-        self.spawn(self.compiler_so + cc_args + [src, '-o', obj] + deps +
+-                   extra_postargs, display = display)
++        if self.detect_language(src) == 'c++':
++            display = '%s: %s' % (os.path.basename(self.compiler_so_cxx[0]), src)
++            self.spawn(self.compiler_so_cxx + cc_args + [src, '-o', obj] + deps +
++                       extra_postargs, display = display)
++        else:
++            display = '%s: %s' % (os.path.basename(self.compiler_so[0]), src)
++            self.spawn(self.compiler_so + cc_args + [src, '-o', obj] + deps +
++                       extra_postargs, display = display)
++
+     except DistutilsExecError:
+         msg = str(get_exception())
+         raise CompileError(msg)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4926,16 +4926,11 @@ in {
 
   Nuitka = callPackage ../development/python-modules/nuitka { };
 
-  numpy = let
-    numpy_ = callPackage ../development/python-modules/numpy { };
-    numpy_2 = numpy_.overridePythonAttrs(oldAttrs: rec {
-      version = "1.16.5";
-      src = oldAttrs.src.override {
-        inherit version;
-        sha256 = "8bb452d94e964b312205b0de1238dd7209da452343653ab214b5d681780e7a0c";
-      };
-    });
-  in if pythonOlder "3.5" then numpy_2 else numpy_;
+  numpy =
+    if pythonOlder "3.5" then
+      callPackage ../development/python-modules/numpy/1.16.nix { }
+    else
+      callPackage ../development/python-modules/numpy { };
 
   numpydoc = callPackage ../development/python-modules/numpydoc { };
 


### PR DESCRIPTION
By applying the old patch (compatible with 1.18.x and older). Also
refactor expression to make presence of the "old" version more
explicit.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

To fix python2Packages in staging next (for #91090)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
