### PR TITLE
ocamlPackages.ocsigen_server: fix build; 2.15.0 → 2.16.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -4,7 +4,7 @@
 , makeWrapper, fetchpatch
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+if !stdenv.lib.versionAtLeast ocaml.version "4.06.1"
 then throw "ocsigenserver is not available for OCaml ${ocaml.version}"
 else
 
@@ -13,14 +13,14 @@ let mkpath = p: n:
 in
 
 stdenv.mkDerivation rec {
-  version = "2.15.0";
+  version = "2.16.0";
   pname = "ocsigenserver";
 
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = "ocsigenserver";
     rev = version;
-    sha256 = "15qdkxcbl9c1bbn0fh9awjw0hjn7r6awcn288a9vyxln7icdbifw";
+    sha256 = "0dd7zfk8dlajv0297dswaaqh96hjk2ppy8zb67jbkd26nimahk9y";
   };
 
   # unreleased fix for Makefile typos breaking compilation

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, which, ocaml, findlib, lwt_react, ssl, lwt_ssl
 , lwt_log, ocamlnet, ocaml_pcre, cryptokit, tyxml, xml-light, ipaddr
 , pgocaml, camlzip, ocaml_sqlite3
-, makeWrapper
+, makeWrapper, fetchpatch
 }:
 
 if !stdenv.lib.versionAtLeast ocaml.version "4.03"
@@ -22,6 +22,12 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "15qdkxcbl9c1bbn0fh9awjw0hjn7r6awcn288a9vyxln7icdbifw";
   };
+
+  # unreleased fix for Makefile typos breaking compilation
+  patches = [ (fetchpatch {
+    url = "https://github.com/ocsigen/ocsigenserver/commit/014aefc4e460686a361b974f16ebb7e0c993b36b.patch";
+    sha256 = "0xda4fj8p5102lh9xmrn5mv3s0ps6yykqj3mpjf72gf4zd6fzcn7";
+  }) ];
 
   buildInputs = [ which makeWrapper ocaml findlib
     lwt_react pgocaml camlzip ocaml_sqlite3


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix current build failure; [lwt 5](https://github.com/ocsigen/ocsigenserver/blob/master/CHANGES#L2).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
