### PR TITLE
spacevim: init at v1.5.0

### DIFF
--- a/pkgs/applications/editors/spacevim/default.nix
+++ b/pkgs/applications/editors/spacevim/default.nix
@@ -1,0 +1,55 @@
+{ ripgrep, gitAndTools, fzf, makeWrapper, vim_configurable, vimPlugins, fetchFromGitHub, writeTextDir
+, stdenv, runCommandNoCC, remarshal, formats, spacevim_config ? import ./init.nix }:
+with stdenv;
+let
+  format = formats.toml {};
+  vim-customized = vim_configurable.customize {
+    name = "vim";
+    # Not clear at the moment how to import plugins such that
+    # SpaceVim finds them and does not auto download them to
+    # ~/.cache/vimfiles/repos
+    vimrcConfig.packages.myVimPackage = with vimPlugins; { start = [ ]; };
+  };
+  spacevimdir = format.generate "init.toml" spacevim_config;
+in mkDerivation rec {
+  pname = "spacevim";
+  version = "1.5.0";
+  src = fetchFromGitHub {
+    owner = "SpaceVim";
+    repo = "SpaceVim";
+    rev = "v${version}";
+    sha256 = "1xw4l262x7wzs1m65bddwqf3qx4254ykddsw3c3p844pb3mzqhh7";
+  };
+
+  nativeBuildInputs = [ makeWrapper vim-customized];
+  buildInputs = [ vim-customized ];
+
+  buildPhase = ''
+    # generate the helptags
+    vim -u NONE -c "helptags $(pwd)/doc" -c q
+  '';
+
+  patches = [ ./helptags.patch ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cp -r $(pwd) $out/SpaceVim
+
+    # trailing slash very important for SPACEVIMDIR
+    makeWrapper "${vim-customized}/bin/vim" "$out/bin/spacevim" \
+        --add-flags "-u $out/SpaceVim/vimrc" --set SPACEVIMDIR "${spacevimdir}/" \
+        --prefix PATH : ${lib.makeBinPath [ fzf gitAndTools.git ripgrep]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Modern Vim distribution";
+    longDescription = ''
+      SpaceVim is a distribution of the Vim editor that’s inspired by spacemacs.
+    '';
+    homepage = "https://spacevim.org/";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.fzakaria ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/editors/spacevim/helptags.patch
+++ b/pkgs/applications/editors/spacevim/helptags.patch
@@ -1,0 +1,18 @@
+diff --git a/autoload/SpaceVim.vim b/autoload/SpaceVim.vim
+index 16688680..fcafd6f7 100644
+--- a/autoload/SpaceVim.vim
++++ b/autoload/SpaceVim.vim
+@@ -1255,13 +1255,6 @@ function! SpaceVim#end() abort
+     let &helplang = 'jp'
+   endif
+   ""
+-  " generate tags for SpaceVim
+-  let help = fnamemodify(g:_spacevim_root_dir, ':p:h') . '/doc'
+-  try
+-    exe 'helptags ' . help
+-  catch
+-    call SpaceVim#logger#warn('Failed to generate helptags for SpaceVim')
+-  endtry
+ 
+   ""
+   " set language

--- a/pkgs/applications/editors/spacevim/init.nix
+++ b/pkgs/applications/editors/spacevim/init.nix
@@ -1,0 +1,46 @@
+# The Nix expression is a 1:1 mapping of the spacevim toml config which you can find on their website: spacevim.org/quick-start-guide/#configuration
+
+{
+  custom_plugins = [{
+    merged = false;
+    name = "lilydjwg/colorizer";
+  }];
+  layers = [
+    { name = "default"; }
+    {
+      enable = true;
+      name = "colorscheme";
+    }
+    { name = "fzf"; }
+    {
+      default_height = 30;
+      default_position = "top";
+      name = "shell";
+    }
+    { name = "edit"; }
+    { name = "VersionControl"; }
+    { name = "git"; }
+    {
+      auto-completion-return-key-behavior = "complete";
+      auto-completion-tab-key-behavior = "cycle";
+      autocomplete_method = "coc";
+      name = "autocomplete";
+    }
+    { name = "lang#ruby"; }
+    { name = "lang#nix"; }
+    { name = "lang#java"; }
+    { name = "lang#kotlin"; }
+    { name = "lang#sh"; }
+    { name = "lang#html"; }
+  ];
+  options = {
+    buffer_index_type = 4;
+    colorscheme = "gruvbox";
+    colorscheme_bg = "dark";
+    enable_guicolors = true;
+    enable_statusline_mode = true;
+    enable_tabline_filetype_icon = true;
+    statusline_separator = "fire";
+    timeoutlen = 500;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2554,6 +2554,8 @@ in
 
   socklog = callPackage ../tools/system/socklog { };
 
+  spacevim = callPackage ../applications/editors/spacevim { };
+
   ssmsh = callPackage ../tools/admin/ssmsh { };
 
   stagit = callPackage ../development/tools/stagit { };


### PR DESCRIPTION
Spacevim is a fully loaded vim/neovim installation in the spirit
of https://www.spacemacs.org/

It's configured with a TOML file rather than vimscript and includes
a wide array of configuration found at https://spacevim.org/.

I tested this by running:
```bash
 nix-build --no-out-link -E 'with import <nixpkgs> {}; callPackage ./pkgs/applications/editors/spacevim {}'

/nix/store/nbxjak1cll8m1rm90cbkld5qpahx3gb2-spacevim/bin/spacevim
```
###### Motivation for this change

I hate configuring my vim & neovim files with plugins or vimrc files.
I like a very curated & hyper opinionated experience which is what spacevim brings to the table.

It's extremely sensible & has a lot of "layers" for almost anything. 
I decided to rename the binary "spacevim" so that it doesn't conflict with other installations of vim.

I will say that at the moment this is one of my first few derivations & it's not _fully_ nix compliant.
I would appreciate help to get it over the finish line.

1. SpaceVim downloads any missing plugins via the specific TOML file to ~/.cache/vimfiles
    I would like to make use of _vimPlugins_ instead

2. It would be better to have users customize the spacevim installation via a nix attrset that gets converted to TOML.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
