### PR TITLE
exim: add DMARC support

### DIFF
--- a/pkgs/development/libraries/opendmarc/default.nix
+++ b/pkgs/development/libraries/opendmarc/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, libmilter }:
+
+stdenv.mkDerivation rec {
+  pname = "opendmarc";
+  version = "1.3.3";
+
+  src = fetchFromGitHub {
+    owner = "trusteddomainproject";
+    repo = "opendmarc";
+    rev = "rel-opendmarc-${builtins.replaceStrings [ "." ] [ "-" ] version}";
+    sha256 = "sha256-SQH85FLfVEEtYhR1+A1XxCDMiTjDgLQX6zifbLxCa5c=";
+  };
+
+  outputs = [ "bin" "dev" "out" "doc" ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  postPatch = ''
+    substituteInPlace configure.ac --replace '	docs/Makefile' ""
+  '';
+
+  configureFlags = [
+    "--with-milter=${libmilter}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A free open source software implementation of the DMARC specification";
+    homepage = "http://www.trusteddomain.org/opendmarc/";
+    license = with licenses; [ bsd3 sendmail ];
+    maintainers = with maintainers; [ ajs124 das_j ];
+  };
+}

--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -4,6 +4,7 @@
 , enableAuthDovecot ? false, dovecot
 , enablePAM ? false, pam
 , enableSPF ? true, libspf2
+, enableDMARC ? true, opendmarc
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +22,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals enableMySQL [ libmysqlclient zlib ]
     ++ stdenv.lib.optional enableAuthDovecot dovecot
     ++ stdenv.lib.optional enablePAM pam
-    ++ stdenv.lib.optional enableSPF libspf2;
+    ++ stdenv.lib.optional enableSPF libspf2
+    ++ stdenv.lib.optional enableDMARC opendmarc;
 
   preBuild = ''
     sed '
@@ -70,6 +72,10 @@ stdenv.mkDerivation rec {
       ${stdenv.lib.optionalString enableSPF ''
         s:^# \(SUPPORT_SPF\)=.*:\1=yes:
         s:^# \(LDFLAGS += -lspf2\):\1:
+      ''}
+      ${stdenv.lib.optionalString enableDMARC ''
+        s:^# \(SUPPORT_DMARC\)=.*:\1=yes:
+        s:^# \(LDFLAGS += -lopendmarc\):\1:
       ''}
       #/^\s*#.*/d
       #/^\s*$/d

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14216,6 +14216,8 @@ in
 
   opencolorio = callPackage ../development/libraries/opencolorio { };
 
+  opendmarc = callPackage ../development/libraries/opendmarc { };
+
   ois = callPackage ../development/libraries/ois {};
 
   openh264 = callPackage ../development/libraries/openh264 { };


### PR DESCRIPTION
###### Motivation for this change
We're running this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
