### PR TITLE
cvc4: 1.6 -> 1.8

### DIFF
--- a/pkgs/applications/science/logic/cvc4/default.nix
+++ b/pkgs/applications/science/logic/cvc4/default.nix
@@ -1,19 +1,20 @@
-{ stdenv, fetchurl, cln, gmp, swig, pkgconfig
-, readline, libantlr3c, boost, jdk, autoreconfHook
-, python3, antlr3_4
+{ stdenv, fetchFromGitHub, cmake, cln, gmp, git, swig, pkgconfig
+, readline, libantlr3c, boost, jdk, python3, antlr3_4
 }:
 
 stdenv.mkDerivation rec {
   pname = "cvc4";
-  version = "1.6";
+  version = "1.8";
 
-  src = fetchurl {
-    url = "https://cvc4.cs.stanford.edu/downloads/builds/src/cvc4-${version}.tar.gz";
-    sha256 = "1iw793zsi48q91lxpf8xl8lnvv0jsj4whdad79rakywkm1gbs62w";
+  src = fetchFromGitHub {
+    owner  = "cvc4";
+    repo   = "cvc4";
+    rev    = version;
+    sha256 = "1rhs4pvzaa1wk00czrczp58b2cxfghpsnq534m0l3snnya2958jp";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ gmp cln readline swig libantlr3c antlr3_4 boost jdk python3 ];
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ gmp git python3.pkgs.toml cln readline swig libantlr3c antlr3_4 boost jdk python3 ];
   configureFlags = [
     "--enable-language-bindings=c,c++,java"
     "--enable-gpl"
@@ -30,6 +31,10 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     patchShebangs ./src/
   '';
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Production"
+  ];
+
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Current version of cvc4 is 1.6, which was released on February 11. I want to use cvc4 with https://github.com/LeventErkok/sbv (whose nix package needs to be patched to reuse the proper cvc4, I can do that after this PR)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
