### PR TITLE
okteto: init at 1.8.15

### DIFF
--- a/pkgs/development/tools/okteto/default.nix
+++ b/pkgs/development/tools/okteto/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "okteteo";
+  version = "1.8.15";
+
+  goPackagePath = "github.com/okteto/okteto";
+  subPackages = ["."];
+
+  buildFlagsArray = [
+    "-tags=osusergo netgo"
+    "-ldflags=-s -w -X ${goPackagePath}/pkg/config.VersionString=${version}"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "okteto";
+    repo = "okteto";
+    rev = version;
+    sha256 = "0eFo0gYciLoHIebMRMqrOMMclG23D9mRoxCQIffvSP0=";
+  };
+
+  vendorSha256 = "5F/SXs5jqLfZXqXPO93KCfDneDcCZNzjhYJ4jqzkfuw=";
+
+  meta = with lib; {
+    description = "Build better applications by developing and testing your code directly in Kubernetes.";
+    homepage = "https://github.com/okteto/okteto";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ offline ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14151,6 +14151,8 @@ in
 
   ogrepaged = callPackage ../development/libraries/ogrepaged { };
 
+  okteto = callPackage ../development/tools/okteto { };
+
   olm = callPackage ../development/libraries/olm { };
 
   one_gadget = callPackage ../development/tools/misc/one_gadget { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Okteto is a tool that allows you to develop your code inside kubernetes cluster.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
