### PR TITLE
dlx: cleanup

### DIFF
--- a/pkgs/misc/emulators/dlx/default.nix
+++ b/pkgs/misc/emulators/dlx/default.nix
@@ -1,31 +1,29 @@
-{ lib, stdenv, fetchurl, unzip }:
+{ lib, stdenv, fetchzip }:
 
-stdenv.mkDerivation {
-  name = "dlx-2012.07.08";
+stdenv.mkDerivation rec {
+  pname = "dlx";
+  version = "2012-07-08";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://www.davidviner.com/zip/dlx/dlx.zip";
-    sha256 = "0q5hildq2xcig7yrqi26n7fqlanyssjirm7swy2a9icfxpppfpkn";
+    sha256 = "0508linnar9ivy3xr99gzrb2l027ngx12dlxaxs7w67cnwqnb0dg";
   };
 
-  nativeBuildInputs = [ unzip ];
-
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" "LINK=${stdenv.cc.targetPrefix}cc" "CFLAGS=-O2" ];
-
   hardeningDisable = [ "format" ];
 
   installPhase = ''
     mkdir -p $out/include/dlx $out/share/dlx/{examples,doc} $out/bin
-    mv -v masm mon dasm $out/bin/
-    mv -v *.i auto.a $out/include/dlx/
-    mv -v *.a *.m $out/share/dlx/examples/
-    mv -v README.txt MANUAL.TXT $out/share/dlx/doc/
+    mv masm mon dasm $out/bin/
+    mv *.i auto.a $out/include/dlx/
+    mv *.a *.m $out/share/dlx/examples/
+    mv README.txt MANUAL.TXT $out/share/dlx/doc/
   '';
 
-  meta = {
-    homepage = "http://www.davidviner.com/dlx.php";
-    description = "DLX Simulator";
-    license = lib.licenses.gpl2;
-    platforms = lib.platforms.all;
+  meta = with lib; {
+    homepage = "https://www.davidviner.com/dlx.html?name=DLX+Simulator";
+    description = "An DLX simulator written in C";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION

###### Motivation for this change
Noticed this derivation looked a bit old. What I've done is a bit cleaner IMO.

homepage url also seemed to have gotten moved, the old one redirects to an generic page on the authors website.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
