### PR TITLE
Add package mockbob

### DIFF
--- a/pkgs/applications/misc/mockbob/default.nix
+++ b/pkgs/applications/misc/mockbob/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mockbob";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "j-brn";
+    repo = "mockbob";
+    rev = version;
+    sha256 = "07ygpdak4h630wvk4xjsqwphvcbrif39zkmxdagj5ic7rkahii26";
+  };
+
+  cargoSha256 = "0n94qpasvplcj1vjgqgvxg5jpczij71hfxk4mvxy9q3wa522q7mq";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/j-brn/mockbob/tree/master";
+    description = "Convert Text to Mocking SpongeBob case <https://knowyourmeme.com/memes/mocking-spongebob>";
+    license = licenses.mit;
+    maintainers = [ maintainers.fionera ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26103,6 +26103,8 @@ in
 
   openzwave = callPackage ../development/libraries/openzwave { };
 
+  mockbob = callPackage ../applications/misc/mockbob { };
+
   mongoc = callPackage ../development/libraries/mongoc { };
 
   mongoose = callPackage ../development/libraries/science/math/mongoose {};


### PR DESCRIPTION
###### Motivation for this change
Adding Mockbob as Package

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
