### PR TITLE
nixos/rspamd: add sandbox

### DIFF
--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -371,6 +371,9 @@ in
     };
     services.postfix.config = mkIf cfg.postfix.enable cfg.postfix.config;
 
+    systemd.services.postfix.serviceConfig.SupplementaryGroups =
+      mkIf cfg.postfix.enable [ postfixCfg.group ];
+
     # Allow users to run 'rspamc' and 'rspamadm'.
     environment.systemPackages = [ pkgs.rspamd ];
 
@@ -399,6 +402,7 @@ in
 
         User = "${cfg.user}";
         Group = "${cfg.group}";
+        SupplementaryGroups = mkIf cfg.postfix.enable [ postfixCfg.group ];
 
         RuntimeDirectory = "rspamd";
         RuntimeDirectoryMode = "0755";
@@ -413,7 +417,8 @@ in
         PrivateDevices = true;
         PrivateMounts = true;
         PrivateTmp = true;
-        PrivateUsers = true;
+        # we need to chown socket to rspamd-milter
+        PrivateUsers = !cfg.postfix.enable;
         ProtectClock = true;
         ProtectControlGroups = true;
         ProtectHome = true;

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -394,16 +394,43 @@ in
       restartTriggers = [ rspamdDir ];
 
       serviceConfig = {
-        ExecStart = "${pkgs.rspamd}/bin/rspamd ${optionalString cfg.debug "-d"} --user=${cfg.user} --group=${cfg.group} --pid=/run/rspamd.pid -c /etc/rspamd/rspamd.conf -f";
+        ExecStart = "${pkgs.rspamd}/bin/rspamd ${optionalString cfg.debug "-d"} -c /etc/rspamd/rspamd.conf -f";
         Restart = "always";
-        RuntimeDirectory = "rspamd";
-        PrivateTmp = true;
-      };
 
-      preStart = ''
-        ${pkgs.coreutils}/bin/mkdir -p /var/lib/rspamd
-        ${pkgs.coreutils}/bin/chown ${cfg.user}:${cfg.group} /var/lib/rspamd
-      '';
+        User = "${cfg.user}";
+        Group = "${cfg.group}";
+
+        RuntimeDirectory = "rspamd";
+        RuntimeDirectoryMode = "0755";
+        StateDirectory = "rspamd";
+        StateDirectoryMode = "0700";
+
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
+        DevicePolicy = "closed";
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "@system-service";
+        UMask = "0077";
+      };
     };
   };
   imports = [

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -405,8 +405,8 @@ in
         StateDirectory = "rspamd";
         StateDirectoryMode = "0700";
 
-        AmbientCapabilities = "";
-        CapabilityBoundingSet = "";
+        AmbientCapabilities = [];
+        CapabilityBoundingSet = [];
         DevicePolicy = "closed";
         LockPersonality = true;
         NoNewPrivileges = true;
@@ -423,7 +423,7 @@ in
         ProtectKernelTunables = true;
         ProtectSystem = "strict";
         RemoveIPC = true;
-        RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX";
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
         RestrictNamespaces = true;
         RestrictRealtime = true;
         RestrictSUIDSGID = true;

--- a/nixos/tests/rspamd.nix
+++ b/nixos/tests/rspamd.nix
@@ -13,10 +13,12 @@ let
     machine.succeed("id rspamd >/dev/null")
   '';
   checkSocket = socket: user: group: mode: ''
-    machine.succeed("ls ${socket} >/dev/null")
-    machine.succeed('[[ "$(stat -c %U ${socket})" == "${user}" ]]')
-    machine.succeed('[[ "$(stat -c %G ${socket})" == "${group}" ]]')
-    machine.succeed('[[ "$(stat -c %a ${socket})" == "${mode}" ]]')
+    machine.succeed(
+        "ls ${socket} >/dev/null",
+        '[[ "$(stat -c %U ${socket})" == "${user}" ]]',
+        '[[ "$(stat -c %G ${socket})" == "${group}" ]]',
+        '[[ "$(stat -c %a ${socket})" == "${mode}" ]]',
+    )
   '';
   simple = name: enableIPv6: makeTest {
     name = "rspamd-${name}";
@@ -54,33 +56,35 @@ in
       services.rspamd = {
         enable = true;
         workers.normal.bindSockets = [{
-          socket = "/run/rspamd.sock";
+          socket = "/run/rspamd/rspamd.sock";
           mode = "0600";
-          owner = "root";
-          group = "root";
+          owner = "rspamd";
+          group = "rspamd";
         }];
         workers.controller.bindSockets = [{
-          socket = "/run/rspamd-worker.sock";
+          socket = "/run/rspamd/rspamd-worker.sock";
           mode = "0666";
-          owner = "root";
-          group = "root";
+          owner = "rspamd";
+          group = "rspamd";
         }];
       };
     };
 
     testScript = ''
       ${initMachine}
-      machine.wait_for_file("/run/rspamd.sock")
-      ${checkSocket "/run/rspamd.sock" "root" "root" "600" }
-      ${checkSocket "/run/rspamd-worker.sock" "root" "root" "666" }
+      machine.wait_for_file("/run/rspamd/rspamd.sock")
+      ${checkSocket "/run/rspamd/rspamd.sock" "rspamd" "rspamd" "600" }
+      ${checkSocket "/run/rspamd/rspamd-worker.sock" "rspamd" "rspamd" "666" }
       machine.log(machine.succeed("cat /etc/rspamd/rspamd.conf"))
       machine.log(
           machine.succeed("grep 'CONFDIR/worker-controller.inc' /etc/rspamd/rspamd.conf")
       )
       machine.log(machine.succeed("grep 'CONFDIR/worker-normal.inc' /etc/rspamd/rspamd.conf"))
-      machine.log(machine.succeed("rspamc -h /run/rspamd-worker.sock stat"))
+      machine.log(machine.succeed("rspamc -h /run/rspamd/rspamd-worker.sock stat"))
       machine.log(
-          machine.succeed("curl --unix-socket /run/rspamd-worker.sock http://localhost/ping")
+          machine.succeed(
+              "curl --unix-socket /run/rspamd/rspamd-worker.sock http://localhost/ping"
+          )
       )
     '';
   };
