### PR TITLE
nrfutil: 5.2 -> 6.1, pc-ble-driver-py: 0.11.4 -> 0.14.2, py-ble-driver: init at 4.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3959,6 +3959,12 @@
     githubId = 4611077;
     name = "Raymond Gauthier";
   };
+  jschievink = {
+    email = "jonasschievink@gmail.com";
+    github = "jonas-schievink";
+    githubId = 1786438;
+    name = "Jonas Schievink";
+  };
   jtcoolen = {
     email = "jtcoolen@pm.me";
     name = "Julien Coolen";

--- a/pkgs/development/libraries/pc-ble-driver/default.nix
+++ b/pkgs/development/libraries/pc-ble-driver/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, git, cmake, catch2, asio, udev }:
+
+stdenv.mkDerivation rec {
+  pname = "pc-ble-driver";
+  version = "4.1.1";
+
+  src = fetchFromGitHub {
+    owner = "NordicSemiconductor";
+    repo = "pc-ble-driver";
+    rev = "v${version}";
+    sha256 = "1llhkpbdbsq9d91m873vc96bprkgpb5wsm5fgs1qhzdikdhg077q";
+  };
+
+  cmakeFlags = [
+    "-DNRF_BLE_DRIVER_VERSION=${version}"
+  ];
+
+  nativeBuildInputs = [ cmake git ];
+  buildInputs = [ catch2 asio udev ];
+
+  meta = with stdenv.lib; {
+    description = "Desktop library for Bluetooth low energy development";
+    homepage = "https://github.com/NordicSemiconductor/pc-ble-driver";
+    license = licenses.unfreeRedistributable;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jschievink ];
+  };
+}

--- a/pkgs/development/python-modules/pc-ble-driver-py/default.nix
+++ b/pkgs/development/python-modules/pc-ble-driver-py/default.nix
@@ -1,45 +1,25 @@
-{ stdenv, buildPythonPackage, fetchpatch, fetchFromGitHub,
-  python, cmake, git, swig, boost, udev,
-  setuptools, enum34, wrapt, future }:
+{ stdenv, fetchFromGitHub, cmake, git, swig, boost, udev, pc-ble-driver
+, buildPythonPackage, enum34, wrapt, future, setuptools, scikit-build }:
 
 buildPythonPackage rec {
   pname = "pc-ble-driver-py";
-  version = "0.11.4";
-  disabled = python.isPy3k;
+  version = "0.14.2";
 
   src = fetchFromGitHub {
     owner = "NordicSemiconductor";
     repo = "pc-ble-driver-py";
     rev = "v${version}";
-    fetchSubmodules = true;
-    sha256 = "0lgmcnrlcivmawmlcwnn4pdp6afdbnf3fyfgq22xzs6v72m9gp81";
+    sha256 = "1zbi3v4jmgq1a3ml34dq48y1hinw2008vwqn30l09r5vqvdgnj8m";
   };
 
-  nativeBuildInputs = [ cmake swig git setuptools ];
-  buildInputs = [ boost udev ];
+  # doCheck tries to write to the global python directory to install things
+  doCheck = false;
+
+  nativeBuildInputs = [ cmake swig git setuptools scikit-build ];
+  buildInputs = [ boost udev pc-ble-driver ];
   propagatedBuildInputs = [ enum34 wrapt future ];
 
-  patches = [
-    # build system expects case-insensitive file system
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/NordicSemiconductor/pc-ble-driver-py/pull/84.patch";
-      sha256 = "0ibx5g2bndr5h9sfnx51bk9b62q4jvpdwhxadbnj3da8kvcz13cy";
-    })
-  ];
-
-  postPatch = ''
-    # do not force static linking of boost
-    sed -i /Boost_USE_STATIC_LIBS/d pc-ble-driver/cmake/*.cmake
-
-    cd python
-  '';
-
-  preBuild = ''
-    pushd ../build
-    cmake ..
-    make -j $NIX_BUILD_CORES
-    popd
-  '';
+  dontUseCmakeConfigure = true;
 
   meta = with stdenv.lib; {
     description = "Bluetooth Low Energy nRF5 SoftDevice serialization";

--- a/pkgs/development/tools/misc/nrfutil/default.nix
+++ b/pkgs/development/tools/misc/nrfutil/default.nix
@@ -1,25 +1,22 @@
-{ stdenv, python2Packages, fetchFromGitHub }:
+{ stdenv, python37Packages, fetchFromGitHub }:
 
-with python2Packages; buildPythonApplication rec {
+with python37Packages; buildPythonApplication rec {
   pname = "nrfutil";
-  version = "5.2.0";
+  version = "6.1";
 
   src = fetchFromGitHub {
     owner = "NordicSemiconductor";
     repo = "pc-nrfutil";
     rev = "v${version}";
-    sha256 = "1hajjgz8r4fjbwqr22p5dvb6k83dpxf8k7mhx20gkbrrx9ivqh79";
+    sha256 = "0g43lf5jmk0qxb7r4h68wr38fli6pjjk67w8l2cpdm9rd8jz4lpn";
   };
 
-  propagatedBuildInputs = [ pc-ble-driver-py six pyserial enum34 click ecdsa
+  propagatedBuildInputs = [ pc-ble-driver-py six pyserial enum34  click ecdsa
     protobuf tqdm piccata pyspinel intelhex pyyaml crcmod libusb1 ipaddress ];
 
   checkInputs = [ nose behave ];
 
   postPatch = ''
-    # remove version bound on pyyaml
-    sed -i /pyyaml/d requirements.txt
-
     mkdir test-reports
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21354,6 +21354,8 @@ in
 
   partio = callPackage ../development/libraries/partio {};
 
+  pc-ble-driver = callPackage ../development/libraries/pc-ble-driver {};
+
   pbis-open = callPackage ../tools/security/pbis { };
 
   pcmanfm = callPackage ../applications/misc/pcmanfm { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix the build of nrfutil by updating it and its dependencies.

cc @gebner

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
