### PR TITLE
stm32cubemx: 5.3.0 -> 5.6.1

### DIFF
--- a/pkgs/development/tools/misc/stm32cubemx/default.nix
+++ b/pkgs/development/tools/misc/stm32cubemx/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, requireFile, makeDesktopItem, libicns, imagemagick, zstd, jre }:
+{ stdenv, requireFile, makeDesktopItem, libicns, imagemagick, jre, fetchzip }:
 
 let
-  version = "5.3.0";
+  version = "5.6.1";
   desktopItem = makeDesktopItem {
     name = "stm32CubeMX";
     exec = "stm32cubemx";
@@ -14,32 +14,19 @@ stdenv.mkDerivation rec {
   pname = "stm32cubemx";
   inherit version;
 
-  src = requireFile rec {
-    name = "STM32CubeMX.tar.zst";
-    message = ''
-      Unfortunately, we cannot download file ${name} automatically.
-      Please proceed with the following steps to download and add it to the Nix
-      store yourself:
 
-      1. get en.STM32CubeMX_${builtins.replaceStrings ["."] ["-"] version}.zip
-      2. unzip en.STM32CubeMX_${builtins.replaceStrings ["."] ["-"] version}.zip
-      3. run the setup: java -jar SetupSTM32CubeMX-${version}.exe
-      4. create a tar from created folder: tar --zstd -cf ${name} STM32CubeMX
-      5. add the result to the store: nix-prefetch-url file://\$PWD/${name}
-
-      Notice: The setup will quit with an error about /bin/chmod
-    '';
-    sha256 = "1r5k5wmsvw1w2nfs3nb4gc6pb3j0x6bqljn9jzc4r8y5bxc34rr8";
+  src = fetchzip {
+    url = "https://sw-center.st.com/packs/resource/library/stm32cube_mx_v${builtins.replaceStrings ["."] [""] version}.zip";
+    sha256 = "1y4a340wcjl88kjw1f1x85ffp4b5g1psryn9mgkd717w2bfpf29l";
+    stripRoot= false;
   };
 
-  nativeBuildInputs = [ libicns imagemagick zstd ];
+  nativeBuildInputs = [ libicns imagemagick ];
 
   buildCommand = ''
-    mkdir -p $out/{bin,opt,share/applications}
-
-    tar --extract --zstd --file $src --directory $out/opt/
+    mkdir -p $out/{bin,opt/STM32CubeMX,share/applications}
+    cp -r $src/. $out/opt/STM32CubeMX/
     chmod +rx $out/opt/STM32CubeMX/STM32CubeMX.exe
-
     cat << EOF > $out/bin/${pname}
     #!${stdenv.shell}
     ${jre}/bin/java -jar $out/opt/STM32CubeMX/STM32CubeMX.exe
@@ -63,7 +50,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = ''
+    description = "A graphical tool for configuring STM32 microcontrollers and microprocessors";
+    longDescription = ''
       A graphical tool that allows a very easy configuration of STM32
       microcontrollers and microprocessors, as well as the generation of the
       corresponding initialization C code for the Arm® Cortex®-M core or a


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Updates the package and removes the manual build steps
Alternative to #90254

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
