### PR TITLE
kpt: init at v0.31.0

### DIFF
--- a/pkgs/applications/networking/cluster/kpt/default.nix
+++ b/pkgs/applications/networking/cluster/kpt/default.nix
@@ -1,0 +1,27 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "kpt";
+  version = "0.31.0";
+
+  src = fetchFromGitHub {
+    owner = "GoogleContainerTools";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1l5mpml6pf37b76wdq6il00k5q6rvw9ds7807m103k27p7pcqgdx";
+  };
+
+  vendorSha256 = "1yb6dwbnimqfamdg57vq68q853fq04qfnh3sfbjg82sd8pz8069g";
+
+  postInstall = ''
+    rm $out/bin/{mdtogo,formula}
+  '';
+
+  meta = with lib; {
+    description = "A toolkit to help you manage, manipulate, customize, and apply Kubernetes Resource configuration data files";
+    homepage = "https://googlecontainertools.github.io/kpt/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mikefaille ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20803,6 +20803,8 @@ in
 
   kotatogram-desktop = qt5.callPackage ../applications/networking/instant-messengers/telegram/kotatogram-desktop { };
 
+  kpt = callPackage ../applications/networking/cluster/kpt { };
+
   krita = libsForQt5.callPackage ../applications/graphics/krita {
     openjpeg = openjpeg_1;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
kpt is a shinny new tool from Google to manage kubernetes assets. Let's adopt it on Nixpkg.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ]Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
