### PR TITLE
inkcut: init at 2.1.1

### DIFF
--- a/pkgs/applications/misc/inkcut/default.nix
+++ b/pkgs/applications/misc/inkcut/default.nix
@@ -1,0 +1,54 @@
+{ lib, python3Packages, fetchFromGitHub, wrapQtAppsHook }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  pname = "inkcut";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1c0mfdfy9iq4l683f3aa7cm7x2w9px83dyigc7655wvaq3bxi2rp";
+  };
+
+  nativeBuildInputs = [ wrapQtAppsHook ];
+
+  propagatedBuildInputs = [
+    enamlx
+    twisted
+    lxml
+    qreactor
+    jsonpickle
+    pyserial
+    pycups
+    qtconsole
+    pyqt5
+  ];
+
+  # QtApplication.instance() does not work during tests?
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "inkcut"
+    "inkcut.cli"
+    "inkcut.console"
+    "inkcut.core"
+    "inkcut.device"
+    "inkcut.job"
+    "inkcut.joystick"
+    "inkcut.monitor"
+    "inkcut.preview"
+  ];
+
+  dontWrapQtApps = true;
+  makeWrapperArgs = [ "\${qtWrapperArgs[@]}" ];
+
+  meta = with lib; {
+    homepage = "https://www.codelv.com/projects/inkcut/";
+    description = "Control 2D plotters, cutters, engravers, and CNC machines";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ raboof ];
+  };
+}

--- a/pkgs/development/python-modules/bytecode/default.nix
+++ b/pkgs/development/python-modules/bytecode/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, aenum
+}:
+
+buildPythonPackage rec {
+  pname = "bytecode";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "vstinner";
+    repo = pname;
+    rev = version;
+    sha256 = "097k83zr0z71pha7bafzhs4ink174wk9ls2883bic274rihsnc5r";
+  };
+
+  disabled = pythonOlder "3.5";
+
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.6") [ aenum ];
+
+  meta = with lib; {
+    homepage = "https://github.com/vstinner/bytecode";
+    description = "Python module to generate and modify bytecode";
+    license = licenses.mit;
+    maintainers = with maintainers; [ raboof ];
+  };
+}

--- a/pkgs/development/python-modules/enaml/default.nix
+++ b/pkgs/development/python-modules/enaml/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, atom
+, ply
+, kiwisolver
+, qtpy
+, sip
+, cppy
+, bytecode
+}:
+
+buildPythonPackage rec {
+  pname = "enaml";
+  version = "0.11.2";
+
+  src = fetchFromGitHub {
+    owner = "nucleic";
+    repo = pname;
+    rev = version;
+    sha256 = "1in5qa5j96qs3gsv8yaxs1l6dbm69xhzvc0pbzg0dd9kpqxfdy1j";
+  };
+
+  # qt bindings cannot be found during tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "enaml"
+    "enaml.applib"
+    "enaml.core"
+    "enaml.core.parser"
+    "enaml.layout"
+    # qt bindings cannot be found during checking
+    #"enaml.qt"
+    #"enaml.qt.docking"
+    "enaml.scintilla"
+    "enaml.stdlib"
+    "enaml.widgets"
+    "enaml.workbench"
+  ];
+
+  propagatedBuildInputs = [
+    atom
+    ply
+    kiwisolver
+    qtpy
+    sip
+    cppy
+    bytecode
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/nucleic/enaml";
+    description = "Declarative User Interfaces for Python";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ raboof ];
+  };
+}

--- a/pkgs/development/python-modules/enamlx/default.nix
+++ b/pkgs/development/python-modules/enamlx/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, enaml
+, pyqtgraph
+, pythonocc-core
+}:
+
+buildPythonPackage rec {
+  pname = "enamlx";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "frmdstryr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0yh7bw9ibk758bym5w2wk7sifghf1hkxa8sd719q8nsz279cpfc0";
+  };
+
+  propagatedBuildInputs = [
+    enaml
+    # Until https://github.com/inkcut/inkcut/issues/105 perhaps
+    pyqtgraph
+    pythonocc-core
+  ];
+
+  # qt_occ_viewer test requires enaml.qt.QtOpenGL which got dropped somewhere
+  # between enaml 0.9.0 and 0.10.0
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "enamlx.core"
+    "enamlx.qt"
+    "enamlx.widgets"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/frmdstryr/enamlx";
+    description = "Additional Qt Widgets for Enaml";
+    license = licenses.mit;
+    maintainers = with maintainers; [ raboof ];
+  };
+}

--- a/pkgs/development/python-modules/qreactor/default.nix
+++ b/pkgs/development/python-modules/qreactor/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, twisted
+, qtpy
+, pyqt5
+}:
+
+buildPythonPackage rec {
+  pname = "qreactor-unstable";
+  version = "2018-09-29";
+
+  src = fetchFromGitHub {
+    owner = "frmdstryr";
+    repo = "qt-reactor";
+    rev = "364b3f561fb0d4d3938404d869baa4db7a982bf0";
+    sha256 = "1nb5iwg0nfz86shw28a2kj5pyhd4jvvxhf73fhnfbl8scgnvjv9h";
+  };
+
+  disabled = pythonOlder "3.0";
+
+  propagatedBuildInputs = [
+    twisted qtpy
+  ];
+
+  checkInputs = [
+    pyqt5
+  ];
+
+  pythonImportsCheck = [
+    "qreactor"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/frmdstryr/qt-reactor";
+    description = "Twisted and PyQt5/qtpy eventloop integration base";
+    license = licenses.mit;
+    maintainers = with maintainers; [ raboof ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20787,6 +20787,8 @@ in
   # Impressive, formerly known as "KeyJNote".
   impressive = callPackage ../applications/office/impressive { };
 
+  inkcut = libsForQt5.callPackage ../applications/misc/inkcut { };
+
   inkscape = callPackage ../applications/graphics/inkscape {
     lcms = lcms2;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -547,6 +547,8 @@ in {
 
   build = callPackage ../development/python-modules/build { };
 
+  bytecode = callPackage ../development/python-modules/bytecode { };
+
   ciso8601 = callPackage ../development/python-modules/ciso8601 { };
 
   deepdiff = callPackage ../development/python-modules/deepdiff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2474,6 +2474,8 @@ in {
 
   envs = callPackage ../development/python-modules/envs { };
 
+  enaml = callPackage ../development/python-modules/enaml { };
+
   etelemetry = callPackage ../development/python-modules/etelemetry { };
 
   eth-hash = callPackage ../development/python-modules/eth-hash { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5859,6 +5859,8 @@ in {
 
   qtpy = callPackage ../development/python-modules/qtpy { };
 
+  qreactor = callPackage ../development/python-modules/qreactor { };
+
   quantities = callPackage ../development/python-modules/quantities { };
 
   qutip = callPackage ../development/python-modules/qutip { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2476,6 +2476,8 @@ in {
 
   enaml = callPackage ../development/python-modules/enaml { };
 
+  enamlx = callPackage ../development/python-modules/enamlx { };
+
   etelemetry = callPackage ../development/python-modules/etelemetry { };
 
   eth-hash = callPackage ../development/python-modules/eth-hash { };


### PR DESCRIPTION
###### Motivation for this change

Great application for driving vinyl cutter machines

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