@@ -91,16 +95,16 @@ in
       services.rspamd = {
         enable = true;
         workers.normal.bindSockets = [{
-          socket = "/run/rspamd.sock";
+          socket = "/run/rspamd/rspamd.sock";
           mode = "0600";
-          owner = "root";
-          group = "root";
+          owner = "rspamd";
+          group = "rspamd";
         }];
         workers.controller.bindSockets = [{
-          socket = "/run/rspamd-worker.sock";
+          socket = "/run/rspamd/rspamd-worker.sock";
           mode = "0666";
-          owner = "root";
-          group = "root";
+          owner = "rspamd";
+          group = "rspamd";
         }];
         workers.controller2 = {
           type = "controller";
@@ -116,9 +120,9 @@ in
 
     testScript = ''
       ${initMachine}
-      machine.wait_for_file("/run/rspamd.sock")
-      ${checkSocket "/run/rspamd.sock" "root" "root" "600" }
-      ${checkSocket "/run/rspamd-worker.sock" "root" "root" "666" }
+      machine.wait_for_file("/run/rspamd/rspamd.sock")
+      ${checkSocket "/run/rspamd/rspamd.sock" "rspamd" "rspamd" "600" }
+      ${checkSocket "/run/rspamd/rspamd-worker.sock" "rspamd" "rspamd" "666" }
       machine.log(machine.succeed("cat /etc/rspamd/rspamd.conf"))
       machine.log(
           machine.succeed("grep 'CONFDIR/worker-controller.inc' /etc/rspamd/rspamd.conf")
@@ -137,9 +141,11 @@ in
       machine.wait_until_succeeds(
           "journalctl -u rspamd | grep -i 'starting controller process' >&2"
       )
-      machine.log(machine.succeed("rspamc -h /run/rspamd-worker.sock stat"))
+      machine.log(machine.succeed("rspamc -h /run/rspamd/rspamd-worker.sock stat"))
       machine.log(
-          machine.succeed("curl --unix-socket /run/rspamd-worker.sock http://localhost/ping")
+          machine.succeed(
+              "curl --unix-socket /run/rspamd/rspamd-worker.sock http://localhost/ping"
+          )
       )
       machine.log(machine.succeed("curl http://localhost:11335/ping"))
     '';


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Better systemd service sandboxing.

###### Things done

- [x] Tested on a mailserver with postfix based on [simple-nixos-mailserver](https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc rspamd maintainers @avnik @fpletz @globin