### PR TITLE
pc-ble-driver: fix Darwin build

### DIFF
--- a/pkgs/development/libraries/pc-ble-driver/default.nix
+++ b/pkgs/development/libraries/pc-ble-driver/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, git, cmake, catch2, asio, udev }:
+{ stdenv, fetchFromGitHub, git, cmake, catch2, asio, udev, IOKit }:
 
 stdenv.mkDerivation rec {
   pname = "pc-ble-driver";
@@ -16,7 +16,15 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake git ];
-  buildInputs = [ catch2 asio udev ];
+  buildInputs = [ catch2 asio ];
+
+  propagatedBuildInputs = [
+
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    IOKit
+  ] ++ stdenv.lib.optionals stdenv.isLinux [
+    udev
+  ];
 
   meta = with stdenv.lib; {
     description = "Desktop library for Bluetooth low energy development";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21419,7 +21419,9 @@ in
 
   partio = callPackage ../development/libraries/partio {};
 
-  pc-ble-driver = callPackage ../development/libraries/pc-ble-driver {};
+  pc-ble-driver = callPackage ../development/libraries/pc-ble-driver {
+    inherit (darwin.apple_sdk.frameworks) IOKit;
+  };
 
   pbis-open = callPackage ../tools/security/pbis { };
 


### PR DESCRIPTION
Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

See https://github.com/NixOS/nixpkgs/pull/91173

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
