### PR TITLE
edukai: init at 4.0/edusong: init at 1.0/eduli: init at 3.0

### DIFF
--- a/pkgs/data/fonts/edukai/default.nix
+++ b/pkgs/data/fonts/edukai/default.nix
@@ -1,0 +1,33 @@
+{ stdenvNoCC, lib, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "edukai";
+  version = "4.0";
+
+  src = fetchzip {
+    name = "${pname}-${version}";
+    url =
+      "http://language.moe.gov.tw/001/Upload/Files/site_content/M0001/edukai-4.0.zip";
+    sha256 = "10m9srvbazvg9gc43943dc89rjzcfc8mm4lx9gb5hnplrn22zrcn";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/
+    mv *.ttf $out/share/fonts/
+  '';
+
+  meta = {
+    description =
+      "The MOE Standard Kai Font, a Chinese font by the Ministry of Education, ROC (Taiwan)";
+    longDescription = ''
+      The MOE Standard Kai Font is a kai (regular srcipt) font
+      provided by
+      the Midistry of Education, Republic of China (Taiwan).
+      It currently includes 13,076 Chinese characters.
+    '';
+    homepage =
+      "http://language.moe.gov.tw/result.aspx?classify_sn=23&subclassify_sn=436&content_sn=47";
+    license = lib.licenses.cc-by-nd-30;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/data/fonts/eduli/default.nix
+++ b/pkgs/data/fonts/eduli/default.nix
@@ -1,0 +1,36 @@
+{ stdenvNoCC, lib, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "eduli";
+  version = "3.0";
+
+  src = fetchzip {
+    name = "${pname}-${version}";
+    url =
+      "http://language.moe.gov.tw/001/Upload/Files/site_content/M0001/MoeLI-3.0.zip";
+    sha256 = "0vpmm2qb429npng0aqkafwgs7cjibq8a3f7bbn9hysbm2lndwxwd";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/
+    for name in *.ttf; do
+      mv "$name" "$out/share/fonts/$(echo $name | sed -r 's/(.*)\(.*\)\.ttf/\1.ttf/')"
+    done
+  '';
+
+  meta = {
+    description =
+      "The MOE Li Font, a clerical Chinese font by the Ministry of Education, ROC (Taiwan)";
+    longDescription = ''
+      The MOE Li Font is a li (clerical srcipt) font
+      provided by
+      the Midistry of Education, Republic of China (Taiwan).
+      It currently includes 4,808 Chinese characters.
+      The clerical script (lishu) is an archaic style of Chinese calligraphy.
+    '';
+    homepage =
+      "http://language.moe.gov.tw/result.aspx?classify_sn=23&subclassify_sn=436&content_sn=49";
+    license = lib.licenses.cc-by-nd-30;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/data/fonts/edusong/default.nix
+++ b/pkgs/data/fonts/edusong/default.nix
@@ -1,0 +1,32 @@
+{ stdenvNoCC, lib, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "edusong";
+  version = "1.0"; # The upstream doesn't provide the version
+
+  src = fetchzip {
+    name = "${pname}-${version}";
+    url =
+      "http://language.moe.gov.tw/001/Upload/Files/site_content/M0001/eduSong_Unicode.zip";
+    sha256 = "1b74wj9hdzlnrvldwlkh21sfhqxwh9qghf1k0fv66zs6n48vb0d4";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/
+    mv *.ttf $out/share/fonts/
+  '';
+
+  meta = {
+    description =
+      "The MOE Standard Song Font, a Chinese font by the Ministry of Education, ROC (Taiwan)";
+    longDescription = ''
+      The MOE Standard Song Font is a Chinese Song font provided by
+      the Midistry of Education, Republic of China (Taiwan).
+      Song or Ming is a category of CKJ typefaces in print.
+    '';
+    homepage =
+      "http://language.moe.gov.tw/result.aspx?classify_sn=23&subclassify_sn=436&content_sn=48";
+    license = lib.licenses.cc-by-nd-30;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18296,6 +18296,8 @@ in
 
   eb-garamond = callPackage ../data/fonts/eb-garamond { };
 
+  edukai = callPackage ../data/fonts/edukai { };
+
   elliptic_curves = callPackage ../data/misc/elliptic_curves { };
 
   equilux-theme = callPackage ../data/themes/equilux-theme { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18298,6 +18298,8 @@ in
 
   edukai = callPackage ../data/fonts/edukai { };
 
+  edusong = callPackage ../data/fonts/edusong { };
+
   elliptic_curves = callPackage ../data/misc/elliptic_curves { };
 
   equilux-theme = callPackage ../data/themes/equilux-theme { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18298,6 +18298,10 @@ in
 
   edukai = callPackage ../data/fonts/edukai { };
 
+  eduli = callPackage ../data/fonts/eduli { };
+
+  moeli = eduli;
+
   edusong = callPackage ../data/fonts/edusong { };
 
   elliptic_curves = callPackage ../data/misc/elliptic_curves { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
These fonts are distributed by the Ministry of Education, Republic of China (Taiwan) under CC BY-ND 3.0.

The MOE Standard Kai Font (教育部標準楷書字形檔) and the MOE Standard Song Font (教育部標準宋體字形檔) follow the standard ("國字標準字體研訂原則") of the Ministry of Education in Taiwan. They would be useful in test sheets, especially when the commercial DFKai-SB (標楷體) is not available.

The MOE Li Font (教育部隸書字形檔) is a piece of font of [clerical script](https://en.wikipedia.org/wiki/Clerical_script) (an archaic style of Chinese calligraphy). If merged, it would probably become the first clerical font in nixpkgs.

I join them into one PR to avoid conflicts in `all-packages.nix`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) (No execution files)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date (No document change needed)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
