### PR TITLE
convos: fix tests

### DIFF
--- a/pkgs/applications/networking/irc/convos/default.nix
+++ b/pkgs/applications/networking/irc/convos/default.nix
@@ -32,16 +32,26 @@ perlPackages.buildPerlPackage rec {
     patchShebangs script/convos
   '';
 
-  # A test fails since gethostbyaddr(127.0.0.1) fails to resolve to localhost in
-  # the sandbox, we replace the this out from a substitution expression
-  #
-  # Module::Install is a runtime dependency not covered by the tests, so we add
-  # a test for it.
-  #
   preCheck = ''
+    # A test fails since gethostbyaddr(127.0.0.1) fails to resolve to localhost in
+    # the sandbox, we replace the this out from a substitution expression
+    #
     substituteInPlace t/web-register-open-to-public.t \
       --replace '!127.0.0.1!' '!localhost!'
 
+    # Time-impurity in test, (fixed in master)
+    #
+    substituteInPlace t/web-load-user.t \
+      --replace '400' '410'
+
+    # Disk-space check fails on zfs, (fixed in master)
+    #
+    substituteInPlace t/web-admin.t \
+      --replace 'qr{/dev/}' 'qr{\w}'
+
+    # Module::Install is a runtime dependency not covered by the tests, so we add
+    # a test for it.
+    #
     echo "use Test::More tests => 1;require_ok('Module::Install')" \
       > t/00_nixpkgs_module_install.t
   '';


### PR DESCRIPTION
- Patch for time() dependent test started to fail after 1594263232.
- Patch for disk space test that fails on zfs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
