### PR TITLE
motion: 4.3.0 -> 4.3.1

### DIFF
--- a/pkgs/applications/video/motion/default.nix
+++ b/pkgs/applications/video/motion/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
-, ffmpeg_3, libjpeg, libmicrohttpd }:
+, ffmpeg, libjpeg, libmicrohttpd }:
 
 stdenv.mkDerivation rec {
   pname = "motion";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
-  buildInputs = [ ffmpeg_3 libjpeg libmicrohttpd ];
+  buildInputs = [ ffmpeg libjpeg libmicrohttpd ];
 
   meta = with stdenv.lib; {
     description = "Monitors the video signal from cameras";

--- a/pkgs/applications/video/motion/default.nix
+++ b/pkgs/applications/video/motion/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "motion";
-  version = "4.3.0";
+  version = "4.3.1";
 
   src = fetchFromGitHub {
     owner  = "Motion-Project";
     repo   = "motion";
-    rev    = "Release-${version}";
-    sha256 = "08mm7ajgs0qnrydywxxyzcll09z80crjnjkjnckdi6ljsj6s96j8";
+    rev    = "release-${version}";
+    sha256 = "01yy4pdgd4wa97bpw27zn5zik9iz719m1jiwkk9lb7m2a2951dhc";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/applications/video/motion/default.nix
+++ b/pkgs/applications/video/motion/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     homepage = "https://motion-project.github.io/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ puffnfresh veprbl ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Bump to the latest minor release: https://github.com/Motion-Project/motion/compare/release-4.3.0...release-4.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
