### PR TITLE
diffoscope: 150 -> 151

### DIFF
--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -16,11 +16,11 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "diffoscope";
-  version = "150";
+  version = "151";
 
   src = fetchurl {
     url    = "https://diffoscope.org/archive/diffoscope-${version}.tar.bz2";
-    sha256 = "0hsjhcaka4nxbwyyk2gajblsp648km9492aq4100drsgnj5d36hg";
+    sha256 = "180sfk0jfajkn3w3d4bw8ai25wh1bj7ca05lpsxxj7k472w6fsg9";
   };
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump for diffoscope.

Changelog:

```
[ Chris Lamb]

* Improvements and bug fixes:

  - Pass the absolute path when extracting members from SquashFS images as we
    run the command with our working directory set to the temporary
    directory. (Closes: #964365, reproducible-builds/diffoscope#189)
  - Increase the minimum length of the output from strings(1) to 8 characters
    to avoid unnecessary diff noise. (Re. reproducible-builds/diffoscope#148)

* Logging improvements:

  - Fix the compare_files message when the file does not have a literal name.
  - Reduce potential log noise by truncating the has_some_content messages.

* Codebase changes:

  - Clarify use of a "null" diff in order to remember an exit code.
  - Don't alias a variable when don't end up it; use "_" instead.
  - Use a  "NullChanges" file to represent missing data in the Debian package
    comparator.
  - Update some miscellaneous terms.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @dezgeg @ma27 @danielfullmer