### PR TITLE
harfbuzz: enable support for gobject-introspection

### DIFF
--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, pkgconfig, glib, freetype, cairo, libintl
+, gobject-introspection
 , icu, graphite2, harfbuzz # The icu variant uses and propagates the non-icu one.
 , ApplicationServices, CoreText
 , withCoreText ? false
@@ -36,10 +37,16 @@ stdenv.mkDerivation {
     # not auto-detected by default
     "--with-graphite2=${if withGraphite2 then "yes" else "no"}"
     "--with-icu=${if withIcu then "yes" else "no"}"
+    "--with-gobject=yes"
+    "--enable-introspection=yes"
   ]
     ++ stdenv.lib.optional withCoreText "--with-coretext=yes";
 
-  nativeBuildInputs = [ pkgconfig libintl ];
+  nativeBuildInputs = [
+    gobject-introspection
+    libintl
+    pkgconfig
+  ];
 
   buildInputs = [ glib freetype cairo ] # recommended by upstream
     ++ stdenv.lib.optionals withCoreText [ ApplicationServices CoreText ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update `harfbuzz` to be able to produce gobject-introspection files.

With this PR:

```console
$ nix-build -A harfbuzz
/nix/store/v8ygn64zxbfwr2izykc5jhl4zzyfh7s3-harfbuzz-2.6.7
$ ls /nix/store/v8ygn64zxbfwr2izykc5jhl4zzyfh7s3-harfbuzz-2.6.7/lib/girepository-1.0/
HarfBuzz-0.0.typelib
```

This `HarfBuzz-0.0.typelib` has been newly generated.

These `*.typelib` files are used by languages that generate bindings automatically.  For instance, the Haskell package `gi-harfbuzz` uses this: https://hackage.haskell.org/package/gi-harfbuzz

If `--enable-introspection` is not enabled in `harfbuzz`, then packages like `gi-harfbuzz` are not able to be built.

This is similar to how packages like `vte` automatically produce bindings.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
