### PR TITLE
pythonPackages.backoff: init at 1.10.0

### DIFF
--- a/pkgs/development/python-modules/backoff/default.nix
+++ b/pkgs/development/python-modules/backoff/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pytestCheckHook, poetry, pytest-asyncio, }:
+
+buildPythonPackage rec {
+  pname = "backoff";
+  version = "1.10.0";
+
+  src = fetchFromGitHub {
+    owner = "litl";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1jj0l6pjx747d2yyvnzd3qbm4qr73sq6cc56dhvd8wqfbp5279x0";
+  };
+
+  format = "pyproject";
+
+  nativeBuildInputs = [ poetry ];
+
+  checkInputs = [ pytestCheckHook pytest-asyncio ];
+
+  meta = with lib; {
+    description = "Function decoration for backoff and retry";
+    homepage = "https://github.com/litl/backoff";
+    license = licenses.mit;
+    maintainers = with maintainers; [ chkno ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1945,6 +1945,8 @@ in {
 
   backcall = callPackage ../development/python-modules/backcall { };
 
+  backoff = callPackage ../development/python-modules/backoff { };
+
   backports_abc = callPackage ../development/python-modules/backports_abc { };
 
   backports_functools_lru_cache = callPackage ../development/python-modules/backports_functools_lru_cache { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested a program that uses this library
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    0 → 110532768
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
