### PR TITLE
dockerTools.buildLayeredImage: fix /nix/store permissions (regression)

### DIFF
--- a/pkgs/build-support/docker/stream_layered_image.py
+++ b/pkgs/build-support/docker/stream_layered_image.py
@@ -74,6 +74,13 @@ def archive_paths_to(obj, paths, mtime, add_nix, filter=None):
         ti.gname = "root"
         return filter(ti)
 
+    # User for /nix and /nix/store, giving owner full permissions and
+    # read/execute to everyone else. The latter is needed to allow the
+    # executables in /nix/store to be ran by non root users.
+    def set_nix_dir_mode(ti):
+        ti.mode = 0o755
+        return ti
+
     def dir(path):
         ti = tarfile.TarInfo(path)
         ti.type = tarfile.DIRTYPE
@@ -84,8 +91,8 @@ def archive_paths_to(obj, paths, mtime, add_nix, filter=None):
         # these directories first when building layer tarballs. But
         # we don't need them on the customisation layer.
         if add_nix:
-            tar.addfile(apply_filters(dir("/nix")))
-            tar.addfile(apply_filters(dir("/nix/store")))
+            tar.addfile(apply_filters(set_nix_dir_mode(dir("/nix"))))
+            tar.addfile(apply_filters(set_nix_dir_mode(dir("/nix/store"))))
 
         for path in paths:
             path = pathlib.Path(path)


### PR DESCRIPTION
Set /nix and /nix/store permissions to 755 (as it used to be before #91084).

@purcell @utdemir @grahamc

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Needed to allow running image as non root user.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).