### PR TITLE
pulumi: 2.2.1 -> 2.6.1

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,58 +1,58 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "2.2.1";
+  version = "2.6.1";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.2.1-linux-x64.tar.gz";
-        sha256 = "0bvwkvsinnhlh1yhh5llffh89w07f412q6z03ypzl19p6fvik1k1";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.6.1-linux-x64.tar.gz";
+        sha256 = "12f81wj8r3pmxj2l8qhcgnmy2m0a6bfzrvq9avl3444h2w29qpy2";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.1.1-linux-amd64.tar.gz";
-        sha256 = "0bj9nlxsb77ycwvmba1vsh1vydyrszq3jxlf9d1qsv71h4s88a90";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.13.0-linux-amd64.tar.gz";
+        sha256 = "03l7ybc9ca63vdm7a2zsvgc8zz8ip973sfxsjqf3bb277r04mnpb";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.1.1-linux-amd64.tar.gz";
-        sha256 = "0ggi1c4lg6pip6d4bh2cji25hcwv3ii870bjwd35ax668z0dc28d";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.13.0-linux-amd64.tar.gz";
+        sha256 = "0ivdiib3a1c1r2ppxmj6blgq26s05s3081969j0j9jlscpa79lap";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.6.0-linux-amd64.tar.gz";
-        sha256 = "0l4vv7vkzsphvk9r28l253ds8ny0wh0fahqjjnz31jqzfbvzyxm8";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.2.0-linux-amd64.tar.gz";
+        sha256 = "0w6ys5bmry1b8ndzj167cz3a8fc6mbl5v9v2almrmd3q6fycm4gj";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.2.0-linux-amd64.tar.gz";
-        sha256 = "1maiy1i43p0gl2w12hfk9zgfz418innzi7nkv68qlyxd4hi5v6mf";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.4.0-linux-amd64.tar.gz";
+        sha256 = "0id3mji08hk76kffz46dlbl2r11kgv5jvlmw869dssg2d0wliv82";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.5.0-linux-amd64.tar.gz";
-        sha256 = "02xjwx2rfh3k9zk8aw39n4k6jnp8chcfc5f1zac7x4xfkqyjlpcy";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.2.2-linux-amd64.tar.gz";
+        sha256 = "07asdmmacxazg65d5hphjxzb5j5d2dcc95wjbxx3wwc1swqma4aq";
       }
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.2.1-darwin-x64.tar.gz";
-        sha256 = "1fizddk1hxazn33xliankps3fv0casx4r8rvwkdzqx1piqq18xy4";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.6.1-darwin-x64.tar.gz";
+        sha256 = "17jf9xwpwpbqk5r20i14j1z4i4rbbx781k0zqyc9yskmv5q4mmwr";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.1.1-darwin-amd64.tar.gz";
-        sha256 = "17iqzv06s4xhnway3j534lsj8gzxld67kfn7awn4ymwh2zn8l3z0";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.13.0-darwin-amd64.tar.gz";
+        sha256 = "18mjf9gm8siskg9jh65x4qp4w8p4wnp19bxxk4jfbq27icdk7ws9";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.1.1-darwin-amd64.tar.gz";
-        sha256 = "1mdchvibk989xq5zfjb7cdzgh9m769cvj2l5dfxmkava7zhmj2bj";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.13.0-darwin-amd64.tar.gz";
+        sha256 = "14iwz1gm34irs9jlpwc4ig1wc8k4aaxq8mz3g22yrvwddrsc4rcw";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.6.0-darwin-amd64.tar.gz";
-        sha256 = "013c13ypvz75x9qppzmlvwg4bnjryw9q16j6v987ibrrfxblan5b";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.2.0-darwin-amd64.tar.gz";
+        sha256 = "0zaxp2n1w5djwyq1afhd3v887dh0yj53jz449riqp19dpyfqf7h7";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.2.0-darwin-amd64.tar.gz";
-        sha256 = "0maca137agmig8njz0fd0yhxahdra7pqaw23mxfxa8m5j44p787a";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.4.0-darwin-amd64.tar.gz";
+        sha256 = "1kzs7k7as9r1vbj746wqz9iph13zfzzw8nsk3waq8aq1hmgh2g1q";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.5.0-darwin-amd64.tar.gz";
-        sha256 = "0kc4il1ixh7ricl4n3vadvjy0rjj0bps7n8lbqgrq8lm5m419izv";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.2.2-darwin-amd64.tar.gz";
+        sha256 = "0hwdghij7g9h58nwimfmaz91lz38wibkrdzwqhi7d426m53g6f5c";
       }
     ];
   };

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
 
-VERSION="2.2.1"
+VERSION="2.6.1"
 
-declare -A plugins
+# Bash 3 compatible for Darwin
 plugins=(
-    ["aws"]="2.5.0"
-    ["gcp"]="3.6.0"
-    ["random"]="2.1.1"
-    ["kubernetes"]="2.2.0"
-    ["postgresql"]="2.1.1"
-)
+    # https://github.com/pulumi/pulumi-aws/releases
+    "aws=2.13.0"
+    # https://github.com/pulumi/pulumi-gcp/releases
+    "gcp=3.13.0"
+    # https://github.com/pulumi/pulumi-random/releases
+    "random=2.2.0"
+    # https://github.com/pulumi/pulumi-kubernetes/releases
+    "kubernetes=2.4.0"
+    # https://github.com/pulumi/pulumi-postgresql/releases
+    "postgresql=2.2.2");
 
 function genMainSrc() {
     local url="https://get.pulumi.com/releases/sdk/pulumi-v${VERSION}-$1-x64.tar.gz"
@@ -22,8 +26,9 @@ function genMainSrc() {
 }
 
 function genSrcs() {
-    for plug in "${!plugins[@]}"; do
-        local version=${plugins[$plug]}
+    for plugVers in "${plugins[@]}"; do
+        local plug=${plugVers%=*}
+        local version=${plugVers#*=}
         # url as defined here
         # https://github.com/pulumi/pulumi/blob/06d4dde8898b2a0de2c3c7ff8e45f97495b89d82/pkg/workspace/plugins.go#L197
         local url="https://api.pulumi.com/releases/plugins/pulumi-resource-${plug}-v${version}-$1-amd64.tar.gz"
@@ -36,7 +41,7 @@ function genSrcs() {
     done
 }
 
-cat <<EOF
+cat <<EOF                     > data.nix
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
@@ -44,13 +49,14 @@ cat <<EOF
   pulumiPkgs = {
     x86_64-linux = [
 EOF
-genMainSrc "linux"
-genSrcs "linux"
-echo "    ];"
+genMainSrc "linux"           >> data.nix
+genSrcs "linux"              >> data.nix
+echo "    ];"                >> data.nix
 
-echo "    x86_64-darwin = ["
-genMainSrc "darwin"
-genSrcs "darwin"
-echo "    ];"
-echo "  };"
-echo "}"
+echo "    x86_64-darwin = [" >> data.nix
+genMainSrc "darwin"          >> data.nix
+genSrcs "darwin"             >> data.nix
+echo "    ];"                >> data.nix
+echo "  };"                  >> data.nix
+echo "}"                     >> data.nix
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update pulumi to version 2.6.1,
update pulumi plugins to the latest version,
improve update.sh script to work on Darwin and generate data.nix automatically.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
