### PR TITLE
Update coc-metals vim plugin

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -521,14 +521,14 @@ let
 
   coc-metals = buildVimPluginFrom2Nix {
     pname = "coc-metals";
-    version = "2020-07-04";
+    version = "2020-07-12";
     src = fetchFromGitHub {
-      owner = "ckipp01";
+      owner = "scalameta";
       repo = "coc-metals";
-      rev = "3dbe29b9462a1dd910ff653564cadd72146386c8";
-      sha256 = "1j2z557lzsr25s9ijdfiyg8zd7f967qnq8imacwn6qzfs1r337nj";
+      rev = "c99a4ea7902293460b4d903cdcce4892f12046f5";
+      sha256 = "0r4xs0mhdxvac81cly89jqnby14h1dmrpkdfs0chz5ji4gbsgair";
     };
-    meta.homepage = "https://github.com/ckipp01/coc-metals/";
+    meta.homepage = "https://github.com/scalameta/coc-metals/";
   };
 
   coc-neco = buildVimPluginFrom2Nix {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -52,7 +52,6 @@ chriskempson/base16-vim
 christoomey/vim-sort-motion
 christoomey/vim-tmux-navigator
 ckarnell/antonys-macro-repeater
-ckipp01/coc-metals
 cloudhead/neovim-fuzzy
 CoatiSoftware/vim-sourcetrail
 cocopon/iceberg.vim
@@ -430,6 +429,7 @@ sakhnik/nvim-gdb
 saltstack/salt-vim
 samoshkin/vim-mergetool
 sbdchd/neoformat
+scalameta/coc-metals
 sebastianmarkow/deoplete-rust
 SevereOverfl0w/deoplete-github
 sheerun/vim-polyglot


### PR DESCRIPTION
###### Motivation for this change

The existing `coc-metals` plugin is quite outdated (`v0.8.3`). It now lives in a different repository. Also, the `nodePackages.coc-metals` was updated to the latest `v0.9.0` but this plugin wasn't, leaving it in an inconsistent state.

As defined in https://raw.githubusercontent.com/NixOS/nixpkgs/master/pkgs/development/node-packages/node-packages.nix

```
coc-metals = nodeEnv.buildNodePackage {
    name = "coc-metals";
    packageName = "coc-metals";
    version = "0.9.0";
    src = fetchurl {
      url = "https://registry.npmjs.org/coc-metals/-/coc-metals-0.9.0.tgz";
      sha512 = "rQPCK+x+/Aij/YqjGTIS5c5WA3dPba2RwubGouXSRkl8+F1I4NyAXiXtHAx2V4W1LYvmjd990i6Dtzr3JLx+5A==";
    };
```

###### Things done

The existing `update.py` doesn't work for me, as reported in https://github.com/NixOS/nixpkgs/pull/91656#issuecomment-657206041 and https://github.com/NixOS/nixpkgs/issues/91339#issuecomment-657206742 so I manually updated `generated.nix` with the necessary information and updated the name of the plugin in `vim-plugin-names` (hope that's enough?).

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).