### PR TITLE
singularity-tools: Check for /bin/sh existence before symlink

### DIFF
--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -86,7 +86,9 @@ rec {
             done
 
             # Create runScript and link shell
-            ln -s ${runtimeShell} bin/sh
+            if [ ! -e bin/sh ]; then
+              ln -s ${runtimeShell} bin/sh
+            fi
             mkdir -p .singularity.d
             ln -s ${runScriptFile} .singularity.d/runscript
 


### PR DESCRIPTION
Fixes the case where the user has `bashInteractive` in the container contents

###### Motivation for this change

Unable to build a singularity container that included `bashInteractive` for readline in my singularity container. 

###### Things done

Just checks for the existence of `/bin/sh` before symlinking the runtime shell, this fixes the case where that is in the `/bin` of one of the contents.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
