### PR TITLE
write_stylus: version 209 -> 300

### DIFF
--- a/pkgs/applications/graphics/write_stylus/default.nix
+++ b/pkgs/applications/graphics/write_stylus/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, stdenv, lib, qtbase, qtsvg, libglvnd, fetchurl, makeDesktopItem }:
+{ mkDerivation, stdenv, lib, qtbase, qtsvg, libglvnd, libX11, libXi, fetchurl, makeDesktopItem }:
 let
   # taken from: https://www.iconfinder.com/icons/50835/edit_pencil_write_icon
   # license: Free for commercial use
@@ -9,7 +9,7 @@ let
 in
 mkDerivation rec {
   pname = "write_stylus";
-  version = "209";
+  version = "300";
 
   desktopItem = makeDesktopItem {
     name = "Write";
@@ -23,7 +23,7 @@ mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.styluslabs.com/write/write${version}.tar.gz";
-    sha256 = "1p6glp4vdpwl8hmhypayc4cvs3j9jfmjfhhrgqm2xkgl5bfbv2qd";
+    sha256 = "1kg4qqxgg7iyxl13hkbl3j27dykra56dj67hbv0392mwdcgavihq";
   };
 
   sourceRoot = ".";
@@ -44,7 +44,9 @@ mkDerivation rec {
       qtbase            # libQt5PrintSupport.so.5
       qtsvg             # libQt5Svg.so.5
       stdenv.cc.cc.lib  # libstdc++.so.6
-      libglvnd          # ibGL.so.1
+      libglvnd          # libGL.so.1
+      libX11            # libX11.so.6
+      libXi             # libXi.so.6
     ];
   in ''
     patchelf \


### PR DESCRIPTION
 <!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Brings Write to version 300. Maybe related to issue #89473.

###### Additional information

It seemed to additionally require libX11 and libXi to execute, asking for the libraries libX11.so.6 and libXi.so.6. Does it make sense to add them to the derivation? 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
