### PR TITLE
python3Packages.HAP-python: 2.8.1 -> 2.9.2

### DIFF
--- a/pkgs/development/python-modules/HAP-python/default.nix
+++ b/pkgs/development/python-modules/HAP-python/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "HAP-python";
-  version = "2.8.1";
+  version = "2.9.2";
 
   # pypi package does not include tests
   src = fetchFromGitHub {
     owner = "ikalchev";
     repo = pname;
     rev = "v${version}";
-    sha256 = "182s3dk7y29wql9bazlnw840xqgsbr44ad72m668qgxd82jl6y9c";
+    sha256 = "1d2ji2psla7jq3f9grb0l665nf8qsy2rlbkr2qg1d1a7mvf80x7k";
   };
 
   disabled = !isPy3k;
@@ -34,6 +34,7 @@ buildPythonPackage rec {
     and not test_send_events \
     and not test_not_standalone_aid \
     and not test_start_stop_async_acc \
+    and not test_external_zeroconf \
     and not test_start_stop_sync_acc'
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release, also includes one new testcase trying to access the network, therefore needs to be ignored 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
