### PR TITLE
reicast: init at 20.04

### DIFF
--- a/pkgs/misc/emulators/reicast/default.nix
+++ b/pkgs/misc/emulators/reicast/default.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, curl
+, alsaLib
+, libGLU
+, libX11
+, libevdev
+, udev
+, libpulseaudio
+}:
+
+stdenv.mkDerivation rec {
+  pname = "reicast";
+  version = "20.04";
+
+  src = fetchFromGitHub {
+    owner = "reicast";
+    repo = "reicast-emulator";
+    rev = "r${version}";
+    sha256 = "0vz3b1hg1qj6nycnqq5zcpzqpcbxw1c2ffamia5z3x7rapjx5d71";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    curl
+    alsaLib
+    libGLU
+    libX11
+    libevdev
+    udev
+    libpulseaudio
+  ];
+
+  # No rule to make target 'install'
+  installPhase = ''
+    runHook preInstall
+
+    install -D ./reicast $out/bin/reicast
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://reicast.com/";
+    description = "A multi-platform Sega Dreamcast emulator";
+    license = with licenses; [ bsd3 gpl2Only lgpl2Only ];
+    platforms = ["x86_64-linux" ];
+    maintainers = [ maintainers.ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6839,6 +6839,8 @@ in
 
   rep = callPackage ../development/tools/rep { };
 
+  reicast = callPackage ../misc/emulators/reicast { };
+
   reredirect = callPackage ../tools/misc/reredirect { };
 
   retext = libsForQt5.callPackage ../applications/editors/retext { };


### PR DESCRIPTION
###### Motivation for this change
App seems to have quite a few licenses, so i thought I'd just include them all. Not sure what the correct approach here is.

When opening the app up it gives you a warning about not being able to find git, however we can just ignore this. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
 