### PR TITLE
nixos/pipewire: add transparent ALSA/PulseAudio/JACK support

### DIFF
--- a/nixos/modules/services/desktops/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire.nix
@@ -100,6 +100,6 @@ in {
       source = "${pkgs.pipewire}/share/alsa/alsa.conf.d/50-pipewire.conf";
     };
     environment.sessionVariables.LD_LIBRARY_PATH =
-      lib.optional (cfg.alsa.enable || cfg.jack.enable || cfg.pulse.enable) "/run/current-system/sw/lib/pipewire";
+      lib.optional (cfg.jack.enable || cfg.pulse.enable) "/run/current-system/sw/lib/pipewire";
   };
 }

--- a/nixos/modules/services/desktops/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire.nix
@@ -9,6 +9,10 @@ let
                            && pkgs.stdenv.isx86_64
                            && pkgs.pkgsi686Linux.pipewire != null;
 
+  # The package doesn't output to $out/lib/pipewire directly so that the
+  # overlays can use the outputs to replace the originals in FHS environments.
+  #
+  # This doesn't work in general because of missing development information.
   jack-libs = pkgs.runCommand "jack-libs" {} ''
     mkdir -p "$out/lib"
     ln -s "${pkgs.pipewire.jack}/lib" "$out/lib/pipewire"
@@ -37,41 +41,16 @@ in {
       };
 
       alsa = {
-        enable = mkOption {
-          default = false;
-          type = types.bool;
-          description = ''
-            Route audio to/from generic ALSA-using applications via the ALSA PIPEWIRE PCM plugin.
-          '';
-        };
-
-        support32Bit = mkOption {
-          default = false;
-          type = types.bool;
-          description = ''
-            Whether to support sound for 32-bit ALSA applications on a 64-bit system.
-          '';
-        };
+        enable = mkEnableOption "ALSA support";
+        support32Bit = mkEnableOption "32-bit ALSA support on 64-bit systems";
       };
 
       jack = {
-        enable = mkOption {
-          default = false;
-          type = types.bool;
-          description = ''
-            Enable transparent JACK audio emulation using LD_LIBRARY_PATH.
-          '';
-        };
+        enable = mkEnableOption "JACK audio emulation";
       };
 
       pulse = {
-        enable = mkOption {
-          default = false;
-          type = types.bool;
-          description = ''
-            Enable transparent PulseAudio emulation using LD_LIBRARY_PATH.
-          '';
-        };
+        enable = mkEnableOption "PulseAudio emulation";
       };
     };
   };
@@ -79,12 +58,25 @@ in {
 
   ###### implementation
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.pulse.enable -> !config.hardware.pulseaudio.enable;
+        message = "PipeWire based PulseAudio emulation doesn't use the PulseAudio service";
+      }
+      {
+        assertion = cfg.jack.enable -> !config.services.jack.jackd.enable;
+        message = "PIpeWire based JACK emulation doesn't use the JACK service";
+      }
+    ];
+
     environment.systemPackages = [ pkgs.pipewire ]
                                  ++ lib.optional cfg.jack.enable jack-libs
                                  ++ lib.optional cfg.pulse.enable pulse-libs;
 
     systemd.packages = [ pkgs.pipewire ];
 
+    # PipeWire depends on DBUS but doesn't list it. Without this booting
+    # into a terminal results in the service crashing with an error.
     systemd.user.sockets.pipewire.wantedBy = lib.mkIf cfg.socketActivation [ "sockets.target" ];
     systemd.user.services.pipewire.bindsTo = [ "dbus.service" ];
     services.udev.packages = [ pkgs.pipewire ];
@@ -107,6 +99,7 @@ in {
     environment.etc."alsa/conf.d/50-pipewire.conf" = mkIf cfg.alsa.enable {
       source = "${pkgs.pipewire}/share/alsa/alsa.conf.d/50-pipewire.conf";
     };
-    environment.sessionVariables.LD_LIBRARY_PATH = [ "/run/current-system/sw/lib/pipewire" ];
+    environment.sessionVariables.LD_LIBRARY_PATH =
+      lib.optional (cfg.alsa.enable || cfg.jack.enable || cfg.pulse.enable) "/run/current-system/sw/lib/pipewire";
   };
 }

