### PR TITLE
cmake.setupHook: define shareDocName

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -34,8 +34,6 @@ stdenv.mkDerivation rec {
     "-DUSE_KWALLET=OFF"
   ];
 
-  # Doc has high risk of collisions
-  postInstall = "rm -r $out/share/doc";
 
   # darktable changed its rpath handling in commit
   # 83c70b876af6484506901e6b381304ae0d073d3c and as a result the

--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -57,9 +57,6 @@ in stdenv.mkDerivation {
   ++ lib.optionals enableQt [ qt5.wrapQtAppsHook ]
   ;
 
-  # Doc has high risk of collisions
-  postInstall = "rm -r $out/share/doc";
-
   buildInputs = [
     openssl
     curl

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -68,6 +68,24 @@ cmakeConfigurePhase() {
     # nix/store directory.
     cmakeFlags="-DCMAKE_INSTALL_NAME_DIR=${!outputLib}/lib $cmakeFlags"
 
+    # The docdir flag needs to include PROJECT_NAME as per GNU guidelines,
+    # try to extract it from CMakeLists.txt.
+    if [[ -z "$shareDocName" ]]; then
+        local cmakeLists="${cmakeDir}/CMakeLists.txt"
+        if [[ -f "$cmakeLists" ]]; then
+            local shareDocName="$(grep --only-matching --perl-regexp --ignore-case '\bproject\s*\(\s*"?\K([^[:space:]")]+)' < "$cmakeLists" | head -n1)"
+        fi
+        # The argument sometimes contains garbage or variable interpolation.
+        # When that is the case, let’s fall back to the derivation name.
+        if [[ -z "$shareDocName" ]] || echo "$shareDocName" | grep -q '[^a-zA-Z0-9_-+]'; then
+            if [[ -n "${pname-}" ]]; then
+                shareDocName="$pname"
+            else
+                shareDocName="$(echo "$name" | sed 's/-[^a-zA-Z].*//')"
+            fi
+        fi
+    fi
+
     # This ensures correct paths with multiple output derivations
     # It requires the project to use variables from GNUInstallDirs module
     # https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The docdir flag needs to include `PROJECT_NAME` according to [GNU guidelines]. We are passing `-DCMAKE_INSTALL_DOCDIR=${!outputDoc}/share/doc/${shareDocName}` but `$shareDocName` was unset.

The `multiple-outputs.sh` setup hook actually only defines `shareDocName` as a local variable so it was not available for cmake setup hook. Making it global would be of limited usability, since it primarily tries to extract the project name from configure script. Additionally, it would not be set because the setup hook defines `setOutputFlags=`, preventing the function defining `shareDocName` from running. And lastly, the function would not run for single-output derivations.

Previously, we tried [not disabling `setOutputFlags`] and passing the directory flags only for multi-output derivations that do not disable `setOutputFlags` but that meant having two different branches of code, making it harder to check correctness. The multi-output one did in fact not work due to aforementioned undefined `shareDocName`. It also broke derivations that set `setOutputFlags=` like [`qtModule` function does] (probably because some Qt modules have configure scripts incompatible with `configureFlags` defined by `multiple-outputs.sh` setup hook). For that reason, it was [reverted], putting us back to start.

Let’s try to extract the project name from CMake in the cmake setup hook.

CMake has a `-L` flag for dumping variables but `PROJECT_NAME` did not seem to be among them when I tested, so I had to resort to parsing the `CMakeLists.txt` file.

The extraction function is limited, it does not deal with

* project name on different line from the `project(` command opening
    - that will just not get matched so we will fall back to using the derivation name
* variable interpolation
    - we will just fall back to using derivation name when the extracted `project_name` contains a dollar character
* multiple [`project`] commands
    - The command sets `PROJECT_NAME` variable anew with each call, so the last `project` call before `include(GNUInstallDirs)` command will be used when the included module would [cache the `CMAKE_INSTALL_DOCDIR` variable]. We will just take the first discovered `project` command for simplicity. Hopefully, there are not many projects that use multiple `project` calls before including `GNUInstallDirs`.

In either case, we will have some subdirectory so the conflicts will be minimized.

[GNU guidelines]: https://www.gnu.org/prep/standards/html_node/Directory-Variables.html#index-docdir
[not disabling `setOutputFlags`]: https://github.com/NixOS/nixpkgs/commit/be1b22538a60e52987d238bb11f93043682b6e9a
[`qtModule` function  does]: https://github.com/NixOS/nixpkgs/pull/12740
[reverted]: https://github.com/NixOS/nixpkgs/pull/92298
[`PROJECT_NAME`]: https://cmake.org/cmake/help/v3.18/variable/PROJECT_NAME.html
[`project`]: https://cmake.org/cmake/help/v3.18/command/project.html
[cache the `CMAKE_INSTALL_DOCDIR` variable]: https://github.com/Kitware/CMake/blob/92e30d576d66ac05254bba0f0ff7d655947beb0f/Modules/GNUInstallDirs.cmake#L298-L299

