### PR TITLE
gerbera: init at 1.6.1

### DIFF
--- a/pkgs/servers/gerbera/default.nix
+++ b/pkgs/servers/gerbera/default.nix
@@ -1,0 +1,78 @@
+{ stdenv, fetchFromGitHub
+, cmake, pkg-config
+# required
+, libupnp, libuuid, pugixml, libiconv, sqlite, zlib, spdlog, fmt
+, pkgs
+# options
+, enableDuktape ? true
+, enableCurl ? true
+, enableTaglib ? true
+, enableLibmagic ? true
+, enableLibmatroska ? true
+, enableAvcodec ? false
+, enableLibexif ? true
+, enableExiv2 ? false
+, enableFFmpegThumbnailer ? false
+, enableInotifyTools ? true
+}:
+
+with stdenv.lib;
+let
+  optionOnOff = option: if option then "on" else "off";
+in stdenv.mkDerivation rec {
+  pname = "gerbera";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    repo = "gerbera";
+    owner = "gerbera";
+    rev = "v${version}";
+    sha256 = "sha256:05ca27r9sidbl7xns9hcdan8wgjrpg26n1wq1vp247c9bqhpyql8";
+  };
+
+  cmakeFlags = [
+    "-DWITH_JS=${optionOnOff enableDuktape}"
+    "-DWITH_CURL=${optionOnOff enableCurl}"
+    "-DWITH_TAGLIB=${optionOnOff enableTaglib}"
+    "-DWITH_MAGIC=${optionOnOff enableLibmagic}"
+    "-DWITH_MATROSKA=${optionOnOff enableLibmatroska}"
+    "-DWITH_AVCODEC=${optionOnOff enableAvcodec}"
+    "-DWITH_EXIF=${optionOnOff enableLibexif}"
+    "-DWITH_EXIV2=${optionOnOff enableExiv2}"
+    "-DWITH_FFMPEGTHUMBNAILER=${optionOnOff enableFFmpegThumbnailer}"
+    "-DWITH_INOTIFY=${optionOnOff enableInotifyTools}"
+    # systemd service will be generated alongside the service
+    "-DWITH_SYSTEMD=OFF"
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [
+    libupnp libuuid pugixml libiconv sqlite zlib fmt.dev
+    spdlog
+  ]
+  ++ optionals enableDuktape [ pkgs.duktape ]
+  ++ optionals enableCurl [ pkgs.curl ]
+  ++ optionals enableTaglib [ pkgs.taglib ]
+  ++ optionals enableLibmagic [ pkgs.file ]
+  ++ optionals enableLibmatroska [ pkgs.libmatroska pkgs.libebml ]
+  ++ optionals enableAvcodec [ pkgs.libav.dev ]
+  ++ optionals enableLibexif [ pkgs.libexif ]
+  ++ optionals enableExiv2 [ pkgs.exiv2 ]
+  ++ optionals enableInotifyTools [ pkgs.inotify-tools ]
+  ++ optionals enableFFmpegThumbnailer [ pkgs.ffmpegthumbnailer ];
+
+
+  meta = with stdenv.lib; {
+    homepage = https://docs.gerbera.io/;
+    description = "UPnP Media Server for 2020";
+    longDescription = ''
+      Gerbera is a Mediatomb fork.
+      It allows to stream your digital media through your home network and consume it on all kinds
+      of UPnP supporting devices.
+    '';
+    license = licenses.gpl2;
+    maintainers = [ maintainers.ardumont ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16507,6 +16507,8 @@ in
 
   grafana_reporter = callPackage ../servers/monitoring/grafana-reporter { };
 
+  gerbera = callPackage ../servers/gerbera { };
+
   gobetween = callPackage ../servers/gobetween { };
 
   h2o = callPackage ../servers/http/h2o { };


### PR DESCRIPTION
Initialize a new and maintained upnp media server (gerbera).
Next step is to open a service which allows to configure it declaratively.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (tested through my own overrides on odroid-n2 at [1] [2])
   - [ ] macOS
   - [x] other Linux distributions: debian with nix
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): +74906824 (new)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note that it works but the compilation displays warnings because that depends on
other commits not yet merged:
- #93048 (this one is duplicated in this very branch as it's required)
- #93099
- #93098 

[1] mypkgs override definition
https://github.com/ardumont/mypkgs/blob/master/default.nix#L10-L33

[2] my own (for now) gerbera configuration declaration for the gerbera service
https://gitlab.com/ardumont/nixos/-/blob/master/odroid/gerbera/default.nix
