### PR TITLE
cloud-hypervisor: init at 0.8.0

### DIFF
--- a/pkgs/applications/virtualization/cloud-hypervisor/cargo-lock-vendor-fix.patch
+++ b/pkgs/applications/virtualization/cloud-hypervisor/cargo-lock-vendor-fix.patch
@@ -1,0 +1,53 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index e566ed25..a661a963 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -689,7 +689,7 @@ dependencies = [
+  "serde",
+  "serde_derive",
+  "serde_json",
+- "vfio-bindings 0.2.0 (git+https://github.com/rust-vmm/vfio-bindings)",
++ "vfio-bindings",
+  "vfio-ioctls",
+  "vm-allocator",
+  "vm-device",
+@@ -1346,17 +1346,12 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+ [[package]]
+ name = "vfio-bindings"
+ version = "0.2.0"
+-source = "git+https://github.com/rust-vmm/vfio-bindings#f08cbcbf4041c981441d9c036c49ebad5098ed1c"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4a21f546f2bda37f5a8cfb138c87f95b8e34d2d78d6a7a92ba3785f4e08604a7"
+ dependencies = [
+  "vmm-sys-util",
+ ]
+ 
+-[[package]]
+-name = "vfio-bindings"
+-version = "0.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4a21f546f2bda37f5a8cfb138c87f95b8e34d2d78d6a7a92ba3785f4e08604a7"
+-
+ [[package]]
+ name = "vfio-ioctls"
+ version = "0.1.0"
+@@ -1366,7 +1361,7 @@ dependencies = [
+  "kvm-bindings",
+  "kvm-ioctls",
+  "log 0.4.8",
+- "vfio-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "vfio-bindings",
+  "vm-memory",
+  "vmm-sys-util",
+ ]
+diff --git a/pci/Cargo.toml b/pci/Cargo.toml
+index 9c6955c7..4ecf8e6b 100644
+--- a/pci/Cargo.toml
++++ b/pci/Cargo.toml
+@@ -23,5 +23,5 @@ vm-memory = "0.2.1"
+ vm-migration = { path = "../vm-migration" }
+ 
+ [dependencies.vfio-bindings]
+-git = "https://github.com/rust-vmm/vfio-bindings"
++version = "0.2.0"
+ features = ["fam-wrappers"]

--- a/pkgs/applications/virtualization/cloud-hypervisor/default.nix
+++ b/pkgs/applications/virtualization/cloud-hypervisor/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchFromGitHub, rustPlatform, pkgconfig, openssl }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cloud-hypervisor";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "cloud-hypervisor";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "h2aWWjycTm84TS89/vhqnAvwOqeeSDtvvCt+Is6I0eI=";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ openssl ];
+
+  cargoPatches = [ ./cargo-lock-vendor-fix.patch ];
+  cargoSha256 = "fOIB+qVDqAAgQPW3bK2NfST24GzYJeRXgaMFXyNPcPQ=";
+
+  meta = with lib; {
+    homepage = "https://github.com/cloud-hypervisor/cloud-hypervisor";
+    description = "Open source Virtual Machine Monitor (VMM) that runs on top of KVM";
+    changelog = "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v${version}";
+    license = with licenses; [ asl20 bsd3 ];
+    maintainers = with maintainers; [ offline ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19308,6 +19308,8 @@ in
 
   cloud-print-connector = callPackage ../servers/cloud-print-connector { };
 
+  cloud-hypervisor = callPackage ../applications/virtualization/cloud-hypervisor { };
+
   clp = callPackage ../applications/science/math/clp { };
 
   cmatrix = callPackage ../applications/misc/cmatrix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Package `cloud-hypervisor` to test with `kata-containers`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
