### PR TITLE
terminal-typeracer: init at 2.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8846,7 +8846,7 @@
     name = "Yochai";
   };
   yoctocell = {
-    email = "yoctocell.code@keemail.me";
+    email = "public@yoctocell.xyz";
     github = "yoctocell";
     githubId = 40352765;
     name = "Yoctocell";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8845,6 +8845,12 @@
     githubId = 1322201;
     name = "Yochai";
   };
+  yoctocell = {
+    email = "yoctocell.code@keemail.me";
+    github = "yoctocell";
+    githubId = 40352765;
+    name = "Yoctocell";
+  };
   yorickvp = {
     email = "yorickvanpelt@gmail.com";
     github = "yorickvp";

--- a/pkgs/applications/misc/terminal-typeracer/default.nix
+++ b/pkgs/applications/misc/terminal-typeracer/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchFromGitLab
+, rustPlatform
+, pkg-config
+, openssl
+, sqlite
+, libiconv
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "terminal-typeracer";
+  version = "2.0.2";
+
+  src = fetchFromGitLab {
+    owner = "ttyperacer";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "187xrqxalk2gxa22ki5q092llvliddrsc68cg4dvvy2xzq254jfy";
+  };
+
+  cargoSha256 = "0ky8m23fjjbv7fr9776fjczpg0d43jxwnjxjpwz56jpynwnihfkl";
+
+  buildInputs = [ openssl sqlite ] ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv Security ];
+  nativeBuildInputs = [ pkg-config ];
+
+  meta = with stdenv.lib; {
+    description = "An open source terminal based version of Typeracer written in rust";
+    homepage = "https://gitlab.com/ttyperacer/terminal-typeracer";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ yoctocell ];
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22820,6 +22820,10 @@ in
 
   twinkle = qt5.callPackage ../applications/networking/instant-messengers/twinkle { };
 
+  terminal-typeracer = callPackage ../applications/misc/terminal-typeracer {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   ueberzug = with python3Packages; toPythonApplication ueberzug;
 
   umurmur = callPackage ../applications/networking/umurmur { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adds [terminal-typeracer](https://gitlab.com/ttyperacer/terminal-typeracer), a TUI for typeracer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
