### PR TITLE
qutebrowser: fix restart patching

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -61,7 +61,7 @@ in mkDerivationWith python3Packages.buildPythonApplication rec {
   dontWrapQtApps = true;
 
   postPatch = ''
-    substituteInPlace qutebrowser/app.py --subst-var-by qutebrowser "$out/bin/qutebrowser"
+    substituteInPlace qutebrowser/misc/quitter.py --subst-var-by qutebrowser "$out/bin/qutebrowser"
 
     sed -i "s,/usr/share/,$out/share/,g" qutebrowser/utils/standarddir.py
   '' + lib.optionalString withPdfReader ''

--- a/pkgs/applications/networking/browsers/qutebrowser/fix-restart.patch
+++ b/pkgs/applications/networking/browsers/qutebrowser/fix-restart.patch
@@ -1,4 +1,4 @@
-diff --git a/quitter.py b/quitterb.py
+diff --git a/quitter.py b/quitter.py
 index a42b9d0..f544ccb 100644
 --- a/qutebrowser/misc/quitter.py
 +++ b/qutebrowser/misc/quitter.py


### PR DESCRIPTION
###### Motivation for this change
Fix (part of) issue #93273


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s)
- [x] Tested compilation of all pkgs that depend on this change (qutebrowser)
- [x] Tested execution of all binary files
- [x] Determined the impact on package closure size (no changes)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
