### PR TITLE
wofi: Package manpages

### DIFF
--- a/pkgs/applications/misc/wofi/default.nix
+++ b/pkgs/applications/misc/wofi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchhg, fetchpatch, pkg-config, meson, ninja, wayland, gtk3, wrapGAppsHook }:
+{ stdenv, lib, fetchhg, fetchpatch, pkg-config, meson, ninja, wayland, gtk3, wrapGAppsHook, installShellFiles }:
 
 stdenv.mkDerivation rec {
   pname = "wofi";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "086j5wshawjbwdmmmldivfagc2rr7g5a2gk11l0snqqslm294xsn";
   };
 
-  nativeBuildInputs = [ pkg-config meson ninja wrapGAppsHook ];
+  nativeBuildInputs = [ pkg-config meson ninja wrapGAppsHook installShellFiles ];
   buildInputs = [ wayland gtk3 ];
 
   # Fixes icon bug on NixOS.
@@ -22,6 +22,10 @@ stdenv.mkDerivation rec {
       sha256 = "1n4jpmh66p7asjhj0z2s94ny91lmaq4hhh2356nj406vlqr15vbb";
     })
   ];
+
+  postInstall = ''
+    installManPage man/wofi*
+  '';
 
   meta = with lib; {
     description = "A launcher/menu program for wlroots based wayland compositors such as sway";


### PR DESCRIPTION
###### Motivation for this change

Wofi's manpages were not avaliable.


###### Things done

Install the shipped manpages using `installManPage`

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
