### PR TITLE
Add matrix corporal

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1855,6 +1855,12 @@
     githubId = 245394;
     name = "Hannu Hartikainen";
   };
+  dandellion = {
+    email = "daniel@dodsorf.as";
+    github = "dali99";
+    githubId = 990767;
+    name = "Daniel Olsen";
+  };
   danderson = {
     email = "dave@natulte.net";
     github = "danderson";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -77,6 +77,7 @@ with lib.maintainers; {
       mguentner
       ekleog
       ralith
+      dandellion
     ];
     scope = "Maintain the ecosystem around Matrix, a decentralized messenger.";
   };

--- a/nixos/modules/services/misc/matrix-corporal.nix
+++ b/nixos/modules/services/misc/matrix-corporal.nix
@@ -1,10 +1,14 @@
 { lib, pkgs, config, ... }:
 let
   cfg = config.services.matrix-corporal;
+  matrix-corporal-config = pkgs.writeTextFile {
+    name = "matrix-corporal-config.json";
+    text = lib.generators.toJSON {} cfg.settings;
+  };
 in
 {
   options.services.matrix-corporal = {
-    enable = lib.mkEnableOption "Enable matrix-corporal";
+    enable = lib.mkEnableOption "matrix-corporal";
 
     package = lib.mkOption {
       type = lib.types.package;
@@ -12,6 +16,7 @@ in
     };
 
     settings = lib.mkOption {
+      type = lib.types.attrs;
       default = {};
       description = ''
         Configuration for matrix-corporal, see <link xlink:href="https://github.com/devture/matrix-corporal/blob/master/docs/configuration.md"/>
@@ -24,9 +29,8 @@ in
     systemd.services.matrix-corporal = {
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        Type = "simple";
-        DynamicUser="yes";
-        ExecStart = "${cfg.package}/bin/matrix-corporal -c ${pkgs.writeTextFile {name = "matrix-corporal-config.json"; text = lib.generators.toJSON {} cfg.settings;}}";
+        DynamicUser = true;
+        ExecStart = "${cfg.package}/bin/matrix-corporal -c ${matrix-corporal-config}}";
       };
     };
   };

--- a/nixos/modules/services/misc/matrix-corporal.nix
+++ b/nixos/modules/services/misc/matrix-corporal.nix
@@ -1,10 +1,8 @@
 { lib, pkgs, config, ... }:
 let
   cfg = config.services.matrix-corporal;
-  matrix-corporal-config = pkgs.writeTextFile {
-    name = "matrix-corporal-config.json";
-    text = lib.generators.toJSON {} cfg.settings;
-  };
+  format = pkgs.formats.json {};
+  matrix-corporal-config = format.generate "matrix-corporal-config.json" cfg.settings;
 in
 {
   options.services.matrix-corporal = {
@@ -18,7 +16,7 @@ in
     settings = lib.mkOption {
       default = {};
       type = lib.types.submodule {
-        config._module.fallbackType = with lib.types; attrsOf (oneOf [ str int bool ]);
+        config._module.fallbackType = format.type;
 
         options.Matrix.HomeserverDomainName = lib.mkOption {
           type = lib.types.str;

--- a/nixos/modules/services/misc/matrix-corporal.nix
+++ b/nixos/modules/services/misc/matrix-corporal.nix
@@ -17,9 +17,10 @@ in
 
     settings = lib.mkOption {
       default = {};
-      type = with lib.types.submodule {
+      type = lib.types.submodule {
         options.Matrix.HomeserverDomainName = lib.mkOption {
           type = lib.types.str;
+          default = "localhost";
           description = ''
             The base domain name of your Matrix homeserver.
             This is what user identifiers contain (@user:example.com), and not necessarily the domain name where the Matrix homeserver is hosted (could actually be matrix.example.com)
@@ -68,8 +69,8 @@ in
           '';
         };
         options.HttpGateway.TimeoutMilliseconds = lib.mkOption {
-          type = lib.types.addCheck lib.types.int (x: x >= cfg.Matrix.TimeoutMilliseconds);
-          default = {};
+          type = lib.types.addCheck lib.types.int (x: x >= cfg.settings.Matrix.TimeoutMilliseconds);
+          default = cfg.settings.Matrix.TimeoutMilliseconds;
           description = ''
             How long (in milliseconds) HTTP requests are allowed to take before being timed out.
             Since clients often use long-polling for /sync (usually with a 30-second limit), setting this to a value of more than 30000 is recommended.
@@ -82,6 +83,11 @@ in
           default = true;
           description = "Whether the HTTP API is enabled or not";
         };
+        options.HttpApi.TimeoutMilliseconds = lib.mkOption {
+          type = lib.types.int;
+          default = 10000; # Seems good?
+          description = "How long (in milliseconds) HTTP requests are allowed to take before being timed out.";
+        };
         options.HttpApi.ListenAddress = lib.mkOption {
           type = lib.types.str;
           default = "127.0.0.1:41081";
@@ -91,10 +97,61 @@ in
           '';
         };
 
-        options.PolicyProvider = {
-          Type = lib.mkOption {
-            type = lib.types.str;
-            default = "static_file";
+        options.PolicyProvider = lib.mkOption {
+          type = lib.types.oneOf [
+            lib.types.submodule {
+              Type = lib.mkOption {
+                type = lib.types.addCheck lib.types.str (x: x == "static_file");
+                default = "static_file";
+                description = "Type of Policy Provider";
+              };
+              Path = lib.mkOption {
+                type = lib.types.path;
+                default = "/etc/matrix-corporal/policy.json";
+                description = "Path to policy file";
+              };
+            }
+            lib.types.submodule {
+              Type = lib.mkOption {
+                type = lib.types.addCheck lib.types.str (x: x == "http");
+                default = "http";
+                description = "Type of Policy Provider";
+              };
+              Uri = lib.mkOption {
+                type = lib.types.str;
+                description = "The URL from which matrix-corporal will fetch the policy (a GET request is made).";
+              };
+              CachePath = lib.mkOption {
+                type = lib.types.nullOr lib.types.path;
+                default = "/var/matrix-corporal/last-policy.json";
+                description = "A path to a local file, where matrix-corporal will store the last-fetched policy. It's important to store it locally to prevent downtime in case the policy provider is temporarily unavailable for some reason. Can be set to null to disable caching (not recommended).";
+              };
+              ReloadIntervalSeconds = lib.mkOption {
+                type = lib.types.nullOr lib.types.ints.positive;
+                default = 1800;
+                description = "An interval duration at which the policy provider will re-fetch the policy from the given URL. Can be set to 0 or null to disable reloading.";
+              };
+              TimeoutMilliseconds = lib.mkOption {
+                type = lib.types.nullOr lib.types.ints.positive;
+                default = 30000;
+                description = "how long (in milliseconds) HTTP requests (from matrix-corporal to the policy-serving Uri) are allowed to take before being timed out. Can be set to null to allow for unlimited waits (not recommended).";
+              };
+            }
+            lib.types.submodule {
+              Type = lib.mkOption {
+                type = lib.types.addCheck lib.types.str (x: x == "last_seen_store_policy");
+                default = "last_seen_store_policy";
+                description = "Type of Policy Provider";
+              };
+              CachePath = lib.mkOption {
+                type = lib.types.nullOr lib.types.path;
+                default = "/var/matrix-corporal/last-policy.json";
+                description = "A path to a local file, where matrix-corporal will store the last-fetched policy. It's important to store it locally to prevent downtime in case the policy provider is temporarily unavailable for some reason. Can be set to null to disable caching (not recommended).";
+              };
+            }
+          ];
+          default = {
+            Type = "static_file";
           };
         };
 
@@ -111,7 +168,7 @@ in
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         DynamicUser = true;
-        ExecStart = "${cfg.package}/bin/matrix-corporal -c ${matrix-corporal-config}";
+        ExecStart = "${cfg.package}/bin/devture-matrix-corporal -config ${matrix-corporal-config}";
       };
     };
   };

--- a/nixos/modules/services/misc/matrix-corporal.nix
+++ b/nixos/modules/services/misc/matrix-corporal.nix
@@ -96,7 +96,7 @@ in
             type = lib.types.str;
             default = "static_file";
           };
-        }
+        };
 
         options.Misc.Debug = lib.mkOption {
           type = lib.types.bool;
@@ -106,7 +106,6 @@ in
       };
     };
   };
-
   config = lib.mkIf cfg.enable {
     systemd.services.matrix-corporal = {
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/misc/matrix-corporal.nix
+++ b/nixos/modules/services/misc/matrix-corporal.nix
@@ -16,7 +16,7 @@ in
     settings = lib.mkOption {
       default = {};
       type = lib.types.submodule {
-        config._module.fallbackType = format.type;
+        freeformType = format.type;
 
         options.Matrix.HomeserverDomainName = lib.mkOption {
           type = lib.types.str;
@@ -80,7 +80,7 @@ in
       Matrix.TimeoutMilliseconds = lib.mkDefault 45000;
       Reconciliation.RetryIntervalMilliseconds = lib.mkDefault 30000;
       HttpGateway.TimeoutMilliseconds = lib.mkDefault cfg.settings.Matrix.TimeoutMilliseconds;
-      HttpApi.TimeoutMilliseconds = lib.mkDefault 10000;
+      HttpApi.TimeoutMilliseconds = lib.mkDefault 15000;
     };
 
     systemd.services.matrix-corporal = {

--- a/nixos/modules/services/misc/matrix-corporal.nix
+++ b/nixos/modules/services/misc/matrix-corporal.nix
@@ -16,35 +16,94 @@ in
     };
 
     settings = lib.mkOption {
-      type = lib.types.attrs;
-      default = {
-        Matrix = {
-          HomeserverApiEndpoint = "localhost:8008";
-          TimeoutMilliseconds = 45000;
+      default = {};
+      type = with lib.types.submodule {
+        options.Matrix.HomeserverDomainName = lib.mkOption {
+          type = lib.types.str;
+          description = ''
+            The base domain name of your Matrix homeserver.
+            This is what user identifiers contain (@user:example.com), and not necessarily the domain name where the Matrix homeserver is hosted (could actually be matrix.example.com)
+          '';
         };
-        Reconciliation = {
-          UserId = "@matrix-corporal:" + cfg.settings.matrix.HomeserverDomainName;
-          RetryIntervalMilliseconds = 30000;
+        options.Matrix.HomeserverAPIEndpoint = lib.mkOption {
+          type = lib.types.str;
+          default = "localhost:8008";
+          description = ''
+            A URI to the Matrix homeserver's API.
+            This would normally be a local address, as it's convenient to run matrix-corporal on the same machine as Matrix Synapse.
+          '';
         };
-        HttpGateway = {
-          ListenAddress = "127.0.0.1:41080";
+        options.Matrix.TimeoutMilliseconds = lib.mkOption {
+          type = lib.types.ints.positive;
+          default = 45000;
+          description = ''
+            how long (in milliseconds) HTTP requests (from matrix-corporal to Matrix Synapse) are allowed to take before being timed out.
+            Since clients often use long-polling for /sync (usually with a 30-second limit), setting this to a value of more than 30000 is recommended.
+          '';
         };
-        HttpApi = {
-          Enabled = true;
-          ListenAddress = "127.0.0.1:41081";
+
+        options.Reconciliation.UserId = lib.mkOption {
+          type = lib.types.str;
+          default = "@matrix-corporal:" + cfg.settings.Matrix.HomeserverDomainName;
+          description = ''
+            A full Matrix user id of the system (needs to have admin privileges), which will be used to perform reconciliation.
+            This user account, with its admin privileges, will be used to find what users are available on the server, what their current state is, etc.
+            This user account will also invite and kick users out of communities and rooms, so you need to make sure this user is joined to, and has the appropriate privileges, in all rooms and communities that you would like to manage.
+          '';
         };
-        PolicyProvider = {
-          Type = "static_file";
-          Path = "/etc/matrix-corporal/policy.json";
+        options.Reconciliation.RetryIntervalMilliseconds = lib.mkOption {
+          type = lib.types.ints.positive;
+          default = 30000;
+          description = ''
+            How long (in milliseconds) to wait before retrying reconciliation, in case the previous reconciliation attempt failed (due to Matrix Synapse being down, etc.).
+          '';
         };
-        Misc = {
-          Debug = true;
+        options.HttpGateway.ListenAddress = lib.mkOption {
+          type = lib.types.str;
+          default = "127.0.0.1:41080";
+          description = ''
+            The network address to listen on.
+            It's most likely a local one, as there's usually a reverse proxy (like nginx) capturing all traffic first and forwarding it here later on.
+            If you're running this inside a container, use something like 0.0.0.0:41080.
+          '';
+        };
+        options.HttpGateway.TimeoutMilliseconds = lib.mkOption {
+          type = lib.types.addCheck lib.types.int (x: x >= cfg.Matrix.TimeoutMilliseconds);
+          default = {};
+          description = ''
+            How long (in milliseconds) HTTP requests are allowed to take before being timed out.
+            Since clients often use long-polling for /sync (usually with a 30-second limit), setting this to a value of more than 30000 is recommended.
+            For this same reason, making this value larger than Matrix.TimeoutMilliseconds is required.
+          '';
+        };
+
+        options.HttpApi.Enabled = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Whether the HTTP API is enabled or not";
+        };
+        options.HttpApi.ListenAddress = lib.mkOption {
+          type = lib.types.str;
+          default = "127.0.0.1:41081";
+          description = ''
+            The network address to listen on.
+            It's most likely a local one, as there's usually a reverse proxy (like nginx) capturing all traffic first and forwarding it here later on. If you're running this inside a container, use something like 0.0.0.0:41081.
+          '';
+        };
+
+        options.PolicyProvider = {
+          Type = lib.mkOption {
+            type = lib.types.str;
+            default = "static_file";
+          };
+        }
+
+        options.Misc.Debug = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Whether to enable debug mode or not (enable for more verbose logs)";
         };
       };
-      description = ''
-        Configuration for matrix-corporal, see <link xlink:href="https://github.com/devture/matrix-corporal/blob/master/docs/configuration.md"/>
-        for supported values.
-      '';
     };
   };
 
@@ -53,7 +112,7 @@ in
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         DynamicUser = true;
-        ExecStart = "${cfg.package}/bin/matrix-corporal -c ${matrix-corporal-config}}";
+        ExecStart = "${cfg.package}/bin/matrix-corporal -c ${matrix-corporal-config}";
       };
     };
   };

--- a/nixos/modules/services/misc/matrix-corporal.nix
+++ b/nixos/modules/services/misc/matrix-corporal.nix
@@ -39,7 +39,7 @@ in
         };
         Misc = {
           Debug = true;
-        };
+        };
       };
       description = ''
         Configuration for matrix-corporal, see <link xlink:href="https://github.com/devture/matrix-corporal/blob/master/docs/configuration.md"/>

--- a/nixos/modules/services/misc/matrix-corporal.nix
+++ b/nixos/modules/services/misc/matrix-corporal.nix
@@ -1,0 +1,33 @@
+{ lib, pkgs, config, ... }:
+let
+  cfg = config.services.matrix-corporal;
+in
+{
+  options.services.matrix-corporal = {
+    enable = lib.mkEnableOption "Enable matrix-corporal";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.matrix-corporal;
+    };
+
+    settings = lib.mkOption {
+      default = {};
+      description = ''
+        Configuration for matrix-corporal, see <link xlink:href="https://github.com/devture/matrix-corporal/blob/master/docs/configuration.md"/>
+        for supported values.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.matrix-corporal = {
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        DynamicUser="yes";
+        ExecStart = "${cfg.package}/bin/matrix-corporal -c ${pkgs.writeTextFile {name = "matrix-corporal-config.json"; text = lib.generators.toJSON {} cfg.settings;}}";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/misc/matrix-corporal.nix
+++ b/nixos/modules/services/misc/matrix-corporal.nix
@@ -79,7 +79,7 @@ in
     services.matrix-corporal.settings = {
       Matrix.TimeoutMilliseconds = lib.mkDefault 45000;
       Reconciliation.RetryIntervalMilliseconds = lib.mkDefault 30000;
-      HttpGateway.TimeoutMilliseconds = lib.mkDefault cfg.settings.Matrix.TimeoutMilliseconds;
+      HttpGateway.TimeoutMilliseconds = 60000;
       HttpApi.TimeoutMilliseconds = lib.mkDefault 15000;
     };
 

--- a/nixos/modules/services/misc/matrix-corporal.nix
+++ b/nixos/modules/services/misc/matrix-corporal.nix
@@ -18,9 +18,10 @@ in
     settings = lib.mkOption {
       default = {};
       type = lib.types.submodule {
+        config._module.fallbackType = with lib.types; attrsOf (oneOf [ str int bool ]);
+
         options.Matrix.HomeserverDomainName = lib.mkOption {
           type = lib.types.str;
-          default = "localhost";
           description = ''
             The base domain name of your Matrix homeserver.
             This is what user identifiers contain (@user:example.com), and not necessarily the domain name where the Matrix homeserver is hosted (could actually be matrix.example.com)
@@ -34,15 +35,6 @@ in
             This would normally be a local address, as it's convenient to run matrix-corporal on the same machine as Matrix Synapse.
           '';
         };
-        options.Matrix.TimeoutMilliseconds = lib.mkOption {
-          type = lib.types.ints.unsigned;
-          default = 45000;
-          description = ''
-            how long (in milliseconds) HTTP requests (from matrix-corporal to Matrix Synapse) are allowed to take before being timed out.
-            Since clients often use long-polling for /sync (usually with a 30-second limit), setting this to a value of more than 30000 is recommended.
-          '';
-        };
-
         options.Reconciliation.UserId = lib.mkOption {
           type = lib.types.str;
           default = "@matrix-corporal:" + cfg.settings.Matrix.HomeserverDomainName;
@@ -50,13 +42,6 @@ in
             A full Matrix user id of the system (needs to have admin privileges), which will be used to perform reconciliation.
             This user account, with its admin privileges, will be used to find what users are available on the server, what their current state is, etc.
             This user account will also invite and kick users out of communities and rooms, so you need to make sure this user is joined to, and has the appropriate privileges, in all rooms and communities that you would like to manage.
-          '';
-        };
-        options.Reconciliation.RetryIntervalMilliseconds = lib.mkOption {
-          type = lib.types.ints.unsigned;
-          default = 30000;
-          description = ''
-            How long (in milliseconds) to wait before retrying reconciliation, in case the previous reconciliation attempt failed (due to Matrix Synapse being down, etc.).
           '';
         };
         options.HttpGateway.ListenAddress = lib.mkOption {
@@ -68,25 +53,10 @@ in
             If you're running this inside a container, use something like 0.0.0.0:41080.
           '';
         };
-        options.HttpGateway.TimeoutMilliseconds = lib.mkOption {
-          type = lib.types.addCheck lib.types.int (x: x >= cfg.settings.Matrix.TimeoutMilliseconds);
-          default = cfg.settings.Matrix.TimeoutMilliseconds;
-          description = ''
-            How long (in milliseconds) HTTP requests are allowed to take before being timed out.
-            Since clients often use long-polling for /sync (usually with a 30-second limit), setting this to a value of more than 30000 is recommended.
-            For this same reason, making this value larger than Matrix.TimeoutMilliseconds is required.
-          '';
-        };
-
         options.HttpApi.Enabled = lib.mkOption {
           type = lib.types.bool;
           default = true;
           description = "Whether the HTTP API is enabled or not";
-        };
-        options.HttpApi.TimeoutMilliseconds = lib.mkOption {
-          type = lib.types.ints.unsigned;
-          default = 10000; # Seems good?
-          description = "How long (in milliseconds) HTTP requests are allowed to take before being timed out.";
         };
         options.HttpApi.ListenAddress = lib.mkOption {
           type = lib.types.str;
@@ -96,49 +66,25 @@ in
             It's most likely a local one, as there's usually a reverse proxy (like nginx) capturing all traffic first and forwarding it here later on. If you're running this inside a container, use something like 0.0.0.0:41081.
           '';
         };
-
-        options.PolicyProvider = {
-          Type = lib.mkOption {
-            type = lib.types.strMatching "static_file|http|last_seen_store_policy";
-            default = "static_file";
+        options.PolicyProvider = lib.mkOption {
+          type = lib.types.attrs;
+          default = {
+            Type = "static_file";
+            Path = "/etc/matrix-corporal/policy.json";
           };
-          Path = lib.mkOption {
-            type = lib.types.path;
-            default = if cfg.settings.PolicyProvider.Type == "static_file" then "/etc/matrix-corporal/policy.json" else {};
-            description = "Path to policy file";
-          };
-          Uri = lib.mkOption {
-            type = lib.types.nullOr lib.types.str;
-            default = if cfg.settings.PolicyProvider.Type == "http" then "https://localhost/policy.json" else null;
-            description = "The URL from which matrix-corporal will fetch the policy (a GET request is made).";
-          };
-          CachePath = lib.mkOption {
-            type = lib.types.nullOr lib.types.path;
-            default = "/var/matrix-corporal/last-policy.json";
-            description = "A path to a local file, where matrix-corporal will store the last-fetched policy. It's important to store it locally to prevent downtime in case the policy provider is temporarily unavailable for some reason. Can be set to null to disable caching (not recommended).";
-          };
-          ReloadIntervalSeconds = lib.mkOption {
-            type = lib.types.nullOr lib.types.ints.positive;
-            default = 1800;
-            description = "An interval duration at which the policy provider will re-fetch the policy from the given URL. Can be set to 0 or null to disable reloading.";
-          };
-          TimeoutMilliseconds = lib.mkOption {
-            type = lib.types.nullOr lib.types.ints.positive;
-            default = 30000;
-            description = "how long (in milliseconds) HTTP requests (from matrix-corporal to the policy-serving Uri) are allowed to take before being timed out. Can be set to null to allow for unlimited waits (not recommended).";
-          };
-
-        };
-
-        options.Misc.Debug = lib.mkOption {
-          type = lib.types.bool;
-          default = true;
-          description = "Whether to enable debug mode or not (enable for more verbose logs)";
+          description = "The policy provider, see <link xlink:href="https://github.com/devture/matrix-corporal/blob/e8250a98292ae250726ce5edd75bc6ece4eb5115/docs/policy-providers.md"/> for supported values";
         };
       };
     };
   };
   config = lib.mkIf cfg.enable {
+    services.matrix-corporal.settings = {
+      Matrix.TimeoutMilliseconds = lib.mkDefault 45000;
+      Reconciliation.RetryIntervalMilliseconds = lib.mkDefault 30000;
+      HttpGateway.TimeoutMilliseconds = lib.mkDefault cfg.settings.Matrix.TimeoutMilliseconds;
+      HttpApi.TimeoutMilliseconds = lib.mkDefault 10000;
+    };
+
     systemd.services.matrix-corporal = {
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {

--- a/nixos/modules/services/misc/matrix-corporal.nix
+++ b/nixos/modules/services/misc/matrix-corporal.nix
@@ -17,7 +17,30 @@ in
 
     settings = lib.mkOption {
       type = lib.types.attrs;
-      default = {};
+      default = {
+        Matrix = {
+          HomeserverApiEndpoint = "localhost:8008";
+          TimeoutMilliseconds = 45000;
+        };
+        Reconciliation = {
+          UserId = "@matrix-corporal:" + cfg.settings.matrix.HomeserverDomainName;
+          RetryIntervalMilliseconds = 30000;
+        };
+        HttpGateway = {
+          ListenAddress = "127.0.0.1:41080";
+        };
+        HttpApi = {
+          Enabled = true;
+          ListenAddress = "127.0.0.1:41081";
+        };
+        PolicyProvider = {
+          Type = "static_file";
+          Path = "/etc/matrix-corporal/policy.json";
+        };
+        Misc = {
+          Debug = true;
+        };
+      };
       description = ''
         Configuration for matrix-corporal, see <link xlink:href="https://github.com/devture/matrix-corporal/blob/master/docs/configuration.md"/>
         for supported values.

--- a/pkgs/servers/matrix-corporal/default.nix
+++ b/pkgs/servers/matrix-corporal/default.nix
@@ -1,0 +1,22 @@
+{lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule {
+  pname = "matrix-corporal";
+  version = "1.9.0";
+
+  src = fetchFromGitHub {
+    owner = "devture";
+    repo = "matrix-corporal";
+    rev = "1.9.0";
+    sha256 = "0zwfvlhp9j3skz6ryi01d7ps3wm8kb3njcbjf0bl1gv2h0cjhlji";
+  };
+
+  vendorSha256 = "1fghbl0b418ld5szjafbiz3vp773skc0l6kaif5c2vsh2ivgr6hl";
+
+  meta = with lib; {
+    homepage = "https://github.com/devture/matrix-corporal";
+    description = "Reconciliator and gateway for a managed Matrix server";
+    maintainers = [ teams.matrix.members ];
+    license = licenses.agpl3;
+  };
+}

--- a/pkgs/servers/matrix-corporal/default.nix
+++ b/pkgs/servers/matrix-corporal/default.nix
@@ -16,7 +16,7 @@ buildGoModule {
   meta = with lib; {
     homepage = "https://github.com/devture/matrix-corporal";
     description = "Reconciliator and gateway for a managed Matrix server";
-    maintainers = [ dandellion ];
+    maintainers = with maintainers; [ dandellion ];
     license = licenses.agpl3;
   };
 }

--- a/pkgs/servers/matrix-corporal/default.nix
+++ b/pkgs/servers/matrix-corporal/default.nix
@@ -16,7 +16,7 @@ buildGoModule {
   meta = with lib; {
     homepage = "https://github.com/devture/matrix-corporal";
     description = "Reconciliator and gateway for a managed Matrix server";
-    maintainers = [ teams.matrix.members ];
+    maintainers = [ dandellion ];
     license = licenses.agpl3;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4848,6 +4848,8 @@ in
 
   matrix-appservice-discord = callPackage ../servers/matrix-appservice-discord { };
 
+  matrix-corporal = callPackage ../servers/matrix-corporal { };
+
   mautrix-telegram = recurseIntoAttrs (callPackage ../servers/mautrix-telegram { });
 
   mautrix-whatsapp = callPackage ../servers/mautrix-whatsapp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
matrix-corporal is a proxy and reconciliator for matrix-synapse letting you allow/deny API endpoints, and automatically join users to rooms/communities according to a configuration policy

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
