### PR TITLE
libupnp: 1.12.0 -> 1.14.0

### DIFF
--- a/pkgs/development/libraries/pupnp/default.nix
+++ b/pkgs/development/libraries/pupnp/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libupnp";
-  version = "1.12.0";
+  version = "1.14.0";
 
   src = fetchFromGitHub {
     owner = "mrjimenez";
     repo = "pupnp";
     rev = "release-${version}";
-    sha256 = "17jhbzx8khz5vbl0lhcipjzgg897p1k2lp5wcc3hiddcfyh05pdj";
+    sha256 = "1wp9sz2ld4g6ak9v59i3s5mbsraxsphi9k91vw9xgrbzfmg8w0a6";
   };
   outputs = [ "dev" "out" ];
 


### PR DESCRIPTION
Trying to package gerbera (upnp media server) which requires at least that
dependency version in its build recipe.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS,
   - [ ] macOS
   - [x] other: debian with nix
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nixpkgs-review pr 93048` [1]
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Impact on package closure size: + 1352 (33560928 -> 33562280)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

[1] 3 packages broke with this, last one (obs-ndi is in the same state as master, needs a license to build):
```
$ nix-shell -p nixpkgs-review --run "nixpkgs-review pr 93048"
...
6 package marked as broken and skipped:
libsForQt5.vlc libsForQt512.vlc libsForQt514.vlc retroshare retroshare06 ring-daemon

4 package failed to build:
amule amuleDaemon gmrender-resurrect obs-ndi
```

Those 3 are fixed with the following PR:
- amule, amuleDaemon: #99893
- gmrender-resurrect: #99899
