### PR TITLE
libhdhomerun: git -> 20200521

### DIFF
--- a/pkgs/development/libraries/libhdhomerun/default.nix
+++ b/pkgs/development/libraries/libhdhomerun/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchgit }:
+{ stdenv, fetchurl }:
 
-stdenv.mkDerivation {
-  name = "libhdhomerun-1efbcb";
+stdenv.mkDerivation rec {
+  pname = "libhdhomerun";
+  version = "20200521";
 
-  src = fetchgit {
-    url = "git://github.com/Silicondust/libhdhomerun.git";
-    rev = "1efbcb2b87b17a82f2b3d873d1c9cc1c6a3a9b77";
-    sha256 = "11iyrfs98xb50n9iqnwfphmmnn5w3mq2l9cjjpf8qp29cvs33cgy";
+  src = fetchurl {
+    url = "https://download.silicondust.com/hdhomerun/libhdhomerun_${version}.tgz";
+    sha256 = "0s0683bwyd10n3r2sanlyd07ii3fmi3vl9w9a2rwlpcclzq3h456";
   };
 
   patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
@@ -23,8 +23,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Implements the libhdhomerun protocol for use with Silicondust HDHomeRun TV tuners";
-    homepage = "https://github.com/Silicondust/libhdhomerun";
-    repositories.git = "https://github.com/Silicondust/libhdhomerun.git";
+    homepage = "https://www.silicondust.com/support/linux";
     license = stdenv.lib.licenses.lgpl2;
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ maintainers.titanous ];

--- a/pkgs/development/libraries/libhdhomerun/default.nix
+++ b/pkgs/development/libraries/libhdhomerun/default.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Implements the libhdhomerun protocol for use with Silicondust HDHomeRun TV tuners";
     homepage = "https://www.silicondust.com/support/linux";
-    license = stdenv.lib.licenses.lgpl2;
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.lgpl21Only;
+    platforms = platforms.unix;
     maintainers = [ maintainers.titanous ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New release 20200521 which is not available on Github: https://github.com/Silicondust/libhdhomerun

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
