### PR TITLE
profiles/base: adding ifenslave

### DIFF
--- a/nixos/modules/profiles/base.nix
+++ b/nixos/modules/profiles/base.nix
@@ -28,6 +28,7 @@
     pkgs.sshfs-fuse
     pkgs.socat
     pkgs.screen
+    pkgs.ifenslave
 
     # Hardware-related tools.
     pkgs.sdparm


### PR DESCRIPTION
#### Motivation for this change

In some enterprise datacenter, the network is setup with LACP 802.3ad by default. In order to get a network connection, you need to create a bonded interface. For this to happen, the `ifenslave` utility is indeed in additional to `ip`/`ifconfig`.

I would like to propose to add this to our default profile for the installation medias, give the utility itself is only 36K, but extremly useful when dealing in non-cloud environments.

```
36K	/nix/store/sgii49fyg2pcsih78h6fmx1dk5bmjp21-ifenslave-1.1.0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
