### PR TITLE
rust: Fix build flags

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -74,6 +74,7 @@ let
   ccForHost="${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc";
   cxxForHost="${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++";
   releaseDir = "target/${rustTarget}/${buildType}";
+  tmpDir = "${releaseDir}-tmp";
 
   # Specify the stdenv's `diff` by abspath to ensure that the user's build
   # inputs do not cause us to find the wrong `diff`.
@@ -193,7 +194,9 @@ stdenv.mkDerivation (args // {
     # This needs to be done after postBuild: packages like `cargo` do a pushd/popd in
     # the pre/postBuild-hooks that need to be taken into account before gathering
     # all binaries to install.
-    bins=$(find $releaseDir \
+    mkdir -p $tmpDir
+    cp -r $releaseDir/* $tmpDir/
+    bins=$(find $tmpDir \
       -maxdepth 1 \
       -type f \
       -executable ! \( -regex ".*\.\(so.[0-9.]+\|so\|a\|dylib\)" \))
@@ -214,13 +217,13 @@ stdenv.mkDerivation (args // {
 
   strictDeps = true;
 
-  inherit releaseDir;
+  inherit releaseDir tmpDir;
 
   installPhase = args.installPhase or ''
     runHook preInstall
 
     # rename the output dir to a architecture independent one
-    mapfile -t targets < <(find "$NIX_BUILD_TOP" -type d | grep '${releaseDir}$')
+    mapfile -t targets < <(find "$NIX_BUILD_TOP" -type d | grep '${tmpDir}$')
     for target in "''${targets[@]}"; do
       rm -rf "$target/../../${buildType}"
       ln -srf "$target" "$target/../../"
@@ -228,7 +231,7 @@ stdenv.mkDerivation (args // {
     mkdir -p $out/bin $out/lib
 
     xargs -r cp -t $out/bin <<< $bins
-    find $releaseDir \
+    find $tmpDir \
       -maxdepth 1 \
       -regex ".*\.\(so.[0-9.]+\|so\|a\|dylib\)" \
       -print0 | xargs -r -0 cp -t $out/lib

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -199,7 +199,7 @@ stdenv.mkDerivation (args // {
       -executable ! \( -regex ".*\.\(so.[0-9.]+\|so\|a\|dylib\)" \))
   '';
 
-  installCheckPhase = args.checkPhase or (let
+  checkPhase = args.checkPhase or (let
     argstr = "${stdenv.lib.optionalString (checkType == "release") "--release"} --target ${rustTarget} --frozen";
   in ''
     ${stdenv.lib.optionalString (buildAndTestSubdir != null) "pushd ${buildAndTestSubdir}"}

--- a/pkgs/development/tools/rust/rustup/default.nix
+++ b/pkgs/development/tools/rust/rustup/default.nix
@@ -39,9 +39,7 @@ rustPlatform.buildRustPackage rec {
     )
   ];
 
-  # Disable tests until they can be run with --features no-self-update
-  doCheck = false;
-  #doCheck = !stdenv.isAarch64 && !stdenv.isDarwin;
+  doCheck = !stdenv.isAarch64 && !stdenv.isDarwin;
 
   postInstall = ''
     pushd $out/bin


### PR DESCRIPTION
###### Motivation for this change

:warning: **Caution:** I only tested this against a few packages. Before merging this, we should ensure to not cause even further regressions.

This PR fixes a bug originally described in #91191: if a package has a special `cargoBuildFlags`-declaration, the binaries in `$out` aren't built with those since the artifacts in `target/release` get modified during `checkPhase` which doesn't use `cargoBuildFlags`.

This change copies the artifacts after `buildPhase` into a temporary location, so that the proper binaries get installed into `$out` and `cargo test` can resume the build-process in the `checkPhase`.

cc #91689
Closes #93119
Closes #91191

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
