### PR TITLE
malcontent: 0.7.0 → 0.8.0

### DIFF
--- a/nixos/modules/services/desktops/malcontent.nix
+++ b/nixos/modules/services/desktops/malcontent.nix
@@ -28,7 +28,10 @@ with lib;
       malcontent-ui
     ];
 
-    services.dbus.packages = [ pkgs.malcontent ];
+    services.dbus.packages = [
+      # D-Bus services are in `out`, not the default `bin` output that would be picked up by `makeDbusConf`.
+      pkgs.malcontent.out
+    ];
 
     services.accounts-daemon.enable = true;
 

--- a/pkgs/development/libraries/malcontent/better-separation.patch
+++ b/pkgs/development/libraries/malcontent/better-separation.patch
@@ -1,18 +1,42 @@
+commit 363c5be465dd6dde35c3d31abd7b5cca9b1f3a9f
+Author: Jan Tojnar <jtojnar@gmail.com>
+Date:   Thu Jul 23 18:49:03 2020 +0200
+
+    Improve separation between malcontent and malcontent-ui packages
+    
+    These artefacts go into both packages by default:
+    
+    * malcontent-control – a CLI tool
+    * PAM module
+    * gettext locale data
+    * help pages ✨
+    * AccountService/D-Bus interfaces
+    * Polkit com.endlessm.ParentalControls rules and policy
+    
+    Items marked with ✨ will go to ui package, while the rest is installed with the base library.
+    
+    See also the packaging done by upstream in Endless:
+    https://github.com/endlessm/malcontent/tree/5482b7eb99aee9b8c344629bc078e193d3c26ffc/debian
+    
+    Cannot upstream this since they are worried about maintainability:
+    https://gitlab.freedesktop.org/pwithnall/malcontent/merge_requests/38#note_437946
+
 diff --git a/meson.build b/meson.build
-index a6c477d..f7b2f0a 100644
+index 6e1dfa5..196350b 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -125,8 +125,8 @@ test_env = [
+@@ -123,9 +123,8 @@ test_env = [
    'LC_ALL=C.UTF-8',
  ]
  
 -subdir('accounts-service')
+-subdir('help')
  if not get_option('use_system_libmalcontent')
 +  subdir('accounts-service')
    subdir('libmalcontent')
  else
    libmalcontent_api_version = '0'
-@@ -137,11 +137,17 @@ endif
+@@ -136,11 +135,16 @@ endif
  if get_option('ui').enabled()
    subdir('libmalcontent-ui')
  endif
@@ -22,14 +46,13 @@ index a6c477d..f7b2f0a 100644
 +endif
  if get_option('ui').enabled()
    subdir('malcontent-control')
- endif
--subdir('pam')
++  subdir('help')
++endif
 +if not get_option('use_system_libmalcontent')
 +  subdir('pam')
-+endif
- subdir('po')
++  subdir('po')
+ endif
+-subdir('pam')
+-subdir('po')
  
--meson.add_install_script('build-aux/meson_post_install.py')
-+if get_option('ui').enabled()
-+  meson.add_install_script('build-aux/meson_post_install.py')
-+endif
+ meson.add_install_script('build-aux/meson_post_install.py')

--- a/pkgs/development/libraries/malcontent/default.nix
+++ b/pkgs/development/libraries/malcontent/default.nix
@@ -3,7 +3,7 @@
 , fetchpatch
 , meson
 , ninja
-, pkgconfig
+, pkg-config
 , gobject-introspection
 , wrapGAppsHook
 , glib
@@ -19,16 +19,16 @@
 
 stdenv.mkDerivation rec {
   pname = "malcontent";
-  version = "0.7.0";
+  version = "0.8.0";
 
-  outputs = [ "bin" "out" "dev" "man" "installedTests" ];
+  outputs = [ "bin" "out" "lib" "pam" "dev" "man" "installedTests" ];
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "pwithnall";
     repo = pname;
     rev = version;
-    sha256 = "0lxakzj75pvpgwbjfyfkg0gyzvry00zhc9h9cd8f0wksg7mabzbh";
+    sha256 = "Y9HzysChzzmKW5PuCLm9AZ4oaBLMpB0I5NyZUOYFzm4=";
   };
 
   patches = [
@@ -37,19 +37,12 @@ stdenv.mkDerivation rec {
 
     # Do not build things that are part of malcontent-ui package
     ./better-separation.patch
-
-    # Fix pam installed test
-    # https://gitlab.freedesktop.org/pwithnall/malcontent/merge_requests/50
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/pwithnall/malcontent/commit/5d102eeb0604e65fc977ca77d4b249e986e634cc.patch";
-      sha256 = "1vs35zfp2sa2rps5h1240h73kvlspmv7mfr6f8mcbzvhj1wgzw74";
-    })
   ];
 
   nativeBuildInputs = [
     meson
     ninja
-    pkgconfig
+    pkg-config
     gobject-introspection
     wrapGAppsHook
   ];
