### PR TITLE
liblinear: 2.30 -> 2.40

### DIFF
--- a/pkgs/development/libraries/liblinear/default.nix
+++ b/pkgs/development/libraries/liblinear/default.nix
@@ -1,34 +1,36 @@
-{ stdenv, fetchurl, fixDarwinDylibNames }:
+{ stdenv, fetchFromGitHub, fixDarwinDylibNames }:
 
-stdenv.mkDerivation rec {
+let
+  soVersion = "4";
+in stdenv.mkDerivation rec {
   pname = "liblinear";
-  version = "2.30";
+  version = "2.40";
 
-  src = fetchurl {
-    url = "https://www.csie.ntu.edu.tw/~cjlin/liblinear/liblinear-${version}.tar.gz";
-    sha256 = "1b66jpg9fdwsq7r52fccr8z7nqcivrin5d8zg2f134ygqqwp0748";
+  src = fetchFromGitHub {
+    owner = "cjlin1";
+    repo = "liblinear";
+    rev = "v${builtins.replaceStrings ["."] [""] version}";
+    sha256 = "041fby9vc7nvj0gls5zd9mhw7yqazm530bmln38mfz7wd06z1d6b";
   };
 
-  buildPhase = ''
-    make
-    make lib
-  '';
+  outputs = [ "bin" "dev" "out" ];
+
+  nativeBuildInputs = stdenv.lib.optionals stdenv.isDarwin [ fixDarwinDylibNames ];
+
+  buildFlags = [ "lib" "predict" "train" ];
 
   installPhase = ''
-    mkdir -p $out/lib $out/bin $out/include
     ${if stdenv.isDarwin then ''
-      cp liblinear.so.3 $out/lib/liblinear.3.dylib
-      ln -s $out/lib/liblinear.3.dylib $out/lib/liblinear.dylib
+      install -D liblinear.so.${soVersion} $out/lib/liblinear.${soVersion}.dylib
+      ln -s $out/lib/liblinear.${soVersion}.dylib $out/lib/liblinear.dylib
     '' else ''
-      cp liblinear.so.3 $out/lib/liblinear.so.3
-      ln -s $out/lib/liblinear.so.3 $out/lib/liblinear.so
+      install -Dt $out/lib liblinear.so.${soVersion}
+      ln -s $out/lib/liblinear.so.${soVersion} $out/lib/liblinear.so
     ''}
-    cp train $out/bin/liblinear-train
-    cp predict $out/bin/liblinear-predict
-    cp linear.h $out/include
+    install -D train $bin/bin/liblinear-train
+    install -D predict $bin/bin/liblinear-predict
+    install -Dm444 -t $dev/include linear.h
   '';
-
-  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin [ fixDarwinDylibNames ];
 
   meta = with stdenv.lib; {
     description = "A library for large linear classification";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Also improve the derivation a bit:

- Use fetchFromGitHub in place of fetchurl.
- Replace buildPhase by buildFlags.
- Create multiple outputs.
- Replace mkdir/cp by install.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
