### PR TITLE
mediatomb: Improve service + add gerbera support and tests

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -226,7 +226,30 @@ GRANT ALL PRIVILEGES ON *.* TO 'mysql'@'localhost' WITH GRANT OPTION;
        <filename>testing-python.nix</filename> respectively.
      </para>
    </listitem>
-  </itemizedlist>
+   <listitem>
+     <para>
+       The <link linked="opt-services.mediatomb">mediatomb service</link>
+       declares new options. It also adapts existing options so the
+       configuration generation is now lazy. The existing option
+       <literal>customCfg</literal> (defaults to false), when enabled, stops
+       the service configuration generation completely. It then expects the
+       users to provide their own correct configuration at the right location
+       (whereas the configuration was generated and not used at all before).
+       The new option <literal>transcodingOption</literal> (defaults to no)
+       allows a generated configuration. It makes the mediatomb service pulls
+       the necessary runtime dependencies in the nix store (whereas it was
+       generated with hardcoded values before). The new option
+       <literal>mediaDirectories</literal> allows the users to declare autoscan
+       media directories from their nixos configuration:
+       <programlisting>
+       services.mediatomb.mediaDirectories = [
+         { path = "/var/lib/mediatomb/pictures"; recursive = false; hidden-files = false; }
+         { path = "/var/lib/mediatomb/audio"; recursive = true; hidden-files = false; }
+       ];
+       </programlisting>
+    </para>
+   </listitem>
+ </itemizedlist>
  </section>
 
  <section xmlns="http://docbook.org/ns/docbook"
@@ -863,6 +886,23 @@ CREATE ROLE postgres LOGIN SUPERUSER;
       </listitem>
      </itemizedlist>
     </para>
+   <listitem>
+     <para>
+       The <link linked="opt-services.mediatomb">mediatomb service</link> is
+       now using by default the new and maintained fork
+       <literal>gerbera</literal> package instead of the unmaintained
+       <literal>mediatomb</literal> package. If you want to keep the old
+       behavior, you must declare it with:
+       <programlisting>
+       services.mediatomb.package = pkgs.mediatomb;
+       </programlisting>
+       One new option <literal>openFirewall<literal> has been introduced which
+       defaults to false. If you relied on the service declaration to add the
+       firewall rules itself before, you should now declare it with:
+       <programlisting>
+       services.mediatomb.openFirewall = true;
+       </programlisting>
+     </para>
    </listitem>
   </itemizedlist>
  </section>

--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -66,9 +66,8 @@ let
 '';
 
   configText = optionalString (! cfg.customCfg) ''
-  <?xml version="1.0" encoding="UTF-8"?>
-  <config version="2" xmlns="http://mediatomb.cc/config/2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://mediatomb.cc/config/2 http://mediatomb.cc/config/2.xsd">
-    <interface>${cfg.interface}</interface>
+<?xml version="1.0" encoding="UTF-8"?>
+<config version="2" xmlns="http://mediatomb.cc/config/2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://mediatomb.cc/config/2 http://mediatomb.cc/config/2.xsd">
     <server>
       <ui enabled="yes" show-tooltips="yes">
         <accounts enabled="no" session-timeout="30">
