### PR TITLE
quisk: init at 4.1.72

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9970,4 +9970,10 @@
     githubId = 19290397;
     name = "Tunc Uzlu";
   };
+  pulsation = {
+    name = "Philippe Sam-Long";
+    email = "1838397+pulsation@users.noreply.github.com";
+    github = "pulsation";
+    githubId = 1838397;
+  };
 }

--- a/pkgs/applications/radio/quisk/default.nix
+++ b/pkgs/applications/radio/quisk/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, python38Packages, fetchPypi
+, fftw, alsaLib, pulseaudio, wxPython_4_0 }:
+
+python38Packages.buildPythonApplication rec {
+  pname = "quisk";
+  version = "4.1.72";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qw00b9d0l3ysdrmd3nr5a2zlwg9ygdil7krnk2gjp5g8bb778k7";
+  };
+
+  buildInputs = [ fftw alsaLib pulseaudio ];
+
+  propagatedBuildInputs = [ wxPython_4_0 ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A SDR transceiver for radios that use the Hermes protocol";
+    longDescription = ''
+      QUISK is a Software Defined Radio (SDR) transceiver. You supply radio
+      hardware that converts signals at the antenna to complex (I/Q) data at an
+      intermediate frequency (IF). Data can come from a sound card, Ethernet or
+      USB. Quisk then filters and demodulates the data and sends the audio to
+      your speakers or headphones. For transmit, Quisk takes the microphone
+      signal, converts it to I/Q data and sends it to the hardware.
+
+      Quisk can be used with SoftRock, Hermes Lite 2, HiQSDR, Odyssey and many
+      radios that use the Hermes protocol. Quisk can connect to digital
+      programs like Fldigi and WSJT-X. Quisk can be connected to other software
+      like N1MM+ and software that uses Hamlib.
+    '';
+    license = licenses.gpl2Plus;
+    homepage = "https://james.ahlstrom.name/quisk/";
+    maintainers = with maintainers; [ pulsation ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23285,6 +23285,8 @@ in
 
   quilter = callPackage ../applications/editors/quilter { };
 
+  quisk = python38Packages.callPackage ../applications/radio/quisk { };
+
   quiterss = libsForQt514.callPackage ../applications/networking/newsreaders/quiterss {};
 
   falkon = libsForQt514.callPackage ../applications/networking/browsers/falkon { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Quisk is a SDR transceiver for radios that use the Hermes protocol.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
