### PR TITLE
nomad: add 0.12, multi-version support

### DIFF
--- a/pkgs/applications/networking/cluster/nomad/0.11.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.11.nix
@@ -1,0 +1,6 @@
+{ callPackage }:
+
+callPackage ./generic.nix {
+  version = "0.11.4";
+  sha256 = "1sykp9sji6f564s7bz0cvnr9w5x92n0l1r1djf1bl7jvv2mi1mcb";
+}

--- a/pkgs/applications/networking/cluster/nomad/0.12.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.12.nix
@@ -1,0 +1,6 @@
+{ callPackage }:
+
+callPackage ./generic.nix {
+  version = "0.12.2";
+  sha256 = "1gc286ag6plk5kxw7jzr32cp3n5rwydj1z7rds1rfd0fyq7an404";
+}

--- a/pkgs/applications/networking/cluster/nomad/default.nix
+++ b/pkgs/applications/networking/cluster/nomad/default.nix
@@ -1,8 +1,23 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub, majorVersion ? "0.11" }:
+
+let
+  versionMap = {
+    "0.11" = {
+      version = "0.11.4";
+      sha256 = "1sykp9sji6f564s7bz0cvnr9w5x92n0l1r1djf1bl7jvv2mi1mcb";
+    };
+    "0.12" = {
+      version = "0.12.2";
+      sha256 = "1gc286ag6plk5kxw7jzr32cp3n5rwydj1z7rds1rfd0fyq7an404";
+    };
+  };
+in
+
+with versionMap.${majorVersion};
 
 buildGoPackage rec {
   pname = "nomad";
-  version = "0.11.3";
+  inherit version;
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/nomad";
@@ -11,8 +26,7 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = pname;
-    inherit rev;
-    sha256 = "1p7g7x2gl77h1w7aip3xji3s530fj46gspargz4j3i6h4wkyvafb";
+    inherit rev sha256;
   };
 
   # ui:

--- a/pkgs/applications/networking/cluster/nomad/generic.nix
+++ b/pkgs/applications/networking/cluster/nomad/generic.nix
@@ -1,19 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, majorVersion ? "0.11" }:
-
-let
-  versionMap = {
-    "0.11" = {
-      version = "0.11.4";
-      sha256 = "1sykp9sji6f564s7bz0cvnr9w5x92n0l1r1djf1bl7jvv2mi1mcb";
-    };
-    "0.12" = {
-      version = "0.12.2";
-      sha256 = "1gc286ag6plk5kxw7jzr32cp3n5rwydj1z7rds1rfd0fyq7an404";
-    };
-  };
-in
-
-with versionMap.${majorVersion};
+{ stdenv, buildGoPackage, fetchFromGitHub, version, sha256 }:
 
 buildGoPackage rec {
   pname = "nomad";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5608,7 +5608,9 @@ in
 
   noip = callPackage ../tools/networking/noip { };
 
-  nomad = callPackage ../applications/networking/cluster/nomad { };
+  nomad = nomad_0_11;
+  nomad_0_11 = callPackage ../applications/networking/cluster/nomad { majorVersion = "0.11"; };
+  nomad_0_12 = callPackage ../applications/networking/cluster/nomad { majorVersion = "0.12"; };
 
   notable = callPackage ../applications/misc/notable { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5609,8 +5609,8 @@ in
   noip = callPackage ../tools/networking/noip { };
 
   nomad = nomad_0_11;
-  nomad_0_11 = callPackage ../applications/networking/cluster/nomad { majorVersion = "0.11"; };
-  nomad_0_12 = callPackage ../applications/networking/cluster/nomad { majorVersion = "0.12"; };
+  nomad_0_11 = callPackage ../applications/networking/cluster/nomad/0.11.nix { };
+  nomad_0_12 = callPackage ../applications/networking/cluster/nomad/0.12.nix { };
 
   notable = callPackage ../applications/misc/notable { };
 


### PR DESCRIPTION
###### Motivation for this change

This commit adds Nomad 0.12 to nixpkgs, but introduces it as an
additional version that is available for install, while keeping 0.11 as
the default.

The reason for introducing it as a seperate version track is that it can
be dangerous to update to early versions of HashiCorp software, and this
allows users to gradually update their Server/Client nodes as required.

My plan for version support is Last 0.x, Current 0.y, and Beta 0.z, with
the `nomad` tag updating to `current` when the current release reaches
some level of stability (around 0.y.2-3 or so).

This is my first time with a contribution that is outside of
adding/updating modules/packages, so let me know if this should have a
different commit structure.

Thanks!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).