### PR TITLE
python-gyp: update with python3 support + drop python2 dependency in nss build

### DIFF
--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, nspr, perl, zlib, sqlite, fixDarwinDylibNames, buildPackages, ninja }:
+{ stdenv, fetchurl, nspr, perl, zlib, sqlite, darwin, fixDarwinDylibNames, buildPackages, ninja }:
 
 let
   nssPEM = fetchurl {
@@ -19,7 +19,8 @@ in stdenv.mkDerivation rec {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-  nativeBuildInputs = [ perl ninja (buildPackages.python3.withPackages (ps: with ps; [ gyp ])) ];
+  nativeBuildInputs = [ perl ninja (buildPackages.python3.withPackages (ps: with ps; [ gyp ])) ]
+    ++ stdenv.lib.optional stdenv.isDarwin darwin.cctools;
 
   buildInputs = [ zlib sqlite ]
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
@@ -52,10 +53,6 @@ in stdenv.mkDerivation rec {
     ];
 
   patchFlags = [ "-p0" ];
-
-  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
-    substituteInPlace nss/coreconf/Darwin.mk --replace '@executable_path/$(notdir $@)' "$out/lib/\$(notdir \$@)"
-  '';
 
   outputs = [ "out" "dev" "tools" ];
 

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-  nativeBuildInputs = [ perl ninja (buildPackages.python2.withPackages (ps: with ps; [ gyp ])) ];
+  nativeBuildInputs = [ perl ninja (buildPackages.python3.withPackages (ps: with ps; [ gyp ])) ];
 
   buildInputs = [ zlib sqlite ]
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;

--- a/pkgs/development/python-modules/gyp/default.nix
+++ b/pkgs/development/python-modules/gyp/default.nix
@@ -6,13 +6,12 @@
 
 buildPythonPackage {
   pname = "gyp";
-  version = "2015-06-11";
-  disabled = isPy3k;
+  version = "2020-05-12";
 
   src = fetchFromGitiles {
     url = "https://chromium.googlesource.com/external/gyp";
-    rev = "fdc7b812f99e48c00e9a487bd56751bbeae07043";
-    sha256 = "1imgxsl4mr1662vsj2mlnpvvrbz71yk00w8p85vi5bkgmc6awgiz";
+    rev = "caa60026e223fc501e8b337fd5086ece4028b1c6";
+    sha256 = "0r9phq5yrmj968vdvy9vivli35wn1j9a6iwshp69wl7q4p0x8q2b";
   };
 
   prePatch = stdenv.lib.optionals stdenv.isDarwin ''


### PR DESCRIPTION
###### Motivation for this change
Follow-up (of sorts) to #91746

This probably doesn't fix the darwin build, but at least it drops the python2 dependency.
Should have checked this sooner…

cc @vcunat @flokli 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
