### PR TITLE
oneshot: 1.1.0 → 1.1.3

### DIFF
--- a/pkgs/tools/networking/oneshot/default.nix
+++ b/pkgs/tools/networking/oneshot/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "oneshot";
-  version = "1.1.0";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "raphaelreyna";
     repo = "oneshot";
     rev = "v${version}";
-    sha256 = "1gcxwamchznkzg3m0gfig7733z2w035lxxj6h18gc6zzcnf6p57w";
+    sha256 = "14s5cl1g0rgqj7fj699xgz2kmkzym1zpckhv3h33ypsn4dq7gjh2";
   };
 
   goPackagePath = "github.com/raphaelreyna/oneshot";


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).