### PR TITLE
element-desktop, element-web: 1.7.0 -> 1.7.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "element-desktop",
   "productName": "Element (Riot)",
   "main": "src/electron-main.js",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A feature-rich client for Matrix.org",
   "author": "Element",
   "repository": {

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-yarndeps.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-yarndeps.nix
@@ -3170,11 +3170,11 @@
       };
     }
     {
-      name = "lodash___lodash_4.17.15.tgz";
+      name = "lodash___lodash_4.17.19.tgz";
       path = fetchurl {
-        name = "lodash___lodash_4.17.15.tgz";
-        url  = "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz";
-        sha1 = "b447f6670a0455bbfeedd11392eff330ea097548";
+        name = "lodash___lodash_4.17.19.tgz";
+        url  = "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz";
+        sha1 = "e48ddedbe30b3321783c5b4301fbd353bc1e4a4b";
       };
     }
     {

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -8,12 +8,12 @@
 
 let
   executableName = "element-desktop";
-  version = "1.7.0";
+  version = "1.7.1";
   src = fetchFromGitHub {
     owner = "vector-im";
     repo = "riot-desktop";
     rev = "v${version}";
-    sha256 = "10qisz2s5w2ykh3j4bldadjzb4j963z5n0jd64dxmz9l2k9id2mk";
+    sha256 = "0sl45mxgp0sngxnba8ilsghzgv6cv36ggah1k2204ggzby13blg6";
   };
   electron = electron_9;
 

--- a/pkgs/applications/networking/instant-messengers/element/element-web.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-web.nix
@@ -12,11 +12,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "element-web";
-  version = "1.7.0";
+  version = "1.7.1";
 
   src = fetchurl {
     url = "https://github.com/vector-im/riot-web/releases/download/v${version}/riot-v${version}.tar.gz";
-    sha256 = "033793zx3c95z5ikq70kxajwlbg2b8785wrgjr1zyha3pjq79bm6";
+    sha256 = "1axmf5h0k709kbpgh3ldsf6f8k9n2q623pk4j0nrshlxa9ighsay";
   };
 
   installPhase = ''


### PR DESCRIPTION
##### Motivation for this change

Small update, mostly an icon fix for element-desktop.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
