### PR TITLE
appimage: switch to gst-plugins-base 1.0

### DIFF
--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -84,6 +84,7 @@ rec {
 
       gst_all_1.gstreamer
       gst_all_1.gst-plugins-ugly
+      gst_all_1.gst-plugins-base
       libdrm
       xorg.xkeyboardconfig
       xorg.libpciaccess
@@ -163,7 +164,6 @@ rec {
       SDL2_ttf
       SDL2_mixer
       gstreamer
-      gst-plugins-base
       libappindicator-gtk2
       libcaca
       libcanberra


### PR DESCRIPTION
###### Motivation for this change
`gst-plugins-base` 0.10 is depricated and marked as broken as of https://github.com/NixOS/nixpkgs/commit/d034a0039d8937aca2f64d1d3911e8b71f416137.

Not sure if we should delete [GStreamer 0.10](https://github.com/NixOS/nixpkgs/blob/0269421b7b63157a6414cd64e1a4a0b4dd44abe8/pkgs/build-support/appimage/default.nix#L166) as well, as [version 1.0 is already in the package](https://github.com/NixOS/nixpkgs/blob/0269421b7b63157a6414cd64e1a4a0b4dd44abe8/pkgs/build-support/appimage/default.nix#L85). (https://github.com/NixOS/nixpkgs/issues/39975)

fixes: #93174

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
19 packages built:
     Sylk appimage-run deltachat-electron devdocs-desktop irccloud joplin-desktop ledger-live-desktop 
     marktext minetime notable obsidian runwayml ssb-patchwork standardnotes station tusk unityhub 
     wootility zulip
```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
