### PR TITLE
routino: enable on darwin

### DIFF
--- a/pkgs/tools/misc/routino/default.nix
+++ b/pkgs/tools/misc/routino/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, zlib, bzip2 }:
+{ stdenv, fetchurl, fetchpatch, perl, zlib, bzip2 }:
 
 stdenv.mkDerivation rec {
   pname = "routino";
@@ -9,11 +9,25 @@ stdenv.mkDerivation rec {
     sha256 = "1ccx3s99j8syxc1gqkzsaqkmyf44l7h3adildnc5iq2md7bp8wab";
   };
 
+  patchFlags = [ "-p0" ];
+  patches = stdenv.lib.optionals stdenv.isDarwin [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/macports/macports-ports/18fd229516a46e7272003acbe555735b2a902db7/gis/routino/files/patch-Makefile_conf.diff";
+      sha256 = "1b7hpa4sizansnwwxq1c031nxwdwh71pg08jl9z9apiab8pjsn53";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/macports/macports-ports/18fd229516a46e7272003acbe555735b2a902db7/gis/routino/files/patch-src_Makefile_dylib_extension.diff";
+      sha256 = "1kigxcfr7977baxdsfvrw6q453cpqlzqakhj7av2agxkcvwyilpv";
+    })
+  ];
+
   nativeBuildInputs = [ perl ];
 
   buildInputs = [ zlib bzip2 ];
 
   outputs = [ "out" "doc" ];
+
+  CLANG = stdenv.lib.optionalString stdenv.cc.isClang "1";
 
   makeFlags = [ "prefix=$(out)" ];
 
@@ -22,6 +36,6 @@ stdenv.mkDerivation rec {
     description = "OpenStreetMap Routing Software";
     license = licenses.agpl3;
     maintainers = with maintainers; [ dotlambda ];
-    platforms = with platforms; linux;
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Enable on darwin.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
```sh
$ curl -O https://download.geofabrik.de/europe/estonia-200712.osm.pbf
$ ./result/bin/planetsplitter --dir=./out --prefix=Estonia \
  --tagging=./result/share/routino/tagging.xml --parse-only --append estonia-200712.osm.pbf
$ ./result/bin/planetsplitter --dir=./out --prefix=Estonia \
  --tagging=./result/share/routino/tagging.xml --process-only
```
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
