### PR TITLE
jellyfin 10.5.5 -> 10.6.0

### DIFF
--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -16,6 +16,14 @@ in
         description = "User account under which Jellyfin runs.";
       };
 
+      package = mkOption {
+        type = types.package;
+        example = literalExample "pkgs.jellyfin";
+        description = ''
+          Jellyfin package to use.
+        '';
+      };
+
       group = mkOption {
         type = types.str;
         default = "jellyfin";
@@ -35,10 +43,15 @@ in
         Group = cfg.group;
         StateDirectory = "jellyfin";
         CacheDirectory = "jellyfin";
-        ExecStart = "${pkgs.jellyfin}/bin/jellyfin --datadir '/var/lib/${StateDirectory}' --cachedir '/var/cache/${CacheDirectory}'";
+        ExecStart = "${cfg.package}/bin/jellyfin --datadir '/var/lib/${StateDirectory}' --cachedir '/var/cache/${CacheDirectory}'";
         Restart = "on-failure";
       };
     };
+
+    services.jellyfin.package = mkDefault (
+      if versionAtLeast config.system.stateVersion "20.09" then pkgs.jellyfin
+        else pkgs.jellyfin_10_5
+    );
 
     users.users = mkIf (cfg.user == "jellyfin") {
       jellyfin = {

--- a/pkgs/servers/jellyfin/10.5.x.nix
+++ b/pkgs/servers/jellyfin/10.5.x.nix
@@ -18,12 +18,12 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "jellyfin";
-  version = "10.6.2";
+  version = "10.5.5";
 
   # Impossible to build anything offline with dotnet
   src = fetchurl {
-    url = "https://repo.jellyfin.org/releases/server/portable/stable/combined/jellyfin_${version}.tar.gz";
-    sha256 = "16yib2k9adch784p6p0whgfb6lrjzwiigg1n14cp88dx64hyhxhb";
+    url = "https://github.com/jellyfin/jellyfin/releases/download/v${version}/jellyfin_${version}_portable.tar.gz";
+    sha256 = "1s3hva1j5w74qc9wyqnmr5clk4smzfi7wvx8qrzrwy81mx7r5w27";
   };
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2021,6 +2021,8 @@ in
 
   jellyfin = callPackage ../servers/jellyfin { };
 
+  jellyfin_10_5 = callPackage ../servers/jellyfin/10.5.x.nix { };
+
   jellyfin-mpv-shim = python3Packages.callPackage ../applications/video/jellyfin-mpv-shim { };
 
   jotta-cli = callPackage ../applications/misc/jotta-cli { };


### PR DESCRIPTION
###### Motivation for this change
Jellyfin 10.6.0 was released, large feature set change


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
