### PR TITLE
nextpnr: fix build on macOS

### DIFF
--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -50,7 +50,7 @@ with stdenv; mkDerivation rec {
       "-DBUILD_TESTS=ON"
       "-DICEBOX_ROOT=${icestorm}/share/icebox"
       "-DTRELLIS_INSTALL_PREFIX=${trellis}"
-      "-DPYTRELLIS_LIBDIR=${trellis}/lib/trellis"
+      "-DTRELLIS_LIBDIR=${trellis}/lib/trellis"
       "-DUSE_OPENMP=ON"
       # warning: high RAM usage
       "-DSERIALIZE_CHIPDB=OFF"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
`PYTRELLIS_LIBDIR` has been replaced by `TRELLIS_LIBDIR` in https://github.com/YosysHQ/nextpnr/commit/1dc1164dce88fade762956c1067aeb97fa3c0f9a, which causes the build to fail on macOS.


<details>
  <summary>This was the result of "nix-env -iA nixpkgs.nextpnr" on macOS</summary>
  
installing 'nextpnr-2020.07.08'
these derivations will be built:
  /nix/store/dzk28bbvmycihx95irikzjx8ms35wgrh-nextpnr-2020.07.08.drv
building '/nix/store/dzk28bbvmycihx95irikzjx8ms35wgrh-nextpnr-2020.07.08.drv'...
unpacking sources
unpacking source archive /nix/store/zm3q9585vwvpaljkympc53sl2iyk6dn1-nextpnr
unpacking source archive /nix/store/qivl98z1fycpzy42jy3vw1wx664jdk4p-nextpnr-tests
source root is nextpnr
patching sources
substituteStream(): WARNING: pattern '${PYTHON_EXECUTABLE}' doesn't match anything in file './ice40/family.cmake'
configuring
fixing cmake files...
cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON -DCMAKE_INSTALL_LOCALEDIR=/nix/store/sn2lnwrwi9jw1358qb7f3ihml9lcmc79-nextpnr-2020.07.08/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/sn2lnwrwi9jw1358qb7f3ihml9lcmc79-nextpnr-2020.07.08/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/sn2lnwrwi9jw1358qb7f3ihml9lcmc79-nextpnr-2020.07.08/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/sn2lnwrwi9jw1358qb7f3ihml9lcmc79-nextpnr-2020.07.08/share/doc/ -DCMAKE_INSTALL_INFODIR=/nix/store/sn2lnwrwi9jw1358qb7f3ihml9lcmc79-nextpnr-2020.07.08/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/sn2lnwrwi9jw1358qb7f3ihml9lcmc79-nextpnr-2020.07.08/share/man -DCMAKE_INSTALL_OLDINCLUDEDIR=/nix/store/sn2lnwrwi9jw1358qb7f3ihml9lcmc79-nextpnr-2020.07.08/include -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/sn2lnwrwi9jw1358qb7f3ihml9lcmc79-nextpnr-2020.07.08/include -DCMAKE_INSTALL_SBINDIR=/nix/store/sn2lnwrwi9jw1358qb7f3ihml9lcmc79-nextpnr-2020.07.08/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/sn2lnwrwi9jw1358qb7f3ihml9lcmc79-nextpnr-2020.07.08/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/sn2lnwrwi9jw1358qb7f3ihml9lcmc79-nextpnr-2020.07.08/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_OSX_SYSROOT= -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_FIND_FRAMEWORK=last -DCMAKE_STRIP=/nix/store/c2pk9h4386c052rbvkhvagw4lsmadxw5-cctools-binutils-darwin-927.0.2/bin/strip -DCMAKE_RANLIB=/nix/store/c2pk9h4386c052rbvkhvagw4lsmadxw5-cctools-binutils-darwin-927.0.2/bin/ranlib -DCMAKE_AR=/nix/store/c2pk9h4386c052rbvkhvagw4lsmadxw5-cctools-binutils-darwin-927.0.2/bin/ar -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/nix/store/sn2lnwrwi9jw1358qb7f3ihml9lcmc79-nextpnr-2020.07.08 -DCURRENT_GIT_VERSION=3cafb16 -DARCH=generic;ice40;ecp5 -DBUILD_TESTS=ON -DICEBOX_ROOT=/nix/store/8m6v25ddpj0bkvhknac4g90yvnd926c7-icestorm-2020.07.08/share/icebox -DTRELLIS_INSTALL_PREFIX=/nix/store/kza6h1zxn1gckfd30zzk3lbl273y3ac6-trellis-2020.06.29 -DPYTRELLIS_LIBDIR=/nix/store/kza6h1zxn1gckfd30zzk3lbl273y3ac6-trellis-2020.06.29/lib/trellis -DUSE_OPENMP=ON -DSERIALIZE_CHIPDB=OFF -DOPENGL_INCLUDE_DIR=/nix/store/xffa58s4428pf6j8yvz60marcjav9zcd-apple-framework-OpenGL/Library/Frameworks 
-- The CXX compiler identification is Clang 7.1.0
-- Check for working CXX compiler: /nix/store/jhfr9mqrjjc1nfjrnjwb8sl889aj8lj9-clang-wrapper-7.1.0/bin/clang++
-- Check for working CXX compiler: /nix/store/jhfr9mqrjjc1nfjrnjwb8sl889aj8lj9-clang-wrapper-7.1.0/bin/clang++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PythonInterp: /nix/store/vlmz2mfdagyr67l4jxyyaqb0h4p5amkw-python3-3.8.3/bin/python3 (found suitable version "3.8.3", minimum required is "3.5") 
-- Found PythonLibs: /nix/store/vlmz2mfdagyr67l4jxyyaqb0h4p5amkw-python3-3.8.3/lib/libpython3.8.dylib (found suitable version "3.8.3", minimum required is "3.5") 
-- Looking for C++ include pthread.h
-- Looking for C++ include pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found Boost: /nix/store/7ck1qpc7dkar7v6vkidjbr26k0cx9v54-boost-1.69.0-dev/include (found version "1.69.0") found components: filesystem program_options iostreams system thread regex chrono date_time atomic 
-- Found OpenGL: /nix/store/xffa58s4428pf6j8yvz60marcjav9zcd-apple-framework-OpenGL/Library/Frameworks/OpenGL.framework   
-- The C compiler identification is Clang 7.1.0
-- Check for working C compiler: /nix/store/jhfr9mqrjjc1nfjrnjwb8sl889aj8lj9-clang-wrapper-7.1.0/bin/clang
-- Check for working C compiler: /nix/store/jhfr9mqrjjc1nfjrnjwb8sl889aj8lj9-clang-wrapper-7.1.0/bin/clang - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Found PythonInterp: /nix/store/vlmz2mfdagyr67l4jxyyaqb0h4p5amkw-python3-3.8.3/bin/python3 (found version "3.8.3") 
CMake Warning at /nix/store/8gi1zcnsv6dpirdiams3i715zyil2xgd-cmake-3.17.3/share/cmake-3.17/Modules/FindBoost.cmake:2007 (message):
  No header defined for python-py383; skipping header check (note:
  header-only libraries have no designated component)
Call Stack (most recent call first):
  CMakeLists.txt:184 (find_package)


CMake Warning at /nix/store/8gi1zcnsv6dpirdiams3i715zyil2xgd-cmake-3.17.3/share/cmake-3.17/Modules/FindBoost.cmake:2007 (message):
  No header defined for python-py38; skipping header check (note: header-only
  libraries have no designated component)
Call Stack (most recent call first):
  CMakeLists.txt:191 (find_package)


CMake Warning at /nix/store/8gi1zcnsv6dpirdiams3i715zyil2xgd-cmake-3.17.3/share/cmake-3.17/Modules/FindBoost.cmake:2007 (message):
  No header defined for python-py3; skipping header check (note: header-only
  libraries have no designated component)
Call Stack (most recent call first):
  CMakeLists.txt:191 (find_package)


-- Found Boost: /nix/store/7ck1qpc7dkar7v6vkidjbr26k0cx9v54-boost-1.69.0-dev/include (found version "1.69.0") found components: program_options filesystem system 
-- Check if the system is big endian
-- Searching 16 bit integer
-- Looking for C++ include sys/types.h
-- Looking for C++ include sys/types.h - found
-- Looking for C++ include stdint.h
-- Looking for C++ include stdint.h - found
-- Looking for C++ include stddef.h
-- Looking for C++ include stddef.h - found
-- Check size of unsigned short
-- Check size of unsigned short - done
-- Searching 16 bit integer - Using unsigned short
-- Check if the system is big endian - little endian
-- Configuring architecture: generic
-- Configuring architecture: ice40
-- Enabled iCE40 devices: 384;1k;5k;u4k;8k
-- Found PythonInterp: /nix/store/vlmz2mfdagyr67l4jxyyaqb0h4p5amkw-python3-3.8.3/bin/python3 (found suitable version "3.8.3", minimum required is "3.5") 
CMake Warning at ice40/CMakeLists.txt:21 (message):
  -DICEBOX_ROOT= is deprecated, use
  -DICESTORM_INSTALL_PREFIX=/nix/store/8m6v25ddpj0bkvhknac4g90yvnd926c7-icestorm-2020.07.08/share/icebox
  instead


-- IceStorm install prefix: /nix/store/8m6v25ddpj0bkvhknac4g90yvnd926c7-icestorm-2020.07.08
-- icebox data directory: /nix/store/8m6v25ddpj0bkvhknac4g90yvnd926c7-icestorm-2020.07.08/share/icebox
-- Using iCE40 chipdb: /private/var/folders/c5/yg8qdfhx76l30_7wkjm9h3gw0000gn/T/nix-build-nextpnr-2020.07.08.drv-0/nextpnr/build/ice40/chipdb
-- Configuring architecture: ecp5
-- Enabled ECP5 devices: 25k;45k;85k
-- Trellis install prefix: /nix/store/kza6h1zxn1gckfd30zzk3lbl273y3ac6-trellis-2020.06.29
-- Searching for pytrellis in: /nix/store/8gi1zcnsv6dpirdiams3i715zyil2xgd-cmake-3.17.3/lib;/nix/store/sn2lnwrwi9jw1358qb7f3ihml9lcmc79-nextpnr-2020.07.08/lib;/sw/lib;/var/empty/local/lib;/nix/store/bwp058sm2y2rxfz2nynjhha1lb25r2aa-Libsystem-osx-10.12.6/lib
CMake Error at ecp5/CMakeLists.txt:64 (message):
  Failed to locate the pytrellis library


-- Configuring incomplete, errors occurred!
See also "/private/var/folders/c5/yg8qdfhx76l30_7wkjm9h3gw0000gn/T/nix-build-nextpnr-2020.07.08.drv-0/nextpnr/build/CMakeFiles/CMakeOutput.log".
builder for '/nix/store/dzk28bbvmycihx95irikzjx8ms35wgrh-nextpnr-2020.07.08.drv' failed with exit code 1
error: build of '/nix/store/dzk28bbvmycihx95irikzjx8ms35wgrh-nextpnr-2020.07.08.drv' failed
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
