### PR TITLE
osqp: init at 0.6.0

### DIFF
--- a/pkgs/development/libraries/science/math/osqp/default.nix
+++ b/pkgs/development/libraries/science/math/osqp/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "osqp";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "oxfordcontrol";
+    repo = "osqp";
+    rev = "v${version}";
+    sha256 = "1gwk1bqsk0rd85zf7xplbwq822y5pnxjmqc14jj6knqbab9afvrs";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "A quadratic programming solver using operator splitting";
+    homepage = "https://osqp.org";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ taktoa ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5837,6 +5837,8 @@ in
 
   osl = callPackage ../development/compilers/osl { };
 
+  osqp = callPackage ../development/libraries/science/math/osqp { };
+
   ossec = callPackage ../tools/security/ossec {};
 
   osslsigncode = callPackage ../development/tools/osslsigncode {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Packaged a quadratic programming solver for NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - Vacuously true, as this is a new package
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - Vacuously true, as this is a library, and does not have any executables
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
