### PR TITLE
buildGoModule: allow modSha256 

### DIFF
--- a/pkgs/applications/blockchains/go-ethereum.nix
+++ b/pkgs/applications/blockchains/go-ethereum.nix
@@ -11,21 +11,8 @@ buildGoModule rec {
     sha256 = "175cy5cqkdhvh3kv2d0madybbz2sdbgxhm8xfb3ydbaf2hzihxmx";
   };
 
-  usb = fetchFromGitHub {
-    owner = "karalabe";
-    repo = "usb";
-    rev = "911d15fe12a9c411cf5d0dd5635231c759399bed";
-    sha256 = "0asd5fz2rhzkjmd8wjgmla5qmqyz4jaa6qf0n2ycia16jsck6wc2";
-  };
-
-  vendorSha256 = "0w2214fllw93xbrlxayhl014aqbjsc8zz7mpik7w5b26m60hn5kr";
-
-  overrideModAttrs = (_: {
-      postBuild = ''
-      cp -r --reflink=auto ${usb}/libusb vendor/github.com/karalabe/usb
-      cp -r --reflink=auto ${usb}/hidapi vendor/github.com/karalabe/usb
-      '';
-    });
+  modvendorCopy = true;
+  vendorSha256 = "0iwcdv6wvjbp84m5d2l3996wpklzik1dx4n70v2kd9fcsqcrgvvq";
 
   subPackages = [
     "cmd/abidump"

--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -13,21 +13,8 @@ buildGoModule rec {
     sha256 = "0qhv8kdv5k1xfk6106lxvsz7f92k7w6wk05ngz7qxbkb6zkcnshw";
   };
 
-  golibsass = fetchFromGitHub {
-    owner = "bep";
-    repo = "golibsass";
-    rev = "8a04397f0baba474190a9f58019ff499ec43057a";
-    sha256 = "0xk3m2ynbydzx87dz573ihwc4ryq0r545vz937szz175ivgfrhh3";
-  };
-
-  overrideModAttrs = (_: {
-      postBuild = ''
-      rm -rf vendor/github.com/bep/golibsass/
-      cp -r --reflink=auto ${golibsass} vendor/github.com/bep/golibsass
-      '';
-    });
-
-  vendorSha256 = "07dkmrldsxw59v6r4avj1gr4hsaxybhb14qv61hc777qix2kq9v1";
+  modvendorCopy = true;
+  vendorSha256 = "0ypgjn9lkdj48s3cbmaimh0l7md18kkxn6j4zrl5riah9a0bmghg";
 
   buildFlags = [ "-tags" "extended" ];
 

--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -13,21 +13,8 @@ buildGoModule rec {
     sha256 = "05qy14k9wmyhsg1hiv4njfx1zn1m9lz4d1p50kc36v7pq0n4csfk";
   };
 
-  libvterm = fetchFromGitHub {
-    owner = "ddevault";
-    repo = "go-libvterm";
-    rev = "b7d861da381071e5d3701e428528d1bfe276e78f";
-    sha256 = "06vv4pgx0i6hjdjcar4ch18hp9g6q6687mbgkvs8ymmbacyhp7s6";
-  };
-
-  vendorSha256 = "1rqn36510m0yb7k4bvq2hgirr3z8a2h5xa7cq5mb84xsmhvf0g69";
-
-  overrideModAttrs = (_: {
-      postBuild = ''
-      cp -r --reflink=auto ${libvterm}/libvterm vendor/github.com/ddevault/go-libvterm
-      cp -r --reflink=auto ${libvterm}/encoding vendor/github.com/ddevault/go-libvterm
-      '';
-    });
+  modvendorCopy = true;
+  vendorSha256 = "08j84p7dk51ydbn63cnxfr463kdp1mvdxnjcz5bw5v9phnabhb38";
 
   nativeBuildInputs = [
     scdoc

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -1,4 +1,4 @@
-{ go, cacert, git, lib, removeReferencesTo, stdenv }:
+{ go, cacert, git, modvendor, lib, removeReferencesTo, stdenv }:
 
 { name ? "${args'.pname}-${args'.version}"
 , src
@@ -20,6 +20,8 @@
 , vendorSha256
 # Whether to delete the vendor folder supplied with the source.
 , deleteVendor ? false
+
+, modvendorCopy ? false
 
 , modSha256 ? null
 
@@ -88,6 +90,9 @@ let
         exit 10
       fi
       go mod vendor
+      if ${ lib.boolToString modvendorCopy }; then
+        ${modvendor}/bin/modvendor -copy="**/*.c **/*.cc **/*.cpp **/*.cxx **/*.h **/*.hh **/*.hpp **/*.hxx **/*.inc **/*.m **/*.proto **/*.s **/*.S **/*.swig **/*.swigcxx **/*.sx **/*.syso" -v
+      fi
       mkdir -p vendor
 
       runHook postBuild

--- a/pkgs/development/tools/modvendor/default.nix
+++ b/pkgs/development/tools/modvendor/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "modvendor";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "goware";
+    repo = "modvendor";
+    rev = "v${version}";
+    sha256 = "1pdh2ck40b2z2www38a86snp65n5dg2w4zbabh6d4g29gq668wyr";
+  };
+
+  vendorSha256 = null;
+
+  meta = with lib; {
+    homepage = "https://github.com/goware/modvendor";
+    description = "Simple tool to copy additional module files into a local vendor folder";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/blockbook/default.nix
+++ b/pkgs/servers/blockbook/default.nix
@@ -23,7 +23,8 @@ buildGoModule rec {
     sha256 = "0da1kav5x2xcmwvdgfk1q70l1k0sqqj3njgx2xx885d40m6qbnrs";
   };
 
-  vendorSha256 = "1qjlvhizl8cy06cgf4phia70bgbm4lj57z5z2gyr8aglx98bnpdn";
+  modvendorCopy = true;
+  vendorSha256 = "1azr7mhw7kwmm3pla9a33xg0j193fr0dniyk4ajli3fcfjmz632j";
 
   nativeBuildInputs = [ packr pkg-config ];
 
@@ -35,20 +36,6 @@ buildGoModule rec {
        -X github.com/trezor/blockbook/common.gitcommit=${commit}
        -X github.com/trezor/blockbook/common.buildDate=unknown
   '';
-
-  goethereum = fetchFromGitHub {
-    owner = "ethereum";
-    repo = "go-ethereum";
-    rev = "v1.8.20";
-    sha256 = "0m2q1nz6f39pyr2rk6vflkwi4ykganzwr7wndpwr9rliw0x8jgi0";
-  };
-
-  overrideModAttrs = (_: {
-    postBuild = ''
-      rm -r vendor/github.com/ethereum/go-ethereum
-      cp -r --reflink=auto ${goethereum} vendor/github.com/ethereum/go-ethereum
-    '';
-  });
 
   preBuild = stdenv.lib.optionalString stdenv.isDarwin ''
     ulimit -n 8192

--- a/pkgs/servers/mautrix-whatsapp/default.nix
+++ b/pkgs/servers/mautrix-whatsapp/default.nix
@@ -13,19 +13,8 @@ buildGoModule rec {
 
   buildInputs = [ olm ];
 
-  vendorSha256 = "0ixfawfavv5r1d01d4gmj87vf5vv6p3f7kv4rkhfv48ys0j0437a";
-
-  overrideModAttrs = _: {
-    postBuild = ''
-      rm -r vendor/github.com/chai2010/webp
-      cp -r --reflink=auto ${fetchFromGitHub {
-        owner = "chai2010";
-        repo = "webp";
-        rev = "3da79ec3d682694d42bfd211db18fc1343c07cd7";
-        sha256 = "0gh3g52vz8na153mjmxkl80g3dvrcjw77xpjs1c02vagpj9jyw46";
-      }} vendor/github.com/chai2010/webp
-    '';
-  };
+  modvendorCopy = true;
+  vendorSha256 = "06zp6995jfbl913jb0p685zaszdscri5z7wid94vws1knljpv6d9";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/tulir/mautrix-whatsapp";

--- a/pkgs/tools/security/saml2aws/default.nix
+++ b/pkgs/tools/security/saml2aws/default.nix
@@ -11,20 +11,8 @@ buildGoModule rec {
     sha256 = "0y5gvdrdr6i9spdwsxvzs1bxs32icxpkqxnglp1bf4gglc580d87";
   };
 
-  hid = fetchFromGitHub {
-    owner = "karalabe";
-    repo = "hid";
-    rev = "9c14560f9ee858c43f40b5cd01392b167aacf4e8";
-    sha256 = "0xc7b8mwha64j7l2fr2g5zy8pz7cqi0vrxx60gii52b6ii31xncx";
-  };
-
-  vendorSha256 = "0f81nrg8v3xh2hcx7g77p3ahr4gyj042bwr1knf2phpahgz9n9rn";
-  overrideModAttrs = (_: {
-      postBuild = ''
-      cp -r --reflink=auto ${hid}/libusb vendor/github.com/karalabe/hid
-      cp -r --reflink=auto ${hid}/hidapi vendor/github.com/karalabe/hid
-      '';
-    });
+  modvendorCopy = true;
+  vendorSha256 = "1zq66dri85mjpw149jc00ngv8g8k5jag4gwjwqndw3x7n2c1p52s";
 
   subPackages = [ "." "cmd/saml2aws" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5331,6 +5331,8 @@ in
 
   modsecurity_standalone = callPackage ../tools/security/modsecurity { };
 
+  modvendor = callPackage ../development/tools/modvendor { };
+
   molly-guard = callPackage ../os-specific/linux/molly-guard { };
 
   moneyplex = callPackage ../applications/office/moneyplex { };
@@ -7342,7 +7344,7 @@ in
   uget = callPackage ../tools/networking/uget { };
 
   uget-integrator = callPackage ../tools/networking/uget-integrator { };
-  
+
   ugrep = callPackage ../tools/text/ugrep { };
 
   uif2iso = callPackage ../tools/cd-dvd/uif2iso { };


### PR DESCRIPTION
I'm not really happy about proposing this but I think we need some way of reliably dealing with these cases when `go mod vendor` doesn't work that doesn't require manual intervention.

Allowing the use of the previous implementation as a last resort seems the easiest approach.

cc @kalbasit @marsam @Mic92 