### PR TITLE
curseofwar,curseofwar-sdl: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/games/curseofwar/default.nix
+++ b/pkgs/games/curseofwar/default.nix
@@ -1,27 +1,19 @@
 { stdenv
 , fetchFromGitHub
-, fetchpatch
 , ncurses
 , SDL
 }:
 
 stdenv.mkDerivation rec {
   pname = "curseofwar";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "a-nikolaev";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1bj3lv5vrnwzzkgj31pyf1lzkz10qphvzlfz7a3j4plqkczjq92y";
+    sha256 = "1wd71wdnj9izg5d95m81yx3684g4zdi7fsy0j5wwnbd9j34ilz1i";
   };
-
-  patches = [(fetchpatch {
-    # Pull request #40: https://github.com/a-nikolaev/curseofwar/pull/40
-    name = "prefix-independent-data";
-    url = "https://github.com/fgaz/curseofwar/commit/947dea527b2bf4c6e107b8e9c66f4c4fd775b6f9.patch";
-    sha256 = "0ak5igaxmbavkbl8101xx6gswhwgzm5f6wyplwapgh7cylnclc61";
-  })];
 
   buildInputs = [
     ncurses

--- a/pkgs/games/curseofwar/default.nix
+++ b/pkgs/games/curseofwar/default.nix
@@ -20,7 +20,11 @@ stdenv.mkDerivation rec {
     SDL
   ];
 
-  makeFlags = (if isNull SDL then [] else [ "SDL=yes" ]) ++ [ "PREFIX=$(out)" ];
+  makeFlags = (if isNull SDL then [] else [ "SDL=yes" ]) ++ [
+    "PREFIX=$(out)"
+    # force platform's cc on darwin, otherwise gcc is used
+    "CC=${stdenv.cc.targetPrefix}cc"
+  ];
 
   meta = with stdenv.lib; {
     description = "A fast-paced action strategy game";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
