### PR TITLE
openhantek6022: init at 3.1.1

### DIFF
--- a/pkgs/applications/science/electronics/openhantek6022/default.nix
+++ b/pkgs/applications/science/electronics/openhantek6022/default.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, lib, fetchFromGitHub, makeWrapper, cmake, qtbase, qttools, fftw, libusb1, libglvnd }:
+
+mkDerivation rec {
+  pname = "openhantek6022";
+  version = "3.1.1";
+
+  src = fetchFromGitHub {
+    owner = "OpenHantek";
+    repo = "OpenHantek6022";
+    rev = version;
+    sha256 = "17b0qmz7g0nk7n7jhbh5xhs135dpj9kv41n42vvpdzwr6z5rk4qm";
+  };
+
+  nativeBuildInputs = [ cmake makeWrapper ];
+  buildInputs = [ fftw libusb1 libglvnd qtbase qttools ];
+
+  postPatch = ''
+    # Fix up install paths & checks
+    sed -i 's#if(EXISTS ".*")#if(1)#g' CMakeLists.txt
+    sed -i 's#/lib/udev#lib/udev#g' CMakeLists.txt
+    sed -i 's#/usr/share#share#g' CMakeLists.txt
+  '';
+
+  meta = with lib; {
+    description = "Free software for Hantek and compatible (Voltcraft/Darkwire/Protek/Acetech) USB digital signal oscilloscopes";
+    homepage    = "https://github.com/OpenHantek/OpenHantek6022";
+    license     = licenses.gpl3;
+    maintainers = with maintainers; [ baracoder ];
+    platforms = qtbase.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5742,6 +5742,8 @@ in
 
   openjade = callPackage ../tools/text/sgml/openjade { };
 
+  openhantek6022 = libsForQt5.callPackage ../applications/science/electronics/openhantek6022 { };
+
   openimagedenoise = callPackage ../development/libraries/openimagedenoise { };
 
   openmvg = callPackage ../applications/science/misc/openmvg { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adding this package for a cheap USB oscilloscope I bought recently.

On NixOS, the package can be added to `services.udev.packages` to set up udev rules.
`TAG+="uaccess", TAG+="udev-acl"` did not do the trick. I have added `GROUP="plugdev", MODE="0666"`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
