### PR TITLE
xdg-desktop-portal-gtk: add gnome-settings-daemon

### DIFF
--- a/pkgs/development/libraries/xdg-desktop-portal-gtk/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-gtk/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
     gsettings-desktop-schemas
     gtk3
     gnome3.gnome-desktop
+    gnome3.gnome-settings-daemon # schemas needed for settings api (fonts, etc)
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

This fixes "xdg-desktop-portal-gtk breaks font hinting".
Aka, nixos/nixpkgs#93199.

I've manually verified this locally. I re-enabled the xdg options that I *had* disabled because of #93199, and then cherry-picked this, rebuilt, logged out, checked wofi/termite and things look as expected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
