### PR TITLE
lvm: cleanups

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -111,8 +111,8 @@ let
       copy_bin_and_libs ${pkgs.utillinux}/sbin/blkid
 
       # Copy dmsetup and lvm.
-      copy_bin_and_libs ${pkgs.lvm2}/sbin/dmsetup
-      copy_bin_and_libs ${pkgs.lvm2}/sbin/lvm
+      copy_bin_and_libs ${getBin pkgs.lvm2}/bin/dmsetup
+      copy_bin_and_libs ${getBin pkgs.lvm2}/bin/lvm
 
       # Add RAID mdadm tool.
       copy_bin_and_libs ${pkgs.mdadm}/sbin/mdadm
@@ -235,7 +235,7 @@ let
             --replace cdrom_id ${extraUtils}/bin/cdrom_id \
             --replace ${pkgs.coreutils}/bin/basename ${extraUtils}/bin/basename \
             --replace ${pkgs.utillinux}/bin/blkid ${extraUtils}/bin/blkid \
-            --replace ${pkgs.lvm2}/sbin ${extraUtils}/bin \
+            --replace ${getBin pkgs.lvm2}/bin ${extraUtils}/bin \
             --replace ${pkgs.mdadm}/sbin ${extraUtils}/sbin \
             --replace ${pkgs.bash}/bin/sh ${extraUtils}/bin/sh \
             --replace ${udev} ${extraUtils}

--- a/nixos/modules/tasks/lvm.nix
+++ b/nixos/modules/tasks/lvm.nix
@@ -1,17 +1,70 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-
-{
-
-  ###### implementation
-
-  config = mkIf (!config.boot.isContainer) {
-
-    environment.systemPackages = [ pkgs.lvm2 ];
-
-    services.udev.packages = [ pkgs.lvm2 ];
-
+let
+  cfg = config.services.lvm;
+in {
+  options.services.lvm = {
+    package = mkOption {
+      type = types.package;
+      default = if cfg.dmeventd.enable then pkgs.lvm2_dmeventd else pkgs.lvm2;
+      internal = true;
+      defaultText = "pkgs.lvm2";
+      description = ''
+        This option allows you to override the LVM package that's used on the system
+        (udev rules, tmpfiles, systemd services).
+        Defaults to pkgs.lvm2, or pkgs.lvm2_dmeventd if dmeventd is enabled.
+      '';
+    };
+    dmeventd.enable = mkEnableOption "the LVM dmevent daemon";
+    boot.thin.enable = mkEnableOption "support for booting from ThinLVs";
   };
+
+  config = mkMerge [
+    (mkIf (!config.boot.isContainer) {
+      environment.etc."tmpfiles.d/lvm2.conf".source = "${cfg.package}/lib/tmpfiles.d/lvm2.conf";
+      environment.systemPackages = [ cfg.package ];
+      systemd.packages = [ cfg.package ];
+
+      # TODO: update once https://github.com/NixOS/nixpkgs/pull/93006 was merged
+      services.udev.packages = [ cfg.package.out ];
+    })
+    (mkIf cfg.dmeventd.enable {
+      systemd.sockets."dm-event".wantedBy = [ "sockets.target" ];
+      systemd.services."lvm2-monitor".wantedBy = [ "sysinit.target" ];
+
+      environment.etc."lvm/lvm.conf".text = ''
+        dmeventd/executable = "${cfg.package}/bin/dmeventd"
+      '';
+    })
+    (mkIf cfg.boot.thin.enable {
+      boot.initrd = {
+        kernelModules = [ "dm-snapshot" "dm-thin-pool" ];
+
+        extraUtilsCommands = ''
+          copy_bin_and_libs ${pkgs.thin-provisioning-tools}/bin/pdata_tools
+          copy_bin_and_libs ${pkgs.thin-provisioning-tools}/bin/thin_check
+        '';
+      };
+
+      environment.etc."lvm/lvm.conf".text = ''
+        global/thin_check_executable = "${pkgs.thin-provisioning-tools}/bin/thin_check"
+      '';
+    })
+    (mkIf (cfg.dmeventd.enable || cfg.boot.thin.enable) {
+      boot.initrd.preLVMCommands = ''
+          mkdir -p /etc/lvm
+          cat << EOF >> /etc/lvm/lvm.conf
+          ${optionalString cfg.boot.thin.enable ''
+            global/thin_check_executable = "$(command -v thin_check)"
+          ''}
+          ${optionalString cfg.dmeventd.enable ''
+            dmeventd/executable = "$(command -v false)"
+            activation/monitoring = 0
+          ''}
+          EOF
+      '';
+    })
+  ];
 
 }

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -555,14 +555,24 @@ in {
           + " mkpart primary 2048M -1s"  # PV2
           + " set 2 lvm on",
           "udevadm settle",
+          "sleep 1",
           "pvcreate /dev/vda1 /dev/vda2",
+          "sleep 1",
           "vgcreate MyVolGroup /dev/vda1 /dev/vda2",
+          "sleep 1",
           "lvcreate --size 1G --name swap MyVolGroup",
+          "sleep 1",
           "lvcreate --size 2G --name nixos MyVolGroup",
+          "sleep 1",
           "mkswap -f /dev/MyVolGroup/swap -L swap",
           "swapon -L swap",
           "mkfs.xfs -L nixos /dev/MyVolGroup/nixos",
           "mount LABEL=nixos /mnt",
+      )
+    '';
+    postBootCommands = ''
+      assert "loaded active" in machine.succeed(
+          "systemctl list-units 'lvm2-pvscan@*' -ql --no-legend | tee /dev/stderr"
       )
     '';
   };

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -5,9 +5,13 @@
 , utillinux
 , libuuid
 , thin-provisioning-tools, libaio
+, enable_cmdlib ? false
 , enable_dmeventd ? false
 , udev ? null
 }:
