### PR TITLE
scons: 4.0.0 -> 4.0.1

### DIFF
--- a/pkgs/development/tools/build-managers/scons/common.nix
+++ b/pkgs/development/tools/build-managers/scons/common.nix
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication rec {
       --replace "build/dist" "dist"
   '';
 
-  # TODO: "Invalid SConscript usage - no parameters":
+  # The release tarballs don't contain any tests (runtest.py and test/*):
   doCheck = lib.versionOlder version "4.0.0";
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/build-managers/scons/default.nix
+++ b/pkgs/development/tools/build-managers/scons/default.nix
@@ -12,7 +12,7 @@ in {
     sha256 = "1yzq2gg9zwz9rvfn42v5jzl3g4qf1khhny6zfbi2hib55zvg60bq";
   }).override { python3Packages = python2Packages; };
   scons_latest = mkScons {
-    version = "4.0.0";
-    sha256 = "1ikw5lh0h206xd74g39jdlrcicb18jj3j80hvm4nbrfgxv1hvibc";
+    version = "4.0.1";
+    sha256 = "0z00l9wzaiqyjq0hapbvsjclvcfjjjq04kmxi7ffq966nl2d2bkj";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`nixpkgs-review` result (failures are unrelated):
```
17 package updated:
bombono d1x-rebirth-full d2x-rebirth-full dxx-rebirth dxx-rebirth dxx-rebirth endless-sky fceux-unstable gambatte godot goxel hammer-e7aa734 mariadb-galera rmlint scons (4.0.0 → 4.0.1) the-powder-toy xsettingsd

2 package failed to build:
d1x-rebirth-full d2x-rebirth-full

13 package built:
bombono d1x_rebirth endless-sky fceux gambatte godot goxel hammer mariadb-galera rmlint scons the-powder-toy xsettingsd
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
