### PR TITLE
flatbuffers: 1.11.0 -> 1.12.0

### DIFF
--- a/pkgs/development/libraries/flatbuffers/default.nix
+++ b/pkgs/development/libraries/flatbuffers/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, fetchpatch, cmake }:
 
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation rec {
   pname = "flatbuffers";
-  version = "1.11.0";
+  version = "1.12.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "flatbuffers";
     rev = "v${version}";
-    sha256 = "1gl8pnykzifh7pnnvl80f5prmj5ga60dp44inpv9az2k9zaqx3qr";
+    sha256 = "0f7xd66vc1lzjbn7jzd5kyqrgxpsfxi4zc7iymhb5xrwyxipjl1g";
   };
 
   preConfigure = stdenv.lib.optional stdenv.buildPlatform.isDarwin ''
@@ -36,12 +36,4 @@ stdenv.mkDerivation (rec {
     platforms = stdenv.lib.platforms.unix;
     homepage = "https://google.github.io/flatbuffers/";
   };
-} // stdenv.lib.optionalAttrs stdenv.hostPlatform.isMusl {
-  # Remove when updating to the next version.
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/google/flatbuffers/commit/2b52494047fb6e97af03e1801b42adc7ed3fd78a.diff";
-      sha256 = "01k07ws0f4w7nnl8nli795wgjm4p94lxd3kva4yf7nf3pg4p8arx";
-    })
-  ];
-})
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/google/flatbuffers/releases/tag/v1.12.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
