### PR TITLE
arcanist: 20200127 -> 20200711

### DIFF
--- a/pkgs/development/tools/misc/arcanist/default.nix
+++ b/pkgs/development/tools/misc/arcanist/default.nix
@@ -1,53 +1,54 @@
-{ stdenv, fetchFromGitHub, php, flex, makeWrapper }:
+{ stdenv, fetchFromGitHub, php, flex }:
 
-let
-  libphutil = fetchFromGitHub {
-    owner = "phacility";
-    repo = "libphutil";
-    rev = "cc2a3dbf590389400da55563cb6993f321ec6d73";
-    sha256 = "1k7sr3racwz845i7r5kdwvgqrz8gldz07pxj3yw77s58rqbix3ad";
-  };
-  arcanist = fetchFromGitHub {
-    owner = "phacility";
-    repo = "arcanist";
-    rev = "21a1828ea06cf031e93082db8664d73efc88290a";
-    sha256 = "05rq9l9z7446ks270viay57r5ibx702b5bnlf4ck529zc4abympx";
-  };
+# Make a custom wrapper. If `wrapProgram` is used, arcanist thinks .arc-wrapped is being
+# invoked and complains about it being an unknown toolset. We could use `makeWrapper`, but
+# then we’d need to still craft a script that does the `php libexec/arcanist/bin/...` dance
+# anyway... So just do everything at once.
+let makeArcWrapper = toolset: ''
+    cat << WRAPPER > $out/bin/${toolset}
+    #!$shell -e
+    export PATH='${php}/bin/'\''${PATH:+':'}\$PATH
+    exec ${php}/bin/php $out/libexec/arcanist/bin/${toolset} "\$@"
+    WRAPPER
+    chmod +x $out/bin/${toolset}
+'';
+
 in
+
 stdenv.mkDerivation {
   pname = "arcanist";
-  version = "20200127";
+  version = "20200711";
 
-  src = [ arcanist libphutil ];
-  buildInputs = [ php makeWrapper flex ];
-
-  unpackPhase = ''
-    cp -aR ${libphutil} libphutil
-    cp -aR ${arcanist} arcanist
-    chmod +w -R libphutil arcanist
-  '';
+  src = fetchFromGitHub {
+    owner = "phacility";
+    repo = "arcanist";
+    rev = "2565cc7b4d1dbce6bc7a5b3c4e72ae94be4712fe";
+    sha256 = "0jiv4aj4m5750dqw9r8hizjkwiyxk4cg4grkr63sllsa2dpiibxw";
+  };
+  buildInputs = [ php flex ];
 
   postPatch = stdenv.lib.optionalString stdenv.isAarch64 ''
-    substituteInPlace libphutil/support/xhpast/Makefile \
+    substituteInPlace support/xhpast/Makefile \
       --replace "-minline-all-stringops" ""
   '';
 
   buildPhase = ''
-    (
-      cd libphutil/support/xhpast
-      make clean all install
-    )
+    make xhpast -C support/xhpast
   '';
+
   installPhase = ''
     mkdir -p $out/bin $out/libexec
-    cp -R libphutil $out/libexec/libphutil
-    cp -R arcanist  $out/libexec/arcanist
-    ${if stdenv.isDarwin then ''
-        echo "#! $shell -e" > $out/bin/arc
-        echo "exec ${php}/bin/php $out/libexec/arcanist/scripts/arcanist.php "'"$@"' >> $out/bin/arc
-        chmod +x $out/bin/arc''
-      else ''
-        ln -s $out/libexec/arcanist/scripts/arcanist.php $out/bin/arc''}
+    make install -C support/xhpast
+    cp -R $src $out/libexec/arcanist
+
+    ${makeArcWrapper "arc"}
+    ${makeArcWrapper "phage"}
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/arc help diff -- > /dev/null
+    $out/bin/phage help alias -- > /dev/null
   '';
 
   meta = {


### PR DESCRIPTION
### Motivation for this change

Note that this arcanist bump introduces some breaking changes to the
tool interface. `arcanist` hasn’t been updated for quite a while now, though, 
to the point where some documentation is no longer applicable to the old
version, leading to confused users and broken workflows.

I verified that the following commands work (provided git is already in the environment):

```bash
arc help
arc branches
arc work
arc todo # changes state in phabricator
arc get-config
arc which
arc tasks
arc look
arc patch
```

I also found that the following commands _fail_ to work:

```bash
arc version # installation is not a git repo
arc anoid   # easter egg, requires python3, not worth the closure size bump 
arc browse # unable to find a browser command to run.
```

r? @thoughtpolice 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
