### PR TITLE
etesync-dav: 0.17.0 -> 0.20.0

### DIFF
--- a/pkgs/applications/misc/etesync-dav/default.nix
+++ b/pkgs/applications/misc/etesync-dav/default.nix
@@ -1,19 +1,19 @@
-{ lib, python3Packages, radicale2 }:
+{ lib, python3Packages, radicale3 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "etesync-dav";
-  version = "0.17.0";
+  version = "0.20.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "0lyjv8rknwbx5b5nvq5bgw26lhkymib4cvmv3s3469mrnn2c0ksp";
+    sha256 = "1q8h89hqi4kxphn1g5nbcia0haz5k57is9rycwaabm55mj9s9fah";
   };
 
   propagatedBuildInputs = with python3Packages; [
     etesync
     flask
     flask_wtf
-    radicale2
+    radicale3
   ];
 
   checkInputs = with python3Packages; [


### PR DESCRIPTION
###### Motivation for this change

version bump. updates the radicale dependency from radicale2 to radicale3, which fixes the build.

related #91168, thanks @dotlambda for the upstream patch

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
