### PR TITLE
break-time: init at 0.1.1

### DIFF
--- a/pkgs/applications/misc/break-time/default.nix
+++ b/pkgs/applications/misc/break-time/default.nix
@@ -1,0 +1,45 @@
+{ fetchFromGitHub
+, glib
+, gtk3
+, openssl
+, pkg-config
+, python3
+, rustPlatform
+, stdenv
+, wrapGAppsHook
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "break-time";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "cdepillabout";
+    repo  = "break-time";
+    rev = "v${version}";
+    sha256 = "18p9gfp0inbnjsc7af38fghyklr7qnl2kkr25isfy9d5m8cpxqc6";
+  };
+
+  cargoSha256 = "0brmgrxhspcpcarm4lvnl95dw2n96r20w736giv18xcg7d5jmgca";
+
+  nativeBuildInputs = [
+    pkg-config
+    python3 # needed for Rust xcb package
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    openssl
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Break timer that forces you to take a break";
+    homepage    = "https://github.com/cdepillabout/break-time";
+    license     = with licenses; [ mit ];
+    maintainers = with maintainers; [ cdepillabout ];
+    platforms   = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19166,6 +19166,8 @@ in
 
   brave = callPackage ../applications/networking/browsers/brave { };
 
+  break-time = callPackage ../applications/misc/break-time { };
+
   breezy = with python3Packages; toPythonApplication breezy;
 
   notmuch-bower = callPackage ../applications/networking/mailreaders/notmuch-bower { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds [`break-time`](https://github.com/cdepillabout/break-time/), an app that forces you to take breaks from your computer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
