### PR TITLE
python-modules.opt-einsum: Fix broken build since upgrading numpy

### DIFF
--- a/pkgs/development/python-modules/opt-einsum/default.nix
+++ b/pkgs/development/python-modules/opt-einsum/default.nix
@@ -17,6 +17,8 @@ buildPythonPackage rec {
     pytest
   '';
 
+  patches = [ ./test-value_error.diff ];
+
   meta = with lib; {
     description = "Optimizing NumPy's einsum function with order optimization and GPU support.";
     homepage = "https://github.com/dgasmith/opt_einsum";

--- a/pkgs/development/python-modules/opt-einsum/test-value_error.diff
+++ b/pkgs/development/python-modules/opt-einsum/test-value_error.diff
@@ -1,0 +1,13 @@
+diff --git a/opt_einsum/tests/test_input.py b/opt_einsum/tests/test_input.py
+index e5c1677..54ea059 100644
+--- a/opt_einsum/tests/test_input.py
++++ b/opt_einsum/tests/test_input.py
+@@ -34,7 +34,7 @@ def test_type_errors():
+         contract("", 0, out='test')
+ 
+     # order parameter must be a valid order
+-    with pytest.raises(TypeError):
++    with pytest.raises(ValueError):
+         contract("", 0, order='W')
+ 
+     # casting parameter must be a valid casting


### PR DESCRIPTION
###### Motivation for this change

The build for opt-einsum was broken since 26. June, probably because of upgrading numpy.

https://hydra.nixos.org/build/123886782

This fixes the apparent problem here, but I'll try to come up with a patch in the upstream project.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
