### PR TITLE
blockbook: fix build on aarch64-linux

### DIFF
--- a/pkgs/servers/blockbook/default.nix
+++ b/pkgs/servers/blockbook/default.nix
@@ -1,15 +1,14 @@
 { stdenv
 , buildGoModule
-, lib
 , fetchFromGitHub
-, rocksdb
-, bzip2
-, zlib
 , packr
-, snappy
 , pkg-config
-, zeromq
+, bzip2
 , lz4
+, rocksdb
+, snappy
+, zeromq
+, zlib
 }:
 
 buildGoModule rec {
@@ -26,9 +25,9 @@ buildGoModule rec {
 
   vendorSha256 = "1qjlvhizl8cy06cgf4phia70bgbm4lj57z5z2gyr8aglx98bnpdn";
 
-  buildInputs = [ bzip2 zlib snappy zeromq lz4 ];
+  nativeBuildInputs = [ packr pkg-config ];
 
-  nativeBuildInputs = [ pkg-config packr ];
+  buildInputs = [ bzip2 lz4 rocksdb snappy zeromq zlib ];
 
   buildFlagsArray = ''
     -ldflags=
@@ -45,17 +44,16 @@ buildGoModule rec {
   };
 
   overrideModAttrs = (_: {
-      postBuild = ''
+    postBuild = ''
       rm -r vendor/github.com/ethereum/go-ethereum
       cp -r --reflink=auto ${goethereum} vendor/github.com/ethereum/go-ethereum
-      '';
-    });
+    '';
+  });
 
-  preBuild = lib.optionalString stdenv.isDarwin ''
+  preBuild = stdenv.lib.optionalString stdenv.isDarwin ''
     ulimit -n 8192
   '' + ''
-    export CGO_CFLAGS="-I${rocksdb}/include"
-    export CGO_LDFLAGS="-L${rocksdb}/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4"
+    export CGO_LDFLAGS="-L${stdenv.cc.cc.lib}/lib -lrocksdb -lz -lbz2 -lsnappy -llz4 -lm -lstdc++"
     packr clean && packr
   '';
 
@@ -67,11 +65,11 @@ buildGoModule rec {
     cp -r $src/static/css/ $out/share/
   '';
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "Trezor address/account balance backend";
     homepage = "https://github.com/trezor/blockbook";
     license = licenses.agpl3;
     maintainers = with maintainers; [ mmahut maintainers."1000101" ];
-    platforms = remove "aarch64-linux" platforms.unix;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This PR fixes the build failure on aarch64-linux. For some reason the aarch64 build does not seem to be able to find the latest libstdc++, so we help a little with adding `-L${stdenv.cc.cc.lib}/lib` explicitly to the `CGO_LDFLAGS`.

Plus I cleaned up the package a little bit

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
