### PR TITLE
python3Packages.torchgpipe: init at 0.0.5

### DIFF
--- a/pkgs/development/python-modules/torchgpipe/default.nix
+++ b/pkgs/development/python-modules/torchgpipe/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, pytest
+, pytestrunner
+, pytestCheckHook
+, pytorch
+}:
+
+buildPythonPackage rec {
+  pname = "torchgpipe";
+  version = "0.0.5";
+
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "kakaobrain";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0mqdavnqb8a320li2r7xw11w2lg03l59xxyg2fxpg4z57v0rbasi";
+  };
+
+  propagatedBuildInputs = [ pytorch ];
+
+  checkInputs = [ pytest pytestrunner pytestCheckHook ];
+  disabledTests = [ "test_inplace_on_requires_grad" ];
+  # seems like a harmless failure:
+  ## AssertionError:
+  ## Pattern 'a leaf Variable that requires grad has been used in an in-place operation.'
+  ## does not match 'a leaf Variable that requires grad is being used in an in-place operation.'
+
+  meta = with lib; {
+    description = "GPipe implemented in Pytorch and optimized for CUDA rather than TPU";
+    homepage = "https://torchgpipe.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = [ maintainers.bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6988,6 +6988,8 @@ in {
 
   torchvision = callPackage ../development/python-modules/torchvision { };
 
+  torchgpipe = callPackage ../development/python-modules/torchgpipe { };
+
   jenkinsapi = callPackage ../development/python-modules/jenkinsapi { };
 
   jenkins-job-builder = callPackage ../development/python-modules/jenkins-job-builder { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
