### PR TITLE
spdlog: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -35,8 +35,8 @@ let
 in
 {
   spdlog_1 = generic {
-    version = "1.6.0";
-    sha256 = "15fn8nd9xj7wrxcg9n4fjffid790qg2m366rx2lq2fc9v9walrxs";
+    version = "1.7.0";
+    sha256 = "1ryaa22ppj60461hcdb8nk7jwj84arp4iw4lyw594py92g4vnx3j";
   };
 
   spdlog_0 = generic {


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS,
   - [ ] macOS
   - [x] other: debian (stable) with nix
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size: 2581792 -> 2582608 (- 816) [1]
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

[1] master (before):

```
/nix/store/c2l6jvasisdpwz3cs7jppimpskghck4n-spdlog-0.17.0            376496
/nix/store/6f6imx474gl4kwgkz74i4pf74jyy351l-spdlog-1.6.0            2581792
```

after:

```
/nix/store/c2l6jvasisdpwz3cs7jppimpskghck4n-spdlog-0.17.0            376496
/nix/store/gx1lp0zq6sh1m9ixhx5v1c0c4hv7r51h-spdlog-1.7.0            2582608
```

