### PR TITLE
[haskell-updates] haskellPackages.haskell-language-server: 0.1.0.0 -> 0.2.0.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1352,15 +1352,18 @@ self: super: {
   # haskell-language-server uses its own fork of ghcide
   # Test disabled: it seems to freeze (is it just that it takes a long time ?)
   hls-ghcide =
-    dontCheck (
+    dontCheck ((
       overrideCabal super.hls-ghcide
         (old: {
           # The integration test run by lsp-test requires the executable to be in the PATH
           preCheck = ''
             export PATH=$PATH:dist/build/ghcide
           '';
-        })
-    );
+        })).override {
+          # we are faster than stack here
+          hie-bios = dontCheck self.hie-bios_0_6_1;
+          lsp-test = dontCheck self.lsp-test_0_11_0_2;
+        });
 
   haskell-language-server = (overrideCabal super.haskell-language-server
     (old: {
@@ -1375,8 +1378,9 @@ self: super: {
     })).override {
       # use a fork of ghcide
       ghcide = self.hls-ghcide;
-      # use specific version
-      ormolu = super.ormolu_0_0_5_0;
+      # we are faster than stack here
+      hie-bios = dontCheck self.hie-bios_0_6_1;
+      lsp-test = dontCheck self.lsp-test_0_11_0_2;
     };
 
   # https://github.com/kowainik/policeman/issues/57

--- a/pkgs/development/tools/haskell/haskell-language-server/default.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/default.nix
@@ -1,28 +1,28 @@
 { mkDerivation, aeson, async, base, base16-bytestring, binary
-, blaze-markup, brittany, bytestring, Cabal, cabal-helper
-, containers, cryptohash-sha1, data-default, deepseq, Diff
-, directory, extra, fetchgit, filepath, floskell, ghc, ghc-check
-, ghc-paths, ghcide, gitrev, hashable, haskell-lsp
-, haskell-lsp-types, hie-bios, hslogger, hspec, hspec-core
-, hspec-expectations, lens, lsp-test, optparse-applicative
-, optparse-simple, ormolu, process, regex-tdfa, safe-exceptions
-, shake, stdenv, stm, stylish-haskell, tasty, tasty-ant-xml
-, tasty-expected-failure, tasty-golden, tasty-hunit, tasty-rerun
-, text, time, transformers, unix, unordered-containers, yaml
+, blaze-markup, brittany, bytestring, cabal-helper, containers
+, cryptohash-sha1, data-default, deepseq, Diff, directory, extra
+, fetchgit, filepath, floskell, ghc, ghc-check, ghc-paths, ghcide
+, gitrev, hashable, haskell-lsp, haskell-lsp-types, hie-bios
+, hslogger, hspec, hspec-core, hspec-expectations, lens, lsp-test
+, optparse-applicative, optparse-simple, ormolu, process
+, regex-tdfa, safe-exceptions, shake, stdenv, stm, stylish-haskell
+, tasty, tasty-ant-xml, tasty-expected-failure, tasty-golden
+, tasty-hunit, tasty-rerun, text, time, transformers, unix
+, unordered-containers, yaml
 }:
 mkDerivation {
   pname = "haskell-language-server";
-  version = "0.1.0.0";
+  version = "0.2.0.0";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "092i32kc9dakl6cg1dpckrb87g4k8s4w1nvrs5x85n9ncgkpqk25";
-    rev = "2a192db290bfe8640dafb6c1d650a0815e70d966";
+    sha256 = "0nkfyb0zg57jwr2gry0f3fycvqvb4rkayx42m841dgd4phyvrfrq";
+    rev = "35205ee3f95a8fbb4ef9a4ae4d9d82ac3d36d3f0";
     fetchSubmodules = true;
   };
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson base binary brittany bytestring Cabal cabal-helper containers
+    aeson base binary brittany bytestring cabal-helper containers
     data-default deepseq Diff directory extra filepath floskell ghc
     ghcide gitrev hashable haskell-lsp hie-bios hslogger lens
     optparse-simple ormolu process regex-tdfa shake stylish-haskell

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-ghcide.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-ghcide.nix
@@ -5,8 +5,8 @@
 , ghc-boot-th, ghc-check, ghc-paths, ghc-typelits-knownnat, gitrev
 , haddock-library, hashable, haskell-lsp, haskell-lsp-types
 , hie-bios, hslogger, lens, lsp-test, mtl, network-uri
-, opentelemetry, optparse-applicative, parser-combinators
-, prettyprinter, prettyprinter-ansi-terminal, process, QuickCheck
+, opentelemetry, optparse-applicative, prettyprinter
+, prettyprinter-ansi-terminal, process, QuickCheck
 , quickcheck-instances, regex-tdfa, rope-utf16-splay
 , safe-exceptions, shake, sorted-list, stdenv, stm, syb, tasty
 , tasty-expected-failure, tasty-hunit, tasty-quickcheck
@@ -18,8 +18,8 @@ mkDerivation {
   version = "0.2.0";
   src = fetchgit {
     url = "https://github.com/wz1000/ghcide";
-    sha256 = "0rifbrfvbgv7szgwc5apzb0i5fbkr2spzqvwg5kzng5b4zrf9a9d";
-    rev = "cc09b6d4cf03efa645c682347c62850c2291be25";
+    sha256 = "12hqqi2qf0bnl8ap6bvc7nzz4d6817qf0kpkj7iimhbsn73fkqkv";
+    rev = "8530b980871f9bc4f6fc2e688a4620e5fe1a0340";
     fetchSubmodules = true;
   };
   isLibrary = true;
@@ -36,21 +36,20 @@ mkDerivation {
     aeson async base base16-bytestring binary bytestring containers
     cryptohash-sha1 data-default deepseq directory extra filepath ghc
     ghc-check ghc-paths gitrev hashable haskell-lsp haskell-lsp-types
-    hie-bios hslogger optparse-applicative safe-exceptions shake text
-    time unordered-containers
+    hie-bios hslogger lsp-test optparse-applicative process
+    safe-exceptions shake text time unordered-containers
   ];
   testHaskellDepends = [
     aeson base bytestring containers directory extra filepath ghc
     ghc-typelits-knownnat haddock-library haskell-lsp haskell-lsp-types
-    lens lsp-test network-uri optparse-applicative parser-combinators
-    process QuickCheck quickcheck-instances rope-utf16-splay
-    safe-exceptions shake tasty tasty-expected-failure tasty-hunit
-    tasty-quickcheck tasty-rerun text
+    lens lsp-test network-uri optparse-applicative process QuickCheck
+    quickcheck-instances rope-utf16-splay safe-exceptions shake tasty
+    tasty-expected-failure tasty-hunit tasty-quickcheck tasty-rerun
+    text
   ];
   benchmarkHaskellDepends = [
-    aeson base bytestring Chart Chart-diagrams containers diagrams
-    diagrams-svg directory extra filepath lsp-test optparse-applicative
-    parser-combinators process safe-exceptions shake text yaml
+    aeson base Chart Chart-diagrams diagrams diagrams-svg directory
+    extra filepath shake text yaml
   ];
   homepage = "https://github.com/digital-asset/ghcide#readme";
   description = "The core of an IDE";


### PR DESCRIPTION
generated by
pkgs/development/tools/haskell/haskell-language-server/update.sh

with some manual tweaks, necessary because of old stack versions for lsp-test and hie-bios.

Thx to @GuillaumeDesforges , your update script made this a real breeze!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
