### PR TITLE
mopidy-youtube: 3.0 -> 3.1

### DIFF
--- a/pkgs/applications/audio/mopidy/youtube.nix
+++ b/pkgs/applications/audio/mopidy/youtube.nix
@@ -2,12 +2,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "mopidy-youtube";
-  version = "3.0";
+  version = "3.1";
 
   src = python3Packages.fetchPypi {
     inherit version;
     pname = "Mopidy-YouTube";
-    sha256 = "0x1q9rfnjx65n6hi8s5rw5ff4xv55h63zy52fwm8aksdnzppr7gd";
+    sha256 = "1bn3nxianbal9f81z9wf2cxi893hndvrz2zdqvh1zpxrhs0cr038";
   };
 
   patchPhase = "sed s/bs4/beautifulsoup4/ -i setup.cfg";


### PR DESCRIPTION
###### Motivation for this change

3.1 was released upstream which fixes* https://github.com/natumbri/mopidy-youtube/issues/150.

\* Added asterisk because GitHub otherwise marks this pull request as fixing that bug due to the magic _fixes_ word.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested by building

```nix
buildEnv {
  name = "mopidy-with-extensions-${mopidy.version}";
  paths = lib.closePropagation [
    pkgs.mopidy-iris
    pkgs.mopidy-local
    pkgs.mopidy-youtube
  ];
  pathsToLink = [ "/${mopidyPackages.python.sitePackages}" ];
  buildInputs = [ makeWrapper ];
  postBuild = ''
    makeWrapper ${mopidy}/bin/mopidy $out/bin/mopidy \
      --prefix PYTHONPATH : $out/${mopidyPackages.python.sitePackages}
  '';
}
```

The upstream bug affected me, and I can confirm that this update resolved it.