### PR TITLE
pythonPackages.dbus-python: 1.2.12 -> 1.2.16

### DIFF
--- a/pkgs/development/python-modules/dbus/default.nix
+++ b/pkgs/development/python-modules/dbus/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "dbus-python";
-  version = "1.2.12";
+  version = "1.2.16";
   format = "other";
 
   outputs = [ "out" "dev" ];
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0q7jmldv0bxxqnbj63cd7i81vs6y85xys4r0n63z4n2y9wndxm6d";
+    sha256 = "196m5rk3qzw5nkmgzjl7wmq0v7vpwfhh8bz2sapdi5f9hqfqy8qi";
   };
 
   patches = [


### PR DESCRIPTION
This upgrades dbus-python to the 1.2.16 release. Reason for this version
upgrade is a the failing hamster application (see. programs.hamster).
With a 1.2.12 dbus-python version hamster can not start and fails with:

    Traceback (most recent call last):
      File "/nix/store/5ax21lyiprc9v5l3pl7dbfr2hqbrh970-hamster-3.0.2/bin/.hamster-wrapped", line 41, in <module>
        from hamster import client, reports
      File "/nix/store/5ax21lyiprc9v5l3pl7dbfr2hqbrh970-hamster-3.0.2/lib/python3.8/site-packages/hamster/client.py", line 46, in <module>
        assert not (
    AssertionError: python3.8 changed str(<dbus integers>).
       That broke hamster (https://github.com/projecthamster/hamster/issues/477).
       Please upgrade to dbus-python >= 1.2.14.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
