### PR TITLE
cpython: add separateDebugInfo, allow use of gdb libpython

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -296,6 +296,8 @@ in with passthru; stdenv.mkDerivation {
     pythonForBuild buildPackages.bash
   ];
 
+  separateDebugInfo = true;
+
   inherit passthru;
 
   enableParallelBuilding = true;

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -279,6 +279,13 @@ in with passthru; stdenv.mkDerivation {
     find $out -name "*.py" | ${pythonForBuildInterpreter} -OO -m compileall -q -f -x "lib2to3" -i -
     '' + optionalString stripBytecode ''
     find $out -type d -name __pycache__ -print0 | xargs -0 -I {} rm -rf "{}"
+    '' + ''
+    # *strip* shebang from libpython gdb script - it should be dual-syntax and
+    # interpretable by whatever python the gdb in question is using, which may
+    # not even match the major version of this python. doing this after the
+    # bytecode compilations for the same reason.
+    mkdir -p $out/share/gdb
+    sed '/^#!/d' Tools/gdb/libpython.py > $out/share/gdb/libpython.py
   '';
 
   preFixup = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''


### PR DESCRIPTION
###### Motivation for this change
The first thing this does is enable `separateDebugInfo` for cpython. Bit surprised we didn't already have this.

It also exposes `Tools/gdb/libpython.py` in the package output. Used together with cpython's debugging symbols, this allows inspection of the python stack of cpython programs in `gdb`. This file is a little different from the rest of the python output by this package, in that it's not intended to be run by the current python being built, instead by whatever python being used by the `gdb` in question, which could be very different. Therefore I placed it placed in its own, but hopefully logical & predictable location: ~`/usr/share/gdb/`~ `/share/gdb/`. Also skipped building bytecode for it for similar reasons.

This, of course, results in a massive rebuild and I'm not sure how I'd ever make a dent in it myself. I've tested `python27` through `python39`. However I'm fairly sure we've got some custom python builds floating around, though I'm not sure how I'd _find_ them.

Tested on linux x86_64 & macos 10.14, though on macos `separateDebugInfo` does nothing leaving this slightly pointless there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
