### PR TITLE
amd-blis: init at 2.2

### DIFF
--- a/pkgs/development/libraries/science/math/amd-blis/default.nix
+++ b/pkgs/development/libraries/science/math/amd-blis/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, fetchFromGitHub
+, perl
+, python3
+
+, blas64 ? false
+, withArchitecture ? "zen"
+, withOpenMP ? true
+}:
+
+let
+  threadingSuffix = if withOpenMP then "-mt" else "";
+  blasIntSize = if blas64 then "64" else "32";
+in stdenv.mkDerivation rec {
+  pname = "amd-blis";
+  version = "2.2";
+
+  src = fetchFromGitHub {
+    owner = "amd";
+    repo = "blis";
+    rev = version;
+    sha256 = "1b2f5bwi0gkw2ih2rb7wfzn3m9hgg7k270kg43rmzpr2acpy86xa";
+  };
+
+  inherit blas64;
+
+  nativeBuildInputs = [
+    perl
+    python3
+  ];
+
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--enable-cblas"
+    "--blas-int-size=${blasIntSize}"
+  ] ++ stdenv.lib.optionals withOpenMP [ "--enable-threading=openmp" ]
+    ++ [ withArchitecture ];
+
+  postPatch = ''
+    patchShebangs configure build/flatten-headers.py
+  '';
+
+  postInstall = ''
+    ln -s $out/lib/libblis${threadingSuffix}.so.2 $out/lib/libblas.so.3
+    ln -s $out/lib/libblis${threadingSuffix}.so.2 $out/lib/libcblas.so.3
+    ln -s $out/lib/libblas.so.3 $out/lib/libblas.so
+    ln -s $out/lib/libcblas.so.3 $out/lib/libcblas.so
+  '';
+
+  meta = with stdenv.lib; {
+    description = "BLAS-compatible library optimized for AMD CPUs";
+    homepage = "https://developer.amd.com/amd-aocl/blas-library/";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.danieldk ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25033,6 +25033,8 @@ in
 
   almonds = callPackage ../applications/science/math/almonds { };
 
+  amd-blis = callPackage ../development/libraries/science/math/amd-blis { };
+
   arpack = callPackage ../development/libraries/science/math/arpack { };
 
   blas = callPackage ../build-support/alternatives/blas { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add the AMD fork of BLIS. This provides a BLAS-compatible library that is optimized for AMD CPUs. A counterpart to MKL, but open source :).

Tested by recompiling `numpy` with AMD BLIS through the new BLAS overlay mechanism.

After this PR, I'll also do a PR for AMD's libflame, so that we have a full AMD BLAS/LAPACK as an alternative.

**Changed to Draft until I figure out why ofborg VMs execute an illegal instruction.**

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
