### PR TITLE
farge: init at 1.0.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4659,6 +4659,12 @@
       fingerprint = "74F5 E5CC 19D3 B5CB 608F  6124 68FF 81E6 A785 0F49";
     }];
   };
+  loafofpiecrust = {
+    email = "taylorsnead@gmail.com";
+    github = "loafofpiecrust";
+    githubId = 3489148;
+    name = "Taylor Snead";
+  };
   lourkeur = {
     name = "Louis Bettens";
     email = "louis@bettens.info";

--- a/pkgs/applications/graphics/farge/default.nix
+++ b/pkgs/applications/graphics/farge/default.nix
@@ -1,0 +1,34 @@
+{ lib, makeWrapper, fetchFromGitHub, bash, imagemagick, slurp, grim
+, wl-clipboard, feh, stdenv, waylandSupport ? true, imageSupport ? true }:
+
+stdenv.mkDerivation rec {
+  pname = "farge";
+  version = "1.0.8";
+  src = fetchFromGitHub {
+    owner = "sdushantha";
+    repo = "farge";
+    rev = "f8fa80f7bebc174ab38efb02292b4d0dec03a7dc";
+    sha256 = "08z7dgc3wygl6s922s4gsi2fkrfmghzy82ivnivxr293b9mll7ar";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ bash imagemagick ]
+    ++ lib.optionals waylandSupport [ slurp grim wl-clipboard ]
+    ++ lib.optionals imageSupport [ feh ];
+
+  makeFlags = [ "DEST=$(out)/bin" ];
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+  postInstall = ''
+    wrapProgram "$out/bin/farge" --prefix PATH : "${lib.makeBinPath buildInputs}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Click on a pixel on your screen and show its color value";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    homepage = "https://github.com/sdushantha/farge";
+    maintainers = [ maintainers.loafofpiecrust ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20018,6 +20018,8 @@ in
 
   termshark = callPackage ../tools/networking/termshark { };
 
+  farge = callPackage ../applications/graphics/farge { };
+
   fbida = callPackage ../applications/graphics/fbida { };
 
   fdupes = callPackage ../tools/misc/fdupes { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I like using [farge](https://github.com/sdushantha/farge) for picking colors, since there doesn't seem to be a solid equivalent on Wayland.
I'm also excited to make my first contribution to `nixpkgs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux) (only tested in Wayland)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) (N/A)
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
