### PR TITLE
simplestreams: init at 2020-06-29

### DIFF
--- a/pkgs/development/python-modules/simplestreams/default.nix
+++ b/pkgs/development/python-modules/simplestreams/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchgit, pythonPackages }:
+
+pythonPackages.buildPythonPackage rec {
+  pname = "simplestreams";
+  version = "2020-06-29";
+
+  src = fetchgit {
+    url = "https://git.launchpad.net/simplestreams";
+    rev = "ff048fdb5d2f4e5b5218107d42f1c86f0a783bfb";
+    sha256 = "0y0mhzjyzp90nmfxasknajfmra5jhll5sf3v67sdkwlscb2f3s96";
+  };
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://launchpad.net/simplestreams";
+    description = "A python library and some tools for interacting with simple streams format";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ mt-caret ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3579,6 +3579,8 @@ in {
 
   screeninfo = callPackage ../development/python-modules/screeninfo { };
 
+  simplestreams = callPackage ../development/python-modules/simplestreams { };
+
   ssdeep = callPackage ../development/python-modules/ssdeep { };
 
   ssdp = callPackage ../development/python-modules/ssdp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add simplestreams, a package to work with Canonical's Simple Streams protocol.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
