### PR TITLE
mysql80: 8.0.17 -> 8.0.21

### DIFF
--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -1,27 +1,31 @@
 { lib, stdenv, fetchurl, bison, cmake, pkgconfig
-, boost, icu, libedit, libevent, lz4, ncurses, openssl, protobuf, re2, readline, zlib
-, numactl, perl, cctools, CoreServices, developer_cmds
+, boost, icu, libedit, libevent, lz4, ncurses, openssl, protobuf, re2, readline
+, zlib, zstd, numactl, perl, cctools, CoreServices, developer_cmds
 }:
 
 let
 self = stdenv.mkDerivation rec {
   pname = "mysql";
-  version = "8.0.17";
+  version = "8.0.21";
 
   src = fetchurl {
     url = "https://dev.mysql.com/get/Downloads/MySQL-${self.mysqlVersion}/${pname}-${version}.tar.gz";
-    sha256 = "1mjrlxn8vigi69r0r674j2dibdnkaar01ji5965gsyx7k60z7qy6";
+    sha256 = "0d00k55rkzdgn5wj32vxankjk5x3ywfqw62zxzg3m503xrg56mmd";
   };
 
   patches = [
     ./abi-check.patch
-    ./libutils.patch
   ];
+
+  postPatch = ''
+    substituteInPlace cmake/libutils.cmake --replace /usr/bin/ ""
+  '';
 
   nativeBuildInputs = [ bison cmake pkgconfig ];
 
   buildInputs = [
     boost icu libedit libevent lz4 ncurses openssl protobuf re2 readline zlib
+    zstd
   ] ++ lib.optionals stdenv.isLinux [
     numactl
   ] ++ lib.optionals stdenv.isDarwin [

--- a/pkgs/servers/sql/mysql/libutils.patch
+++ b/pkgs/servers/sql/mysql/libutils.patch
@@ -1,5 +1,0 @@
---- a/cmake/libutils.cmake
-+++ b/cmake/libutils.cmake
-@@ -345 +345 @@ MACRO(MERGE_CONVENIENCE_LIBRARIES)
--      COMMAND /usr/bin/libtool -static -o $<TARGET_FILE:${TARGET}>
-+      COMMAND libtool -static -o $<TARGET_FILE:${TARGET}>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16288,7 +16288,7 @@ in
   mysql80 = callPackage ../servers/sql/mysql/8.0.x.nix {
     inherit (darwin) cctools developer_cmds;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
-    boost = boost169; # Configure checks for specific version.
+    boost = boost172; # Configure checks for specific version.
     protobuf = protobuf3_7;
   };
 


### PR DESCRIPTION
Hopefully substituteInPlace will be less brittle than the patch.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
