### PR TITLE
pythonPackages.tempita: fix sources location

### DIFF
--- a/pkgs/development/python-modules/tempita/default.nix
+++ b/pkgs/development/python-modules/tempita/default.nix
@@ -1,20 +1,28 @@
-{ lib, buildPythonPackage, fetchFromGitHub, nose }:
+{ lib, buildPythonPackage, fetchFromBitbucket, isPy3k, nose }:
 
-buildPythonPackage {
-  version = "0.5.3-2016-09-28";
+buildPythonPackage rec {
   pname = "tempita";
+  version = "0.5.3";
 
-  src = fetchFromGitHub {
-    owner = "gjhiggins";
-    repo = "tempita";
-    rev = "47414a7c6e46a9a9afe78f0bce2ea299fa84d10";
-    sha256 = "0f33jjjs5rvp7ar2j6ggyfykcrsrn04jaqcq71qfvycf6b7nw3rn";
+  src = fetchFromBitbucket {
+    owner = "ianb";
+    repo = pname;
+    rev = "97392d008cc8";
+    sha256 = "10jz1n2qwz8vcfh68xya2jlazd7p9dn2790q4w0k5kagd4h25f07";
   };
 
   buildInputs = [ nose ];
 
+  # When this library is installed by pip, it runs 2to3 automatically to make it compatible with Python3.
+  # Nix doesn't follow the same approach and doesn't seem to respect setuptools build arguments `use_2to3=True`
+  # (see https://bitbucket.org/ianb/tempita/src/97392d008cc8819afb99583f4d40c18ab9990082/setup.py#lines-39),
+  # so we need to run this step manually before the build phase.
+  preBuild = lib.optionalString isPy3k ''
+    2to3 -w -n .
+  '';
+
   meta = {
-    homepage = "https://github.com/gjhiggins/tempita";
+    homepage = "https://bitbucket.org/ianb/tempita";
     description = "A very small text templating language";
     license = lib.licenses.mit;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Addresses the issues brought up in #79207 and finalizing the work
by specifying the correct location for what's look like an abandoned package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