+
+# configure: error: --enable-dmeventd requires --enable-cmdlib to be used as well
+assert enable_dmeventd -> enable_cmdlib;
 
 stdenv.mkDerivation rec {
   pname = "lvm2" + stdenv.lib.optionalString enable_dmeventd "with-dmeventd";
@@ -24,8 +28,8 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--disable-readline"
     "--enable-pkgconfig"
-    "--enable-cmdlib"
   ] ++ stdenv.lib.optional enable_dmeventd " --enable-dmeventd"
+  ++ stdenv.lib.optional enable_cmdlib "--enable-cmdlib"
   ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -8,6 +8,7 @@
 , enableCmdlib ? false
 , enableDmeventd ? false
 , udev ? null
+, nixosTests
 }:
 
 # configure: error: --enable-dmeventd requires --enable-cmdlib to be used as well
@@ -114,6 +115,8 @@ stdenv.mkDerivation rec {
   postInstall = stdenv.lib.optionalString (enableCmdlib != true) ''
     moveToOutput lib/libdevmapper.so $lib
   '';
+
+  passthru.tests.installer = nixosTests.installer.lvm;
 
   meta = with stdenv.lib; {
     homepage = "http://sourceware.org/lvm2/";

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -31,8 +31,14 @@ stdenv.mkDerivation rec {
     "--bindir=${placeholder "bin"}/bin"
     "--sbindir=${placeholder "bin"}/bin"
     "--libdir=${placeholder "lib"}/lib"
-  ] ++ stdenv.lib.optional enable_dmeventd " --enable-dmeventd"
-  ++ stdenv.lib.optional enable_cmdlib "--enable-cmdlib"
+    "--with-default-locking-dir=/run/lock/lvm"
+    "--with-default-run-dir=/run/lvm"
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+  ] ++ stdenv.lib.optionals enable_dmeventd [
+    "--enable-dmeventd"
+    "--with-dmeventd-pidfile=/run/dmeventd/pid"
+    "--with-default-dm-run-dir=/run/dmeventd"
+  ] ++ stdenv.lib.optional enable_cmdlib "--enable-cmdlib"
   ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -9,17 +9,13 @@
 , udev ? null
 }:
 
