### PR TITLE
dijo: init at 0.1.5

### DIFF
--- a/pkgs/tools/misc/dijo/default.nix
+++ b/pkgs/tools/misc/dijo/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, rustPlatform, fetchFromGitHub, ncurses, CoreServices }:
+let version = "0.1.5"; in
+rustPlatform.buildRustPackage {
+  pname = "dijo";
+  inherit version;
+  buildInputs = [ ncurses ] ++ lib.optional stdenv.isDarwin CoreServices;
+  src = fetchFromGitHub {
+    owner = "NerdyPepper";
+    repo = "dijo";
+    rev = "v${version}";
+    sha256 = "1ch320j2d66zn9mbs7xl0bkfcm2hpak6izk0yspz1gcji1l7grsc";
+  };
+  cargoSha256 = "1p6apz3wd4gqp0z24ygfw8nmpkh44d000jp6x7svqzmpphnmb0ji";
+
+  meta = with lib; {
+    description = "Scriptable, curses-based, digital habit tracker.";
+    homepage = "https://github.com/NerdyPepper/dijo";
+    license = licenses.mit;
+    maintainers = with maintainers; [ infinisil ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1707,6 +1707,10 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  dijo = callPackage ../tools/misc/dijo {
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
+  };
+
   ding = callPackage ../applications/misc/ding {
     aspellDicts_de = aspellDicts.de;
     aspellDicts_en = aspellDicts.en;


### PR DESCRIPTION
###### Motivation for this change
Adds [dijo](https://github.com/NerdyPepper/dijo), a scriptable, curses-based, digital habit tracker

![](https://u.peppe.rs/HZ.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
