### PR TITLE
sortmerna: 3.0.3 -> 4.2.0

### DIFF
--- a/pkgs/applications/science/biology/sortmerna/default.nix
+++ b/pkgs/applications/science/biology/sortmerna/default.nix
@@ -2,31 +2,38 @@
 
 stdenv.mkDerivation rec {
   pname = "sortmerna";
-  version = "3.0.3";
+  version = "4.2.0";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "biocore";
     rev = "v${version}";
-    sha256 = "0zx5fbzyr8wdr0zwphp8hhcn1xz43s5lg2ag4py5sv0pv5l1jh76";
+    sha256 = "0r91viylzr069jm7kpcgb45kagvf8sqcj5zc1af4arl9sgfs1f3j";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "CMakeInstallPrefix.patch";
-      url = "https://github.com/biocore/sortmerna/commit/4d36d620a3207e26cf3f588d4ec39889ea21eb79.patch";
-      sha256 = "0hc3jwdr6ylbyigg52q8islqc0mb1k8rrjadvjfqaxnili099apd";
-    })
-  ];
-
-  nativeBuildInputs = [ cmake rapidjson pkgconfig ];
+  nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ zlib rocksdb rapidjson ];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
-    "-DROCKSDB_HOME=${rocksdb}"
+    "-DPORTABLE=off"
     "-DRAPIDJSON_HOME=${rapidjson}"
+    "-DROCKSDB_HOME=${rocksdb}"
+    "-DROCKSDB_STATIC=off"
+    "-DZLIB_STATIC=off"
   ];
+
+  postPatch = ''
+    # Fix formatting string error:
+    # https://github.com/biocore/sortmerna/issues/255
+    substituteInPlace src/sortmerna/indexdb.cpp \
+      --replace 'is_verbose, ss' 'is_verbose, "%s", ss'
+
+    # Fix missing pthread dependency for the main binary.
+    substituteInPlace src/sortmerna/CMakeLists.txt \
+      --replace "target_link_libraries(sortmerna" \
+        "target_link_libraries(sortmerna Threads::Threads"
+  '';
 
   meta = with stdenv.lib; {
     description = "Tools for filtering, mapping, and OTU-picking from shotgun genomics data";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Fixes build against rocksdb 6.10.2
- Use dynamic rocksdb and zlib libraries
- Build a dynamic binary

I don't know anything about sorting RNA, so all I can do is checking that the binary runs ;).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc: @prusnak 