### PR TITLE
nixos/printing: fix extraConf configuration option

### DIFF
--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -86,6 +86,47 @@ let
 
     LogLevel ${cfg.logLevel}
 
+    DefaultAuthType Basic
+
+    <Location />
+      Order allow,deny
+      ${cfg.allowFrom}
+    </Location>
+
+    <Location /admin>
+      Order allow,deny
+      ${cfg.allowFrom}
+    </Location>
+
+    <Location /admin/conf>
+      AuthType Basic
+      Require user @SYSTEM
+      Order allow,deny
+      ${cfg.allowFrom}
+    </Location>
+
+    <Policy default>
+      <Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job CUPS-Move-Job>
+        Require user @OWNER @SYSTEM
+        Order deny,allow
+      </Limit>
+
+      <Limit Pause-Printer Resume-Printer Set-Printer-Attributes Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After CUPS-Add-Printer CUPS-Delete-Printer CUPS-Add-Class CUPS-Delete-Class CUPS-Accept-Jobs CUPS-Reject-Jobs CUPS-Set-Default>
+        AuthType Basic
+        Require user @SYSTEM
+        Order deny,allow
+      </Limit>
+
+      <Limit Cancel-Job CUPS-Authenticate-Job>
+        Require user @OWNER @SYSTEM
+        Order deny,allow
+      </Limit>
+
+      <Limit All>
+        Order deny,allow
+      </Limit>
+    </Policy>
+
     ${cfg.extraConf}
   '';
 
@@ -406,50 +447,6 @@ in
 
         restartTriggers = [ browsedFile ];
       };
-
-    services.printing.extraConf =
-      ''
-        DefaultAuthType Basic
-
-        <Location />
-          Order allow,deny
-          ${cfg.allowFrom}
-        </Location>
-
-        <Location /admin>
-          Order allow,deny
-          ${cfg.allowFrom}
-        </Location>
-
-        <Location /admin/conf>
-          AuthType Basic
-          Require user @SYSTEM
-          Order allow,deny
-          ${cfg.allowFrom}
-        </Location>
-
-        <Policy default>
-          <Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job CUPS-Move-Job>
-            Require user @OWNER @SYSTEM
-            Order deny,allow
-          </Limit>
-
-          <Limit Pause-Printer Resume-Printer Set-Printer-Attributes Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After CUPS-Add-Printer CUPS-Delete-Printer CUPS-Add-Class CUPS-Delete-Class CUPS-Accept-Jobs CUPS-Reject-Jobs CUPS-Set-Default>
-            AuthType Basic
-            Require user @SYSTEM
-            Order deny,allow
-          </Limit>
-
-          <Limit Cancel-Job CUPS-Authenticate-Job>
-            Require user @OWNER @SYSTEM
-            Order deny,allow
-          </Limit>
-
-          <Limit All>
-            Order deny,allow
-          </Limit>
-        </Policy>
-      '';
 
     security.pam.services.cups = {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The config option `services.printing.extraConf` was set in the printing module implementation, making it hard for users to configure additional cupsd.conf settings.

###### Things done
Fixed cupsd.conf generation (now similar to cups-files.conf generation).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@matthewbauer @Ma27 