### PR TITLE
gscan2pdf: 2.8.0 -> 2.8.1

### DIFF
--- a/pkgs/applications/graphics/gscan2pdf/default.nix
+++ b/pkgs/applications/graphics/gscan2pdf/default.nix
@@ -10,11 +10,11 @@ with stdenv.lib;
 
 perlPackages.buildPerlPackage rec {
   pname = "gscan2pdf";
-  version = "2.8.0";
+  version = "2.8.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/gscan2pdf/${version}/${pname}-${version}.tar.xz";
-    sha256 = "0rqx41hkppil3lp1dhkxwlhv0kwp8w8fkgzlapryq1yd9pgkx6lw";
+    sha256 = "00g2vw7lz3yb4nq358x8d3r4mf3hkrq2vw1g9lli27zdp5p6jja1";
   };
 
   nativeBuildInputs = [ wrapGAppsHook ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump for gscan2pdf.
```
Changelog for 2.8.1:
* Pass resolution to tesseract to avoid messages like
  "Warning! Invalid resolution 0 dpi. Using 70 instead"
* Cope better if data model becomes corrupted
* + restart option to 'device not found' mini-wizard & if tmp directory
  changed.
* When saving a session file, note that pages have been saved to avoid
  'Some pages have not been saved. Do you really want to quit?' message.
* Improvements to the Crashed sessions dialog to make it more intuitive.
* Update position of OCR text when cropping
* Create PS level 3 instead of 1.
* Fix check for unpaper version. Closes #285 (Scan fails if unpaper is
  not installed but selected in post processing)
* Fix check for tesseract version. Remove support for
  tesseract < 3.04.00.
* Update to Hungarian translation (thanks to csola)
* Update to Brazilian Portuguese translation (thanks to Arthur
  Rodrigues)
* Update to German translation (thanks to Matthias Sprau)
* Update to Ukrainian translation (thanks to Yuri Chornoivan)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