@@ -268,16 +267,19 @@ in {
       };
 
       user = mkOption {
+        type = types.str;
         default = "mediatomb";
         description = "User account under which ${name} runs.";
       };
 
       group = mkOption {
+        type = types.str;
         default = "mediatomb";
         description = "Group account under which ${name} runs.";
       };
 
       port = mkOption {
+        type = types.int;
         default = 49152;
         description = ''
           The network port to listen on.
@@ -285,6 +287,7 @@ in {
       };
 
       interface = mkOption {
+        type = types.str;
         default = "";
         description = ''
           A specific interface to bind to.
@@ -292,6 +295,7 @@ in {
       };
 
       uuid = mkOption {
+        type = types.str;
         default = "fdfc8a4e-a3ad-4c1d-b43d-a2eedb03a687";
         description = ''
           A unique (on your network) to identify the server by.
@@ -335,7 +339,7 @@ in {
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig.ExecStart = "${binaryCommand} --port ${toString cfg.port} ${interfaceFlag} ${configFlag} --home ${cfg.dataDir}";
-      serviceConfig.User = "${cfg.user}";
+      serviceConfig.User = cfg.user;
     };
 
     users.groups = optionalAttrs (cfg.group == "mediatomb") {
@@ -346,7 +350,7 @@ in {
       mediatomb = {
         isSystemUser = true;
         group = cfg.group;
-        home = "${cfg.dataDir}";
+        home = cfg.dataDir;
         createHome = true;
         description = "${name} DLNA Server User";
       };

--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -57,13 +57,14 @@ let
       <home>${cfg.dataDir}</home>
       <interface>${cfg.interface}</interface>
       <webroot>${pkg}/share/${name}/web</webroot>
+      <pc-directory upnp-hide="${optionYesNo cfg.pcDirectoryHide}"/>
       <storage>
         <sqlite3 enabled="yes">
           <database-file>${name}.db</database-file>
         </sqlite3>
       </storage>
       <protocolInfo extend="${optionYesNo cfg.ps3Support}"/>
-      ${lib.optionalString cfg.dsmSupport ''
+      ${optionalString cfg.dsmSupport ''
       <custom-http-headers>
         <add header="X-User-Agent: redsonic"/>
       </custom-http-headers>
@@ -229,6 +230,14 @@ in {
         default = "/var/lib/${name}";
         description = ''
           The directory where ${cfg.serverName} stores its state, data, etc.
+        '';
+      };
+
+      pcDirectoryHide = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to list the top-level directory or not (from upnp client standpoint).
         '';
       };
 

--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -9,6 +9,38 @@ let
   name = cfg.package.pname;
   pkg = cfg.package;
   optionYesNo = option: if option then "yes" else "no";
+  transcodingConfig = if cfg.transcoding then with pkgs; ''
+    <transcoding enabled="yes">
+      <mimetype-profile-mappings>
+        <transcode mimetype="video/x-flv" using="vlcmpeg" />
+        <transcode mimetype="application/ogg" using="vlcmpeg" />
+        <transcode mimetype="audio/ogg" using="ogg2mp3" />
+        <transcode mimetype="audio/x-flac" using="oggflac2raw"/>
+      </mimetype-profile-mappings>
+      <profiles>
+        <profile name="ogg2mp3" enabled="no" type="external">
+          <mimetype>audio/mpeg</mimetype>
+          <accept-url>no</accept-url>
+          <first-resource>yes</first-resource>
+          <accept-ogg-theora>no</accept-ogg-theora>
+          <agent command="${ffmpeg}/bin/ffmpeg" arguments="-y -i %in -f mp3 %out" />
+          <buffer size="1048576" chunk-size="131072" fill-size="262144" />
+        </profile>
+        <profile name="vlcmpeg" enabled="no" type="external">
+          <mimetype>video/mpeg</mimetype>
+          <accept-url>yes</accept-url>
+          <first-resource>yes</first-resource>
+          <accept-ogg-theora>yes</accept-ogg-theora>
+          <agent command="${libsForQt5.vlc}/bin/vlc"
+            arguments="-I dummy %in --sout #transcode{venc=ffmpeg,vcodec=mp2v,vb=4096,fps=25,aenc=ffmpeg,acodec=mpga,ab=192,samplerate=44100,channels=2}:standard{access=file,mux=ps,dst=%out} vlc:quit" />
+          <buffer size="14400000" chunk-size="512000" fill-size="120000" />
+        </profile>
+      </profiles>
+    </transcoding>
+'' else ''
+    <transcoding enabled="no">
+    </transcoding>
+'';
 
   mtConf = pkgs.writeText "config.xml" ''
   <?xml version="1.0" encoding="UTF-8"?>
@@ -121,37 +153,11 @@ let
         </YouTube>
       </online-content>
     </import>
-    <transcoding enabled="${if cfg.transcoding then "yes" else "no"}">
-      <mimetype-profile-mappings>
-        <transcode mimetype="video/x-flv" using="vlcmpeg"/>
-        <transcode mimetype="application/ogg" using="vlcmpeg"/>
-        <transcode mimetype="application/ogg" using="oggflac2raw"/>
-        <transcode mimetype="audio/x-flac" using="oggflac2raw"/>
-      </mimetype-profile-mappings>
-      <profiles>
-        <profile name="oggflac2raw" enabled="no" type="external">
-          <mimetype>audio/L16</mimetype>
-          <accept-url>no</accept-url>
-          <first-resource>yes</first-resource>
-          <accept-ogg-theora>no</accept-ogg-theora>
-          <agent command="ogg123" arguments="-d raw -o byteorder:big -f %out %in"/>
-          <buffer size="1048576" chunk-size="131072" fill-size="262144"/>
-        </profile>
-        <profile name="vlcmpeg" enabled="no" type="external">
-          <mimetype>video/mpeg</mimetype>
-          <accept-url>yes</accept-url>
-          <first-resource>yes</first-resource>
-          <accept-ogg-theora>yes</accept-ogg-theora>
-          <agent command="vlc" arguments="-I dummy %in --sout #transcode{venc=ffmpeg,vcodec=mp2v,vb=4096,fps=25,aenc=ffmpeg,acodec=mpga,ab=192,samplerate=44100,channels=2}:standard{access=file,mux=ps,dst=%out} vlc:quit"/>
-          <buffer size="14400000" chunk-size="512000" fill-size="120000"/>
-        </profile>
-      </profiles>
-    </transcoding>
+    ${transcodingConfig}
   </config>
-  '';
+'';
 
 in {
-
 
   ###### interface
 

--- a/nixos/tests/mediatomb.nix
+++ b/nixos/tests/mediatomb.nix
@@ -14,14 +14,11 @@ import ./make-test-python.nix ({ pkgs, ... }:
           serverName = "Gerbera";
           package = pkgs.gerbera;
           interface = "eth1";  # accessible from test
+          openFirewall = true;
           mediaDirectories = [
             { path = "/var/lib/gerbera/pictures"; recursive = false; hidden-files = false; }
             { path = "/var/lib/gerbera/audio"; recursive = true; hidden-files = false; }
           ];
-        };
-        networking.firewall = {
-          allowedUDPPorts = [ 1900 port ];
-          allowedTCPPorts = [ port ];
         };
       };
 
@@ -41,7 +38,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
             { path = "/var/lib/mediatomb/audio"; recursive = true; hidden-files = false; }
           ];
         };
-        networking.firewall = {
+        networking.firewall.interfaces.eth1 = {
           allowedUDPPorts = [ 1900 port ];
           allowedTCPPorts = [ port ];
         };

--- a/nixos/tests/mediatomb.nix
+++ b/nixos/tests/mediatomb.nix
@@ -1,0 +1,84 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+{
+  name = "mediatomb";
+
+  nodes = {
+    serverGerbera =
+      { ... }:
+      let port = 49152;
+      in {
+        imports = [ ../modules/profiles/minimal.nix ];
+        services.mediatomb = {
+          enable = true;
+          serverName = "Gerbera";
+          package = pkgs.gerbera;
+          interface = "eth1";  # accessible from test
+          mediaDirectories = [
+            { path = "/var/lib/gerbera/pictures"; recursive = false; hidden-files = false; }
+            { path = "/var/lib/gerbera/audio"; recursive = true; hidden-files = false; }
+          ];
+        };
+        networking.firewall = {
+          allowedUDPPorts = [ 1900 port ];
+          allowedTCPPorts = [ port ];
+        };
+      };
+
+    serverMediatomb =
+      { ... }:
+      let port = 49151;
+      in {
+        imports = [ ../modules/profiles/minimal.nix ];
+        services.mediatomb = {
+          enable = true;
+          serverName = "Mediatomb";
+          package = pkgs.mediatomb;
+          interface = "eth1";
+          inherit port;
+          mediaDirectories = [
+            { path = "/var/lib/mediatomb/pictures"; recursive = false; hidden-files = false; }
+            { path = "/var/lib/mediatomb/audio"; recursive = true; hidden-files = false; }
+          ];
+        };
+        networking.firewall = {
+          allowedUDPPorts = [ 1900 port ];
+          allowedTCPPorts = [ port ];
+        };
+      };
+
+      client = { ... }: { };
+  };
+
+  testScript =
+  ''
+    start_all()
+
+    port = 49151
+    serverMediatomb.succeed("mkdir -p /var/lib/mediatomb/{pictures,audio}")
+    serverMediatomb.succeed("chown -R mediatomb:mediatomb /var/lib/mediatomb")
+    serverMediatomb.wait_for_unit("mediatomb")
+    serverMediatomb.wait_for_open_port(port)
+    serverMediatomb.succeed(f"curl --fail http://serverMediatomb:{port}/")
+    page = client.succeed(f"curl --fail http://serverMediatomb:{port}/")
+    assert "MediaTomb" in page and "Gerbera" not in page
+    serverMediatomb.shutdown()
+
+    port = 49152
+    serverGerbera.succeed("mkdir -p /var/lib/mediatomb/{pictures,audio}")
+    serverGerbera.succeed("chown -R mediatomb:mediatomb /var/lib/mediatomb")
+    # service running gerbera fails the first time claiming something is already bound
+    # gerbera[715]: 2020-07-18 23:52:14   info: Please check if another instance of Gerbera or
+    # gerbera[715]: 2020-07-18 23:52:14   info: another application is running on port TCP 49152 or UDP 1900.
+    # I did not find anything so here I work around this
+    serverGerbera.succeed("sleep 2")
+    serverGerbera.wait_until_succeeds("systemctl restart mediatomb")
+    serverGerbera.wait_for_unit("mediatomb")
+    serverGerbera.succeed(f"curl --fail http://serverGerbera:{port}/")
+    page = client.succeed(f"curl --fail http://serverGerbera:{port}/")
+    assert "Gerbera" in page and "MediaTomb" not in page
+
+    serverGerbera.shutdown()
+    client.shutdown()
+  '';
+})


### PR DESCRIPTION
# Motivations

- Allow service to run with the most recent maintained mediatomb fork (gerbera)
- Add more configuration options (e.g. media directories to autoscan, ...)
- Leverage options to make the configuration lazy
- Fix `transcoding` option which if enabled installs the necessary dependencies to actually work
- Add tests to the service (there was none), testing scenario are:
  1. service runs with existing mediatomb package
  2. service runs with the new gerbera package
- Add types to existing service options which did not declare one
- Open a new option `openFirewall` (defaults to false) and improve the firewall declaration using it.
- Add release note (20.09) information about new options and breaking change (`openFirewall` off by default now)

# Actions

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (`Linux alderaan 5.7.7 #1-NixOS SMP Tue Jun 30 20:21:22 UTC 2020 x86_64 GNU/Linux`)
   - [ ] macOS
   - [x] other Linux distributions: debian with nix (`Linux yavin4 4.19.0-9-amd64 #1 SMP Debian 4.19.118-2+deb10u1 (2020-06-07) x86_64 GNU/Linux`)
- [x] Added tests as none existed
- [x] Tested compilation of all pkgs that depend on this: nixpkgs-review pr 93450
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

# Notes

I built the diff on the started works [1] [2]

[1] #82429 (apparently idle, asked but got no reply so i continued from it)

[2] #93226 (my own work about gerbera, merged now)

[4]

```
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0 pull/93450/head:refs/nixpkgs-review/1
$ git worktree add /home/tony/.cache/nixpkgs-review/pr-93450-4/nixpkgs 9fab6f9b2b2d8927d3984a7549ed4c56829d2065
Preparing worktree (detached HEAD 9fab6f9b2b2)
Updating files: 100% (22851/22851), done.
HEAD is now at 9fab6f9b2b2 Merge pull request #98823 from r-ryantm/auto-update/multimon-ng
$ nix-env -f /home/tony/.cache/nixpkgs-review/pr-93450-4/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit 2c4cf27d61b07dfbac3ffa73658471c8180eb972
Automatic merge went well; stopped before committing as requested
$ nix-env -f /home/tony/.cache/nixpkgs-review/pr-93450-4/nixpkgs -qaP --xml --out-path --show-trace --meta
Nothing to be built.
https://github.com/NixOS/nixpkgs/pull/93450
$ nix-shell /home/tony/.cache/nixpkgs-review/pr-93450-4/shell.nixnixpkgs-review pr 93450
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0 pull/93450/head:refs/nixpkgs-review/1
$ git worktree add /home/tony/.cache/nixpkgs-review/pr-93450-4/nixpkgs 9fab6f9b2b2d8927d3984a7549ed4c56829d2065
Preparing worktree (detached HEAD 9fab6f9b2b2)
Updating files: 100% (22851/22851), done.
HEAD is now at 9fab6f9b2b2 Merge pull request #98823 from r-ryantm/auto-update/multimon-ng
$ nix-env -f /home/tony/.cache/nixpkgs-review/pr-93450-4/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit 2c4cf27d61b07dfbac3ffa73658471c8180eb972
Automatic merge went well; stopped before committing as requested
$ nix-env -f /home/tony/.cache/nixpkgs-review/pr-93450-4/nixpkgs -qaP --xml --out-path --show-trace --meta
Nothing to be built.
https://github.com/NixOS/nixpkgs/pull/93450
$ nix-shell /home/tony/.cache/nixpkgs-review/pr-93450-4/shell.nix
```

Cheers,
