### PR TITLE
kicad: fix build

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, gnome3, pkgs, wxGTK30, wxGTK31
+{ lib, stdenv, gnome3, wxGTK30, wxGTK31
+, makeWrapper
 , gsettings-desktop-schemas, hicolor-icon-theme
 , callPackage, callPackages
 , librsvg, cups
@@ -8,7 +9,7 @@
 , oceSupport ? false, opencascade
 , withOCCT ? true, opencascade-occt
 , ngspiceSupport ? true, libngspice
-, scriptingSupport ? true, swig, python3
+, scriptingSupport ? false, swig, python3
 , debug ? false, valgrind
 , with3d ? true
 , withI18n ? true
@@ -31,9 +32,8 @@ let
     # but brings high DPI support?
     else wxGTK31.override { withGtk2 = false; };
 
-  pythonPackages = python.pkgs;
   python = python3;
-  wxPython = pythonPackages.wxPython_4_0;
+  wxPython = python.pkgs.wxPython_4_0;
 
 in
 stdenv.mkDerivation rec {
@@ -55,10 +55,11 @@ stdenv.mkDerivation rec {
   dontFixup = true;
 
   pythonPath = optionals (scriptingSupport)
-    [ wxPython pythonPackages.six ];
+    [ wxPython python.pkgs.six ];
 
-  nativeBuildInputs = optionals (scriptingSupport)
-    [ pythonPackages.wrapPython ];
+  nativeBuildInputs = [ makeWrapper ]
+    ++ optionals (scriptingSupport)
+      [ python.pkgs.wrapPython ];
 
   # wrapGAppsHook added the equivalent to ${base}/share
   # though i noticed no difference without it

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -27,23 +27,23 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2020-05-14";
+      version =			"2020-07-21";
       src = {
-        rev =			"3b8465359135e9f6dea4b0a5fcb62377753fe890";
-        sha256 =		"18xsg2s0pxx176rnblygq1f8xpmryw59lcjzm897gifz0sj0nhvx";
+        rev =			"9a801d8b72f24e297a7d9d6e8cee2eef6cab2988";
+        sha256 =		"0yilmmng7y3rz1bxw2b0s0aqs8hdqr7ach2r45bx8v1f4bih4ka9";
       };
     };
     libVersion = {
-      version =			"2020-05-14";
+      version =			"2020-07-21";
       libSources = {
-        i18n.rev =		"c4460d0d8e1075691d43dc928ffc332fa1282592";
-        i18n.sha256 =		"1gkrbfyfzsr5q7sahhlyhgfpfwm6b83lzf0q1v854gwxdfabvi0y";
-        symbols.rev =		"614b5f6256fbae82c2bba399086506bbe435bd94";
-        symbols.sha256 =	"10ix3wdcl832r4ha5q8phpx8j97gzngb41nczdli1qkhjmiw9y8r";
-        templates.rev =		"7db8d4d0ea0711f1961d117853547fb3edbc3857";
-        templates.sha256 =	"1hppcsrkn4dk6ggby6ckh0q65qxkywrbyxa4lwpaf7pxjyv498xg";
-        footprints.rev =	"240804c6c89b66af808379e1fc94ea6011433cbe";
-        footprints.sha256 =	"1jh71004lrn7bl384zfmbqqdbs28gjb6diwn6hyb587jpivdnl3g";
+        i18n.rev =		"a311975d139caf8be9848dd613a9800570adc245";
+        i18n.sha256 =		"1bkn2hhwcg8xdpn9yfm9nnqsg02c1nizhpxd4yhpxgifhh4psz1g";
+        symbols.rev =		"18572c4c118fe8ef779edf3131eebf2c33c6fa46";
+        symbols.sha256 =	"0hqx0aznzrnlbdkpsnl8mbs9bdgiv029d6zjh10nyjzcw27q3hxz";
+        templates.rev =		"ae16953b81055855bcede4a33305413599d86a15";
+        templates.sha256 =	"1pkv90p3liy3bj4nklxsvpzh9m56p0k5ldr22armvgqfaqaadx9v";
+        footprints.rev =	"4835f80b4a52256aa7a3eb650e6e0fef33a77d0d";
+        footprints.sha256 =	"00rc6phxmkry35i0xzry14axvh2akvvkly45s3xxi06vaydaw7i5";
         packages3d.rev =	"9b560cf94a35b692ca516d37bdaf392ce10e549d";
         packages3d.sha256 =	"0b9jglf77fy0n0r8xs4yqkv6zvipyfvp0z5dnqlzp32csy5aqpi1";
       };


### PR DESCRIPTION
###### Motivation for this change
#92261 broke the build via wxPython
and apparently makeWrapper wasn't passed in explicitly

###### Things done

- disabled scriptingSupport by default, it pulls in wxPython, and that's broken
  - wxPython 4.1 may fix that, but that's another can of worms (#90654)
- add `makeWrapper` to `nativeBuildInputs`
- bump `kicad-unstable` to the latest master commit (and checked if it works somewhat)

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
