### PR TITLE
wolframscript: init at 12.1.0

### DIFF
--- a/pkgs/applications/science/math/wolframscript/default.nix
+++ b/pkgs/applications/science/math/wolframscript/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, requireFile, dpkg, glibc, gcc-unwrapped, autoPatchelfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "wolframscript";
+  version = "12.1.0";
+
+  src = requireFile rec {
+    name = "WolframScript_${version}_LINUX64_amd64.deb";
+    message = ''
+      This nix expression requires that ${name} is
+      already part of the store. Download file from wolfram website
+      https://account.wolfram.com/products/downloads/wolframscript
+      and add it to the nix store with nix-store --add-fixed sha256 <FILE>.
+    '';
+    sha256 = "397b67fd1879c6009d23b40c55a43ff104a7253abb87de221faeeb374765aca1";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook # Automatically setup the loader, and do the magic
+    dpkg
+  ];
+
+  buildInputs = [
+    glibc
+    gcc-unwrapped
+  ];
+
+  unpackPhase = "true";
+
+  installPhase = ''
+    mkdir -p $out $out/share/wolframscript
+
+    # install binaries
+    dpkg --fsys-tarfile $src | \
+      tar --strip-components=4 -xv -C $out ./opt/Wolfram/WolframScript
+
+    # install share folder
+    dpkg --fsys-tarfile $src | \
+      tar --strip-components=3 -xv -C $out/share/wolframscript ./usr/share
+  '';
+
+  meta = with stdenv.lib; {
+    description = "WolframScript enables Wolfram Language code to be run from any terminal";
+    homepage = https://www.wolfram.com/wolframscript/;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ offline ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25193,6 +25193,8 @@ in
   mathematica10 = callPackage ../applications/science/math/mathematica/10.nix { };
   mathematica11 = callPackage ../applications/science/math/mathematica/11.nix { };
 
+  wolframscript = callPackage ../applications/science/math/wolframscript { };
+
   metis = callPackage ../development/libraries/science/math/metis {};
 
   nauty = callPackage ../applications/science/math/nauty {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Sometimes it's useful to do some symbolic calculations using wolfram cloud.

###### Testing

```
wolframscript -authenticate
wolframscript -cloud -code 'Integrate[2x+4, x]'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
