### PR TITLE
dune-release: 1.3.3 → 1.4.0

### DIFF
--- a/pkgs/development/tools/ocaml/dune-release/default.nix
+++ b/pkgs/development/tools/ocaml/dune-release/default.nix
@@ -1,6 +1,6 @@
 { lib, buildDunePackage, fetchurl, makeWrapper
 , curly, fmt, bos, cmdliner, re, rresult, logs
-, odoc, opam-format, opam-core, opam-state
+, odoc, opam-format, opam-core, opam-state, yojson
 , opam, git, findlib, mercurial, bzip2, gnutar, coreutils
 , alcotest, mdx
 }:
@@ -10,27 +10,33 @@
 let runtimeInputs = [ opam findlib git mercurial bzip2 gnutar coreutils ];
 in buildDunePackage rec {
   pname = "dune-release";
-  version = "1.3.3";
+  version = "1.4.0";
 
   minimumOCamlVersion = "4.06";
 
   src = fetchurl {
     url = "https://github.com/ocamllabs/${pname}/releases/download/${version}/${pname}-${version}.tbz";
-    sha256 = "04qmgvjh1233ri878wi5kifdd1070w5pbfkd8yk3nnqnslz35zlb";
+    sha256 = "1frinv1rsrm30q6jclicsswpshkdwwdgxx7sp6q9w4c2p211n1ln";
   };
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ curly fmt cmdliner re opam-format opam-state opam-core
-                  rresult logs odoc bos ];
-  checkInputs = [ alcotest mdx ];
+                  rresult logs odoc bos yojson ];
+  checkInputs = [ alcotest mdx ] ++ runtimeInputs;
   doCheck = true;
 
   useDune2 = true;
 
-  # remove check for curl in PATH, since curly is patched
-  # to have a fixed path to the binary in nix store
   postPatch = ''
+    # remove check for curl in PATH, since curly is patched
+    # to have a fixed path to the binary in nix store
     sed -i '/must_exist (Cmd\.v "curl"/d' lib/github.ml
+
+    # set bogus user info in git so git commit doesn't fail
+    sed -i '/git init/ a \    $ git config user.name test; git config user.email "pseudo@pseudo.invalid"' \
+      tests/bin/{delegate_info,errors,tag,no_doc,x-commit-hash}/run.t
+    # ignore weird yes error message
+    sed -i 's/yes |/yes 2>\/dev\/null |/' tests/bin/no_doc/run.t
   '';
 
   # tool specific env vars have been deprecated, use PATH


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/ocamllabs/dune-release/releases/tag/1.4.0>

###### Things done

Required a bit of fiddling around to get the `mdx` tests to work, but seems good now. `yes` for some reason would complain about a broken pipe in the `no_doc` test which I couldn't reproduce outside of `nix-build`. Seems to be safe to just ignore by piping it to `/dev/null` which makes the output match up again. No idea what's causing this.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
