### PR TITLE
pythonPackages.pystray: 0.15.0 -> 0.16.0

### DIFF
--- a/pkgs/development/python-modules/pystray/default.nix
+++ b/pkgs/development/python-modules/pystray/default.nix
@@ -3,13 +3,13 @@
 
 buildPythonPackage rec {
   pname = "pystray";
-  version = "0.15.0";
+  version = "0.16.0";
 
   src = fetchFromGitHub {
     owner = "moses-palmer";
     repo = "pystray";
     rev = "v${version}";
-    sha256 = "0m5raxahyix3lmmbjbrsfd9yhr4vdil8gcy155hh6lqm2b1fmmss";
+    sha256 = "0q5yqfm5mzffx9vnp9xcnclgjzgs0b7f50i9xmxn1m1iha1zawh1";
   };
 
   propagatedBuildInputs = [ pillow xlib six ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New release https://github.com/moses-palmer/pystray/releases/tag/v0.16.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
4 packages updated:
jellyfin-mpv-shim python27Packages.pystray (0.15.0 → 0.16.0) python37Packages.pystray (0.15.0 → 0.16.0) python38Packages.pystray (0.15.0 → 0.16.0)

4 packages built:
jellyfin-mpv-shim python27Packages.pystray python37Packages.pystray python38Packages.pystray
```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/rj6158nfn75byd49pznqmw2sqvkp5pwq-python3.8-pystray-0.15.0	  129790840
/nix/store/9b7cg0xnzy4swjydnp7dhvb31drzpbmw-python3.8-pystray-0.16.0	  129801328
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
