### PR TITLE
kcollectd: init at 0.11.99.0

### DIFF
--- a/pkgs/tools/misc/kcollectd/default.nix
+++ b/pkgs/tools/misc/kcollectd/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, fetchFromGitLab
+, mkDerivation
+, qtbase
+, cmake
+, kconfig
+, kio
+, kiconthemes
+, kxmlgui
+, ki18n
+, kguiaddons
+, extra-cmake-modules
+, boost
+, shared-mime-info
+, rrdtool
+, breeze-icons
+}:
+
+mkDerivation rec {
+  pname = "kcollectd";
+  version = "0.11.99.0";
+  src = fetchFromGitLab {
+    owner = "aerusso";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0h4ymvzihzbmyv3z0bp28g94wxc6c7lgi3my0xbka3advxr811gn";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    shared-mime-info
+  ];
+
+  buildInputs = [
+    qtbase
+    kconfig
+    kio
+    kxmlgui
+    kiconthemes
+    ki18n
+    kguiaddons
+    boost
+    rrdtool
+    # otherwise some buttons are blank
+    breeze-icons
+  ];
+
+  meta = with lib; {
+    description = "A graphical frontend to collectd";
+    homepage = "https://www.antonioerusso.com/projects/kcollectd/";
+    maintainers = [ maintainers.symphorien ];
+    license = [ lib.licenses.gpl3Plus ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5301,6 +5301,8 @@ in
 
   file-rename = callPackage ../tools/filesystems/file-rename { };
 
+  kcollectd = libsForQt5.callPackage ../tools/misc/kcollectd {};
+
   kea = callPackage ../tools/networking/kea { };
 
   keysmith = libsForQt5.callPackage ../tools/security/keysmith { };


### PR DESCRIPTION
###### Motivation for this change

new package
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
