### PR TITLE
python3Packages.sh: 1.12.14 -> 1.13.1

### DIFF
--- a/pkgs/development/python-modules/sh/default.nix
+++ b/pkgs/development/python-modules/sh/default.nix
@@ -1,28 +1,22 @@
-{ stdenv, buildPythonPackage, fetchPypi, fetchpatch, python, coverage, lsof, glibcLocales }:
+{ lib, buildPythonPackage, fetchPypi, fetchpatch, python, coverage, lsof, glibcLocales, coreutils }:
 
 buildPythonPackage rec {
   pname = "sh";
-  version = "1.12.14";
+  version = "1.13.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1z2hx357xp3v4cv44xmqp7lli3frndqpyfmpbxf7n76h7s1zaaxm";
+    sha256 = "18w6wawmpzfh52s0jimwn59a7rfa7blrmg7bhwnq8siwbqhd58wp";
   };
 
   patches = [
-    # Disable tests that fail on Darwin
-    # Some of the failures are due to Nix using GNU coreutils
+    # Disable tests that fail on Darwin sandbox
     ./disable-broken-tests-darwin.patch
-    # Fix tests for Python 3.7. See: https://github.com/amoffat/sh/pull/468
-    (fetchpatch {
-      url = "https://github.com/amoffat/sh/commit/b6202f75706473f02084d819e0765056afa43664.patch";
-      sha256 = "1kzxyxcc88zhgn2kmfg9yrbs4n405b2jq7qykb453l52hy10vi94";
-      excludes = [ ".travis.yml" ];
-    })
   ];
 
   postPatch = ''
     sed -i 's#/usr/bin/env python#${python.interpreter}#' test.py
+    sed -i 's#/bin/sleep#${coreutils.outPath}/bin/sleep#' test.py
   '';
 
   checkInputs = [ coverage lsof glibcLocales ];
@@ -33,9 +27,10 @@ buildPythonPackage rec {
     HOME=$(mktemp -d)
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Python subprocess interface";
     homepage = "https://pypi.python.org/pypi/sh/";
-    license = stdenv.lib.licenses.mit;
+    license = licenses.mit;
+    maintainers = with maintainers; [ siriobalmelli ];
   };
 }

--- a/pkgs/development/python-modules/sh/disable-broken-tests-darwin.patch
+++ b/pkgs/development/python-modules/sh/disable-broken-tests-darwin.patch
@@ -1,49 +1,49 @@
-From 264f2f6a04d25156bba43524a6b172d2e99c53f4 Mon Sep 17 00:00:00 2001
-From: Ben Wolsieffer <benwolsieffer@gmail.com>
-Date: Fri, 21 Dec 2018 17:39:45 -0500
-Subject: [PATCH] Disable tests that fail on OSX.
+From c596ad546fe7460b57a62799837757eb641309c1 Mon Sep 17 00:00:00 2001
+From: Sirio Balmelli <sirio@b-ad.ch>
+Date: Mon, 20 Jul 2020 19:51:20 +0200
+Subject: [PATCH] Disable tests that fail on Darwin (macOS) or with sandboxing
 
-Some of the failures are due to the use of GNU ls.
+Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>
 ---
  test.py | 4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/test.py b/test.py
-index 68ef40c..2f53360 100644
+index f8029c0..ba1d141 100644
 --- a/test.py
 +++ b/test.py
-@@ -352,6 +352,7 @@ exit(3)
+@@ -404,6 +404,7 @@ exit(3)
          self.assertEqual(sed(_in="one test three", e="s/test/two/").strip(),
-                 "one two three")
+                          "one two three")
  
-+    @not_osx
++    @not_macos
      def test_ok_code(self):
          from sh import ls, ErrorReturnCode_1, ErrorReturnCode_2
  
-@@ -498,6 +499,7 @@ while True:
-         self.assertEqual(out, match)
+@@ -1004,6 +1005,7 @@ print(sys.argv[1])
+         now = time.time()
+         self.assertGreater(now - start, sleep_time)
  
- 
-+    @not_osx
-     def test_environment(self):
-         """ tests that environments variables that we pass into sh commands
-         exist in the environment, and on the sh module """
-@@ -861,6 +863,7 @@ print(sys.argv[1])
-         self.assertTrue(now - start > sleep_time)
- 
- 
-+    @not_osx
++    @not_macos
      def test_background_exception(self):
          from sh import ls, ErrorReturnCode_1, ErrorReturnCode_2
-         p = ls("/ofawjeofj", _bg=True) # should not raise
-@@ -2036,6 +2039,7 @@ else:
-         self.assertEqual(p, "test")
+         p = ls("/ofawjeofj", _bg=True, _bg_exc=False)  # should not raise
+@@ -1801,6 +1803,7 @@ exit(49)
+         p = python(py.name, _ok_code=49, _bg=True)
+         self.assertEqual(49, p.exit_code)
  
++    @not_macos
+     def test_cwd(self):
+         from sh import pwd
+         from os.path import realpath
+@@ -2899,6 +2902,7 @@ print("hi")
+         python(py.name, _in=stdin)
  
-+    @not_osx
-     def test_signal_exception(self):
-         from sh import SignalException_15
+     @requires_utf8
++    @skipUnless(False, "Does not work in sandbox")
+     def test_unicode_path(self):
+         from sh import Command
  
 -- 
-2.20.0
+2.27.0
 


### PR DESCRIPTION
Sandbox build will now succeed on Darwin and Linux

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Could not build with sandboxing on Darwin 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
