### PR TITLE
julia: Remove version 0.7 and 1.1

### DIFF
--- a/pkgs/development/compilers/julia/0.7.nix
+++ b/pkgs/development/compilers/julia/0.7.nix
@@ -1,9 +1,0 @@
-import ./shared.nix {
-  majorVersion = "0";
-  minorVersion = "7";
-  maintenanceVersion = "0";
-  src_sha256 = "1j57569qm2ii8ddzsp08hds2navpk7acdz83kh27dvk44axhwj6f";
-
-  libuvVersion = "ed3700c849289ed01fe04273a7bf865340b2bd7e";
-  libuvSha256 = "137w666zsjw1p0ma3lf94d75hr1q45sgkfmbizkyji2qm57cnxjs";
-}

--- a/pkgs/development/compilers/julia/1.1.nix
+++ b/pkgs/development/compilers/julia/1.1.nix
@@ -1,9 +1,0 @@
-import ./shared.nix {
-  majorVersion = "1";
-  minorVersion = "1";
-  maintenanceVersion = "1";
-  src_sha256 = "1yqjd0n42xf9hzxpvc9vysyjj98p42by216jkdqakdy7dkjcmnhq";
-
-  libuvVersion = "2348256acf5759a544e5ca7935f638d2bc091d60";
-  libuvSha256 = "1363f4vqayfcv5zqg07qmzjff56yhad74k16c22ian45lram8mv8";
-}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -218,6 +218,8 @@ mapAliases ({
   joseki = apache-jena-fuseki; # added 2016-02-28
   json_glib = json-glib; # added 2018-02-25
   kdecoration-viewer = throw "kdecoration-viewer has been removed from nixpkgs, as there is no upstream activity"; # 2020-06-16
+  julia_07 = throw "deprecated in favor of julia_10 LTS"; # added 2020-09-15
+  julia_11 = throw "deprecated in favor of latest Julia version"; # added 2020-09-15
   kdiff3-qt5 = kdiff3; # added 2017-02-18
   keepass-keefox = keepass-keepassrpc; # backwards compatibility alias, added 2018-02
   keepassx-community = keepassxc; # added 2017-11

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9277,11 +9277,6 @@ in
 
   javacard-devkit = pkgsi686Linux.callPackage ../development/compilers/javacard-devkit { };
 
-  julia_07 = callPackage ../development/compilers/julia/0.7.nix {
-    gmp = gmp6;
-    inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
-  };
-
   julia_10 = callPackage ../development/compilers/julia/1.0.nix {
     gmp = gmp6;
     inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9282,11 +9282,6 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
   };
 
-  julia_11 = callPackage ../development/compilers/julia/1.1.nix {
-    gmp = gmp6;
-    inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
-  };
-
   julia_13 = callPackage ../development/compilers/julia/1.3.nix {
     gmp = gmp6;
     inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Everyone using 0.7 are strongly recommended to switch to 1.0 LTS. 1.1 can be removed because there is already 1.3, and 1.1 is not an LTS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
N/A
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
