### PR TITLE
Add buildFontPackage with test

### DIFF
--- a/pkgs/data/fonts/3270font/default.nix
+++ b/pkgs/data/fonts/3270font/default.nix
@@ -1,26 +1,19 @@
-{ lib, fetchzip }:
-let
+{ buildFontPackage, fetchzip, lib }:
+
+buildFontPackage rec {
+  pname = "3270font";
   version = "2.0.4";
-in
-fetchzip rec {
-  name = "3270font-${version}";
 
-  url = "https://github.com/rbanffy/3270font/releases/download/v${version}/3270_fonts_ece94f6.zip";
-
-  sha256 = "04q7dnrlq5hm30iibh3jafb33m5lwsgb3g9n9i188sg02ydkrsl9";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.woff -d $out/share/fonts/woff
-  '';
+  src = fetchzip {
+    url = "https://github.com/rbanffy/3270font/releases/download/v${version}/3270_fonts_ece94f6.zip";
+    sha256 = "18mffq99lkbx8gprxqh0r9jv6vh7aqcmcy68ylpgbqkz2f86zlxc";
+    stripRoot=false;
+  };
 
   meta = with lib; {
     description = "Monospaced font based on IBM 3270 terminals";
     homepage = "https://github.com/rbanffy/3270font";
     license = [ licenses.bsd3 licenses.ofl ];
     maintainers = [ maintainers.marsam ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/data/fonts/agave/default.nix
+++ b/pkgs/data/fonts/agave/default.nix
@@ -1,26 +1,23 @@
-{ lib, fetchurl }:
+{ buildFontPackage, lib, fetchurl }:
 
-let
+buildFontPackage rec {
   pname = "agave";
   version = "16";
-in fetchurl {
-  name = "${pname}-${version}";
-  url = "https://github.com/agarick/agave/releases/download/v${version}/Agave-Regular.ttf";
 
-  downloadToTemp = true;
-  recursiveHash = true;
-  postFetch = ''
-    install -D $downloadedFile $out/share/fonts/truetype/Agave-Regular.ttf
-  '';
-
-  sha256 = "108jvcijnx06v1jzhnb28ql9nvmwqd83309834wcd4aii6bgf9ka";
+  src = fetchurl {
+    url = "https://github.com/agarick/agave/releases/download/v${version}/Agave-Regular.ttf";
+    downloadToTemp = true;
+    recursiveHash = true;
+    sha256 = "1d9651khizylqz15ixzyhawyzrl386l1ymsxb76s0j6j2acbhfii";
+    postFetch = ''
+      install -D $downloadedFile $out/Agave-Regular.ttf
+    '';
+  };
 
   meta = with lib; {
     description = "truetype monospaced typeface designed for X environments";
     homepage = "https://b.agaric.net/page/agave";
     license = licenses.mit;
     maintainers = with maintainers; [ dtzWill ];
-    platforms = platforms.all;
   };
 }
-

--- a/pkgs/data/fonts/generic/README.md
+++ b/pkgs/data/fonts/generic/README.md
@@ -1,0 +1,38 @@
+# buildFontPackage
+
+Packaging and updating fonts in nixpkgs is relatively easy. With `buildFontPackage` you only need the `src` in form of a directory (not a single file) and package metadata.
+
+See ../agave/default.nix and ../3270font/default.nix for example.
+
+You can run the test with `nix-build ~/code/nixpkgs -A 3270font.tests`.
+
+It will create previews for all font files. This way we know, that they are usable.
+
+```
+[user@nixos:~]$ nix-build ~/code/nixpkgs -A _3270font.tests
+these derivations will be built:
+  /nix/store/lhrkq4551w0hf9q7gyh9nfm8ik8vd3zv-3270font-2.0.4.drv
+  /nix/store/v1lny7vra0ymr6652v544h00cicglj2i-3270font-test.drv
+building '/nix/store/lhrkq4551w0hf9q7gyh9nfm8ik8vd3zv-3270font-2.0.4.drv'...
+unpacking sources
+unpacking source archive /nix/store/gma0xqzfhwlmvm0xh58k751crs3pgiw3-source
+source root is source
+patching sources
+installing
+building '/nix/store/v1lny7vra0ymr6652v544h00cicglj2i-3270font-test.drv'...
+/nix/store/rnmqdjpv89ik2k86chz0lc8r6ppgn20n-3270font-test
+
+[user@nixos:~]$ tree /nix/store/rnmqdjpv89ik2k86chz0lc8r6ppgn20n-3270font-test
+/nix/store/rnmqdjpv89ik2k86chz0lc8r6ppgn20n-3270font-test
+├── 3270Condensed-Regular.otf.png
+├── 3270Condensed-Regular.ttf.png
+├── 3270Condensed-Regular.woff.png
+├── 3270-Regular.otf.png
+├── 3270-Regular.ttf.png
+├── 3270-Regular.woff.png
+├── 3270SemiCondensed-Regular.otf.png
+├── 3270SemiCondensed-Regular.ttf.png
+└── 3270SemiCondensed-Regular.woff.png
+
+0 directories, 9 files
+```

--- a/pkgs/data/fonts/generic/default.nix
+++ b/pkgs/data/fonts/generic/default.nix
@@ -1,0 +1,36 @@
+{ pkgs, lib, stdenv, callPackage }:
+
+{ buildInputs ? [], nativeBuildInputs ? []
+, enableParallelBuilding ? true
+, meta ? {}
+, platforms ? lib.platforms.all
+, ... } @ args:
+
+stdenv.mkDerivation ( args // {
+  dontConfigure = args.dontConfigure or true;
+  dontBuild = args.dontBuild or true;
+  doCheck = args.doCheck or false;
+  dontFixup = args.dontFixup or true;
+
+  installPhase = args.configurePhase or ''
+    runHook preInstall
+
+    #TODO: Use SOURCE_DATE_EPOCH with install
+    find $src -name '*.otf' -exec install -D -t "$out/share/fonts/opentype/" {} \;
+    find $src -name '*.ttf' -exec install -D -t "$out/share/fonts/truetype/" {} \;
+    find $src -name '*.woff' -exec install -D -t "$out/share/fonts/woff/" {} \;
+
+    runHook postInstall
+  '';
+
+  enableParallelBuilding = enableParallelBuilding;
+
+  passthru.tests = {
+    render-font-preview-test = callPackage ./test.nix { pname = "${lib.getName args}"; };
+  };
+
+  meta = {
+    # Add default meta information
+    platforms = platforms;
+  } // meta;
+})

--- a/pkgs/data/fonts/generic/test.nix
+++ b/pkgs/data/fonts/generic/test.nix
@@ -1,0 +1,20 @@
+{ runCommand, pname, fontforge, _3270font }:
+
+runCommand "${pname}-test" { meta.timeout = 3; }
+  ''
+  files=$(find ${_3270font} \( -name '*.otf' \
+    -o -name '*.ttf' \
+    -o -name '*.woff' \) \
+    -print)
+
+  if [ -z "$files" ]; then
+      echo "No fonts found"
+      exit 1
+  fi
+
+  mkdir $out
+  text="The quick brown fox jumps over the lazy dog."
+  for file in $files; do
+    ${fontforge}/bin/fontimage --o $out/$(basename $file).png --fontname --text "$text" $file &>/dev/null
+  done
+  ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18046,6 +18046,8 @@ in
 
   ### DATA
 
+  buildFontPackage = callPackage ../data/fonts/generic { };
+
   _3270font = callPackage ../data/fonts/3270font { };
 
   adapta-backgrounds = callPackage ../data/misc/adapta-backgrounds { };


### PR DESCRIPTION
###### Motivation for this change

This makes it easier to package and update fonts and improves quality with a test.

Closes https://github.com/NixOS/nixpkgs/issues/93108

I don't know what i'm doing. Just copied `buildEmscriptenPackage` and fiddled around until it works as intended. Please give feedback on the structure!

I have documentation, but only inside the directory in Markdown. The alternative is no documentation.

Still WIP, please help!

- [ ] Use the buildFontPackage inside the test
- [x] make `install` reproducible

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
