### PR TITLE
glogg: enable on darwin

### DIFF
--- a/pkgs/tools/text/glogg/default.nix
+++ b/pkgs/tools/text/glogg/default.nix
@@ -1,20 +1,33 @@
-{ mkDerivation, stdenv, fetchurl, qmake, boost }:
+{ mkDerivation, stdenv, fetchFromGitHub, qmake, boost }:
 
 mkDerivation rec {
-
   pname = "glogg";
   version = "1.1.4";
 
-  src = fetchurl {
-    url = "https://glogg.bonnefon.org/files/${pname}-${version}.tar.gz";
-    sha256 = "0nwnfk9bcz2k7rf08w2cb6qipzdhwmxznik44jxmn9gwxdrdq78c";
+  src = fetchFromGitHub {
+    owner = "nickbnf";
+    repo = "glogg";
+    rev = "v${version}";
+    sha256 = "0hf1c2m8n88frmxmyn0ndr8129p7iky49nq565sw1asaydm5z6pb";
   };
+
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace glogg.pro \
+      --replace "boost_program_options-mt" "boost_program_options"
+  '';
 
   nativeBuildInputs = [ qmake ];
   buildInputs = [ boost ];
 
-  qmakeFlags = [ "glogg.pro" ];
+  qmakeFlags = [ "VERSION=${version}" ];
   enableParallelBuilding = true;
+
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    mv $out/bin/glogg.app $out/Applications/glogg.app
+    rm -fr $out/{bin,share}
+    wrapQtApp $out/Applications/glogg.app/Contents/MacOS/glogg
+  '';
 
   meta = with stdenv.lib; {
     description = "The fast, smart log explorer";
@@ -23,7 +36,7 @@ mkDerivation rec {
     '';
     homepage = "https://glogg.bonnefon.org/";
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ c0bw3b ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Enable on darwin.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
