### PR TITLE
sgtk-menu: init at 1.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9139,4 +9139,10 @@
     github = "deifactor";
     githubId = 30192992;
   };
+  berbiche = {
+    name = "Nicolas Berbiche";
+    email = "nicolas@normie.dev";
+    github = "berbiche";
+    githubId = 20448408;
+  };
 }

--- a/pkgs/applications/misc/sgtk-menu/default.nix
+++ b/pkgs/applications/misc/sgtk-menu/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, buildPythonApplication, wrapGAppsHook
+, gobject-introspection, gtk3, gdk-pixbuf, librsvg, glib
+, setuptools, pango, pygobject3, pycairo
+}:
+
+buildPythonApplication rec {
+  pname = "sgtk-menu";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "nwg-piotr";
+    repo = "sgtk-menu";
+    rev = "v${version}";
+    sha256 = "1b5bp0ln493c8y63hx0dywjbv4k7z2qgdiy89c99mxdpznb0g3bd";
+  };
+
+  # Tests read files in $HOME/.config
+  doCheck = false;
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  buildInputs = [ gtk3 gobject-introspection librsvg gdk-pixbuf glib ];
+
+  propagatedBuildInputs = [ setuptools pygobject3 pycairo ];
+
+  # Required for librsvg & gdk-pixbuf to work
+  strictDeps = false;
+
+  meta = with stdenv.lib; {
+    description = "A themeable, searchable, gtk3-based system launcher.";
+    homepage = "https://github.com/nwg-piotr/sgtk-menu";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ berbiche ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20460,6 +20460,8 @@ in
   swaylock = callPackage ../applications/window-managers/sway/lock.nix { };
   sway-contrib = recurseIntoAttrs (callPackages ../applications/window-managers/sway/contrib.nix { });
 
+  sgtk-menu = python3Packages.callPackage ../applications/misc/sgtk-menu { };
+
   swaylock-fancy = callPackage ../applications/window-managers/sway/lock-fancy.nix { };
 
   swaylock-effects = callPackage ../applications/window-managers/sway/lock-effects.nix { };


### PR DESCRIPTION
###### Motivation for this change

Packages sgtk-menu. Fixes #78370.

The wiki mentions the package `python-pynput` is needed to spawn the widget at the pointer location but `python-pynput` is not currently packaged.

cc @eoli3n if you want to test this out.

When testing the program, right clicks made `sgtk-grid` exit successfully without launching any application.
I don't know whether this is intended behavior since I've never used the program before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
