### PR TITLE
vaapiIntel: Refactor and improve the build expression

### DIFF
--- a/pkgs/development/libraries/vaapi-intel/default.nix
+++ b/pkgs/development/libraries/vaapi-intel/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, gnum4, pkgconfig, python2
+{ stdenv, fetchFromGitHub, autoreconfHook, gnum4, pkg-config, python3
 , intel-gpu-tools, libdrm, libva, libX11, libGL, wayland, libXext
 , enableHybridCodec ? false, vaapi-intel-hybrid
 }:
@@ -14,25 +14,19 @@ stdenv.mkDerivation rec {
     sha256 = "1cidki3av9wnkgwi7fklxbg3bh6kysf8w3fk2qadjr05a92mx3zp";
   };
 
-  patchPhase = ''
-    patchShebangs ./src/shaders/gpp.py
-  '';
-
-  preConfigure = ''
-    sed -i -e "s,LIBVA_DRIVERS_PATH=.*,LIBVA_DRIVERS_PATH=$out/lib/dri," configure
-  '';
+  # Set the correct install path:
+  LIBVA_DRIVERS_PATH = "${placeholder "out"}/lib/dri";
 
   postInstall = stdenv.lib.optionalString enableHybridCodec ''
     ln -s ${vaapi-intel-hybrid}/lib/dri/* $out/lib/dri/
   '';
 
   configureFlags = [
-    "--enable-drm"
     "--enable-x11"
     "--enable-wayland"
   ] ++ stdenv.lib.optional enableHybridCodec "--enable-hybrid-codec";
 
-  nativeBuildInputs = [ autoreconfHook gnum4 pkgconfig python2 ];
+  nativeBuildInputs = [ autoreconfHook gnum4 pkg-config python3 ];
 
   buildInputs = [ intel-gpu-tools libdrm libva libX11 libXext libGL wayland ]
     ++ stdenv.lib.optional enableHybridCodec vaapi-intel-hybrid;
@@ -42,8 +36,18 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://01.org/linuxmedia";
     license = licenses.mit;
-    description = "Intel driver for the VAAPI library";
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ ];
+    description = "VA-API user mode driver for Intel GEN Graphics family";
+    longDescription = ''
+      This VA-API video driver backend provides a bridge to the GEN GPUs through
+      the packaging of buffers and commands to be sent to the i915 driver for
+      exercising both hardware and shader functionality for video decode,
+      encode, and processing.
+      VA-API is an open-source library and API specification, which provides
+      access to graphics hardware acceleration capabilities for video
+      processing. It consists of a main library and driver-specific acceleration
+      backends for each supported hardware vendor.
+    '';
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = with maintainers; [ primeos ];
   };
 }


### PR DESCRIPTION
This doesn't cause any changes to the contents of the output path (apart
from the $out reference changing due to the modified expression).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
