### PR TITLE
libappindicator: 12.10.0 -> 12.10.1+20.10.20200706.1

### DIFF
--- a/pkgs/development/libraries/libappindicator/default.nix
+++ b/pkgs/development/libraries/libappindicator/default.nix
@@ -1,11 +1,11 @@
 # TODO: Resolve the issues with the Mono bindings.
 
-{ stdenv, fetchurl, fetchpatch, lib
+{ stdenv, fetchgit, lib
 , pkgconfig, autoreconfHook
 , glib, dbus-glib, gtkVersion ? "3"
 , gtk2 ? null, libindicator-gtk2 ? null, libdbusmenu-gtk2 ? null
 , gtk3 ? null, libindicator-gtk3 ? null, libdbusmenu-gtk3 ? null
-, vala, gobject-introspection
+, gtk-doc, vala, gobject-introspection
 , monoSupport ? false, mono ? null, gtk-sharp-2_0 ? null
  }:
 
@@ -15,18 +15,17 @@ with lib;
 stdenv.mkDerivation rec {
   name = let postfix = if gtkVersion == "2" && monoSupport then "sharp" else "gtk${gtkVersion}";
           in "libappindicator-${postfix}-${version}";
-  version = "${versionMajor}.${versionMinor}";
-  versionMajor = "12.10";
-  versionMinor = "0";
+  version = "12.10.1+20.10.20200706.1";
 
   outputs = [ "out" "dev" ];
 
-  src = fetchurl {
-    url = "${meta.homepage}/${versionMajor}/${version}/+download/libappindicator-${version}.tar.gz";
-    sha256 = "17xlqd60v0zllrxp8bgq3k5a1jkj0svkqn8rzllcyjh8k0gpr46m";
+  src = fetchgit {
+    url = "https://git.launchpad.net/ubuntu/+source/libappindicator";
+    rev = "fe25e53bc7e39cd59ad6b3270cd7a6a9c78c4f44";
+    sha256 = "0xjvbl4gn7ra2fs6gn2g9s787kzb5cg9hv79iqsz949rxh4iw32d";
   };
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook vala gobject-introspection ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook vala gobject-introspection gtk-doc ];
 
   propagatedBuildInputs =
     if gtkVersion == "2"
@@ -39,14 +38,9 @@ stdenv.mkDerivation rec {
     then [ libindicator-gtk2 ] ++ optionals monoSupport [ mono gtk-sharp-2_0 ]
     else [ libindicator-gtk3 ]);
 
-  patches = [
-    # Remove python2 from libappindicator.
-    (fetchpatch {
-      name = "no-python.patch";
-      url = "https://src.fedoraproject.org/rpms/libappindicator/raw/8508f7a52437679fd95a79b4630373f08315f189/f/nopython.patch";
-      sha256 = "18b1xzvwsbhhfpbzf5zragij4g79pa04y1dk6v5ci1wsjvii725s";
-    })
-  ];
+  preAutoreconf = ''
+    gtkdocize
+  '';
 
   configureFlags = [
     "CFLAGS=-Wno-error"


### PR DESCRIPTION
This moves libappindicator to use a different upstream source. Rather
than use the 8 year old (!) version displayed on its homepage
(https://launchpad.net/libappindicator), this switches us to the
maintained lp:libappindicator branch, browseable over here:
https://code.launchpad.net/~indicator-applet-developers/libappindicator/trunk.

This includes numerous fixes, remains updated, and matches what ubuntu
uses.

Due to a personal preference for git over bzr, I have the package using
ubuntu's git mirror of the package for the source rather than the bzr
repo where I _think_ development actually takes place.

This also removes the no-python patch, because per revision 292
(https://bazaar.launchpad.net/~indicator-applet-developers/libappindicator/trunk/revision/292),
that has been dropped from upstream already, so the patch is no longer
needed.

The primary motivation behind this change is to fix a crash with
libappindicator (reported
https://bugs.launchpad.net/ubuntu/+source/libappindicator/+bug/1867996
and in various other places).

The relevant patch for that should be included in this version.

###### Motivation for this change

Fix crashes in libappindicator apps that have been fixed in the more-up-to-date upstream fork of libappindicator (maintained by canonical)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note: For "tested compilation of all packages", it did result in failures:

```
$ nixpkgs-review rev update-libappindicator
81 packages updated:
appimage-run audio-recorder autokey blueman caja-dropbox deltachat-electron devdocs-desktop discord discord-canary discord-ptb dropbox dropbox-cli elementary-greeter gitter gnome-control-center gromit-mpx gSpeech gxneur handbrake hubstaff indicator-application-gtk2 indicator-application-gtk3 irccloud joplin-desktop kazam keybase-gui ledger-live-desktop libappindicator-gtk2 (12.10.0 → 12.10.1+20.10.20200706.1) libappindicator (12.10.0 → 12.10.1+20.10.20200706.1) libappindicator-gtk3 (12.10.0 → 12.10.1+20.10.20200706.1) marktext-v0.16.2-binary mate-control-center mate-polkit meteo minetime minishift modem-manager-gui mullvad-vpn network-manager-applet notable obsidian pasystray Patchwork perl5.28.3-Gtk2-AppIndicator perl5.30.3-Gtk2-AppIndicator quodlibet-full quodlibet-xine-full radiotray-ng redshift redshift-plasma-applet redshift-wlr remmina runwayml safeeyes sc-controller shutter signal-desktop skypeforlinux skypeforlinux slack slack standardnotes station steam-run switchboard switchboard-plug-network Sylk syncthing-gtk syncthing-gtk syncthing-tray systrayhelper tusk-v0.23.0 udiskie uget uget-integrator ulauncher unityhub wingpanel wootility xflux-gui zulip


error: build of '/nix/store/3bx27pfs6410i1ali3lss3c8ch7cn834-env.drv' failed
22 packages failed to build:
Sylk appimage-run deltachat-electron devdocs-desktop irccloud joplin-desktop ledger-live-desktop marktext minetime notable obsidian quodlibet-full quodlibet-xine-full runwayml ssb-patchwork standardnotes station steam-run-native tusk unityhub wootility zulip
```

For those error packages, picking a random set to retry manually, I get that they're marked as broken due to a transitive dependency on a broken gst-plugins-base. For example:

```
nix-build -I . -E 'with import ./. {}; pkgs.zulip'
error: Package ‘gst-plugins-base-0.10.36’ in /home/esk/dev/nix/nixpkgs/pkgs/development/libraries/gstreamer/legacy/gst-plugins-base/default.nix:55 is marked as broken, refusing to evaluate.

a) For `nixos-rebuild` you can set
  { nixpkgs.config.allowBroken = true; }
in configuration.nix to override this.
```
I didn't see a clean way to exaustively verify all of them were broken in that same way, but the ones I sampled were.
