### PR TITLE
sublime-music: init at 0.11.0

### DIFF
--- a/pkgs/applications/audio/sublime-music/default.nix
+++ b/pkgs/applications/audio/sublime-music/default.nix
@@ -1,0 +1,60 @@
+{ lib, python3Packages, gobject-introspection, gtk3, pango, wrapGAppsHook
+
+, chromecastSupport ? false
+, serverSupport ? false
+, keyringSupport ? true
+, notifySupport ? true, libnotify
+, networkSupport ? true, networkmanager
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "sublime-music";
+  version = "0.11.0";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "1rnjc8pjfaq67mq10gy939g77azc80lxf77s9nsaxds4q5j1yrl2";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    python3Packages.setuptools
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    pango
+  ]
+   ++ lib.optional notifySupport libnotify
+   ++ lib.optional networkSupport networkmanager
+  ;
+
+  propagatedBuildInputs = with python3Packages; [
+    dataclasses-json
+    deepdiff
+    fuzzywuzzy
+    mpv
+    peewee
+    pygobject3
+    python-Levenshtein
+    python-dateutil
+    requests
+    semver
+  ]
+   ++ lib.optional chromecastSupport PyChromecast
+   ++ lib.optional keyringSupport keyring
+   ++ lib.optional serverSupport bottle
+  ;
+
+  # hook for gobject-introspection doesn't like strictDeps
+  # https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  meta = with lib; {
+    description = "GTK3 Subsonic/Airsonic client";
+    homepage = "https://sublimemusic.app/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ albakham ];
+  };
+}

--- a/pkgs/development/python-modules/dataclasses-json/default.nix
+++ b/pkgs/development/python-modules/dataclasses-json/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, stringcase
+, typing-inspect
+, marshmallow-enum
+}:
+
+buildPythonPackage rec {
+  pname = "dataclasses-json";
+  version = "0.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0nkgp4pd7j7ydrciiix4x0w56l5w6qvj2vgxpwj42h4f2wdv2f3f";
+  };
+
+  propagatedBuildInputs = [
+    stringcase
+    typing-inspect
+    marshmallow-enum
+  ];
+
+  meta = with lib; {
+    description = "Simple API for encoding and decoding dataclasses to and from JSON";
+    homepage = "https://github.com/lidatong/dataclasses-json";
+    license = licenses.mit;
+    maintainers = with maintainers; [ albakham ];
+  };
+}

--- a/pkgs/development/python-modules/typing-inspect/default.nix
+++ b/pkgs/development/python-modules/typing-inspect/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, typing-extensions
+, mypy-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "typing-inspect";
+  version = "0.6.0";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "typing_inspect";
+    sha256 = "1dzs9a1pr23dhbvmnvms2jv7l7jk26023g5ysf0zvnq8b791s6wg";
+  };
+
+  propagatedBuildInputs = [
+    typing-extensions
+    mypy-extensions
+  ];
+
+  meta = with lib; {
+    description = "Runtime inspection utilities for Python typing module";
+    homepage = "https://github.com/ilevkivskyi/typing_inspect";
+    license = licenses.mit;
+    maintainers = with maintainers; [ albakham ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22486,6 +22486,8 @@ in
     pythonBindings = true;
   });
 
+  sublime-music = callPackage ../applications/audio/sublime-music { };
+
   subunit = callPackage ../development/libraries/subunit { };
 
   surf = callPackage ../applications/networking/browsers/surf { gtk = gtk2; };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5866,6 +5866,8 @@ in {
 
   typing-extensions = callPackage ../development/python-modules/typing-extensions { };
 
+  typing-inspect = callPackage ../development/python-modules/typing-inspect { };
+
   typeguard = callPackage ../development/python-modules/typeguard { };
 
   typesentry = callPackage ../development/python-modules/typesentry { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2132,6 +2132,8 @@ in {
 
   dataclasses = callPackage ../development/python-modules/dataclasses { };
 
+  dataclasses-json = callPackage ../development/python-modules/dataclasses-json { };
+
   debian = callPackage ../development/python-modules/debian {};
 
   defusedxml = callPackage ../development/python-modules/defusedxml {};


### PR DESCRIPTION
###### Motivation for this change

Package the sublime-music application.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
