### PR TITLE
gitAndTools.delta: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/delta/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/delta/default.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "delta";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "dandavison";
     repo = pname;
     rev = version;
-    sha256 = "15c7rsmiinnpxh12520jz3wr0j86vgzjq1ss5pf30fa7lcgicb32";
+    sha256 = "0y3gkan5v0d6637yf5p5a9dklyv5zngw7a8pyqzj4ixys72ixg20";
   };
 
-  cargoSha256 = "0lzz32qh80s4dxr0d4pg0qagkn549lr4vbqknl2l0cmlq1bvvq6g";
+  cargoSha256 = "15sh2lsc16nf9w7sp3avy77f4vyj0rdsm6m1bn60y8gmv2r16v6i";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
###### Motivation for this change

New upstream release: [0.3.0](https://github.com/dandavison/delta/releases/tag/0.3.0)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
