### PR TITLE
rocm-smi: init at 3.5.0

### DIFF
--- a/pkgs/tools/system/rocm-smi/default.nix
+++ b/pkgs/tools/system/rocm-smi/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonApplication, fetchFromGitHub }:
+
+buildPythonApplication rec {
+  pname = "rocm-smi";
+  version = "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = "RadeonOpenCompute";
+    repo = "ROC-smi";
+    rev = "rocm-${version}";
+    sha256 = "189mpvmcv46nfwshyc1wla6k71kbraldik5an20g4v9s13ycrpx9";
+  };
+
+  format = "other";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm0755 rocm_smi.py $out/bin/rocm-smi
+  '';
+
+  meta = with lib; {
+    description = "System management interface for AMD GPUs supported by ROCm";
+    homepage = "https://github.com/RadeonOpenCompute/ROC-smi";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9286,6 +9286,9 @@ in
 
   rocm-runtime-ext = callPackage ../development/libraries/rocm-runtime-ext { };
 
+  # Python >= 3.8 still gives a bunch of warnings.
+  rocm-smi = python37.pkgs.callPackage ../tools/system/rocm-smi { };
+
   rocm-thunk = callPackage ../development/libraries/rocm-thunk { };
 
   rtags = callPackage ../development/tools/rtags {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This utility reports information about AMD GPUs that are supported by
the ROCm stack. It also exposes functionality for clock and
temperature management.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
