### PR TITLE
SL1ToPhoton: init at 0.1.3

### DIFF
--- a/pkgs/applications/misc/sl1-to-photon/default.nix
+++ b/pkgs/applications/misc/sl1-to-photon/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, pillow
+, pyside2
+, numpy
+, pyphotonfile
+, shiboken2
+, which
+}:
+let
+  version = "0.1.3";
+in
+ buildPythonApplication rec {
+  pname = "sl1-to-photon";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "fookatchu";
+    repo = "SL1toPhoton";
+    rev = "v${version}";
+    sha256 = "1hmb74rcky3nax4lxn7pw6lcd5a66fdbwrm11c84zb31xb51bakw";
+  };
+
+  propagatedBuildInputs = [ pyphotonfile pillow numpy pyside2 shiboken2 ];
+
+  format = "other";
+
+  installPhase = ''
+    install -D -m 0755 SL1_to_Photon.py $out/bin/${pname}
+    sed -i '1i#!/usr/bin/env python' $out/bin/${pname}
+  '';
+
+  meta = with lib; {
+    maintainers = [ maintainers.cab404 ];
+    license = licenses.gpl3Plus;
+    description = "Tool for converting Slic3r PE's SL1 files to Photon files for the Anycubic Photon 3D-Printer";
+    homepage = "https://github.com/fookatchu/SL1toPhoton";
+  };
+
+}

--- a/pkgs/development/python-modules/pyphotonfile/default.nix
+++ b/pkgs/development/python-modules/pyphotonfile/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pillow
+, numpy
+}:
+let
+  version = "0.2.1";
+in
+buildPythonPackage {
+  pname = "pyphotonfile";
+  inherit version;
+  propagatedBuildInputs = [ pillow numpy ];
+  
+  src = fetchFromGitHub {
+    owner = "fookatchu";
+    repo = "pyphotonfile";
+    rev = "v${version}";
+    sha256 = "1hh1fcn7q3kyk2413pjs18xnxvzrchrisbpj2cd59jrdp0qzgv2s";
+  };
+
+  meta = with lib; {
+    maintainers = [ maintainers.cab404 ];
+    license = licenses.gpl3Plus;
+    description = "Library for reading and writing files for the Anycubic Photon 3D-Printer";
+    homepage = "https://github.com/fookatchu/pyphotonfile";
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3060,6 +3060,8 @@ in
 
   doom-bcc = callPackage ../games/zdoom/bcc-git.nix { };
 
+  sl1-to-photon = python3Packages.callPackage ../applications/misc/sl1-to-photon { };
+
   slade = callPackage ../applications/misc/slade {
     wxGTK = wxGTK30;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1106,6 +1106,8 @@ in {
 
   pyperf = callPackage ../development/python-modules/pyperf { };
 
+  pyphotonfile = callPackage ../development/python-modules/pyphotonfile { };
+
   pefile = callPackage ../development/python-modules/pefile { };
 
   perfplot = callPackage ../development/python-modules/perfplot { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I needed this to convert files from Prusa SL1 to Photon format. This is needed for PrusaSlicer export to work with any printers using cbddip format.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
