### PR TITLE
go-task: init at 2.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6160,6 +6160,12 @@
     githubId = 20792;
     name = "Sebastian Galkin";
   };
+  parasrah = {
+    email = "nixos@parasrah.com";
+    github = "parasrah";
+    githubId = 14935550;
+    name = "Brad Pfannmuller";
+  };
   pashashocky = {
     email = "pashashocky@gmail.com";
     github = "pashashocky";

--- a/pkgs/development/tools/go-task/default.nix
+++ b/pkgs/development/tools/go-task/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-task";
+  version = "2.8.1";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = "task";
+    rev = "v${version}";
+    sha256 = "1yf5s22q4hsxvgzrj4k6gbbq0whl5b9j12mbwimxaf53q535wy4q";
+  };
+
+  vendorSha256 = null;
+
+  subPackages = [ "cmd/task" ];
+
+  buildFlagsArray = [
+    "-ldflags=-s -w -X main.version=${version}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/task $out/bin/go-task
+  '';
+
+  meta = with lib; {
+    homepage = "https://taskfile.dev/";
+    description = "A task runner / simpler Make alternative written in Go";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ parasrah ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17679,6 +17679,8 @@ in
 
   gotags = callPackage ../development/tools/gotags { };
 
+  go-task = callPackage ../development/tools/go-task { };
+
   golint = callPackage ../development/tools/golint { };
 
   golangci-lint = callPackage ../development/tools/golangci-lint { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

to add `go-task` to nixpkgs (a make alternative). This is my first time contributing to `nixpkgs` so please let me know if there is anything I'm missing or should have done differently. I didn't try building from source because it appears that `go-task` uses itself in the build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
