### PR TITLE
sacc: init at 1.01

### DIFF
--- a/pkgs/applications/networking/gopher/sacc/default.nix
+++ b/pkgs/applications/networking/gopher/sacc/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchgit, ncurses
+, patches ? [] # allow users to easily override config.def.h
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sacc";
+  version = "1.01";
+
+  src = fetchgit {
+    url = "git://bitreich.org/sacc";
+    rev = version;
+    sha256 = "0n6ghbi715m7hrxzqggx1bpqj8h7569s72b9bzk6m4gd29jaq9hz";
+  };
+
+  inherit patches;
+
+  buildInputs = [ ncurses ];
+
+  postPatch = ''
+    substituteInPlace config.mk \
+      --replace curses ncurses \
+      --replace "/usr/local" "$out"
+    '';
+
+  meta = with stdenv.lib; {
+    description = "A terminal gopher client";
+    homepage = "gopher://bitreich.org/1/scm/sacc";
+    license = licenses.isc;
+    maintainers = [ maintainers.sternenseemann ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22249,6 +22249,8 @@ in
 
   udiskie = callPackage ../applications/misc/udiskie { };
 
+  sacc = callPackage ../applications/networking/gopher/sacc { };
+
   sakura = callPackage ../applications/misc/sakura { };
 
   sayonara = libsForQt5.callPackage ../applications/audio/sayonara { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add sacc, a simple (n)curses gopher client.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
