### PR TITLE
babashka: 0.0.97 -> 0.1.3

### DIFF
--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -1,25 +1,25 @@
-{ stdenv, fetchurl, graalvm8, glibcLocales }:
+{ stdenv, fetchurl, graalvm11-ce, glibcLocales }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "babashka";
-  version = "0.0.97";
+  version = "0.1.3";
 
   reflectionJson = fetchurl {
     name = "reflection.json";
     url = "https://github.com/borkdude/${pname}/releases/download/v${version}/${pname}-${version}-reflection.json";
-    sha256 = "1gd9ih9l02n1j9qkbxb36d3cb5sddwvxiw8kkicgc4xig77lsa7z";
+    sha256 = "0hsdckf1gmw3vppnx605yiqz01nyw2wcwq9w3y9w17kxn0ghl4h1";
   };
 
   src = fetchurl {
     url = "https://github.com/borkdude/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
-    sha256 = "08py6bawfrhg90fbcnv2mq4c91g5wa1q2q6zdjy2i1b9q4x1654r";
+    sha256 = "0c2p54b6k6l8p43bxg1hipid7gj1wxvs0k6904531r7lyb5jpw0n";
   };
 
   dontUnpack = true;
 
   LC_ALL = "en_US.UTF-8";
-  nativeBuildInputs = [ graalvm8 glibcLocales ];
+  nativeBuildInputs = [ graalvm11-ce glibcLocales ];
 
   buildPhase = ''
     native-image \
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/borkdude/babashka";
     license = licenses.epl10;
-    platforms = graalvm8.meta.platforms;
-    maintainers = with maintainers; [ bandresen bhougland DerGuteMoritz jlesquembre ];
+    platforms = graalvm11-ce.meta.platforms;
+    maintainers = with maintainers; [ bennyandresen bhougland DerGuteMoritz jlesquembre ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
latest version

the latest versions of babashka require graalvm20 and therefor the dependency changed from graalvm8 (at major version 19) to graalvm11-ce (major version 20)

see #93139

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
