### PR TITLE
dash: fix compilation on darwin

### DIFF
--- a/pkgs/shells/dash/0001-fix-dirent64-et-al-on-darwin.patch
+++ b/pkgs/shells/dash/0001-fix-dirent64-et-al-on-darwin.patch
@@ -1,0 +1,41 @@
+From 7e75779eaeacdbb46a387a59d9aaf1481a1da3e5 Mon Sep 17 00:00:00 2001
+From: Adrian Gierakowski <agierakowski@gmail.com>
+Date: Sun, 19 Jul 2020 08:38:05 +0100
+Subject: [PATCH] fix dirent64 et al on darwin
+
+---
+ configure.ac | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index b8faca9..cee1e4d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -139,6 +139,7 @@ if test "$ac_cv_func_signal" != yes; then
+ 				 [klibc has bsd_signal instead of signal])])
+ fi
+ 
++dnl TODO: stat64 is deprecated since macOS 10.6
+ dnl Check for stat64 (dietlibc/klibc).
+ AC_CHECK_FUNC(stat64,, [
+ 	AC_DEFINE(fstat64, fstat, [64-bit operations are the same as 32-bit])
+@@ -155,6 +156,16 @@ AC_CHECK_FUNC(open64,, [
+ 	AC_DEFINE(open64, open, [64-bit operations are the same as 32-bit])
+ ])
+ 
++dnl OS X apparently has stat64 but not readdir64.
++AC_CHECK_FUNC(readdir64,, [
++	AC_DEFINE(readdir64, readdir, [64-bit operations are the same as 32-bit])
++])
++
++dnl OS X apparently has stat64 but not dirent64.
++AC_CHECK_TYPE(struct dirent64,, [
++	AC_DEFINE(dirent64, dirent, [64-bit operations are the same as 32-bit])
++],[#include <dirent.h>])
++
+ dnl Check if struct stat has st_mtim.
+ AC_MSG_CHECKING(for stat::st_mtim)
+ AC_COMPILE_IFELSE(
+-- 
+2.15.1
+

--- a/pkgs/shells/dash/default.nix
+++ b/pkgs/shells/dash/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ autoreconfHook, lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "dash-0.5.11.1";
@@ -9,6 +9,10 @@ stdenv.mkDerivation rec {
   };
 
   hardeningDisable = [ "format" ];
+
+  # Temporary fix until a proper one is accepted upstream
+  patches = lib.lists.optional stdenv.isDarwin ./0001-fix-dirent64-et-al-on-darwin.patch;
+  nativeBuildInputs = lib.lists.optional stdenv.isDarwin autoreconfHook;
 
   meta = with stdenv.lib; {
     homepage = "http://gondor.apana.org.au/~herbert/dash/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

it's been broken since: https://github.com/NixOS/nixpkgs/commit/adbace3c212a64cfa151590f907965aa3eaabf8b
see: https://hydra.nixos.org/job/nixpkgs/trunk/dash.x86_64-darwin

NOTE: this is a quickfix until a patch is accepted upstream

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).