### PR TITLE
gama: init at 2.09

### DIFF
--- a/pkgs/applications/science/geometry/gama/default.nix
+++ b/pkgs/applications/science/geometry/gama/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, lib, expat, octave, libxml2, texinfo }:
+stdenv.mkDerivation rec {
+  pname = "gama";
+  version = "2.09";
+
+  src = fetchurl {
+    url = "mirror://gnu/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "0c1b28frl6109arj09v4zr1xs859krn8871mkvis517g5pb55dc9";
+  };
+
+  buildInputs = [ expat ];
+
+  nativeBuildInputs = [ texinfo ];
+
+  checkInputs = [ octave libxml2 ];
+  doCheck = true;
+
+  meta = with lib ; {
+    description = "Tools for adjustment of geodetic networks";
+    homepage = "https://www.gnu.org/software/gama/";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -990,6 +990,8 @@ in
 
   gaia = callPackage ../development/libraries/gaia { };
 
+  gama = callPackage ../applications/science/geometry/gama { };
+
   gamecube-tools = callPackage ../development/tools/gamecube-tools { };
 
   gammy = qt5.callPackage ../tools/misc/gammy { };


### PR DESCRIPTION
###### Motivation for this change

Add GNU gama to nixpkgs.

See https://www.gnu/.org/software/gama/ for description

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
