### PR TITLE
gnome-commander: init at 1.10.3

### DIFF
--- a/pkgs/applications/misc/gnome-commander/default.nix
+++ b/pkgs/applications/misc/gnome-commander/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, fetchurl
+, substituteAll
+, gtk2
+, exiv2
+, libgsf
+, taglib
+, libunique
+, poppler
+, gnome2
+, gettext
+, gexiv2
+, glib
+, gnome3
+, itstool
+, libxml2
+, pkg-config
+, shared-mime-info
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-commander";
+  version = "1.10.3";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "7xMIUQWNYxlPeQv7uie2vitvKQbZI8zshHucxZUZOi4=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      schemadir = glib.makeSchemaPath "" "${pname}-${version}";
+    })
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    gettext
+    glib # for glib-compile-schemas
+    itstool
+    libxml2 # for xmllint
+    shared-mime-info
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk2
+    exiv2
+    libgsf
+    taglib
+    libunique
+    poppler
+    gnome2.gnome_vfs
+  ];
+
+  enableParallelBuilding = true;
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Powerful file manager for the GNOME desktop environment";
+    homepage = https://gcmd.github.io/;
+    license = licenses.gpl2Plus;
+    maintainers = gnome3.maintainers;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/gnome-commander/fix-paths.patch
+++ b/pkgs/applications/misc/gnome-commander/fix-paths.patch
@@ -1,0 +1,26 @@
+diff --git a/plugins/fileroller/file-roller-plugin.cc b/plugins/fileroller/file-roller-plugin.cc
+index b6623c19..da628917 100644
+--- a/plugins/fileroller/file-roller-plugin.cc
++++ b/plugins/fileroller/file-roller-plugin.cc
+@@ -91,7 +91,7 @@ static GSettingsSchemaSource* GetGlobalSchemaSource()
+     GSettingsSchemaSource   *global_schema_source;
+     std::string              g_schema_path(PREFIX);
+ 
+-    g_schema_path.append("/share/glib-2.0/schemas");
++    g_schema_path.append("@schemadir@");
+ 
+     global_schema_source = g_settings_schema_source_get_default ();
+ 
+diff --git a/src/gnome-cmd-data.cc b/src/gnome-cmd-data.cc
+index af73f583..95b23916 100644
+--- a/src/gnome-cmd-data.cc
++++ b/src/gnome-cmd-data.cc
+@@ -65,7 +65,7 @@ GSettingsSchemaSource* GnomeCmdData::GetGlobalSchemaSource()
+     GSettingsSchemaSource   *global_schema_source;
+     std::string              g_schema_path(PREFIX);
+ 
+-    g_schema_path.append("/share/glib-2.0/schemas");
++    g_schema_path.append("@schemadir@");
+ 
+     global_schema_source = g_settings_schema_source_get_default ();
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20206,6 +20206,8 @@ in
 
   celluloid = callPackage ../applications/video/celluloid { };
 
+  gnome-commander = callPackage ../applications/misc/gnome-commander { };
+
   gnome-recipes = callPackage ../applications/misc/gnome-recipes {
     inherit (gnome3) gnome-autoar;
   };


### PR DESCRIPTION
###### Motivation for this change
Finished packaging job I started in August last year. At least [this June’s release](https://gcmd.github.io/2020/06/19/Release-v1-10-3.html) made it no longer depend on libgnomeui (after [ten years it has been deprecated](https://gitlab.gnome.org/GNOME/gnome-commander/-/issues/34)) but it still requires GNOME VFS daemon running for remote file systems.

I am posting it in case someone is interested but I will not maintain it myself until it stops using GNOME 2 stack.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
