### PR TITLE
lxsession: init at 0.5.5

### DIFF
--- a/pkgs/desktops/lxde/core/lxsession/default.nix
+++ b/pkgs/desktops/lxde/core/lxsession/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoconf
+, automake
+, docbook_xml_dtd_412
+, docbook_xsl
+, intltool
+, libxml2
+, libxslt
+, pkg-config
+, wrapGAppsHook
+, gtk2-x11
+, libX11
+, polkit
+, vala
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lxsession";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "lxde";
+    repo = "lxsession";
+    rev = version;
+    sha256 = "17sqsx57ymrimm5jfmcyrp7b0nzi41bcvpxsqckmwbhl19g6c17d";
+  };
+
+  patches = [ ./xmlcatalog_patch.patch ];
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    docbook_xml_dtd_412
+    docbook_xsl
+    intltool
+    libxml2
+    libxslt
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk2-x11
+    libX11
+    polkit
+    vala
+  ];
+
+  configureFlags = [
+    "--enable-man"
+    "--disable-buildin-clipboard"
+    "--disable-buildin-polkit"
+    "--with-xml-catalog=${docbook_xml_dtd_412}/xml/dtd/docbook/catalog.xml"
+  ];
+
+  preConfigure = "./autogen.sh";
+
+  meta = with lib; {
+    description = "Classic LXDE session manager";
+    license = licenses.gpl2Plus;
+    homepage = "https://wiki.lxde.org/en/LXSession";
+    maintainers = [ maintainers.shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/lxde/core/lxsession/xmlcatalog_patch.patch
+++ b/pkgs/desktops/lxde/core/lxsession/xmlcatalog_patch.patch
@@ -1,0 +1,23 @@
+diff --color -ur a/configure.ac b/configure.ac
+--- a/configure.ac	2021-01-18 12:39:19.556844678 +0100
++++ b/configure.ac	2021-01-18 17:26:47.989410501 +0100
+@@ -167,18 +167,7 @@
+ AM_GLIB_GNU_GETTEXT
+ AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [Gettext package.])
+ 
+-if test x"$enable_man" = x"yes"; then
+-	AC_PATH_PROG([XSLTPROC], [xsltproc])
+-	if test -z "$XSLTPROC"; then
+-		enable_man=no
+-	fi
+-
+-	dnl check for DocBook DTD and stylesheets in the local catalog.
+-	JH_CHECK_XML_CATALOG([-//OASIS//DTD DocBook XML V4.1.2//EN],
+-		[DocBook XML DTD V4.1.2], [], enable_man=no)
+-	JH_CHECK_XML_CATALOG([http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl],
+-		[DocBook XSL Stylesheets >= 1.70.1], [], enable_man=no)
+-fi
++AC_PATH_PROG([XSLTPROC], [xsltproc])
+ 
+ AM_CONDITIONAL(ENABLE_REGENERATE_MAN, test "x$enable_man" != "xno")
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9692,6 +9692,8 @@ in
 
   lxrandr = callPackage ../desktops/lxde/core/lxrandr { };
 
+  lxsession = callPackage ../desktops/lxde/core/lxsession { };
+
   kona = callPackage ../development/interpreters/kona {};
 
   lolcode = callPackage ../development/interpreters/lolcode { };


### PR DESCRIPTION
###### Motivation for this change
Needed lxpolkit

###### Things done
Packaged lxsession with documentation, without buitin clipboard and without builtin polkit (same as arch package). 

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
