### PR TITLE
erlangR22 and R23: upgrade wxGTK to 3.1

### DIFF
--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -1,4 +1,4 @@
-{ callPackage, wxGTK30, openssl_1_0_2 }:
+{ callPackage, wxGTK30, wxGTK31, openssl_1_0_2 }:
 
 rec {
   lib = callPackage ../development/beam-modules/lib.nix {};
@@ -17,7 +17,7 @@ rec {
 
     # R23
     erlangR23 = lib.callErlang ../development/interpreters/erlang/R23.nix {
-      wxGTK = wxGTK30;
+      wxGTK = wxGTK31;
       # Can be enabled since the bug has been fixed in https://github.com/erlang/otp/pull/2508
       parallelBuild = true;
     };
@@ -30,7 +30,7 @@ rec {
 
     # R22
     erlangR22 = lib.callErlang ../development/interpreters/erlang/R22.nix {
-      wxGTK = wxGTK30;
+      wxGTK = wxGTK31;
       # Can be enabled since the bug has been fixed in https://github.com/erlang/otp/pull/2508
       parallelBuild = true;
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Erlang fails to build since `gst-plugins-base` 0.10.36 is marked as broken. Erlang depends on `wxGTK` 3.0, which depends on the broken gst-plugins-base. Upgrading to wxGTK 3.1 solves this issue. wxWidgets 3.1 seems supported as it is mentioned a couple of times in the release notes of the [wxErlang](https://erlang.org/doc/apps/wx/notes.html) module.

Verified that it works by building `erlangR22` and running `erl -eval 'observer:start().'` which to my knowledge is an application that uses wxWidgets.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
