### PR TITLE
miniflux: 2.0.21 -> 2.0.23

### DIFF
--- a/pkgs/servers/miniflux/default.nix
+++ b/pkgs/servers/miniflux/default.nix
@@ -1,17 +1,20 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, installShellFiles }:
+{ stdenv, buildGoModule, fetchFromGitHub, installShellFiles, nixosTests }:
 
-buildGoPackage rec {
+let
   pname = "miniflux";
-  version = "2.0.21";
+  version = "2.0.23";
+
+in buildGoModule {
+  inherit pname version;
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "0yhzmfs35jfc7vq26r9c14v4lnv8sxj3pv23r2cx2rfx47b1zmk7";
+    sha256 = "0v0n5lvrfn3ngs1s1m3hv95dvnqn8ysksb044m4ifk2cr3b77ryc";
   };
 
-  goPackagePath = "miniflux.app";
+  vendorSha256 = "1iin5r9l8wb9gm0bwgdmpx0cp1q35ij4y7zf98lnj2kvb3jv5crp";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -23,8 +26,10 @@ buildGoPackage rec {
 
   postInstall = ''
     mv $out/bin/miniflux.app $out/bin/miniflux
-    installManPage go/src/${goPackagePath}/miniflux.1
+    installManPage miniflux.1
   '';
+
+  passthru.tests = nixosTests.miniflux;
 
   meta = with stdenv.lib; {
     description = "Minimalist and opinionated feed reader";
@@ -33,4 +38,3 @@ buildGoPackage rec {
     maintainers = with maintainers; [ rvolosatovs benpye ];
   };
 }
-


### PR DESCRIPTION

#### Motivation for this change
Changelog: https://github.com/miniflux/miniflux/releases/tag/2.0.22

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
