### PR TITLE
faust: unstable-2020-06-08 -> unstable-2020-08-03

### DIFF
--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -20,13 +20,13 @@ with stdenv.lib.strings;
 
 let
 
-  version = "unstable-2020-06-08";
+  version = "unstable-2020-08-03";
 
   src = fetchFromGitHub {
     owner = "grame-cncm";
     repo = "faust";
-    rev = "f0037e289987818b65d3f6fb1ad943aaad2a2b28";
-    sha256 = "0h08902rgx7rhzpng4h1qw8i2nzv50f79vrlbzdk5d35wa4zibh4";
+    rev = "b6045f4592384076d3b383d116e602a95a000eb3";
+    sha256 = "1wcpilwnkc7rrbv9gbkj5hb7kamkh8nrc3r4hbcvbz5ar2pfc6d5";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -5,7 +5,8 @@
 , pkgconfig
 , cmake
 , llvm
-, emscripten
+# TODO: put back when it builds again
+# , emscripten
 , openssl
 , libsndfile
 , libmicrohttpd
@@ -46,7 +47,7 @@ let
     inherit src;
 
     nativeBuildInputs = [ makeWrapper pkgconfig cmake vim which ];
-    buildInputs = [ llvm emscripten openssl libsndfile libmicrohttpd gnutls libtasn1 p11-kit ];
+    buildInputs = [ llvm /*emscripten*/ openssl libsndfile libmicrohttpd gnutls libtasn1 p11-kit ];
 
 
     passthru = {

--- a/pkgs/applications/audio/faust/faustlive.nix
+++ b/pkgs/applications/audio/faust/faustlive.nix
@@ -1,26 +1,34 @@
 { stdenv, fetchFromGitHub
 , llvm, qt48Full, qrencode, libmicrohttpd, libjack2, alsaLib, faust, curl
-, bc, coreutils, which
+, bc, coreutils, which, libsndfile, pkg-config
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "faustlive";
-  version = "2017-12-05";
+  version = "2.5.4";
   src = fetchFromGitHub {
     owner = "grame-cncm";
     repo = "faustlive";
-    rev = "281fcb852dcd94f8c57ade1b2a7a3937542e1b2d";
-    sha256 = "0sw44yd9928rid9ib0b5mx2x129m7zljrayfm6jz6hrwdc5q3k9a";
+    rev = version;
+    sha256 = "0npn8fvq8iafyamq4wrj1k1bmk4xd0my2sp3gi5jdjfx6hc1sm3n";
+    fetchSubmodules = true;
   };
 
   buildInputs = [
     llvm qt48Full qrencode libmicrohttpd libjack2 alsaLib faust curl
-    bc coreutils which
+    bc coreutils which libsndfile pkg-config
   ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  preBuild = "patchShebangs Build/Linux/buildversion";
+  postPatch = "cd Build";
+
+  installPhase = ''
+    install -d "$out/bin"
+    install -d "$out/share/applications"
+    install FaustLive/FaustLive "$out/bin"
+    install rsrc/FaustLive.desktop "$out/share/applications"
+  '';
 
   meta = with stdenv.lib; {
     description = "A standalone just-in-time Faust compiler";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

There was a new faust release in the meantime, but it has a bug that is fixed in this commit.

See: grame-cncm/faust#473

I also did some housekeeping and  update a related pkg: faustlive.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested this compiler by building all pkgs in nixpkgs that use it.
The only exception is the pure module, since idk how to test it.  