### PR TITLE
mpd: 0.21.23 -> 0.21.25

### DIFF
--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -110,28 +110,14 @@ let
 
     in stdenv.mkDerivation rec {
       pname = "mpd";
-      version = "0.21.23";
+      version = "0.21.25";
 
       src = fetchFromGitHub {
         owner  = "MusicPlayerDaemon";
         repo   = "MPD";
         rev    = "v${version}";
-        sha256 = "0jnhjhm1ilpcwb4f58b8pgyzjq3dlr0j2xyk0zck0afwkdxyj9cb";
+        sha256 = "1yjp8pwr2zn0mp39ls1w0pl37zrjn5m9ycgjmcsw2wpa4709r356";
       };
-
-      # Won't be needed when 0.21.24 will be out
-      patches = [
-        # Tests fail otherwise, see https://github.com/MusicPlayerDaemon/MPD/issues/844
-        (fetchpatch {
-          url = "https://github.com/MusicPlayerDaemon/MPD/commit/7aea2853612743e111ae5e947c8d467049e291a8.patch";
-          sha256 = "1bmxlsaiz3wlg1yyc4rkwsmgvc0pirv0s1vdxxsn91yssmh16c2g";
-          excludes = [
-            # The patch fails otherwise because it tries to update the NEWS
-            # file which doesn't have the title "ver 0.21.24" yet.
-            "NEWS"
-          ];
-        })
-      ];
 
       buildInputs = [
         glib


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Changelog at https://raw.githubusercontent.com/MusicPlayerDaemon/MPD/v0.21.25/NEWS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
