### PR TITLE
diskonaut: 0.3.0 -> 0.9.0

### DIFF
--- a/pkgs/tools/misc/diskonaut/default.nix
+++ b/pkgs/tools/misc/diskonaut/default.nix
@@ -2,21 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "diskonaut";
-  version = "0.3.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "imsnif";
     repo = "diskonaut";
     rev = version;
-    sha256 = "0vnmch2cac0j9b44vlcpqnayqhfdfdwvfa01bn7lwcyrcln5cd0z";
+    sha256 = "125ba9qwh7j8bz74w2zbw729s1wfnjg6dg8yicqrp6559x9k7gq5";
   };
 
-  cargoSha256 = "03hqdg6pnfxnhwk0xwhwmbrk4dicjpjllbbai56a3391xac5wmi6";
-
-  # some tests fail due to non-portable (in terms of filesystems) measurements of block sizes
-  # try to re-enable tests once actual-file-size is added
-  # see https://github.com/imsnif/diskonaut/issues/50 for more info
-  doCheck = false;
+  cargoSha256 = "0vvbrlmviyn9w8i416767vhvd1gqm3qjvia730m0rs0w5h8khiqf";
 
   meta = with stdenv.lib; {
     description = "Terminal disk space navigator";


### PR DESCRIPTION
Bump diskonaut from 0.3.0 to 0.9.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Diskonaut now measures file sizes consistently and tests can be run
without modification

discussion: https://github.com/imsnif/diskonaut/issues/50
tracking issue: https://github.com/imsnif/diskonaut/issues/56
implementation: https://github.com/imsnif/diskonaut/pull/66


###### Things done
- remove special handling for `checkPhase`
- tested on F2FS and EXT4