### PR TITLE
Add Redox OS as a target

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -32,6 +32,7 @@ rec {
         /**/ if final.isDarwin              then "libSystem"
         else if final.isMinGW               then "msvcrt"
         else if final.isWasi                then "wasilibc"
+        else if final.isRedox               then "relibc"
         else if final.isMusl                then "musl"
         else if final.isUClibc              then "uclibc"
         else if final.isAndroid             then "bionic"
@@ -65,6 +66,7 @@ rec {
           freebsd = "FreeBSD";
           openbsd = "OpenBSD";
           wasi = "Wasi";
+          redox = "Redox";
           genode = "Genode";
         }.${final.parsed.kernel.name} or null;
 

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -22,6 +22,8 @@ let
 
     "wasm64-wasi" "wasm32-wasi"
 
+    "x86_64-redox"
+
     "powerpc64le-linux"
 
     "riscv32-linux" "riscv64-linux"
@@ -69,6 +71,7 @@ in {
   openbsd = filterDoubles predicates.isOpenBSD;
   unix    = filterDoubles predicates.isUnix;
   wasi    = filterDoubles predicates.isWasi;
+  redox   = filterDoubles predicates.isRedox;
   windows = filterDoubles predicates.isWindows;
   genode  = filterDoubles predicates.isGenode;
 

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -164,6 +164,15 @@ rec {
   };
 
   #
+  # Redox
+  #
+
+  x86_64-unknown-redox = {
+    config = "x86_64-unknown-redox";
+    libc = "relibc";
+  };
+
+  #
   # Darwin
   #
 

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -33,7 +33,7 @@ rec {
 
     isBSD          = { kernel = { families = { inherit (kernelFamilies) bsd; }; }; };
     isDarwin       = { kernel = { families = { inherit (kernelFamilies) darwin; }; }; };
-    isUnix         = [ isBSD isDarwin isLinux isSunOS isCygwin ];
+    isUnix         = [ isBSD isDarwin isLinux isSunOS isCygwin isRedox ];
 
     isMacOS        = { kernel = kernels.macos; };
     isiOS          = { kernel = kernels.ios; };
@@ -46,6 +46,7 @@ rec {
     isCygwin       = { kernel = kernels.windows; abi = abis.cygnus; };
     isMinGW        = { kernel = kernels.windows; abi = abis.gnu; };
     isWasi         = { kernel = kernels.wasi; };
+    isRedox        = { kernel = kernels.redox; };
     isGhcjs        = { kernel = kernels.ghcjs; };
     isGenode       = { kernel = kernels.genode; };
     isNone         = { kernel = kernels.none; };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -277,6 +277,7 @@ rec {
     openbsd = { execFormat = elf;     families = { inherit bsd; }; };
     solaris = { execFormat = elf;     families = { }; };
     wasi    = { execFormat = wasm;    families = { }; };
+    redox   = { execFormat = elf;     families = { }; };
     windows = { execFormat = pe;      families = { }; };
     ghcjs   = { execFormat = unknown; families = { }; };
     genode  = { execFormat = elf;     families = { }; };
@@ -390,6 +391,8 @@ rec {
         then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = "windows";                    }
       else if (elemAt l 2 == "wasi")
         then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = "wasi";                       }
+      else if (elemAt l 2 == "redox")
+        then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = "redox";                      }
       else if hasPrefix "netbsd" (elemAt l 2)
         then { cpu = elemAt l 0; vendor = elemAt l 1;    kernel = elemAt l 2;                }
       else if (elem (elemAt l 2) ["eabi" "eabihf" "elf"])

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -12,22 +12,23 @@ let
     expected = lib.sort lib.lessThan y;
   };
 in with lib.systems.doubles; lib.runTests {
-  testall = mseteq all (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos ++ wasi ++ windows ++ embedded ++ js ++ genode);
+  testall = mseteq all (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos ++ wasi ++ windows ++ embedded ++ js ++ genode ++ redox);
 
   testarm = mseteq arm [ "armv5tel-linux" "armv6l-linux" "armv6l-none" "armv7a-linux" "armv7l-linux" "arm-none" "armv7a-darwin" ];
   testi686 = mseteq i686 [ "i686-linux" "i686-freebsd" "i686-netbsd" "i686-openbsd" "i686-cygwin" "i686-windows" "i686-none" "i686-darwin" ];
   testmips = mseteq mips [ "mipsel-linux" ];
-  testx86_64 = mseteq x86_64 [ "x86_64-linux" "x86_64-darwin" "x86_64-freebsd" "x86_64-genode" "x86_64-openbsd" "x86_64-netbsd" "x86_64-cygwin" "x86_64-solaris" "x86_64-windows" "x86_64-none" ];
+  testx86_64 = mseteq x86_64 [ "x86_64-linux" "x86_64-darwin" "x86_64-freebsd" "x86_64-genode" "x86_64-redox" "x86_64-openbsd" "x86_64-netbsd" "x86_64-cygwin" "x86_64-solaris" "x86_64-windows" "x86_64-none" ];
 
   testcygwin = mseteq cygwin [ "i686-cygwin" "x86_64-cygwin" ];
   testdarwin = mseteq darwin [ "x86_64-darwin" "i686-darwin" "aarch64-darwin" "armv7a-darwin" ];
   testfreebsd = mseteq freebsd [ "i686-freebsd" "x86_64-freebsd" ];
   testgenode = mseteq genode [ "aarch64-genode" "x86_64-genode" ];
+  testredox = mseteq redox [ "x86_64-redox" ];
   testgnu = mseteq gnu (linux /* ++ kfreebsd ++ ... */);
   testillumos = mseteq illumos [ "x86_64-solaris" ];
   testlinux = mseteq linux [ "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux" "armv7l-linux" "i686-linux" "mipsel-linux" "riscv32-linux" "riscv64-linux" "x86_64-linux" "powerpc64le-linux" ];
   testnetbsd = mseteq netbsd [ "i686-netbsd" "x86_64-netbsd" ];
   testopenbsd = mseteq openbsd [ "i686-openbsd" "x86_64-openbsd" ];
   testwindows = mseteq windows [ "i686-cygwin" "x86_64-cygwin" "i686-windows" "x86_64-windows" ];
-  testunix = mseteq unix (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos ++ cygwin);
+  testunix = mseteq unix (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos ++ cygwin ++ redox);
 }

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -64,9 +64,9 @@ let majorVersion = "6";
 
     inherit (stdenv) buildPlatform hostPlatform targetPlatform;
 
-    patches =
-      [ ../use-source-date-epoch.patch ./0001-Fix-build-for-glibc-2.31.patch ]
-      ++ optional (targetPlatform != hostPlatform) ../libstdc++-target.patch
+    patches = optionals (!stdenv.targetPlatform.isRedox) [
+      ../use-source-date-epoch.patch ./0001-Fix-build-for-glibc-2.31.patch
+    ] ++ optional (targetPlatform != hostPlatform) ../libstdc++-target.patch
       ++ optional noSysDirs ../no-sys-dirs.patch
       ++ optional langAda ../gnat-cflags.patch
       ++ optional langFortran ../gfortran-driving.patch
@@ -120,6 +120,11 @@ stdenv.mkDerivation ({
     repo = "gcc-vc4";
     rev = "e90ff43f9671c760cf0d1dd62f569a0fb9bf8918";
     sha256 = "0gxf66hwqk26h8f853sybphqa5ca0cva2kmrw5jsiv6139g0qnp8";
+  } else if stdenv.targetPlatform.isRedox then fetchFromGitHub {
+    owner = "redox-os";
+    repo = "gcc";
+    rev = "f360ac095028d286fc6dde4d02daed48f59813fa"; # `redox` branch
+    sha256 = "1an96h8l58pppyh3qqv90g8hgcfd9hj7igvh2gigmkxbrx94khfl";
   } else fetchurl {
     url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.xz";
     sha256 = "0i89fksfp6wr1xg9l8296aslcymv2idn60ip31wr9s4pwin7kwby";
@@ -182,7 +187,7 @@ stdenv.mkDerivation ({
   nativeBuildInputs = [ texinfo which gettext ]
     ++ (optional (perl != null) perl)
     ++ (optional javaAwtGtk pkgconfig)
-    ++ (optional (stdenv.targetPlatform.isVc4) flex);
+    ++ (optional (with stdenv.targetPlatform; isVc4 || isRedox) flex);
 
   # For building runtime libs
   depsBuildTarget =

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -90,7 +90,7 @@ in stdenv.mkDerivation rec {
     "${setBuild}.llvm-config=${llvmSharedForBuild}/bin/llvm-config"
     "${setHost}.llvm-config=${llvmSharedForHost}/bin/llvm-config"
     "${setTarget}.llvm-config=${llvmSharedForTarget}/bin/llvm-config"
-  ] ++ optionals stdenv.isLinux [
+  ] ++ optionals (stdenv.isLinux && !stdenv.targetPlatform.isRedox) [
     "--enable-profiler" # build libprofiler_builtins
   ];
 

--- a/pkgs/development/libraries/relibc/default.nix
+++ b/pkgs/development/libraries/relibc/default.nix
@@ -1,0 +1,32 @@
+{ stdenvNoCC, buildPackages, fetchurl }:
+
+stdenvNoCC.mkDerivation {
+  name = "binary-relibc-latest";
+
+  # snapshot of https://static.redox-os.org/toolchain/x86_64-unknown-redox/relibc-install.tar.gz
+  src = fetchurl {
+    name = "relibc-install.tar.gz";
+    url = "https://gateway.pinata.cloud/ipfs/QmNp6fPTjPA6LnCYvW1UmbAHcPpU7tqZhstfSpSXMJCRwp";
+    sha256 = "1hjdzrj67jdag3pm8h2dqh6xipbfxr6f4navdra6q1h83gl7jkd9";
+  };
+
+  # to avoid "unpacker produced multiple directories"
+  unpackPhase = "unpackFile $src";
+
+  dontBuild = true;
+  dontPatchELF = true;
+  dontStrip = true;
+  installPhase = ''
+    mkdir $out/
+    cp -r x86_64-unknown-redox/* $out/
+    rm -rf $out/bin
+  '';
+
+  meta = with stdenvNoCC.lib; {
+    homepage = "https://gitlab.redox-os.org/redox-os/relibc";
+    description = "C Library in Rust for Redox and Linux";
+    license = licenses.mit;
+    maintainers = [ maintainers.aaronjanse ];
+    platforms = platforms.redox;
+  };
+}

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -38,7 +38,7 @@ in lib.init bootStages ++ [
   (buildPackages: {
     inherit config;
     overlays = overlays ++ crossOverlays
-      ++ (if crossSystem.isWasm then [(import ../../top-level/static.nix)] else []);
+      ++ (if (with crossSystem; isWasm || isRedox) then [(import ../../top-level/static.nix)] else []);
     selfBuild = false;
     stdenv = buildPackages.stdenv.override (old: rec {
       buildPlatform = localSystem;
@@ -72,7 +72,7 @@ in lib.init bootStages ++ [
              (hostPlatform.isLinux && !buildPlatform.isLinux)
              [ buildPackages.patchelf ]
         ++ lib.optional
-             (let f = p: !p.isx86 || p.libc == "musl" || p.libc == "wasilibc" || p.isiOS; in f hostPlatform && !(f buildPlatform))
+             (let f = p: !p.isx86 || builtins.elem p.libc [ "musl" "wasilibc" "relibc" ] || p.isiOS; in f hostPlatform && !(f buildPlatform))
              buildPackages.updateAutotoolsGnuConfigScriptsHook
            # without proper `file` command, libtool sometimes fails
            # to recognize 64-bit DLLs


### PR DESCRIPTION
# lib/systems: Add Redox platform definitions

###### Motivation for this change

[Redox](https://redox-os.org) is a Unix-like Operating System written in Rust, aiming to bring the innovations of Rust to a modern microkernel and full set of applications.

Per [RFC0046](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md), I hope for Redox to be a tier 5 platform, unsupported and somewhat functional. I'm developing a [redoxpkgs](https://github.com/aaronjanse/redoxpkgs) overlay (inspired by @ehmry's [genodepkgs](https://git.sr.ht/~ehmry/genodepkgs/)) to patch packages to work for Redox. With this overlay, I can compile functioning packages such as `binutils` and the Rust cross-compiler. In turn, packages such as `hexyl` can be compiled without further modification beyond adding Redox to the package's `meta.plaforms`.

I marked this PR as a draft because it contains some changes (see below) that may need to be removed. More specifically, I made a few conditional changes that I couldn't figure out how to do via an overlay.

Note that `relibc` is downloaded precompiled from a filehosting service. It's precompiled because I've [tried to compile relibc from source](https://gist.github.com/aaronjanse/18dcfeebe895f86622cee294a4d73f42) but it crashes during runtime on Redox. It's from a filehosting service because https://static.redox-os.org continually replaces its contents with new versions, breaking the Nix fetch hash. I've contacted Redox maintainers about this; it sounds like https://static.redox-os.org will have pinned versions in the future. I understand if using a third party filehosting service is a blocking security issue.

###### Things done

Things I'd like to keep in this PR:
- updated `lib/system` to add `x86_64-redox`
- added derivation `relibc`, the POSIX C standard library for Redox.
- enabled the static overlay for Redox

Things I'm comfortable removing from this PR if necessary:
- slightly modified `gcc6` and `rustc` to support Redox (see note above)
- slightly modified `all-packages.nix` to choose versions of toolchain packages based on `isRedox`

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I think @NixOS/exotic-platform-maintainers would find this PR interesting, so I'll ping them here