### PR TITLE
macvim: add configuration similar to vim_configurable and neovim

### DIFF
--- a/pkgs/applications/editors/vim/macvim-configurable.nix
+++ b/pkgs/applications/editors/vim/macvim-configurable.nix
@@ -1,0 +1,67 @@
+{ stdenv, callPackage, vimUtils, buildEnv, makeWrapper }:
+
+let
+  macvim = callPackage ./macvim.nix { inherit stdenv; };
+
+  makeCustomizable = macvim: macvim // {
+    # configure expects the same args as vimUtils.vimrcFile.
+    # This is the same as the value given to neovim.override { configure = … }
+    # or the value of vim_configurable.customize { vimrcConfig = … }
+    #
+    # Note: Like neovim and vim_configurable, configuring macvim disables the
+    # sourcing of the user's vimrc. Use `customRC = "source $HOME/.vim/vimrc"`
+    # if you want to preserve that behavior.
+    configure = let
+      inherit (stdenv) lib;
+      doConfig = config: let
+        vimrcConfig = config // {
+          # always source the bundled system vimrc
+          beforePlugins = ''
+            source $VIM/vimrc
+            ${config.beforePlugins or ""}
+          '';
+        };
+      in buildEnv {
+        name = macvim.name;
+        paths = [ macvim ];
+        pathsToLink = [
+          "/"
+          "/bin"
+          "/Applications/MacVim.app/Contents/MacOS"
+          "/Applications/MacVim.app/Contents/bin"
+        ];
+        buildInputs = [ makeWrapper ];
+        # We need to do surgery on the resulting app. We can't just make a wrapper for vim because this
+        # is a GUI app. We need to copy the actual GUI executable image as AppKit uses the loaded image's
+        # path to locate the bundle. We can use symlinks for other executables and resources though.
+        postBuild = ''
+          # Replace the Contents/MacOS/MacVim symlink with the original file
+          target=$(readlink $out/Applications/MacVim.app/Contents/MacOS/MacVim)
+          rm $out/Applications/MacVim.app/Contents/MacOS/MacVim
+          cp -a -t $out/Applications/MacVim.app/Contents/MacOS "$target"
+
+          # Wrap the Vim binary for our vimrc
+          wrapProgram $out/Applications/MacVim.app/Contents/MacOS/Vim \
+            --add-flags "-u ${vimUtils.vimrcFile vimrcConfig}"
+
+          # Replace each symlink in bin/ with the original. Most of them point at other symlinks
+          # and we need those original symlinks to point into our new app bundle.
+          for prefix in bin Applications/MacVim.app/Contents/bin; do
+            for link in $out/$prefix/*; do
+              target=$(readlink "$link")
+              # don't copy binaries like vimtutor, but we do need mvim
+              [ -L "$target" ] || [ "$(basename "$target")" = mvim ] || continue;
+              rm "$link"
+              cp -a -t $out/$prefix "$target"
+            done
+          done
+        '';
+        meta = macvim.meta;
+      };
+    in lib.makeOverridable (lib.setFunctionArgs doConfig (lib.functionArgs vimUtils.vimrcFile));
+
+    override = f: makeCustomizable (macvim.override f);
+    overrideAttrs = f: makeCustomizable (macvim.overrideAttrs f);
+  };
+in
+  makeCustomizable macvim

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23812,7 +23812,7 @@ in
 
   vimiv = callPackage ../applications/graphics/vimiv { };
 
-  macvim = callPackage ../applications/editors/vim/macvim.nix { stdenv = clangStdenv; };
+  macvim = callPackage ../applications/editors/vim/macvim-configurable.nix { stdenv = clangStdenv; };
 
   vimHugeX = vim_configurable;
 


### PR DESCRIPTION
###### Motivation for this change
I wanted to stop managing my own plugins as much as possible, I'd rather have Nix just keep them up to date. It also bothered me that vim and neovim supports Nix configuration but MacVim didn't.

To that end, this PR adds configuration to MacVim similar to vim_configurable and neovim. In MacVim's case, it looks like

```nix
macvim.configure {
  customRC = ''
    # Your configuration here
  '';
  packages.myVimPackage = with pkgs.vimPlugins; {
    start = [ youcompleteme fugitive ];
    opt = [ phpCompletion elm-vim ];
  };
}
```

The resulting derivation just wraps the original MacVim rather than rebuilding it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I didn't update documentation on Vim in the manual because I think MacVim is a rather esoteric package for people to be using and documentation on it doesn't apply to most Nix users.
