### PR TITLE
nextcloud: restrict web server support to nginx; stop sharing nginx user/group; improve setup service

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -45,6 +45,12 @@ let
   inherit (config.system) stateVersion;
 
 in {
+
+  imports = [
+    ( mkRemovedOptionModule [ "services" "nextcloud" "nginx" "enable" ]
+      "The nextcloud module dropped support for other webservers than nginx.")
+  ];
+
   options.services.nextcloud = {
     enable = mkEnableOption "nextcloud";
     hostName = mkOption {
@@ -465,7 +471,7 @@ in {
               if [ ! -e $dir ]; then
                 install -o nextcloud -g nextcloud -d $dir
               elif [ $(stat -c "%G" $dir) != "nextcloud" ]; then
-                chown -R nextcloud:nextcloud $dir
+                chgrp -R nextcloud $dir
               fi
             done
 
@@ -524,8 +530,8 @@ in {
       users.groups.nextcloud.members = [ "nextcloud" config.services.nginx.user ];
 
       environment.systemPackages = [ occ ];
-    
-      services.nginx.enable = true;
+
+      services.nginx.enable = mkDefault true;
       services.nginx.virtualHosts.${cfg.hostName} = {
         root = cfg.package;
         locations = {

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -510,7 +510,7 @@ in {
           };
           settings = mapAttrs (name: mkDefault) {
             "listen.owner" = config.services.nginx.user;
-            "listen.group" = config.users.users.${config.services.nginx.user}.group;
+            "listen.group" = config.services.nginx.group;
           } // cfg.poolSettings;
           extraConfig = cfg.poolConfig;
         };

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -531,65 +531,81 @@ in {
 
       environment.systemPackages = [ occ ];
 
-      services.nginx.enable = mkDefault true;
-      services.nginx.virtualHosts.${cfg.hostName} = {
-        root = cfg.package;
-        locations = {
-          "= /robots.txt" = {
-            priority = 100;
-            extraConfig = ''
-              allow all;
-              log_not_found off;
+      services.nginx = mkDefault {
+        enable = true;
+        virtualHosts.${cfg.hostName} = {
+          root = cfg.package;
+          locations = {
+            "= /robots.txt" = {
+              priority = 100;
+              extraConfig = ''
+                allow all;
+                log_not_found off;
+                access_log off;
+              '';
+            };
+            "/" = {
+              priority = 200;
+              extraConfig = "rewrite ^ /index.php;";
+            };
+            "~ ^/store-apps" = {
+              priority = 201;
+              extraConfig = "root ${cfg.home};";
+            };
+            "= /.well-known/carddav" = {
+              priority = 210;
+              extraConfig = "return 301 $scheme://$host/remote.php/dav;";
+            };
+            "= /.well-known/caldav" = {
+              priority = 210;
+              extraConfig = "return 301 $scheme://$host/remote.php/dav;";
+            };
+            "~ ^\\/(?:build|tests|config|lib|3rdparty|templates|data)\\/" = {
+              priority = 300;
+              extraConfig = "deny all;";
+            };
+            "~ ^\\/(?:\\.|autotest|occ|issue|indie|db_|console)" = {
+              priority = 300;
+              extraConfig = "deny all;";
+            };
+            "~ ^\\/(?:index|remote|public|cron|core/ajax\\/update|status|ocs\\/v[12]|updater\\/.+|ocs-provider\\/.+|ocm-provider\\/.+)\\.php(?:$|\\/)" = {
+              priority = 500;
+              extraConfig = ''
+                include ${config.services.nginx.package}/conf/fastcgi.conf;
+                fastcgi_split_path_info ^(.+\.php)(\\/.*)$;
+                try_files $fastcgi_script_name =404;
+                fastcgi_param PATH_INFO $fastcgi_path_info;
+                fastcgi_param HTTPS ${if cfg.https then "on" else "off"};
+                fastcgi_param modHeadersAvailable true;
+                fastcgi_param front_controller_active true;
+                fastcgi_pass unix:${fpm.socket};
+                fastcgi_intercept_errors on;
+                fastcgi_request_buffering off;
+                fastcgi_read_timeout 120s;
+              '';
+            };
+            "~ ^\\/(?:updater|ocs-provider|ocm-provider)(?:$|\\/)".extraConfig = ''
+              try_files $uri/ =404;
+              index index.php;
+            '';
+            "~ \\.(?:css|js|woff2?|svg|gif)$".extraConfig = ''
+              try_files $uri /index.php$request_uri;
+              add_header Cache-Control "public, max-age=15778463";
+              add_header X-Content-Type-Options nosniff;
+              add_header X-XSS-Protection "1; mode=block";
+              add_header X-Robots-Tag none;
+              add_header X-Download-Options noopen;
+              add_header X-Permitted-Cross-Domain-Policies none;
+              add_header X-Frame-Options sameorigin;
+              add_header Referrer-Policy no-referrer;
+              access_log off;
+            '';
+            "~ \\.(?:png|html|ttf|ico|jpg|jpeg|bcmap|mp4|webm)$".extraConfig = ''
+              try_files $uri /index.php$request_uri;
               access_log off;
             '';
           };
-          "/" = {
-            priority = 200;
-            extraConfig = "rewrite ^ /index.php;";
-          };
-          "~ ^/store-apps" = {
-            priority = 201;
-            extraConfig = "root ${cfg.home};";
-          };
-          "= /.well-known/carddav" = {
-            priority = 210;
-            extraConfig = "return 301 $scheme://$host/remote.php/dav;";
-          };
-          "= /.well-known/caldav" = {
-            priority = 210;
-            extraConfig = "return 301 $scheme://$host/remote.php/dav;";
-          };
-          "~ ^\\/(?:build|tests|config|lib|3rdparty|templates|data)\\/" = {
-            priority = 300;
-            extraConfig = "deny all;";
-          };
-          "~ ^\\/(?:\\.|autotest|occ|issue|indie|db_|console)" = {
-            priority = 300;
-            extraConfig = "deny all;";
-          };
-          "~ ^\\/(?:index|remote|public|cron|core/ajax\\/update|status|ocs\\/v[12]|updater\\/.+|ocs-provider\\/.+|ocm-provider\\/.+)\\.php(?:$|\\/)" = {
-            priority = 500;
-            extraConfig = ''
-              include ${config.services.nginx.package}/conf/fastcgi.conf;
-              fastcgi_split_path_info ^(.+\.php)(\\/.*)$;
-              try_files $fastcgi_script_name =404;
-              fastcgi_param PATH_INFO $fastcgi_path_info;
-              fastcgi_param HTTPS ${if cfg.https then "on" else "off"};
-              fastcgi_param modHeadersAvailable true;
-              fastcgi_param front_controller_active true;
-              fastcgi_pass unix:${fpm.socket};
-              fastcgi_intercept_errors on;
-              fastcgi_request_buffering off;
-              fastcgi_read_timeout 120s;
-            '';
-          };
-          "~ ^\\/(?:updater|ocs-provider|ocm-provider)(?:$|\\/)".extraConfig = ''
-            try_files $uri/ =404;
-            index index.php;
-          '';
-          "~ \\.(?:css|js|woff2?|svg|gif)$".extraConfig = ''
-            try_files $uri /index.php$request_uri;
-            add_header Cache-Control "public, max-age=15778463";
+          extraConfig = ''
             add_header X-Content-Type-Options nosniff;
             add_header X-XSS-Protection "1; mode=block";
             add_header X-Robots-Tag none;
@@ -597,39 +613,25 @@ in {
             add_header X-Permitted-Cross-Domain-Policies none;
             add_header X-Frame-Options sameorigin;
             add_header Referrer-Policy no-referrer;
-            access_log off;
-          '';
-          "~ \\.(?:png|html|ttf|ico|jpg|jpeg|bcmap|mp4|webm)$".extraConfig = ''
-            try_files $uri /index.php$request_uri;
-            access_log off;
+            add_header Strict-Transport-Security "max-age=15552000; includeSubDomains" always;
+            error_page 403 /core/templates/403.php;
+            error_page 404 /core/templates/404.php;
+            client_max_body_size ${cfg.maxUploadSize};
+            fastcgi_buffers 64 4K;
+            fastcgi_hide_header X-Powered-By;
+            gzip on;
+            gzip_vary on;
+            gzip_comp_level 4;
+            gzip_min_length 256;
+            gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
+            gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
+
+            ${optionalString cfg.webfinger ''
+              rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
+              rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
+            ''}
           '';
         };
-        extraConfig = ''
-          add_header X-Content-Type-Options nosniff;
-          add_header X-XSS-Protection "1; mode=block";
-          add_header X-Robots-Tag none;
-          add_header X-Download-Options noopen;
-          add_header X-Permitted-Cross-Domain-Policies none;
-          add_header X-Frame-Options sameorigin;
-          add_header Referrer-Policy no-referrer;
-          add_header Strict-Transport-Security "max-age=15552000; includeSubDomains" always;
-          error_page 403 /core/templates/403.php;
-          error_page 404 /core/templates/404.php;
-          client_max_body_size ${cfg.maxUploadSize};
-          fastcgi_buffers 64 4K;
-          fastcgi_hide_header X-Powered-By;
-          gzip on;
-          gzip_vary on;
-          gzip_comp_level 4;
-          gzip_min_length 256;
-          gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
-          gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
-
-          ${optionalString cfg.webfinger ''
-            rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
-            rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-          ''}
-        '';
       };
     }
   ]);

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -458,7 +458,17 @@ in {
           script = ''
             chmod og+x ${cfg.home}
             ln -sf ${cfg.package}/apps ${cfg.home}/
-            install -o nextcloud -g nextcloud -d ${cfg.home}/config ${cfg.home}/data ${cfg.home}/store-apps
+
+            # create nextcloud directories.
+            # if the directories exist already with wrong permissions, we fix that
+            for dir in ${cfg.home}/config ${cfg.home}/data ${cfg.home}/store-apps; do
+              if [ ! -e $dir ]; then
+                install -o nextcloud -g nextcloud -d $dir
+              elif [ $(stat -c "%G" $dir) != "nextcloud" ]; then
+                chown -R nextcloud:nextcloud $dir
+              fi
+            done
+
             ln -sf ${overrideConfig} ${cfg.home}/config/override.config.php
 
             # Do not install if already installed

--- a/nixos/tests/nextcloud/basic.nix
+++ b/nixos/tests/nextcloud/basic.nix
@@ -33,7 +33,6 @@ in {
 
       services.nextcloud = {
         enable = true;
-        nginx.enable = true;
         hostName = "nextcloud";
         config = {
           # Don't inherit adminuser since "root" is supposed to be the default

--- a/nixos/tests/nextcloud/with-mysql-and-memcached.nix
+++ b/nixos/tests/nextcloud/with-mysql-and-memcached.nix
@@ -17,7 +17,6 @@ in {
       services.nextcloud = {
         enable = true;
         hostName = "nextcloud";
-        nginx.enable = true;
         https = true;
         caching = {
           apcu = true;

--- a/nixos/tests/nextcloud/with-postgresql-and-redis.nix
+++ b/nixos/tests/nextcloud/with-postgresql-and-redis.nix
@@ -17,7 +17,6 @@ in {
       services.nextcloud = {
         enable = true;
         hostName = "nextcloud";
-        nginx.enable = true;
         caching = {
           apcu = false;
           redis = true;


### PR DESCRIPTION
###### Things done
(This description is heavily outdated. Plans changed a lot due to the discussions. See below)
 - user and group used by all nextcloud related services are now unified and configurable. If nginx is enabled, the group will be forced to `nginx` and an error is raised if group is set manually.
- nginx is enabled by default now. (In favor of having a working default configuration)
- phpfpm also uses configured nextcloud user + group
- In the setup service instead of `mkdir` + `chown` now `install` is used to setup the directories.
  This has the disadvantage that the group of nextcloud cannot be changed anymore on an existing installation without having to fix the ownership of files manually. But it think `chown`ing all files on every single startup is bad since it's a very intense operation and can take very long depending on the amount of files stored. Also the `chown` operation itself might not be allowed depending on the filesystem. I for example use a sshfs mount for my nextcloud files where this fails

fixes #69261
fixes #48881

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
