### PR TITLE
pytmx: 3.21.7 -> 3.22.0

### DIFF
--- a/pkgs/development/python-modules/pytmx/default.nix
+++ b/pkgs/development/python-modules/pytmx/default.nix
@@ -2,26 +2,20 @@
 
 buildPythonPackage rec {
   pname = "pytmx";
-  version = "3.21.7";
+  version = "3.22.0";
 
   src = fetchFromGitHub {
     # The release was not git tagged.
     owner = "bitcraft";
     repo = "PyTMX";
-    rev = "38519b94ab9a2db7cacb8e18de4d83750ec6fac2";
-    sha256 = "0p2gc6lgian1yk4qvhbkxfkmndf9ras70amigqzzwr02y2jvq7j8";
+    rev = "187fd429dadcdc5828e78e6748a983aa1434e4d2";
+    sha256 = "0480pr61v54bwdyzb983sk0fqkyfbcgrdn8k11yf1yck4zb119gc";
   };
 
   propagatedBuildInputs = [ pygame pyglet pysdl2 six ];
 
-  # The tests are failing for Python 2.7.
-  doCheck = isPy3k;
   checkPhase = ''
-    # The following test imports an example file from the current working
-    # directory. Thus, we're cd'ing into the test directory.
-
-    cd tests/
-    python -m unittest test_pytmx
+    python -m unittest tests.pytmx.test_pytmx
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Next to the version bump, this fixes the test for Python 2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
