### PR TITLE
pythonPackages.clikit: make it installable on python3.5

### DIFF
--- a/pkgs/development/python-modules/clikit/default.nix
+++ b/pkgs/development/python-modules/clikit/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi
-, isPy27
+, isPy27, pythonAtLeast
 , pylev, pastel, typing, enum34, crashtest }:
 
 buildPythonPackage rec {
@@ -12,8 +12,10 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    crashtest pylev pastel
-  ] ++ lib.optionals isPy27 [ typing enum34 ];
+    pylev pastel
+  ]
+    ++ lib.optionals (pythonAtLeast "3.6") [ crashtest ]
+    ++ lib.optionals isPy27 [ typing enum34 ];
 
   # The Pypi tarball doesn't include tests, and the GitHub source isn't
   # buildable until we bootstrap poetry, see

--- a/pkgs/development/python-modules/crashtest/default.nix
+++ b/pkgs/development/python-modules/crashtest/default.nix
@@ -1,9 +1,9 @@
-{ lib, buildPythonPackage, fetchFromGitHub, fetchPypi, isPy27, pytest }:
+{ lib, buildPythonPackage, fetchFromGitHub, fetchPypi, pythonAtLeast, pytest }:
 
 buildPythonPackage rec {
   pname = "crashtest";
   version = "0.3.0";
-  disabled = isPy27;
+  disabled = !(pythonAtLeast "3.6");
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change

`nix-build ./default.nix -A python35Packages.clikit --no-out-link` fails with this error:

> ERROR: Package 'crashtest' requires a different Python: 3.5.9 not in '>=3.6,<4.0'

(This was against: 017c7a4940a3c62002d725ae848b16793922eac9, Nix 2.3.1)

Diagnosis: crashtest shouldn't be a dependency when python version is `<3.6`:
https://github.com/sdispater/clikit/blob/0.6.2/pyproject.toml#L25

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
