### PR TITLE
deno: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -18,16 +18,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "deno";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "denoland";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0wxwsp8g5i8jsjn3fsry81xj4lyp1ik6ngcypwvb5v8x30jci6ng";
+    sha256 = "0dxagp4gyn7057zcp78bhhr9qfbblvsynds2b0f4b3di8kg65m7f";
     fetchSubmodules = true;
   };
-  cargoSha256 = "0sss85v9k3f5narnmdv428sblqzkyb47xvvavz1m6x03qw11h8zh";
+  cargoSha256 = "1fgi6hbziky7szw18wma87bx8i74ax9dc90yyldvjikn4hjc8ipc";
 
   # Install completions post-install
   nativeBuildInputs = [ installShellFiles ];

--- a/pkgs/development/web/deno/deps.nix
+++ b/pkgs/development/web/deno/deps.nix
@@ -2,11 +2,11 @@
 {}:
 rec {
   rustyV8Lib = {
-    version = "0.6.0";
+    version = "0.7.0";
     sha256s = {
-      x86_64-linux = "1mpgddlcsfc5jpkqpwpbld9d2pr3dflkbd1w9ryai0aymv8r2rmb";
-      aarch64-linux = "0qqr0i6z39fb298azp2rm0ns0bw3il3xj5zy58cn96h624rxkn67";
-      x86_64-darwin = "0pj7127cvz01kq6vs91sdxkwkbjx7j3cv7lwvyilifbl01j3vwip";
+      x86_64-linux = "0ggbbppb65pdj92qbqw8sy8w84ir42fnhyk599pihyx1mqqih606";
+      aarch64-linux = "1n30xi4fac77cvd5qfr3mkgvipp9pq0mw24jbxbhlcl0n8mvpxjv";
+      x86_64-darwin = "1kdcapzj9my3ippqlkgdgp2dnj4klyl1wz1jwwps3b00l593nmfh";
     };
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Bump `deno` version to `1.2.1`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
