### PR TITLE
hunspell-dicts: add support for Danish dictionary

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4705,6 +4705,12 @@
     githubId = 1202012;
     name = "Ignat Loskutov";
   };
+  louisdk1 = {
+    email = "louis@louis.dk";
+    github = "louisdk1";
+    githubId = 4969294;
+    name = "Louis Tim Larsen";
+  };
   lovek323 = {
     email = "jason@oconal.id.au";
     github = "lovek323";

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -754,4 +754,33 @@ in rec {
     readmeFile = "README_sk.txt";
     license = with stdenv.lib.licenses; [ gpl2 lgpl21 mpl11 ];
   };
+
+  /* DANISH */
+
+  da_DK = da-dk;
+  da-dk = mkDict rec {
+    name = "hunspell-dict-da-dk-${version}";
+    version = "2.5.137";
+
+    src = fetchurl {
+      url = "https://stavekontrolden.dk/dictionaries/da_DK/da_DK-${version}.oxt";
+      sha256 = "16y0smkg1mq0133r1fbw5ak6s2xw39281knk5ivhanakayq789qx";
+    };
+
+    shortName = "da-dk";
+    shortDescription = "Danish (Danmark)";
+    dictFileName = "da_DK";
+    readmeFile = "README_da_DK.txt";
+    nativeBuildInputs = [ unzip ];
+    unpackCmd = ''
+      unzip $src ${dictFileName}.dic ${dictFileName}.aff ${readmeFile} -d ${dictFileName}
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Hunspell dictionary for Danish (Denmark) from Stavekontrolden";
+      homepage = "https://github.com/jeppebundsgaard/stavekontrolden";
+      license = with stdenv.lib.licenses; [ gpl2Only lgpl21Only mpl11 ];
+      maintainers = with maintainers; [ louisdk1 ];
+    };
+  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Danish dictionary for hunspell is missing in nixpkga

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
