### PR TITLE
meteor: enable on darwin

### DIFF
--- a/pkgs/servers/meteor/default.nix
+++ b/pkgs/servers/meteor/default.nix
@@ -2,15 +2,25 @@
 
 let
   version = "1.12";
+
+  inherit (stdenv.hostPlatform) system;
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://static-meteor.netdna-ssl.com/packages-bootstrap/${version}/meteor-bootstrap-os.linux.x86_64.tar.gz";
+      sha256 = "0l3zc76djzypvc0dm5ikv5ybb6574qd6kdbbkarzc2dxx64wkyvb";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://static-meteor.netdna-ssl.com/packages-bootstrap/${version}/meteor-bootstrap-os.osx.x86_64.tar.gz";
+      sha256 = "01gn3m6qacp3ibvp0rcvm2pq7fi1xds02ws0irypldh7vz3930jl";
+    };
+  };
 in
 
 stdenv.mkDerivation {
   inherit version;
   pname = "meteor";
-  src = fetchurl {
-    url = "https://static-meteor.netdna-ssl.com/packages-bootstrap/${version}/meteor-bootstrap-os.linux.x86_64.tar.gz";
-    sha256 = "0l3zc76djzypvc0dm5ikv5ybb6574qd6kdbbkarzc2dxx64wkyvb";
-  };
+  src = srcs.${system};
 
   #dontStrip = true;
 
@@ -30,38 +40,6 @@ stdenv.mkDerivation {
     toolsDir=$(dirname $(find $out/packages -print | grep "meteor-tool/.*/tools/index.js$"))
     ln -s $toolsDir $out/tools
 
-    # Patch Meteor to dynamically fixup shebangs and ELF metadata where
-    # necessary.
-    pushd $out
-    patch -p1 < ${./main.patch}
-    popd
-    substituteInPlace $out/tools/cli/main.js \
-      --replace "@INTERPRETER@" "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --replace "@RPATH@" "${lib.makeLibraryPath [ stdenv.cc.cc zlib ]}" \
-      --replace "@PATCHELF@" "${patchelf}/bin/patchelf"
-
-    # Patch node.
-    node=$devBundle/bin/node
-    patchelf \
-      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-      --set-rpath "$(patchelf --print-rpath $node):${stdenv.cc.cc.lib}/lib" \
-      $node
-
-    # Patch mongo.
-    for p in $devBundle/mongodb/bin/mongo{,d}; do
-      patchelf \
-        --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-        --set-rpath "$(patchelf --print-rpath $p):${lib.makeLibraryPath [ stdenv.cc.cc zlib ]}" \
-        $p
-    done
-
-    # Patch node dlls.
-    for p in $(find $out/packages -name '*.node'); do
-      patchelf \
-        --set-rpath "$(patchelf --print-rpath $p):${stdenv.cc.cc.lib}/lib" \
-        $p || true
-    done
-
     # Meteor needs an initial package-metadata in $HOME/.meteor,
     # otherwise it fails spectacularly.
     mkdir -p $out/bin
@@ -75,16 +53,49 @@ stdenv.mkDerivation {
       chmod +w "\$HOME/.meteor/package-metadata/v2.0.1/packages.data.db"
     fi
 
-    $node \''${TOOL_NODE_FLAGS} $out/tools/index.js "\$@"
+    $out/dev_bundle/bin/node --no-wasm-code-gc \''${TOOL_NODE_FLAGS} $out/tools/index.js "\$@"
     EOF
     chmod +x $out/bin/meteor
+  '';
+
+  postFixup = lib.optionalString stdenv.isLinux ''
+      # Patch Meteor to dynamically fixup shebangs and ELF metadata where
+      # necessary.
+      pushd $out
+      patch -p1 < ${./main.patch}
+      popd
+      substituteInPlace $out/tools/cli/main.js \
+        --replace "@INTERPRETER@" "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --replace "@RPATH@" "${lib.makeLibraryPath [ stdenv.cc.cc zlib ]}" \
+        --replace "@PATCHELF@" "${patchelf}/bin/patchelf"
+
+      # Patch node.
+      patchelf \
+        --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+        --set-rpath "$(patchelf --print-rpath $out/dev_bundle/bin/node):${stdenv.cc.cc.lib}/lib" \
+        $out/dev_bundle/bin/node
+
+      # Patch mongo.
+      for p in $out/dev_bundle/mongodb/bin/mongo{,d}; do
+        patchelf \
+          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          --set-rpath "$(patchelf --print-rpath $p):${lib.makeLibraryPath [ stdenv.cc.cc zlib ]}" \
+          $p
+      done
+
+      # Patch node dlls.
+      for p in $(find $out/packages -name '*.node'); do
+        patchelf \
+          --set-rpath "$(patchelf --print-rpath $p):${stdenv.cc.cc.lib}/lib" \
+          $p || true
+      done
   '';
 
   meta = with lib; {
     description = "Complete open source platform for building web and mobile apps in pure JavaScript";
     homepage = "http://www.meteor.com";
     license = licenses.mit;
-    platforms = [ "x86_64-linux" ];
+    platforms = builtins.attrNames srcs;
     maintainers = with maintainers; [ cstrahan ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
1. enable on darwin
2. add `--no-wasm-code-gc` node flag ([Fix fatal error with wasm gc and node-fibers in node 12.11+](https://github.com/meteor/meteor/commit/c37bab64a4750eafbc6483ee82f67e6ff6221029))

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
```sh
$ ./result/bin/meteor create --react test-app
$ cd test-app
$ ../result/bin/meteor run
```
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
