### PR TITLE
mod_cspnonce: init at 1.3

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_cspnonce/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_cspnonce/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchFromGitHub, apacheHttpd }:
+
+stdenv.mkDerivation rec {
+  pname = "mod_cspnonce";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "wyattoday";
+    repo = "mod_cspnonce";
+    rev = version;
+    sha256 = "0kqvxf1dn8r0ywrfiwsxryjrxii2sq11wisbjnm7770sjwckwqh5";
+  };
+
+  buildInputs = [ apacheHttpd ];
+
+  buildPhase = ''
+    apxs -ca mod_cspnonce.c
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/modules
+    cp .libs/mod_cspnonce.so $out/modules
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "An Apache2 module that makes it dead simple to add nonce values to the CSP";
+    homepage = "https://github.com/wyattoday/mod_cspnonce";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dasj19 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20698,6 +20698,7 @@ with pkgs;
     mod_ca = callPackage ../servers/http/apache-modules/mod_ca { };
     mod_crl = callPackage ../servers/http/apache-modules/mod_crl { };
     mod_csr = callPackage ../servers/http/apache-modules/mod_csr { };
+    mod_cspnonce = callPackage ../servers/http/apache-modules/mod_cspnonce { };
     mod_ocsp = callPackage ../servers/http/apache-modules/mod_ocsp{ };
     mod_scep = callPackage ../servers/http/apache-modules/mod_scep { };
     mod_pkcs12 = callPackage ../servers/http/apache-modules/mod_pkcs12 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Packaged mod_cspnonce which deals with Content Security Policy.
This module enables a carefully generated nonce to be added in the server headers and thus improving CSP of the server.

I have it running on my server and works like a charm.

The way I have it running is:
```
  services.httpd.extraModules = [
    "rewrite" "headers" "proxy" "proxy_http" "proxy_ftp"
    { name = "cspnonce"; path = "${pkgs.mod_cspnonce}/modules/mod_cspnonce.so"; }
  ];

```

and...

```
  services.httpd.virtualHosts."searx.gnu.style".extraConfig = ''
    Header set Content-Security-Policy "script-src 'self' 'nonce-%{CSP_NONCE}e';
  '';
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
