### PR TITLE
nixos/moodle: add plugins

### DIFF
--- a/nixos/modules/services/web-apps/moodle.nix
+++ b/nixos/modules/services/web-apps/moodle.nix
@@ -40,7 +40,7 @@ let
   $CFG->disableupdateautodeploy = true;
 
   $CFG->pathtogs = '${pkgs.ghostscript}/bin/gs';
-  $CFG->pathtophp = '${pkgs.php}/bin/php';
+  $CFG->pathtophp = '${phpExt}/bin/php';
   $CFG->pathtodu = '${pkgs.coreutils}/bin/du';
   $CFG->aspellpath = '${pkgs.aspell}/bin/aspell';
   $CFG->pathtodot = '${pkgs.graphviz}/bin/dot';
@@ -55,6 +55,9 @@ let
 
   mysqlLocal = cfg.database.createLocally && cfg.database.type == "mysql";
   pgsqlLocal = cfg.database.createLocally && cfg.database.type == "pgsql";
+
+  phpExt = pkgs.php.withExtensions
+        ({ enabled, all }: with all; [ iconv mbstring curl openssl tokenizer xmlrpc soap ctype zip gd simplexml dom  intl json sqlite3 pgsql pdo_sqlite pdo_pgsql pdo_odbc pdo_mysql pdo mysqli session zlib xmlreader fileinfo ]);
 in
 {
   # interface
@@ -222,6 +225,7 @@ in
 
     services.phpfpm.pools.moodle = {
       inherit user group;
+      phpPackage = phpExt;
       phpEnv.MOODLE_CONFIG = "${moodleConfig}";
       phpOptions = ''
         zend_extension = opcache.so
@@ -263,13 +267,13 @@ in
       after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
       environment.MOODLE_CONFIG = moodleConfig;
       script = ''
-        ${pkgs.php}/bin/php ${cfg.package}/share/moodle/admin/cli/check_database_schema.php && rc=$? || rc=$?
+        ${phpExt}/bin/php ${cfg.package}/share/moodle/admin/cli/check_database_schema.php && rc=$? || rc=$?
 
-        [ "$rc" == 1 ] && ${pkgs.php}/bin/php ${cfg.package}/share/moodle/admin/cli/upgrade.php \
+        [ "$rc" == 1 ] && ${phpExt}/bin/php ${cfg.package}/share/moodle/admin/cli/upgrade.php \
           --non-interactive \
           --allow-unstable
 
-        [ "$rc" == 2 ] && ${pkgs.php}/bin/php ${cfg.package}/share/moodle/admin/cli/install_database.php \
+        [ "$rc" == 2 ] && ${phpExt}/bin/php ${cfg.package}/share/moodle/admin/cli/install_database.php \
           --agree-license \
           --adminpass=${cfg.initialPassword}
 
@@ -289,7 +293,7 @@ in
       serviceConfig = {
         User = user;
         Group = group;
-        ExecStart = "${pkgs.php}/bin/php ${cfg.package}/share/moodle/admin/cli/cron.php";
+        ExecStart = "${phpExt}/bin/php ${cfg.package}/share/moodle/admin/cli/cron.php";
       };
     };
 

--- a/pkgs/servers/web-apps/moodle/default.nix
+++ b/pkgs/servers/web-apps/moodle/default.nix
@@ -1,23 +1,23 @@
-{ stdenv, fetchurl, writeText }:
+{ lib, stdenv, fetchurl, writeText, plugins ? [ ] }:
 
 let
   version = "3.9.1";
   stableVersion = builtins.substring 0 2 (builtins.replaceStrings ["."] [""] version);
-in
 
-stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   pname = "moodle";
   inherit version;
 
   src = fetchurl {
-    url = "https://download.moodle.org/stable${stableVersion}/${pname}-${version}.tgz";
-    sha256 = "1ysnrk013gmc21ml3jwijvl16rx3p478a4vriy6h8hfli48460p9";
+    url =
+      "https://download.moodle.org/stable${stableVersion}/${pname}-${version}.tgz";
+    sha256 = "dffe8c1ac68938f50a987b46b0bfc74f01235d0198ac96fb4fc4f1df5bd7f4ea";
   };
 
   phpConfig = writeText "config.php" ''
-  <?php
-    return require(getenv('MOODLE_CONFIG'));
-  ?>
+    <?php
+      return require(getenv('MOODLE_CONFIG'));
+    ?>
   '';
 
   installPhase = ''
@@ -27,11 +27,34 @@ stdenv.mkDerivation rec {
     cp -r . $out/share/moodle
     cp ${phpConfig} $out/share/moodle/config.php
 
+    ${lib.concatStringsSep "\n" (map (p:
+      let
+        dir = if p.pluginType == "mod" then
+          "mod"
+        else if p.pluginType == "theme" then
+          "theme"
+        else if p.pluginType == "block" then
+          "blocks"
+        else if p.pluginType == "question" then
+          "question/type"
+        else if p.pluginType == "course" then
+          "course/format"
+        else if p.pluginType == "report" then
+          "admin/report"
+        else
+          throw "unknown moodle plugin type";
+        # we have to copy it, because the plugins have refrences to .. inside
+      in ''
+        mkdir -p $out/share/moodle/${dir}/${p.name}
+        cp -r ${p}/* $out/share/moodle/${dir}/${p.name}/
+      '') plugins)}
+
     runHook postInstall
   '';
 
   meta = with stdenv.lib; {
-    description = "Free and open-source learning management system (LMS) written in PHP";
+    description =
+      "Free and open-source learning management system (LMS) written in PHP";
     license = licenses.gpl3Plus;
     homepage = "https://moodle.org/";
     maintainers = with maintainers; [ aanderse ];

--- a/pkgs/servers/web-apps/moodle/default.nix
+++ b/pkgs/servers/web-apps/moodle/default.nix
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchurl {
     url =
       "https://download.moodle.org/stable${stableVersion}/${pname}-${version}.tgz";
-    sha256 = "dffe8c1ac68938f50a987b46b0bfc74f01235d0198ac96fb4fc4f1df5bd7f4ea";
+    sha256 = "sha256-6QJDEInUQQSNj3kThQ65o2cT6JaRy0FrEKy+EcDMVvs=";
   };
 
   phpConfig = writeText "config.php" ''

--- a/pkgs/servers/web-apps/moodle/moodle-utils.nix
+++ b/pkgs/servers/web-apps/moodle/moodle-utils.nix
@@ -1,0 +1,32 @@
+{ stdenv, unzip, ... }:
+
+let
+  buildMoodlePlugin = a@{
+    name,
+    src,
+    pluginType,
+    configuraPhase ? ":",
+    buildPhase ? ":",
+    buildInputs ? [ ],
+    ...
+  }:
+  stdenv.mkDerivation (a // {
+    name = name;
+
+    inherit pluginType;
+    inherit configuraPhase buildPhase;
+
+    buildInputs = [ unzip ] ++ buildInputs;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out"
+      mv * $out/
+
+      runHook postInstall
+    '';
+  });
+in {
+  inherit buildMoodlePlugin;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16074,6 +16074,8 @@ in
 
   moodle = callPackage ../servers/web-apps/moodle { };
 
+  moodle-utils = callPackage ../servers/web-apps/moodle/moodle-utils.nix { };
+
   morty = callPackage ../servers/web-apps/morty { };
 
   mullvad-vpn = callPackage ../applications/networking/mullvad-vpn { };


### PR DESCRIPTION
###### Motivation for this change
Support Plugins for moodle

###### Things done
Upgraded moodle to 3.9.1 and add a plugin attribute to install plugins into moodle.


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC: @aanderse 
