### PR TITLE
[haskell-updates] bluespec: Fix build without ghc 844

### DIFF
--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -6,7 +6,6 @@
 , fontconfig
 , gmp
 , gperf
-, haskell
 , libX11
 , libpoly
 , perl
@@ -14,16 +13,14 @@
 , verilog
 , xorg
 , zlib
+, ghc
 }:
 
 let
   # yices wants a libgmp.a and fails otherwise
   gmpStatic = gmp.override { withStatic = true; };
 
-  # Compiling PreludeBSV fails with more recent GHC versions
-  # > imperative statement (not BVI context)
-  # https://github.com/B-Lang-org/bsc/issues/20#issuecomment-583724030
-  ghcWithPackages = haskell.packages.ghc844.ghc.withPackages (g: (with g; [old-time regex-compat syb]));
+  ghcWithPackages = ghc.withPackages (g: (with g; [old-time regex-compat syb]));
 in stdenv.mkDerivation rec {
   pname = "bluespec";
   version = "unstable-2020.02.09";
@@ -94,6 +91,5 @@ in stdenv.mkDerivation rec {
     # darwin fails at https://github.com/B-Lang-org/bsc/pull/35#issuecomment-583731562
     # aarch64 fails, as GHC fails with "ghc: could not execute: opt"
     maintainers = with stdenv.lib.maintainers; [ flokli thoughtpolice ];
-    broken = true;  # ghc-8.4.4 is gone from Nixpkgs
   };
 }


### PR DESCRIPTION
ghc 8.4.4 was only required before the merge of

https://github.com/B-Lang-org/bsc/pull/42

which actually is already contained in the commit we are using.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This fixes bluespec and the issues we had with ofBorg in the last days.

\cc @peti @flokli 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
