### PR TITLE
play-with-mpv: init at 2020-05-18

### DIFF
--- a/pkgs/tools/video/play-with-mpv/default.nix
+++ b/pkgs/tools/video/play-with-mpv/default.nix
@@ -2,7 +2,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "play-with-mpv";
-  version = "2020-05-18";
+  version = "unstable-2020-05-18";
 
   src = fetchFromGitHub {
       owner = "thann";
@@ -19,7 +19,7 @@ python3Packages.buildPythonApplication rec {
   nativeBuildInputs = [ git ];
   propagatedBuildInputs = [ youtube-dl ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace setup.py --replace \
     '"https://github.com/thann/install_freedesktop/tarball/master#egg=install_freedesktop-0.2.0"' \
     '"file://${install_freedesktop}#egg=install_freedesktop-0.2.0"'

--- a/pkgs/tools/video/play-with-mpv/default.nix
+++ b/pkgs/tools/video/play-with-mpv/default.nix
@@ -1,5 +1,11 @@
 { lib, python3Packages, fetchFromGitHub, fetchurl, youtube-dl, git }:
 
+let
+  install_freedesktop = fetchurl {
+    url = "https://github.com/thann/install_freedesktop/tarball/2673e8da4a67bee0ffc52a0ea381a541b4becdd4";
+    sha256 = "0j8d5jdcyqbl5p6sc1ags86v3hr2sghmqqi99d1mvc064g90ckrv";
+  };
+in
 python3Packages.buildPythonApplication rec {
   pname = "play-with-mpv";
   version = "unstable-2020-05-18";
@@ -9,11 +15,6 @@ python3Packages.buildPythonApplication rec {
       repo = "play-with-mpv";
       rev = "656448e03fe9de9e8bd21959f2a3b47c4acb8c3e";
       sha256 = "1qma8b3lnkdhxdjsnrq7n9zgy53q62j4naaqqs07kjxbn72zb4p4";
-  };
-
-  install_freedesktop = fetchurl {
-    url = "https://github.com/thann/install_freedesktop/tarball/2673e8da4a67bee0ffc52a0ea381a541b4becdd4";
-    sha256 = "0j8d5jdcyqbl5p6sc1ags86v3hr2sghmqqi99d1mvc064g90ckrv";
   };
 
   nativeBuildInputs = [ git ];

--- a/pkgs/tools/video/play-with-mpv/default.nix
+++ b/pkgs/tools/video/play-with-mpv/default.nix
@@ -1,0 +1,34 @@
+{ lib, python3Packages, fetchFromGitHub, fetchurl, youtube-dl, git }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "play-with-mpv";
+  version = "2020-05-18";
+
+  src = fetchFromGitHub {
+      owner = "thann";
+      repo = "play-with-mpv";
+      rev = "656448e03fe9de9e8bd21959f2a3b47c4acb8c3e";
+      sha256 = "1qma8b3lnkdhxdjsnrq7n9zgy53q62j4naaqqs07kjxbn72zb4p4";
+  };
+
+  install_freedesktop = fetchurl {
+    url = "https://github.com/thann/install_freedesktop/tarball/2673e8da4a67bee0ffc52a0ea381a541b4becdd4";
+    sha256 = "0j8d5jdcyqbl5p6sc1ags86v3hr2sghmqqi99d1mvc064g90ckrv";
+  };
+
+  nativeBuildInputs = [ git ];
+  propagatedBuildInputs = [ youtube-dl ];
+
+  patchPhase = ''
+    substituteInPlace setup.py --replace \
+    '"https://github.com/thann/install_freedesktop/tarball/master#egg=install_freedesktop-0.2.0"' \
+    '"file://${install_freedesktop}#egg=install_freedesktop-0.2.0"'
+  '';
+
+  meta = with lib; {
+    description = "Chrome extension and python server that allows you to play videos in webpages with MPV instead";
+    homepage = "https://github.com/Thann/play-with-mpv";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dawidsowa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1102,6 +1102,8 @@ in
 
   pebble = callPackage ../tools/admin/pebble { };
 
+  play-with-mpv = callPackage ../tools/video/play-with-mpv { };
+
   reattach-to-user-namespace = callPackage ../os-specific/darwin/reattach-to-user-namespace {};
 
   skhd = callPackage ../os-specific/darwin/skhd {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds [play-with-mpv](https://github.com/Thann/play-with-mpv), which allows using [this extension](https://chrome.google.com/webstore/detail/play-with-mpv/hahklcmnfgffdlchjigehabfbiigleji?hl=pl).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
