### PR TITLE
python3Packages.etelemetry: unbreak

### DIFF
--- a/pkgs/development/python-modules/ci-info/default.nix
+++ b/pkgs/development/python-modules/ci-info/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, isPy27, fetchPypi, pytest, pytestCheckHook }:
+
+buildPythonPackage rec {
+  version = "0.2.0";
+  pname = "ci-info";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05j6pamk8sd51qmvpkl3f7sxajmncrqm0cz6n6bqgsvzjwn66w6x";
+  };
+
+  checkInputs = [ pytest pytestCheckHook ];
+
+  doCheck = false;  # both tests access network
+
+  pythonImportsCheck = [ "ci_info" ];
+
+  meta = with lib; {
+    description = "Gather continuous integration information on the fly";
+    homepage = "https://github.com/mgxd/ci-info";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/ci-py/default.nix
+++ b/pkgs/development/python-modules/ci-py/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, pytest, pytestrunner, pytestCheckHook }:
+
+buildPythonPackage rec {
+  version = "1.0.0";
+  pname = "ci-py";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12ax07n81vxbyayhwzi1q6x7gfmwmvrvwm1n4ii6qa6fqlp9pzj7";
+  };
+
+  nativeBuildInputs = [ pytestrunner ];  # pytest-runner included in setup-requires
+  checkInputs = [ pytest pytestCheckHook ];
+
+  pythonImportsCheck = [ "ci" ];
+
+  meta = with lib; {
+    description = "Library for working with Continuous Integration services";
+    homepage = "https://github.com/grantmcconnaughey/ci.py";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/etelemetry/default.nix
+++ b/pkgs/development/python-modules/etelemetry/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, requests, pytest }:
+{ lib, buildPythonPackage, fetchPypi, isPy27, ci-info, ci-py, requests, pytest }:
 
 buildPythonPackage rec {
   version = "0.2.1";
@@ -7,10 +7,10 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bfb58f58e98f63eae20caffb8514fb68c572332aa6e773cf3fcbde9b408d88e7";
+    sha256 = "1rw8im09ppnb7z7p7rx658rp5ib8zca8byxg1kiflqwgx5c8zddz";
   };
 
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [ ci-info ci-py requests ];
 
   # all 2 of the tests both try to pull down from a url
   doCheck = false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2074,6 +2074,8 @@ in {
 
   ci-info = callPackage ../development/python-modules/ci-info { };
 
+  ci-py = callPackage ../development/python-modules/ci-py { };
+
   cli-helpers = callPackage ../development/python-modules/cli-helpers {};
 
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2072,6 +2072,8 @@ in {
 
   chevron = callPackage ../development/python-modules/chevron {};
 
+  ci-info = callPackage ../development/python-modules/ci-info { };
+
   cli-helpers = callPackage ../development/python-modules/cli-helpers {};
 
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };


### PR DESCRIPTION
by adding dependencies missed in the last Python mass update

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
