### PR TITLE
qemu: drop invalid and redundant qemu.desktop

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -133,15 +133,18 @@ stdenv.mkDerivation rec {
   dontWrapGApps = true;
 
   postFixup = ''
-      # copy qemu-ga (guest agent) to separate output
-      mkdir -p $ga/bin
-      cp $out/bin/qemu-ga $ga/bin/
-    '' + optionalString gtkSupport ''
-      # wrap GTK Binaries
-      for f in $out/bin/qemu-system-*; do
-        wrapGApp $f
-      done
-    '';
+    # the .desktop is both invalid and pointless
+    rm $out/share/applications/qemu.desktop
+
+    # copy qemu-ga (guest agent) to separate output
+    mkdir -p $ga/bin
+    cp $out/bin/qemu-ga $ga/bin/
+  '' + optionalString gtkSupport ''
+    # wrap GTK Binaries
+    for f in $out/bin/qemu-system-*; do
+      wrapGApp $f
+    done
+  '';
 
   # Add a ‘qemu-kvm’ wrapper for compatibility/convenience.
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Under KDE, launching any graphical application will spit out the
following error as the qemu.desktop file in qemu is invalid:

```sh
$ gwenview .
kf5.kservice.services: The desktop entry file "/run/current-system/sw/share/applications/qemu.desktop" has Type= "Application" but no Exec line
kf5.kservice.sycoca: Invalid Service :  "/run/current-system/sw/share/applications/qemu.desktop"
```

As there are no graphical applications, it's pointless to have this around
in the first place.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).