@@ -72,6 +65,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dinstalled_tests=true"
     "-Dinstalled_test_prefix=${placeholder "installedTests"}"
+    "-Dpamlibdir=${placeholder "pam"}/lib/security"
     "-Dui=disabled"
   ];
 
@@ -83,6 +77,13 @@ stdenv.mkDerivation rec {
       --replace "/bin/false" "${coreutils}/bin/false"
   '';
 
+  postInstall = ''
+    # `giDiscoverSelf` only picks up paths in `out` output.
+    # This needs to be in `postInstall` so that it runs before
+    # `gappsWrapperArgsHook` that runs as one of `preFixupPhases`.
+    addToSearchPath GI_TYPELIB_PATH "$lib/lib/girepository-1.0"
+  '';
+
   passthru = {
     tests = {
       installedTests = nixosTests.installed-tests.malcontent;
@@ -90,6 +91,10 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
+    # We need to install Polkit & AccountsService data files in `out`
+    # but `buildEnv` only uses `bin` when both `bin` and `out` are present.
+    outputsToInstall = [ "bin" "out" "man" ];
+
     description = "Parental controls library";
     homepage = "https://gitlab.freedesktop.org/pwithnall/malcontent";
     license = licenses.lgpl21Plus;

--- a/pkgs/development/libraries/malcontent/ui.nix
+++ b/pkgs/development/libraries/malcontent/ui.nix
@@ -3,6 +3,7 @@
 , ninja
 , pkg-config
 , gobject-introspection
+, itstool
 , wrapGAppsHook
 , glib
 , accountsservice
@@ -20,7 +21,7 @@ stdenv.mkDerivation rec {
 
   inherit (malcontent) version src;
 
-  outputs = [ "bin" "out" "dev" ];
+  outputs = [ "out" "lib" "dev" ];
 
   patches = [
     # Allow installing installed tests to a separate output.
@@ -35,6 +36,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     gobject-introspection
+    itstool
     desktop-file-utils
     wrapGAppsHook
   ];


### PR DESCRIPTION
###### Motivation for this change

* Update: https://gitlab.freedesktop.org/pwithnall/malcontent/-/releases/0.8.0
    * Fix the separation patch.
    * Add `itstool` to ui (needed for building localized help).
* Use `pkg-config` instead of the `pkgconfig` alias.
* Fix some issues related to multiple outputs:
    * Make the module pass specific output to `dbus.packages` since the `dbus` NixOS module will not generate configuration with correct interface paths otherwise.
    * Change `malcontent-ui` package to primarily-a-program type derivation (`out`+`lib` instead of `bin`+`out`) since there are more and more `malcontent-control`-specific assets.
        * This also fixes the issue where application data (desktop files, icons…) were installed to `out`, which is not installed by `environment.systemPackages`/`system-path.nix`’s `buildEnv` by default when
`bin` output is also present.
    * Make `malcontent` package install `out` output too so that `system-path.nix` links that too. It contains the AccountsService & Polkit data files.
    * Split the library and PAM module out of `malcontent.out` so that they are not installed with the data files.
        * This revealed a bug in the `gobject-introspection` setup hook.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @worldofpeace