### PR TITLE
oraclejdk11: init at 11.0.8, oraclejdk14: init at 14.0.2

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk11-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk11-linux.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, requireFile
+, xorg
+, zlib
+, freetype
+, alsaLib
+, setJavaClassPath
+}:
+
+let result = stdenv.mkDerivation rec {
+  pname = "oraclejdk";
+  version = "11.0.8";
+
+  src = requireFile {
+    name = "jdk-${version}_linux-x64_bin.tar.gz";
+    url = "https://www.oracle.com/java/technologies/javase-jdk11-downloads.html";
+    sha256 = "6390878c91e29bad7b2483eb0b470620bd145269600f3b6a9d65724e6f83b6fd";
+  };
+
+  installPhase = ''
+    mv ../$sourceRoot $out
+
+    mkdir -p $out/nix-support
+    printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
+
+    # Set JAVA_HOME automatically.
+    cat <<EOF >> $out/nix-support/setup-hook
+    if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+    EOF
+  '';
+
+  postFixup = ''
+    rpath="$out/lib/jli:$out/lib/server:$out/lib:${stdenv.lib.strings.makeLibraryPath [ zlib xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXrender freetype alsaLib]}"
+
+    for f in $(find $out -name "*.so") $(find $out -type f -perm -0100); do
+      patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$f" || true
+      patchelf --set-rpath   "$rpath"                                    "$f" || true
+    done
+
+    for f in $(find $out -name "*.so") $(find $out -type f -perm -0100); do
+      if ldd "$f" | fgrep 'not found'; then echo "in file $f"; fi
+    done
+  '';
+
+  passthru.jre = result;
+  passthru.home = result;
+
+  dontStrip = true; # See: https://github.com/NixOS/patchelf/issues/10
+
+  meta = with stdenv.lib; {
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}; in result

--- a/pkgs/development/compilers/oraclejdk/jdk14-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk14-linux.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, requireFile
+, xorg
+, zlib
+, freetype
+, alsaLib
+, setJavaClassPath
+}:
+
+let result = stdenv.mkDerivation rec {
+  pname = "oraclejdk";
+  version = "14.0.2";
+
+  src = requireFile {
+    name = "jdk-${version}_linux-x64_bin.tar.gz";
+    url = "https://www.oracle.com/java/technologies/javase-jdk14-downloads.html";
+    sha256 = "cb811a86926cc0f529d16bec7bd2e25fb73e75125bbd1775cdb9a96998593dde";
+  };
+
+  installPhase = ''
+    mv ../$sourceRoot $out
+
+    mkdir -p $out/nix-support
+    printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
+
+    # Set JAVA_HOME automatically.
+    cat <<EOF >> $out/nix-support/setup-hook
+    if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+    EOF
+  '';
+
+  postFixup = ''
+    rpath="$out/lib/jli:$out/lib/server:$out/lib:${stdenv.lib.strings.makeLibraryPath [ stdenv.cc.cc zlib xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXrender freetype alsaLib]}"
+
+    for f in $(find $out -name "*.so") $(find $out -type f -perm -0100); do
+      patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$f" || true
+      patchelf --set-rpath   "$rpath"                                    "$f" || true
+    done
+
+    for f in $(find $out -name "*.so") $(find $out -type f -perm -0100); do
+      if ldd "$f" | fgrep 'not found'; then echo "in file $f"; fi
+    done
+  '';
+
+  passthru.jre = result;
+  passthru.home = result;
+
+  dontStrip = true; # See: https://github.com/NixOS/patchelf/issues/10
+
+  meta = with stdenv.lib; {
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}; in result

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8967,6 +8967,10 @@ in
         inherit installjdk pluginSupport;
       });
 
+  oraclejdk11 = callPackage ../development/compilers/oraclejdk/jdk11-linux.nix { };
+
+  oraclejdk14 = callPackage ../development/compilers/oraclejdk/jdk14-linux.nix { };
+
   jasmin = callPackage ../development/compilers/jasmin { };
 
   java-service-wrapper = callPackage ../tools/system/java-service-wrapper { };


### PR DESCRIPTION
###### Motivation for this change

Newer Oracle JDKs

In newer Oracle JDKs there is no Mozilla Plugins, no `javaws`, no JRE, no platforms other than `x84_64-linux`, so they are much simpler than `oraclejdk8`.
Basically `unzip` then `patchelf`

Fixes: https://github.com/NixOS/nixpkgs/issues/93500

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
