### PR TITLE
bitlbee: propagate glib dependency

### DIFF
--- a/pkgs/applications/networking/instant-messengers/bitlbee-discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-discord/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ bitlbee glib ];
+  buildInputs = [ bitlbee ];
 
   preConfigure = ''
     export BITLBEE_PLUGINDIR=$out/lib/bitlbee

--- a/pkgs/applications/networking/instant-messengers/bitlbee-facebook/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-facebook/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoconf automake libtool pkgconfig ];
 
-  buildInputs = [ bitlbee glib json-glib ];
+  buildInputs = [ bitlbee json-glib ];
 
   preConfigure = ''
     export BITLBEE_PLUGINDIR=$out/lib/bitlbee

--- a/pkgs/applications/networking/instant-messengers/bitlbee-mastodon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-mastodon/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ bitlbee glib ];
+  buildInputs = [ bitlbee ];
 
   preConfigure = ''
     export BITLBEE_PLUGINDIR=$out/lib/bitlbee

--- a/pkgs/applications/networking/instant-messengers/bitlbee-steam/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-steam/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ bitlbee autoconf automake libtool glib libgcrypt ];
+  buildInputs = [ bitlbee autoconf automake libtool libgcrypt ];
 
   preConfigure = ''
     export BITLBEE_PLUGINDIR=$out/lib/bitlbee

--- a/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
@@ -14,9 +14,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ] ++ optional doCheck check;
 
-  buildInputs = [ gnutls glib libotr python ]
+  buildInputs = [ gnutls libotr python ]
     ++ optional enableLibPurple pidgin
     ++ optional enablePam pam;
+
+  propagatedBuildInputs = [ glib ];
 
   configureFlags = [
     "--otr=1"


### PR DESCRIPTION
bitlbee.pc requires glib, so all packages that depend on bitlbee will
also depend on glib.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
