### PR TITLE
librealsense: add pyrealsense2 Python bindings + command line tools

### DIFF
--- a/pkgs/development/libraries/librealsense/py_sitepackages_dir.patch
+++ b/pkgs/development/libraries/librealsense/py_sitepackages_dir.patch
@@ -1,0 +1,15 @@
+--- a/wrappers/python/CMakeLists.txt
++++ b/wrappers/python/CMakeLists.txt
+@@ -10,11 +10,11 @@
+ if (CMAKE_VERSION VERSION_LESS 3.12)
+   find_package(PythonInterp REQUIRED)
+   find_package(PythonLibs REQUIRED)
+-  set(PYTHON_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
++  set(PYTHON_INSTALL_DIR "${XXNIX_PYTHON_SITEPACKAGES}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
+   set(CMAKECONFIG_PY_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/pyrealsense2")
+ else()
+   find_package(Python REQUIRED COMPONENTS Interpreter Development)
+-  set(PYTHON_INSTALL_DIR "${Python_SITEARCH}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
++  set(PYTHON_INSTALL_DIR "${XXNIX_PYTHON_SITEPACKAGES}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
+   set(CMAKECONFIG_PY_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/pyrealsense2")
+ endif()

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1336,6 +1336,11 @@ in {
 
   pydsdl = callPackage ../development/python-modules/pydsdl { };
 
+  pyrealsense2 = toPythonModule (pkgs.librealsense.override {
+    withPython = true;
+    pythonPackages = self;
+  });
+
   pyside = callPackage ../development/python-modules/pyside {
     inherit (pkgs) mesa;
   };


### PR DESCRIPTION
##### Motivation for this change
Python bindings are a big use case for librealsense. I've named them "pyrealsense2" after the package on PyPI. I also turned on building of the command line examples as these are useful for validating operation of the library.

NOTE: testing this package isn't really possible without owning one of the supported cameras. I have some and have tested them appropriately on all Python versions and with the example binaries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
