### PR TITLE
 thunderbird, thunderbird-bin: 68.10.0 -> 78.0 [High security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/68.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/68.nix
@@ -1,0 +1,183 @@
+# This pakcage is keeped until Thunderbird 78 supports OpenPGP.
+# https://www.thunderbird.net/en-US/thunderbird/78.0.1/releasenotes/
+{ stdenv, fetchurl, config, makeWrapper
+, alsaLib
+, at-spi2-atk
+, atk
+, cairo
+, cups
+, curl
+, dbus-glib
+, dbus
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, glibc
+, gtk2
+, gtk3
+, kerberos
+, libX11
+, libXScrnSaver
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXext
+, libXfixes
+, libXi
+, libXinerama
+, libXrender
+, libXt
+, libxcb
+, libcanberra
+, gnome3
+, libGLU, libGL
+, nspr
+, nss
+, pango
+, writeScript
+, xidel
+, coreutils
+, gnused
+, gnugrep
+, gnupg
+, runtimeShell
+}:
+
+# imports `version` and `sources`
+with (import ./68_sources.nix);
+
+let
+  arch = if stdenv.hostPlatform.system == "i686-linux"
+    then "linux-i686"
+    else "linux-x86_64";
+
+  isPrefixOf = prefix: string:
+    builtins.substring 0 (builtins.stringLength prefix) string == prefix;
+
+  sourceMatches = locale: source:
+      (isPrefixOf source.locale locale) && source.arch == arch;
+
+  systemLocale = config.i18n.defaultLocale or "en-US";
+
+  defaultSource = stdenv.lib.findFirst (sourceMatches "en-US") {} sources;
+
+  source = stdenv.lib.findFirst (sourceMatches systemLocale) defaultSource sources;
+
+  name = "thunderbird-bin-${version}";
+in
+
+stdenv.mkDerivation {
+  inherit name;
+
+  src = fetchurl {
+    url = "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/${version}/${source.arch}/${source.locale}/thunderbird-${version}.tar.bz2";
+    inherit (source) sha512;
+  };
+
+  phases = "unpackPhase installPhase";
+
+  libPath = stdenv.lib.makeLibraryPath
+    [ stdenv.cc.cc
+      alsaLib
+      at-spi2-atk
+      atk
+      cairo
+      cups
+      curl
+      dbus-glib
+      dbus
+      fontconfig
+      freetype
+      gdk-pixbuf
+      glib
+      glibc
+      gtk2
+      gtk3
+      kerberos
+      libX11
+      libXScrnSaver
+      libXcomposite
+      libXcursor
+      libXdamage
+      libXext
+      libXfixes
+      libXi
+      libXinerama
+      libXrender
+      libXt
+      libxcb
+      libcanberra
+      libGLU libGL
+      nspr
+      nss
+      pango
+    ] + ":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" [
+      stdenv.cc.cc
+    ];
+
+  buildInputs = [ gtk3 gnome3.adwaita-icon-theme ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase =
+    ''
+      mkdir -p "$prefix/usr/lib/thunderbird-bin-${version}"
+      cp -r * "$prefix/usr/lib/thunderbird-bin-${version}"
+
+      mkdir -p "$out/bin"
+      ln -s "$prefix/usr/lib/thunderbird-bin-${version}/thunderbird" "$out/bin/"
+
+      for executable in \
+        thunderbird crashreporter thunderbird-bin plugin-container updater
+      do
+        patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+          "$out/usr/lib/thunderbird-bin-${version}/$executable"
+      done
+
+      find . -executable -type f -exec \
+        patchelf --set-rpath "$libPath" \
+          "$out/usr/lib/thunderbird-bin-${version}/{}" \;
+
+      # Create a desktop item.
+      mkdir -p $out/share/applications
+      cat > $out/share/applications/thunderbird.desktop <<EOF
+      [Desktop Entry]
+      Type=Application
+      Exec=$out/bin/thunderbird
+      Icon=$out/usr/lib/thunderbird-bin-${version}/chrome/icons/default/default256.png
+      Name=Thunderbird
+      GenericName=Mail Reader
+      Categories=Application;Network;
+      EOF
+
+      # SNAP_NAME: https://github.com/NixOS/nixpkgs/pull/61980
+      # MOZ_LEGACY_PROFILES and MOZ_ALLOW_DOWNGRADE:
+      #   commit 87e261843c4236c541ee0113988286f77d2fa1ee
+      wrapProgram "$out/bin/thunderbird" \
+        --argv0 "$out/bin/.thunderbird-wrapped" \
+        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:" \
+        --suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS" \
+        --set SNAP_NAME "thunderbird" \
+        --set MOZ_LEGACY_PROFILES 1 \
+        --set MOZ_ALLOW_DOWNGRADE 1
+    '';
+
+  passthru.updateScript = import ./../../browsers/firefox-bin/update.nix {
+    inherit name writeScript xidel coreutils gnused gnugrep curl gnupg runtimeShell;
+    baseName = "thunderbird";
+    channel = "release";
+    basePath = "pkgs/applications/networking/mailreaders/thunderbird-bin";
+    baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";
+  };
+  meta = with stdenv.lib; {
+    description = "Mozilla Thunderbird, a full-featured email client (binary package)";
+    homepage = "http://www.mozilla.org/thunderbird/";
+    license = {
+      free = false;
+      url = "http://www.mozilla.org/en-US/foundation/trademarks/policy/";
+    };
+    maintainers = with stdenv.lib.maintainers; [ ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/68_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/68_sources.nix
@@ -1,0 +1,615 @@
+{
+  version = "68.10.0";
+  sources = [
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ar/thunderbird-68.10.0.tar.bz2";
+      locale = "ar";
+      arch = "linux-x86_64";
+      sha512 = "2f49abd71f7542042ef2823cd420e225bb1015684dc258fd7e8eb1104ac9865957b0e6c975043e3611d4d884c085ad670ce21af8c8cab1da80f08aa302078059";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ast/thunderbird-68.10.0.tar.bz2";
+      locale = "ast";
+      arch = "linux-x86_64";
+      sha512 = "91043afae8c2f31f6d2aa5b7f6c7f874150c7f8ef0ef7401132b12822bbdde8c7d7f24022f3f5d0cec262100a2b8791f440a55f0ed00c30acb9429290aa290f5";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/be/thunderbird-68.10.0.tar.bz2";
+      locale = "be";
+      arch = "linux-x86_64";
+      sha512 = "6167bd7fe2d980af40a0d5594e67dfc262bb7ab5fb76ea07c919136d967505e84b4d27448d883a31323db7aafd33b4222cff63d27d10ec914354ba4264736459";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/bg/thunderbird-68.10.0.tar.bz2";
+      locale = "bg";
+      arch = "linux-x86_64";
+      sha512 = "885c5ee186933eac265ed530f9b8b3cabc934e1ff4efc50b10381f8e53ddc39fe385e21e22041d93ef987e031ec41c2b98e898bcceacec004542bcaa35d0ccca";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/br/thunderbird-68.10.0.tar.bz2";
+      locale = "br";
+      arch = "linux-x86_64";
+      sha512 = "e5c31ab8b32f9f0bd72a03207d4c9a2ca75d0c5f28e497456850bf92f75020784258725942079e52f6b38c0740e7d2ec80ef24bd88aca9fe35e9386f65cf7c1a";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ca/thunderbird-68.10.0.tar.bz2";
+      locale = "ca";
+      arch = "linux-x86_64";
+      sha512 = "2d727f09dd202291cbb908c2e7805ecc7ec29302bb2481b63a5df1f43c29c39d1ae26bcf3b5dea550619391a96982d3d2bb831548a9a2331e986345c64b4b6b4";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/cak/thunderbird-68.10.0.tar.bz2";
+      locale = "cak";
+      arch = "linux-x86_64";
+      sha512 = "1e74db72b4bc0ca3db90b9ae678dea551293dd54eb5cc5e5c124c51e61ef0d4cb074769bf807ba2d680db10f6086bb3bbcf5d082e815bff10fb8c6ae14c5a72a";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/cs/thunderbird-68.10.0.tar.bz2";
+      locale = "cs";
+      arch = "linux-x86_64";
+      sha512 = "9c89e7328879f82cec0e2c5f7efb2711242cb3f36a4ccf6a014c6ed589f0e02748c997ea98909d546ca33478022bc9143987710945eed1e191517d1348f8a064";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/cy/thunderbird-68.10.0.tar.bz2";
+      locale = "cy";
+      arch = "linux-x86_64";
+      sha512 = "46e234560ac4a9e7c5b54816bde0f22f2677b6ea117ce5c528260222e940b5e47b12d8b08b24d2ee9bcfc4dd72168faa036207c88f5bc573051fd7eea2281fd0";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/da/thunderbird-68.10.0.tar.bz2";
+      locale = "da";
+      arch = "linux-x86_64";
+      sha512 = "8ef4fb0210a21df0be22e1866859ac316890cc90e6b157e0cad2725d59360b06db068aa000627ffa750c05cdc8314cb564c32476dcea3975bb63f66b20873059";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/de/thunderbird-68.10.0.tar.bz2";
+      locale = "de";
+      arch = "linux-x86_64";
+      sha512 = "b3c7673728c8af318c0c8e0c3af8e1b7ba457bfd2c5a67bf3df4df6c3c990970d45e1a0884c03aa0a3d973efb12983afea40de55c8831d2b254acfb742c71478";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/dsb/thunderbird-68.10.0.tar.bz2";
+      locale = "dsb";
+      arch = "linux-x86_64";
+      sha512 = "adeba633f288fff864e7247e36b4d7f49046a3901de0e4f93f12ada6fef275578b494441d01e820400045d5f7d64048684554934be678d1b7259910a162a4ed8";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/el/thunderbird-68.10.0.tar.bz2";
+      locale = "el";
+      arch = "linux-x86_64";
+      sha512 = "6ed60a3cb194de3e2bcffbdf1d0c89460b2c2416878f348c913aaaff911f43e9a624a8de87d46df366c8bd608c47f6a6de8b90fec9c0c82e38afe860ca760f65";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/en-GB/thunderbird-68.10.0.tar.bz2";
+      locale = "en-GB";
+      arch = "linux-x86_64";
+      sha512 = "a09f578de9b8f23c9b24123092abecedc70e5b48c9c15089505ca049258621f14d8a4f02c8154f7d2c729ed002814af17e08bf211708fc59e5345c92cb259fa2";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/en-US/thunderbird-68.10.0.tar.bz2";
+      locale = "en-US";
+      arch = "linux-x86_64";
+      sha512 = "3f7d4c844185b0be0ee3354130112ecc034f06cc2335681998e210b79537df7365f251b005387f319b0a2d2dd6a6337fd6287a007fd54ac03c39315c42893dfe";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/es-AR/thunderbird-68.10.0.tar.bz2";
+      locale = "es-AR";
+      arch = "linux-x86_64";
+      sha512 = "a028429230c625b0dcb9e200b2e21c6d4db8e96a93313881701b5965dc25db31a0992d4d6da6072a6ed73eb5891d15ac71f19f343172796db82d6e98355baa75";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/es-ES/thunderbird-68.10.0.tar.bz2";
+      locale = "es-ES";
+      arch = "linux-x86_64";
+      sha512 = "58afe4eb60993bae1271fa03a45ce13611a1d83e4defc1f237ed47b243785881c8309f5fa8a5257fa5b343e2dec7595c8ba6143faa63f49749453ad229ee8102";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/et/thunderbird-68.10.0.tar.bz2";
+      locale = "et";
+      arch = "linux-x86_64";
+      sha512 = "402c33c3fd7194a3f5c0d6afb81f639fd4a0cfebdaa61043858938fb5b2690844ec2fabfe9f73d41f45c26d56adcb121234fb1baa76b2455c87863dd79cf065d";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/eu/thunderbird-68.10.0.tar.bz2";
+      locale = "eu";
+      arch = "linux-x86_64";
+      sha512 = "ace87496370c17b663971365da8c1f88000b76247aba2a6fd5d29a31b5d4b02bf9b56e101c477d48553ca56416e73209aff7f729ea2b8c044e33b9307009321f";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/fi/thunderbird-68.10.0.tar.bz2";
+      locale = "fi";
+      arch = "linux-x86_64";
+      sha512 = "775c937de9d9ed49ec70850a1d8ccbe22c964e12a932c52d3dc360425643f2be5487857caa811556e341d94bc62ed9b8dba5e94039c2cff6de50bdf16e364c89";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/fr/thunderbird-68.10.0.tar.bz2";
+      locale = "fr";
+      arch = "linux-x86_64";
+      sha512 = "1ac4d3e23f71bedf77a8d2dd4fe8d02fbd1083977a8892d2c6db394a9d345bcff73a916f34a078ddd0850e8ac1bb0486aec06d6e36875eafcac0dab08bdedde1";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/fy-NL/thunderbird-68.10.0.tar.bz2";
+      locale = "fy-NL";
+      arch = "linux-x86_64";
+      sha512 = "b62676e5302cc265a6ee65de7a31585bade7bfd51395bd56257f733fc9a6f4c391e5318aad3b48441464e5d8bcbe3606cca1edcd6fca6517b205814b9e39b635";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ga-IE/thunderbird-68.10.0.tar.bz2";
+      locale = "ga-IE";
+      arch = "linux-x86_64";
+      sha512 = "81ba90087282fdfcd15a534e9065fdd94a859dedd6a85dc9da94de4af698eef6b31a19d3a007eaa27e08944682c9f6108a0d0991f1e394451da881018e5cc70c";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/gd/thunderbird-68.10.0.tar.bz2";
+      locale = "gd";
+      arch = "linux-x86_64";
+      sha512 = "1db39cc3ea8990ec8d9ff214d554bf95a6f2699e3f1bf625180b7f84ebc3284e1eec8e2cfdcf87b3a31b466ef2f84dd0a56d771078f4cb06962a28531ee085d8";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/gl/thunderbird-68.10.0.tar.bz2";
+      locale = "gl";
+      arch = "linux-x86_64";
+      sha512 = "dbaa3cd2341d8ad4834b9db4982b731fbcb1125398cc4a7ce6a9cbc44db7218a165392781e144b68618781ed8d26216f11e1bf172ce4ba9b18515cce0feb9bf4";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/he/thunderbird-68.10.0.tar.bz2";
+      locale = "he";
+      arch = "linux-x86_64";
+      sha512 = "547795f844b60b347a10abc8e609f7d311b63ae4cf76b2b0cb0b0605f597ec0e1c7ec3347042161a4b15201f816f99c391851004de9a957754aca6f50a055d7d";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hr/thunderbird-68.10.0.tar.bz2";
+      locale = "hr";
+      arch = "linux-x86_64";
+      sha512 = "6c72a46406396578c329b1ba1c47a46c124f22fb5c47eb1f16af7672e4269bb84f62ac4c1d9b61a5e8e46eaa4c91e5169b59e9908ad61606b243ed21ce31d859";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hsb/thunderbird-68.10.0.tar.bz2";
+      locale = "hsb";
+      arch = "linux-x86_64";
+      sha512 = "e06eeaceffa7b39810faf42640f22b8edef8ad501530f1602a7b13265f5a9b34a1d9304a19a514e3beff2b3c7e8ba92c72aaae6b34cede15e6fa59125344c026";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hu/thunderbird-68.10.0.tar.bz2";
+      locale = "hu";
+      arch = "linux-x86_64";
+      sha512 = "9ab3e1b47a3120b74adb1f0f0ec657443578203f4c7f7e00804ef61bfeb2c7cd36721256943e8c86e0a62f90c1576e16a9051b33dc9a0006cb7fcf55bc90fc0c";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hy-AM/thunderbird-68.10.0.tar.bz2";
+      locale = "hy-AM";
+      arch = "linux-x86_64";
+      sha512 = "614da904a59666d5e67852296eb22ea0ee0d137764ba9fc4f60edee2f547b91659147d14849ca83927671e94b32847f748f97df4bcd93569d46f3cfb0f8f372d";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/id/thunderbird-68.10.0.tar.bz2";
+      locale = "id";
+      arch = "linux-x86_64";
+      sha512 = "13e01f8fe23f10d24b4399da8540c2afdeb762b1068f10984945c0920882b67bdef48f0f26180786a8d944ca1ea601e3c51bbf6f0cb64697fca0c0b0acb08b84";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/is/thunderbird-68.10.0.tar.bz2";
+      locale = "is";
+      arch = "linux-x86_64";
+      sha512 = "176492bbf4ac3b2bb4367848f1283c7dbb805b5bfe6c71cab6c8893578f1d0ca1b9edcbc1e736748d04f2d0ca78f4d6edb21671b78379e26d41d9c43e8727075";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/it/thunderbird-68.10.0.tar.bz2";
+      locale = "it";
+      arch = "linux-x86_64";
+      sha512 = "41d10acbb84fde6556530253ecb5926ba4b5d81a38349a00281a7273669cf37245640f789dae7363c4e1a0224127885fae3dac701926dab6e4512df723d39548";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ja/thunderbird-68.10.0.tar.bz2";
+      locale = "ja";
+      arch = "linux-x86_64";
+      sha512 = "8124ccd221818d37d6d22f204baaf34bd87e7907c50ab380a3a1bf252432b41caa71dc3ba2b575903bfd255f16b702cc89d91903f494437547a7b8fa16469cbf";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ka/thunderbird-68.10.0.tar.bz2";
+      locale = "ka";
+      arch = "linux-x86_64";
+      sha512 = "464a9e0aebda0fa6412665e4cf2d6f590d44636bc395f8a03f96ffa7e8f5423e51499bd801f9ffb65c0c931960b761d00df3ac8f391b2157ab411ad49c7054b2";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/kab/thunderbird-68.10.0.tar.bz2";
+      locale = "kab";
+      arch = "linux-x86_64";
+      sha512 = "d99305c424e0475ed2c1890e2c5cc96d1e4925d329948c33ac0183e3affadd960266e76e380c4fbc017e24538428439888d96f49d73468f9f6162dcb51a358f1";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/kk/thunderbird-68.10.0.tar.bz2";
+      locale = "kk";
+      arch = "linux-x86_64";
+      sha512 = "9398172a5d2f902256b2b36df5f936a39e5f2d253ee4ee566109f67a49f2e2bd4239b92802475b459d79acb5af7e4839f6f5f0a5db1c7da10fa35873c470003d";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ko/thunderbird-68.10.0.tar.bz2";
+      locale = "ko";
+      arch = "linux-x86_64";
+      sha512 = "80e7f9929a197ea4b431376f168fcfaf42718b1744bbf0bddf8672346ff08e65c35af5816a21effaac6794d9e55009885037007e87a05571e1d7eaaf7c86f30c";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/lt/thunderbird-68.10.0.tar.bz2";
+      locale = "lt";
+      arch = "linux-x86_64";
+      sha512 = "74ca7346f87b078cb9f598e79278ee39498b09370be5517a3893dc4bc2d5efe81f9b9076b27891be0c8d170802a02ac67dabeffa022fe222e95b73455b40ff34";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ms/thunderbird-68.10.0.tar.bz2";
+      locale = "ms";
+      arch = "linux-x86_64";
+      sha512 = "90c71d0b3f598c21026441dd5b34efca7276f34153ffacd327f09d2c78296c9dbc2ae9eb8e1f7635b8e3cafed15f07cc3c19254405de2e6c9e1fd4300b844876";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/nb-NO/thunderbird-68.10.0.tar.bz2";
+      locale = "nb-NO";
+      arch = "linux-x86_64";
+      sha512 = "08da0c8a887c820d246559bb7c1394282a68f2971ba2f2943084ebf3cafdd2580477ef5a9ca06c1e5aac353287276aa88aab8346beb95addfa95d5014cd4974a";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/nl/thunderbird-68.10.0.tar.bz2";
+      locale = "nl";
+      arch = "linux-x86_64";
+      sha512 = "f846e221c2bf3cebd93961e6af10c24215b698cb8318c6446224f5de5b533e887e76818b6b902adc839a3f7c5ec24e9b13aae63b5d601d6716643f64aa29b7da";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/nn-NO/thunderbird-68.10.0.tar.bz2";
+      locale = "nn-NO";
+      arch = "linux-x86_64";
+      sha512 = "c33a600e2d64c94cdda74f2a94fc54f05133cc543c795dee70909b00b92eb5a48b183600f328f45fc8c9bdabb59f455a4875e68e6e62ce4f6309cfc0aed24fc0";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/pl/thunderbird-68.10.0.tar.bz2";
+      locale = "pl";
+      arch = "linux-x86_64";
+      sha512 = "555b0fb0c4117521f020f7d9846b19dd18ccbec585cd89282384e0a311dd5bbedab84101bd55064c7ae20ecd811c70f31948da26befcb12abe0937ed2736b9b1";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/pt-BR/thunderbird-68.10.0.tar.bz2";
+      locale = "pt-BR";
+      arch = "linux-x86_64";
+      sha512 = "a51b74e5d9394ee2ebc26149e1e01766b9c4cde5815fcd915bbc5307095a851e6242fb007c8e93027ea0a77b3074679041c65a1996528435f30f7f17b06959a6";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/pt-PT/thunderbird-68.10.0.tar.bz2";
+      locale = "pt-PT";
+      arch = "linux-x86_64";
+      sha512 = "4912989c47a3c021a28ed56629e308d2326a07ec99dc00b624889a10013f36445fbfe11a8cdde7ff4f69c965b0d2221c61c246933cc313df9f63ae3ec65db891";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/rm/thunderbird-68.10.0.tar.bz2";
+      locale = "rm";
+      arch = "linux-x86_64";
+      sha512 = "70298a29589b928748d32adcf83b12c006d23cd3a171af1eb790eaa34eae4b1a8e97056fc71f9a795a9b9e07f5d8e2a9f4ffc475eaa4b06b9390976fd6359668";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ro/thunderbird-68.10.0.tar.bz2";
+      locale = "ro";
+      arch = "linux-x86_64";
+      sha512 = "7c36cefeec21820b90a8acc09856aaedf4cf94215cae71daa8142a1d166de79dd0114495b92d954f978d1be88c06ad5fa269fb33ae0b307ca05f3d7ae90844d5";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ru/thunderbird-68.10.0.tar.bz2";
+      locale = "ru";
+      arch = "linux-x86_64";
+      sha512 = "b7dbd077b0271818ba33d8651fc60e371f9a89771020113ce2a0785c2d228b90d219fcf944e6ee2645fd683fbc1d597529382c4b808ee4cf81f7123e1de9d583";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/si/thunderbird-68.10.0.tar.bz2";
+      locale = "si";
+      arch = "linux-x86_64";
+      sha512 = "b9217a815c7f042bb33e0ea2ef9129e8ef1c825af315d0cddb6c0760bc87f1b8932b6f7cca747d50a29a55ac66a21d8113febc360e5f963566399a38e3b5a2a2";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sk/thunderbird-68.10.0.tar.bz2";
+      locale = "sk";
+      arch = "linux-x86_64";
+      sha512 = "494ffad5906f35f9b3141fb06f6900e0d82553c16c8f3d99b50d6718643cac21fbd6a205af146df54125c009f190285281b09bb42996505a2fc120dd85bde882";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sl/thunderbird-68.10.0.tar.bz2";
+      locale = "sl";
+      arch = "linux-x86_64";
+      sha512 = "d34836dbf915e4d5157a1f8760dae8d8659ceda2ceb594d737da7384139f245915f01a0b025585c117762f2d3261dffdf1c7efa5c2e1f920fe5a350d85406015";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sq/thunderbird-68.10.0.tar.bz2";
+      locale = "sq";
+      arch = "linux-x86_64";
+      sha512 = "909aa9e820cb984459deae17b80488db09718eb428e32a35ecb1723fa3c8d7ed974f6cb17a07db8e642cdb51b885291a3fca518542372fe2c2b3360553b3527b";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sr/thunderbird-68.10.0.tar.bz2";
+      locale = "sr";
+      arch = "linux-x86_64";
+      sha512 = "aa39d12ff81a371722609a4ec401021512f651c4f592159f8ef9bcfcb641b55a8f6ccea970b4d8375cb326e0cfd5fa18097ee3131e7546c53b1e29d14058622f";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sv-SE/thunderbird-68.10.0.tar.bz2";
+      locale = "sv-SE";
+      arch = "linux-x86_64";
+      sha512 = "3f373131df39c343579ddd851e8c5eef3147650a5c75a5fc3ce84c2e1a694494cd6e3ab12b3cf86018880384f02ca38a54fcca8cc04f3074699fb89c4ded78e0";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/tr/thunderbird-68.10.0.tar.bz2";
+      locale = "tr";
+      arch = "linux-x86_64";
+      sha512 = "2c91ad17ddad9db19ff2eb47ff7a10253febd30faee710301dcb96ed0472f81153de5d7d906b3dc706d39ff058eefcdb9210ac274469fcc02a39cdbb99a126f0";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/uk/thunderbird-68.10.0.tar.bz2";
+      locale = "uk";
+      arch = "linux-x86_64";
+      sha512 = "d98a132e14a5921b6a75a8fe7cf3c1aaf22e83c4c8252dcbd5aa0434b98a7d9d88711b68cc470e6007027e6e588cf9ea00dd78a2d97b48b975adef1cd059e79d";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/uz/thunderbird-68.10.0.tar.bz2";
+      locale = "uz";
+      arch = "linux-x86_64";
+      sha512 = "dac94504203e7862608333f1f84134d7afe0e1f534eec9b91ec48a850e0143b625f4be311c2e6e716a16c941d3c2f5dd2101abfae205c802749ca95428b7e754";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/vi/thunderbird-68.10.0.tar.bz2";
+      locale = "vi";
+      arch = "linux-x86_64";
+      sha512 = "684626eb432e89e85b9d3270198ee20470e675ea7294222755b5b588db7e318c20fd8d2fc9a0c95374e8ed53e792ab0e24e826709aa619fbab059a77e6341213";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/zh-CN/thunderbird-68.10.0.tar.bz2";
+      locale = "zh-CN";
+      arch = "linux-x86_64";
+      sha512 = "8a25fd27a555b18bc41ae31f024e80adc1b06de064bf2391c1db5510869af8c145780a01a26f6cb465d2c6b53f4ceeb924657eefeb95f7ae2ac584ddfc4a56d2";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/zh-TW/thunderbird-68.10.0.tar.bz2";
+      locale = "zh-TW";
+      arch = "linux-x86_64";
+      sha512 = "8f202b1a79ae831bf5a28356a06213586bb2c0f4410516a8121c73a8902d0ce7e54f8e6fd7d2c74b300c9692eb3ad4a9b9290cc93ce3205f73842d93a46cb77c";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ar/thunderbird-68.10.0.tar.bz2";
+      locale = "ar";
+      arch = "linux-i686";
+      sha512 = "868f092cc144611611133f50be9317161cb34ba2d0012d238789f2d1124b547c52d2aa02d4daa090322e327a4652808cc882835195f02bbea8e67818d22ca8da";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ast/thunderbird-68.10.0.tar.bz2";
+      locale = "ast";
+      arch = "linux-i686";
+      sha512 = "bb077167ec58446aaaaaa7439e04332946d62cc6a35ff00bdda20a03eccf80b09bce70524c3b3351fe0b821dda0762cd666c66b00314751301a67d635c2d37e5";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/be/thunderbird-68.10.0.tar.bz2";
+      locale = "be";
+      arch = "linux-i686";
+      sha512 = "a8ec19464c57509ccea6f83305d441aa9c61ddf0bfe2af172df24f67d7abaf2e568eeabfdfea9e0a843d42ff9c6d2610b1e1e5c060ccb50bce4045b47586f204";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/bg/thunderbird-68.10.0.tar.bz2";
+      locale = "bg";
+      arch = "linux-i686";
+      sha512 = "9c8ef811f0bf04066f3c55e4b02107450d88a1774417ee503027423917bdf16ab9b102eb0f7f4c777ee60039998f8391164f1719bb8abc4d79774664041fa6c1";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/br/thunderbird-68.10.0.tar.bz2";
+      locale = "br";
+      arch = "linux-i686";
+      sha512 = "e94fa2e49fca5bd6e6f1139adb86604482deeb1160cc8fe348a1cfab2bb19c8ba694ca5743ed6e5da81c9789521e8b6018db4ecc68ec91c8a277916c6a553521";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ca/thunderbird-68.10.0.tar.bz2";
+      locale = "ca";
+      arch = "linux-i686";
+      sha512 = "4dc73850268e885b9791b29573f35704d730e9a9ac833265f47413eadb2e3d359b8b56405ebfa58816b8b2ba390077c14f17a769fec94870652147d2a2915243";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/cak/thunderbird-68.10.0.tar.bz2";
+      locale = "cak";
+      arch = "linux-i686";
+      sha512 = "569d8b373efc412180cf01ad9333a1b2f05687f3b8cfc4286c81c9309681d390d9ccc2767248e36db7931e2b941dce6ca209a00e7ba5dbebea6d40c710dc2cdd";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/cs/thunderbird-68.10.0.tar.bz2";
+      locale = "cs";
+      arch = "linux-i686";
+      sha512 = "e87eebe5c3486b02f46784209019b5f5dbfbeb36be8914604416c194bfebda2827861172019ca33bf754bc86ad91327ce5e29ecabcc77390d84be80c2f682e29";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/cy/thunderbird-68.10.0.tar.bz2";
+      locale = "cy";
+      arch = "linux-i686";
+      sha512 = "e97bde29c976e200f418b2ec150969459e4e17872184dfef548b08e16286f948259d2fc84d0d07965a5dedae8d5e3268c3a6ac0794cb0c3a739ffc86b2a6f748";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/da/thunderbird-68.10.0.tar.bz2";
+      locale = "da";
+      arch = "linux-i686";
+      sha512 = "7bfbeb6e8bb427e7e3aee31e897d025e338a4c4da59eb2700b52dd08cd53efaf6dfe1d33e456572c0203fe6927bc069ff297288cc47dec2ef9835e047a5d2938";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/de/thunderbird-68.10.0.tar.bz2";
+      locale = "de";
+      arch = "linux-i686";
+      sha512 = "15da351e919e0b931dfe48f77b9eeeaec40e94c973de507560c62a86e2b106f7d4afa7602186829fad2984f9964ad23792ca88bd5b94976972bc103f0560ee4d";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/dsb/thunderbird-68.10.0.tar.bz2";
+      locale = "dsb";
+      arch = "linux-i686";
+      sha512 = "1b8c1b12b8d7979a0ce45db282bc2a3b933bda3711c07097533a8a04b38edae3f0bd00298cbd485954ab09fa57b10aca5238e8a7bf4e23ea80ebed2dba1d73e2";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/el/thunderbird-68.10.0.tar.bz2";
+      locale = "el";
+      arch = "linux-i686";
+      sha512 = "67c5dad2a95ff1b8b3ab2ebcb0c1c4af87c5325e22d43c24f4f1c0df9ac328b43b0b25247408c8c95cb5f98b9396a1714b0cb39cd2e43ecd04b28f8bd1dc43ab";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/en-GB/thunderbird-68.10.0.tar.bz2";
+      locale = "en-GB";
+      arch = "linux-i686";
+      sha512 = "c9feebac54a357470523029377699fc9c0bca08e4705374dd1b8756cc8461237426cded2d9ee994b7ee529c60d50a555e4e1c2d9ec71ceccb7fccc651e35058c";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/en-US/thunderbird-68.10.0.tar.bz2";
+      locale = "en-US";
+      arch = "linux-i686";
+      sha512 = "9280a58b42f93b38f4c9ab26b8b6c2956ccb135ae959c61799cd3ce3b3419c9642f86418ac53e9c4f69e0430508c0619db4cf856a28d233a8d319e262755f4a4";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/es-AR/thunderbird-68.10.0.tar.bz2";
+      locale = "es-AR";
+      arch = "linux-i686";
+      sha512 = "9c17d648a2ed9c2b6dc7d403436dc9aad91e10e63579e26e4dafe3d5b3a15633167c87b67924026882a03f1aab05673566a0c5f0d84efb656b6b3d7d4b812e5e";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/es-ES/thunderbird-68.10.0.tar.bz2";
+      locale = "es-ES";
+      arch = "linux-i686";
+      sha512 = "d22ba4fbd7e8d22f70950b61354b99ffa6bb1c298504f8f05297cbc20f0c89a9d657c74ab367480906cbc4b699df6c603d6f6b936ccdb4213e178f3eb153a314";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/et/thunderbird-68.10.0.tar.bz2";
+      locale = "et";
+      arch = "linux-i686";
+      sha512 = "107fa0cd997edeba0a88d365c52fe48ea0d355ca8bf8723f5bf2ad4a930711e8fcdad27b457d309a5d4dfc0f29f6988f2b04f153b83384484ed397261c07db7d";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/eu/thunderbird-68.10.0.tar.bz2";
+      locale = "eu";
+      arch = "linux-i686";
+      sha512 = "ba50b4fed2d682f1c46699f72d86b219a1bb398b1b2180cdfd246bf4eaffd61e34e24222bcd82ebcc68b9cfa9f98f56fe859cc6d5bd744a7223e7264d6d4f261";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/fi/thunderbird-68.10.0.tar.bz2";
+      locale = "fi";
+      arch = "linux-i686";
+      sha512 = "6f4fde19af18845d50f591940786402233bb77f518f1f8f9cda727bd458e21669f692681cc691617a0ce05f8516383ce38b7b51445e3937ff8c1868e84a92ae0";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/fr/thunderbird-68.10.0.tar.bz2";
+      locale = "fr";
+      arch = "linux-i686";
+      sha512 = "7e9dc42478dae325a51f44781048a55fea3e2bedcbf663c534510404e59dfa10216dfc0df4efd40e0bf1f4fea3abdc9867b6c6b33f199e406ab07d68b68acfe5";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/fy-NL/thunderbird-68.10.0.tar.bz2";
+      locale = "fy-NL";
+      arch = "linux-i686";
+      sha512 = "1b665dce92e8c1de000063f1a12192a2fa5aff2c65db9aa6769ca16604e7e97a602baad9761110124c65dc479fdbce7640020701fb280b3c62e5c78368fb496f";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ga-IE/thunderbird-68.10.0.tar.bz2";
+      locale = "ga-IE";
+      arch = "linux-i686";
+      sha512 = "42faafcbe85ab995b549bf072942dcc2e87780099b3bcb2974ca3eff6acade40be7bd8ded5cb0db6a02bfdc255c60e252061a767543b2215719a1fc2600fdd81";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/gd/thunderbird-68.10.0.tar.bz2";
+      locale = "gd";
+      arch = "linux-i686";
+      sha512 = "e1455ef926d71ecfdad24ebcf4b3de59d04611bf641ba381534bd1b94c2f7b730687cf2e8412e6910d37e402b58f32588482089f4d12308a7b9cf6af82b66e97";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/gl/thunderbird-68.10.0.tar.bz2";
+      locale = "gl";
+      arch = "linux-i686";
+      sha512 = "344d619a5437d0efe2e522680849dd809b07c3aa9cf2831610aaf7ce28e81f16782a4a8174c01cc339914e02a23cb3ce603d04dd0dca8eb4f547e0d0e780d8f6";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/he/thunderbird-68.10.0.tar.bz2";
+      locale = "he";
+      arch = "linux-i686";
+      sha512 = "c081d81f3c1a61d2922bdad144a97c8568326e97fe29909d4319ca9019d9bd466dccabc6f2069eadafaa6bf6bb5bd50e8cf0c070dd992cc095411dd909b43f06";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hr/thunderbird-68.10.0.tar.bz2";
+      locale = "hr";
+      arch = "linux-i686";
+      sha512 = "2c142b9bed17fc1fef3e4339f0477d3f469923083a37ec3b2dc3d4690a44ee34d5a23faa37876cec2f3bcd02c1048ec343f16bd02a1771296e77cf3f63ca787e";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hsb/thunderbird-68.10.0.tar.bz2";
+      locale = "hsb";
+      arch = "linux-i686";
+      sha512 = "fcbcc78b1d5620c27b7cfb7ee88463dc81664f5eba679a81920ac6923b0e3f05bc70b99ba7268017b59219872921e76860a113fbba757cebf942641ba0591517";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hu/thunderbird-68.10.0.tar.bz2";
+      locale = "hu";
+      arch = "linux-i686";
+      sha512 = "d59024db516156a89cbcc0148a5bf85059ac2393f41709e224f109abca6fea693b822d7c4a3ce5e360435c8700010aaeb4b26ef9e163827bcc8b6cf1761d3781";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hy-AM/thunderbird-68.10.0.tar.bz2";
+      locale = "hy-AM";
+      arch = "linux-i686";
+      sha512 = "17876cefb335375b7884080315690fef116983b7559421f86ad0ef787bdfdf5aed283d84114cc1c1d3cb3119d735f50e975f94ead6fcab6046c207d4c1a8fc8b";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/id/thunderbird-68.10.0.tar.bz2";
+      locale = "id";
+      arch = "linux-i686";
+      sha512 = "0c74ca260ffee635cd556c0710a13ed091a1f2eb63a1b1ac2a745ea0e86d42b52b08b00f648c406356e1e170c77242d43d9a4d2b2f0bb1fb26d4dc83b4179a8c";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/is/thunderbird-68.10.0.tar.bz2";
+      locale = "is";
+      arch = "linux-i686";
+      sha512 = "97fdf5fa7dd6fade8ec7efc179f6a65bda90cfb285341e3e98b9b2ab70ba91ebc8c47bf8948189d4c181566c9ed950fbd0fb6b4d4cd96b2e3329c0085e32771c";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/it/thunderbird-68.10.0.tar.bz2";
+      locale = "it";
+      arch = "linux-i686";
+      sha512 = "3d42b5a8c55519accb3246c5a7f50def9d854ccaffa0e34b20e6e2f51cc07a787a9ab0c0b205e28b40d9ec4f55f1176f391ff9156076327f8a4416a9ff6ea8ae";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ja/thunderbird-68.10.0.tar.bz2";
+      locale = "ja";
+      arch = "linux-i686";
+      sha512 = "bf90c9c27abac84ef91a2fe3ceea142ac7041c10d41a0e5a2ee31742f9f64b2b24a331af769e8ae93c7b09bf8645dc4d274524281fbfe69a908fd22aaac7c2d8";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ka/thunderbird-68.10.0.tar.bz2";
+      locale = "ka";
+      arch = "linux-i686";
+      sha512 = "8e2fb192c6776ad702ea7aaa9bc9dd31b20c1c66e2ce4dd91aa10eda5528172680740e28f8a7bab52a7c6eae92578822669d6ad068bbc85a04d97c91a4b7e08b";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/kab/thunderbird-68.10.0.tar.bz2";
+      locale = "kab";
+      arch = "linux-i686";
+      sha512 = "10b9418db83b328353afb73b7630add081309cc0b55fac8aec38f6e09036968082d3d12386efb6b4347b33977998bbd906501adc45a8c8d27dfd0f8d98288bde";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/kk/thunderbird-68.10.0.tar.bz2";
+      locale = "kk";
+      arch = "linux-i686";
+      sha512 = "7dcfb10ce402c90452815523d5672a1cd60201b33b997c5b769341e904f4840ff57685eab61dc3073f789bf042453f3d144e54bec32afae2dd65367a0f1768a1";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ko/thunderbird-68.10.0.tar.bz2";
+      locale = "ko";
+      arch = "linux-i686";
+      sha512 = "fddcd08f00cc4f3de59993c8c917e20e77918d87e2c23e989e8e8aaf78c6130f42e546acc17eb6f8c9a24550c596ad201d63f325e7ba078a6c791fc94589e0a5";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/lt/thunderbird-68.10.0.tar.bz2";
+      locale = "lt";
+      arch = "linux-i686";
+      sha512 = "ab221093a0df2876f558ff2e0df090b95872281e1cae8ac23c9753dadd6305608c6e7ec5104d491ca3a3f1c1ebd830b8094080ce99bba49b19b46e617238cc87";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ms/thunderbird-68.10.0.tar.bz2";
+      locale = "ms";
+      arch = "linux-i686";
+      sha512 = "ce6b0e1ba8a1a1bbfd4d2e265a45430c2d931530d13eff67fea4179c4a8e2a204ff35103c921073bc33c3e2a8f8f3f55fb91b3218cab9718df76da696ed09750";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/nb-NO/thunderbird-68.10.0.tar.bz2";
+      locale = "nb-NO";
+      arch = "linux-i686";
+      sha512 = "07e73fd67e0c1974c5e5b90d74e555b75820b66ae9bca0470b6d291e848e5f28fea680cf09c2167dd56b0765ae0e3682b5f2ab7f33cc5b059e60252236dc24cd";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/nl/thunderbird-68.10.0.tar.bz2";
+      locale = "nl";
+      arch = "linux-i686";
+      sha512 = "a24ed7d30e53058653c0de6b96867fa9621118fa43e109940502eea798a5c7b8688c65bf08d765f3c6dc6e8ab0dabfef98ae005e00c465f847454b384953276f";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/nn-NO/thunderbird-68.10.0.tar.bz2";
+      locale = "nn-NO";
+      arch = "linux-i686";
+      sha512 = "4bddbdd0a2353f8c43e65cbce5974911809cf28c3d7ce521d662d782f8858b469575857688a5c674f6d028acd55869c062edf9f55dfa3d387fab8fb60f6f2fad";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/pl/thunderbird-68.10.0.tar.bz2";
+      locale = "pl";
+      arch = "linux-i686";
+      sha512 = "953d9e547eb343a0d7f96f501bb87ece71e2f860f8517fb13b76301c7b3e77d7f572a8106fdd43c2b390654457e43703b22566bd3159ace962af2eb1f8bc6ca8";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/pt-BR/thunderbird-68.10.0.tar.bz2";
+      locale = "pt-BR";
+      arch = "linux-i686";
+      sha512 = "b3807897100857c33768478c9dec57024f968a83188b51bd2708b7caf7c53edb39b15cc8dfb5f73ca937c298fa83551edf82d7f43c065bc2fc25467a02343d20";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/pt-PT/thunderbird-68.10.0.tar.bz2";
+      locale = "pt-PT";
+      arch = "linux-i686";
+      sha512 = "e50bf636697714fc4dfd04e1a8d6d7d87239553f01064bb566e218395a2e5d9b16ef22c01509f18f9f562b75eb19a2616d8c7f8a4d212a9a445b1eece17527f7";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/rm/thunderbird-68.10.0.tar.bz2";
+      locale = "rm";
+      arch = "linux-i686";
+      sha512 = "1480eb4c77d88fc461000f423179e5bc693b2f25abe5c6384f4c98494f698c620fdd53e65d75ebd17ce9546c5fb00ef8f40bfffd9b31114417cd10262569a54d";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ro/thunderbird-68.10.0.tar.bz2";
+      locale = "ro";
+      arch = "linux-i686";
+      sha512 = "d9cfc8f03d75f3a58fe103c34eb0fdcb3530f0ebc68c0acae7fe1b783bf11c0585e266556d16fa3db174aaafcc319cef9cfa363361cad7b1053a504101b13880";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ru/thunderbird-68.10.0.tar.bz2";
+      locale = "ru";
+      arch = "linux-i686";
+      sha512 = "d67f550615eb195b80f7338708b7ecf7455203f86aff1682f2e8e654d019fb49c6468eb1c099f7fc78797b97d41c9f42aff5498f27b6cb458f049fd8b6aa3d4e";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/si/thunderbird-68.10.0.tar.bz2";
+      locale = "si";
+      arch = "linux-i686";
+      sha512 = "6dd9d78a9f2ef4ed28a95e83e76e9779d02c950ba906ca14d8fac0bf7300ad2d7d5ad9cfa3973cc8c861011dc8f1c58a6ea5909206443cd2f24bf5bcfe8c5673";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sk/thunderbird-68.10.0.tar.bz2";
+      locale = "sk";
+      arch = "linux-i686";
+      sha512 = "ba40286898a7722533f8a65e1e9bb494bc28212d2fe21c820f64b1a8bcaad6d0ca1d7a870d5289792a79a6c4851931236b13c1ba07b812b591b3d4c6004ff78d";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sl/thunderbird-68.10.0.tar.bz2";
+      locale = "sl";
+      arch = "linux-i686";
+      sha512 = "bc8e926583e92f4cfe3081a1bb618d7c5fbe9e1f93af378040a72820b820a38915ff1c74deb6069bbaf2957adc536b78faf1df853e8ff6390a9396d909ee040e";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sq/thunderbird-68.10.0.tar.bz2";
+      locale = "sq";
+      arch = "linux-i686";
+      sha512 = "084bce04b0d83ab24682d04f4c788d61a2a6bfe0777f44f4c9a07d8fd7fef4251464e9a0e523f4e111bd5323ceb398fa09ae3391295047beac3157ce9d2e8905";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sr/thunderbird-68.10.0.tar.bz2";
+      locale = "sr";
+      arch = "linux-i686";
+      sha512 = "544ed1f0cb8beeac3ac1b2ed02078c3acc5961d6fe4c3f0722b1a36208740226053236453a215e564371453cc5acb541a6f307d594524081a5f4c96aa077c21f";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sv-SE/thunderbird-68.10.0.tar.bz2";
+      locale = "sv-SE";
+      arch = "linux-i686";
+      sha512 = "806ea4d93a8cb3e5dba8cbc59dd25adbb19e048306124ffebbf1b2a56d49f236d9a79d0e14b5fc0c15537c266a85408ce1a5568e8e6e4417dd94f1b98d9bf36e";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/tr/thunderbird-68.10.0.tar.bz2";
+      locale = "tr";
+      arch = "linux-i686";
+      sha512 = "cf30e9ebaf5770437415377c9a13d66b44a7de7c85bec9b980d9e2e059db7f3756f2c3a888ebf9185c59451e2473440fe2c1ff28a979e066225719effecb1c38";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/uk/thunderbird-68.10.0.tar.bz2";
+      locale = "uk";
+      arch = "linux-i686";
+      sha512 = "a7f5f6b0f1bc849a3a48a30edc8e408eec0c5e544bb4444a8ade969b1fe7ef1fb9d26a0fea3d4d31bf88eb67570e895fb5d916b9ac88c2a8455abcec60d56ca0";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/uz/thunderbird-68.10.0.tar.bz2";
+      locale = "uz";
+      arch = "linux-i686";
+      sha512 = "716e1c0a7b9b0ea33d1464930b68f3f817ce3310bee9000199f9e6bdc4d0d68dc6098665423ada94d7ede600cb0c965adcbb413068adf1415cbc048a7f847ebf";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/vi/thunderbird-68.10.0.tar.bz2";
+      locale = "vi";
+      arch = "linux-i686";
+      sha512 = "1667ab35ed705e739c5192246444eda912ec86a153dd1fc3ed83a5ed61d47d5849270492015198cca82827720bc019fa561e710df5fa77a758864e6cfb09d4aa";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/zh-CN/thunderbird-68.10.0.tar.bz2";
+      locale = "zh-CN";
+      arch = "linux-i686";
+      sha512 = "4ef6c9933ce8671442aa86f804085b4ce9a73aa4f8cd598b7d41a844be37d54cbd8a2dc39d6ab97f160856435475093f3240f960a206e53d327a4b2e47fac45d";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/zh-TW/thunderbird-68.10.0.tar.bz2";
+      locale = "zh-TW";
+      arch = "linux-i686";
+      sha512 = "ab19d7c1114835a380e035dafc2e30849e8084cdac9175eb5eb3a9fde81d49cb710d9dce21652780a35011d139e070c0f61840275aa8d0e99252bfa5a8aa1735";
+    }
+    ];
+}

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/${version}/${source.arch}/${source.locale}/thunderbird-${version}.tar.bz2";
-    inherit (source) sha512;
+    inherit (source) sha256;
   };
 
   phases = "unpackPhase installPhase";

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.0.1";
+  version = "78.1.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/af/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/af/thunderbird-78.1.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "2050aae67c7058ea8991adbfc8c0533c2df2baccf4b5f9d42c794a914c8b893a";
+      sha256 = "6e98afba5a93cd7ce496838974022d7c61c0188f32ab0504d9cecd6ee3e20360";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ar/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ar/thunderbird-78.1.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "1fc387ed18cae62280795729ce61a04942e319fb1162d54740ed6b3b73198987";
+      sha256 = "129ce719947a59c647ab28ceddad28a2ce1e06c63839bcd5b43b084b80c2bdca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ast/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ast/thunderbird-78.1.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "cfedbfe2c96814fef42c8e2e4b5aba9f9add0e3c70a2c01ff7528d878a6ab659";
+      sha256 = "0baf79a7d38c5a3728cba78510efbd4735e1c4e4d23ab574533d590a7d523ad8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/be/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/be/thunderbird-78.1.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "e1d6ec9ca197d2fe5312b9b0e403e3ee2ee32be05b2d329ff0b21d9c42ba77a6";
+      sha256 = "870ca1c07897b8df1e2985165cb0802a5cf1fe87886e0aca5f46d0d8b1e6acf1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/bg/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/bg/thunderbird-78.1.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "9b8b5322b6808185fcaa9614b7def311ccaf14b0939447a538b8b13fdd7ffcec";
+      sha256 = "bd2bb102a09132afa0a4110522fa7dd98ae3b0ddf9b28a97d21070880212f391";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/br/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/br/thunderbird-78.1.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "1f8429ba0563ab22cb1c30e15ee80d42864f01b0713e37448059335b8f1cdee9";
+      sha256 = "cee91b71a6735e9c71a705e0c7a8a97d5acb733efac1d8bf8ddcd31a62fa439f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ca/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ca/thunderbird-78.1.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "bdee4855e082b473f0434f5a16aa704eadc3ed4b0c186b42aaf5aa600f29d066";
+      sha256 = "257d027850fc31fa5e5f4b0fc4dd2205db2b9fe04dd5b8c0f34453df11eacd4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/cak/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/cak/thunderbird-78.1.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "9d6188ecacf4b76a91c2f4a8cbabf194eba05ffca54b79b3e0ee44919540e353";
+      sha256 = "405d409fad9a42a8c58196ac390dcccae100da950d9225f03b5755842642af47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/cs/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/cs/thunderbird-78.1.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "edc391204cfc8c1eb1c93fca5f2ec67708c76fa4a1b972defd55f1645ccb3c56";
+      sha256 = "fb554ed67ea40a31a296b37f95428f4fa9f81532c8048ec3b4563b91fbb989af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/cy/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/cy/thunderbird-78.1.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "e179d9c7252b2915e84d2cb0e1c0c1b9568374bbe65348456e4dedf2f883023e";
+      sha256 = "f74999b180cf8f32e634afd68340cdb8fb40c064fb1b78d4c4b2666a9bfe7121";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/da/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/da/thunderbird-78.1.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "53b9e2107a1bc89132e7a3e1d08d4acebff872c19a639100ef1c0ebb4c3d0b2c";
+      sha256 = "feea7e8ba58473d9f0159152aad4748827c88d3b575ebd5bfab18f3c08e1add3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/de/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/de/thunderbird-78.1.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "03bed4f7360142dcaa1824ce5deae519a9ba00f43427fbef78246036de159466";
+      sha256 = "4b067335dee19144898485c711eec865b4d0fd0be0ff95d6532f6a7c62b2651d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/dsb/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/dsb/thunderbird-78.1.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "50217d664170eaf71da7a5111337583aad4a181dfd32eb3686f7a31ec6fdf4be";
+      sha256 = "349db67666bbda6c269c7b55e376cb3740e3b3eb7a4e6f0fcf44037dc7fe822b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/el/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/el/thunderbird-78.1.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "b6d1f45955cdd99d097b955e6c2fd017afbfdaa8d0b505d231548acea5d31e74";
+      sha256 = "40bd9509793e81a2601ea0746f6e27a65a364d95d7772eeb71c5eab24f31fbae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/en-CA/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/en-CA/thunderbird-78.1.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "f1f9c597816f4a3b30561c186c0944e6fc0fd47616292002d858341a0c6ef5a0";
+      sha256 = "55acc02d61ed7a2b0ef2262346ff27afbcf836b03cb14dc67fb8cbc26bb5d6ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/en-GB/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/en-GB/thunderbird-78.1.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "a771190706f3bb163a7962bf4767b9177c324cc3bdc28470375a4ea26022881b";
+      sha256 = "f18cba25a9ab2b10f1f464163c904f7b1ec1afa5b79728c9b1fc1497971edca8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/en-US/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/en-US/thunderbird-78.1.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "428af66882e1abd047491c6a4a317eda6095191bd0ab81308d162c4a3c8d227e";
+      sha256 = "0768e00b6a7737bd4ce5dac4d3afc331e8d1dd5307bccd130d9581347c6ea35c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/es-AR/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/es-AR/thunderbird-78.1.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "b1fae29c0caa3f2c5cfdea0ee169fa4f080027fd4e0347db6546f335bd7b6759";
+      sha256 = "106b8a385e8f4bbd4fcbae08620fc621f69a3920b04300305ebc000b7007b512";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/es-ES/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/es-ES/thunderbird-78.1.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "58c1a11820860e2efe3f38b889962f794e56de4e2d1d94855e10bab1fc4d21af";
+      sha256 = "02a67358ed38587bdb67c5faa67d989cafda448441dfa60bcb56587d10a052b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/et/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/et/thunderbird-78.1.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "71fac7d3c3e74bff029b5432f8caaa76abdd19d38a64ba6192d371c97a09e353";
+      sha256 = "649bbbc89da5fb44f118be6c8f8a142e00aac26e50d7aa5217937d8356a8745b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/eu/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/eu/thunderbird-78.1.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "60492decef4b40d8a24e6c04ae0494b178a47a4782388eca7c3e2c2b7b0823ec";
+      sha256 = "4884b806aa36ef0d1f11cd876594d94614cd9a95a1dc8b072dea57f9b1664106";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/fa/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/fa/thunderbird-78.1.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "d3bf790906b9b3c016cce51aeb1671c9d80f28d3c959073bfab0c14dc952d85b";
+      sha256 = "a8e8de1f187a103a9bea2d0bc4ad8359f80d2eb0f5148d0c93f3351e1e8efff6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/fi/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/fi/thunderbird-78.1.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "7e6c77c994027e8e941a498d8dcc6e82911cd4b6e3a61c78206fe7bc114ae006";
+      sha256 = "4c7fd4083382830646486390efec548a6875f41fa373d1c35b83f1e7b1890352";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/fr/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/fr/thunderbird-78.1.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "d4e073368df92a81eae6b3480f3d06d461aab18841a0ed64d7f8d1c5b4623168";
+      sha256 = "3574bafabec4266fee05552a1be248af63531d6ca1993d8c8d61e0dc472a0786";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/fy-NL/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/fy-NL/thunderbird-78.1.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "41e161d7447b64438652210d9091517b42edcf9b011f01c8c1ceb87539acd295";
+      sha256 = "688346105eac2d51505f147c2baa74ac5a16915f2440e0e08d666eb77c702c3e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ga-IE/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ga-IE/thunderbird-78.1.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "a3f1b487d585ed66089b051a01b8b4da6edea684d2bdca94570dcb7cb283c8ba";
+      sha256 = "aa75c3c00bded7ea7a8fb9043b24e264aed02598152e60a3a2d6644433e3f6b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/gd/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/gd/thunderbird-78.1.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "ebcedbf87577cffae7ba8ed83e9b9f981fd205e178701084cd2f813e30a8adee";
+      sha256 = "7eae8fc579878437ee25f988189c49a7d7121f66230d1f60e496d575f518497c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/gl/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/gl/thunderbird-78.1.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "ffdfe4c9c22ac161e801d44599fe507c1ab9d7a8f46181cf1cdce023bccc4161";
+      sha256 = "c2ccf567d2c4ac7598204a2a129678730ef2dc1d84ed3c547b569de3455723b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/he/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/he/thunderbird-78.1.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "cad855f0c469056e1830d2f08be9c42ee348a5ccf74015585451161a0d7fb432";
+      sha256 = "aec6e559b34d539161a3367e434773f6016978f3e837431d27737a935d156fe2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/hr/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/hr/thunderbird-78.1.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "86b80d641ac0e5f7ffbfca3a5539cc1422d67a6b36cefaef9d92d03284955648";
+      sha256 = "37b478337cc9918cb386471000c5cc90d2f5de3023a67431b418781cac1d4cac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/hsb/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/hsb/thunderbird-78.1.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "062f55ebb24178c604527173511277115cdb49a7bc416f9824359cc700686a7d";
+      sha256 = "6d08be19b9aaa9a0f11bf23aab8cf42c1e04288882d860ad45a625a9ad2d8ea5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/hu/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/hu/thunderbird-78.1.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "281479c1f791cea5c5b64ec103ade785844470d0d803d6298d1f1ec505d7eba8";
+      sha256 = "ff2b7d098e466cd6a9508f3d85e599de544eb8e3cf0cda15d5278fc61efab22d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/hy-AM/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/hy-AM/thunderbird-78.1.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "cb436991d7bb7705c29fa8b51a6d4c2910689b58210002a3370820917955dd93";
+      sha256 = "2d53c3979a54981dc38c0db892b00b042cc6316972c42cffa6ff9409ad7753d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/id/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/id/thunderbird-78.1.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "325319f3d1791c9aa91522c1c6f90aa72d511ad774a190d60a0dfcaf85cce934";
+      sha256 = "d599ca640aadf1d6441e16f47c39553cc58d3676a5638f613ffadc0b26983831";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/is/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/is/thunderbird-78.1.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "e61096339f49ef5c1ba457e448f80a306c7f9058f280acaade9945d57209af1a";
+      sha256 = "004c1b4b00f3ab32e8e39fdbe8c8900cc4d36d716e81eb92cb49c7e0c105954b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/it/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/it/thunderbird-78.1.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "daad0be2b8e9419d47a6ae2fd3b30002d206451f9f8f8a0dfa04199175024647";
+      sha256 = "8818951a98306959571060a673093397e6f337c5edb08d91c7202b2dd46a96ab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ja/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ja/thunderbird-78.1.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "ae8093def67bdde2086d568a2837f427e62f41e0d6ed80d9a64919467e7442e2";
+      sha256 = "f30ab0ece47a1bb9220f414f12158ae264261456728c2debb2acfd9860dcceaf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ka/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ka/thunderbird-78.1.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "57a1406e4e4d70b5fc23f356aa21a55abddaa3401127f279f58f3f73e6756987";
+      sha256 = "ef3bfc1a4afb1f7cab9188848d789778e36ad2c376daaf5245611fade7c758f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/kab/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/kab/thunderbird-78.1.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "86041ae0c0bd55923256ed64c0ed23f5c3913ed4892dba58d2c064049deecb4c";
+      sha256 = "a1240d9ff2ef510cc039f3e29c571eaac738caea1a737d872931923fe1f9adc8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/kk/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/kk/thunderbird-78.1.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "715626b9f4ffdd68ac9b689dbc48cf47d37d93f128e61d999c5dd14219d1bda8";
+      sha256 = "ed991b239aeac8c0b8e92ae59acb1cb949357514326e7377c2b028a0c9bf8be9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ko/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ko/thunderbird-78.1.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "d470fd22fe9e185db70090cf5124697dc9b7015768181748d8976a04cde09239";
+      sha256 = "dbbd6291a1253c125cd6b1757c1f8a0a7bdbd8e611032db0d5d2efb5f6efd232";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/lt/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/lt/thunderbird-78.1.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "ebd83f3fdf84aea2021fb318671bda5a08a8480b61eff689544566d7c3b4dc5f";
+      sha256 = "86b3a09435b20c398572a9d261d2b64c7f25346ac1977fcdddd78340a36a7774";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ms/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ms/thunderbird-78.1.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "0a1c461603c60e16ca911fc3bcca0d5d1b6ac29a1a5a63524decb360a960e047";
+      sha256 = "4cead9cf204b460230eb35174898741fabefcec7d6a08bda13f67484400a61dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/nb-NO/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/nb-NO/thunderbird-78.1.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "89ef517fe3d97a95306b34212c96e83a3afbd5fa5d9c3c3ca3b019c8b742d422";
+      sha256 = "2f955e1436e78a2abf8395aeab59917001ea3affe763f12412247e48809867a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/nl/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/nl/thunderbird-78.1.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "1c0632de4a2a13fcebd6bf3dadcc6a19125f37b8b54d16a9b8fe57fcde6d84ee";
+      sha256 = "246b0dc99ae05a9fc559c3d587f4ebf501a6bc264494960cb6295f7b8ee5d12c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/nn-NO/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/nn-NO/thunderbird-78.1.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "684cfbc77db1f16ed8f271ce1f2700e6d6e486da47cb961bc09b53bda79e773d";
+      sha256 = "9d6b8c48bf483860cbba470fdf221fae906fdf1b1b3762055ee2dad841d266b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/pa-IN/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/pa-IN/thunderbird-78.1.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "140010e3f1db608d1978f02fd28c0d9305dd4cfc2666b1689eca5e8b7aa64bae";
+      sha256 = "3a62c8d1909353efdf67c758e49a5e938508fa8d433d887fd47faa768fbc4015";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/pl/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/pl/thunderbird-78.1.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "1bcb8a7d3936f22286fc6c1a5b0ed492cb345a22406eafedbe439c6737c7c422";
+      sha256 = "d20f0e0c1b60efc5b549a347ea6055b5ab659e47ef0b28ceda91b03066c89606";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/pt-BR/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/pt-BR/thunderbird-78.1.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "41b8f99c1f73f16bd4ce4dbd76dea58209487c033a42b02412b237f98bf32903";
+      sha256 = "ad633496d5183a99251128321810842623de0c4aa4f8895e23df756cbca6a4bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/pt-PT/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/pt-PT/thunderbird-78.1.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "864524017e892942d31212acabd4b4b6425153b53cc622df728540d9b65237bf";
+      sha256 = "e1ed2749803c255e16f7c5bc8e264adbe53381b33c15d7ec7995cf048a86260c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/rm/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/rm/thunderbird-78.1.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "7933777df1f87786842e9615528e3aef3ae0a78ed4089dc5b8472f2d7b7d7b53";
+      sha256 = "e07c2f7600965d46a6db1bbc5082897f0a9d3b1d66555c388c9dca9b02bcc057";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ro/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ro/thunderbird-78.1.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "59a2f5b81c777cfb705ec93c395d78b7d73a98cc632efcd980490817ddde06ae";
+      sha256 = "2b34d996f2130b3738bc2b2cc8f784ad9e62b207722c7038e1469929c174aaeb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ru/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ru/thunderbird-78.1.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "0954dd904e87505aa849db172351684c477f80395baf46b7ada5bcc6e0614c2a";
+      sha256 = "3cdb2afc48e70a6f27022fb672eed016ab5aede684d2791b4771e764f64befaa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/si/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/si/thunderbird-78.1.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "c8d9c1384f98e8664e73e3b3790dc99aff51c9188116d6dfe8b88a238f09e524";
+      sha256 = "6207418917124e654283592fcbf8c05bdb47369486ac3f4cfa63376ce5c4f780";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/sk/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/sk/thunderbird-78.1.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "651932961b463312ed8757a26714383d34b5296620e0f957417c0d853e591d9a";
+      sha256 = "e5551cda807e0c490fc3c6fb8c0ca3c2b75f2093984537f862d1cd3b9cf1f080";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/sl/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/sl/thunderbird-78.1.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "073fc40fbdb1d45b0df5e8984216422e1b79f5740537d9deb11b05b11e9a6622";
+      sha256 = "d43ff3688f641d07dc6bc4b9b6a5045ee64f76b94c8a90fabab76ccb3682990a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/sq/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/sq/thunderbird-78.1.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "05cab7f922d15f839c73b8405bb1e2785e7f327a0f155595a40936b792852ad4";
+      sha256 = "08ea55f8bb49ad16d0ef16b1a95c9cb5657690e811608f147c93f79171dc6b9b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/sr/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/sr/thunderbird-78.1.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "26fd9a66bcc583acecaaaec732cefdc4909923fd5ca478f1c9705bf7ad787eff";
+      sha256 = "a9a1a33b195ef2c18da5a18ecbe09cd5dfc9c48aaf445937642a9df1cc2694c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/sv-SE/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/sv-SE/thunderbird-78.1.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "610a21baa667f8dce1e9cbd18dbf582af6a9a0c61e574dd509a2121536407e8d";
+      sha256 = "9f7994ec48a0b70ce6ce33092b4d5252c2cf180f2589a46fc85009503671fb56";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/th/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/th/thunderbird-78.1.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "520745d3bf636919963a014baa565efbc14a4d5e6d77ba8e1d0cd6b5a8b370cc";
+      sha256 = "d1ffeae4472df5483c8f55beab128456f3176b07e11444ca48f651a582b8d80f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/tr/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/tr/thunderbird-78.1.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "91ede7f8e4520586e35b0fefe616477dd9773c047b03c2c92b8264bcdf1131c3";
+      sha256 = "79fa59071ceb5f643759cd4e9161325f3717a099607407844ed58e854c680eb2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/uk/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/uk/thunderbird-78.1.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "46bda6c807fb26e1ba698590912c9f427648e37f26b791697562d912249c519f";
+      sha256 = "f41e9756c31a5d2047d7beb8f8f4d3a3f09d6b72d8ef8b375c8f0ce16ff25409";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/uz/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/uz/thunderbird-78.1.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "2029d7023605baf17c138031977bb2f36ddbacac605d00e93967b366c22df4ed";
+      sha256 = "9748985b628e76b75f15814b6d48641319716bdff8c3947c346b01be27e16854";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/vi/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/vi/thunderbird-78.1.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "d345f774c89b276a5393b17522d5c7d60f8c661594334e0e6bb8ee06fa134a11";
+      sha256 = "cba83119c8e36f76d4697acd689e1f94effdb980e7738853cf27f6633a48c187";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/zh-CN/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/zh-CN/thunderbird-78.1.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "931d29a118de6eb1a73da6d36f919b2b98112b15e15ede6171b39c2b1f85b8b3";
+      sha256 = "f06c5cbefd99d2da20b1bb64518c29907f746740d30f79d4b7d59ee286690194";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/zh-TW/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/zh-TW/thunderbird-78.1.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "59b7484654101e016819b998c903ac43bf43427a16d288f90cb1ec47efc2c61f";
+      sha256 = "82cfbf08584867e6d36d357e67ea6abe2ab3e2747de014bd747ed169065b0f07";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/af/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/af/thunderbird-78.1.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "5fa7d8defeececcbf3794845695b3c4ff84e4269a26f3eaf709fb67e8549f164";
+      sha256 = "ecd85c75ce2935f776dabfd42402342526cc9f7050c6f444219618cdfd12930b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ar/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ar/thunderbird-78.1.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "946887ca372e60fbe401c60d5a2758e49b3e771837d1c4e77073e6f7c569aa8f";
+      sha256 = "1ad1466a524f505abe1a80fd6dc4ddeb4441a26ce6f63c07b9bd8c0cd27f75d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ast/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ast/thunderbird-78.1.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "596e5665341f5c2d4551f216e8935bfc4c390666d01464b8c289386a2fd7c168";
+      sha256 = "5683300f0c423c5ea2c62cea619d0f894d7ef5d4e46f952f67ba56863350c829";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/be/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/be/thunderbird-78.1.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "e95af9c6be7a8e30b1589a9fe9b7568876dfa920f2d01d3e6c0f0e2ff4f34ea1";
+      sha256 = "882463c8e120438c418a540da6d7ad324eb071f400d1abfea43c04d7a8e978d5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/bg/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/bg/thunderbird-78.1.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "3c509d3861074c2a5d2da2f0d7f2d3d19a132745dae3ccbbb259e60419b70895";
+      sha256 = "1ead6033fc9a7bfd504890a453ccbcad34a5421f6a33e2a382cdbd0ccd15c60c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/br/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/br/thunderbird-78.1.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "9dd7e920583f0a3bd0eda01d569142f81f91061ee64703d43685ad277651f13f";
+      sha256 = "4aaa832ef4a2cba04d03c2ce8f956bd38bbd88c0c5732db02b73ac6d1097c55a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ca/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ca/thunderbird-78.1.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "34026e985a3ee383104e4882d2e9b3025f84b7b36bb9c13233cd56c20b86d2ac";
+      sha256 = "a237f035c3b7c6281096accb036f35d6c2b421ca9bc4144240ccbe44f30092af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/cak/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/cak/thunderbird-78.1.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "c513f2bca776ac47ad40a656ad40eed682c1e1f37d3f8a41686868b10301d700";
+      sha256 = "c92a7700e7ff6184ecfb1f36615d1a6f68a5b534eacc3417233602d290ec3c2d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/cs/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/cs/thunderbird-78.1.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "499148f0871bab7ed8012cde000942815529cfe59d6dfe4a861a937f5bc861d4";
+      sha256 = "7417c763b5a4c680d136c2f0f2e62276b4c616a1442282ee9e979bbd56748886";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/cy/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/cy/thunderbird-78.1.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "12e468d45538b0bf2f699bfdc7cc8f294852394175c57a7720ee217dcdd662ca";
+      sha256 = "0099ae95225562e2376a9ae7b5416b82b43d62e5e3c1672ac9a404c4fd4afc3b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/da/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/da/thunderbird-78.1.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "e49296cbddfc1a5d27f0b85c9ae16c6fae12aea3fa386c458dc436964214944f";
+      sha256 = "f58de0e53576831b345e38c30fbd0809f8fbf06aaeb8072ff24c6bc3254844ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/de/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/de/thunderbird-78.1.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "548c2d3dec0270e859a56e7d85ae08840ba6e1b858f1651e484f197d08840c98";
+      sha256 = "4ec7d297c251a6af2bc94f69b1416819173e5a067e751dbb44b2b4d78a8866a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/dsb/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/dsb/thunderbird-78.1.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "c130c0adc523580cf771c3a16cc0805563bd4a7f3b0990109972698b4d77f1fe";
+      sha256 = "642a8a455fd5baee6443c5db7e971d41c9576e5c930913f1ab04d5c611a85e2e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/el/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/el/thunderbird-78.1.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "9c2b18946cde4e962191442587a7935658217bea530caa89f25f35c9f6c95034";
+      sha256 = "e0040116779db8e0a48ceadbadc78f29ba6f7a30b287f631606e8e710605af62";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/en-CA/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/en-CA/thunderbird-78.1.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "3b1a6e1bcc6619221ba29df1af414d2ffe8fa935ec098e95210ba59b5c518239";
+      sha256 = "d020ee801bee8a6384e3da9dfcff135d62dc523f2d0e183417508214fbcf8384";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/en-GB/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/en-GB/thunderbird-78.1.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "7fc649ebd174fa6b534b075758ab6895c4c9a78b9bbbc06f135c26f7db24c282";
+      sha256 = "31124523570c294f1615af0f3fcedb91f2509d7446c93760c063383b70faac11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/en-US/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/en-US/thunderbird-78.1.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "b2a3bab7cde73523f8a516541170cf701db45e15bd46fbd3c200dfa056d0252e";
+      sha256 = "242bf4bacb3d99fc79845f3c5a27e317f1ce9878b124c41b2d9fcbec54460fd4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/es-AR/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/es-AR/thunderbird-78.1.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "af7d15f1776476ef7ea421bb91af9ab1dbffb0369fa12b9054478197b0d902b7";
+      sha256 = "178819d715fe526a086d6abf392e2b2ea5d7b8a803199b02cb0005561219f886";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/es-ES/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/es-ES/thunderbird-78.1.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "4ef89f9997094ff1c57ca7c630ee15fe443e214fb3c8b40253cebf8a83e9e5e0";
+      sha256 = "88fd17b25de55a567c0e6eecce7edd5657d8f4bf6fa1c8e5c6221b53b6dd21ba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/et/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/et/thunderbird-78.1.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "f70280ce83fcb31a73a5e7230a3e6ab7abaa776c969cc4d98953bee4529dfac1";
+      sha256 = "eaec9c4c0b80d69ba8215e44f64d3bcfc392b5fce47f1a154a8d973ac60991f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/eu/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/eu/thunderbird-78.1.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "f34516a026d2adbab2cd3730d034abf326113f96f90bbee3889fb0e7cb1b41ba";
+      sha256 = "cea1fe6066c348d27b1de6645f7250e03c9beb22a545a4dac3e50dc1af983013";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/fa/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/fa/thunderbird-78.1.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "d004a5e3c3dcd5d2fcb204e9fafa943d1bf6ad1e6cf11aee88796a4f0149e44e";
+      sha256 = "01976fc28112097ff160c6adeaffed75b6f998eeba8cbb14328127738972144d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/fi/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/fi/thunderbird-78.1.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "b740e866a690e6a6ecd0e910f63822f546389d297f9c923f38983b5f78be255c";
+      sha256 = "9f7406c2cd4f11c93d3515691c228940c7b1514df56ec2c8630a7a2e94e2ecaa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/fr/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/fr/thunderbird-78.1.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "eab1bdf57527a2fbe4f7de0a3314eba9966df5a2bb9a998c32a73fa372a7f85e";
+      sha256 = "46fa514a8a041d9ad6a84333bd6f815cea1ee2c69ef37b17e68f944d93400e67";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/fy-NL/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/fy-NL/thunderbird-78.1.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "bdd5b279a134e305002b87fb6b708e54132158d111b99bb100efbf2dcbcaa606";
+      sha256 = "33a5b2f524666b3e5add090ac552d72c3c20f81b97982bcaf2e7939fb3ad5c98";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ga-IE/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ga-IE/thunderbird-78.1.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "f76ad9888686fb09c33d2fc1f92849adf9102c265b302640d50f4b63803ab416";
+      sha256 = "331d44093ef699538b72aa2abc12ac0aa5eed8a2c0ddcb48b2550820b418fffb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/gd/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/gd/thunderbird-78.1.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "54abde7a6b6f6864bd260b1d31dddf1d578b9f9c2b9f928c2bdcbaa141d14163";
+      sha256 = "0d31fb4fc586e4e0f307335144f4e52b6bd8e1f2cef1707143715d4ba5d7143a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/gl/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/gl/thunderbird-78.1.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "6d10c320adb9880ce31404034a501f3d349227d851120c2ada5c4edd6b7f4fe9";
+      sha256 = "66c9159758d4639e2334e0ed37145a9b3fb51a53ae15919c956f6ab59ac431a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/he/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/he/thunderbird-78.1.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "d635c4b9203d03b9bd78b81e507074ba5e6b8c4b066ea996f32d353b557250a6";
+      sha256 = "927b657eea49b18a5bae6e23c0614178a33a90db1e6a4bb8e62978be2e5b165e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/hr/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/hr/thunderbird-78.1.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "0a50d18b9c53ac5d325aa343cf7114307e90d98e2392f0474ea469508c329cb9";
+      sha256 = "7c76abbc7fe94d910002a0786d18973a1fce553a36bbc26123fffdf8bb63b1c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/hsb/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/hsb/thunderbird-78.1.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "34b1f83011ea6297e11d55a126f8fc8c87fd560e2144a4e64f4b377177ddd0c7";
+      sha256 = "a34c51c6059effdc861bf1892b9ae2f7f88f7b06344dc73d1c0d02da919c2883";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/hu/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/hu/thunderbird-78.1.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "6a4f2e4f026efabe45f45bdf691c84e1c393ab223aee045ec8e21092158cc4f7";
+      sha256 = "acdc7d7423570b707bba3941bef2c1654d51c9e1e23d263561e1d9393b2e3e74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/hy-AM/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/hy-AM/thunderbird-78.1.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "dd8762372b789ee7bb6d11994f8216cfb9fcf493d6dd27c3b292f29675e9559a";
+      sha256 = "c3bb6b743016d39c6ee5e7e3776e7617bb1d6d3a32c0ce04fc7e0a962cf4fc30";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/id/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/id/thunderbird-78.1.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "cb811617137d3b57160e64af7b901329b0b6df46f0525ceed04de9a5aaab8bf1";
+      sha256 = "125562d267d38c3f4a5cfb9d747dc3c16634ab82cdeecfe18352c5cc85bd37ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/is/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/is/thunderbird-78.1.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "e0d7e51f390aa0af3dbbb2505fdc6eb5a3560c97b031fb67e14bd4af57868bbf";
+      sha256 = "f2028467188c85d34108a5a72ab01921cb51cd65bd821780cf264351e72f78ed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/it/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/it/thunderbird-78.1.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "9c88972bd6ee1ab726e16a6eaba32aa78e3d8475506d3394254337eedc47a9fb";
+      sha256 = "06663b6d3800c4175ff8c16309174a323cc1a000b140e944d73e74ebeac2c08b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ja/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ja/thunderbird-78.1.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "0fad6c18b92fcec16684bd9905dd0a3b6bcbdf8c2bfd6d271baea48849a0fa8e";
+      sha256 = "90e9dd8d19552e286f0b88252f64de5de9b9798b1122c48470de4795ae833b9f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ka/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ka/thunderbird-78.1.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "75c454ca20ea0667caab5223c55a210f68165fc72b1493fc8afc76881cfa823c";
+      sha256 = "0998d6b871bdde86830d061bef1e6aa93ad7840ea5c705db05b6d6475246c324";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/kab/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/kab/thunderbird-78.1.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "8a928f4b5fa7d0374e361a47857c85a34d271d2cbbc760332a6e588e3361fa62";
+      sha256 = "88bd997d123541041594f16496baced969c06335079fb7d08473a09cb001a8fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/kk/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/kk/thunderbird-78.1.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "18b851bc36799910965c3eb14a8c9a57f29dde91c570e25a8f7f172a8bea7771";
+      sha256 = "56bc7376e0a7dcc1e6ca45b41de2769f887ed647320531895f6b3aee99b05592";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ko/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ko/thunderbird-78.1.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "108142a8cbd48dfe07626f4672178a35c5f253c84efcb924c7bd4c1531f6ab38";
+      sha256 = "6bbc9f93dcc3c78d17806933020b45a6145e6df3ea0a155492500bcb500f0a31";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/lt/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/lt/thunderbird-78.1.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "5c65eb6b01e8fe82db99390ae889870cad107d4307e02b04d5f9390eee81f098";
+      sha256 = "49e2cbd0d86578f74623ab0c72f551a48d3835a583a5b7269303ab920f14b9c7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ms/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ms/thunderbird-78.1.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "78ce19d598b2fa59ecea9d6fd4e67e93b2ba00b2e9569579f687700486e80c24";
+      sha256 = "53306a0a9a149fbc7d1e24c24c8ca3ea154ad766be23dc70aeb3bf90ef1bc5b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/nb-NO/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/nb-NO/thunderbird-78.1.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "e8a1f9f4666a3ee423c5541c61fccfe448989d0d7d4840dd36bbc0826cb96537";
+      sha256 = "fa2b3f9de332a40df46b32f4ab5451fb16fa400454b2269543c08f8ee156b52e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/nl/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/nl/thunderbird-78.1.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "f9292bdc80157d2e2076b7be81af66813aeabc722356c3e514ae18638720192b";
+      sha256 = "4439bfa046cea7d823e12f837625fda5ce1953ded9f0af9dec252d9d58dae04e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/nn-NO/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/nn-NO/thunderbird-78.1.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "956b0c99d47845c9b0a1c7d101f576e5b4a7a514893da938d36616db9f5bfce9";
+      sha256 = "3a9fc65618790837bb6d998c5ef6ec01019db8240b01c904a61c463bf17b848d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/pa-IN/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/pa-IN/thunderbird-78.1.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "50cdbca944f98eef40479a9070b58729f7f743bda55925c74b6410c163ac784f";
+      sha256 = "b433e58bb809a2f47cfc82848db5145cd92280725ce3b5d1bfafdc0e5f616076";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/pl/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/pl/thunderbird-78.1.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "fe2de7bba7b057022e02f040bb65ddfababb39999fcc573e65cd2bc0c848cf41";
+      sha256 = "9ec00ac58795a5e7947a9effa2646081d4fdeed801f7e91ed651d2b457317774";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/pt-BR/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/pt-BR/thunderbird-78.1.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "6b219f0cb715f2d5a3fa72f34b079b401d850f571a9b2ad21c97871a5b83b9af";
+      sha256 = "fe187123f5c9b472de5154e126a1d736e1eae0d88fe11f5ca1c771006f37202f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/pt-PT/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/pt-PT/thunderbird-78.1.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "deca0d48ba8bb002444c3649514a2d7e39a698c75382ab53df080ff2c484eee4";
+      sha256 = "6a09eab3e662f093ec5428c3d5b0dabd5ef8ca8a734f92bb52088a545dd5707c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/rm/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/rm/thunderbird-78.1.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "3799e8dbdf5edd6be276ce4634418c1bbc52862a5366d43460e1bf727f11c27d";
+      sha256 = "87f96161f0d415ed24abd2bf7d88ffcadf327910b23c285a4fa7126612011cb1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ro/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ro/thunderbird-78.1.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "a599d873eeb1ecff1c7df37ff89b9e71527192d65c3b0e593d87b0c68bc28062";
+      sha256 = "6b6f0125a4354320abf34333353cf52a30ebaa764d1ae17b1fa48e7d1ad53b52";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ru/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ru/thunderbird-78.1.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "b488c44be9c1acd9715f9b872e61f1c8f4a0cedcdda6d291f8ad165013b5f06b";
+      sha256 = "3d3c72390d333abd6710b0653f8c95e0283b50580cc6aad3e7c38a90c369cb9b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/si/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/si/thunderbird-78.1.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "b60c002886df2ab941fb5c445d6b33d31de8a2d9feb15523c2af561da7ab09d9";
+      sha256 = "f436f26b6baa8cbcbd407133c099669c45bea518202a34d7538260bd76fc7b19";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/sk/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/sk/thunderbird-78.1.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "0c59cc63c01ddf7564331a6a9f2ba89c5ab263c227f517c9fa066a3c7f8e8a55";
+      sha256 = "ab89336f29fdda1525e827f4f4419b2eb0137279717511ca3de32f221d5335fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/sl/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/sl/thunderbird-78.1.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "2039f31a243f43553c893232d79a27cbc249bf73f083ed05b2914333dea6c5bb";
+      sha256 = "fb43a4f2b360774a1c7e337a38bf9388cc1e453b987b7d8ac38e2dde255ae3f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/sq/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/sq/thunderbird-78.1.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "f46914a1a18d989c385f29cd34f95f409f5d56d601b279d8106aa8f224a61c26";
+      sha256 = "1029c843c2ff06842dca2af05054d60b87927674b36f6c6890118143f5aeadec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/sr/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/sr/thunderbird-78.1.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "a72776da8c85de9f970f1a55ef2f56d2e9fd3fd73b7e6d39761ab6bca7066980";
+      sha256 = "e20f00961f70dec27c306c9442315a4e5061840604650ec62123d1cc74a3006b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/sv-SE/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/sv-SE/thunderbird-78.1.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "466378b9542c4a8550fc6e7143fe56e04e5ae15a20bc6ddec5da4eea231fb928";
+      sha256 = "1e2d290254f610e1dd8c4d8037e9aaad3abee6d7b7373471e53ff698b736af83";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/th/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/th/thunderbird-78.1.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "7943c3257f4ef6a842008b0fd6171f87e99043263ccaf4666850ccebec28725f";
+      sha256 = "1a80c2986f7f69228c1ae6f2829d3502154ccc9e92ea8bdb2530b82b3a933349";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/tr/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/tr/thunderbird-78.1.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "a5120107b8fc5418c49d70cf61730ea2b8e833d21d8e6b797d64d2637803709b";
+      sha256 = "136a7cd134f8782537a8063da75fca86340597da5832dc87468b9a353aba0b89";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/uk/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/uk/thunderbird-78.1.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "a85b53cd72b313e49ab439f9b1900c4e8f7610be085d757bda4123f5e9293cd8";
+      sha256 = "ad0ebfd63617b7807fcb658744650a95c5a8a03328d152f64c48f8ed46a5825a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/uz/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/uz/thunderbird-78.1.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "7dcce5d00f6e83b756f3b83067fcf78d00240cb540815e3e63d40302272d5e4c";
+      sha256 = "4af26e15a2e1afb84ce9ff0024286b31b6f77b6810897906d7139ffa884ca623";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/vi/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/vi/thunderbird-78.1.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "4b94684748f81444d8a8beeac54053673bb4705b6284f8b5d86a5f03fb9a2ce8";
+      sha256 = "4695f995cbf7e62eab32aa17a8c9b5cd01c7ccc16e50911436e940b0ff1a28bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/zh-CN/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/zh-CN/thunderbird-78.1.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "346222badaa7b34a7e21f28045c68be815d187a5d34432446b7ffb8b959fea0e";
+      sha256 = "d70c7e9667240f2fc9f705a66be84c2decb691af581e73bf2637f97b08f3f14d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/zh-TW/thunderbird-78.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/zh-TW/thunderbird-78.1.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "deecd348a6c260bc50b1e112966d736ee4bc211a1f42f791f37b10a69f7c1c2a";
+      sha256 = "1359fc351ef156bbc00a134de4f7dc878fa1bfa77a461ac289f90dc7f870ecd4";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.0";
+  version = "78.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/af/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/af/thunderbird-78.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "6ff0f696c6caef049d0489085e7b9c3f7240e242c23aef9a36905c67bcbdef33";
+      sha256 = "2050aae67c7058ea8991adbfc8c0533c2df2baccf4b5f9d42c794a914c8b893a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ar/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ar/thunderbird-78.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "54b09003901703c2820b20534d403cfbe0b59d7dfb5962cd370049795552e88e";
+      sha256 = "1fc387ed18cae62280795729ce61a04942e319fb1162d54740ed6b3b73198987";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ast/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ast/thunderbird-78.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "98c159c6ece97f113614107a1ba351901cc4f816d165f6fb2b3ceee7c5fbed6c";
+      sha256 = "cfedbfe2c96814fef42c8e2e4b5aba9f9add0e3c70a2c01ff7528d878a6ab659";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/be/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/be/thunderbird-78.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "abc376f1525e53aa734d00a8a52d30ba2c95fe0f2d053c54e019eecd35191f47";
+      sha256 = "e1d6ec9ca197d2fe5312b9b0e403e3ee2ee32be05b2d329ff0b21d9c42ba77a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/bg/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/bg/thunderbird-78.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "a53deb5c4d83719e380b69a41f3a80e634c8d251a1724e1d49e5ad8ac5da1aca";
+      sha256 = "9b8b5322b6808185fcaa9614b7def311ccaf14b0939447a538b8b13fdd7ffcec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/br/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/br/thunderbird-78.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "8424ab87bfb1c1622d244961896bf4109fac2a38bccfbc6facfc7ce723a6ef06";
+      sha256 = "1f8429ba0563ab22cb1c30e15ee80d42864f01b0713e37448059335b8f1cdee9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ca/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ca/thunderbird-78.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "8283ed7294338be053900ea85e4d9e26ed5ef5a53d419298ddb4d4b0cfd3a8fd";
+      sha256 = "bdee4855e082b473f0434f5a16aa704eadc3ed4b0c186b42aaf5aa600f29d066";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/cak/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/cak/thunderbird-78.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "10cca56df7a22ea31fcc3f2fdcc4cea8344727183ca4d7cc1f6d78cd881879d4";
+      sha256 = "9d6188ecacf4b76a91c2f4a8cbabf194eba05ffca54b79b3e0ee44919540e353";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/cs/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/cs/thunderbird-78.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "fa476dde45d9f3796e71ed26126ef99569f92344d9c5754dd154df2b79513312";
+      sha256 = "edc391204cfc8c1eb1c93fca5f2ec67708c76fa4a1b972defd55f1645ccb3c56";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/cy/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/cy/thunderbird-78.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "319919e66b178aaa86f74717aaf7a7dc54c53c4d400fc0f54d3ff0a4bcb5ea3f";
+      sha256 = "e179d9c7252b2915e84d2cb0e1c0c1b9568374bbe65348456e4dedf2f883023e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/da/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/da/thunderbird-78.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "9a3eb38c50fb9c1a1fe58899c304884c2a3e295a278feb40296a48f845f4a8e9";
+      sha256 = "53b9e2107a1bc89132e7a3e1d08d4acebff872c19a639100ef1c0ebb4c3d0b2c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/de/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/de/thunderbird-78.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "260dd2a5227225168327dca79f44ddba7bef4a1a0411a731a192163b36a217a6";
+      sha256 = "03bed4f7360142dcaa1824ce5deae519a9ba00f43427fbef78246036de159466";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/dsb/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/dsb/thunderbird-78.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "559bdb00b7741897c245d367c5147503e580d446b2a6b90e83af2ac9b64ecdd0";
+      sha256 = "50217d664170eaf71da7a5111337583aad4a181dfd32eb3686f7a31ec6fdf4be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/el/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/el/thunderbird-78.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "2f8fdf4aa2347cafa43c1b7e7c7cb6a358878e8470b45d04634566efc089e1a8";
+      sha256 = "b6d1f45955cdd99d097b955e6c2fd017afbfdaa8d0b505d231548acea5d31e74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/en-CA/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/en-CA/thunderbird-78.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "e3921e80a168544f41c39d0281ea32a4660fee8146a7a0b85292f360186ad876";
+      sha256 = "f1f9c597816f4a3b30561c186c0944e6fc0fd47616292002d858341a0c6ef5a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/en-GB/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/en-GB/thunderbird-78.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "a1c2c9f9e7a14ad0abf83d7b268c47e0ef13d4bd3966adedd0ad46bcd4c7f8c6";
+      sha256 = "a771190706f3bb163a7962bf4767b9177c324cc3bdc28470375a4ea26022881b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/en-US/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/en-US/thunderbird-78.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "57384c634f511c249c3618adcbbd9d2c0fa2a711c2af145d3a390d0950b94209";
+      sha256 = "428af66882e1abd047491c6a4a317eda6095191bd0ab81308d162c4a3c8d227e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/es-AR/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/es-AR/thunderbird-78.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "e727f4a725f5e389d99d929fa6792863c74e57e23452e3be1a88a3852c83f7ed";
+      sha256 = "b1fae29c0caa3f2c5cfdea0ee169fa4f080027fd4e0347db6546f335bd7b6759";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/es-ES/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/es-ES/thunderbird-78.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "2fac6c47b544fa7b663126f137e4850f5bbe1da115a845b99353454ae0c175a0";
+      sha256 = "58c1a11820860e2efe3f38b889962f794e56de4e2d1d94855e10bab1fc4d21af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/et/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/et/thunderbird-78.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "e3bf4000c8e5d04ddd9bf0a86dfd8aff02304b5d86c55f649fa43deb3ab9809b";
+      sha256 = "71fac7d3c3e74bff029b5432f8caaa76abdd19d38a64ba6192d371c97a09e353";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/eu/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/eu/thunderbird-78.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "3c6249fc0d2707b9472ef5b3876fefc3cbafca617ca27037ad8e98706d509eb5";
+      sha256 = "60492decef4b40d8a24e6c04ae0494b178a47a4782388eca7c3e2c2b7b0823ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/fa/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/fa/thunderbird-78.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "7e2edcf08b456f53d8274d17e1bcbd9efb997f74b164224d3e153d64ac7fe60e";
+      sha256 = "d3bf790906b9b3c016cce51aeb1671c9d80f28d3c959073bfab0c14dc952d85b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/fi/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/fi/thunderbird-78.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "1f6cc927ec2e21a67e61c7d09d93f846d5c1bb1ef54644b618ed806a4541170e";
+      sha256 = "7e6c77c994027e8e941a498d8dcc6e82911cd4b6e3a61c78206fe7bc114ae006";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/fr/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/fr/thunderbird-78.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "f471719cecaca31e5a940bb82908648703a37b74f647d7c1c434f8db339ef974";
+      sha256 = "d4e073368df92a81eae6b3480f3d06d461aab18841a0ed64d7f8d1c5b4623168";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/fy-NL/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/fy-NL/thunderbird-78.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "405daca824b721680f77e3ad8936246825d132c11da4ec2277a022f899ee2ce7";
+      sha256 = "41e161d7447b64438652210d9091517b42edcf9b011f01c8c1ceb87539acd295";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ga-IE/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ga-IE/thunderbird-78.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "899127ff4f98f922e405844df1162e66d484443e5a84bb6c575cc28658b52649";
+      sha256 = "a3f1b487d585ed66089b051a01b8b4da6edea684d2bdca94570dcb7cb283c8ba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/gd/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/gd/thunderbird-78.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "183f757b4d70b999064f8a8e495bbe9a6a9783d939811bd93181c9cbf61dc880";
+      sha256 = "ebcedbf87577cffae7ba8ed83e9b9f981fd205e178701084cd2f813e30a8adee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/gl/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/gl/thunderbird-78.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "58130045fbcdbcd10541ea6c2d13b95455af8e5fb9893a80d999b79d814eaf17";
+      sha256 = "ffdfe4c9c22ac161e801d44599fe507c1ab9d7a8f46181cf1cdce023bccc4161";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/he/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/he/thunderbird-78.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "719ce3b7d4e3841a7092e658f43a8960d68d82ebad6b6dc43d12708a07054a8f";
+      sha256 = "cad855f0c469056e1830d2f08be9c42ee348a5ccf74015585451161a0d7fb432";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/hr/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/hr/thunderbird-78.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "49f9f0c18ad45a73361520a055f02b6b8da22419c37c8423dab64ab13f253834";
+      sha256 = "86b80d641ac0e5f7ffbfca3a5539cc1422d67a6b36cefaef9d92d03284955648";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/hsb/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/hsb/thunderbird-78.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "7abc5362bc14853c7a9d93c84f1d04dd5d4f0ebdd7c71c782b83e8f56d716516";
+      sha256 = "062f55ebb24178c604527173511277115cdb49a7bc416f9824359cc700686a7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/hu/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/hu/thunderbird-78.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "5bb475dc366e9cae5e9e1422bb4f7e1eb1b605dd5e5193ccc253dffc11c4a0aa";
+      sha256 = "281479c1f791cea5c5b64ec103ade785844470d0d803d6298d1f1ec505d7eba8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/hy-AM/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/hy-AM/thunderbird-78.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "c42d6cc12203ac812b5794234ccbd38ea83114844234868cb02004a82e8307ec";
+      sha256 = "cb436991d7bb7705c29fa8b51a6d4c2910689b58210002a3370820917955dd93";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/id/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/id/thunderbird-78.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "13e4bf8bb6356966d44e4049e2e90f96b097e6a2ec2c54fd39cbf74e45dc4d3e";
+      sha256 = "325319f3d1791c9aa91522c1c6f90aa72d511ad774a190d60a0dfcaf85cce934";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/is/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/is/thunderbird-78.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "bdf740e2545ad41de9920a213afd6a476f261a15746ffb201461b3d2e0dcf06f";
+      sha256 = "e61096339f49ef5c1ba457e448f80a306c7f9058f280acaade9945d57209af1a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/it/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/it/thunderbird-78.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "cd66931d6cff87b16d637340d82d459cac1878fbefdbdb201cf7ed561dc0f6dc";
+      sha256 = "daad0be2b8e9419d47a6ae2fd3b30002d206451f9f8f8a0dfa04199175024647";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ja/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ja/thunderbird-78.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "10da3af84f726a9aad3dc5c8ca24136831c136cc2e52f6573b27695f33f48a1b";
+      sha256 = "ae8093def67bdde2086d568a2837f427e62f41e0d6ed80d9a64919467e7442e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ka/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ka/thunderbird-78.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "575f382c4f155f93a6cbd5a81fdb988196e2a95d0b8896af454a3cc5e3048d3d";
+      sha256 = "57a1406e4e4d70b5fc23f356aa21a55abddaa3401127f279f58f3f73e6756987";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/kab/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/kab/thunderbird-78.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "bffa3681eb858a55c18b5f396bd08464eeeeda1328ec65a7c67fe4d7c7805757";
+      sha256 = "86041ae0c0bd55923256ed64c0ed23f5c3913ed4892dba58d2c064049deecb4c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/kk/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/kk/thunderbird-78.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "866191e1d87c0b00f4bb5f2eaa0e1f66719a7ca68a175d1b30ed9a5735005705";
+      sha256 = "715626b9f4ffdd68ac9b689dbc48cf47d37d93f128e61d999c5dd14219d1bda8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ko/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ko/thunderbird-78.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "f66f91f0e0b04344db0e5cbe8d48721448c775ba8f4ac69ceb1d848b7e07cda0";
+      sha256 = "d470fd22fe9e185db70090cf5124697dc9b7015768181748d8976a04cde09239";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/lt/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/lt/thunderbird-78.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "2294425187c5e5404af6cbca9b495902fb9bc05354eb6e3866b1e8366ea64e2d";
+      sha256 = "ebd83f3fdf84aea2021fb318671bda5a08a8480b61eff689544566d7c3b4dc5f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ms/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ms/thunderbird-78.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "f21e85113e0f63d57f91c61e2830f1a9e721138cc00269d2fcc521d1c74666ff";
+      sha256 = "0a1c461603c60e16ca911fc3bcca0d5d1b6ac29a1a5a63524decb360a960e047";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/nb-NO/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/nb-NO/thunderbird-78.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "5b7982cf136c4d6120ffc7e40c65ddbb3495392181e38141ed80e3a67aeb1038";
+      sha256 = "89ef517fe3d97a95306b34212c96e83a3afbd5fa5d9c3c3ca3b019c8b742d422";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/nl/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/nl/thunderbird-78.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "d9619e1ca19ef4c75eae31de3dcb6cc23146c4d1b98046473a3ebcfb3a610c52";
+      sha256 = "1c0632de4a2a13fcebd6bf3dadcc6a19125f37b8b54d16a9b8fe57fcde6d84ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/nn-NO/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/nn-NO/thunderbird-78.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "e9d2a6955fb98c0dc492a5cb16977a1fc7cad778650dd601934bbc9f543b112e";
+      sha256 = "684cfbc77db1f16ed8f271ce1f2700e6d6e486da47cb961bc09b53bda79e773d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/pa-IN/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/pa-IN/thunderbird-78.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "a3279bd605960f37ddc071b0f3d91726a9d911a311c13e9418013c5a1f7a5089";
+      sha256 = "140010e3f1db608d1978f02fd28c0d9305dd4cfc2666b1689eca5e8b7aa64bae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/pl/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/pl/thunderbird-78.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "b22737a3a5b7c5ff3d8d22fd338490b0aff9016049bd7bf6cf6b25f15a027935";
+      sha256 = "1bcb8a7d3936f22286fc6c1a5b0ed492cb345a22406eafedbe439c6737c7c422";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/pt-BR/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/pt-BR/thunderbird-78.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "a6a18c8988db47d8163c79c465995aa0d3cd42da97bf2347b5be4d26e09e4628";
+      sha256 = "41b8f99c1f73f16bd4ce4dbd76dea58209487c033a42b02412b237f98bf32903";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/pt-PT/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/pt-PT/thunderbird-78.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "8717f41a166cf8e271086987196be9b88f585a70c30119ec15199291bea1819f";
+      sha256 = "864524017e892942d31212acabd4b4b6425153b53cc622df728540d9b65237bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/rm/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/rm/thunderbird-78.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "02b1131751a82c66341e58b757c1f4e438e5ef8fa44a58b904790c0a5ec66b44";
+      sha256 = "7933777df1f87786842e9615528e3aef3ae0a78ed4089dc5b8472f2d7b7d7b53";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ro/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ro/thunderbird-78.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "b7d82398f43112b5b9ab1907643cd8c39012246a1e9b74b3c4e37487df7d5bb1";
+      sha256 = "59a2f5b81c777cfb705ec93c395d78b7d73a98cc632efcd980490817ddde06ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ru/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/ru/thunderbird-78.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "155c7f4e678f6f3b91c07f2aa1313c08305a2c3166c199a9d8575d58c7448ffe";
+      sha256 = "0954dd904e87505aa849db172351684c477f80395baf46b7ada5bcc6e0614c2a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/si/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/si/thunderbird-78.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "1af756f61e5c57c0d6018b3efc0072e55d7344c3a9fd343686bfb16773551503";
+      sha256 = "c8d9c1384f98e8664e73e3b3790dc99aff51c9188116d6dfe8b88a238f09e524";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/sk/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/sk/thunderbird-78.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "b06bc92b4ffdfe25a5003f3662ae168600a6ae8855b60353ad68de6a24067d4d";
+      sha256 = "651932961b463312ed8757a26714383d34b5296620e0f957417c0d853e591d9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/sl/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/sl/thunderbird-78.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "19cc8710f257c229c4700b0a9deab471b1114a21f6cde0838f6a23e29faad6b1";
+      sha256 = "073fc40fbdb1d45b0df5e8984216422e1b79f5740537d9deb11b05b11e9a6622";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/sq/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/sq/thunderbird-78.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "13c8c4893947a8178066ce7a767eea21e78b1989c94be4d573f03f98e7f43011";
+      sha256 = "05cab7f922d15f839c73b8405bb1e2785e7f327a0f155595a40936b792852ad4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/sr/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/sr/thunderbird-78.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "68939bdf7b57320dfb608d6487b877baf0d801ef3aaf0da48becd87beb41aa89";
+      sha256 = "26fd9a66bcc583acecaaaec732cefdc4909923fd5ca478f1c9705bf7ad787eff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/sv-SE/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/sv-SE/thunderbird-78.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "36689c205cd7a6f212a5971fcc226631937232173f84cd0a2c40a87f95de001c";
+      sha256 = "610a21baa667f8dce1e9cbd18dbf582af6a9a0c61e574dd509a2121536407e8d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/th/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/th/thunderbird-78.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "392267ae08739866f14d2ddf0a853a47d18b2c99856bad369b567e7360d2aff9";
+      sha256 = "520745d3bf636919963a014baa565efbc14a4d5e6d77ba8e1d0cd6b5a8b370cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/tr/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/tr/thunderbird-78.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "15f45f9794ab34f79951a3b9ef990f25788c45eccd65dd1aab565d2908965c66";
+      sha256 = "91ede7f8e4520586e35b0fefe616477dd9773c047b03c2c92b8264bcdf1131c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/uk/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/uk/thunderbird-78.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "e9b1765f80620ca7ac534c91656345ecc3218ef8a606b2a8f48f3fc1c170cbc2";
+      sha256 = "46bda6c807fb26e1ba698590912c9f427648e37f26b791697562d912249c519f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/uz/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/uz/thunderbird-78.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "ed2258512e980e3c72b9130b2f5f839dbbff1df05aa5cb948f4519681491ca34";
+      sha256 = "2029d7023605baf17c138031977bb2f36ddbacac605d00e93967b366c22df4ed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/vi/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/vi/thunderbird-78.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "fa23f6d7c4b64776df71b5015743e8dd475cfa2a329370a92d36210711e0fd41";
+      sha256 = "d345f774c89b276a5393b17522d5c7d60f8c661594334e0e6bb8ee06fa134a11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/zh-CN/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/zh-CN/thunderbird-78.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "741bfc0c297a8dc9b5b4348f26886a12c75a81af11b0a6090094e6e21348e6f2";
+      sha256 = "931d29a118de6eb1a73da6d36f919b2b98112b15e15ede6171b39c2b1f85b8b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/zh-TW/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-x86_64/zh-TW/thunderbird-78.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "cd4296eacde34b302c794beeaff0eb46bdf0f12c67aba98172133529506897af";
+      sha256 = "59b7484654101e016819b998c903ac43bf43427a16d288f90cb1ec47efc2c61f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/af/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/af/thunderbird-78.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "300da8f92fff4e596e5d5604002fbb5732bda61d6f54c7f79a20e2fc268a7ce2";
+      sha256 = "5fa7d8defeececcbf3794845695b3c4ff84e4269a26f3eaf709fb67e8549f164";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ar/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ar/thunderbird-78.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "e382faafeff426536f355e2a711dbfad7d86de3619a4d3a60868ecd8e9593b40";
+      sha256 = "946887ca372e60fbe401c60d5a2758e49b3e771837d1c4e77073e6f7c569aa8f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ast/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ast/thunderbird-78.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "45c3c612f072277e9dd83fbe22bd4cf9018d481a35ea25334d12f6826c879915";
+      sha256 = "596e5665341f5c2d4551f216e8935bfc4c390666d01464b8c289386a2fd7c168";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/be/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/be/thunderbird-78.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "6e9fc38265fb9185915c9447ffb2d38e4e024446039704c8d45b91e152a38f86";
+      sha256 = "e95af9c6be7a8e30b1589a9fe9b7568876dfa920f2d01d3e6c0f0e2ff4f34ea1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/bg/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/bg/thunderbird-78.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "cc041a49ac017568b815a5e03a37031a6a17c25110b77d37bdb96c4d53d869d0";
+      sha256 = "3c509d3861074c2a5d2da2f0d7f2d3d19a132745dae3ccbbb259e60419b70895";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/br/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/br/thunderbird-78.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "3cd798a70f493ac5a75895be3db025bb3793836e21550c3ddea6b27f7dcf6d7e";
+      sha256 = "9dd7e920583f0a3bd0eda01d569142f81f91061ee64703d43685ad277651f13f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ca/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ca/thunderbird-78.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "553ea37490cf180bbb1f0ebcd23d87e82456797ab9f5604ee862227b0854ef12";
+      sha256 = "34026e985a3ee383104e4882d2e9b3025f84b7b36bb9c13233cd56c20b86d2ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/cak/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/cak/thunderbird-78.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "307e3234abbcee8a4aeeb46d1b8bb02c8642f1a2140dae9a2d6295bb32548742";
+      sha256 = "c513f2bca776ac47ad40a656ad40eed682c1e1f37d3f8a41686868b10301d700";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/cs/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/cs/thunderbird-78.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "a08537b88425e2b813aed80b94d763d3c31ed9aeecf5b3b8e358c08233997ce5";
+      sha256 = "499148f0871bab7ed8012cde000942815529cfe59d6dfe4a861a937f5bc861d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/cy/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/cy/thunderbird-78.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "36b75de4d73075026f256c6502caeebd35a89ca567cbc9fd6db461608b922be1";
+      sha256 = "12e468d45538b0bf2f699bfdc7cc8f294852394175c57a7720ee217dcdd662ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/da/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/da/thunderbird-78.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "7b81b6b22888c298cba1dba3c9786249ccb0aeba8b93d998a268e33ca249c7cb";
+      sha256 = "e49296cbddfc1a5d27f0b85c9ae16c6fae12aea3fa386c458dc436964214944f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/de/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/de/thunderbird-78.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "e5fa962eb83d4cc7dc2de5a2080a0d06fff4bb3b6e30c53dc979d7bfad8542f5";
+      sha256 = "548c2d3dec0270e859a56e7d85ae08840ba6e1b858f1651e484f197d08840c98";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/dsb/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/dsb/thunderbird-78.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "3745a7966cb96c79b49e0f8431d8b1e90cd5f01d7ce57eeb4ab3e5f80ddea26b";
+      sha256 = "c130c0adc523580cf771c3a16cc0805563bd4a7f3b0990109972698b4d77f1fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/el/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/el/thunderbird-78.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "037a51d7e44360a9748420ff584790abca6285d4bab8ee84414cfa602ec4c6aa";
+      sha256 = "9c2b18946cde4e962191442587a7935658217bea530caa89f25f35c9f6c95034";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/en-CA/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/en-CA/thunderbird-78.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "a12288cf187b5e3075a23e420bc58ae90370c224b0c73b8706ef52c34705d6d3";
+      sha256 = "3b1a6e1bcc6619221ba29df1af414d2ffe8fa935ec098e95210ba59b5c518239";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/en-GB/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/en-GB/thunderbird-78.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "dc3637519c9b40260217e5302dcf4174a66298f98b478d1a6caebe154b9b549f";
+      sha256 = "7fc649ebd174fa6b534b075758ab6895c4c9a78b9bbbc06f135c26f7db24c282";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/en-US/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/en-US/thunderbird-78.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "8e425ac9e0ac12d6142ef7a397dee969c87aa27fe21010a88d76a91f034328e8";
+      sha256 = "b2a3bab7cde73523f8a516541170cf701db45e15bd46fbd3c200dfa056d0252e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/es-AR/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/es-AR/thunderbird-78.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "4da82ae1bed1ac257b878e5f8de6be6490131f15ee9db44de4aa10202a790e5d";
+      sha256 = "af7d15f1776476ef7ea421bb91af9ab1dbffb0369fa12b9054478197b0d902b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/es-ES/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/es-ES/thunderbird-78.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "706ae91e5d36cc85f35833d5508ab7f3d0b8505491b5a86ca4447139b532b929";
+      sha256 = "4ef89f9997094ff1c57ca7c630ee15fe443e214fb3c8b40253cebf8a83e9e5e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/et/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/et/thunderbird-78.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "f74858d4b770245f3fa1d4f9ceebd274524dee73320fd4bdeb0e251a5d11c253";
+      sha256 = "f70280ce83fcb31a73a5e7230a3e6ab7abaa776c969cc4d98953bee4529dfac1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/eu/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/eu/thunderbird-78.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "aa02f9fb911a61da3183df79dc4d3760a5d6a259305da72932ff962cfe390d48";
+      sha256 = "f34516a026d2adbab2cd3730d034abf326113f96f90bbee3889fb0e7cb1b41ba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/fa/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/fa/thunderbird-78.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "6b41612ea00a38e8bd4d1a796cbf5e3bb6d413cebcb473bcf9c5bde0d074cbfd";
+      sha256 = "d004a5e3c3dcd5d2fcb204e9fafa943d1bf6ad1e6cf11aee88796a4f0149e44e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/fi/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/fi/thunderbird-78.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "f64e3e2e266478c36c50cc19a161dd9496db6f668f2078bc182c1ddeedf3410c";
+      sha256 = "b740e866a690e6a6ecd0e910f63822f546389d297f9c923f38983b5f78be255c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/fr/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/fr/thunderbird-78.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "eae396eae122ba4bc965fd8036264bf8bf88f52944558c7c1c0891a4254d04ee";
+      sha256 = "eab1bdf57527a2fbe4f7de0a3314eba9966df5a2bb9a998c32a73fa372a7f85e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/fy-NL/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/fy-NL/thunderbird-78.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "3163461706339a7bc34b8d7b83005b2ca962f6b6830b9da32c58aa7613c4efc4";
+      sha256 = "bdd5b279a134e305002b87fb6b708e54132158d111b99bb100efbf2dcbcaa606";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ga-IE/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ga-IE/thunderbird-78.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "e2d1d31528e7b2773e898202adc2fefc3fac38843792d6ad57e093d3de6ee4c7";
+      sha256 = "f76ad9888686fb09c33d2fc1f92849adf9102c265b302640d50f4b63803ab416";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/gd/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/gd/thunderbird-78.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "429160e98e24545f7890372eae1f2ef732b3a7ecd6529fde4ca247fbe251475a";
+      sha256 = "54abde7a6b6f6864bd260b1d31dddf1d578b9f9c2b9f928c2bdcbaa141d14163";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/gl/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/gl/thunderbird-78.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "215c0f6f3409200db5c25cf26c2f305917cc7b9b10b734d22be2bea7d4b34443";
+      sha256 = "6d10c320adb9880ce31404034a501f3d349227d851120c2ada5c4edd6b7f4fe9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/he/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/he/thunderbird-78.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "9b13364552d3afdc4fbdd2683d70b32b3f3c91633528c8b3684c7d9060431818";
+      sha256 = "d635c4b9203d03b9bd78b81e507074ba5e6b8c4b066ea996f32d353b557250a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/hr/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/hr/thunderbird-78.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "92a043ec615e0f92ff301df498023a31e5a32fdbcb01be0e95ee91917ad88112";
+      sha256 = "0a50d18b9c53ac5d325aa343cf7114307e90d98e2392f0474ea469508c329cb9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/hsb/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/hsb/thunderbird-78.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "a73b9619b2da033be6913c4342fe23886a9ba6710a65496878490e3f6c016901";
+      sha256 = "34b1f83011ea6297e11d55a126f8fc8c87fd560e2144a4e64f4b377177ddd0c7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/hu/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/hu/thunderbird-78.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "b1e938c785946d91e5759cc5f34d75fbbbf421b4f8b5dbe1eee9158fc277198d";
+      sha256 = "6a4f2e4f026efabe45f45bdf691c84e1c393ab223aee045ec8e21092158cc4f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/hy-AM/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/hy-AM/thunderbird-78.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "7ad07de9dc366057b004893f3d77900dcd4cb6532127a60b07b343752b96ef96";
+      sha256 = "dd8762372b789ee7bb6d11994f8216cfb9fcf493d6dd27c3b292f29675e9559a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/id/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/id/thunderbird-78.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "51b239fc75b2b0769faab37ba8c03973dc9a275eb8730193100f5d3cfd5b1621";
+      sha256 = "cb811617137d3b57160e64af7b901329b0b6df46f0525ceed04de9a5aaab8bf1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/is/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/is/thunderbird-78.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "69299e2873cd042e64146faa329f72039c079645014270acf08a2a0357a7025e";
+      sha256 = "e0d7e51f390aa0af3dbbb2505fdc6eb5a3560c97b031fb67e14bd4af57868bbf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/it/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/it/thunderbird-78.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "dfc2f83084ea80483a258e2ef879bcdd31256c55920f2d86fa170dd0ba432091";
+      sha256 = "9c88972bd6ee1ab726e16a6eaba32aa78e3d8475506d3394254337eedc47a9fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ja/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ja/thunderbird-78.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "7b1cbca9399856b3c413e7277617c808b3f670c6470e3c243c6fde9aa035d563";
+      sha256 = "0fad6c18b92fcec16684bd9905dd0a3b6bcbdf8c2bfd6d271baea48849a0fa8e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ka/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ka/thunderbird-78.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "2ab93932f7e567b3e9ebae4fd4c1d032917c656408b5b74cfd51f0e35bf14af6";
+      sha256 = "75c454ca20ea0667caab5223c55a210f68165fc72b1493fc8afc76881cfa823c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/kab/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/kab/thunderbird-78.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "c6bf87d821095326487e4822e6c373b4c5ec9ebd9dfcee511c4b85031ae7caa2";
+      sha256 = "8a928f4b5fa7d0374e361a47857c85a34d271d2cbbc760332a6e588e3361fa62";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/kk/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/kk/thunderbird-78.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "06cd2284afca05ebfb16ebabd128d66f8a45751fc7a5c1f4ef39a2753dc8e88c";
+      sha256 = "18b851bc36799910965c3eb14a8c9a57f29dde91c570e25a8f7f172a8bea7771";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ko/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ko/thunderbird-78.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "bbbb6e7c1c444168ab9b7c3797ca1bffa3c885980e2f215c914780a1ae5d1871";
+      sha256 = "108142a8cbd48dfe07626f4672178a35c5f253c84efcb924c7bd4c1531f6ab38";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/lt/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/lt/thunderbird-78.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "b64e1a057623a85841137b7aae1832d4757766ac1d37452453a0130582043474";
+      sha256 = "5c65eb6b01e8fe82db99390ae889870cad107d4307e02b04d5f9390eee81f098";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ms/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ms/thunderbird-78.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "eaeb81daf522f0282d57c5b77f54b736c9a723c3a2ad0ddbc2501683cd3dff63";
+      sha256 = "78ce19d598b2fa59ecea9d6fd4e67e93b2ba00b2e9569579f687700486e80c24";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/nb-NO/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/nb-NO/thunderbird-78.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "5db8562f43efcfff4f950c1e2f6837d8ceb9e73543e7c7dd75e695709defbc61";
+      sha256 = "e8a1f9f4666a3ee423c5541c61fccfe448989d0d7d4840dd36bbc0826cb96537";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/nl/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/nl/thunderbird-78.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "77ea8f460f82d05369ff110b85c4b995623caa7b62e38ebb5d8e0f7ecbfeabd6";
+      sha256 = "f9292bdc80157d2e2076b7be81af66813aeabc722356c3e514ae18638720192b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/nn-NO/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/nn-NO/thunderbird-78.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "83d2439498fca42c3b4095515c9359f89500bd11029fa58ba19e6058d3b696dc";
+      sha256 = "956b0c99d47845c9b0a1c7d101f576e5b4a7a514893da938d36616db9f5bfce9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/pa-IN/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/pa-IN/thunderbird-78.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "805947c3014c660ec66d5382dce6a733efe196b45b445a7d2467e209ce889727";
+      sha256 = "50cdbca944f98eef40479a9070b58729f7f743bda55925c74b6410c163ac784f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/pl/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/pl/thunderbird-78.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "a7eade7fc0b68361e0a8d6a1cde62d7253f938dc0e93fda56d0ed296304b162f";
+      sha256 = "fe2de7bba7b057022e02f040bb65ddfababb39999fcc573e65cd2bc0c848cf41";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/pt-BR/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/pt-BR/thunderbird-78.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "7e5a89cc9460ef65f1b5141d7bbbfd39f2d38aac599b50c8f57b39ff2218f7db";
+      sha256 = "6b219f0cb715f2d5a3fa72f34b079b401d850f571a9b2ad21c97871a5b83b9af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/pt-PT/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/pt-PT/thunderbird-78.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "809945bd2390457d2ffc1f232e120aa68c0e8232a69d14b6cd1207ed4fc62bae";
+      sha256 = "deca0d48ba8bb002444c3649514a2d7e39a698c75382ab53df080ff2c484eee4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/rm/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/rm/thunderbird-78.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "82849eb2a8db39d99cc1fb514d0a4a78c1380fa5ad75434d0969860b5fa0c5f3";
+      sha256 = "3799e8dbdf5edd6be276ce4634418c1bbc52862a5366d43460e1bf727f11c27d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ro/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ro/thunderbird-78.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "c9abc67c0612e3da4d9519d93cd87718898e6465f8275cae9edd7127f3e9c964";
+      sha256 = "a599d873eeb1ecff1c7df37ff89b9e71527192d65c3b0e593d87b0c68bc28062";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ru/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/ru/thunderbird-78.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "77c7e1f174c5540bc683ae71653392e24dd70737f6a6f9298c746cdbbb1f2e3d";
+      sha256 = "b488c44be9c1acd9715f9b872e61f1c8f4a0cedcdda6d291f8ad165013b5f06b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/si/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/si/thunderbird-78.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "d45b2a6492fd732652ac4d160b74f612261c33dee7f8f7c21bb1a8e0d45d72a1";
+      sha256 = "b60c002886df2ab941fb5c445d6b33d31de8a2d9feb15523c2af561da7ab09d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/sk/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/sk/thunderbird-78.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "cb4e2492618d70b67b2deb803ed5d02a2851dbdad26098c305c804017d27290e";
+      sha256 = "0c59cc63c01ddf7564331a6a9f2ba89c5ab263c227f517c9fa066a3c7f8e8a55";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/sl/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/sl/thunderbird-78.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "b731685c0de6ba0350259f84a2b4c597849459bbe5cd632796a09370d2697ab0";
+      sha256 = "2039f31a243f43553c893232d79a27cbc249bf73f083ed05b2914333dea6c5bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/sq/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/sq/thunderbird-78.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "4c2013d3b64cceec11bbf58cfd3dd306653410ffde95ffdc649c3ffd2390e542";
+      sha256 = "f46914a1a18d989c385f29cd34f95f409f5d56d601b279d8106aa8f224a61c26";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/sr/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/sr/thunderbird-78.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "ad0fbf13c2e0aea8b5ba97516d0ec53bf2fd4868155e66df5297cc95a27246db";
+      sha256 = "a72776da8c85de9f970f1a55ef2f56d2e9fd3fd73b7e6d39761ab6bca7066980";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/sv-SE/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/sv-SE/thunderbird-78.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "4af730894f076b9a48afd5a202f7e78a11f050a11e5e2011726370e1b14ce70f";
+      sha256 = "466378b9542c4a8550fc6e7143fe56e04e5ae15a20bc6ddec5da4eea231fb928";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/th/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/th/thunderbird-78.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "901c62b2adabd67d98314a18782638c8f7e9f55d8ebcb0686b2c7355696f71f8";
+      sha256 = "7943c3257f4ef6a842008b0fd6171f87e99043263ccaf4666850ccebec28725f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/tr/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/tr/thunderbird-78.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "ac7794552303525a4b72dac166624c06b7392fbdb063144a793a39d4ad6fbac0";
+      sha256 = "a5120107b8fc5418c49d70cf61730ea2b8e833d21d8e6b797d64d2637803709b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/uk/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/uk/thunderbird-78.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "890373ce0813c7cd4cf8eec39af6a362d1e88c4bf967ccb3482b7dbb806dd228";
+      sha256 = "a85b53cd72b313e49ab439f9b1900c4e8f7610be085d757bda4123f5e9293cd8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/uz/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/uz/thunderbird-78.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "0153af7da918e0b3a9d50e2970f946dcc3ca2ba0b92782f82917153a2fb850b5";
+      sha256 = "7dcce5d00f6e83b756f3b83067fcf78d00240cb540815e3e63d40302272d5e4c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/vi/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/vi/thunderbird-78.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "55ba1938bc0b894f92bb17435b0bbf19e15da8163dfcfb377b87db02aff8e564";
+      sha256 = "4b94684748f81444d8a8beeac54053673bb4705b6284f8b5d86a5f03fb9a2ce8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/zh-CN/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/zh-CN/thunderbird-78.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "921619f82d094b35d74dd54071191ce00487aeb90190e2d2b6f229610e016878";
+      sha256 = "346222badaa7b34a7e21f28045c68be815d187a5d34432446b7ffb8b959fea0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/zh-TW/thunderbird-78.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0.1/linux-i686/zh-TW/thunderbird-78.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "28a03fc23a2961bdb1ea3cf1fa08be57302627071f4dc096eb9aca58124e5058";
+      sha256 = "deecd348a6c260bc50b1e112966d736ee4bc211a1f42f791f37b10a69f7c1c2a";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,615 +1,665 @@
 {
-  version = "68.10.0";
+  version = "78.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ar/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/af/thunderbird-78.0.tar.bz2";
+      locale = "af";
+      arch = "linux-x86_64";
+      sha256 = "6ff0f696c6caef049d0489085e7b9c3f7240e242c23aef9a36905c67bcbdef33";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ar/thunderbird-78.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "2f49abd71f7542042ef2823cd420e225bb1015684dc258fd7e8eb1104ac9865957b0e6c975043e3611d4d884c085ad670ce21af8c8cab1da80f08aa302078059";
+      sha256 = "54b09003901703c2820b20534d403cfbe0b59d7dfb5962cd370049795552e88e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ast/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ast/thunderbird-78.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "91043afae8c2f31f6d2aa5b7f6c7f874150c7f8ef0ef7401132b12822bbdde8c7d7f24022f3f5d0cec262100a2b8791f440a55f0ed00c30acb9429290aa290f5";
+      sha256 = "98c159c6ece97f113614107a1ba351901cc4f816d165f6fb2b3ceee7c5fbed6c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/be/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/be/thunderbird-78.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "6167bd7fe2d980af40a0d5594e67dfc262bb7ab5fb76ea07c919136d967505e84b4d27448d883a31323db7aafd33b4222cff63d27d10ec914354ba4264736459";
+      sha256 = "abc376f1525e53aa734d00a8a52d30ba2c95fe0f2d053c54e019eecd35191f47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/bg/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/bg/thunderbird-78.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "885c5ee186933eac265ed530f9b8b3cabc934e1ff4efc50b10381f8e53ddc39fe385e21e22041d93ef987e031ec41c2b98e898bcceacec004542bcaa35d0ccca";
+      sha256 = "a53deb5c4d83719e380b69a41f3a80e634c8d251a1724e1d49e5ad8ac5da1aca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/br/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/br/thunderbird-78.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "e5c31ab8b32f9f0bd72a03207d4c9a2ca75d0c5f28e497456850bf92f75020784258725942079e52f6b38c0740e7d2ec80ef24bd88aca9fe35e9386f65cf7c1a";
+      sha256 = "8424ab87bfb1c1622d244961896bf4109fac2a38bccfbc6facfc7ce723a6ef06";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ca/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ca/thunderbird-78.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "2d727f09dd202291cbb908c2e7805ecc7ec29302bb2481b63a5df1f43c29c39d1ae26bcf3b5dea550619391a96982d3d2bb831548a9a2331e986345c64b4b6b4";
+      sha256 = "8283ed7294338be053900ea85e4d9e26ed5ef5a53d419298ddb4d4b0cfd3a8fd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/cak/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/cak/thunderbird-78.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "1e74db72b4bc0ca3db90b9ae678dea551293dd54eb5cc5e5c124c51e61ef0d4cb074769bf807ba2d680db10f6086bb3bbcf5d082e815bff10fb8c6ae14c5a72a";
+      sha256 = "10cca56df7a22ea31fcc3f2fdcc4cea8344727183ca4d7cc1f6d78cd881879d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/cs/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/cs/thunderbird-78.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "9c89e7328879f82cec0e2c5f7efb2711242cb3f36a4ccf6a014c6ed589f0e02748c997ea98909d546ca33478022bc9143987710945eed1e191517d1348f8a064";
+      sha256 = "fa476dde45d9f3796e71ed26126ef99569f92344d9c5754dd154df2b79513312";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/cy/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/cy/thunderbird-78.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "46e234560ac4a9e7c5b54816bde0f22f2677b6ea117ce5c528260222e940b5e47b12d8b08b24d2ee9bcfc4dd72168faa036207c88f5bc573051fd7eea2281fd0";
+      sha256 = "319919e66b178aaa86f74717aaf7a7dc54c53c4d400fc0f54d3ff0a4bcb5ea3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/da/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/da/thunderbird-78.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "8ef4fb0210a21df0be22e1866859ac316890cc90e6b157e0cad2725d59360b06db068aa000627ffa750c05cdc8314cb564c32476dcea3975bb63f66b20873059";
+      sha256 = "9a3eb38c50fb9c1a1fe58899c304884c2a3e295a278feb40296a48f845f4a8e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/de/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/de/thunderbird-78.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "b3c7673728c8af318c0c8e0c3af8e1b7ba457bfd2c5a67bf3df4df6c3c990970d45e1a0884c03aa0a3d973efb12983afea40de55c8831d2b254acfb742c71478";
+      sha256 = "260dd2a5227225168327dca79f44ddba7bef4a1a0411a731a192163b36a217a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/dsb/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/dsb/thunderbird-78.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "adeba633f288fff864e7247e36b4d7f49046a3901de0e4f93f12ada6fef275578b494441d01e820400045d5f7d64048684554934be678d1b7259910a162a4ed8";
+      sha256 = "559bdb00b7741897c245d367c5147503e580d446b2a6b90e83af2ac9b64ecdd0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/el/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/el/thunderbird-78.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "6ed60a3cb194de3e2bcffbdf1d0c89460b2c2416878f348c913aaaff911f43e9a624a8de87d46df366c8bd608c47f6a6de8b90fec9c0c82e38afe860ca760f65";
+      sha256 = "2f8fdf4aa2347cafa43c1b7e7c7cb6a358878e8470b45d04634566efc089e1a8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/en-GB/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/en-CA/thunderbird-78.0.tar.bz2";
+      locale = "en-CA";
+      arch = "linux-x86_64";
+      sha256 = "e3921e80a168544f41c39d0281ea32a4660fee8146a7a0b85292f360186ad876";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/en-GB/thunderbird-78.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "a09f578de9b8f23c9b24123092abecedc70e5b48c9c15089505ca049258621f14d8a4f02c8154f7d2c729ed002814af17e08bf211708fc59e5345c92cb259fa2";
+      sha256 = "a1c2c9f9e7a14ad0abf83d7b268c47e0ef13d4bd3966adedd0ad46bcd4c7f8c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/en-US/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/en-US/thunderbird-78.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "3f7d4c844185b0be0ee3354130112ecc034f06cc2335681998e210b79537df7365f251b005387f319b0a2d2dd6a6337fd6287a007fd54ac03c39315c42893dfe";
+      sha256 = "57384c634f511c249c3618adcbbd9d2c0fa2a711c2af145d3a390d0950b94209";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/es-AR/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/es-AR/thunderbird-78.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "a028429230c625b0dcb9e200b2e21c6d4db8e96a93313881701b5965dc25db31a0992d4d6da6072a6ed73eb5891d15ac71f19f343172796db82d6e98355baa75";
+      sha256 = "e727f4a725f5e389d99d929fa6792863c74e57e23452e3be1a88a3852c83f7ed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/es-ES/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/es-ES/thunderbird-78.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "58afe4eb60993bae1271fa03a45ce13611a1d83e4defc1f237ed47b243785881c8309f5fa8a5257fa5b343e2dec7595c8ba6143faa63f49749453ad229ee8102";
+      sha256 = "2fac6c47b544fa7b663126f137e4850f5bbe1da115a845b99353454ae0c175a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/et/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/et/thunderbird-78.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "402c33c3fd7194a3f5c0d6afb81f639fd4a0cfebdaa61043858938fb5b2690844ec2fabfe9f73d41f45c26d56adcb121234fb1baa76b2455c87863dd79cf065d";
+      sha256 = "e3bf4000c8e5d04ddd9bf0a86dfd8aff02304b5d86c55f649fa43deb3ab9809b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/eu/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/eu/thunderbird-78.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "ace87496370c17b663971365da8c1f88000b76247aba2a6fd5d29a31b5d4b02bf9b56e101c477d48553ca56416e73209aff7f729ea2b8c044e33b9307009321f";
+      sha256 = "3c6249fc0d2707b9472ef5b3876fefc3cbafca617ca27037ad8e98706d509eb5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/fi/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/fa/thunderbird-78.0.tar.bz2";
+      locale = "fa";
+      arch = "linux-x86_64";
+      sha256 = "7e2edcf08b456f53d8274d17e1bcbd9efb997f74b164224d3e153d64ac7fe60e";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/fi/thunderbird-78.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "775c937de9d9ed49ec70850a1d8ccbe22c964e12a932c52d3dc360425643f2be5487857caa811556e341d94bc62ed9b8dba5e94039c2cff6de50bdf16e364c89";
+      sha256 = "1f6cc927ec2e21a67e61c7d09d93f846d5c1bb1ef54644b618ed806a4541170e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/fr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/fr/thunderbird-78.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "1ac4d3e23f71bedf77a8d2dd4fe8d02fbd1083977a8892d2c6db394a9d345bcff73a916f34a078ddd0850e8ac1bb0486aec06d6e36875eafcac0dab08bdedde1";
+      sha256 = "f471719cecaca31e5a940bb82908648703a37b74f647d7c1c434f8db339ef974";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/fy-NL/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/fy-NL/thunderbird-78.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "b62676e5302cc265a6ee65de7a31585bade7bfd51395bd56257f733fc9a6f4c391e5318aad3b48441464e5d8bcbe3606cca1edcd6fca6517b205814b9e39b635";
+      sha256 = "405daca824b721680f77e3ad8936246825d132c11da4ec2277a022f899ee2ce7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ga-IE/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ga-IE/thunderbird-78.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "81ba90087282fdfcd15a534e9065fdd94a859dedd6a85dc9da94de4af698eef6b31a19d3a007eaa27e08944682c9f6108a0d0991f1e394451da881018e5cc70c";
+      sha256 = "899127ff4f98f922e405844df1162e66d484443e5a84bb6c575cc28658b52649";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/gd/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/gd/thunderbird-78.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "1db39cc3ea8990ec8d9ff214d554bf95a6f2699e3f1bf625180b7f84ebc3284e1eec8e2cfdcf87b3a31b466ef2f84dd0a56d771078f4cb06962a28531ee085d8";
+      sha256 = "183f757b4d70b999064f8a8e495bbe9a6a9783d939811bd93181c9cbf61dc880";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/gl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/gl/thunderbird-78.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "dbaa3cd2341d8ad4834b9db4982b731fbcb1125398cc4a7ce6a9cbc44db7218a165392781e144b68618781ed8d26216f11e1bf172ce4ba9b18515cce0feb9bf4";
+      sha256 = "58130045fbcdbcd10541ea6c2d13b95455af8e5fb9893a80d999b79d814eaf17";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/he/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/he/thunderbird-78.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "547795f844b60b347a10abc8e609f7d311b63ae4cf76b2b0cb0b0605f597ec0e1c7ec3347042161a4b15201f816f99c391851004de9a957754aca6f50a055d7d";
+      sha256 = "719ce3b7d4e3841a7092e658f43a8960d68d82ebad6b6dc43d12708a07054a8f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/hr/thunderbird-78.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "6c72a46406396578c329b1ba1c47a46c124f22fb5c47eb1f16af7672e4269bb84f62ac4c1d9b61a5e8e46eaa4c91e5169b59e9908ad61606b243ed21ce31d859";
+      sha256 = "49f9f0c18ad45a73361520a055f02b6b8da22419c37c8423dab64ab13f253834";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hsb/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/hsb/thunderbird-78.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "e06eeaceffa7b39810faf42640f22b8edef8ad501530f1602a7b13265f5a9b34a1d9304a19a514e3beff2b3c7e8ba92c72aaae6b34cede15e6fa59125344c026";
+      sha256 = "7abc5362bc14853c7a9d93c84f1d04dd5d4f0ebdd7c71c782b83e8f56d716516";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hu/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/hu/thunderbird-78.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "9ab3e1b47a3120b74adb1f0f0ec657443578203f4c7f7e00804ef61bfeb2c7cd36721256943e8c86e0a62f90c1576e16a9051b33dc9a0006cb7fcf55bc90fc0c";
+      sha256 = "5bb475dc366e9cae5e9e1422bb4f7e1eb1b605dd5e5193ccc253dffc11c4a0aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hy-AM/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/hy-AM/thunderbird-78.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "614da904a59666d5e67852296eb22ea0ee0d137764ba9fc4f60edee2f547b91659147d14849ca83927671e94b32847f748f97df4bcd93569d46f3cfb0f8f372d";
+      sha256 = "c42d6cc12203ac812b5794234ccbd38ea83114844234868cb02004a82e8307ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/id/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/id/thunderbird-78.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "13e01f8fe23f10d24b4399da8540c2afdeb762b1068f10984945c0920882b67bdef48f0f26180786a8d944ca1ea601e3c51bbf6f0cb64697fca0c0b0acb08b84";
+      sha256 = "13e4bf8bb6356966d44e4049e2e90f96b097e6a2ec2c54fd39cbf74e45dc4d3e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/is/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/is/thunderbird-78.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "176492bbf4ac3b2bb4367848f1283c7dbb805b5bfe6c71cab6c8893578f1d0ca1b9edcbc1e736748d04f2d0ca78f4d6edb21671b78379e26d41d9c43e8727075";
+      sha256 = "bdf740e2545ad41de9920a213afd6a476f261a15746ffb201461b3d2e0dcf06f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/it/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/it/thunderbird-78.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "41d10acbb84fde6556530253ecb5926ba4b5d81a38349a00281a7273669cf37245640f789dae7363c4e1a0224127885fae3dac701926dab6e4512df723d39548";
+      sha256 = "cd66931d6cff87b16d637340d82d459cac1878fbefdbdb201cf7ed561dc0f6dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ja/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ja/thunderbird-78.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "8124ccd221818d37d6d22f204baaf34bd87e7907c50ab380a3a1bf252432b41caa71dc3ba2b575903bfd255f16b702cc89d91903f494437547a7b8fa16469cbf";
+      sha256 = "10da3af84f726a9aad3dc5c8ca24136831c136cc2e52f6573b27695f33f48a1b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ka/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ka/thunderbird-78.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "464a9e0aebda0fa6412665e4cf2d6f590d44636bc395f8a03f96ffa7e8f5423e51499bd801f9ffb65c0c931960b761d00df3ac8f391b2157ab411ad49c7054b2";
+      sha256 = "575f382c4f155f93a6cbd5a81fdb988196e2a95d0b8896af454a3cc5e3048d3d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/kab/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/kab/thunderbird-78.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "d99305c424e0475ed2c1890e2c5cc96d1e4925d329948c33ac0183e3affadd960266e76e380c4fbc017e24538428439888d96f49d73468f9f6162dcb51a358f1";
+      sha256 = "bffa3681eb858a55c18b5f396bd08464eeeeda1328ec65a7c67fe4d7c7805757";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/kk/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/kk/thunderbird-78.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "9398172a5d2f902256b2b36df5f936a39e5f2d253ee4ee566109f67a49f2e2bd4239b92802475b459d79acb5af7e4839f6f5f0a5db1c7da10fa35873c470003d";
+      sha256 = "866191e1d87c0b00f4bb5f2eaa0e1f66719a7ca68a175d1b30ed9a5735005705";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ko/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ko/thunderbird-78.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "80e7f9929a197ea4b431376f168fcfaf42718b1744bbf0bddf8672346ff08e65c35af5816a21effaac6794d9e55009885037007e87a05571e1d7eaaf7c86f30c";
+      sha256 = "f66f91f0e0b04344db0e5cbe8d48721448c775ba8f4ac69ceb1d848b7e07cda0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/lt/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/lt/thunderbird-78.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "74ca7346f87b078cb9f598e79278ee39498b09370be5517a3893dc4bc2d5efe81f9b9076b27891be0c8d170802a02ac67dabeffa022fe222e95b73455b40ff34";
+      sha256 = "2294425187c5e5404af6cbca9b495902fb9bc05354eb6e3866b1e8366ea64e2d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ms/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ms/thunderbird-78.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "90c71d0b3f598c21026441dd5b34efca7276f34153ffacd327f09d2c78296c9dbc2ae9eb8e1f7635b8e3cafed15f07cc3c19254405de2e6c9e1fd4300b844876";
+      sha256 = "f21e85113e0f63d57f91c61e2830f1a9e721138cc00269d2fcc521d1c74666ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/nb-NO/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/nb-NO/thunderbird-78.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "08da0c8a887c820d246559bb7c1394282a68f2971ba2f2943084ebf3cafdd2580477ef5a9ca06c1e5aac353287276aa88aab8346beb95addfa95d5014cd4974a";
+      sha256 = "5b7982cf136c4d6120ffc7e40c65ddbb3495392181e38141ed80e3a67aeb1038";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/nl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/nl/thunderbird-78.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "f846e221c2bf3cebd93961e6af10c24215b698cb8318c6446224f5de5b533e887e76818b6b902adc839a3f7c5ec24e9b13aae63b5d601d6716643f64aa29b7da";
+      sha256 = "d9619e1ca19ef4c75eae31de3dcb6cc23146c4d1b98046473a3ebcfb3a610c52";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/nn-NO/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/nn-NO/thunderbird-78.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "c33a600e2d64c94cdda74f2a94fc54f05133cc543c795dee70909b00b92eb5a48b183600f328f45fc8c9bdabb59f455a4875e68e6e62ce4f6309cfc0aed24fc0";
+      sha256 = "e9d2a6955fb98c0dc492a5cb16977a1fc7cad778650dd601934bbc9f543b112e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/pl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/pa-IN/thunderbird-78.0.tar.bz2";
+      locale = "pa-IN";
+      arch = "linux-x86_64";
+      sha256 = "a3279bd605960f37ddc071b0f3d91726a9d911a311c13e9418013c5a1f7a5089";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/pl/thunderbird-78.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "555b0fb0c4117521f020f7d9846b19dd18ccbec585cd89282384e0a311dd5bbedab84101bd55064c7ae20ecd811c70f31948da26befcb12abe0937ed2736b9b1";
+      sha256 = "b22737a3a5b7c5ff3d8d22fd338490b0aff9016049bd7bf6cf6b25f15a027935";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/pt-BR/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/pt-BR/thunderbird-78.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "a51b74e5d9394ee2ebc26149e1e01766b9c4cde5815fcd915bbc5307095a851e6242fb007c8e93027ea0a77b3074679041c65a1996528435f30f7f17b06959a6";
+      sha256 = "a6a18c8988db47d8163c79c465995aa0d3cd42da97bf2347b5be4d26e09e4628";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/pt-PT/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/pt-PT/thunderbird-78.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "4912989c47a3c021a28ed56629e308d2326a07ec99dc00b624889a10013f36445fbfe11a8cdde7ff4f69c965b0d2221c61c246933cc313df9f63ae3ec65db891";
+      sha256 = "8717f41a166cf8e271086987196be9b88f585a70c30119ec15199291bea1819f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/rm/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/rm/thunderbird-78.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "70298a29589b928748d32adcf83b12c006d23cd3a171af1eb790eaa34eae4b1a8e97056fc71f9a795a9b9e07f5d8e2a9f4ffc475eaa4b06b9390976fd6359668";
+      sha256 = "02b1131751a82c66341e58b757c1f4e438e5ef8fa44a58b904790c0a5ec66b44";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ro/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ro/thunderbird-78.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "7c36cefeec21820b90a8acc09856aaedf4cf94215cae71daa8142a1d166de79dd0114495b92d954f978d1be88c06ad5fa269fb33ae0b307ca05f3d7ae90844d5";
+      sha256 = "b7d82398f43112b5b9ab1907643cd8c39012246a1e9b74b3c4e37487df7d5bb1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ru/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/ru/thunderbird-78.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "b7dbd077b0271818ba33d8651fc60e371f9a89771020113ce2a0785c2d228b90d219fcf944e6ee2645fd683fbc1d597529382c4b808ee4cf81f7123e1de9d583";
+      sha256 = "155c7f4e678f6f3b91c07f2aa1313c08305a2c3166c199a9d8575d58c7448ffe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/si/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/si/thunderbird-78.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "b9217a815c7f042bb33e0ea2ef9129e8ef1c825af315d0cddb6c0760bc87f1b8932b6f7cca747d50a29a55ac66a21d8113febc360e5f963566399a38e3b5a2a2";
+      sha256 = "1af756f61e5c57c0d6018b3efc0072e55d7344c3a9fd343686bfb16773551503";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sk/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/sk/thunderbird-78.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "494ffad5906f35f9b3141fb06f6900e0d82553c16c8f3d99b50d6718643cac21fbd6a205af146df54125c009f190285281b09bb42996505a2fc120dd85bde882";
+      sha256 = "b06bc92b4ffdfe25a5003f3662ae168600a6ae8855b60353ad68de6a24067d4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/sl/thunderbird-78.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "d34836dbf915e4d5157a1f8760dae8d8659ceda2ceb594d737da7384139f245915f01a0b025585c117762f2d3261dffdf1c7efa5c2e1f920fe5a350d85406015";
+      sha256 = "19cc8710f257c229c4700b0a9deab471b1114a21f6cde0838f6a23e29faad6b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sq/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/sq/thunderbird-78.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "909aa9e820cb984459deae17b80488db09718eb428e32a35ecb1723fa3c8d7ed974f6cb17a07db8e642cdb51b885291a3fca518542372fe2c2b3360553b3527b";
+      sha256 = "13c8c4893947a8178066ce7a767eea21e78b1989c94be4d573f03f98e7f43011";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/sr/thunderbird-78.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "aa39d12ff81a371722609a4ec401021512f651c4f592159f8ef9bcfcb641b55a8f6ccea970b4d8375cb326e0cfd5fa18097ee3131e7546c53b1e29d14058622f";
+      sha256 = "68939bdf7b57320dfb608d6487b877baf0d801ef3aaf0da48becd87beb41aa89";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sv-SE/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/sv-SE/thunderbird-78.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "3f373131df39c343579ddd851e8c5eef3147650a5c75a5fc3ce84c2e1a694494cd6e3ab12b3cf86018880384f02ca38a54fcca8cc04f3074699fb89c4ded78e0";
+      sha256 = "36689c205cd7a6f212a5971fcc226631937232173f84cd0a2c40a87f95de001c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/tr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/th/thunderbird-78.0.tar.bz2";
+      locale = "th";
+      arch = "linux-x86_64";
+      sha256 = "392267ae08739866f14d2ddf0a853a47d18b2c99856bad369b567e7360d2aff9";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/tr/thunderbird-78.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "2c91ad17ddad9db19ff2eb47ff7a10253febd30faee710301dcb96ed0472f81153de5d7d906b3dc706d39ff058eefcdb9210ac274469fcc02a39cdbb99a126f0";
+      sha256 = "15f45f9794ab34f79951a3b9ef990f25788c45eccd65dd1aab565d2908965c66";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/uk/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/uk/thunderbird-78.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "d98a132e14a5921b6a75a8fe7cf3c1aaf22e83c4c8252dcbd5aa0434b98a7d9d88711b68cc470e6007027e6e588cf9ea00dd78a2d97b48b975adef1cd059e79d";
+      sha256 = "e9b1765f80620ca7ac534c91656345ecc3218ef8a606b2a8f48f3fc1c170cbc2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/uz/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/uz/thunderbird-78.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "dac94504203e7862608333f1f84134d7afe0e1f534eec9b91ec48a850e0143b625f4be311c2e6e716a16c941d3c2f5dd2101abfae205c802749ca95428b7e754";
+      sha256 = "ed2258512e980e3c72b9130b2f5f839dbbff1df05aa5cb948f4519681491ca34";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/vi/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/vi/thunderbird-78.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "684626eb432e89e85b9d3270198ee20470e675ea7294222755b5b588db7e318c20fd8d2fc9a0c95374e8ed53e792ab0e24e826709aa619fbab059a77e6341213";
+      sha256 = "fa23f6d7c4b64776df71b5015743e8dd475cfa2a329370a92d36210711e0fd41";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/zh-CN/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/zh-CN/thunderbird-78.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "8a25fd27a555b18bc41ae31f024e80adc1b06de064bf2391c1db5510869af8c145780a01a26f6cb465d2c6b53f4ceeb924657eefeb95f7ae2ac584ddfc4a56d2";
+      sha256 = "741bfc0c297a8dc9b5b4348f26886a12c75a81af11b0a6090094e6e21348e6f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/zh-TW/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-x86_64/zh-TW/thunderbird-78.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "8f202b1a79ae831bf5a28356a06213586bb2c0f4410516a8121c73a8902d0ce7e54f8e6fd7d2c74b300c9692eb3ad4a9b9290cc93ce3205f73842d93a46cb77c";
+      sha256 = "cd4296eacde34b302c794beeaff0eb46bdf0f12c67aba98172133529506897af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ar/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/af/thunderbird-78.0.tar.bz2";
+      locale = "af";
+      arch = "linux-i686";
+      sha256 = "300da8f92fff4e596e5d5604002fbb5732bda61d6f54c7f79a20e2fc268a7ce2";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ar/thunderbird-78.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "868f092cc144611611133f50be9317161cb34ba2d0012d238789f2d1124b547c52d2aa02d4daa090322e327a4652808cc882835195f02bbea8e67818d22ca8da";
+      sha256 = "e382faafeff426536f355e2a711dbfad7d86de3619a4d3a60868ecd8e9593b40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ast/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ast/thunderbird-78.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "bb077167ec58446aaaaaa7439e04332946d62cc6a35ff00bdda20a03eccf80b09bce70524c3b3351fe0b821dda0762cd666c66b00314751301a67d635c2d37e5";
+      sha256 = "45c3c612f072277e9dd83fbe22bd4cf9018d481a35ea25334d12f6826c879915";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/be/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/be/thunderbird-78.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "a8ec19464c57509ccea6f83305d441aa9c61ddf0bfe2af172df24f67d7abaf2e568eeabfdfea9e0a843d42ff9c6d2610b1e1e5c060ccb50bce4045b47586f204";
+      sha256 = "6e9fc38265fb9185915c9447ffb2d38e4e024446039704c8d45b91e152a38f86";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/bg/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/bg/thunderbird-78.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "9c8ef811f0bf04066f3c55e4b02107450d88a1774417ee503027423917bdf16ab9b102eb0f7f4c777ee60039998f8391164f1719bb8abc4d79774664041fa6c1";
+      sha256 = "cc041a49ac017568b815a5e03a37031a6a17c25110b77d37bdb96c4d53d869d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/br/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/br/thunderbird-78.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "e94fa2e49fca5bd6e6f1139adb86604482deeb1160cc8fe348a1cfab2bb19c8ba694ca5743ed6e5da81c9789521e8b6018db4ecc68ec91c8a277916c6a553521";
+      sha256 = "3cd798a70f493ac5a75895be3db025bb3793836e21550c3ddea6b27f7dcf6d7e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ca/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ca/thunderbird-78.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "4dc73850268e885b9791b29573f35704d730e9a9ac833265f47413eadb2e3d359b8b56405ebfa58816b8b2ba390077c14f17a769fec94870652147d2a2915243";
+      sha256 = "553ea37490cf180bbb1f0ebcd23d87e82456797ab9f5604ee862227b0854ef12";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/cak/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/cak/thunderbird-78.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "569d8b373efc412180cf01ad9333a1b2f05687f3b8cfc4286c81c9309681d390d9ccc2767248e36db7931e2b941dce6ca209a00e7ba5dbebea6d40c710dc2cdd";
+      sha256 = "307e3234abbcee8a4aeeb46d1b8bb02c8642f1a2140dae9a2d6295bb32548742";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/cs/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/cs/thunderbird-78.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "e87eebe5c3486b02f46784209019b5f5dbfbeb36be8914604416c194bfebda2827861172019ca33bf754bc86ad91327ce5e29ecabcc77390d84be80c2f682e29";
+      sha256 = "a08537b88425e2b813aed80b94d763d3c31ed9aeecf5b3b8e358c08233997ce5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/cy/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/cy/thunderbird-78.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "e97bde29c976e200f418b2ec150969459e4e17872184dfef548b08e16286f948259d2fc84d0d07965a5dedae8d5e3268c3a6ac0794cb0c3a739ffc86b2a6f748";
+      sha256 = "36b75de4d73075026f256c6502caeebd35a89ca567cbc9fd6db461608b922be1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/da/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/da/thunderbird-78.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "7bfbeb6e8bb427e7e3aee31e897d025e338a4c4da59eb2700b52dd08cd53efaf6dfe1d33e456572c0203fe6927bc069ff297288cc47dec2ef9835e047a5d2938";
+      sha256 = "7b81b6b22888c298cba1dba3c9786249ccb0aeba8b93d998a268e33ca249c7cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/de/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/de/thunderbird-78.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "15da351e919e0b931dfe48f77b9eeeaec40e94c973de507560c62a86e2b106f7d4afa7602186829fad2984f9964ad23792ca88bd5b94976972bc103f0560ee4d";
+      sha256 = "e5fa962eb83d4cc7dc2de5a2080a0d06fff4bb3b6e30c53dc979d7bfad8542f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/dsb/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/dsb/thunderbird-78.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "1b8c1b12b8d7979a0ce45db282bc2a3b933bda3711c07097533a8a04b38edae3f0bd00298cbd485954ab09fa57b10aca5238e8a7bf4e23ea80ebed2dba1d73e2";
+      sha256 = "3745a7966cb96c79b49e0f8431d8b1e90cd5f01d7ce57eeb4ab3e5f80ddea26b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/el/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/el/thunderbird-78.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "67c5dad2a95ff1b8b3ab2ebcb0c1c4af87c5325e22d43c24f4f1c0df9ac328b43b0b25247408c8c95cb5f98b9396a1714b0cb39cd2e43ecd04b28f8bd1dc43ab";
+      sha256 = "037a51d7e44360a9748420ff584790abca6285d4bab8ee84414cfa602ec4c6aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/en-GB/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/en-CA/thunderbird-78.0.tar.bz2";
+      locale = "en-CA";
+      arch = "linux-i686";
+      sha256 = "a12288cf187b5e3075a23e420bc58ae90370c224b0c73b8706ef52c34705d6d3";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/en-GB/thunderbird-78.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "c9feebac54a357470523029377699fc9c0bca08e4705374dd1b8756cc8461237426cded2d9ee994b7ee529c60d50a555e4e1c2d9ec71ceccb7fccc651e35058c";
+      sha256 = "dc3637519c9b40260217e5302dcf4174a66298f98b478d1a6caebe154b9b549f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/en-US/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/en-US/thunderbird-78.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "9280a58b42f93b38f4c9ab26b8b6c2956ccb135ae959c61799cd3ce3b3419c9642f86418ac53e9c4f69e0430508c0619db4cf856a28d233a8d319e262755f4a4";
+      sha256 = "8e425ac9e0ac12d6142ef7a397dee969c87aa27fe21010a88d76a91f034328e8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/es-AR/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/es-AR/thunderbird-78.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "9c17d648a2ed9c2b6dc7d403436dc9aad91e10e63579e26e4dafe3d5b3a15633167c87b67924026882a03f1aab05673566a0c5f0d84efb656b6b3d7d4b812e5e";
+      sha256 = "4da82ae1bed1ac257b878e5f8de6be6490131f15ee9db44de4aa10202a790e5d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/es-ES/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/es-ES/thunderbird-78.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "d22ba4fbd7e8d22f70950b61354b99ffa6bb1c298504f8f05297cbc20f0c89a9d657c74ab367480906cbc4b699df6c603d6f6b936ccdb4213e178f3eb153a314";
+      sha256 = "706ae91e5d36cc85f35833d5508ab7f3d0b8505491b5a86ca4447139b532b929";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/et/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/et/thunderbird-78.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "107fa0cd997edeba0a88d365c52fe48ea0d355ca8bf8723f5bf2ad4a930711e8fcdad27b457d309a5d4dfc0f29f6988f2b04f153b83384484ed397261c07db7d";
+      sha256 = "f74858d4b770245f3fa1d4f9ceebd274524dee73320fd4bdeb0e251a5d11c253";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/eu/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/eu/thunderbird-78.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "ba50b4fed2d682f1c46699f72d86b219a1bb398b1b2180cdfd246bf4eaffd61e34e24222bcd82ebcc68b9cfa9f98f56fe859cc6d5bd744a7223e7264d6d4f261";
+      sha256 = "aa02f9fb911a61da3183df79dc4d3760a5d6a259305da72932ff962cfe390d48";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/fi/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/fa/thunderbird-78.0.tar.bz2";
+      locale = "fa";
+      arch = "linux-i686";
+      sha256 = "6b41612ea00a38e8bd4d1a796cbf5e3bb6d413cebcb473bcf9c5bde0d074cbfd";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/fi/thunderbird-78.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "6f4fde19af18845d50f591940786402233bb77f518f1f8f9cda727bd458e21669f692681cc691617a0ce05f8516383ce38b7b51445e3937ff8c1868e84a92ae0";
+      sha256 = "f64e3e2e266478c36c50cc19a161dd9496db6f668f2078bc182c1ddeedf3410c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/fr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/fr/thunderbird-78.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "7e9dc42478dae325a51f44781048a55fea3e2bedcbf663c534510404e59dfa10216dfc0df4efd40e0bf1f4fea3abdc9867b6c6b33f199e406ab07d68b68acfe5";
+      sha256 = "eae396eae122ba4bc965fd8036264bf8bf88f52944558c7c1c0891a4254d04ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/fy-NL/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/fy-NL/thunderbird-78.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "1b665dce92e8c1de000063f1a12192a2fa5aff2c65db9aa6769ca16604e7e97a602baad9761110124c65dc479fdbce7640020701fb280b3c62e5c78368fb496f";
+      sha256 = "3163461706339a7bc34b8d7b83005b2ca962f6b6830b9da32c58aa7613c4efc4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ga-IE/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ga-IE/thunderbird-78.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "42faafcbe85ab995b549bf072942dcc2e87780099b3bcb2974ca3eff6acade40be7bd8ded5cb0db6a02bfdc255c60e252061a767543b2215719a1fc2600fdd81";
+      sha256 = "e2d1d31528e7b2773e898202adc2fefc3fac38843792d6ad57e093d3de6ee4c7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/gd/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/gd/thunderbird-78.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "e1455ef926d71ecfdad24ebcf4b3de59d04611bf641ba381534bd1b94c2f7b730687cf2e8412e6910d37e402b58f32588482089f4d12308a7b9cf6af82b66e97";
+      sha256 = "429160e98e24545f7890372eae1f2ef732b3a7ecd6529fde4ca247fbe251475a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/gl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/gl/thunderbird-78.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "344d619a5437d0efe2e522680849dd809b07c3aa9cf2831610aaf7ce28e81f16782a4a8174c01cc339914e02a23cb3ce603d04dd0dca8eb4f547e0d0e780d8f6";
+      sha256 = "215c0f6f3409200db5c25cf26c2f305917cc7b9b10b734d22be2bea7d4b34443";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/he/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/he/thunderbird-78.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "c081d81f3c1a61d2922bdad144a97c8568326e97fe29909d4319ca9019d9bd466dccabc6f2069eadafaa6bf6bb5bd50e8cf0c070dd992cc095411dd909b43f06";
+      sha256 = "9b13364552d3afdc4fbdd2683d70b32b3f3c91633528c8b3684c7d9060431818";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/hr/thunderbird-78.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "2c142b9bed17fc1fef3e4339f0477d3f469923083a37ec3b2dc3d4690a44ee34d5a23faa37876cec2f3bcd02c1048ec343f16bd02a1771296e77cf3f63ca787e";
+      sha256 = "92a043ec615e0f92ff301df498023a31e5a32fdbcb01be0e95ee91917ad88112";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hsb/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/hsb/thunderbird-78.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "fcbcc78b1d5620c27b7cfb7ee88463dc81664f5eba679a81920ac6923b0e3f05bc70b99ba7268017b59219872921e76860a113fbba757cebf942641ba0591517";
+      sha256 = "a73b9619b2da033be6913c4342fe23886a9ba6710a65496878490e3f6c016901";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hu/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/hu/thunderbird-78.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "d59024db516156a89cbcc0148a5bf85059ac2393f41709e224f109abca6fea693b822d7c4a3ce5e360435c8700010aaeb4b26ef9e163827bcc8b6cf1761d3781";
+      sha256 = "b1e938c785946d91e5759cc5f34d75fbbbf421b4f8b5dbe1eee9158fc277198d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hy-AM/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/hy-AM/thunderbird-78.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "17876cefb335375b7884080315690fef116983b7559421f86ad0ef787bdfdf5aed283d84114cc1c1d3cb3119d735f50e975f94ead6fcab6046c207d4c1a8fc8b";
+      sha256 = "7ad07de9dc366057b004893f3d77900dcd4cb6532127a60b07b343752b96ef96";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/id/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/id/thunderbird-78.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "0c74ca260ffee635cd556c0710a13ed091a1f2eb63a1b1ac2a745ea0e86d42b52b08b00f648c406356e1e170c77242d43d9a4d2b2f0bb1fb26d4dc83b4179a8c";
+      sha256 = "51b239fc75b2b0769faab37ba8c03973dc9a275eb8730193100f5d3cfd5b1621";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/is/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/is/thunderbird-78.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "97fdf5fa7dd6fade8ec7efc179f6a65bda90cfb285341e3e98b9b2ab70ba91ebc8c47bf8948189d4c181566c9ed950fbd0fb6b4d4cd96b2e3329c0085e32771c";
+      sha256 = "69299e2873cd042e64146faa329f72039c079645014270acf08a2a0357a7025e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/it/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/it/thunderbird-78.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "3d42b5a8c55519accb3246c5a7f50def9d854ccaffa0e34b20e6e2f51cc07a787a9ab0c0b205e28b40d9ec4f55f1176f391ff9156076327f8a4416a9ff6ea8ae";
+      sha256 = "dfc2f83084ea80483a258e2ef879bcdd31256c55920f2d86fa170dd0ba432091";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ja/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ja/thunderbird-78.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "bf90c9c27abac84ef91a2fe3ceea142ac7041c10d41a0e5a2ee31742f9f64b2b24a331af769e8ae93c7b09bf8645dc4d274524281fbfe69a908fd22aaac7c2d8";
+      sha256 = "7b1cbca9399856b3c413e7277617c808b3f670c6470e3c243c6fde9aa035d563";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ka/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ka/thunderbird-78.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "8e2fb192c6776ad702ea7aaa9bc9dd31b20c1c66e2ce4dd91aa10eda5528172680740e28f8a7bab52a7c6eae92578822669d6ad068bbc85a04d97c91a4b7e08b";
+      sha256 = "2ab93932f7e567b3e9ebae4fd4c1d032917c656408b5b74cfd51f0e35bf14af6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/kab/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/kab/thunderbird-78.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "10b9418db83b328353afb73b7630add081309cc0b55fac8aec38f6e09036968082d3d12386efb6b4347b33977998bbd906501adc45a8c8d27dfd0f8d98288bde";
+      sha256 = "c6bf87d821095326487e4822e6c373b4c5ec9ebd9dfcee511c4b85031ae7caa2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/kk/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/kk/thunderbird-78.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "7dcfb10ce402c90452815523d5672a1cd60201b33b997c5b769341e904f4840ff57685eab61dc3073f789bf042453f3d144e54bec32afae2dd65367a0f1768a1";
+      sha256 = "06cd2284afca05ebfb16ebabd128d66f8a45751fc7a5c1f4ef39a2753dc8e88c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ko/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ko/thunderbird-78.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "fddcd08f00cc4f3de59993c8c917e20e77918d87e2c23e989e8e8aaf78c6130f42e546acc17eb6f8c9a24550c596ad201d63f325e7ba078a6c791fc94589e0a5";
+      sha256 = "bbbb6e7c1c444168ab9b7c3797ca1bffa3c885980e2f215c914780a1ae5d1871";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/lt/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/lt/thunderbird-78.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "ab221093a0df2876f558ff2e0df090b95872281e1cae8ac23c9753dadd6305608c6e7ec5104d491ca3a3f1c1ebd830b8094080ce99bba49b19b46e617238cc87";
+      sha256 = "b64e1a057623a85841137b7aae1832d4757766ac1d37452453a0130582043474";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ms/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ms/thunderbird-78.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "ce6b0e1ba8a1a1bbfd4d2e265a45430c2d931530d13eff67fea4179c4a8e2a204ff35103c921073bc33c3e2a8f8f3f55fb91b3218cab9718df76da696ed09750";
+      sha256 = "eaeb81daf522f0282d57c5b77f54b736c9a723c3a2ad0ddbc2501683cd3dff63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/nb-NO/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/nb-NO/thunderbird-78.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "07e73fd67e0c1974c5e5b90d74e555b75820b66ae9bca0470b6d291e848e5f28fea680cf09c2167dd56b0765ae0e3682b5f2ab7f33cc5b059e60252236dc24cd";
+      sha256 = "5db8562f43efcfff4f950c1e2f6837d8ceb9e73543e7c7dd75e695709defbc61";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/nl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/nl/thunderbird-78.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "a24ed7d30e53058653c0de6b96867fa9621118fa43e109940502eea798a5c7b8688c65bf08d765f3c6dc6e8ab0dabfef98ae005e00c465f847454b384953276f";
+      sha256 = "77ea8f460f82d05369ff110b85c4b995623caa7b62e38ebb5d8e0f7ecbfeabd6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/nn-NO/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/nn-NO/thunderbird-78.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "4bddbdd0a2353f8c43e65cbce5974911809cf28c3d7ce521d662d782f8858b469575857688a5c674f6d028acd55869c062edf9f55dfa3d387fab8fb60f6f2fad";
+      sha256 = "83d2439498fca42c3b4095515c9359f89500bd11029fa58ba19e6058d3b696dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/pl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/pa-IN/thunderbird-78.0.tar.bz2";
+      locale = "pa-IN";
+      arch = "linux-i686";
+      sha256 = "805947c3014c660ec66d5382dce6a733efe196b45b445a7d2467e209ce889727";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/pl/thunderbird-78.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "953d9e547eb343a0d7f96f501bb87ece71e2f860f8517fb13b76301c7b3e77d7f572a8106fdd43c2b390654457e43703b22566bd3159ace962af2eb1f8bc6ca8";
+      sha256 = "a7eade7fc0b68361e0a8d6a1cde62d7253f938dc0e93fda56d0ed296304b162f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/pt-BR/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/pt-BR/thunderbird-78.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "b3807897100857c33768478c9dec57024f968a83188b51bd2708b7caf7c53edb39b15cc8dfb5f73ca937c298fa83551edf82d7f43c065bc2fc25467a02343d20";
+      sha256 = "7e5a89cc9460ef65f1b5141d7bbbfd39f2d38aac599b50c8f57b39ff2218f7db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/pt-PT/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/pt-PT/thunderbird-78.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "e50bf636697714fc4dfd04e1a8d6d7d87239553f01064bb566e218395a2e5d9b16ef22c01509f18f9f562b75eb19a2616d8c7f8a4d212a9a445b1eece17527f7";
+      sha256 = "809945bd2390457d2ffc1f232e120aa68c0e8232a69d14b6cd1207ed4fc62bae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/rm/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/rm/thunderbird-78.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "1480eb4c77d88fc461000f423179e5bc693b2f25abe5c6384f4c98494f698c620fdd53e65d75ebd17ce9546c5fb00ef8f40bfffd9b31114417cd10262569a54d";
+      sha256 = "82849eb2a8db39d99cc1fb514d0a4a78c1380fa5ad75434d0969860b5fa0c5f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ro/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ro/thunderbird-78.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "d9cfc8f03d75f3a58fe103c34eb0fdcb3530f0ebc68c0acae7fe1b783bf11c0585e266556d16fa3db174aaafcc319cef9cfa363361cad7b1053a504101b13880";
+      sha256 = "c9abc67c0612e3da4d9519d93cd87718898e6465f8275cae9edd7127f3e9c964";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ru/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/ru/thunderbird-78.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "d67f550615eb195b80f7338708b7ecf7455203f86aff1682f2e8e654d019fb49c6468eb1c099f7fc78797b97d41c9f42aff5498f27b6cb458f049fd8b6aa3d4e";
+      sha256 = "77c7e1f174c5540bc683ae71653392e24dd70737f6a6f9298c746cdbbb1f2e3d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/si/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/si/thunderbird-78.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "6dd9d78a9f2ef4ed28a95e83e76e9779d02c950ba906ca14d8fac0bf7300ad2d7d5ad9cfa3973cc8c861011dc8f1c58a6ea5909206443cd2f24bf5bcfe8c5673";
+      sha256 = "d45b2a6492fd732652ac4d160b74f612261c33dee7f8f7c21bb1a8e0d45d72a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sk/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/sk/thunderbird-78.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "ba40286898a7722533f8a65e1e9bb494bc28212d2fe21c820f64b1a8bcaad6d0ca1d7a870d5289792a79a6c4851931236b13c1ba07b812b591b3d4c6004ff78d";
+      sha256 = "cb4e2492618d70b67b2deb803ed5d02a2851dbdad26098c305c804017d27290e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/sl/thunderbird-78.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "bc8e926583e92f4cfe3081a1bb618d7c5fbe9e1f93af378040a72820b820a38915ff1c74deb6069bbaf2957adc536b78faf1df853e8ff6390a9396d909ee040e";
+      sha256 = "b731685c0de6ba0350259f84a2b4c597849459bbe5cd632796a09370d2697ab0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sq/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/sq/thunderbird-78.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "084bce04b0d83ab24682d04f4c788d61a2a6bfe0777f44f4c9a07d8fd7fef4251464e9a0e523f4e111bd5323ceb398fa09ae3391295047beac3157ce9d2e8905";
+      sha256 = "4c2013d3b64cceec11bbf58cfd3dd306653410ffde95ffdc649c3ffd2390e542";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/sr/thunderbird-78.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "544ed1f0cb8beeac3ac1b2ed02078c3acc5961d6fe4c3f0722b1a36208740226053236453a215e564371453cc5acb541a6f307d594524081a5f4c96aa077c21f";
+      sha256 = "ad0fbf13c2e0aea8b5ba97516d0ec53bf2fd4868155e66df5297cc95a27246db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sv-SE/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/sv-SE/thunderbird-78.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "806ea4d93a8cb3e5dba8cbc59dd25adbb19e048306124ffebbf1b2a56d49f236d9a79d0e14b5fc0c15537c266a85408ce1a5568e8e6e4417dd94f1b98d9bf36e";
+      sha256 = "4af730894f076b9a48afd5a202f7e78a11f050a11e5e2011726370e1b14ce70f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/tr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/th/thunderbird-78.0.tar.bz2";
+      locale = "th";
+      arch = "linux-i686";
+      sha256 = "901c62b2adabd67d98314a18782638c8f7e9f55d8ebcb0686b2c7355696f71f8";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/tr/thunderbird-78.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "cf30e9ebaf5770437415377c9a13d66b44a7de7c85bec9b980d9e2e059db7f3756f2c3a888ebf9185c59451e2473440fe2c1ff28a979e066225719effecb1c38";
+      sha256 = "ac7794552303525a4b72dac166624c06b7392fbdb063144a793a39d4ad6fbac0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/uk/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/uk/thunderbird-78.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "a7f5f6b0f1bc849a3a48a30edc8e408eec0c5e544bb4444a8ade969b1fe7ef1fb9d26a0fea3d4d31bf88eb67570e895fb5d916b9ac88c2a8455abcec60d56ca0";
+      sha256 = "890373ce0813c7cd4cf8eec39af6a362d1e88c4bf967ccb3482b7dbb806dd228";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/uz/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/uz/thunderbird-78.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "716e1c0a7b9b0ea33d1464930b68f3f817ce3310bee9000199f9e6bdc4d0d68dc6098665423ada94d7ede600cb0c965adcbb413068adf1415cbc048a7f847ebf";
+      sha256 = "0153af7da918e0b3a9d50e2970f946dcc3ca2ba0b92782f82917153a2fb850b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/vi/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/vi/thunderbird-78.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "1667ab35ed705e739c5192246444eda912ec86a153dd1fc3ed83a5ed61d47d5849270492015198cca82827720bc019fa561e710df5fa77a758864e6cfb09d4aa";
+      sha256 = "55ba1938bc0b894f92bb17435b0bbf19e15da8163dfcfb377b87db02aff8e564";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/zh-CN/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/zh-CN/thunderbird-78.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "4ef6c9933ce8671442aa86f804085b4ce9a73aa4f8cd598b7d41a844be37d54cbd8a2dc39d6ab97f160856435475093f3240f960a206e53d327a4b2e47fac45d";
+      sha256 = "921619f82d094b35d74dd54071191ce00487aeb90190e2d2b6f229610e016878";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/zh-TW/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.0/linux-i686/zh-TW/thunderbird-78.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "ab19d7c1114835a380e035dafc2e30849e8084cdac9175eb5eb3a9fde81d49cb710d9dce21652780a35011d139e070c0f61840275aa8d0e99252bfa5a8aa1735";
+      sha256 = "28a03fc23a2961bdb1ea3cf1fa08be57302627071f4dc096eb9aca58124e5058";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/68.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/68.nix
@@ -1,0 +1,343 @@
+# This pakcage is keeped until Thunderbird 78 supports OpenPGP.
+# https://www.thunderbird.net/en-US/thunderbird/78.0.1/releasenotes/
+{ autoconf213
+, bzip2
+, cargo
+, common-updater-scripts
+, coreutils
+, curl
+, dbus
+, dbus-glib
+, fetchurl
+, file
+, fontconfig
+, freetype
+, glib
+, gnugrep
+, gnused
+, icu
+, jemalloc
+, lib
+, libGL
+, libGLU
+, libevent
+, libjpeg
+, libnotify
+, libpng
+, libstartup_notification
+, libvpx
+, libwebp
+, llvmPackages
+, m4
+, makeDesktopItem
+, nasm
+, nodejs
+, nspr
+, nss
+, pango
+, perl
+, pkgconfig
+, python2
+, python3
+, runtimeShell
+, rust-cbindgen
+, rustc
+, sqlite
+, stdenv
+, systemd
+, unzip
+, which
+, writeScript
+, xidel
+, xorg
+, yasm
+, zip
+, zlib
+
+, debugBuild ? false
+
+, alsaSupport ? stdenv.isLinux, alsaLib
+, pulseaudioSupport ? stdenv.isLinux, libpulseaudio
+, gtk3Support ? true, gtk2, gtk3, wrapGAppsHook
+, waylandSupport ? true
+, libxkbcommon, calendarSupport ? true
+
+, # If you want the resulting program to call itself "Thunderbird" instead
+# of "Earlybird" or whatever, enable this option.  However, those
+# binaries may not be distributed without permission from the
+# Mozilla Foundation, see
+# http://www.mozilla.org/foundation/trademarks/.
+enableOfficialBranding ? false
+}:
+
+assert waylandSupport -> gtk3Support == true;
+
+stdenv.mkDerivation rec {
+  pname = "thunderbird";
+  version = "68.10.0";
+
+  src = fetchurl {
+    url =
+      "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
+    sha512 =
+      "24jq4wxhk58403ax8jf6p82fyzf0vszz8am5d8jb6j559da3lp6wv4m5xqavvcf9i57rdivzrmqw9agr8mypfxs8zb908aln5iy7d4d";
+  };
+
+  nativeBuildInputs = [
+    autoconf213
+    cargo
+    gnused
+    llvmPackages.llvm
+    m4
+    nasm
+    nodejs
+    perl
+    pkgconfig
+    python2
+    python3
+    rust-cbindgen
+    rustc
+    which
+    yasm
+  ] ++ lib.optional gtk3Support wrapGAppsHook;
+
+  buildInputs = [
+    bzip2
+    dbus
+    dbus-glib
+    file
+    fontconfig
+    freetype
+    glib
+    gtk2
+    icu
+    jemalloc
+    libGL
+    libGLU
+    libevent
+    libjpeg
+    libnotify
+    libpng
+    libstartup_notification
+    libvpx
+    libwebp
+    nspr
+    nss
+    pango
+    perl
+    sqlite
+    unzip
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcursor
+    xorg.libXext
+    xorg.libXft
+    xorg.libXi
+    xorg.libXrender
+    xorg.libXt
+    xorg.pixman
+    xorg.xorgproto
+    zip
+    zlib
+  ] ++ lib.optional alsaSupport alsaLib
+    ++ lib.optional gtk3Support gtk3
+    ++ lib.optional pulseaudioSupport libpulseaudio
+    ++ lib.optional waylandSupport libxkbcommon;
+
+  NIX_CFLAGS_COMPILE =[
+    "-I${glib.dev}/include/gio-unix-2.0"
+    "-I${nss.dev}/include/nss"
+  ];
+
+  patches = [
+    ./no-buildconfig-68.patch
+  ];
+
+  postPatch = ''
+    rm -rf obj-x86_64-pc-linux-gnu
+  '';
+
+  hardeningDisable = [ "format" ];
+
+  preConfigure = ''
+    # remove distributed configuration files
+    rm -f configure
+    rm -f js/src/configure
+    rm -f .mozconfig*
+
+    configureScript="$(realpath ./mach) configure"
+    # AS=as in the environment causes build failure https://bugzilla.mozilla.org/show_bug.cgi?id=1497286
+    unset AS
+
+    export MOZCONFIG=$(pwd)/mozconfig
+
+    # Set C flags for Rust's bindgen program. Unlike ordinary C
+    # compilation, bindgen does not invoke $CC directly. Instead it
+    # uses LLVM's libclang. To make sure all necessary flags are
+    # included we need to look in a few places.
+    # TODO: generalize this process for other use-cases.
+
+    BINDGEN_CFLAGS="$(< ${stdenv.cc}/nix-support/libc-cflags) \
+      $(< ${stdenv.cc}/nix-support/cc-cflags) \
+      $(< ${stdenv.cc}/nix-support/libcxx-cxxflags) \
+      ${
+        lib.optionalString stdenv.cc.isClang
+        "-idirafter ${stdenv.cc.cc}/lib/clang/${
+          lib.getVersion stdenv.cc.cc
+        }/include"
+      } \
+      ${
+        lib.optionalString stdenv.cc.isGNU
+        "-isystem ${stdenv.cc.cc}/include/c++/${
+          lib.getVersion stdenv.cc.cc
+        } -isystem ${stdenv.cc.cc}/include/c++/${
+          lib.getVersion stdenv.cc.cc
+        }/${stdenv.hostPlatform.config}"
+      } \
+      $NIX_CFLAGS_COMPILE"
+
+    echo "ac_add_options BINDGEN_CFLAGS='$BINDGEN_CFLAGS'" >> $MOZCONFIG
+  '';
+
+  configureFlags = let
+    toolkitSlug = if gtk3Support then
+      "3${lib.optionalString waylandSupport "-wayland"}"
+    else
+      "2";
+    toolkitValue = "cairo-gtk${toolkitSlug}";
+  in [
+    "--enable-application=comm/mail"
+
+    "--with-system-bz2"
+    "--with-system-icu"
+    "--with-system-jpeg"
+    "--with-system-libevent"
+    "--with-system-nspr"
+    "--with-system-nss"
+    "--with-system-png" # needs APNG support
+    "--with-system-icu"
+    "--with-system-zlib"
+    "--with-system-webp"
+    "--with-system-libvpx"
+
+    "--enable-rust-simd"
+    "--enable-crashreporter"
+    "--enable-default-toolkit=${toolkitValue}"
+    "--enable-js-shell"
+    "--enable-necko-wifi"
+    "--enable-startup-notification"
+    "--enable-system-ffi"
+    "--enable-system-pixman"
+    "--enable-system-sqlite"
+
+    "--disable-gconf"
+    "--disable-tests"
+    "--disable-updater"
+    "--enable-jemalloc"
+  ] ++ (if debugBuild then [
+    "--enable-debug"
+    "--enable-profiling"
+  ] else [
+    "--disable-debug"
+    "--enable-release"
+    "--disable-debug-symbols"
+    "--enable-optimize"
+    "--enable-strip"
+  ]) ++ lib.optionals (!stdenv.hostPlatform.isi686) [
+    # on i686-linux: --with-libclang-path is not available in this configuration
+    "--with-libclang-path=${llvmPackages.libclang}/lib"
+    "--with-clang-path=${llvmPackages.clang}/bin/clang"
+  ] ++ lib.optional alsaSupport "--enable-alsa"
+  ++ lib.optional calendarSupport "--enable-calendar"
+  ++ lib.optional enableOfficialBranding "--enable-official-branding"
+  ++ lib.optional pulseaudioSupport "--enable-pulseaudio";
+
+  enableParallelBuilding = true;
+
+  postConfigure = ''
+    cd obj-*
+  '';
+
+  makeFlags = lib.optionals enableOfficialBranding [
+    "MOZILLA_OFFICIAL=1"
+    "BUILD_OFFICIAL=1"
+  ];
+
+  doCheck = false;
+
+  postInstall = let
+    desktopItem = makeDesktopItem {
+      categories = lib.concatStringsSep ";" [ "Application" "Network" ];
+      desktopName = "Thunderbird";
+      genericName = "Mail Reader";
+      name = "thunderbird";
+      exec = "thunderbird %U";
+      icon = "$out/lib/thunderbird/chrome/icons/default/default256.png";
+      mimeType = lib.concatStringsSep ";" [
+        # Email
+        "x-scheme-handler/mailto"
+        "message/rfc822"
+        # Feeds
+        "x-scheme-handler/feed"
+        "application/rss+xml"
+        "application/x-extension-rss"
+        # Newsgroups
+        "x-scheme-handler/news"
+        "x-scheme-handler/snews"
+        "x-scheme-handler/nntp"
+      ];
+    };
+  in ''
+    # TODO: Move to a dev output?
+    rm -rf $out/include $out/lib/thunderbird-devel-* $out/share/idl
+
+    ${desktopItem.buildCommand}
+  '';
+
+  preFixup = ''
+    # Needed to find Mozilla runtime
+    gappsWrapperArgs+=(
+      --argv0 "$out/bin/thunderbird"
+      --set MOZ_APP_LAUNCHER thunderbird
+      # https://github.com/NixOS/nixpkgs/pull/61980
+      --set SNAP_NAME "thunderbird"
+      --set MOZ_LEGACY_PROFILES 1
+      --set MOZ_ALLOW_DOWNGRADE 1
+    )
+  '';
+
+  # FIXME: The XUL portion of this can probably be removed as soon as we
+  # package a Thunderbird >=71.0 since XUL shouldn't be anymore (in use)?
+  postFixup = ''
+    local xul="$out/lib/thunderbird/libxul.so"
+    patchelf --set-rpath "${libnotify}/lib:${systemd.lib}/lib:$(patchelf --print-rpath $xul)" $xul
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    "$out/bin/thunderbird" --version
+  '';
+
+  disallowedRequisites = [
+    stdenv.cc
+  ];
+
+  passthru.updateScript = import ./../../browsers/firefox/update.nix {
+    attrPath = "thunderbird";
+    baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";
+    inherit writeScript lib common-updater-scripts xidel coreutils gnused
+      gnugrep curl runtimeShell;
+  };
+
+  meta = with stdenv.lib; {
+    description = "A full-featured e-mail client";
+    homepage = "https://www.thunderbird.net";
+    maintainers = with maintainers; [
+      eelco
+      lovesegfault
+      pierron
+    ];
+    platforms = platforms.linux;
+    license = licenses.mpl20;
+  };
+}

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -72,13 +72,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.0.1";
+  version = "78.1.0";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "1lh0rsibkd3m6fk4mp07payn5srambslqqlsqkg6mc11rbaim0b4m5256iq670r614nb8w61yc8d0khhpyqgrvlxd4zgdv6s3n17d7w";
+      "2m1gqq11k5cql5f49mwrfjk06rm2r24lf9l0hrvj569gqxckyh8wdch3dn339x3yn5fhxqlw0l770p2ssr2kkllv3yy20qqzjqgfpgh";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -72,13 +72,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.0";
+  version = "78.0.1";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "0l5cgd95lxwny365x85pih71z7b9zgmix3wc8916k1xj5p46szr20ylf7b20gwwl7kajm4mrxjdldzmfvc9qzdyss76za5r76c25wwr";
+      "1lh0rsibkd3m6fk4mp07payn5srambslqqlsqkg6mc11rbaim0b4m5256iq670r614nb8w61yc8d0khhpyqgrvlxd4zgdv6s3n17d7w";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -316,7 +316,7 @@ stdenv.mkDerivation rec {
   ];
 
   passthru.updateScript = import ./../../browsers/firefox/update.nix {
-    attrPath = "thunderbird";
+    attrPath = "thunderbird-78";
     baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";
     inherit writeScript lib common-updater-scripts xidel coreutils gnused
       gnugrep curl runtimeShell;

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -72,13 +72,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "68.10.0";
+  version = "78.0";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "24jq4wxhk58403ax8jf6p82fyzf0vszz8am5d8jb6j559da3lp6wv4m5xqavvcf9i57rdivzrmqw9agr8mypfxs8zb908aln5iy7d4d";
+      "0l5cgd95lxwny365x85pih71z7b9zgmix3wc8916k1xj5p46szr20ylf7b20gwwl7kajm4mrxjdldzmfvc9qzdyss76za5r76c25wwr";
   };
 
   nativeBuildInputs = [
@@ -206,14 +206,12 @@ stdenv.mkDerivation rec {
   in [
     "--enable-application=comm/mail"
 
-    "--with-system-bz2"
     "--with-system-icu"
     "--with-system-jpeg"
     "--with-system-libevent"
     "--with-system-nspr"
     "--with-system-nss"
     "--with-system-png" # needs APNG support
-    "--with-system-icu"
     "--with-system-zlib"
     "--with-system-webp"
     "--with-system-libvpx"
@@ -223,12 +221,9 @@ stdenv.mkDerivation rec {
     "--enable-default-toolkit=${toolkitValue}"
     "--enable-js-shell"
     "--enable-necko-wifi"
-    "--enable-startup-notification"
     "--enable-system-ffi"
     "--enable-system-pixman"
-    "--enable-system-sqlite"
 
-    "--disable-gconf"
     "--disable-tests"
     "--disable-updater"
     "--enable-jemalloc"

--- a/pkgs/applications/networking/mailreaders/thunderbird/no-buildconfig-68.patch
+++ b/pkgs/applications/networking/mailreaders/thunderbird/no-buildconfig-68.patch
@@ -1,0 +1,35 @@
+diff -ru -x '*~' a/docshell/base/nsAboutRedirector.cpp b/docshell/base/nsAboutRedirector.cpp
+--- a/docshell/base/nsAboutRedirector.cpp	2017-07-31 18:20:51.000000000 +0200
++++ b/docshell/base/nsAboutRedirector.cpp	2017-09-26 22:02:00.814151731 +0200
+@@ -32,8 +32,6 @@
+     {"about", "chrome://global/content/aboutAbout.xhtml", 0},
+     {"addons", "chrome://mozapps/content/extensions/extensions.xul",
+      nsIAboutModule::ALLOW_SCRIPT},
+-    {"buildconfig", "chrome://global/content/buildconfig.html",
+-     nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT},
+     {"checkerboard", "chrome://global/content/aboutCheckerboard.xhtml",
+      nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT |
+          nsIAboutModule::ALLOW_SCRIPT},
+diff -ru -x '*~' a/toolkit/content/jar.mn b/toolkit/content/jar.mn
+--- a/toolkit/content/jar.mn	2017-07-31 18:20:52.000000000 +0200
++++ b/toolkit/content/jar.mn	2017-09-26 22:01:42.383350314 +0200
+@@ -39,7 +39,6 @@
+    content/global/plugins.css
+    content/global/browser-child.js
+    content/global/browser-content.js
+-*   content/global/buildconfig.html
+    content/global/buildconfig.css
+    content/global/contentAreaUtils.js
+    content/global/datepicker.xhtml
+--- a/comm/mail/base/jar.mn
++++ b/comm/mail/base/jar.mn
+@@ -117,9 +117,7 @@
+ % override chrome://mozapps/content/profile/profileDowngrade.js chrome://messenger/content/profileDowngrade.js
+ % override chrome://mozapps/content/profile/profileDowngrade.xul chrome://messenger/content/profileDowngrade.xul
+ 
+-*   content/messenger/buildconfig.html              (content/buildconfig.html)
+     content/messenger/buildconfig.css               (content/buildconfig.css)
+-% override chrome://global/content/buildconfig.html chrome://messenger/content/buildconfig.html
+ % override chrome://global/content/buildconfig.css chrome://messenger/content/buildconfig.css
+ 
+ # L10n resources and overrides.

--- a/pkgs/applications/networking/mailreaders/thunderbird/no-buildconfig.patch
+++ b/pkgs/applications/networking/mailreaders/thunderbird/no-buildconfig.patch
@@ -1,31 +1,32 @@
 diff -ru -x '*~' a/docshell/base/nsAboutRedirector.cpp b/docshell/base/nsAboutRedirector.cpp
---- a/docshell/base/nsAboutRedirector.cpp	2017-07-31 18:20:51.000000000 +0200
-+++ b/docshell/base/nsAboutRedirector.cpp	2017-09-26 22:02:00.814151731 +0200
-@@ -32,8 +32,6 @@
-     {"about", "chrome://global/content/aboutAbout.xhtml", 0},
-     {"addons", "chrome://mozapps/content/extensions/extensions.xul",
+--- a/docshell/base/nsAboutRedirector.cpp
++++ b/docshell/base/nsAboutRedirector.cpp
+@@ -63,8 +63,6 @@
+     {"about", "chrome://global/content/aboutAbout.html", 0},
+     {"addons", "chrome://mozapps/content/extensions/extensions.xhtml",
       nsIAboutModule::ALLOW_SCRIPT},
 -    {"buildconfig", "chrome://global/content/buildconfig.html",
 -     nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT},
-     {"checkerboard", "chrome://global/content/aboutCheckerboard.xhtml",
+     {"checkerboard", "chrome://global/content/aboutCheckerboard.html",
       nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT |
           nsIAboutModule::ALLOW_SCRIPT},
 diff -ru -x '*~' a/toolkit/content/jar.mn b/toolkit/content/jar.mn
---- a/toolkit/content/jar.mn	2017-07-31 18:20:52.000000000 +0200
-+++ b/toolkit/content/jar.mn	2017-09-26 22:01:42.383350314 +0200
-@@ -39,7 +39,6 @@
-    content/global/plugins.css
+--- a/toolkit/content/jar.mn
++++ b/toolkit/content/jar.mn
+@@ -35,7 +35,6 @@
+    content/global/plugins.js
     content/global/browser-child.js
     content/global/browser-content.js
 -*   content/global/buildconfig.html
     content/global/buildconfig.css
     content/global/contentAreaUtils.js
     content/global/datepicker.xhtml
+diff -ru -x '*~' a/comm/mail/base/jar.mn b/comm/mail/base/jar.mn
 --- a/comm/mail/base/jar.mn
 +++ b/comm/mail/base/jar.mn
-@@ -117,9 +117,7 @@
+@@ -119,9 +119,7 @@
  % override chrome://mozapps/content/profile/profileDowngrade.js chrome://messenger/content/profileDowngrade.js
- % override chrome://mozapps/content/profile/profileDowngrade.xul chrome://messenger/content/profileDowngrade.xul
+ % override chrome://mozapps/content/profile/profileDowngrade.xhtml chrome://messenger/content/profileDowngrade.xhtml
  
 -*   content/messenger/buildconfig.html              (content/buildconfig.html)
      content/messenger/buildconfig.css               (content/buildconfig.css)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22789,6 +22789,13 @@ in
     nss = nss_3_44; # 68.x won't build with newest nss anymore (like firefox-esr-68)
   };
 
+  thunderbird-68 = callPackage ../applications/networking/mailreaders/thunderbird/68.nix {
+    inherit (rustPackages_1_44) cargo rustc;
+    libpng = libpng_apng;
+    nss = nss_3_44;
+    gtk3Support = true;
+  };
+
   thunderbolt = callPackage ../os-specific/linux/thunderbolt {};
 
   thunderbird-bin = callPackage ../applications/networking/mailreaders/thunderbird-bin { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22785,8 +22785,9 @@ in
   thunderbird = callPackage ../applications/networking/mailreaders/thunderbird {
     inherit (rustPackages_1_44) cargo rustc;
     libpng = libpng_apng;
+    icu = icu67;
+    libvpx = libvpx_1_8;
     gtk3Support = true;
-    nss = nss_3_44; # 68.x won't build with newest nss anymore (like firefox-esr-68)
   };
 
   thunderbird-68 = callPackage ../applications/networking/mailreaders/thunderbird/68.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22793,6 +22793,8 @@ in
 
   thunderbird-bin = callPackage ../applications/networking/mailreaders/thunderbird-bin { };
 
+  thunderbird-bin-68 = callPackage ../applications/networking/mailreaders/thunderbird-bin/68.nix { };
+
   ticpp = callPackage ../development/libraries/ticpp { };
 
   tig = gitAndTools.tig;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22782,7 +22782,7 @@ in
 
   thonny = callPackage ../applications/editors/thonny { };
 
-  thunderbird = callPackage ../applications/networking/mailreaders/thunderbird {
+  thunderbird-78 = callPackage ../applications/networking/mailreaders/thunderbird {
     inherit (rustPackages_1_44) cargo rustc;
     libpng = libpng_apng;
     icu = icu67;
@@ -22790,7 +22790,7 @@ in
     gtk3Support = true;
   };
 
-  thunderbird-68 = callPackage ../applications/networking/mailreaders/thunderbird/68.nix {
+  thunderbird = callPackage ../applications/networking/mailreaders/thunderbird/68.nix {
     inherit (rustPackages_1_44) cargo rustc;
     libpng = libpng_apng;
     nss = nss_3_44;
@@ -22799,9 +22799,9 @@ in
 
   thunderbolt = callPackage ../os-specific/linux/thunderbolt {};
 
-  thunderbird-bin = callPackage ../applications/networking/mailreaders/thunderbird-bin { };
+  thunderbird-bin-78 = callPackage ../applications/networking/mailreaders/thunderbird-bin { };
 
-  thunderbird-bin-68 = callPackage ../applications/networking/mailreaders/thunderbird-bin/68.nix { };
+  thunderbird-bin = callPackage ../applications/networking/mailreaders/thunderbird-bin/68.nix { };
 
   ticpp = callPackage ../development/libraries/ticpp { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- High security fixes
- Various updates

https://www.mozilla.org/en-US/security/advisories/mfsa2020-29/
https://www.thunderbird.net/en-US/thunderbird/78.0/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
