### PR TITLE
fontpreview: init at 1.0.6

### DIFF
--- a/pkgs/applications/misc/fontpreview/default.nix
+++ b/pkgs/applications/misc/fontpreview/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper, xdotool, fzf, imagemagick, sxiv, getopt }:
+
+stdenv.mkDerivation rec {
+  pname = "fontpreview";
+  version = "1.0.6";
+
+  src = fetchFromGitHub {
+    owner = "sdushantha";
+    repo = pname;
+    rev = version;
+    sha256 = "0g3i2k6n2yhp88rrcf0hp6ils7836db7hx73hw9qnpcbmckz0i4w";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  preInstall = "mkdir -p $out/bin";
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/fontpreview \
+      --prefix PATH : ${lib.makeBinPath [ xdotool fzf imagemagick sxiv getopt ]}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/sdushantha/fontpreview";
+    description = "Highly customizable and minimal font previewer written in bash";
+    longDescription = ''
+      fontpreview is a commandline tool that lets you quickly search for fonts
+      that are installed on your machine and preview them. The fuzzy search
+      feature is provided by fzf and the preview is generated with imagemagick
+      and then displayed using sxiv. This tool is highly customizable, almost
+      all of the variables in this tool can be changed using the commandline
+      flags or you can configure them using environment variables.
+    '';
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.erictapen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19809,6 +19809,8 @@ in
 
   font-manager = callPackage ../applications/misc/font-manager { };
 
+  fontpreview = callPackage ../applications/misc/fontpreview { };
+
   foo-yc20 = callPackage ../applications/audio/foo-yc20 { };
 
   fossil = callPackage ../applications/version-management/fossil { };


### PR DESCRIPTION

###### Motivation for this change

Add `fontpreview` package, was also sorta requested in https://github.com/NixOS/nixpkgs/issues/93108.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
