### PR TITLE
udpt: 2017-09-27 -> 3.1.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -527,6 +527,14 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
    </listitem>
    <listitem>
     <para>
+      <literal>udpt</literal> experienced a complete rewrite from C++ to rust. The configuration format changed from ini to toml.
+      The new configuration documentation can be found at
+      <link xlink:href="https://naim94a.github.io/udpt/config.html">the official website</link> and example
+      configuration is packaged in <literal>${udpt}/share/udpt/udpt.toml</literal>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      We now have a unified <xref linkend="opt-services.xserver.displayManager.autoLogin"/> option interface
      to be used for every display-manager in NixOS.
     </para>

--- a/pkgs/servers/udpt/default.nix
+++ b/pkgs/servers/udpt/default.nix
@@ -1,45 +1,21 @@
-{ stdenv, fetchFromGitHub, boost, sqlite, cmake, gtest }:
+{ stdenv, rustPlatform, fetchFromGitHub }:
 
-stdenv.mkDerivation {
+rustPlatform.buildRustPackage rec {
   pname = "udpt";
-  version = "2017-09-27";
-
-  enableParallelBuilding = true;
-
-  # Suitable for a network facing daemon.
-  hardeningEnable = [ "pie" ];
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "naim94a";
     repo = "udpt";
-    rev = "e0dffc83c8ce76b08a41a4abbd5f8065535d534f";
-    sha256 = "187dw96mzgcmh4k9pvfpb7ckbb8d4vlikamr2x8vkpwzgjs3xd6g";
+    rev = "${pname}-${version}";
+    sha256 = "1g6l0y5x9pdra3i1npkm474glysicm4hf2m01700ack2rp43vldr";
   };
 
-  doCheck = true;
+  cargoSha256 = "1cmd80ndjxdmyfjpm1f04rwf64501nyi6wdsj7lxidgd1v92wy2c";
+  verifyCargoDeps = true;
 
-  checkPhase = ''
-    runHook preCheck
-
-    make test
-
-    runHook postCheck
-  '';
-
-  buildInputs = [ boost sqlite cmake gtest ];
-
-  postPatch = ''
-    # Enabling optimization (implied by fortify hardening) causes htons
-    # to be re-defined as a macro, turning this use of :: into a syntax error.
-    sed -i '104a#undef htons' src/udpTracker.cpp
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin $out/etc/
-    cp udpt $out/bin
-    cp ../udpt.conf $out/etc/
-    # without this, the resulting binary is unstripped.
-    runHook postInstall
+  postInstall = ''
+    install -D udpt.toml $out/share/udpt/udpt.toml
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
udpt did a complete rewrite from cpp to rust.
This Commit uses rust with cargo to build the package.
The Configuration format changed form .conf to .toml and
the binary changed from udpt to udpt-rs



###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date - update release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
