### PR TITLE
nixos/udev: use udev rules from $lib if present, otherwise $out

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -699,6 +699,12 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
      There are no functional changes, however this may require updating some configurations to use correct types for all attributes.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     In the case of multiple output derivations, the <link linkend="opt-services.udev.packages">services.udev.packages</link> option
+     now takes udev rules from <literal>lib</literal>, not <literal>bin</literal>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -190,7 +190,7 @@ in
           <filename><replaceable>pkg</replaceable>/lib/udev/rules.d</filename>
           will be included.
         '';
-        apply = map getBin;
+        apply = map getLib;
       };
 
       path = mkOption {

--- a/pkgs/development/libraries/kde-frameworks/bluez-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/bluez-qt.nix
@@ -14,6 +14,6 @@ mkDerivation {
   propagatedBuildInputs = [ qtbase ];
   preConfigure = ''
     substituteInPlace CMakeLists.txt \
-      --replace /lib/udev/rules.d "$bin/lib/udev/rules.d"
+      --replace /lib/udev/rules.d "$out/lib/udev/rules.d"
   '';
 }


### PR DESCRIPTION
`$bin` is meant for executable binaries, not udev rules, and
`./{lib,etc}/udev/rules.d` also doesn't suggest for these to be in
`$bin`.

###### Motivation for this change
I was packaging something with multiple outputs and both `$bin` and `$lib` outputs, and was wondering myself a lot on why they weren't picked up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
