### PR TITLE
nwg-launchers: init at 0.2.0

### DIFF
--- a/pkgs/applications/misc/nwg-launchers/default.nix
+++ b/pkgs/applications/misc/nwg-launchers/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, gtkmm3
+, meson
+, ninja
+, nlohmann_json
+, pkgconfig
+, swaylock
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nwg-launchers";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "nwg-piotr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1mlym0mpg6njwgwniwlk95fk6wfwlzq8nwmkb5mkjlm2nqv5bdv1";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    cmake
+    makeWrapper
+  ];
+
+  buildInputs = [
+    gtkmm3
+    nlohmann_json
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/nwgbar \
+      --prefix PATH : "${swaylock}/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GTK-based launchers: application grid, button bar, dmenu for sway and other window managers";
+    homepage = "https://github.com/nwg-piotr/nwg-launchers";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ bbigras ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21356,6 +21356,8 @@ in
   nootka = qt5.callPackage ../applications/audio/nootka { };
   nootka-unstable = qt5.callPackage ../applications/audio/nootka/unstable.nix { };
 
+  nwg-launchers = callPackage ../applications/misc/nwg-launchers { };
+
   open-policy-agent = callPackage ../development/tools/open-policy-agent { };
 
   openshift = callPackage ../applications/networking/cluster/openshift { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

`swaylock` needs to be in path. I wonder if we should just wrap `result/bin/nwgbar`.