### PR TITLE
add github action to wait for ofborg

### DIFF
--- a/.github/workflows/wait-ofborg.yml
+++ b/.github/workflows/wait-ofborg.yml
@@ -1,0 +1,28 @@
+name: "Wait for ofborg"
+on:
+  pull_request:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Wait for ofborg CI
+      run: |
+        # wait for ~10min
+        set -x
+        for i in $(seq 120); do
+          res=$(curl --silent \
+            -H "Accept: application/vnd.github.antiope-preview+json" \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            "https://api.github.com/repos/NixOS/nixpkgs/commits/${COMMIT}/check-runs" | \
+            jq ".check_runs | map(.app) | map(.id) | contains([${OFBORG_APP_ID}])")
+          if [[ "$res" == "true" ]]; then
+            exit 0
+          fi
+          sleep 5
+        done
+        echo "Timeout!"
+        exit 1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        COMMIT: ${{ github.event.pull_request.head.sha }}
+        OFBORG_APP_ID: 20500


### PR DESCRIPTION
In case ofborg is down this will not mark the CI as green.
Also if other github actions are used and pass
checks will be still marked as pending even if other other github
actions have passed.