### PR TITLE
homeassistant: 0.112.3 -> 0.113.0

### DIFF
--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.112.3";
+  version = "0.113.0";
   components = {
     "abode" = ps: with ps; [ ]; # missing inputs: abodepy
     "acer_projector" = ps: with ps; [ pyserial];
@@ -28,7 +28,7 @@
     "amcrest" = ps: with ps; [ ha-ffmpeg]; # missing inputs: amcrest
     "ampio" = ps: with ps; [ ]; # missing inputs: asmog
     "android_ip_webcam" = ps: with ps; [ ]; # missing inputs: pydroid-ipcam
-    "androidtv" = ps: with ps; [ ]; # missing inputs: adb-shell androidtv pure-python-adb
+    "androidtv" = ps: with ps; [ ]; # missing inputs: adb-shell[async] androidtv[async] pure-python-adb
     "anel_pwrctrl" = ps: with ps; [ ]; # missing inputs: anel_pwrctrl-homeassistant
     "anthemav" = ps: with ps; [ ]; # missing inputs: anthemav
     "apache_kafka" = ps: with ps; [ aiokafka];
@@ -90,6 +90,7 @@
     "bmp280" = ps: with ps; [ ]; # missing inputs: RPi.GPIO adafruit-circuitpython-bmp280
     "bmw_connected_drive" = ps: with ps; [ ]; # missing inputs: bimmer_connected
     "bom" = ps: with ps; [ ]; # missing inputs: bomradarloop
+    "bond" = ps: with ps; [ ]; # missing inputs: bond-home
     "braviatv" = ps: with ps; [ bravia-tv];
     "broadlink" = ps: with ps; [ broadlink];
     "brother" = ps: with ps; [ ]; # missing inputs: brother
@@ -160,6 +161,7 @@
     "device_sun_light_trigger" = ps: with ps; [ ];
     "device_tracker" = ps: with ps; [ ];
     "devolo_home_control" = ps: with ps; [ ]; # missing inputs: devolo-home-control-api
+    "dexcom" = ps: with ps; [ ]; # missing inputs: pydexcom
     "dht" = ps: with ps; [ ]; # missing inputs: Adafruit-DHT
     "dialogflow" = ps: with ps; [ aiohttp-cors];
     "digital_ocean" = ps: with ps; [ digital-ocean];
@@ -175,7 +177,7 @@
     "dnsip" = ps: with ps; [ aiodns];
     "dominos" = ps: with ps; [ aiohttp-cors]; # missing inputs: pizzapi
     "doods" = ps: with ps; [ pillow]; # missing inputs: pydoods
-    "doorbird" = ps: with ps; [ aiohttp-cors sqlalchemy]; # missing inputs: doorbirdpy home-assistant-frontend
+    "doorbird" = ps: with ps; [ aiohttp-cors]; # missing inputs: doorbirdpy
     "dovado" = ps: with ps; [ ]; # missing inputs: dovado
     "downloader" = ps: with ps; [ ];
     "dsmr" = ps: with ps; [ ]; # missing inputs: dsmr_parser
@@ -338,7 +340,7 @@
     "home_connect" = ps: with ps; [ aiohttp-cors]; # missing inputs: homeconnect
     "homeassistant" = ps: with ps; [ ];
     "homekit" = ps: with ps; [ HAP-python pyqrcode aiohttp-cors ha-ffmpeg zeroconf]; # missing inputs: PyTurboJPEG base36 fnvhash
-    "homekit_controller" = ps: with ps; [ ]; # missing inputs: aiohomekit[IP]
+    "homekit_controller" = ps: with ps; [ aiohttp-cors zeroconf]; # missing inputs: aiohomekit[IP]
     "homematic" = ps: with ps; [ pyhomematic];
     "homematicip_cloud" = ps: with ps; [ ]; # missing inputs: homematicip
     "homeworks" = ps: with ps; [ ]; # missing inputs: pyhomeworks
@@ -606,6 +608,7 @@
     "plum_lightpad" = ps: with ps; [ ]; # missing inputs: plumlightpad
     "pocketcasts" = ps: with ps; [ ]; # missing inputs: pocketcasts
     "point" = ps: with ps; [ aiohttp-cors]; # missing inputs: pypoint
+    "poolsense" = ps: with ps; [ ]; # missing inputs: poolsense
     "powerwall" = ps: with ps; [ ]; # missing inputs: tesla-powerwall
     "prezzibenzina" = ps: with ps; [ ]; # missing inputs: prezzibenzina-py
     "proliphix" = ps: with ps; [ ]; # missing inputs: proliphix
@@ -773,7 +776,7 @@
     "switchbot" = ps: with ps; [ ]; # missing inputs: PySwitchbot
     "switcher_kis" = ps: with ps; [ ]; # missing inputs: aioswitcher
     "switchmate" = ps: with ps; [ ]; # missing inputs: pySwitchmate
-    "syncthru" = ps: with ps; [ ]; # missing inputs: pysyncthru
+    "syncthru" = ps: with ps; [ ]; # missing inputs: pysyncthru url-normalize
     "synology" = ps: with ps; [ ]; # missing inputs: py-synology
     "synology_chat" = ps: with ps; [ ];
     "synology_dsm" = ps: with ps; [ ]; # missing inputs: python-synology

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -27,11 +27,6 @@ let
     (mkOverride "astral" "1.10.1"
       "d2a67243c4503131c856cafb1b1276de52a86e5b8a1d507b7e08bee51cb67bf1")
 
-    # Required by cast component. Can probably be removed in 0.113.x
-    # https://github.com/home-assistant/core/commit/86c27b50f1282658b75fe71f9f6fd2fcabc2eaa2
-    (mkOverride "PyChromecast" "6.0.0"
-      "05f8r3b2pdqbl76hwi5sv2xdi1r7g9lgm69x8ja5g22mn7ysmghm")
-
     # We have 3.x in nixpkgs which is incompatible with home-assistant atm:
     # https://github.com/home-assistant/core/blob/dev/requirements_all.txt
     (mkOverride "pyowm" "2.10.0"
@@ -77,7 +72,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.112.3";
+  hassVersion = "0.113.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -86,7 +81,7 @@ in with py.pkgs; buildPythonApplication rec {
   disabled = pythonOlder "3.5";
 
   patches = [
-    ./0001-setup.py-relax-dependencies.patch
+    ./relax-dependencies.patch
   ];
 
   inherit availableComponents;
@@ -96,7 +91,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "1azfbjnyaamdnl2f3cllh6pd3kinl1wjqb4hlb569gb8zqs5bsx2";
+    sha256 = "1yb943wkiawh5p4mj5089qcsjfnwb91ga666qriz32bzpfgrzrna";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20200702.1";
+  version = "20200716.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0ikzqwwm4m15x2m5byy7r005cfdxk7ajfyz9ljv4nsa3y3g2riw4";
+    sha256 = "07h8llin0rx06c5v2skkij5756gqdq079ysxzmrm6xnzk9mcvfsk";
   };
 
   # no Python tests implemented

--- a/pkgs/servers/home-assistant/relax-dependencies.patch
+++ b/pkgs/servers/home-assistant/relax-dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/setup.py b/setup.py
-index 4e46f63217..b1aafee59d 100755
+index c2042ab245..98f348510f 100755
 --- a/setup.py
 +++ b/setup.py
 @@ -32,7 +32,7 @@ PROJECT_URLS = {
@@ -20,6 +20,5 @@ index 4e46f63217..b1aafee59d 100755
 +    "requests>=2.23.0",
 +    "ruamel.yaml>=0.15.100",
      "voluptuous==0.11.7",
--    "voluptuous-serialize==2.3.0",
-+    "voluptuous-serialize>=2.3.0",
+     "voluptuous-serialize==2.4.0",
  ]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://www.home-assistant.io/blog/2020/07/22/release-113/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
