### PR TITLE
Fix Raspberry Pi 4B SD-Card Install Image

### DIFF
--- a/nixos/lib/make-ext4-fs.nix
+++ b/nixos/lib/make-ext4-fs.nix
@@ -46,7 +46,10 @@ pkgs.stdenv.mkDerivation {
       (
         GLOBIGNORE=".:.."
         shopt -u dotglob
-        cp -a --reflink=auto ./files/* -t ./rootImage/
+
+        for f in ./files/*; do
+            cp -a --reflink=auto -t ./rootImage/ "$f"
+        done
       )
 
       # Also include a manifest of the closures in a format suitable for nix-store --load-db


### PR DESCRIPTION
In 9ac1ab10c963a86457c2c9b1edf31542ff3737cd  / #82718 make-ext4-fs was refactored to use mkfs.ext4 instead of cptofs. This introduced a problem:

- If populateImageCommands would create no files (which is fine), a cp
invocation would fail due to missing source arguments.

Note that `mkfs.ext4` relies on `fakeroot` to generate sane uids/gids and this currently fails when using the `aarch64-linux` binfmt emulation on x86.

I've used the following command for testing:

```
% nix-build nixos -I nixos-config=nixos/modules/installer/cd-dvd/sd-image-raspberrypi4.nix -A config.system.build.sdImage --argstr system aarch64-linux
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
