### PR TITLE
singularity: 3.2.1 -> 3.6.1

### DIFF
--- a/pkgs/applications/virtualization/singularity/default.nix
+++ b/pkgs/applications/virtualization/singularity/default.nix
@@ -1,13 +1,16 @@
 {stdenv
 , removeReferencesTo
 , lib
-, fetchFromGitHub
+, fetchurl
 , utillinux
+, gpgme
 , openssl
+, libuuid
 , coreutils
 , go
 , which
 , makeWrapper
+, cryptsetup
 , squashfsTools
 , buildGoPackage}:
 
@@ -15,24 +18,22 @@ with lib;
 
 buildGoPackage rec {
   pname = "singularity";
-  version = "3.2.1";
+  version = "3.6.1";
 
-  src = fetchFromGitHub {
-    owner = "sylabs";
-    repo = "singularity";
-    rev = "v${version}";
-    sha256 = "14lhxwy21s7q081x7kbnvkjsbxgsg2f181qlzmlxcn6n7gfav3kj";
+  src = fetchurl {
+    url = "https://github.com/hpcng/singularity/releases/download/v${version}/singularity-${version}.tar.gz";
+    sha256 = "070jj6kbiw23sd2p4xhvmyb8gd83imwgisdf18ahkwp7dq85db3c";
   };
 
   goPackagePath = "github.com/sylabs/singularity";
   goDeps = ./deps.nix;
 
-  buildInputs = [ openssl utillinux ];
-  nativeBuildInputs = [ removeReferencesTo which makeWrapper ];
+  buildInputs = [ gpgme openssl libuuid ];
+  nativeBuildInputs = [ removeReferencesTo utillinux which makeWrapper cryptsetup ];
   propagatedBuildInputs = [ coreutils squashfsTools ];
 
-  prePatch = ''
-    substituteInPlace internal/pkg/build/copy/copy.go \
+  postPatch = ''
+    substituteInPlace internal/pkg/build/files/copy.go \
       --replace /bin/cp ${coreutils}/bin/cp
   '';
 
@@ -46,24 +47,28 @@ buildGoPackage rec {
 
     # Don't install SUID binaries
     sed -i 's/-m 4755/-m 755/g' builddir/Makefile
-
   '';
 
   buildPhase = ''
+    runHook preBuild
     make -C builddir
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
     make -C builddir install LOCALSTATEDIR=$out/var
     chmod 755 $out/libexec/singularity/bin/starter-suid
-    wrapProgram $out/bin/singularity --prefix PATH : ${stdenv.lib.makeBinPath propagatedBuildInputs}
+
+    # Explicitly configure paths in the config file
+    sed -i 's|^# mksquashfs path =.*$|mksquashfs path = ${stdenv.lib.makeBinPath [squashfsTools]}/mksquashfs|' $out/etc/singularity/singularity.conf
+    sed -i 's|^# cryptsetup path =.*$|cryptsetup path = ${stdenv.lib.makeBinPath [cryptsetup]}/cryptsetup|' $out/etc/singularity/singularity.conf
+
+    runHook postInstall
   '';
 
   postFixup = ''
     find $out/libexec/ -type f -executable -exec remove-references-to -t ${go} '{}' + || true
-
-    # These etc scripts shouldn't have their paths patched
-    cp etc/actions/* $out/etc/singularity/actions/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -97,6 +97,7 @@ rec {
             cd ..
             mkdir -p /var/singularity/mnt/{container,final,overlay,session,source}
             echo "root:x:0:0:System administrator:/root:/bin/sh" > /etc/passwd
+            echo > /etc/resolv.conf
             TMPDIR=$(pwd -P) singularity build $out ./img
           '');
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to latest release. Resolves #92466 and also a hardening bug.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
