### PR TITLE
dsd: init at 2018-07-01

### DIFF
--- a/pkgs/applications/radio/dsd/default.nix
+++ b/pkgs/applications/radio/dsd/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchFromGitHub, cmake
+, mbelib, libsndfile, itpp
+, portaudioSupport ? true, portaudio ? null
+}:
+
+assert portaudioSupport -> portaudio != null;
+
+stdenv.mkDerivation rec {
+  pname = "dsd";
+  version = "2018-07-01";
+
+  src = fetchFromGitHub {
+    owner = "szechyjs";
+    repo = "dsd";
+    rev = "f175834e45a1a190171dff4597165b27d6b0157b";
+    sha256 = "0w4r13sxvjwacdwxr326zr6p77a8p6ny0g6im574jliw5j3shlhr";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    mbelib libsndfile itpp
+  ] ++ stdenv.lib.optionals portaudioSupport [ portaudio ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+  preCheck = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD
+    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Digital Speech Decoder";
+    longDescription = ''
+      DSD is able to decode several digital voice formats from discriminator
+      tap audio and synthesize the decoded speech. Speech synthesis requires
+      mbelib, which is a separate package.
+    '';
+    homepage = https://github.com/szechyjs/dsd;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ andrew-d ];
+  };
+}

--- a/pkgs/development/libraries/audio/mbelib/default.nix
+++ b/pkgs/development/libraries/audio/mbelib/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "mbelib";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "szechyjs";
+    repo = "mbelib";
+    rev = "v${version}";
+    sha256 = "0v6b7nf8fgxy7vzgcwffqyql5zhldrz30c88k1ylbjp78hwh4rif";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+  preCheck = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD
+    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD
+  '';
+
+  meta = with stdenv.lib; {
+    description = "P25 Phase 1 and ProVoice vocoder";
+    homepage = https://github.com/szechyjs/mbelib;
+    license = licenses.isc;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ andrew-d ];
+  };
+}

--- a/pkgs/development/libraries/science/math/itpp/default.nix
+++ b/pkgs/development/libraries/science/math/itpp/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, fetchurl
+, cmake
+, gtest
+, blas
+, fftw
+, liblapack
+, gfortran
+}:
+
+stdenv.mkDerivation rec {
+  pname = "it++";
+  version = "4.3.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/itpp/itpp-${version}.tar.bz2";
+    sha256 = "0xxqag9wi0lg78xgw7b40rp6wxqp5grqlbs9z0ifvdfzqlhpcwah";
+  };
+
+  nativeBuildInputs = [ cmake gfortran ];
+  buildInputs = [
+    fftw
+    liblapack
+
+    # NOTE: OpenBLAS doesn't work here because IT++ doesn't pass aligned
+    # buffers, which causes segfaults in the optimized kernels :-(
+    blas
+  ];
+
+  cmakeFlags = [
+    "-DBLAS_FOUND:BOOL=TRUE"
+    "-DBLAS_LIBRARIES:STRING=${blas}/lib/libblas.so"
+    "-DLAPACK_FOUND:BOOL=TRUE"
+    "-DLAPACK_LIBRARIES:STRING=${liblapack}/lib/liblapack.so"
+    "-DGTEST_DIR:PATH=${gtest.src}/googletest"
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  checkPhase = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD/itpp
+    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD/itpp
+    ./gtests/itpp_gtests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "IT++ is a C++ library of mathematical, signal processing and communication classes and functions.";
+    homepage = http://itpp.sourceforge.net/;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ andrew-d ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16961,6 +16961,8 @@ in
 
   irqbalance = callPackage ../os-specific/linux/irqbalance { };
 
+  itpp = callPackage ../development/libraries/science/math/itpp { };
+
   iw = callPackage ../os-specific/linux/iw { };
 
   iwd = callPackage ../os-specific/linux/iwd { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17534,6 +17534,8 @@ in
 
   lvm2 = callPackage ../os-specific/linux/lvm2 { };
 
+  mbelib = callPackage ../development/libraries/audio/mbelib { };
+
   mbpfan = callPackage ../os-specific/linux/mbpfan { };
 
   mdadm = mdadm4;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16836,6 +16836,8 @@ in
 
   dropwatch = callPackage ../os-specific/linux/dropwatch { };
 
+  dsd = callPackage ../applications/radio/dsd { };
+
   dstat = callPackage ../os-specific/linux/dstat { };
 
   # unstable until the first 1.x release


### PR DESCRIPTION

###### Motivation for this change
Add a new package, `dsd`, which is a common ham radio library for decoding digital voice:

> DSD is able to decode several digital voice formats from discriminator tap audio and synthesize the decoded speech.

Also add the two required libraries that aren't already in Nixpkgs: `mbelib`, by the same author as `dsd`, and `IT++`, a C++ signal processing library (http://itpp.sourceforge.net/4.3.1/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Picking a few reviewers for things that are SDR/radio-related:
r? @bjornfor @fpletz @Alkeryn 