### PR TITLE
fmt: Open enableShared option

### DIFF
--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -1,8 +1,10 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake
+, enableShared ? false }:
 
 stdenv.mkDerivation rec {
   pname = "fmt";
   version = "6.2.1";
+  inherit enableShared;
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
Some application (e.g. gerbera) requires the possibility to compile fmt as external.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS,
   - [ ] macOS
   - [x] other: debian with nix
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] impact on package closure size: No change [1]
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

----

[1] with the following command:

```
% nix-build --expr "(import <nixpkgs> {}).callPackage ./pkgs/development/libraries/fmt {
  enableShared = (true|false); }"
```

before:
/nix/store/gijq38rh428pcy7xivbwpwafqv2al4bw-fmt-6.2.1              39607656

after:
/nix/store/bnzn9f2dgdgigad2snahr9fk6x97if21-fmt-6.2.1              39607656
