### PR TITLE
wormhole-william: init at v1.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6432,6 +6432,12 @@
       fingerprint = "86E6 792F C27B FD47 8860  C110 91F3 B339 B9A0 2A3D";
     }];
   };
+  psanford = {
+    email = "psanford@sanford.io";
+    github = "psanford";
+    githubId = 33375;
+    name = "Peter Sanford";
+  };
   pshendry = {
     email = "paul@pshendry.com";
     github = "pshendry";

--- a/pkgs/tools/networking/wormhole-william/default.nix
+++ b/pkgs/tools/networking/wormhole-william/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "wormhole-william";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "psanford";
+    repo = "wormhole-william";
+    rev = "v${version}";
+    sha256 = "1v6kw10gqhyd1adj0wwrr5bmpjqbshdnywsrjpqgg9bl61m5j3wr";
+  };
+
+  vendorSha256 = "1niky252gcxai6vz0cx7pvflg530bc1lmcd2wm2hqg6446r1yxsq";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/psanford/wormhole-william";
+    description = "End-to-end encrypted file transfers";
+    changelog = "https://github.com/psanford/wormhole-william/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ psanford ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7545,6 +7545,8 @@ in
     inherit (xorg) libxkbfile;
   };
 
+  wormhole-william = callPackage ../tools/networking/wormhole-william { };
+
   wpscan = callPackage ../tools/security/wpscan { };
 
   wsmancli = callPackage ../tools/system/wsmancli {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add package for `wormhole-william` end-to-end encrypted file transfer tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
