### PR TITLE
rocm-runtime: make ROCR_EXT_DIR handling more local

### DIFF
--- a/pkgs/development/libraries/rocm-runtime/rocr-ext-dir.diff
+++ b/pkgs/development/libraries/rocm-runtime/rocr-ext-dir.diff
@@ -1,24 +1,23 @@
-diff --git a/src/core/util/lnx/os_linux.cpp b/src/core/util/lnx/os_linux.cpp
-index fdbe19a..42d4ef8 100644
---- a/src/core/util/lnx/os_linux.cpp
-+++ b/src/core/util/lnx/os_linux.cpp
-@@ -161,8 +161,17 @@ static_assert(sizeof(Mutex) == sizeof(pthread_mutex_t*), "OS abstraction size mi
- static_assert(sizeof(Thread) == sizeof(os_thread*), "OS abstraction size mismatch");
+diff --git a/src/core/runtime/runtime.cpp b/src/core/runtime/runtime.cpp
+index dd6a15c..fb6de49 100644
+--- a/src/core/runtime/runtime.cpp
++++ b/src/core/runtime/runtime.cpp
+@@ -1358,7 +1358,17 @@ void Runtime::LoadExtensions() {
+                           core::HsaApiTable::HSA_EXT_FINALIZER_API_TABLE_ID);
  
- LibHandle LoadLib(std::string filename) {
--  void* ret = dlopen(filename.c_str(), RTLD_LAZY);
--  if (ret == nullptr) debug_print("LoadLib(%s) failed: %s\n", filename.c_str(), dlerror());
-+  std::string extDirFilename = GetEnvVar("ROCR_EXT_DIR") + "/" + filename;
-+  void* ret = dlopen(extDirFilename.c_str(), RTLD_LAZY);
-+
-+  // Attempt to load from the directory hardcoded by rocrExtDir.
-+  if (ret == nullptr) {
-+    std::string runpathFilename = std::string("@rocrExtDir@") + "/" + filename;
-+    ret = dlopen(runpathFilename.c_str(), RTLD_LAZY);
-+
-+    if (ret == nullptr) debug_print("LoadLib(%s) failed: %s\n", filename.c_str(), dlerror());
+   // Update Hsa Api Table with handle of Image extension Apis
+-  extensions_.LoadImage(kImageLib[os_index(os::current_os)]);
++  //
++  // Use ROCR_EXT_DIR when it is non-empty. Otherwise, try to load the
++  // library from the OpenGL driver path.
++  std::string extDirVar = os::GetEnvVar("ROCR_EXT_DIR");
++  if (!extDirVar.empty()) {
++    extensions_.LoadImage(extDirVar + "/" + kImageLib[os_index(os::current_os)]);
++  } else {
++    std::string globalDriverDir("@rocrExtDir@");
++    extensions_.LoadImage(globalDriverDir + "/" + kImageLib[os_index(os::current_os)]);
 +  }
 +
-   return *(LibHandle*)&ret;
+   hsa_api_table_.LinkExts(&extensions_.image_api,
+                           core::HsaApiTable::HSA_EXT_IMAGE_API_TABLE_ID);
  }
- 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Make `ROCR_EXT_DIR` handling more local. Avoid that our patching messes up loading other libraries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
