### PR TITLE
simplenes: init at unstable-2019-03-13

### DIFF
--- a/pkgs/misc/emulators/simplenes/default.nix
+++ b/pkgs/misc/emulators/simplenes/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, sfml
+}:
+
+stdenv.mkDerivation rec {
+  pname = "simplenes";
+  version = "unstable-2019-03-13";
+
+  src = fetchFromGitHub {
+    owner = "amhndu";
+    repo = "SimpleNES";
+    rev = "4edb7117970c21a33b3bfe11a6606764fffc5173";
+    sha256 = "1nmwj431iwqzzcykxd4xinqmg0rm14mx7zsjyhcc5skz7pihz86g";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ sfml ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./SimpleNES $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/amhndu/SimpleNES";
+    description = "An NES emulator written in C++";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ivar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2241,6 +2241,8 @@ in
 
   simg2img = callPackage ../tools/filesystems/simg2img { };
 
+  simplenes = callPackage ../misc/emulators/simplenes { };
+
   snipes = callPackage ../games/snipes { };
 
   snippetpixie = callPackage ../tools/text/snippetpixie { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
