### PR TITLE
Fix make-ext4-fs.nix to work with empty files folder

### DIFF
--- a/nixos/lib/make-ext4-fs.nix
+++ b/nixos/lib/make-ext4-fs.nix
@@ -46,7 +46,9 @@ pkgs.stdenv.mkDerivation {
       (
         GLOBIGNORE=".:.."
         shopt -u dotglob
-        cp -a --reflink=auto ./files/* -t ./rootImage/
+        if [ "$(ls -A ./files)" ]; then
+          cp -a --reflink=auto ./files/* -t ./rootImage/
+        fi
       )
 
       # Also include a manifest of the closures in a format suitable for nix-store --load-db


### PR DESCRIPTION
##### Motivation for this change
Since the file `nixos/modules/installer/cd-dvd/sd-image-raspberrypi4.nix` specifies `sdImage.populateRootCommands = ""`, the folder `./files` is empty and the glob `./files/*` is empty. As a result the `cp` command fails due to missing operands.

This should be a non-breaking change.

**Log output**
The failing build log looks like:
```
[...]
copying path '/nix/store/6ibcrm0ix9jqk6d2f8mdjfvcj4cyc2vg-zstd-1.4.5-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/p7g2yn99srn46q6vh0r3dl7gs0apk8d0-zstd-1.4.5-man' from 'https://cache.nixos.org'...
Preparing store paths for image...
/nix/store/qyfkk34jqq9ax0dd2b7k1vqw6m8ifn11-coreutils-8.31/bin/cp: missing file operand
Try '/nix/store/qyfkk34jqq9ax0dd2b7k1vqw6m8ifn11-coreutils-8.31/bin/cp --help' for more information.
builder for '/nix/store/ic5nm8b7ywy0swazzrsd6wskbhlhlkiy-ext4-fs.img.zst.drv' failed with exit code
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
