### PR TITLE
easypdkprog: 1.2 -> 1.3

### DIFF
--- a/pkgs/development/tools/misc/easypdkprog/default.nix
+++ b/pkgs/development/tools/misc/easypdkprog/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "easypdkprog";
-  version = "1.2";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "free-pdk";
     repo = "easy-pdk-programmer-software";
     rev = version;
-    sha256 = "06bn86rd57ff567l0ipx38raih0zll3y16lg5fpn7c601a9jldps";
+    sha256 = "0hc3gdmn6l01z63hzzwdhbdyy288gh5v219bsfm8fb1498vpnd6f";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
