### PR TITLE
just: 0.6.0 -> 0.7.1

### DIFF
--- a/pkgs/development/tools/just/default.nix
+++ b/pkgs/development/tools/just/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "just";
-  version = "0.6.0";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "casey";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1sl235wr4fdsw0f0x7jynv6ljhvgis4d87xzpvjzajhdaappdp8d";
+    sha256 = "07fjixz8y5rxfwpyr1kiimnn27jhc20gacd17i0yvfcpy5qf8z5p";
   };
 
-  cargoSha256 = "0k3aqwvdm95403s279gkksklnikgyjpf5qvngsvsrm5xqda438jk";
+  cargoSha256 = "1zn0kiqi8p25lscjd661gczay631nwzadl36cfzqnbww6blayy1j";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -40,16 +40,7 @@ rustPlatform.buildRustPackage rec {
 
   # Skip "edit" when running "cargo test",
   # since this test case needs "cat".
-  checkPhase = ''
-    runHook preCheck
-    echo "Running cargo test --
-        --skip edit
-        ''${checkFlags} ''${checkFlagsArray+''${checkFlagsArray[@]}}"
-    cargo test -- \
-        --skip edit \
-        ''${checkFlags} ''${checkFlagsArray+"''${checkFlagsArray[@]}"}
-    runHook postCheck
-  '';
+  checkFlagsArray = [ "--skip=edit" ];
 
   meta = with stdenv.lib; {
     description = "A handy way to save and run project-specific commands";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

[v0.7.1](https://github.com/casey/just/blob/master/CHANGELOG.md#v071---2020-7-19)
[v0.7.0](https://github.com/casey/just/blob/master/CHANGELOG.md#v070---2020-7-16)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
