### PR TITLE
oneDNN: 1.5 -> 1.5.1

### DIFF
--- a/pkgs/development/libraries/oneDNN/default.nix
+++ b/pkgs/development/libraries/oneDNN/default.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
 
   # The test driver doesn't add an RPath to the build libdir
   preCheck = ''
-    export LD_LIBRARY_PATH=$PWD/src
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD/src
+    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD/src
   '';
 
   # The cmake install gets tripped up and installs a nix tree into $out, in
@@ -36,7 +37,7 @@ stdenv.mkDerivation rec {
     homepage = "https://01.org/dnnl";
     changelog = "https://github.com/oneapi-src/oneDNN/releases/tag/v${version}";
     license = licenses.asl20;
-    platforms = [ "aarch64-linux" "x86_64-linux" ];
+    platforms = platforms.all;
     maintainers = with maintainers; [ alexarice bhipple ];
   };
 }

--- a/pkgs/development/libraries/oneDNN/default.nix
+++ b/pkgs/development/libraries/oneDNN/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "oneAPI Deep Neural Network Library (oneDNN)";
-    homepage = "https://01.org/dnnl";
+    homepage = "https://01.org/oneDNN";
     changelog = "https://github.com/oneapi-src/oneDNN/releases/tag/v${version}";
     license = licenses.asl20;
     platforms = platforms.all;

--- a/pkgs/development/libraries/oneDNN/default.nix
+++ b/pkgs/development/libraries/oneDNN/default.nix
@@ -5,13 +5,13 @@
 # https://github.com/oneapi-src/oneDNN#oneapi-deep-neural-network-library-onednn
 stdenv.mkDerivation rec {
   pname = "oneDNN";
-  version = "1.5";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "oneapi-src";
     repo = "oneDNN";
     rev = "v${version}";
-    sha256 = "0diiy3g4wz5lnz5mdvka5p2nwmrpfldsz83sssr5yiir29m4lqap";
+    sha256 = "1l66gkidldjpznp8pb01wdgrmm0rmrbndv8lzidz8fp9hf473zgl";
   };
 
   outputs = [ "out" "dev" "doc" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

also fixes https://github.com/NixOS/nixpkgs/issues/93127 cc: @mstone 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
