### PR TITLE
pythonPackages.flower: 0.9.4 -> 0.9.5

### DIFF
--- a/pkgs/development/python-modules/flower/default.nix
+++ b/pkgs/development/python-modules/flower/default.nix
@@ -1,34 +1,35 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, Babel
 , celery
-, future
 , humanize
-, importlib-metadata
 , mock
 , pytz
 , tornado
+, prometheus_client
 }:
 
 buildPythonPackage rec {
   pname = "flower";
-  version = "0.9.4";
+  version = "0.9.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "25782840f7ffc25dcf478d94535a2d815448de4aa6c71426be6abfa9ca417448";
+    sha256 = "171zckhk9ni14f1d82wf62hhciy0gx13fd02sr9m9qlj50fnv4an";
   };
 
-  # flower and humanize aren't listed in setup.py but imported
+  postPatch = ''
+    # rely on using example programs (flowers/examples/tasks.py) which
+    # are not part of the distribution
+    rm tests/load.py
+  '';
+
   propagatedBuildInputs = [
-    Babel
     celery
-    future
-    importlib-metadata
     pytz
     tornado
     humanize
+    prometheus_client
   ];
 
   checkInputs = [ mock ];


### PR DESCRIPTION
##### Motivation for this change

Noticed the build was failing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
