### PR TITLE
mathpix-snipping-tool: init at 02.04.0002

### DIFF
--- a/pkgs/applications/science/math/mathpix-snipping-tool/default.nix
+++ b/pkgs/applications/science/math/mathpix-snipping-tool/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchurl, squashfsTools, makeWrapper, xorg, qt5 }:
+
+stdenv.mkDerivation rec {
+  pname = "mathpix-snipping-tool";
+  version = "02.04.0002";
+  rev = "155";
+
+  # for updates check: https://snapcraft.io/mathpix-snipping-tool
+  src = fetchurl {
+    url = "https://api.snapcraft.io/api/v1/snaps/download/jnlZEYdmdXGhh6oJTtMsawNGZzEWmMhk_${rev}.snap";
+    sha256 = "rUfjMRc4DZa3FTtAb2H9qAasTeKU4c6R8EWsg8gcUS4=";
+  };
+
+  buildInputs = [ squashfsTools makeWrapper ];
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  unpackPhase = ''
+    runHook preUnpack
+    unsquashfs "$src" 'usr/bin/mathpix-snipping-tool' 'meta/gui/mathpix-snipping-tool.desktop' 'meta/gui/icon.svg'
+    cd squashfs-root
+    runHook postUnpack
+  '';
+
+  libPath = stdenv.lib.makeLibraryPath [
+    qt5.qtbase
+    qt5.qtwebkit
+    qt5.qtx11extras
+    stdenv.cc.cc # libstdc++.so.6
+    xorg.libX11 # libX11.so.6
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    mv ./usr/* $out/
+
+    patchelf \
+      --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath $libPath \
+      $out/bin/mathpix-snipping-tool
+
+    wrapProgram $out/bin/mathpix-snipping-tool \
+      --set QT_QPA_PLATFORM_PLUGIN_PATH ${qt5.qtbase.bin}/lib/qt-*/plugins/platforms
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://mathpix.com/";
+    description = "Extract equations from PDFs or handwritten notes in seconds just by taking a screenshot.";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ offline ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25151,6 +25151,8 @@ in
 
   lrs = callPackage ../development/libraries/science/math/lrs { };
 
+  mathpix-snipping-tool = callPackage ../applications/science/math/mathpix-snipping-tool { };
+
   m4ri = callPackage ../development/libraries/science/math/m4ri { };
 
   m4rie = callPackage ../development/libraries/science/math/m4rie { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Mathpix-snipping-tool allows you to convert math equations to latex using OCR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