--- a/nixos/modules/services/desktops/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire.nix
@@ -87,6 +87,7 @@ in {
 
     systemd.user.sockets.pipewire.wantedBy = lib.mkIf cfg.socketActivation [ "sockets.target" ];
 
+    # If any paths are updated here they must also be updated in the package test.
     sound.extraConfig = mkIf cfg.alsa.enable ''
       pcm_type.pipewire {
         libs.native = ${pkgs.pipewire.lib}/lib/alsa-lib/libasound_module_pcm_pipewire.so ;

--- a/nixos/modules/services/desktops/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire.nix
@@ -11,11 +11,11 @@ let
 
   jack-libs = pkgs.runCommand "jack-libs" {} ''
     mkdir -p "$out/lib"
-    ln -s "${pkgs.pipewire.lib}"/lib/pipewire-*/jack "$out/lib/pipewire"
+    ln -s "${pkgs.pipewire.jack}/lib" "$out/lib/pipewire"
   '';
   pulse-libs = pkgs.runCommand "pulse-libs" {} ''
     mkdir -p "$out/lib"
-    ln -s "${pkgs.pipewire.lib}"/lib/pipewire-*/pulse "$out/lib/pipewire"
+    ln -s "${pkgs.pipewire.pulse}/lib" "$out/lib/pipewire"
   '';
 in {
 

--- a/nixos/modules/services/desktops/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire.nix
@@ -107,6 +107,6 @@ in {
     environment.etc."alsa/conf.d/50-pipewire.conf" = mkIf cfg.alsa.enable {
       source = "${pkgs.pipewire}/share/alsa/alsa.conf.d/50-pipewire.conf";
     };
-    environment.sessionVariables.LD_LIBRARY_PATH = "/run/current-system/sw/lib/pipewire";
+    environment.sessionVariables.LD_LIBRARY_PATH = [ "/run/current-system/sw/lib/pipewire" ];
   };
 }

--- a/nixos/modules/services/desktops/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire.nix
@@ -11,11 +11,11 @@ let
 
   jack-libs = pkgs.runCommand "jack-libs" {} ''
     mkdir -p "$out/lib"
-    ln -s "${pkgs.pipewire.lib}/lib/pipewire-0.3/jack" "$out/lib/pipewire"
+    ln -s "${pkgs.pipewire.lib}"/lib/pipewire-*/jack "$out/lib/pipewire"
   '';
   pulse-libs = pkgs.runCommand "pulse-libs" {} ''
     mkdir -p "$out/lib"
-    ln -s "${pkgs.pipewire.lib}/lib/pipewire-0.3/pulse" "$out/lib/pipewire"
+    ln -s "${pkgs.pipewire.lib}"/lib/pipewire-*/pulse "$out/lib/pipewire"
   '';
 in {
 

--- a/nixos/modules/services/desktops/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire.nix
@@ -5,7 +5,9 @@ with lib;
 
 let
   cfg = config.services.pipewire;
-  packages = with pkgs; [ pipewire ];
+  enable32BitAlsaPlugins = cfg.alsa.support32Bit
+                           && pkgs.stdenv.isx86_64
+                           && pkgs.pkgsi686Linux.pipewire != null;
 
 in {
 
@@ -25,17 +27,52 @@ in {
           Automatically run pipewire when connections are made to the pipewire socket.
         '';
       };
+
+      alsa = {
+        enable = mkOption {
+          default = false;
+          type = types.bool;
+          description = ''
+            Route audio to/from generic ALSA-using applications via the ALSA PIPEWIRE PCM plugin.
+          '';
+        };
+
+        support32Bit = mkOption {
+          default = false;
+          type = types.bool;
+          description = ''
+            Whether to support sound for 32-bit ALSA applications on a 64-bit system.
+          '';
+        };
+      };
     };
   };
 
 
   ###### implementation
   config = mkIf cfg.enable {
-    environment.systemPackages = packages;
+    environment.systemPackages = [ pkgs.pipewire ];
 
-    systemd.packages = packages;
+    systemd.packages = [ pkgs.pipewire ];
 
     systemd.user.sockets.pipewire.wantedBy = lib.mkIf cfg.socketActivation [ "sockets.target" ];
-  };
 
+    sound.extraConfig = mkIf cfg.alsa.enable ''
+      pcm_type.pipewire {
+        libs.native = ${pkgs.pipewire.lib}/lib/alsa-lib/libasound_module_pcm_pipewire.so ;
+        ${optionalString enable32BitAlsaPlugins
+          "libs.32Bit = ${pkgs.pkgsi686Linux.pipewire.lib}/lib/alsa-lib/libasound_module_pcm_pipewire.so ;"}
+      }
+      pcm.!default {
+        @func getenv
+        vars [ PCM ]
+        default "plug:pipewire"
+        playback_mode "-1"
+        capture_mode "-1"
+      }
+    '';
+    environment.etc."alsa/conf.d/50-pipewire.conf" = mkIf cfg.alsa.enable {
+      source = "${pkgs.pipewire}/share/alsa/alsa.conf.d/50-pipewire.conf";
+    };
+  };
 }

