### PR TITLE
ocamlPackages.markup: 0.7.5 → 0.8.2

### DIFF
--- a/pkgs/development/ocaml-modules/markup/default.nix
+++ b/pkgs/development/ocaml-modules/markup/default.nix
@@ -1,28 +1,20 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, uutf, lwt }:
+{ lib, buildDunePackage, fetchzip, uutf }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
   pname = "markup";
-  version = "0.7.5";
-  name = "ocaml${ocaml.version}-${pname}-${version}";
+  version = "0.8.2";
 
   src = fetchzip {
     url = "https://github.com/aantron/markup.ml/archive/${version}.tar.gz";
-    sha256 = "09qm73m6c6wjh51w61vnfsnis37m28cf1r6hnkr3bbg903ahwbp5";
+    sha256 = "13zcrwzjmifniv3bvjbkd2ah8wwa3ld75bxh1d8hrzdvfxzh9szn";
     };
-
-  buildInputs = [ ocaml findlib ocamlbuild lwt ];
-
-  installPhase = "make ocamlfind-install";
 
   propagatedBuildInputs = [ uutf ];
 
-  createFindlibDestdir = true;
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/aantron/markup.ml/";
     description = "A pair of best-effort parsers implementing the HTML5 and XML specifications";
-    license = licenses.bsd2;
-    platforms = ocaml.meta.platforms or [];
+    license = licenses.mit;
     maintainers = with maintainers; [
       gal_bolle
       ];


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/aantron/markup.ml/releases

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
