### PR TITLE
beamerpresenter: 0.1.1 -> 0.1.2

### DIFF
--- a/pkgs/applications/office/beamerpresenter/default.nix
+++ b/pkgs/applications/office/beamerpresenter/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, mkDerivation, fetchFromGitHub, makeDesktopItem, installShellFiles,
+{ stdenv, mkDerivation, fetchFromGitHub, installShellFiles,
   qmake, qtbase, poppler, qtmultimedia }:
 
 mkDerivation rec {
   pname = "beamerpresenter";
-  version = "0.1.1";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "stiglers-eponym";
     repo = "BeamerPresenter";
     rev = "v${version}";
-    sha256 = "0j7wx3qqwhda33ig2464bi0j0a473y5p7ndy5f7f8x9cqdal1d01";
+    sha256 = "12xngnhwa3haf0pdxczgvhq1j20zbsr30y2bfn9qwmlhbwklhkj2";
   };
 
   nativeBuildInputs = [ qmake installShellFiles ];
@@ -26,22 +26,9 @@ mkDerivation rec {
   installPhase = ''
     install -m755 beamerpresenter -Dt $out/bin/
     install -m644 src/icons/beamerpresenter.svg -Dt $out/share/icons/hicolor/scalable/apps/
-    install -m644 $desktopItem/share/applications/*.desktop -Dt $out/share/applications/
+    install -m644 share/applications/beamerpresenter.desktop -Dt $out/share/applications/
     installManPage man/*.{1,5}
   '';
-
-  # TODO: replace with upstream's .desktop file once available.
-  # https://github.com/stiglers-eponym/BeamerPresenter/pull/4
-  desktopItem = makeDesktopItem {
-    name = pname;
-    desktopName = "BeamerPresenter";
-    genericName = "Beamer presentation viewer";
-    comment = "Simple dual screen pdf presentation software";
-    icon = "beamerpresenter";
-    categories = "Office;";
-    exec = "beamerpresenter %F";
-    mimeType = "application/pdf;application/x-pdf;";
-  };
 
   meta = with stdenv.lib; {
     description = "Simple dual screen pdf presentation software";


### PR DESCRIPTION
###### Motivation for this change

Updating to the latest version.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