--- a/nixos/modules/services/desktops/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire.nix
@@ -86,6 +86,7 @@ in {
     systemd.packages = [ pkgs.pipewire ];
 
     systemd.user.sockets.pipewire.wantedBy = lib.mkIf cfg.socketActivation [ "sockets.target" ];
+    services.udev.packages = [ pkgs.pipewire ];
 
     # If any paths are updated here they must also be updated in the package test.
     sound.extraConfig = mkIf cfg.alsa.enable ''

--- a/nixos/modules/services/desktops/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire.nix
@@ -86,6 +86,7 @@ in {
     systemd.packages = [ pkgs.pipewire ];
 
     systemd.user.sockets.pipewire.wantedBy = lib.mkIf cfg.socketActivation [ "sockets.target" ];
+    systemd.user.services.pipewire.bindsTo = [ "dbus.service" ];
     services.udev.packages = [ pkgs.pipewire ];
 
     # If any paths are updated here they must also be updated in the package test.

--- a/nixos/tests/installed-tests/default.nix
+++ b/nixos/tests/installed-tests/default.nix
@@ -101,5 +101,6 @@ in
   libxmlb = callInstalledTest ./libxmlb.nix {};
   malcontent = callInstalledTest ./malcontent.nix {};
   ostree = callInstalledTest ./ostree.nix {};
+  pipewire = callInstalledTest ./pipewire.nix {};
   xdg-desktop-portal = callInstalledTest ./xdg-desktop-portal.nix {};
 }

--- a/nixos/tests/installed-tests/pipewire.nix
+++ b/nixos/tests/installed-tests/pipewire.nix
@@ -1,0 +1,5 @@
+{ pkgs, lib, makeInstalledTest, ... }:
+
+makeInstalledTest {
+  tested = pkgs.pipewire;
+}

--- a/pkgs/development/libraries/pipewire/alsa-profiles-use-libdir.patch
+++ b/pkgs/development/libraries/pipewire/alsa-profiles-use-libdir.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index ffee41b4..f3e4ec74 100644
+--- a/meson.build
++++ b/meson.build
+@@ -53,7 +53,7 @@ endif
+ 
+ spa_plugindir = join_paths(pipewire_libdir, spa_name)
+ 
+-alsadatadir = join_paths(pipewire_datadir, 'alsa-card-profile', 'mixer')
++alsadatadir = join_paths(pipewire_libdir, '..', 'share', 'alsa-card-profile', 'mixer')
+ 
+ pipewire_headers_dir = join_paths(pipewire_name, 'pipewire')
+ 

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -1,43 +1,44 @@
 { stdenv
+, lib
 , fetchFromGitLab
-, fetchpatch
 , meson
 , ninja
+, systemd
 , pkgconfig
 , doxygen
 , graphviz
 , valgrind
 , glib
 , dbus
-, gst_all_1
 , alsaLib
-, ffmpeg_3
 , libjack2
 , udev
 , libva
-, xorg
-, sbc
-, SDL2
 , libsndfile
-, bluez
 , vulkan-headers
 , vulkan-loader
 , libpulseaudio
 , makeFontsConf
 , callPackage
 , nixosTests
-, ofonoSupport ? true
+, gstreamerSupport ? true, gst_all_1 ? null
+, ffmpegSupport ? true, ffmpeg ? null
+, bluezSupport ? true, bluez ? null, sbc ? null
 , nativeHspSupport ? true
+, ofonoSupport ? true
+, hsphfpdSupport ? false
 }:
 
 let
   fontsConf = makeFontsConf {
     fontDirectories = [];
   };
+
+  mesonBool = b: if b then "true" else "false";
 in
 stdenv.mkDerivation rec {
   pname = "pipewire";
-  version = "0.3.11";
+  version = "0.3.12";
 
   outputs = [
     "out"
@@ -54,7 +55,7 @@ stdenv.mkDerivation rec {
     owner = "pipewire";
     repo = "pipewire";
     rev = version;
-    sha256 = "1wbir3napjxcpjy2m70im0l2x1ylg541rwq6hhvm8z0n5khxgfy7";
+    sha256 = "14w9sgznrvcs31qzbzz1vyp4p2sljawbrzhr93921ss0iqivhfwl";
   };
 
   patches = [
@@ -74,39 +75,39 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkgconfig
-    valgrind
   ];
 
   buildInputs = [
-    SDL2
     alsaLib
-    bluez
     dbus
-    ffmpeg_3
     glib
-    gst_all_1.gst-plugins-base
-    gst_all_1.gstreamer
     libjack2
     libpulseaudio
     libsndfile
-    libva
-    sbc
     udev
     vulkan-headers
     vulkan-loader
-    xorg.libX11
-  ];
+    valgrind
+    systemd
+  ] ++ lib.optionals gstreamerSupport [ gst_all_1.gst-plugins-base gst_all_1.gstreamer ]
+  ++ lib.optional ffmpegSupport ffmpeg
+  ++ lib.optionals bluezSupport [ bluez sbc ];
 
   mesonFlags = [
     "-Ddocs=true"
     "-Dman=false" # we don't have xmltoman
-    "-Dgstreamer=true"
+    "-Dexamples=true" # only needed for `pipewire-media-session`
     "-Dudevrulesdir=lib/udev/rules.d"
     "-Dinstalled_tests=true"
     "-Dlibpulse-path=${placeholder "pulse"}/lib"
     "-Dlibjack-path=${placeholder "jack"}/lib"
-  ] ++ stdenv.lib.optional nativeHspSupport "-Dbluez5-backend-native=true"
-  ++ stdenv.lib.optional ofonoSupport "-Dbluez5-backend-ofono=true";
+    "-Dgstreamer=${mesonBool gstreamerSupport}"
+    "-Dffmpeg=${mesonBool ffmpegSupport}"
+    "-Dbluez5=${mesonBool bluezSupport}"
+    "-Dbluez5-backend-native=${mesonBool nativeHspSupport}"
+    "-Dbluez5-backend-ofono=${mesonBool ofonoSupport}"
+    "-Dbluez5-backend-hsphfpd=${mesonBool hsphfpdSupport}"
+  ];
 
   FONTCONFIG_FILE = fontsConf; # Fontconfig error: Cannot load default config file
 

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -40,7 +40,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "pipewire";
-  version = "0.3.12";
+  version = "0.3.13";
 
   outputs = [
     "out"
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     owner = "pipewire";
     repo = "pipewire";
     rev = version;
-    sha256 = "14w9sgznrvcs31qzbzz1vyp4p2sljawbrzhr93921ss0iqivhfwl";
+    sha256 = "19j5kmb7iaivkq2agfzncfm2qms41ckqi0ddxvhpc91ihwprdc5w";
   };
 
   patches = [

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -65,9 +65,6 @@ stdenv.mkDerivation rec {
     ./installed-tests-path.patch
   ];
 
-  postPatch = ''
-    substituteInPlace meson.build --subst-var-by installed_tests_dir "$installedTests"
-  '';
 
   nativeBuildInputs = [
     doxygen
@@ -99,6 +96,7 @@ stdenv.mkDerivation rec {
     "-Dexamples=true" # only needed for `pipewire-media-session`
     "-Dudevrulesdir=lib/udev/rules.d"
     "-Dinstalled_tests=true"
+    "-Dinstalled_test_prefix=${placeholder "installedTests"}"
     "-Dlibpulse-path=${placeholder "pulse"}/lib"
     "-Dlibjack-path=${placeholder "jack"}/lib"
     "-Dgstreamer=${mesonBool gstreamerSupport}"

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -37,7 +37,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "pipewire";
-  version = "0.3.9";
+  version = "0.3.11";
 
   outputs = [
     "out"
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     owner = "pipewire";
     repo = "pipewire";
     rev = version;
-    sha256 = "0q781r32mnm3qy6xcdd2rnb8g50gdi7mi50zmdiq24s24sr8f8r9";
+    sha256 = "1wbir3napjxcpjy2m70im0l2x1ylg541rwq6hhvm8z0n5khxgfy7";
   };
 
   patches = [

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -39,7 +39,15 @@ stdenv.mkDerivation rec {
   pname = "pipewire";
   version = "0.3.9";
 
-  outputs = [ "out" "lib" "dev" "doc" "installedTests" ];
+  outputs = [
+    "out"
+    "lib"
+    "pulse"
+    "jack"
+    "dev"
+    "doc"
+    "installedTests"
+  ];
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
@@ -95,6 +103,8 @@ stdenv.mkDerivation rec {
     "-Dgstreamer=true"
     "-Dudevrulesdir=lib/udev/rules.d"
     "-Dinstalled_tests=true"
+    "-Dlibpulse-path=${placeholder "pulse"}/lib"
+    "-Dlibjack-path=${placeholder "jack"}/lib"
   ] ++ stdenv.lib.optional nativeHspSupport "-Dbluez5-backend-native=true"
   ++ stdenv.lib.optional ofonoSupport "-Dbluez5-backend-ofono=true";
 

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -130,8 +130,6 @@ stdenv.mkDerivation rec {
       ];
       paths-lib = [
         "lib/alsa-lib/libasound_module_pcm_pipewire.so"
-        "lib/pipewire-0.3/jack"
-        "lib/pipewire-0.3/pulse"
         "share/alsa-card-profile/mixer"
       ];
     };

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -112,6 +112,14 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  preFixup = ''
+    # The rpaths mistakenly points to libpulseaudio instead
+    for file in "$pulse"/lib/*.so; do
+      oldrpath="$(patchelf --print-rpath "$file")"
+      patchelf --set-rpath "$pulse/lib:$oldrpath" "$file"
+    done
+  '';
+
   passthru.tests = {
     installedTests = nixosTests.installed-tests.pipewire;
 

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -24,6 +24,8 @@
 , vulkan-loader
 , libpulseaudio
 , makeFontsConf
+, ofonoSupport ? true
+, nativeHspSupport ? true
 }:
 
 let
@@ -33,7 +35,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "pipewire";
-  version = "0.3.7";
+  version = "0.3.9";
 
   outputs = [ "out" "lib" "dev" "doc" ];
 
@@ -42,8 +44,13 @@ stdenv.mkDerivation rec {
     owner = "pipewire";
     repo = "pipewire";
     rev = version;
-    sha256 = "04l66p0wj553gp2zf3vwwh6jbr1vkf6wrq4za9zlm9dn144am4j2";
+    sha256 = "0q781r32mnm3qy6xcdd2rnb8g50gdi7mi50zmdiq24s24sr8f8r9";
   };
+
+  patches = [
+    # Break up a dependency cycle between outputs.
+    ./alsa-profiles-use-libdir.patch
+  ];
 
   nativeBuildInputs = [
     doxygen
@@ -78,7 +85,9 @@ stdenv.mkDerivation rec {
     "-Ddocs=true"
     "-Dman=false" # we don't have xmltoman
     "-Dgstreamer=true"
-  ];
+    "-Dudevrulesdir=lib/udev/rules.d"
+  ] ++ stdenv.lib.optional nativeHspSupport "-Dbluez5-backend-native=true"
+  ++ stdenv.lib.optional ofonoSupport "-Dbluez5-backend-ofono=true";
 
   FONTCONFIG_FILE = fontsConf; # Fontconfig error: Cannot load default config file
 

--- a/pkgs/development/libraries/pipewire/installed-tests-path.patch
+++ b/pkgs/development/libraries/pipewire/installed-tests-path.patch
@@ -1,5 +1,5 @@
 diff --git a/meson.build b/meson.build
-index ffee41b4..b75921f9 100644
+index ffee41b4..bab6f019 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -318,8 +318,8 @@ alsa_dep = (get_option('pipewire-alsa')
@@ -8,8 +8,22 @@ index ffee41b4..b75921f9 100644
  
 -installed_tests_metadir = join_paths(pipewire_datadir, 'installed-tests', pipewire_name)
 -installed_tests_execdir = join_paths(pipewire_libexecdir, 'installed-tests', pipewire_name)
-+installed_tests_metadir = join_paths('@installed_tests_dir@', 'share', 'installed-tests', pipewire_name)
-+installed_tests_execdir = join_paths('@installed_tests_dir@', 'libexec', 'installed-tests', pipewire_name)
++installed_tests_metadir = join_paths(get_option('installed_test_prefix'), 'share', 'installed-tests', pipewire_name)
++installed_tests_execdir = join_paths(get_option('installed_test_prefix'), 'libexec', 'installed-tests', pipewire_name)
  installed_tests_enabled = get_option('installed_tests')
  installed_tests_template = files('template.test.in')
  
+diff --git a/meson_options.txt b/meson_options.txt
+index f03033c3..32df6c53 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -18,6 +18,9 @@ option('installed_tests',
+        description: 'Install manual and automated test executables',
+        type: 'boolean',
+        value: false)
++option('installed_test_prefix',
++       description: 'Prefix for installed tests',
++       type: 'string')
+ option('gstreamer',
+        description: 'Build GStreamer plugins',
+        type: 'boolean',

--- a/pkgs/development/libraries/pipewire/installed-tests-path.patch
+++ b/pkgs/development/libraries/pipewire/installed-tests-path.patch
@@ -1,0 +1,15 @@
+diff --git a/meson.build b/meson.build
+index ffee41b4..b75921f9 100644
+--- a/meson.build
++++ b/meson.build
+@@ -318,8 +318,8 @@ alsa_dep = (get_option('pipewire-alsa')
+     ? dependency('alsa', version : '>=1.1.7')
+     : dependency('', required: false))
+ 
+-installed_tests_metadir = join_paths(pipewire_datadir, 'installed-tests', pipewire_name)
+-installed_tests_execdir = join_paths(pipewire_libexecdir, 'installed-tests', pipewire_name)
++installed_tests_metadir = join_paths('@installed_tests_dir@', 'share', 'installed-tests', pipewire_name)
++installed_tests_execdir = join_paths('@installed_tests_dir@', 'libexec', 'installed-tests', pipewire_name)
+ installed_tests_enabled = get_option('installed_tests')
+ installed_tests_template = files('template.test.in')
+ 

--- a/pkgs/development/libraries/pipewire/test-paths.nix
+++ b/pkgs/development/libraries/pipewire/test-paths.nix
@@ -1,0 +1,20 @@
+{ lib, runCommand, pipewire, paths-out, paths-lib }:
+
+runCommand "pipewire-test-paths" { } ''
+  ${lib.concatMapStringsSep "\n" (p: ''
+    if [ ! -f "${pipewire.lib}/${p}" ] && [ ! -d "${pipewire.lib}/${p}" ]; then
+      printf "pipewire failed to find the following path: %s\n" "${pipewire.lib}/${p}"
+      error=error
+    fi
+  '') paths-lib}
+
+  ${lib.concatMapStringsSep "\n" (p: ''
+    if [ ! -f "${pipewire}/${p}" ] && [ ! -d "${pipewire}/${p}" ]; then
+      printf "pipewire failed to find the following path: %s\n" "${pipewire}/${p}"
+      error=error
+    fi
+  '') paths-out}
+
+  [ -n "$error" ] && exit 1
+  touch $out
+''


### PR DESCRIPTION
###### Motivation for this change
This allows ALSA programs to interact through PipeWire.

The options are the same as in the JACK module for consistency. I enabled it by default since that is what JACK does and it seems less confusing for end users however this technically makes it backwards incompatible. If you prefer it off by default I can do that instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
