### PR TITLE
clickhouse-cli: init at 0.3.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9099,4 +9099,10 @@
     github = "tfmoraes";
     githubId = 351108;
   };
+  johnpyp = {
+    name = "John Paul Penaloza";
+    email = "20625636+johnpyp@users.noreply.github.com";
+    github = "johnpyp";
+    githubId = 20625636;
+  };
 }

--- a/pkgs/development/tools/database/clickhouse-cli/default.nix
+++ b/pkgs/development/tools/database/clickhouse-cli/default.nix
@@ -1,0 +1,32 @@
+{ lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "clickhouse-cli";
+  version = "0.3.6";
+
+  disabled = python3Packages.isPy27;
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "0w3bzfnmh90zywbrvzxxh9bfwf92whhx24mywa6d6iix01vmcf7v";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    click
+    prompt_toolkit
+    pygments
+    requests
+    sqlparse
+  ];
+
+  checkPhase = ''
+    $out/bin/clickhouse-cli --help > /dev/null
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/hatarist/clickhouse-cli";
+    description = "A third-party client for the Clickhouse DBMS server.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ johnpyp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15790,6 +15790,8 @@ in
     inherit (llvmPackages_9) clang-unwrapped lld lldClang llvm;
   };
 
+  clickhouse-cli = callPackage ../development/tools/database/clickhouse-cli { };
+
   couchdb = callPackage ../servers/http/couchdb {
     spidermonkey = spidermonkey_1_8_5;
     sphinx = python27Packages.sphinx;


### PR DESCRIPTION
###### Motivation for this change

Add clickhouse-cli

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
