### PR TITLE
pkgs.terraform: add terraform-provider-shell 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5640,6 +5640,12 @@
     githubId = 5047140;
     name = "Victor Collod";
   };
+  mupdt = {
+    email = "nix@pdtpartners.com";
+    github = "mupdt";
+    githubId = 25388474;
+    name = "Matej Urbas";
+  };
   mvnetbiz = {
     email = "mvnetbiz@gmail.com";
     github = "mvnetbiz";

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -144,6 +144,7 @@ let
     elasticsearch = callPackage ./elasticsearch {};
     libvirt = callPackage ./libvirt {};
     lxd = callPackage ./lxd {};
+    shell = callPackage ./shell {};
     vpsadmin = callPackage ./vpsadmin {};
   };
 in

--- a/pkgs/applications/networking/cluster/terraform-providers/shell/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/shell/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, buildGoModule }:
+buildGoModule rec {
+  pname = "terraform-provider-shell";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "scottwinkler";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "0jxb30vw93ibnwz8nfqapac7p9r2famzvsf2h4nfbmhkm6mpan4l";
+  };
+
+  vendorSha256 = "1p2ja6cw3dl7mx41svri6frjpgb9pxsrl7sq0rk1d3sviw0f88sg";
+
+  subPackages = [ "." ];
+
+  # Terraform allows checking the provider versions, but this breaks
+  # if the versions are not provided via file paths.
+  postInstall = "mv $out/bin/${pname}{,_v${version}}";
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Terraform provider for executing shell commands and saving output to state file";
+    changelog = "https://github.com/scottwinkler/terraform-provider-shell/releases/tag/v${version}";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ mupdt ];
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This new Terraform provider allows users to wrap APIs of resources that are not supported by existing providers.

cc: @zimbatm @peterhoeg @marsam @babariviere 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
