### PR TITLE
pythonPackages.gdbgui: 0.13.2.0 -> 0.13.2.1

### DIFF
--- a/pkgs/development/tools/misc/gdbgui/default.nix
+++ b/pkgs/development/tools/misc/gdbgui/default.nix
@@ -8,11 +8,13 @@
 , pygdbmi
 , pygments
 , gevent
+, gevent-websocket
+, eventlet
 , }:
 
 buildPythonApplication rec {
   pname = "gdbgui";
-  version = "0.13.2.0";
+  version = "0.13.2.1";
 
   buildInputs = [ gdb ];
   propagatedBuildInputs = [
@@ -22,11 +24,13 @@ buildPythonApplication rec {
     pygdbmi
     pygments
     gevent
+    gevent-websocket
+    eventlet
   ];
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0m1fnwafzrpk77yj3p26vszlz11cv4g2lj38kymk1ilcifh4gqw0";
+    sha256 = "0zn5wi47m8pn4amx574ryyhqvhynipxzyxbx0878ap6g36vh6l1h";
   };
 
   postPatch = ''
@@ -45,6 +49,7 @@ buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     description = "A browser-based frontend for GDB";
+    homepage = "https://www.gdbgui.com/";
     license = licenses.gpl3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ yrashk ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Upon launching `gdbgui`, this message is printed:
> WARNING - WebSocket transport not available. Install gevent-websocket for improved performance.

After adding the dependency to `propagatedBuildInputs`, the message disappears, though I have not benchmarked performance. 
I figure it is "better" as advertised.
___
###### Things done

Add gevent-websocket to propagatedBuildInputs to suppress the error message
and supposedly improve performance
___
Update gdbgui from [0.13.2.0 ](https://github.com/cs01/gdbgui/releases/tag/0.13.2.0)to [0.13.2.1](https://github.com/cs01/gdbgui/releases/tag/v0.13.2.1)
Add eventlet to `propagatedBuildInputs`
___
Closure size increase seems negligible/acceptable
```
/nix/store/sk3bc7v4md4z0hgszvblcl1v0i2pgxy1-gdbgui-0.13.2.0        3.0M  171.6M
/nix/store/cqnyp16jhin5c5agfryz96x1f978zicl-gdbgui-0.13.2.1        3.0M  176.8M
```