### PR TITLE
pupnp: Open enableReuseAddr configure option

### DIFF
--- a/pkgs/development/libraries/pupnp/default.nix
+++ b/pkgs/development/libraries/pupnp/default.nix
@@ -1,4 +1,5 @@
-{ fetchFromGitHub, stdenv, autoreconfHook, pkg-config }:
+{ fetchFromGitHub, stdenv, autoreconfHook, pkg-config
+, enableReuseAddr ? false }:
 
 stdenv.mkDerivation rec {
   pname = "libupnp";
@@ -13,6 +14,8 @@ stdenv.mkDerivation rec {
   outputs = [ "dev" "out" ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  configureFlags = stdenv.lib.optionals enableReuseAddr "--enable-reuseaddr";
 
   hardeningDisable = [ "fortify" ];
 


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS,
   - [ ] macOS
   - [x] other: debian with nix
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` [1] [2]
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] impact on package closure size: 8 bytes less: 33534240 (after, flag enabled), 33534248 (before or after with flag off, the default)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

----

Both tested with the following to ensure the flip does take place (checking the configure output):
```
nix-build --expr "(import <nixpkgs> {}).callPackage ./pkgs/development/libraries/pupnp { enableReuseAddr = false; }"
nix-build --expr "(import <nixpkgs> {}).callPackage ./pkgs/development/libraries/pupnp { enableReuseAddr = true; }"
```

[1]
```
nixpkgs-review wip
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
$ git worktree add /home/tony/.cache/nixpkgs-review/rev-8326dc9cff1059e31451de4979f13c6b222c5315-dirty/nixpkgs c00959877fb06b09468562518b408acda886c79e
Preparing worktree (detached HEAD c00959877fb)
Updating files: 100% (23364/23364), done.
HEAD is now at c00959877fb Merge pull request #105425 from r-ryantm/auto-update/python3.7-mac_alias
$ nix-env -f /home/tony/.cache/nixpkgs-review/rev-8326dc9cff1059e31451de4979f13c6b222c5315-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```

[2]
```
nixpkgs-review pr 93099
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0 pull/93099/head:refs/nixpkgs-review/1
From https://github.com/NixOS/nixpkgs
 + ba9ade5c557...8326dc9cff1 refs/pull/93099/head -> refs/nixpkgs-review/1  (forced update)
$ git worktree add /home/tony/.cache/nixpkgs-review/pr-93099/nixpkgs c00959877fb06b09468562518b408acda886c79e
Preparing worktree (detached HEAD c00959877fb)
Updating files: 100% (23364/23364), done.
HEAD is now at c00959877fb Merge pull request #105425 from r-ryantm/auto-update/python3.7-mac_alias
$ nix-env -f /home/tony/.cache/nixpkgs-review/pr-93099/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit 8326dc9cff1059e31451de4979f13c6b222c5315
Updating c00959877fb..8326dc9cff1
Fast-forward
 pkgs/development/libraries/pupnp/default.nix | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)
$ nix-env -f /home/tony/.cache/nixpkgs-review/pr-93099/nixpkgs -qaP --xml --out-path --show-trace --meta
Nothing to be built.
https://github.com/NixOS/nixpkgs/pull/93099
$ nix-shell /home/tony/.cache/nixpkgs-review/pr-93099/shell.nix
...
[nix-shell:~/.cache/nixpkgs-review/pr-93099]$ exit
$ git worktree prune
```