### PR TITLE
python3Packages.pytest-localserver: fix build

### DIFF
--- a/pkgs/development/python-modules/pytest-localserver/default.nix
+++ b/pkgs/development/python-modules/pytest-localserver/default.nix
@@ -1,9 +1,6 @@
 { buildPythonPackage
 , lib
 , fetchPypi
-, requests
-, pytest
-, six
 , werkzeug
 }:
 
@@ -17,16 +14,16 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ werkzeug ];
-  checkInputs = [ pytest six requests ];
 
-  checkPhase = ''
-    pytest
-  '';
+  # all tests access network: does not work in sandbox
+  doCheck = false;
+  pythonImportsCheck = [ "pytest_localserver" ];
 
-  meta = {
+  meta = with lib; {
     description = "Plugin for the pytest testing framework to test server connections locally";
     homepage = "https://pypi.python.org/pypi/pytest-localserver";
-    license = lib.licenses.mit;
+    license = licenses.mit;
+    maintainers = with maintainers; [ siriobalmelli ];
   };
 }
 


### PR DESCRIPTION
All package tests rely on networking which breaks sandboxed builds.
Fall back to pythonImportsCheck instead.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Building on a machine with sandboxing enabled

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).