### PR TITLE
bazel-kazel: init at 0.0.7

### DIFF
--- a/pkgs/development/tools/bazel-kazel/default.nix
+++ b/pkgs/development/tools/bazel-kazel/default.nix
@@ -1,0 +1,24 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "bazel-kazel";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    owner = "kubernetes";
+    repo = "repo-infra";
+    rev = "v${version}";
+    sha256 = "0g4lgz5xgmxabaa8pygmdnrnslfrcb84vgr6bninl9v5zz4wajbm";
+  };
+
+  vendorSha256 = "1lizvg9r7cck1cgk20np2syv4ljbc0zj1kydiiajf7y5x7d3lwha";
+
+  subPackages = [ "cmd/kazel" ];
+
+  meta = with lib; {
+    description = "kazel - a BUILD file generator for go and bazel";
+    homepage = "https://github.com/kubernetes/repo-infra";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ kalbasit ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10218,6 +10218,8 @@ in
 
   bazel-gazelle = callPackage ../development/tools/bazel-gazelle { };
 
+  bazel-kazel = callPackage ../development/tools/bazel-kazel { };
+
   bazelisk = callPackage ../development/tools/bazelisk { };
 
   buildBazelPackage = callPackage ../build-support/build-bazel-package { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

[Kazel](https://github.com/kubernetes/repo-infra/tree/master/cmd/kazel) is a useful command for maintaining Bazel build files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
