### PR TITLE
gnvim: icon support (GDK_PIXBUF_MODULE_FILE)

### DIFF
--- a/pkgs/applications/editors/neovim/gnvim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/gnvim/wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, gnvim-unwrapped, neovim, makeWrapper }:
+{ stdenv, gnvim-unwrapped, neovim, makeWrapper, librsvg }:
 
 stdenv.mkDerivation {
   pname = "gnvim";
@@ -14,6 +14,7 @@ stdenv.mkDerivation {
   '' else ''
     makeWrapper '${gnvim-unwrapped}/bin/gnvim' "$out/bin/gnvim" \
       --prefix PATH : "${neovim}/bin" \
+      --set GDK_PIXBUF_MODULE_FILE "${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
       --set GNVIM_RUNTIME_PATH "${gnvim-unwrapped}/share/gnvim/runtime"
 
     mkdir -p "$out/share"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->
There might be better ways of solving this I dont know about, but this seems to work on my pc, while the current package does not.

###### Motivation for this change
When running gnvim on nixos, i get the following error when autocomplete dropdown opens.
(The dropdown contains icons)
`Error { domain: gdk-pixbuf-error-quark, code: 3, message: "Unrecognized image file format" }'`
Full error here: https://github.com/vhakulinen/gnvim/issues/127#issuecomment-662434580


###### Things done
setting GDK_PIXBUF_MODULE_FILE in wrapper fixes the error, so I added:
`--set GDK_PIXBUF_MODULE_FILE "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \`
to makeWrapper, inspired by whats done here: https://github.com/NixOS/nixpkgs/pull/43421/files

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
