### PR TITLE
sunflower: init at 2020-07-03-unstable

### DIFF
--- a/pkgs/applications/misc/sunflower/default.nix
+++ b/pkgs/applications/misc/sunflower/default.nix
@@ -1,0 +1,68 @@
+{ python3
+, lib
+, fetchFromGitHub
+, fetchpatch
+, gtk3
+, glib
+, libnotify
+, vte
+, gvfs
+, gsettings-desktop-schemas
+, gnome3
+, gobject-introspection
+, wrapGAppsHook
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "sunflower";
+  version = "2020-07-16-unstable";
+
+  src = fetchFromGitHub {
+    owner = "MeanEYE";
+    repo = "Sunflower";
+    rev = "841252d0f05c029ef89f52e7547d3630ff20091d";
+    sha256 = "zhyNJsCsX67n38j+/L2Z5sBhjhm4IP9CpX0KYkZt0/Y=";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libnotify
+    vte
+    gvfs
+    gsettings-desktop-schemas # for font settings
+    gnome3.libgnome-keyring
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.pygobject3
+    python3.pkgs.chardet
+  ];
+
+  # See https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  # There are no tests.
+  doCheck = false;
+
+  postPatch = ''
+    # Outside of Nix, Python modules are installed under Python’s prefix
+    # or into a virtual environment, that overrides sys.prefix.
+    # https://docs.python.org/3/library/sys.html#sys.prefix
+    # We do neither so we need to override the variable ourselves.
+    echo "import sys; sys.prefix = '${placeholder "out"}'" | cat - sunflower/__init__.py > temp && mv temp sunflower/__init__.py
+  '';
+
+  meta = with lib; {
+    description = "Small and highly customizable twin-panel file manager for Linux with support for plugins";
+    homepage = "https://sunflower-fm.org/";
+    license = licenses.gpl3;
+    maintainers = [ ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6908,6 +6908,8 @@ in
 
   sundtek = callPackage ../misc/drivers/sundtek { };
 
+  sunflower = callPackage ../applications/misc/sunflower { };
+
   sunxi-tools = callPackage ../development/tools/sunxi-tools { };
 
   sumorobot-manager = python3Packages.callPackage ../applications/science/robotics/sumorobot-manager { };


### PR DESCRIPTION
###### Motivation for this change
Not really usable at the moment either: https://github.com/MeanEYE/Sunflower/issues/443

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
