### PR TITLE
python3Packages.pytest-black: 0.3.9 -> 0.3.10

### DIFF
--- a/pkgs/development/python-modules/pytest-black/default.nix
+++ b/pkgs/development/python-modules/pytest-black/default.nix
@@ -7,16 +7,18 @@
 
 buildPythonPackage rec {
   pname = "pytest-black";
-  version = "0.3.9";
+  version = "0.3.10";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c743dfeffe6b2cb25c0ed1a84cc306dff4b504b713b5a6d1bc3824fa73a7d693";
+    sha256 = "0dvlfic7nvfj97rg5fwj7ahw83n9yj3jjbp5m60n47mlx7z0qg2z";
   };
 
   nativeBuildInputs = [ setuptools_scm ];
 
   propagatedBuildInputs = [ black pytest toml ];
+
+  pythonImportsCheck = [ "pytest_black" ];
 
   meta = with lib; {
     description = "A pytest plugin to enable format checking with black";


### PR DESCRIPTION
###### Motivation for this change
noticed it was out-of-date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
