### PR TITLE
mbrola: init at 3.3

### DIFF
--- a/pkgs/applications/audio/espeak-ng/default.nix
+++ b/pkgs/applications/audio/espeak-ng/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchFromGitHub, autoconf, automake, which, libtool, pkg-config
-, ronn
+, ronn, substituteAll
+, mbrolaSupport ? true, mbrola
 , pcaudiolibSupport ? true, pcaudiolib
 , sonicSupport ? true, sonic }:
 
@@ -14,12 +15,25 @@ stdenv.mkDerivation rec {
     sha256 = "0jkqhf2h94vbqq7mg7mmm23bq372fa7mdk941my18c3vkldcir1b";
   };
 
+  patches = lib.optionals mbrolaSupport [
+    # Hardcode correct mbrola paths.
+    (substituteAll {
+      src = ./mbrola.patch;
+      inherit mbrola;
+    })
+  ];
+
   nativeBuildInputs = [ autoconf automake which libtool pkg-config ronn ];
 
-  buildInputs = lib.optional pcaudiolibSupport pcaudiolib
+  buildInputs = lib.optional mbrolaSupport mbrola
+             ++ lib.optional pcaudiolibSupport pcaudiolib
              ++ lib.optional sonicSupport sonic;
 
   preConfigure = "./autogen.sh";
+
+  configureFlags = [
+    "--with-mbrola=${if mbrolaSupport then "yes" else "no"}"
+  ];
 
   postInstall = lib.optionalString stdenv.isLinux ''
     patchelf --set-rpath "$(patchelf --print-rpath $out/bin/espeak-ng)" $out/bin/speak-ng
@@ -29,7 +43,7 @@ stdenv.mkDerivation rec {
     description = "Open source speech synthesizer that supports over 70 languages, based on eSpeak";
     homepage = "https://github.com/espeak-ng/espeak-ng";
     changelog = "https://github.com/espeak-ng/espeak-ng/blob/${version}/CHANGELOG.md";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ aske ];
     platforms = platforms.all;
   };

--- a/pkgs/applications/audio/espeak-ng/mbrola.patch
+++ b/pkgs/applications/audio/espeak-ng/mbrola.patch
@@ -1,0 +1,22 @@
+--- a/src/libespeak-ng/mbrowrap.c
++++ b/src/libespeak-ng/mbrowrap.c
+@@ -205,7 +205,7 @@
+ 		signal(SIGTERM, SIG_IGN);
+ 
+ 		snprintf(charbuf, sizeof(charbuf), "%g", mbr_volume);
+-		execlp("mbrola", "mbrola", "-e", "-v", charbuf,
++		execlp("@mbrola@/bin/mbrola", "mbrola", "-e", "-v", charbuf,
+ 		       voice_path, "-", "-.wav", (char *)NULL);
+ 		/* if execution reaches this point then the exec() failed */
+ 		snprintf(mbr_errorbuf, sizeof(mbr_errorbuf),
+--- a/src/libespeak-ng/synth_mbrola.c
++++ b/src/libespeak-ng/synth_mbrola.c
+@@ -85,7 +85,7 @@
+ 	if (!load_MBR())
+ 		return ENS_MBROLA_NOT_FOUND;
+ 
+-	sprintf(path, "%s/mbrola/%s", path_home, mbrola_voice);
++	sprintf(path, "@mbrola@/share/mbrola/voices/%s/%s", mbrola_voice, mbrola_voice);
+ #ifdef PLATFORM_POSIX
+ 	// if not found, then also look in
+ 	//   usr/share/mbrola/xx, /usr/share/mbrola/xx/xx, /usr/share/mbrola/voices/xx

--- a/pkgs/applications/audio/mbrola/default.nix
+++ b/pkgs/applications/audio/mbrola/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+let
+  voices = fetchFromGitHub {
+    owner = "numediart";
+    repo = "MBROLA-voices";
+    rev = "fe05a0ccef6a941207fd6aaad0b31294a1f93a51";  # using latest commit
+    sha256 = "1w0y2xjp9rndwdjagp2wxh656mdm3d6w9cs411g27rjyfy1205a0";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "mbrola";
+  version = "3.3";
+
+  src = fetchFromGitHub {
+    owner = "numediart";
+    repo = "MBROLA";
+    rev = version;
+    sha256 = "1w86gv6zs2cbr0731n49z8v6xxw0g8b0hzyv2iqb9mqcfh38l8zy";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -D Bin/mbrola $out/bin/mbrola
+
+    # TODO: package separately because it's very big
+    install -d $out/share/mbrola/voices
+    cp -R ${voices}/data/* $out/share/mbrola/voices/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Speech synthesizer based on the concatenation of diphones";
+    homepage = "https://github.com/numediart/MBROLA";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ davidak ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23571,6 +23571,8 @@ in
 
   mblaze = callPackage ../applications/networking/mailreaders/mblaze { };
 
+  mbrola = callPackage ../applications/audio/mbrola { };
+
   mcomix3 = callPackage ../applications/graphics/mcomix3 {};
 
   mcpp = callPackage ../development/compilers/mcpp { };


### PR DESCRIPTION
###### Motivation for this change

espeak voices sound terrible. it might get a little better with mbrola

Closes https://github.com/NixOS/nixpkgs/pull/45580

###### Unsolved problems

espeak-ng don't find mbrola unless it's also installed. adding it as a dependency has not solved it

```
[davidak@ethmoid:~/code/nixpkgs]$ espeak -v mb/mb-de1 "ich mag züge"
mbrola: mbrola: No such file or directory
mbrowrap error: mbrola exited with status 1
Error: Could not load the specified mbrola voice file.
```

when i install mbrola, it don't finds the voices in `/home/davidak/.nix-profile/share/mbrola`. can we do anything about that except from waiting on upstream to solve it? https://github.com/numediart/MBROLA/issues/23

```
[davidak@ethmoid:~/code/nixpkgs]$ espeak -v mb/mb-de1 "ich mag züge"
mbrola: FATAL ERROR : cannot find file /usr/share/mbrola/voices/de1 !
mbrowrap error: mbrola closed stderr and did not exit
Error: Could not load the specified mbrola voice file.
```

maybe @jtojnar has some idea?

###### Things done


- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
