### PR TITLE
Purity checking should accept $TMP and not just /tmp

### DIFF
--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -69,9 +69,9 @@ badPath() {
     # directory (including the build directory).
     test \
         "$p" != "/dev/null" -a \
-        "${p:0:${#NIX_STORE}}" != "$NIX_STORE" -a \
-        "${p:0:4}" != "/tmp" -a \
-        "${p:0:${#NIX_BUILD_TOP}}" != "$NIX_BUILD_TOP"
+        "${p#${NIX_STORE}}" = "$p" -a \
+        "${p#${TMP:-/tmp}}" = "$p" -a \
+        "${p#${NIX_BUILD_TOP}}" = "$p"
 }
 
 expandResponseParams() {


### PR DESCRIPTION
###### Motivation for this change

The `badPath` routine used by the various compiler paths to check purity is hard coded to accept `/tmp`. This can cause issues with `nix-shell` as it overrides `/tmp` by setting the various temporary variables (`TMP`,`TEMP`,`TMPDIR`, and `TEMPDIR`) to `/run/user/$UID`.

Normally this is masked by the fact `NIX_BUILD_TOP` is also set to `/run/user/$UID` so the usage of temporary storage by the tools gets covered under `NIX_BUILD_TOP`. In circumstances when the `TMP` and `NIX_BUILD_TOP` don't coincide though, things fall apart.

Here is a small example that demonstrates this

```
$ nix-shell -A hello
$ export NIX_ENFORCE_PURITY=1
$ echo $NIX_BUILD_TOP
/run/user/1000
$ echo $TMP
/run/user/1000
$ export NIX_BUILD_TOP=/tmp
$ cd $NIX_BUILD_TOP
$ eval "${unpackPhase:-unpackPhase}"
$ cd hello-2.10
$ eval "${patchPhase:-patchPhase}"
$ eval "${configurePhase:-configurePhase}"
...
configure: error: in `/tmp/hello-2.10':
configure: error: C compiler cannot create executables
See `config.log' for more details
```

Another example is issue #91431.

###### Things done

I have verified the above GNU helloworld (see above) compiles correctly in the above example once this change is made. This is actually quite extensive as change the `badPath` routine does result in a fairly significant rebuild of dependencies.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
