### PR TITLE
rocm-runtime-ext: init at 3.5.1

### DIFF
--- a/pkgs/development/libraries/rocm-runtime-ext/default.nix
+++ b/pkgs/development/libraries/rocm-runtime-ext/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, autoPatchelfHook, rpmextract, rocm-runtime }:
+
+stdenv.mkDerivation rec {
+  pname = "rocm-runtime-ext";
+  version = "3.5.1";
+
+  src = fetchurl {
+    url = "https://repo.radeon.com/rocm/yum/3.5.1/hsa-ext-rocr-dev-1.1.30501.0-rocm-rel-3.5-34-def83d8a-Linux.rpm";
+    sha256 = "0r7lrmnplr10hs6wrji55i3dnczfzlmp8jahm1g3mhq2x12zmly0";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook rpmextract ];
+
+  buildInputs = [ rocm-runtime stdenv.cc.cc ];
+
+  unpackPhase = "rpmextract ${src}";
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp -R opt/rocm-${version}/hsa/lib $out/lib/rocm-runtime-ext
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  meta = with stdenv.lib; {
+    description = "Platform runtime for ROCm (closed-source extensions)";
+    longDescription = ''
+      This package provides closed-source extensions to the ROCm
+      runtime. Currently this adds support for OpenCL image
+      processing.
+
+      In order for the ROCm runtime to pick up the extension, you
+      should either set the ROCR_EXT_DIR environment variable should
+      be set to ''${rocm-runtime-ext}/lib/rocm-runtime-ext or this
+      package should be added to the hardware.opengl.extraPackages
+      NixOS configuration option.
+    '';
+    homepage = "https://github.com/RadeonOpenCompute/ROCR-Runtime";
+    license = with licenses; [ unfreeRedistributable ];
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/development/libraries/rocm-runtime-ext/setup-hook.sh
+++ b/pkgs/development/libraries/rocm-runtime-ext/setup-hook.sh
@@ -1,0 +1,7 @@
+addRocmRuntimeExtDir () {
+    if [[ -z "${ROCR_EXT_DIR-}" ]]; then
+       export ROCR_EXT_DIR="@out@/lib/rocm-runtime-ext"
+    fi
+}
+
+addEnvHooks "$hostOffset" addRocmRuntimeExtDir

--- a/pkgs/development/libraries/rocm-runtime/rocr-ext-dir.diff
+++ b/pkgs/development/libraries/rocm-runtime/rocr-ext-dir.diff
@@ -1,0 +1,24 @@
+diff --git a/src/core/util/lnx/os_linux.cpp b/src/core/util/lnx/os_linux.cpp
+index fdbe19a..42d4ef8 100644
+--- a/src/core/util/lnx/os_linux.cpp
++++ b/src/core/util/lnx/os_linux.cpp
+@@ -161,8 +161,17 @@ static_assert(sizeof(Mutex) == sizeof(pthread_mutex_t*), "OS abstraction size mi
+ static_assert(sizeof(Thread) == sizeof(os_thread*), "OS abstraction size mismatch");
+ 
+ LibHandle LoadLib(std::string filename) {
+-  void* ret = dlopen(filename.c_str(), RTLD_LAZY);
+-  if (ret == nullptr) debug_print("LoadLib(%s) failed: %s\n", filename.c_str(), dlerror());
++  std::string extDirFilename = GetEnvVar("ROCR_EXT_DIR") + "/" + filename;
++  void* ret = dlopen(extDirFilename.c_str(), RTLD_LAZY);
++
++  // Attempt to load from the directory hardcoded by rocrExtDir.
++  if (ret == nullptr) {
++    std::string runpathFilename = std::string("@rocrExtDir@") + "/" + filename;
++    ret = dlopen(runpathFilename.c_str(), RTLD_LAZY);
++
++    if (ret == nullptr) debug_print("LoadLib(%s) failed: %s\n", filename.c_str(), dlerror());
++  }
++
+   return *(LibHandle*)&ret;
+ }
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9282,6 +9282,8 @@ in
 
   rocm-runtime = callPackage ../development/libraries/rocm-runtime { };
 
+  rocm-runtime-ext = callPackage ../development/libraries/rocm-runtime-ext { };
+
   rocm-thunk = callPackage ../development/libraries/rocm-thunk { };
 
   rtags = callPackage ../development/tools/rtags {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This package provides the closed-source extension for `rocm-runtime` that is necessary for OpenCL image processing.

E.g.:

```
❯ `nix-build --no-out-link -A clinfo`/bin/clinfo | grep Image
  Image support                                   No
❯ export OCL_ICD_VENDORS=`nix-build --no-out-link -A rocm-opencl-icd`/etc/OpenCL/vendors/ 
❯ export ROCR_EXT_DIR=`nix-build --no-out-link -A rocm-runtime-ext`/lib 
 `nix-build --no-out-link -A clinfo`/bin/clinfo | grep Image
  Image support                                   Yes
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
