### PR TITLE
ubidump: init at unstable-2019-09-11

### DIFF
--- a/pkgs/tools/filesystems/ubidump/default.nix
+++ b/pkgs/tools/filesystems/ubidump/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, python3, makeWrapper }:
+
+python3.pkgs.buildPythonApplication rec {
+
+  pname = "ubidump";
+  version = "unstable-2019-09-11";
+
+  src = fetchFromGitHub {
+    owner = "nlitsme";
+    repo = pname;
+    rev = "0691f1a9a38604c2baf8c9af6b826eb2632af74a";
+    sha256 = "1hiivlgni4r3nd5n2rzl5qzw6y2wpjpmyls5lybrc8imd6rmj3w2";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [ crcmod python-lzo ];
+
+  phases = [ "unpackPhase" "patchPhase" "installPhase" "installCheckPhase" ];
+
+  patchPhase = ''
+    sed -i '1s;^;#!${python3.interpreter}\n;' ubidump.py
+    patchShebangs ubidump.py
+  '';
+
+  installPhase = ''
+    install -D -m755 ubidump.py $out/bin/ubidump
+    wrapProgram $out/bin/ubidump --set PYTHONPATH $PYTHONPATH
+  '';
+
+  installCheckPhase = ''
+    $out/bin/ubidump -h  > /dev/null
+  '';
+
+  meta = with stdenv.lib; {
+    description = "View or extract the contents of UBIFS images";
+    homepage = "https://github.com/nlitsme/ubidump";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sgo ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7597,6 +7597,8 @@ in
 
   ua = callPackage ../tools/networking/ua { };
 
+  ubidump = python3Packages.callPackage ../tools/filesystems/ubidump { };
+
   ubridge = callPackage ../tools/networking/ubridge { };
 
   ucl = callPackage ../development/libraries/ucl { };


### PR DESCRIPTION
###### Motivation for this change

Adds the `ubidump` utility which is useful for inspecting and dumping UBIFS images.

https://github.com/nlitsme/ubidump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
