### PR TITLE
nixos/ssh: hash ssh_known_hosts file

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -531,6 +531,14 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
      to be used for every display-manager in NixOS.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     SSH public keys in <literal>programs.ssh.knownHosts</literal> now produce a <literal>ssh_known_hosts</literal>
+     file, that only contains hashed entries.  This provides security as an attacker cannot easily derive
+     the remotes accessible from a compromised machine.  At the same time the contents of that file are now
+     illegible for legitimate use cases.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 


### PR DESCRIPTION
###### Motivation for this change

This would harden the handling of SSH keys in NixOS a bit, without compromising usability imho.

Consider this use case: A NixOS machine is defined with

```nix
{
  programs.ssh.knownHosts = {
    "myremote" = {
      hostNames = [ "10.0.0.2" "example.com" ];
      publicKey = "ssh-rsa ... root@example.com";
    };
  };
}
```

and then is deployed in a way, that the `*.nix` files don't end up on the remote host (e.g. by using NixOps or by building locally, copying the closure with `nix copy` and then activating on the remote side).

Now let's say an attacker gains access to that machine. Without this pull request they can easily see how to access `root@example.com` and derive from the existence of the `known_hosts` entry, that they might have access to that host. With this PR they only see hashed hosts, which would require them to figure out the remote URL by themselfes. That would make hopping from machine to machine and therefore compromising the whole network considerably harder.

See also ssh-keygen(1):

> -H     Hash a known_hosts file.  This replaces all hostnames and
>        addresses with hashed representations within the specified
>        file;  the original content is moved to a file with a .old
>        suffix.  These hashes may be used normally by ssh and sshd,
>        but they do not reveal identifying information should the
>        file's contents be disclosed.  This option will not modify
>        existing hashed hostnames and is therefore safe to use on
>        files that mix hashed and non-hashed names.

At the same time I don't know of any good use cases to look at `/etc/ssh/ssh_known_hosts` and derive any legible information from that file. So no usability tradeoffs in sight for me. If there should the need arise, one could change this behaviour by introducing an option lke `hashKnownHosts ? true`.

###### Things done

- Hash knownHosts
- Wrote an release notes entry.

Also I tested this commit for the past three months on my setup.

I didn't write a NixOS test, as `programs.ssh.knownHosts` isn't tested yet.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Pinging @aszlig @edolstra as they maintain the openssh test.
Pinging @Izorkin @alyssais @philandstuff @edef1c as the recently contributed to `nixos/modules/programs/ssh.nix`.