### PR TITLE
python3Packages.pq: init at 1.8.1

### DIFF
--- a/pkgs/development/python-modules/pq/default.nix
+++ b/pkgs/development/python-modules/pq/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, psycopg2
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "pq";
+  version = "1.8.1";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "9e2c0195488263902ebc9da8df6c82bebe4ee32c79d9ecd0cdc2945afbf7ad32";
+  };
+
+  # psycopg2cffi is compatible with psycopg2 and author states that
+  # module is compatible with psycopg2
+  postConfigure = ''
+    substituteInPlace setup.py \
+      --replace "psycopg2cffi" "psycopg2"
+
+    substituteInPlace pq/tests.py \
+      --replace "psycopg2cffi" "psycopg2"
+  '';
+
+  checkInputs = [
+    psycopg2
+  ];
+
+  # tests require running postgresql cluster
+  doCheck = false;
+
+  meta = with lib; {
+    description = "PQ is a transactional queue for PostgreSQL";
+    homepage = https://github.com/malthe/pq/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5290,6 +5290,8 @@ in {
 
   pproxy = callPackage ../development/python-modules/pproxy { };
 
+  pq = callPackage ../development/python-modules/pq { };
+
   praw = if isPy3k then callPackage ../development/python-modules/praw { }
     else callPackage ../development/python-modules/praw/6.3.nix { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Needed a simple task queue library to work with our existing postgresql instance.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
