### PR TITLE
sndio: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/misc/sndio/default.nix
+++ b/pkgs/misc/sndio/default.nix
@@ -1,22 +1,16 @@
-{ stdenv, fetchurl, alsaLib }:
+{ stdenv, fetchurl, alsaLib, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
   pname = "sndio";
   version = "1.7.0";
   enableParallelBuilding = true;
-  buildInputs = stdenv.lib.optionals stdenv.isLinux [ alsaLib ];
+  buildInputs = stdenv.lib.optionals stdenv.isLinux [ alsaLib ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ fixDarwinDylibNames ];
 
   src = fetchurl {
     url = "http://www.sndio.org/sndio-${version}.tar.gz";
     sha256 = "0ljmac0lnjn61admgbcwjfcr5fwccrsblx9rj9bys8wlhz8f796x";
   };
-
-  postFixup = stdenv.lib.optionalString stdenv.isDarwin ''
-    install_name_tool -id $out/lib/libsndio.7.0.dylib $out/lib/libsndio.7.0.dylib
-    for file in $out/bin/*; do
-      install_name_tool -change libsndio.7.0.dylib $out/lib/libsndio.dylib $file
-    done
-  '';
 
   meta = with stdenv.lib; {
     homepage = "http://www.sndio.org";

--- a/pkgs/misc/sndio/default.nix
+++ b/pkgs/misc/sndio/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sndio";
-  version = "1.6.0";
+  version = "1.7.0";
   enableParallelBuilding = true;
   buildInputs = stdenv.lib.optionals stdenv.isLinux [ alsaLib ];
 
   src = fetchurl {
     url = "http://www.sndio.org/sndio-${version}.tar.gz";
-    sha256 = "1havdx3q4mipgddmd2bnygr1yh6y64567m1yqwjapkhsq550dq4r";
+    sha256 = "0ljmac0lnjn61admgbcwjfcr5fwccrsblx9rj9bys8wlhz8f796x";
   };
 
   postFixup = stdenv.lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
###### Motivation for this change
Updates sndio to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
