### PR TITLE
krunner: add upstream patch for deprecated virtual method

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -83,7 +83,7 @@ let
 
           in mkDerivation (args // {
             name = "${name}-${version}";
-            inherit meta outputs setupHook src;
+            inherit meta outputs setupHook src version;
           });
 
       };

--- a/pkgs/development/libraries/kde-frameworks/krunner.nix
+++ b/pkgs/development/libraries/kde-frameworks/krunner.nix
@@ -1,17 +1,26 @@
 {
-  mkDerivation, lib,
+  mkDerivation, lib, fetchpatch,
   extra-cmake-modules,
   kconfig, kcoreaddons, ki18n, kio, kservice, plasma-framework, qtbase,
   qtdeclarative, solid, threadweaver, kwindowsystem
 }:
 
-mkDerivation {
-  name = "krunner";
-  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = [
-    kconfig kcoreaddons ki18n kio kservice qtdeclarative solid
-    threadweaver
-  ];
-  propagatedBuildInputs = [ plasma-framework qtbase kwindowsystem ];
-}
+let
+  self = mkDerivation {
+    name = "krunner";
+    meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+    patches = [
+      # Un-deprecate virtual method to restore binary compatibility.
+      (assert !(lib.versionOlder "5.72" self.version); fetchpatch {
+        url = "https://invent.kde.org/frameworks/krunner/-/commit/8f7ce559b84ee0c21de0256e6591793e4b95f411.diff";
+        sha256 = "06h9g04syv6x3hqi0iy9wll78yf9ys95r5vm104sc25pnszvjbxv";
+      })
+    ];
+    nativeBuildInputs = [ extra-cmake-modules ];
+    buildInputs = [
+      kconfig kcoreaddons ki18n kio kservice qtdeclarative solid
+      threadweaver
+    ];
+    propagatedBuildInputs = [ plasma-framework qtbase kwindowsystem ];
+  };
+in self


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Upstream requests that we carry this patch for KDE Frameworks 5.72.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
