### PR TITLE
moodle: fix typo

### DIFF
--- a/pkgs/servers/web-apps/moodle/moodle-utils.nix
+++ b/pkgs/servers/web-apps/moodle/moodle-utils.nix
@@ -5,7 +5,7 @@ let
     name,
     src,
     pluginType,
-    configuraPhase ? ":",
+    configurePhase ? ":",
     buildPhase ? ":",
     buildInputs ? [ ],
     ...
@@ -14,7 +14,7 @@ let
     name = name;
 
     inherit pluginType;
-    inherit configuraPhase buildPhase;
+    inherit configurePhase buildPhase;
 
     buildInputs = [ unzip ] ++ buildInputs;
 


### PR DESCRIPTION
###### Motivation for this change

Fix typo introduced in b6eca9a2afa143bcbee3b4ae1bdc13993bc71784
cc @Lassulus @Kloenk @aanderse 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
