### PR TITLE
Update friture to master branch, add necessary python packages

### DIFF
--- a/pkgs/applications/audio/friture/default.nix
+++ b/pkgs/applications/audio/friture/default.nix
@@ -4,18 +4,14 @@ let
   py = python3Packages;
 in py.buildPythonApplication rec {
   pname = "friture";
-  version = "0.37";
+  version = "unstable-2020-02-16";
 
   src = fetchFromGitHub {
     owner = "tlecomte";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "1ivy5qfd90w1s1icsphvvdnnqz563v3fhg5pws2zn4483cgnzc2y";
+    rev = "4460b4e72a9c55310d6438f294424b5be74fc0aa";
+    sha256 = "1pmxzq78ibifby3gbir1ah30mgsqv0y7zladf5qf3sl5r1as0yym";
   };
-
-  # module imports scipy.misc.factorial, but it has been removed since scipy
-  # 1.3.0; use scipy.special.factorial instead
-  patches = [ ./factorial.patch ];
 
   nativeBuildInputs = (with py; [ numpy cython scipy ]) ++
     [ wrapQtAppsHook ];
@@ -23,11 +19,17 @@ in py.buildPythonApplication rec {
   propagatedBuildInputs = with py; [
     sounddevice
     pyopengl
+    pyopengl-accelerate
     docutils
     numpy
     pyqt5
     appdirs
     pyrr
+    rtmixer
+  ];
+
+  patches = [
+    ./unlock_constraints.patch
   ];
 
   postFixup = ''

--- a/pkgs/applications/audio/friture/unlock_constraints.patch
+++ b/pkgs/applications/audio/friture/unlock_constraints.patch
@@ -1,0 +1,34 @@
+diff --git a/setup.py b/setup.py
+index f31eeec..ac0927b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -50,19 +50,19 @@ ext_modules = [LateIncludeExtension("friture_extensions.exp_smoothing_conv",
+ # these will be installed when calling 'pip install friture'
+ # they are also retrieved by 'requirements.txt'
+ install_requires = [
+-    "sounddevice==0.3.14",
+-    "rtmixer==0.1.0",
+-    "PyOpenGL==3.1.4",
+-    "PyOpenGL-accelerate==3.1.4",
+-    "docutils==0.15.2",
+-    "numpy==1.17.4",
+-    "PyQt5==5.13.2",
+-    "appdirs==1.4.3",
+-    "pyrr==0.10.3",
++    "sounddevice>=0.3.14",
++    "rtmixer>=0.1.0",
++    "PyOpenGL>=3.1.4",
++    "PyOpenGL-accelerate>=3.1.4",
++    "docutils>=0.15.2",
++    "numpy>=1.17.4",
++    "PyQt5>=5.13.2",
++    "appdirs>=1.4.3",
++    "pyrr>=0.10.3",
+ ]
+ 
+ # Cython and numpy are needed when running setup.py, to build extensions
+-setup_requires=["numpy==1.17.4", "Cython==0.29.14"]
++setup_requires=["numpy>=1.17.4", "Cython>=0.29.14"]
+ 
+ with open(join(dirname(__file__), 'README.rst')) as f:
+     long_description = f.read()

--- a/pkgs/development/python-modules/pa-ringbuffer/default.nix
+++ b/pkgs/development/python-modules/pa-ringbuffer/default.nix
@@ -1,0 +1,20 @@
+{ fetchFromGitHub, buildPythonPackage, lib }:
+
+buildPythonPackage rec {
+  pname = "pa-ringbuffer";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "spatialaudio";
+    repo = "python-pa-ringbuffer";
+    rev = "${version}";
+    sha256 = "0afpydy1l20hd1xncjppjhqa2c8dj5h9nlv4z8m55cs9hc9h1mxv";
+  };
+
+  meta = {
+    description = "Adds ring buffer functionality";
+    homepage = "https://github.com/spatialaudio/python-pa-ringbuffer";
+    maintainers = with lib.maintainers; [ laikq ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/pyopengl-accelerate/default.nix
+++ b/pkgs/development/python-modules/pyopengl-accelerate/default.nix
@@ -1,0 +1,23 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "pyopengl-accelerate";
+  version = "3.1.5";
+
+  src = fetchPypi {
+    pname = "PyOpenGL-accelerate";
+    inherit version;
+    sha256 = "01iggy5jwxv7lxnj51zbmlbhag9wcb7dvrbwgi97i90n0a5m3r8j";
+  };
+
+  meta = {
+    description = "This set of C (Cython) extensions provides acceleration of common operations for slow points in PyOpenGL 3.x";
+    homepage = "http://pyopengl.sourceforge.net/";
+    maintainers = with lib.maintainers; [ laikq ];
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/rtmixer/default.nix
+++ b/pkgs/development/python-modules/rtmixer/default.nix
@@ -1,0 +1,40 @@
+{ fetchFromGitHub
+, buildPythonPackage
+, isPy27
+, cython
+, portaudio
+, cffi
+, pa-ringbuffer
+, sounddevice
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "rtmixer";
+  version = "0.1.1";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "spatialaudio";
+    repo = "python-rtmixer";
+    rev = "${version}";
+    sha256 = "1bvgzzxiypvvb3qacbcry6761x9sk3dnx7jga7pli63f69vakg4y";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ portaudio ];
+  nativeBuildInputs = [ cython ];
+
+  propagatedBuildInputs = [
+    cffi
+    pa-ringbuffer
+    sounddevice
+  ];
+
+  meta = {
+    description = "Reliable low-latency audio playback and recording with Python, using PortAudio via the sounddevice module";
+    homepage = "https://python-rtmixer.readthedocs.io";
+    maintainers = with lib.maintainers; [ laikq ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3238,6 +3238,8 @@ in {
 
   libagent = callPackage ../development/python-modules/libagent { };
 
+  pa-ringbuffer = callPackage ../development/python-modules/pa-ringbuffer { };
+
   libais = callPackage ../development/python-modules/libais { };
 
   libarchive-c = callPackage ../development/python-modules/libarchive-c { inherit (pkgs) libarchive; };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3500,6 +3500,8 @@ in {
 
   mailman-web = callPackage ../servers/mail/mailman/web.nix { };
 
+  rtmixer = callPackage ../development/python-modules/rtmixer { };
+
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
   Mako = callPackage ../development/python-modules/Mako { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5478,6 +5478,8 @@ in {
 
   pytest-helpers-namespace = callPackage ../development/python-modules/pytest-helpers-namespace { };
 
+  pyopengl-accelerate = callPackage ../development/python-modules/pyopengl-accelerate { };
+
   pytest-html = callPackage ../development/python-modules/pytest-html { };
 
   pytest-httpbin = callPackage ../development/python-modules/pytest-httpbin { };


### PR DESCRIPTION
###### Motivation for this change

Package upgrade. I didn't upgrade to v0.41 because there were [two](https://github.com/tlecomte/friture/commit/e5c945a13d6f1d9de1cbb88c2b916fdb0401a5be#diff-ea9d37ceb9e1cd81324233c69786dbe1) [issues](https://github.com/tlecomte/friture/commit/1997a79e83e25f28a410d0406292fc1506dea719) with it that broke the package.

I didn't run tests for the python packages added with these commits, but friture seems to be able to use them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
