### PR TITLE
meson: 0.54.2 → 0.55.0

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -1,31 +1,19 @@
 { lib
-, python3Packages
+, python3
 , stdenv
 , writeTextDir
 , substituteAll
 , pkgsHostHost
 }:
 
-python3Packages.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "meson";
-  version = "0.54.2";
+  version = "0.55.0";
 
-  src = python3Packages.fetchPypi {
+  src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "0m84zb0q67vnxmd6ldz477w6yjdnk9c44xhlwh1g1pzqx3m6wwd7";
+    sha256 = "Chriv+KuFKxHWTU3+TKQ+3npt3XFW0xTwoK8PKN0WzU=";
   };
-
-  postFixup = ''
-    pushd $out/bin
-    # undo shell wrapper as meson tools are called with python
-    for i in *; do
-      mv ".$i-wrapped" "$i"
-    done
-    popd
-
-    # Do not propagate Python
-    rm $out/nix-support/propagated-build-inputs
-  '';
 
   patches = [
     # Upstream insists on not allowing bindir and other dir options
@@ -63,10 +51,26 @@ python3Packages.buildPythonApplication rec {
   # workaround until https://github.com/mesonbuild/meson/pull/6512 lands.
   depsHostHostPropagated = [ pkgsHostHost.stdenv.cc ];
 
+  pythonPath = [
+    python3.pkgs.setuptools # for pkg_resources
+  ];
+
   # 0.45 update enabled tests but they are failing
   doCheck = false;
   # checkInputs = [ ninja pkgconfig ];
   # checkPhase = "python ./run_project_tests.py";
+
+  postFixup = ''
+    pushd $out/bin
+    # undo shell wrapper as meson tools are called with python
+    for i in *; do
+      mv ".$i-wrapped" "$i"
+    done
+    popd
+
+    # Do not propagate Python
+    rm $out/nix-support/propagated-build-inputs
+  '';
 
   meta = with lib; {
     homepage = "https://mesonbuild.com";

--- a/pkgs/development/tools/build-managers/meson/fix-rpath.patch
+++ b/pkgs/development/tools/build-managers/meson/fix-rpath.patch
@@ -1,56 +1,24 @@
---- a/mesonbuild/linkers.py
-+++ b/mesonbuild/linkers.py
-@@ -527,8 +527,10 @@ class GnuLikeDynamicLinkerMixin:
-         # In order to avoid relinking for RPATH removal, the binary needs to contain just
-         # enough space in the ELF header to hold the final installation RPATH.
-         paths = ':'.join(all_paths)
--        if len(paths) < len(install_rpath):
--            padding = 'X' * (len(install_rpath) - len(paths))
-+        store_paths = ':'.join(filter(lambda path: path.startswith('@storeDir@'), all_paths))
-+        extra_space_needed = len(install_rpath + (':' if install_rpath and store_paths else '') + store_paths) - len(paths)
-+        if extra_space_needed > 0:
-+            padding = 'X' * extra_space_needed
-             if not paths:
-                 paths = padding
-             else:
-@@ -902,8 +904,10 @@ class SolarisDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
-         # In order to avoid relinking for RPATH removal, the binary needs to contain just
-         # enough space in the ELF header to hold the final installation RPATH.
-         paths = ':'.join(all_paths)
--        if len(paths) < len(install_rpath):
--            padding = 'X' * (len(install_rpath) - len(paths))
-+        store_paths = ':'.join(filter(lambda path: path.startswith('@storeDir@'), all_paths))
-+        extra_space_needed = len(install_rpath + (':' if install_rpath and store_paths else '') + store_paths) - len(paths)
-+        if extra_space_needed > 0:
-+            padding = 'X' * extra_space_needed
-             if not paths:
-                 paths = padding
-             else:
---- a/mesonbuild/scripts/depfixer.py
-+++ b/mesonbuild/scripts/depfixer.py
-@@ -303,6 +303,14 @@ class Elf(DataSizes):
-             return
-         self.bf.seek(rp_off)
-         old_rpath = self.read_str()
+--- a/mesonbuild/backend/backends.py
++++ b/mesonbuild/backend/backends.py
+@@ -453,6 +453,21 @@ class Backend:
+                 args.extend(self.environment.coredata.get_external_link_args(target.for_machine, lang))
+             except Exception:
+                 pass
 +
-+        if new_rpath:
-+            new_rpath += b':'
-+        else:
-+            new_rpath = b''
++        nix_ldflags = os.environ.get('NIX_LDFLAGS', '').split()
++        next_is_path = False
++        # Try to add rpaths set by user or ld-wrapper so that they are not removed.
++        # Based on https://github.com/NixOS/nixpkgs/blob/69711a2f5ffe8cda208163be5258266172ff527f/pkgs/build-support/bintools-wrapper/ld-wrapper.sh#L148-L177
++        for flag in nix_ldflags:
++            if flag == '-rpath' or flag == '-L':
++                next_is_path = True
++            elif next_is_path or flag.startswith('-L/'):
++                if flag.startswith('-L/'):
++                    flag = flag[2:]
++                if flag.startswith('@storeDir@'):
++                    dirs.add(flag)
++                next_is_path = False
 +
-+        new_rpath += b':'.join(filter(lambda path: path.startswith(b'@storeDir@'), old_rpath.split(b':')))
-+
-         if len(old_rpath) < len(new_rpath):
-             sys.exit("New rpath must not be longer than the old one.")
-         # The linker does read-only string deduplication. If there is a
-@@ -316,6 +324,10 @@ class Elf(DataSizes):
-         if not new_rpath:
-             self.remove_rpath_entry(entrynum)
-         else:
-+            # clean old rpath to avoid stale references
-+            # (see https://github.com/NixOS/nixpkgs/pull/46020)
-+            self.bf.seek(rp_off)
-+            self.bf.write(b'\0'*len(old_rpath))
-             self.bf.seek(rp_off)
-             self.bf.write(new_rpath)
-             self.bf.write(b'\0')
+         for arg in args:
+             if arg.startswith('-Wl,-rpath='):
+                 for dir in arg.replace('-Wl,-rpath=','').split(':'):


### PR DESCRIPTION
https://mesonbuild.com/Release-notes-for-0-55-0.html
https://github.com/mesonbuild/meson/releases/tag/0.55.0
https://github.com/mesonbuild/meson/compare/0.54.2...0.55.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
