### PR TITLE
haskellPackages.termonad: Fix dependency on gi-vte

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1458,6 +1458,11 @@ self: super: {
       gi-gdkpixbuf = self.gi-gdkpixbuf_2_0_24;
       gi-gio = self.gi-gio_2_0_27;
       gi-glib = self.gi-glib_2_0_24;
+      gi-harfbuzz = overrideCabal super.gi-harfbuzz (oldAttrs: {
+        postUnpack = (oldAttrs.postUnpack or "") + ''
+          substituteInPlace gi-harfbuzz-*/gi-harfbuzz.cabal --replace 'pkgconfig-depends: harfbuzz >= 1' 'pkgconfig-depends: harfbuzz >= 1, harfbuzz-gobject'
+        '';
+      });
       gi-gobject =
         let
           patch = pkgs.fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1461,8 +1461,28 @@ self: super: {
       gi-gobject = self.gi-gobject_2_0_23;
       gi-gtk = self.gi-gtk_3_0_35;
       gi-pango = self.gi-pango_1_0_23;
-      haskell-gi = self.haskell-gi_0_24_2;
-      haskell-gi-base = addBuildDepend self.haskell-gi-base_0_24_1 pkgs.gobject-introspection;
+      haskell-gi-base =
+        let
+          patch = pkgs.fetchpatch {
+            url= "https://github.com/haskell-gi/haskell-gi/commit/1eccb3083bdc44f46f3c912718f4dcbd9bed3eb7.diff";
+            sha256 = "0k01i37jgkq89r78c3sl0kbbcis510fh28sd300llhc290zh520b";
+            excludes = [ "Data/GI/CodeGen/CodeGen.hs" "Data/GI/GIR/Object.hs" ];
+            stripLen = 2;
+            extraPrefix = "";
+          };
+        in
+        appendPatch (addBuildDepend super.haskell-gi-base_0_24_1 pkgs.gobject-introspection) patch;
+      haskell-gi =
+        let
+          patch = pkgs.fetchpatch {
+            url= "https://github.com/haskell-gi/haskell-gi/commit/1eccb3083bdc44f46f3c912718f4dcbd9bed3eb7.diff";
+            sha256 = "1mx5mn1k1hjkab65y7i48da0i17828bihb0mpz9a3yxbxwhlk95z";
+            excludes = [ "base/c/hsgclosure.c" "base/Data/GI/Base/BasicTypes.hsc" ];
+            stripLen = 1;
+            extraPrefix = "";
+          };
+        in
+        appendPatch super.haskell-gi_0_24_2 patch;
   });
 
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1458,7 +1458,16 @@ self: super: {
       gi-gdkpixbuf = self.gi-gdkpixbuf_2_0_24;
       gi-gio = self.gi-gio_2_0_27;
       gi-glib = self.gi-glib_2_0_24;
-      gi-gobject = self.gi-gobject_2_0_23;
+      gi-gobject =
+        let
+          patch = pkgs.fetchpatch {
+            url= "https://github.com/haskell-gi/haskell-gi/commit/a470a2662d1e854f29005b3ead983fec788b9840.diff";
+            sha256 = "09qvrn4qg8d63gix0cjyc6y1cr8vaps0wn1ic6wsddk7nvcwgr1w";
+            stripLen = 3;
+            extraPrefix = "";
+          };
+        in
+        appendPatch super.gi-gobject_2_0_23 patch;
       gi-gtk = self.gi-gtk_3_0_35;
       gi-pango = self.gi-pango_1_0_23;
       haskell-gi-base =

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1451,4 +1451,18 @@ self: super: {
     };
   };
 
+  termonad = super.termonad.overrideScope (self: super: {
+      gi-atk = self.gi-atk_2_0_22;
+      gi-cairo = self.gi-cairo_1_0_24;
+      gi-gdk = self.gi-gdk_3_0_23;
+      gi-gdkpixbuf = self.gi-gdkpixbuf_2_0_24;
+      gi-gio = self.gi-gio_2_0_27;
+      gi-glib = self.gi-glib_2_0_24;
+      gi-gobject = self.gi-gobject_2_0_23;
+      gi-gtk = self.gi-gtk_3_0_35;
+      gi-pango = self.gi-pango_1_0_23;
+      haskell-gi = self.haskell-gi_0_24_2;
+      haskell-gi-base = addBuildDepend self.haskell-gi-base_0_24_1 pkgs.gobject-introspection;
+  });
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2560,6 +2560,8 @@ extra-packages:
   - generic-deriving == 1.10.5.*        # new versions don't compile with GHC 7.10.x
   - ghc-check == 0.3.0.1                # only version compatible with ghcide 0.2.0
   - ghc-tcplugins-extra ==0.3.2         # required for polysemy-plugin 0.2.5.0
+  - gi-gdk ==3.0.23                     # required for gi-vte-2.91.27
+  - gi-gtk ==3.0.35                     # required for gi-vte-2.91.27
   - gloss < 1.9.3                       # new versions don't compile with GHC 7.8.x
   - haddock == 2.22.*                   # required on GHC 8.0.x
   - haddock == 2.23.*                   # required on GHC < 8.10.x
@@ -10208,7 +10210,6 @@ broken-packages:
   - termbox-bindings
   - terminal-text
   - termination-combinators
-  - termonad
   - termplot
   - terntup
   - terrahs

--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, pkgconfig, glib, freetype, cairo, libintl
+, gobject-introspection
 , icu, graphite2, harfbuzz # The icu variant uses and propagates the non-icu one.
 , ApplicationServices, CoreText
 , withCoreText ? false
@@ -36,10 +37,16 @@ stdenv.mkDerivation {
     # not auto-detected by default
     "--with-graphite2=${if withGraphite2 then "yes" else "no"}"
     "--with-icu=${if withIcu then "yes" else "no"}"
+    "--with-gobject=yes"
+    "--enable-introspection=yes"
   ]
     ++ stdenv.lib.optional withCoreText "--with-coretext=yes";
 
-  nativeBuildInputs = [ pkgconfig libintl ];
+  nativeBuildInputs = [
+    gobject-introspection
+    libintl
+    pkgconfig
+  ];
 
   buildInputs = [ glib freetype cairo ] # recommended by upstream
     ++ stdenv.lib.optionals withCoreText [ ApplicationServices CoreText ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Termonad broke in https://github.com/NixOS/nixpkgs/commit/4c8da32eaee9cb9f2e011cb22eaddfd013069409, because a new version of `gi-vte` was released upstream that requires bumped versions of all the `gi-*` libraries:

https://hackage.haskell.org/package/gi-vte-2.91.27

However, this PR depends on #93799, which needs to be merged into `master` first.

I also wanted to point out to @maralorn the `overrideScope` attribute. It allows you to do a "deep" override, so you don't have to recursively override stuff by hand.  I thought this might be able to be used to clean up the `neuron` overrides slightly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
