### PR TITLE
filtron: init at 0.2.0

### DIFF
--- a/pkgs/servers/filtron/default.nix
+++ b/pkgs/servers/filtron/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "filtron";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "asciimoo";
+    repo = "filtron";
+    rev = "v${version}";
+    sha256 = "18d3h0i2sfqbc0bjx26jm2n9f37zwp8z9z4wd17sw7nvkfa72a26";
+  };
+
+  vendorSha256 = "05q2g591xl08h387mm6njabvki19yih63dfsafgpc9hyk5ydf2n9";
+
+  # The upstream test checks are obsolete/unmaintained.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Reverse HTTP proxy to filter requests by different rules.";
+    homepage = "https://github.com/asciimoo/filtron";
+    license = licenses.agpl3;
+    maintainers = [ maintainers.dasj19 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15366,6 +15366,8 @@ with pkgs;
 
   filter-audio = callPackage ../development/libraries/filter-audio {};
 
+  filtron = callPackage ../servers/filtron {};
+
   flann = callPackage ../development/libraries/flann { };
 
   flatcc = callPackage ../development/libraries/flatcc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I packaged `filtron` in order to protect a `searx` instance from bots and unwanted traffic.
I packaged its go dependencies as well.

The code I use to run filtron as a service:

```
  # Startup a filtron server.
  systemd.services.filtron-main = {
      wantedBy = [ "multi-user.target" ]; 
      after = [ "network.target" ];
      description = "Start a filtron instance.";
      serviceConfig = {
        User = "filtronm";
        ExecStart = ''
          ${pkgs.filtron}/bin/filtron -rules /etc/nixos/filtron-rules.json -target "127.0.0.1:8100"
        '';
      };
   };
```
My searx instance running as a service on port 8100 (I use a systemd service because I have two searx instances on the server)
```
  # Startup a main searx server.
  systemd.services.searx-main = {
      wantedBy = [ "multi-user.target" ]; 
      after = [ "network.target" ];
      description = "Start a main searx instance.";
      serviceConfig = {
        User = "searxm";
        ExecStart = ''
          ${pkgs.searx}/bin/searx-run
        '';
        Environment = [
          "SEARX_SETTINGS_PATH=/etc/nixos/searx-config.yml"
        ];         
      };
   };
```
Apache configuration:
```
  services.httpd.virtualHosts."searx.example".extraConfig = ''
    # Disable logs for privacy.
    SetEnvIf Request_URI "/" dontlog
    # Proxy addresses.
    ProxyPass / http://127.0.0.1:4004/
    ProxyPassReverse / http://127.0.0.1:4004/
  '';
```



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
