### PR TITLE
flatpak-builder: 1.0.10 → 1.0.11

### DIFF
--- a/pkgs/development/tools/flatpak-builder/default.nix
+++ b/pkgs/development/tools/flatpak-builder/default.nix
@@ -46,13 +46,13 @@ let
   installed_test_metadir = "${placeholder "installedTests"}/share/installed-tests/flatpak-builder";
 in stdenv.mkDerivation rec {
   pname = "flatpak-builder";
-  version = "1.0.10";
+  version = "1.0.11";
 
   outputs = [ "out" "doc" "man" "installedTests" ];
 
   src = fetchurl {
     url = "https://github.com/flatpak/flatpak-builder/releases/download/${version}/${pname}-${version}.tar.xz";
-    sha256 = "1fn61cl1d33yd1jgqm8jpffjw3xlyyhkn032g14d9gnwkcaf4649";
+    sha256 = "EYNLdrvSs8S/GCYy0jGsnP1+C988y1j7WzcLfczM1Ew=";
   };
 
   nativeBuildInputs = [
@@ -87,9 +87,11 @@ in stdenv.mkDerivation rec {
   patches = [
     # patch taken from gtk_doc
     ./respect-xml-catalog-files-var.patch
+
+    # Hardcode paths
     (substituteAll {
       src = ./fix-paths.patch;
-      bzr = "${breezy}/bin/bzr";
+      brz = "${breezy}/bin/brz";
       cp = "${coreutils}/bin/cp";
       patch = "${patch}/bin/patch";
       tar = "${gnutar}/bin/tar";

--- a/pkgs/development/tools/flatpak-builder/fix-paths.patch
+++ b/pkgs/development/tools/flatpak-builder/fix-paths.patch
@@ -1,5 +1,16 @@
+diff --git a/src/builder-context.c b/src/builder-context.c
+index dde12790..3a379297 100644
 --- a/src/builder-context.c
 +++ b/src/builder-context.c
+@@ -256,7 +256,7 @@ builder_context_init (BuilderContext *self)
+   g_autofree char *path = NULL;
+ 
+   self->rofiles_file_lock = init;
+-  path = g_find_program_in_path ("rofiles-fuse");
++  path = g_find_program_in_path ("@rofilesfuse@");
+   self->have_rofiles = path != NULL;
+ }
+ 
 @@ -800,7 +800,7 @@ builder_context_enable_rofiles (BuilderContext *self,
    g_autoptr(GFile) rofiles_base = NULL;
    g_autoptr(GFile) rofiles_dir = NULL;
@@ -9,6 +20,8 @@
                     "-o",
                     "kernel_cache,entry_timeout=60,attr_timeout=60,splice_write,splice_move",
                     (char *)flatpak_file_get_path_cached (self->app_dir),
+diff --git a/src/builder-git.c b/src/builder-git.c
+index ef517adb..6ab095f0 100644
 --- a/src/builder-git.c
 +++ b/src/builder-git.c
 @@ -44,7 +44,7 @@ git (GFile   *dir,
@@ -29,6 +42,8 @@
    va_end (ap);
  
    return res;
+diff --git a/src/builder-source-archive.c b/src/builder-source-archive.c
+index 3c694e57..0de62318 100644
 --- a/src/builder-source-archive.c
 +++ b/src/builder-source-archive.c
 @@ -443,7 +443,7 @@ tar (GFile   *dir,
@@ -67,17 +82,21 @@
    va_end (ap);
  
    return res;
+diff --git a/src/builder-source-bzr.c b/src/builder-source-bzr.c
+index ceeec94a..8abe6f53 100644
 --- a/src/builder-source-bzr.c
 +++ b/src/builder-source-bzr.c
 @@ -124,7 +124,7 @@ bzr (GFile   *dir,
+   gboolean res;
    va_list ap;
  
-   va_start (ap, error);
--  res = flatpak_spawn (dir, output, 0, error, "bzr", ap);
-+  res = flatpak_spawn (dir, output, 0, error, "@bzr@", ap);
-   va_end (ap);
+-  brz = g_find_program_in_path ("brz");
++  brz = g_find_program_in_path ("@brz@");
  
-   return res;
+   va_start (ap, error);
+   res = flatpak_spawn (dir, output, 0, error, brz ? brz : "bzr", ap);
+diff --git a/src/builder-source-patch.c b/src/builder-source-patch.c
+index 8721e1e4..d7f4d840 100644
 --- a/src/builder-source-patch.c
 +++ b/src/builder-source-patch.c
 @@ -247,15 +247,15 @@ patch (GFile      *dir,
@@ -99,6 +118,8 @@
    }
    for (i = 0; extra_options != NULL && extra_options[i] != NULL; i++)
      g_ptr_array_add (args, (gchar *) extra_options[i]);
+diff --git a/src/builder-utils.c b/src/builder-utils.c
+index f1c06db5..2e3347c5 100644
 --- a/src/builder-utils.c
 +++ b/src/builder-utils.c
 @@ -149,7 +149,7 @@ strip (GError **error,


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


https://github.com/flatpak/flatpak-builder/releases/tag/1.0.11

Also try to fix: #73325



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
