### PR TITLE
petsc: Fix install_name_tool patch

### DIFF
--- a/pkgs/development/libraries/science/math/petsc/default.nix
+++ b/pkgs/development/libraries/science/math/petsc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv , fetchurl , blas , gfortran , lapack , python }:
+{ stdenv , darwin , fetchurl , blas , gfortran , lapack , python }:
 
 stdenv.mkDerivation rec {
   pname = "petsc";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
       --replace /bin/sh /usr/bin/python
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace config/install.py \
-      --replace /usr/bin/install_name_tool install_name_tool
+      --replace /usr/bin/install_name_tool ${darwin.cctools}/bin/install_name_tool
   '';
 
   preConfigure = ''


### PR DESCRIPTION
The PETSc library's config/install.py script checks whether
/usr/bin/install_name_tool is an existing file:

https://gitlab.com/petsc/petsc/-/blob/master/config/install.py#L368

Therefore, it is not enough to replace it with something that we expect
to be on the PATH, as this will cause the linked if statement to be
silently skipped. The consequence is that applications linked against
this version of petsc will fail at runtime on MacOS with a dynamic
loading error.

Instead, we should replace install_name_tool with the absolute path of a
binary we know will be present at build time.

Note that this should be fixed upstream as well, but this is sufficient
to fix the runtime error.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
