### PR TITLE
mongodb: use pname instead of name

### DIFF
--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -27,7 +27,7 @@ let
 
 in stdenv.mkDerivation rec {
   inherit version;
-  name = "mongodb-${version}";
+  pname = "mongodb";
 
   src = fetchurl {
     url = "https://fastdl.mongodb.org/src/mongodb-src-r${version}.tar.gz";


### PR DESCRIPTION


##### Motivation for this change

For selectively allowing unfree packages, one can use

```nix
{
nixpkgs.config.allowUnfreePredicate =
  (
    pkg: builtins.elem (builtins.parseDrvName pkg.pname).name [
      "unifi-controller"
      "mongodb"
    ]
  );
}
```

But that only works if `mongodb` has a `pname` attribute.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
