### PR TITLE
nixos/speechd: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -219,6 +219,7 @@
   ./services/audio/slimserver.nix
   ./services/audio/snapserver.nix
   ./services/audio/squeezelite.nix
+  ./services/audio/speechd.nix
   ./services/audio/spotifyd.nix
   ./services/audio/ympd.nix
   ./services/backup/automysqlbackup.nix

--- a/nixos/modules/services/audio/speechd.nix
+++ b/nixos/modules/services/audio/speechd.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.speechd;
+#  configDir = pkgs.writeTextDir "pdns.conf" "${cfg.extraConfig}";
+in {
+  options = {
+    services.speechd = {
+      enable = mkEnableOption "Speech-Dispatcher";
+
+#      extraConfig = mkOption {
+#        type = types.lines;
+#        default = "launch=bind";
+#        description = ''
+#          Extra lines to be added verbatim to the config file.
+#        '';
+#      };
+
+    };
+  };
+
+  config = mkIf config.services.speechd.enable {
+    systemd = {
+      packages = [ pkgs.speechd ];
+
+#      services.pdns = {
+#        wantedBy = [ "multi-user.target" ];
+#        serviceConfig = {
+#          ExecStart = [
+ #           ""
+#            "${pkgs.powerdns}/bin/pdns_server --guardian=no --daemon=no --disable-syslog --log-timestamp=no --write-pid=no --config-dir=${configDir}"
+#          ];
+#        };
+        
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/39500

This might be a start. I need a test system next to install nixos from this PR.

I'm not sure yet how speechd works at all.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
