### PR TITLE
librealsense: refactor to allow use of cuda, and prepare for python integration

### DIFF
--- a/pkgs/development/libraries/librealsense/default.nix
+++ b/pkgs/development/libraries/librealsense/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchFromGitHub, cmake, libusb1, ninja, pkgconfig }:
+{ stdenv, config, lib, fetchFromGitHub, cmake, libusb1, ninja, pkgconfig, gcc
+, cudaSupport ? config.cudaSupport or false, cudatoolkit
+, enablePython ? false, pythonPackages ? null }:
+
+assert cudaSupport -> cudatoolkit != null;
+assert enablePython -> pythonPackages != null;
 
 stdenv.mkDerivation rec {
   pname = "librealsense";
@@ -15,6 +20,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libusb1
+    gcc.cc.lib
+  ] ++ lib.optional cudaSupport cudatoolkit
+    ++ lib.optional enablePython pythonPackages.python;
+
+  patches = lib.optionals enablePython [
+    ./py_sitepackage_dir.patch
   ];
 
   nativeBuildInputs = [
@@ -23,7 +34,22 @@ stdenv.mkDerivation rec {
     pkgconfig
   ];
 
-  cmakeFlags = [ "-DBUILD_EXAMPLES=false" ];
+  cmakeFlags = [
+    "-DBUILD_EXAMPLES=ON"
+    "-DBUILD_GRAPHICAL_EXAMPLES=OFF"
+    "-DBUILD_GLSL_EXTENSIONS=OFF"
+  ] ++ lib.optionals enablePython [
+    "-DBUILD_PYTHON_BINDINGS:bool=true"
+    "-DXXNIX_PYTHON_SITEPACKAGES=${placeholder "out"}/${pythonPackages.python.sitePackages}"
+  ] ++ lib.optional cudaSupport "-DBUILD_WITH_CUDA:bool=true";
+
+  # ensure python package contains its __init__.py. for some reason the install
+  # script does not do this, and it's questionable if intel knows it should be
+  # done
+  # ( https://github.com/IntelRealSense/meta-intel-realsense/issues/20 )
+  postInstall = lib.optionalString enablePython  ''
+    cp ../wrappers/python/pyrealsense2/__init__.py $out/${pythonPackages.python.sitePackages}/pyrealsense2
+  '';
 
   meta = with stdenv.lib; {
     description = "A cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300)";

--- a/pkgs/development/libraries/librealsense/py_sitepackage_dir.patch
+++ b/pkgs/development/libraries/librealsense/py_sitepackage_dir.patch
@@ -1,0 +1,15 @@
+--- a/wrappers/python/CMakeLists.txt
++++ b/wrappers/python/CMakeLists.txt
+@@ -10,11 +10,11 @@
+ if (CMAKE_VERSION VERSION_LESS 3.12)
+   find_package(PythonInterp REQUIRED)
+   find_package(PythonLibs REQUIRED)
+-  set(PYTHON_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
++  set(PYTHON_INSTALL_DIR "${XXNIX_PYTHON_SITEPACKAGES}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
+   set(CMAKECONFIG_PY_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/pyrealsense2")
+ else()
+   find_package(Python REQUIRED COMPONENTS Interpreter Development)
+-  set(PYTHON_INSTALL_DIR "${Python_SITEARCH}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
++  set(PYTHON_INSTALL_DIR "${XXNIX_PYTHON_SITEPACKAGES}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
+   set(CMAKECONFIG_PY_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/pyrealsense2")
+ endif()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17708,6 +17708,14 @@ in
 
   librealsense = callPackage ../development/libraries/librealsense { };
 
+  librealsenseWithCuda = callPackage ../development/libraries/librealsense {
+    cudaSupport = true;
+  };
+
+  librealsenseWithoutCuda = callPackage ../development/libraries/librealsense {
+    cudaSupport = false;
+  };
+
   libsass = callPackage ../development/libraries/libsass { };
 
   libsepol = callPackage ../os-specific/linux/libsepol { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2620,6 +2620,21 @@ in {
 
   pyhs100 = callPackage ../development/python-modules/pyhs100 { };
 
+  pyrealsense2 = toPythonModule (pkgs.librealsense.override {
+    enablePython = true;
+    pythonPackages = self;
+  });
+
+  pyrealsense2WithCuda = toPythonModule (pkgs.librealsenseWithCuda.override {
+    enablePython = true;
+    pythonPackages = self;
+  });
+
+  pyrealsense2WithoutCuda = toPythonModule (pkgs.librealsenseWithoutCuda.override {
+    enablePython = true;
+    pythonPackages = self;
+  });
+
   pytest = if isPy3k then self.pytest_5 else self.pytest_4;
 
   pytest_5 = callPackage ../development/python-modules/pytest {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

librealsense can be compiled to use CUDA to improve some algorithms.
This patch adds two conditional parametes to add python support and cuda
support

also adds two variations (like tensorflow does):

* pkgs.librealsense (original, uses config.cudaSupport dynamically)
* pkgs.librealsenseWithCuda - forces cudaSupport
* pkgs.librealsenseWithoutCuda - forces no cudaSupport

and for python:

* pkgs.python3Packages.pyrealsense2
* pkgs.python3Packages.pyrealsense2WithCuda
* pkgs.python3Packages.pyrealsense2WithoutCuda

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).