### PR TITLE
oven-media-engine: init at 0.10.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4787,6 +4787,12 @@
     githubId = 34683288;
     name = "Luke Bentley-Fox";
   };
+  lukegb = {
+    email = "nix@lukegb.com";
+    github = "lukegb";
+    githubId = 246745;
+    name = "Luke Granger-Brown";
+  };
   lukego = {
     email = "luke@snabb.co";
     github = "lukego";

--- a/pkgs/servers/misc/oven-media-engine/default.nix
+++ b/pkgs/servers/misc/oven-media-engine/default.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, fetchFromGitHub
+, srt
+, ffmpeg_3_4
+, bc
+, pkgconfig
+, perl
+, openssl
+, zlib
+, ffmpeg
+, libvpx
+, libopus
+, srtp
+, jemalloc
+, ... }:
+
+let
+  ffmpeg = ffmpeg_3_4.overrideAttrs (super: {
+    pname = "${super.pname}-ovenmediaengine";
+    src = fetchFromGitHub {
+      owner = "Airensoft";
+      repo = "FFmpeg";
+      rev = "142b4bb64b64e337f80066e6af935a68627fedae";  # ome/3.4
+      sha256 = "0fla3940q3z0c0ik2xzkbvdfvrdg06ban7wi6y94y8mcipszpp11";
+    };
+  });
+in
+stdenv.mkDerivation rec {
+  pname = "oven-media-engine";
+  version = "0.10.4";
+
+  src = fetchFromGitHub {
+    owner = "AirenSoft";
+    repo = "OvenMediaEngine";
+    rev = "v${version}";
+    sha256 = "15lrlynsldlpa21ryzccf5skgiih6y5fc9qg0bfqh557wnnmml6w";
+  };
+
+  sourceRoot = "source/src";
+  makeFlags = "release CONFIG_LIBRARY_PATHS= CONFIG_PKG_PATHS= GLOBAL_CC=$(CC) GLOBAL_CXX=$(CXX) GLOBAL_LD=$(CXX) SHELL=${stdenv.shell}";
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ bc pkgconfig perl ];
+  buildInputs = [ openssl srt zlib ffmpeg libvpx libopus srtp jemalloc ];
+
+  preBuild = ''
+    patchShebangs core/colorg++
+    patchShebangs core/colorgcc
+    patchShebangs projects/main/update_git_info.sh
+
+    sed -i -e '/^CC =/d' -e '/^CXX =/d' -e '/^AR =/d' projects/third_party/pugixml-1.9/scripts/pugixml.make
+  '';
+
+  installPhase = ''
+    install -Dm0755 bin/RELEASE/OvenMediaEngine $out/bin/OvenMediaEngine
+    install -Dm0644 ../misc/conf_examples/Origin.xml $out/share/examples/origin_conf/Server.xml
+    install -Dm0644 ../misc/conf_examples/Logger.xml $out/share/examples/origin_conf/Logger.xml
+    install -Dm0644 ../misc/conf_examples/Edge.xml $out/share/examples/edge_conf/Server.xml
+    install -Dm0644 ../misc/conf_examples/Logger.xml $out/share/examples/edge_conf/Logger.xml
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Open-source streaming video service with sub-second latency";
+    homepage    = "https://ovenmediaengine.com";
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ lukegb ];
+    platforms   = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16108,6 +16108,8 @@ in
 
   osrm-backend = callPackage ../servers/osrm-backend { };
 
+  oven-media-engine = callPackage ../servers/misc/oven-media-engine { };
+
   p910nd = callPackage ../servers/p910nd { };
 
   petidomo = callPackage ../servers/mail/petidomo { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Application for ingesting RTMP and outputting other video feeds over e.g. WebRTC

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
