### PR TITLE
uncertainties: 3.1.2 -> 3.1.4

### DIFF
--- a/pkgs/development/python-modules/uncertainties/default.nix
+++ b/pkgs/development/python-modules/uncertainties/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, fetchPypi, buildPythonPackage, nose, numpy }:
+{ stdenv, fetchPypi, buildPythonPackage
+, nose, numpy, future
+}:
 
 buildPythonPackage rec {
   pname = "uncertainties";
-  version = "3.1.2";
+  version = "3.1.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "07kahmr0vfmncf8y4x6ldjrghnd4gsf0fwykgjj5ijvqi9xc21xs";
+    sha256 = "0s69kdhl8vhqazhxqdvb06l83x0iqdm0yr4vp3p52alzi6a8lm33";
   };
 
-  buildInputs = [ nose numpy ];
+  propagatedBuildInputs = [ future ];
+  checkInputs = [ nose numpy ];
 
-  # No tests included
-  doCheck = false;
+  checkPhase = "python setup.py nosetests -sv";
 
   meta = with stdenv.lib; {
     homepage = "https://pythonhosted.org/uncertainties/";


### PR DESCRIPTION
###### Motivation for this change
Version bump and enable tests.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via `nix-shell --pure -I nixpkgs=$PWD -p 'python3.withPackages (p: [ p.uncertainties])' --run 'python3 -c "import uncertainties as u; print(u.ufloat(1.2, 0.1)**2)"'``
- [x] Tested compilation of all pkgs that depend on this
- [x] Tested execution of all binary files (none)
- [x] Determined the impact on package closure size (identical)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).