### PR TITLE
python3.pkgs.pygobject3: 3.36.0 → 3.36.1

### DIFF
--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -3,13 +3,13 @@ pycairo, cairo, which, ncurses, meson, ninja, isPy3k, gnome3 }:
 
 buildPythonPackage rec {
   pname = "pygobject";
-  version = "3.36.0";
+  version = "3.36.1";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1vysyr586mfjm7biraw1nynpw4f1qajynkm6m40ybadsnpgx50w6";
+    sha256 = "0b9CgC0c7BE7Wtqg579/N0W0RSHcIWNYjSdtXNYdcY8=";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
##### Motivation for this change

This won’t get picked up by r-ryantm.


[Changes](https://ftp.gnome.org/pub/GNOME/sources/pygobject/3.36/pygobject-3.36.1.news) look okay:

> 3.36.1 - 2020-05-06
> -------------------
> 
> * tests: Fix failing tests with pytest 5.4.0+
> * Gtk: Add override to make sure both TreeModelSort.new_with_model and
>   TreeModel.sort_new_with_model exist independend of the gtk version
> * Gtk.Template: Fix initialisation order errors with Widgets getting created from C
>   (potentially through other templates) [:issue:`257`](https://gitlab.gnome.org/GNOME/pygobject/issues/257) [:issue:`386`](https://gitlab.gnome.org/GNOME/pygobject/issues/386) [:issue:`341`](https://gitlab.gnome.org/GNOME/pygobject/issues/341) [:mr:`140`](https://gitlab.gnome.org/GNOME/pygobject/merge_requests/140) (:user:`Jean Felder <jfelder>`)
> * Gtk.Template: Fix errors when calling init_template() multiple times [:mr:`140`](https://gitlab.gnome.org/GNOME/pygobject/merge_requests/140) (:user:`Jean Felder <jfelder>`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