-let
-  version = "2.03.01";
-in
-
-{
+stdenv.mkDerivation rec {
   pname = "lvm2" + stdenv.lib.optionalString enable_dmeventd "with-dmeventd";
-  inherit version;
+  version = "2.03.09";
 
   src = fetchurl {
     url = "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${version}.tgz";
-    sha256 = "02sk6p8w3f6fpm1mrsisqfc0jnah4pzimyhm0f7c0phrfjq5hkj2";
+    sha256 = "0xdr9qbqw6kja267wmx6ajnfv1nhw056gpxx9v2qmfh3bj6qnfn0";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -53,6 +53,9 @@ stdenv.mkDerivation rec {
     sed -i /DEFAULT_PROFILE_DIR/d conf/Makefile.in
     substituteInPlace scripts/lvm2_activation_generator_systemd_red_hat.c \
       --replace /usr/bin/udevadm /run/current-system/systemd/bin/udevadm
+    # https://github.com/lvmteam/lvm2/issues/36
+    substituteInPlace udev/69-dm-lvm-metad.rules.in \
+      --replace "(BINDIR)/systemd-run" /run/current-system/systemd/bin/systemd-run
 
     substituteInPlace make.tmpl.in --replace "@systemdsystemunitdir@" "$out/lib/systemd/system"
     substituteInPlace libdm/make.tmpl.in --replace "@systemdsystemunitdir@" "$out/lib/systemd/system"

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -89,6 +89,6 @@ in
     description = "Tools to support Logical Volume Management (LVM) on Linux";
     platforms = platforms.linux;
     license = with licenses; [ gpl2 bsd2 lgpl21 ];
-    maintainers = with maintainers; [ raskin ];
+    maintainers = with maintainers; [ raskin ajs124 ];
   };
 }

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -5,16 +5,16 @@
 , utillinux
 , libuuid
 , thin-provisioning-tools, libaio
-, enable_cmdlib ? false
-, enable_dmeventd ? false
+, enableCmdlib ? false
+, enableDmeventd ? false
 , udev ? null
 }:
 
 # configure: error: --enable-dmeventd requires --enable-cmdlib to be used as well
-assert enable_dmeventd -> enable_cmdlib;
+assert enableDmeventd -> enableCmdlib;
 
 stdenv.mkDerivation rec {
-  pname = "lvm2" + stdenv.lib.optionalString enable_dmeventd "with-dmeventd";
+  pname = "lvm2" + stdenv.lib.optionalString enableDmeventd "with-dmeventd";
   version = "2.03.09";
 
   src = fetchurl {
@@ -31,12 +31,12 @@ stdenv.mkDerivation rec {
     "--with-default-locking-dir=/run/lock/lvm"
     "--with-default-run-dir=/run/lvm"
     "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
-  ] ++ stdenv.lib.optionals (!enable_cmdlib) [
+  ] ++ stdenv.lib.optionals (!enableCmdlib) [
     "--bindir=${placeholder "bin"}/bin"
     "--sbindir=${placeholder "bin"}/bin"
     "--libdir=${placeholder "lib"}/lib"
-  ] ++ stdenv.lib.optional enable_cmdlib "--enable-cmdlib"
-  ++ stdenv.lib.optionals enable_dmeventd [
+  ] ++ stdenv.lib.optional enableCmdlib "--enable-cmdlib"
+  ++ stdenv.lib.optionals enableDmeventd [
     "--enable-dmeventd"
     "--with-dmeventd-pidfile=/run/dmeventd/pid"
     "--with-default-dm-run-dir=/run/dmeventd"
@@ -106,12 +106,12 @@ stdenv.mkDerivation rec {
     "out"
     "dev"
     "man"
-  ] ++ stdenv.lib.optionals (enable_cmdlib != true) [
+  ] ++ stdenv.lib.optionals (enableCmdlib != true) [
     "bin"
     "lib"
   ];
 
-  postInstall = stdenv.lib.optionalString (enable_cmdlib != true) ''
+  postInstall = stdenv.lib.optionalString (enableCmdlib != true) ''
     moveToOutput lib/libdevmapper.so $lib
   '';
 

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -28,6 +28,9 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--disable-readline"
     "--enable-pkgconfig"
+    "--bindir=${placeholder "bin"}/bin"
+    "--sbindir=${placeholder "bin"}/bin"
+    "--libdir=${placeholder "lib"}/lib"
   ] ++ stdenv.lib.optional enable_dmeventd " --enable-dmeventd"
   ++ stdenv.lib.optional enable_cmdlib "--enable-cmdlib"
   ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
@@ -87,6 +90,12 @@ stdenv.mkDerivation rec {
     "install_systemd_units"
     "install_tmpfiles_configuration"
   ];
+
+  postInstall = ''
+    moveToOutput lib/libdevmapper.so $lib
+  '';
+
+  outputs = [ "out" "bin" "lib" "dev" "man" ];
 
   meta = with stdenv.lib; {
     homepage = "http://sourceware.org/lvm2/";

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -1,6 +1,6 @@
 { stdenv
-, fetchgit
 , fetchpatch
+, fetchurl
 , pkgconfig
 , utillinux
 , libuuid
@@ -17,10 +17,9 @@ in
   pname = "lvm2" + stdenv.lib.optionalString enable_dmeventd "with-dmeventd";
   inherit version;
 
-  src = fetchgit {
-    url = "git://sourceware.org/git/lvm2.git";
-    rev = "v${builtins.replaceStrings [ "." ] [ "_" ] version}";
-    sha256 = "0jlaswf1srdxiqpgpp97j950ddjds8z0kr4pbwmal2za2blrgvbl";
+  src = fetchurl {
+    url = "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${version}.tgz";
+    sha256 = "02sk6p8w3f6fpm1mrsisqfc0jnah4pzimyhm0f7c0phrfjq5hkj2";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -49,6 +49,11 @@ stdenv.mkDerivation rec {
     substituteInPlace libdm/make.tmpl.in --replace "@systemdsystemunitdir@" "$out/lib/systemd/system"
   '';
 
+  postConfigure = ''
+    sed -i 's|^#define LVM_CONFIGURE_LINE.*$|#define LVM_CONFIGURE_LINE "<removed>"|g' ./include/configure.h
+  '';
+
+
   patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {
       name = "fix-stdio-usage.patch";

--- a/pkgs/os-specific/linux/lvm2/default.upstream
+++ b/pkgs/os-specific/linux/lvm2/default.upstream
@@ -1,4 +1,0 @@
-url ftp://sources.redhat.com/pub/lvm2/
-version_link '[.]tgz$'
-version '.*[^0-9.][^.]*[.]([0-9.]+)[.].*' '\1'
-do_overwrite () { do_overwrite_just_version; }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -557,6 +557,7 @@ mapAliases ({
   surf-webkit2 = surf; # added 2017-04-02
   sup = throw "deprecated in 2019-09-10: abandoned by upstream";
   system_config_printer = system-config-printer;  # added 2016-01-03
+  systemd_with_lvm2 = throw "obsolete, enabled by default via the lvm module"; # added 2020-07-12
   systool = sysfsutils; # added 2018-04-25
   tahoelafs = tahoe-lafs; # added 2018-03-26
   tangogps = foxtrotgps; # added 2020-01-26

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17521,8 +17521,8 @@ in
 
   lvm2 = callPackage ../os-specific/linux/lvm2 { };
   lvm2_dmeventd = callPackage ../os-specific/linux/lvm2 {
-    enable_dmeventd = true;
-    enable_cmdlib = true;
+    enableDmeventd = true;
+    enableCmdlib = true;
   };
 
   mbpfan = callPackage ../os-specific/linux/mbpfan { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16817,7 +16817,7 @@ in
 
   directvnc = callPackage ../os-specific/linux/directvnc { };
 
-  dmraid = callPackage ../os-specific/linux/dmraid { };
+  dmraid = callPackage ../os-specific/linux/dmraid { lvm2 = lvm2_dmeventd; };
 
   drbd = callPackage ../os-specific/linux/drbd { };
 
@@ -17520,6 +17520,10 @@ in
   lsscsi = callPackage ../os-specific/linux/lsscsi { };
 
   lvm2 = callPackage ../os-specific/linux/lvm2 { };
+  lvm2_dmeventd = callPackage ../os-specific/linux/lvm2 {
+    enable_dmeventd = true;
+    enable_cmdlib = true;
+  };
 
   mbpfan = callPackage ../os-specific/linux/mbpfan { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16817,9 +16817,7 @@ in
 
   directvnc = callPackage ../os-specific/linux/directvnc { };
 
-  dmraid = callPackage ../os-specific/linux/dmraid {
-    lvm2 = lvm2.override {enable_dmeventd = true;};
-  };
+  dmraid = callPackage ../os-specific/linux/dmraid { };
 
   drbd = callPackage ../os-specific/linux/drbd { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17842,14 +17842,6 @@ in
   # standalone cryptsetup generator for systemd
   systemd-cryptsetup-generator = callPackage ../os-specific/linux/systemd/cryptsetup-generator.nix { };
 
-  # In nixos, you can set systemd.package = pkgs.systemd_with_lvm2 to get
-  # LVM2 working in systemd.
-  systemd_with_lvm2 = pkgs.appendToName "with-lvm2" (pkgs.lib.overrideDerivation pkgs.systemd (p: {
-      postInstall = p.postInstall + ''
-        cp "${pkgs.lvm2}/lib/systemd/system-generators/"* $out/lib/systemd/system-generators
-      '';
-  }));
-
   systemd-wait = callPackage ../os-specific/linux/systemd-wait { };
 
   sysvinit = callPackage ../os-specific/linux/sysvinit { };


### PR DESCRIPTION
This includes quite some fixes to lvm2 accumulated while working on enabling cryptsetup support in systemd (https://github.com/NixOS/nixpkgs/pull/66856). I intend to rebase #66856 on top of the changes here.

lvm2 is now a multi-output derivation, which helps for closure size reduction, but also becomes necessary as soon as you try to build systemd with cryptsetup support (that requires the libdevmapper component of lvm2) - due to lvm itself also containing references to libsystemd (via their shipped systemd generators).

Properly splitting this avoids getting rid of hacks like `systemd_with_lvm2`.

This also contains quite some cleanups in the unit itself, making it more maintainable in the longer run.

```
nixos/tests/installer: lvm: test lvm2-pvscan@ units
nixos/test/installer: add postBootCommands
systemd_with_lvm2: remove
nixos/tasks/lvm: add dmeventd and lvmthin support
lvm2: only split bin and lib out from out if cmdlib isn't enabled
lvm2: fix location to systemd-run invocation
lvm2: fix paths to use /run instead of /var/run.
lvm2: add multiple output support
lvm2: don't embed ./configure line in lvm2 binary
lvm2: make --enable-cmdlib optional
lvm2: 2.03.01 -> 2.03.09
lvm2: fetch sources from http instead of git
lvm2: add myself as maintainer
lvm2: cleanups, make udev optional
lvm2: remove unused default.upstream file
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
