### PR TITLE
amd-blis: init at 2.2

### DIFF
--- a/pkgs/development/libraries/science/math/amd-blis/default.nix
+++ b/pkgs/development/libraries/science/math/amd-blis/default.nix
@@ -1,0 +1,67 @@
+{ stdenv
+, fetchFromGitHub
+, perl
+, python3
+
+# Enable BLAS interface with 64-bit integer width.
+, blas64 ? false
+
+# Target architecture, use "zen" or "zen2", optimization for Zen and
+# other families is pretty much mutually exclusive in the AMD fork of
+# BLIS.
+, withArchitecture ? "zen"
+
+# Enable OpenMP-based threading.
+, withOpenMP ? true
+}:
+
+let
+  threadingSuffix = if withOpenMP then "-mt" else "";
+  blasIntSize = if blas64 then "64" else "32";
+in stdenv.mkDerivation rec {
+  pname = "amd-blis";
+  version = "2.2";
+
+  src = fetchFromGitHub {
+    owner = "amd";
+    repo = "blis";
+    rev = version;
+    sha256 = "1b2f5bwi0gkw2ih2rb7wfzn3m9hgg7k270kg43rmzpr2acpy86xa";
+  };
+
+  inherit blas64;
+
+  nativeBuildInputs = [
+    perl
+    python3
+  ];
+
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--enable-cblas"
+    "--blas-int-size=${blasIntSize}"
+  ] ++ stdenv.lib.optionals withOpenMP [ "--enable-threading=openmp" ]
+    ++ [ withArchitecture ];
+
+  postPatch = ''
+    patchShebangs configure build/flatten-headers.py
+  '';
+
+  postInstall = ''
+    ln -s $out/lib/libblis${threadingSuffix}.so.2 $out/lib/libblas.so.3
+    ln -s $out/lib/libblis${threadingSuffix}.so.2 $out/lib/libcblas.so.3
+    ln -s $out/lib/libblas.so.3 $out/lib/libblas.so
+    ln -s $out/lib/libcblas.so.3 $out/lib/libcblas.so
+  '';
+
+  meta = with stdenv.lib; {
+    description = "BLAS-compatible library optimized for AMD CPUs";
+    homepage = "https://developer.amd.com/amd-aocl/blas-library/";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.danieldk ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25033,6 +25033,8 @@ in
 
   almonds = callPackage ../applications/science/math/almonds { };
 
+  amd-blis = callPackage ../development/libraries/science/math/amd-blis { };
+
   arpack = callPackage ../development/libraries/science/math/arpack { };
 
   blas = callPackage ../build-support/alternatives/blas { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add BLIS optimized for AMD Zen CPUs.

We compile specifically for Zen:

- Zen/Zen2 are not included in the x86_64 or amd64 configurations.
- Including them breaks AMD BLIS in other places, since some functions
  have Zen-specific definitions that fail on other platforms.

Non-Zen CI runners will succeed when they are Haswell or later, since
a Haswell kernel is compiled as a dependency.

Tested: building numpy against AMD BLIS.

This is a resubmission of #92981.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
