### PR TITLE
audacity: 2.4.1 -> 2.4.2

### DIFF
--- a/pkgs/applications/audio/audacity/default.nix
+++ b/pkgs/applications/audio/audacity/default.nix
@@ -1,27 +1,20 @@
-{ stdenv, fetchzip, wxGTK30, pkgconfig, file, gettext,
+{ stdenv, fetchzip, wxGTK31, pkgconfig, file, gettext,
   libvorbis, libmad, libjack2, lv2, lilv, serd, sord, sratom, suil, alsaLib, libsndfile, soxr, flac, lame,
   expat, libid3tag, ffmpeg_3, soundtouch, /*, portaudio - given up fighting their portaudio.patch */
-  autoconf, automake, libtool
+  pcre, vamp-plugin-sdk, portmidi, twolame, git,
+  cmake, libtool
   }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "2.4.1";
+  version = "2.4.2";
   pname = "audacity";
 
   src = fetchzip {
     url = "https://github.com/audacity/audacity/archive/Audacity-${version}.tar.gz";
-    sha256 = "1xk0piv72d2xd3p7igr916fhcbrm76fhjr418k1rlqdzzg1hfljn";
+    sha256 = "0lklcvqkxrr2gkb9gh3422iadzl2rv9v0a8s76rwq43lj2im7546";
   };
-
-  preConfigure = /* we prefer system-wide libs */ ''
-    autoreconf -vi # use system libraries
-
-    # we will get a (possibly harmless) warning during configure without this
-    substituteInPlace configure \
-      --replace /usr/bin/file ${file}/bin/file
-  '';
 
   configureFlags = [
     "--with-libsamplerate"
@@ -43,11 +36,12 @@ stdenv.mkDerivation rec {
     "-lswscale"
   ];
 
-  nativeBuildInputs = [ pkgconfig autoconf automake libtool ];
+  nativeBuildInputs = [ pkgconfig cmake libtool git ];
   buildInputs = [
-    file gettext wxGTK30 expat alsaLib
-    libsndfile soxr libid3tag libjack2 lv2 lilv serd sord sratom suil wxGTK30.gtk
+    file gettext wxGTK31 expat alsaLib
+    libsndfile soxr libid3tag libjack2 lv2 lilv serd sord sratom suil wxGTK31.gtk
     ffmpeg_3 libmad lame libvorbis flac soundtouch
+    pcre vamp-plugin-sdk portmidi twolame
   ]; #ToDo: detach sbsms
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Not quite ready yet: some libraries, like lame, are still incorrectly taken from 'local' instead of 'system'

Does seem to work nicely.

/cc @lheckemann 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
