### PR TITLE
tailscale: 0.99.1-0 -> 0.100.0-153

### DIFF
--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "tailscale";
-  # Tailscale uses "git describe" as version numbers. 0.99.1-0 means
-  # "tag v0.99.1 plus 0 commits", which corresponds to rev="v0.99.1"
-  # below.
-  version = "0.99.1-0";
+  # Tailscale uses "git describe" as version numbers. 0.100.0-153
+  # means "tag v0.100.0 plus 153 commits", which corresponds to the
+  # commit hash below.
+  version = "0.100.0-153";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    rev = "v0.99.1";
-    sha256 = "1kq4x5xknv0qq6n78xj5wjbf6svbdyw4nzs7z5gjb3ylj2vl97pb";
+    rev = "v${version}";
+    sha256 = "1alvsbkpmkra26imhr2927jqwqxcp9id6y8l9mgxhyh3z7qzql8w";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -19,7 +19,7 @@ buildGoModule rec {
   CGO_ENABLED = 0;
 
   goPackagePath = "tailscale.com";
-  vendorSha256 = "0yf2zdpd12w4qf4sbv7bkr40hw5faqynr6lb84v7w6v0az0nfzds";
+  vendorSha256 = "0xp8dq3bsaipn9hyp3daqljj3k7zrkbbyk9jph0x59qwpljl0nhz";
   subPackages = [ "cmd/tailscale" "cmd/tailscaled" ];
 
   postInstall = ''


### PR DESCRIPTION
Signed-off-by: David Anderson <dave@natulte.net>

###### Motivation for this change

Update to current stable release of Tailscale.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
