### PR TITLE
firefox/packages: drop old aliases

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -54,23 +54,4 @@ rec {
       versionKey = "ffversion";
     };
   };
-} // lib.optionalAttrs (config.allowAliases or true) {
-  #### ALIASES
-  #### remove after 20.03 branchoff
-
-  firefox-esr-52 = throw ''
-    firefoxPackages.firefox-esr-52 was removed as it's an unsupported ESR with
-    open security issues. If you need it because you need to run some plugins
-    not having been ported to WebExtensions API, import it from an older
-    nixpkgs checkout still containing it.
-  '';
-  firefox-esr-60 = throw "firefoxPackages.firefox-esr-60 was removed as it's an unsupported ESR with open security issues.";
-
-  icecat = throw "firefoxPackages.icecat was removed as even its latest upstream version is based on an unsupported ESR release with open security issues.";
-  icecat-52 = throw "firefoxPackages.icecat was removed as even its latest upstream version is based on an unsupported ESR release with open security issues.";
-
-  tor-browser-7-5 = throw "firefoxPackages.tor-browser-7-5 was removed because it was out of date and inadequately maintained. Please use tor-browser-bundle-bin instead. See #77452.";
-  tor-browser-8-5 = throw "firefoxPackages.tor-browser-8-5 was removed because it was out of date and inadequately maintained. Please use tor-browser-bundle-bin instead. See #77452.";
-  tor-browser = throw "firefoxPackages.tor-browser was removed because it was out of date and inadequately maintained. Please use tor-browser-bundle-bin instead. See #77452.";
-
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -77,7 +77,6 @@ mapAliases ({
   clangAnalyzer = clang-analyzer;  # added 2015-02-20
   clawsMail = claws-mail; # added 2016-04-29
   clutter_gtk = clutter-gtk; # added 2018-02-25
-  conkerorWrapper = conkeror; # added 2015-01
   compton = picom; # added 2019-12-02
   compton-git = compton; # added 2019-05-20
   conntrack_tools = conntrack-tools; # added 2018-05
@@ -128,17 +127,6 @@ mapAliases ({
   firefox-esr-wrapper = firefox-esr;  # 2016-01
   firefox-wrapper = firefox;          # 2016-01
   firefoxWrapper = firefox;           # 2015-09
-  firefox-esr-52           = firefoxPackages.firefox-esr-52; # 2020-02, remove after 20.03 branchoff
-  firefox-esr-52-unwrapped = firefoxPackages.firefox-esr-52; # 2020-02, remove after 20.03 branchoff
-  firefox-esr-60           = firefoxPackages.firefox-esr-60; # 2020-02, remove after 20.03 branchoff
-  firefox-esr-60-unwrapped = firefoxPackages.firefox-esr-60; # 2020-02, remove after 20.03 branchoff
-  icecat                   = firefoxPackages.icecat;         # 2020-02, remove after 20.03 branchoff
-  icecat-unwrapped         = firefoxPackages.icecat;         # 2020-02, remove after 20.03 branchoff
-  conkeror-unwrapped       = conkeror; # 2020-02, remove after 20.03 branchoff
-  conkeror                 = throw ''
-    Conkeror doesn't work with any secure firefox release.
-    Please move to some of the alternatives at http://conkeror.org/Alternatives
-  ''; # 2020-02, remove after 20.03 branchoff
 
   firestr = throw "firestr has been removed."; # added 2019-12-08
   flameGraph = flamegraph; # added 2018-04-25


### PR DESCRIPTION
The 20.03 branch-off happened months ago