### PR TITLE
tensorflow: 1.15.2 -> 1.15.3 

### DIFF
--- a/pkgs/development/python-modules/tensorflow/1/default.nix
+++ b/pkgs/development/python-modules/tensorflow/1/default.nix
@@ -72,7 +72,7 @@ let
 
   tfFeature = x: if x then "1" else "0";
 
-  version = "1.15.2";
+  version = "1.15.3";
   variant = if cudaSupport then "-gpu" else "";
   pname = "tensorflow${variant}";
 
@@ -103,7 +103,7 @@ let
       owner = "tensorflow";
       repo = "tensorflow";
       rev = "v${version}";
-      sha256 = "1q0848drjvnaaa38dgns8knmpmkj5plzsc98j20m5ybv68s55w78";
+      sha256 = "1pzh2srfjblmnvas0166ckpksm1w7pnyji5f834rjl9wdqpbdrz8";
     };
 
     patches = [
@@ -307,9 +307,9 @@ let
 
       # cudaSupport causes fetch of ncclArchive, resulting in different hashes
       sha256 = if cudaSupport then
-        "09j57w6kc0vkfcdwr0qggy3qgrgq82kfa2jrwvvcnij4bl3wj40j"
+        "1w5hppxshdy38dwiqqh7kx0d14xpbvv39y4ivni7nbb8b934218q"
       else
-        "14g8z49qz7d8n1c2mcsfhr7yqpcy7mhmpm6hgmqvpgb8vm7yvwrc";
+        "02anlijahpwyh95pr3xpll540l9mnfrxxgv855g4dpn2ajr7h4k1";
     };
 
     buildAttrs = {


### PR DESCRIPTION
#### Motivation for this change

tensorflow 1.15.3 was released.

~The first commit fixes the build for opt-einsum (see PR #93107), but I also wanted to check whether tensorflow builds.~

Actually, my main motivation for this is that I want to upgrade bazel to 3.4.1, but they removed the `--incompatible_disable_deprecated_attr_params` command line flag, which is used by dm-sonnet. So I tried to upgrade dm-sonnet, hoping that they would not need this flag anymore. But that did not work because it depends on tensorflow and tensorflow did not build because of the broken test in opt-einsum.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
