### PR TITLE
tealdeer: cleanup

### DIFF
--- a/pkgs/tools/misc/tealdeer/default.nix
+++ b/pkgs/tools/misc/tealdeer/default.nix
@@ -4,7 +4,6 @@
 , pkg-config
 , installShellFiles
 , openssl
-, cacert
 , Security
 }:
 
@@ -21,8 +20,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "0jvgcf493rmkrh85j0fkf8ffanva80syyxclzkvkrzvvwwj78b5l";
 
-  buildInputs = [ openssl cacert ]
-    ++ (stdenv.lib.optional stdenv.isDarwin Security);
+  buildInputs = if stdenv.isDarwin then [ Security ] else [ openssl ];
 
   nativeBuildInputs = [ installShellFiles pkg-config ];
 
@@ -31,8 +29,6 @@ rustPlatform.buildRustPackage rec {
     installShellCompletion --fish --name tealdeer.fish fish_tealdeer
     installShellCompletion --zsh --name _tealdeer zsh_tealdeer
   '';
-
-  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   # disable tests for now since one needs network
   # what is unavailable in sandbox build
@@ -44,6 +40,5 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/dbrgn/tealdeer";
     maintainers = with maintainers; [ davidak ];
     license = with licenses; [ asl20 mit ];
-    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`cacert` could have been removed with `curl` in https://github.com/NixOS/nixpkgs/commit/11464a5611ba140f3ffa7e99fed9d97f710e6c3c but I didn't check.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
