### PR TITLE
watson: 1.9.0 -> 1.10.0

### DIFF
--- a/pkgs/applications/office/watson/default.nix
+++ b/pkgs/applications/office/watson/default.nix
@@ -1,26 +1,17 @@
-{ stdenv, fetchFromGitHub, pythonPackages, fetchpatch, installShellFiles }:
+{ stdenv, fetchFromGitHub, pythonPackages, installShellFiles }:
 
 with pythonPackages;
 
 buildPythonApplication rec {
   pname = "watson";
-  version = "1.9.0";
+  version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "TailorDev";
     repo = "Watson";
     rev = version;
-    sha256 = "0f0ldwadjf0xncx3m4w4wwqddd4wjwcsrbhby8vgsnqsn48dnfcx";
+    sha256 = "1s0k86ldqky6avwjaxkw1y02wyf59qwqldcahy3lhjn1b5dgsb3s";
   };
-
-  patches = [
-    # https://github.com/TailorDev/Watson/pull/380
-    # The nixpkgs' arrow version is too new / not supported by Watson's latest release.
-    (fetchpatch {
-      url = "https://github.com/TailorDev/Watson/commit/69b9ad25551525d52060f7fb2eef3653e872a455.patch";
-      sha256 = "0zrswgr0y219f92zi41m7cymfaspkhmlada4v9ijnsjjdb4bn2c9";
-    })
-  ];
 
   checkPhase = ''
     pytest -vs tests
@@ -39,6 +30,6 @@ buildPythonApplication rec {
     homepage = "https://tailordev.github.io/Watson/";
     description = "A wonderful CLI to track your time!";
     license = licenses.mit;
-    maintainers = with maintainers; [ mguentner nathyong ];
+    maintainers = with maintainers; [ mguentner nathyong geistesk ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update watson to its latest release version 1.10.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
