### PR TITLE
nixos/do-agent: use .service from upstream

### DIFF
--- a/nixos/modules/services/monitoring/do-agent.nix
+++ b/nixos/modules/services/monitoring/do-agent.nix
@@ -4,6 +4,7 @@ with lib;
 
 let
   cfg = config.services.do-agent;
+
 in
 {
   options.services.do-agent = {
@@ -11,23 +12,13 @@ in
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.do-agent ];
+    systemd.packages = [ pkgs.do-agent ];
 
     systemd.services.do-agent = {
-      description = "DigitalOcean Droplet Metrics Agent";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
       serviceConfig = {
-        ExecStart = "${pkgs.do-agent}/bin/do-agent --syslog";
-        Restart = "always";
-        OOMScoreAdjust = -900;
-        SyslogIdentifier = "DigitalOceanAgent";
-        PrivateTmp = "yes";
-        ProtectSystem = "full";
-        ProtectHome = "yes";
-        NoNewPrivileges = "yes";
-        DynamicUser = "yes";
+        ExecStart = [ "" "${pkgs.do-agent}/bin/do-agent --syslog" ];
+        DynamicUser = true;
       };
     };
   };

--- a/pkgs/servers/monitoring/do-agent/default.nix
+++ b/pkgs/servers/monitoring/do-agent/default.nix
@@ -18,6 +18,10 @@ buildGoModule rec {
 
   vendorSha256 = null;
 
+  postInstall = ''
+    install -Dm444 -t $out/lib/systemd/system $src/packaging/etc/systemd/system/do-agent.service
+  '';
+
   meta = with lib; {
     description = "DigitalOcean droplet system metrics agent";
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change

Use upstream's do-agent.service to avoid duplication. Instead just
override the parts that we care about.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).