### PR TITLE
ios-deploy: move out of nodePackages

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -43,17 +43,6 @@ let
       name = "bitwarden-cli-${drv.version}";
     });
 
-    ios-deploy = super.ios-deploy.override (drv: {
-      nativeBuildInputs = drv.nativeBuildInputs or [] ++ [ pkgs.buildPackages.rsync ];
-      preRebuild = ''
-        LD=$CC
-        tmp=$(mktemp -d)
-        ln -s /usr/bin/xcodebuild $tmp
-        export PATH="$PATH:$tmp"
-      '';
-      meta.platforms = [ pkgs.lib.platforms.darwin ];
-    });
-
     fast-cli = super."fast-cli-1.x".override {
       preRebuild = ''
         # Simply ignore the phantomjs --version check. It seems to need a display but it is safe to ignore

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -90,7 +90,6 @@
 , "indium"
 , "insect"
 , "ionic"
-, "ios-deploy"
 , { "iosevka-build-deps": "../../data/fonts/iosevka" }
 , "jake"
 , "javascript-typescript-langserver"

--- a/pkgs/os-specific/darwin/ios-deploy/default.nix
+++ b/pkgs/os-specific/darwin/ios-deploy/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenvNoCC, rsync, fetchFromGitHub }:
+
+# Note this is impure, using system XCode to build ios-deploy. We
+# should have a special flag for users to enable this.
+
+let version = "1.11.0";
+in stdenvNoCC.mkDerivation {
+  pname = "ios-deploy";
+  inherit version;
+  src = fetchFromGitHub {
+    owner = "ios-control";
+    repo = "ios-deploy";
+    rev = version;
+    sha256 = "0hqwikdrcnslx4kkw9b0n7n443gzn2gbrw15pp2fnkcw5s0698sc";
+  };
+  nativeBuildInputs = [ rsync ];
+  buildPhase = ''
+    LD=$CC
+    tmp=$(mktemp -d)
+    ln -s /usr/bin/xcodebuild $tmp
+    export PATH="$PATH:$tmp"
+    xcodebuild -configuration Release SYMROOT=build OBJROOT=$tmp
+  '';
+  checkPhase = ''
+    xcodebuild test -scheme ios-deploy-tests -configuration Release SYMROOT=build
+  '';
+  installPhase = ''
+    install -D build/Release/ios-deploy $out/bin/ios-deploy
+  '';
+  meta = {
+    platforms = lib.platforms.darwin;
+    description = "Install and debug iOS apps from the command line. Designed to work on un-jailbroken devices";
+    license = lib.licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -86,4 +86,6 @@ in
 
   libtapi = callPackage ../os-specific/darwin/libtapi {};
 
+  ios-deploy = callPackage ../os-specific/darwin/ios-deploy {};
+
 })


### PR DESCRIPTION
This doesn’t need nodePackages to work, so we can move it to
pkgs/os-specific/darwin. Note that it still requires xcodebuild to
work.

Also, the one in nodePackages was broken. This fixes that.

