### PR TITLE
Teleport SSH/PKI Cluster Module: Init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -747,6 +747,7 @@
   ./services/networking/tcpcrypt.nix
   ./services/networking/teamspeak3.nix
   ./services/networking/tedicross.nix
+  ./services/networking/teleport.nix
   ./services/networking/thelounge.nix
   ./services/networking/tinc.nix
   ./services/networking/tinydns.nix

--- a/nixos/modules/services/networking/teleport.nix
+++ b/nixos/modules/services/networking/teleport.nix
@@ -27,7 +27,7 @@ let
       pkgs.writeText "teleport.yml" cfg.configText
     else generatedTeleportYml;
 
-  cmdlineArgs = "-c ${teleportYml}";
+  cmdlineArgs = "-c ${teleportYml} --pid-file=/run/teleport.pid";
 
 in
 
@@ -65,7 +65,7 @@ in
         after    = [ "network.target" ];
         serviceConfig = {
           Type = "simple";
-          ExecStart = "${pkgs.teleport}/bin/teleport start ${cmdlineArgs}" --pid-file=/run/teleport.pid;
+          ExecStart = "${pkgs.teleport}/bin/teleport start ${cmdlineArgs}";
           ExecReload = "/run/current-system/sw/bin/kill -HUP $MAINPID";
           PIDFile = "run/teleport.pid";
           Restart = "on-failure";

--- a/nixos/modules/services/networking/teleport.nix
+++ b/nixos/modules/services/networking/teleport.nix
@@ -1,0 +1,75 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.teleport;
+
+  # Pretty-print JSON to a file
+  writePrettyJSON = name: x:
+    pkgs.runCommand name { } ''
+      echo '${builtins.toJSON x}' | ${pkgs.jq}/bin/jq . > $out
+    '';
+  # This becomes the main config file
+  # To be used in the future when I add seperate option sections for each part of teleport
+  # Rather then writing a single yaml file directly into your nix file.
+  telConfig = {
+    global = cfg.globalConfig;
+    rule_files = cfg.ruleFiles ++ [
+      (pkgs.writeText "teleport.rules" (concatStringsSep "\n" cfg.rules))
+    ];
+  };
+
+  generatedTeleportYml = writePrettyJSON "teleport.yaml" telConfig;
+
+  teleportYml =
+    if cfg.configText != null then
+      pkgs.writeText "teleport.yml" cfg.configText
+    else generatedTeleportYml;
+
+  cmdlineArgs = "-c ${teleportYml}";
+
+in
+
+{
+  options = {
+    services.teleport = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the Teleport Cluster SSH daemon.
+        '';
+      };
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/teleport/";
+        description = ''
+          Directory to store Prometheus metrics data.
+        '';
+      };
+      configText = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        description = ''
+          If non-null, this option defines the text that is written to
+          teleport.yml.
+        '';
+      };
+  };
+
+    config = mkIf cfg.enable {
+      systemd.services.teleport = {
+        wantedBy = [ "multi-user.target" ];
+        after    = [ "network.target" ];
+        serviceConfig = {
+          User = "root";
+          ExecStart = ''${pkgs.teleport}/bin/teleport start ${cmdlineArgs}'';
+          ExecStop = ''/run/current-system/sw/bin/kill -HUP $MAINPID'';
+          PIDFile = "/var/run/teleport.pid";
+          Restart  = "on-failure";
+          WorkingDirectory = "${cfg.dataDir}";
+        };
+      };
+   };
+}

--- a/nixos/modules/services/networking/teleport.nix
+++ b/nixos/modules/services/networking/teleport.nix
@@ -45,7 +45,7 @@ in
         type = types.path;
         default = "/var/lib/teleport/";
         description = ''
-          Directory to store Prometheus metrics data.
+          Directory to store Teleport Service data.
         '';
       };
       configText = mkOption {

--- a/nixos/modules/services/networking/teleport.nix
+++ b/nixos/modules/services/networking/teleport.nix
@@ -56,6 +56,7 @@ in
           teleport.yml.
         '';
       };
+    };
   };
 
     config = mkIf cfg.enable {

--- a/nixos/modules/services/networking/teleport.nix
+++ b/nixos/modules/services/networking/teleport.nix
@@ -7,9 +7,9 @@ let
 
   # Pretty-print JSON to a file
   writePrettyJSON = name: x:
-    pkgs.runCommand name { } ''
+    pkgs.runCommand name { } "
       echo '${builtins.toJSON x}' | ${pkgs.jq}/bin/jq . > $out
-    '';
+    ";
   # This becomes the main config file
   # To be used in the future when I add seperate option sections for each part of teleport
   # Rather then writing a single yaml file directly into your nix file.
@@ -34,27 +34,27 @@ in
 {
   options = {
     services.teleport = {
-      enable = mkOption {
+      enable = mkEnableOption {
         type = types.bool;
         default = false;
-        description = ''
+        description = "
           Enable the Teleport Cluster SSH daemon.
-        '';
+        ";
       };
       dataDir = mkOption {
         type = types.path;
         default = "/var/lib/teleport/";
-        description = ''
+        description = "
           Directory to store Teleport Service data.
-        '';
+        ";
       };
       configText = mkOption {
         type = types.nullOr types.lines;
         default = null;
-        description = ''
+        description = "
           If non-null, this option defines the text that is written to
           teleport.yml.
-        '';
+        ";
       };
     };
   };
@@ -64,12 +64,12 @@ in
         wantedBy = [ "multi-user.target" ];
         after    = [ "network.target" ];
         serviceConfig = {
-          User = "root";
-          ExecStart = ''${pkgs.teleport}/bin/teleport start ${cmdlineArgs}'';
-          ExecStop = ''/run/current-system/sw/bin/kill -HUP $MAINPID'';
-          PIDFile = "/var/run/teleport.pid";
+          Type = "simple";
+          ExecStart = "${pkgs.teleport}/bin/teleport start ${cmdlineArgs}" --pid-file=/run/teleport.pid;
+          ExecReload = "/run/current-system/sw/bin/kill -HUP $MAINPID";
+          PIDFile = "run/teleport.pid";
           Restart  = "on-failure";
-          WorkingDirectory = "${cfg.dataDir}";
+          WorkingDirectory = ${cfg.dataDir};
         };
       };
    };

--- a/nixos/modules/services/networking/teleport.nix
+++ b/nixos/modules/services/networking/teleport.nix
@@ -68,7 +68,7 @@ in
           ExecStart = "${pkgs.teleport}/bin/teleport start ${cmdlineArgs}" --pid-file=/run/teleport.pid;
           ExecReload = "/run/current-system/sw/bin/kill -HUP $MAINPID";
           PIDFile = "run/teleport.pid";
-          Restart  = "on-failure";
+          Restart = "on-failure";
           WorkingDirectory = ${cfg.dataDir};
         };
       };

--- a/nixos/modules/services/networking/teleport.nix
+++ b/nixos/modules/services/networking/teleport.nix
@@ -7,9 +7,8 @@ let
 
   # Pretty-print JSON to a file
   writePrettyJSON = name: x:
-    pkgs.runCommand name { } "
-      echo '${builtins.toJSON x}' | ${pkgs.jq}/bin/jq . > $out
-    ";
+    pkgs.runCommand name { }
+    "\n      echo '${builtins.toJSON x}' | ${pkgs.jq}/bin/jq . > $out\n    ";
   # This becomes the main config file
   telConfig = {
     teleport = {
@@ -24,158 +23,177 @@ let
 
   generatedTeleportYml = writePrettyJSON "teleport.yaml" telConfig;
 
-  teleportYml =
-    if cfg.configText != null then
-      pkgs.writeText "teleport.yml" cfg.configText
-    else generatedTeleportYml;
+  teleportYml = if cfg.configText != null then
+    pkgs.writeText "teleport.yml" cfg.configText
+  else
+    generatedTeleportYml;
 
   cmdlineArgs = "-c ${teleportYml} --pid-file=/run/teleport.pid";
 
-  telTypes.auth_service = types.submodule {
-    options = {
-      enabled = mkEnableOption {
+  telTypes.auth_service = {
+    enabled = mkOption {
+      type = types.str;
+      default = "off";
+    };
+    cluster_name = mkOption {
+      type = types.str;
+      default = "";
+    };
+    authentication = {
+      type = mkOption {
+        type = types.str;
+        default = "local";
+      };
+      second_factor = mkOption {
+        type = types.str;
+        default = "otp";
+      };
+    };
+    listen_addr = mkOption {
+      type = types.str;
+      default = "";
+    };
+    public_addr = mkOption {
+      type = types.str;
+      default = "";
+    };
+    tokens = mkOption {
+      type = types.listOf types.str;
+      default = [ "" ];
+    };
+    session_recording = mkOption {
+      type = types.str;
+      default = "node";
+    };
+    client_idle_timeout = mkOption {
+      type = types.str;
+      default = "1hr";
+    };
+    disconnect_expired_cert = mkOption {
+      type = types.str;
+      default = "yes";
+    };
+    keep_alive_interval = mkOption {
+      type = types.int;
+      default = 15;
+    };
+    keep_alive_count_max = mkOption {
+      type = types.int;
+      default = 3;
+    };
+  };
+  telTypes.ssh_service = {
+    enabled = mkOption {
+      type = types.str;
+      default = "on";
+    };
+    listen_addr = mkOption {
+      type = types.str;
+      default = "0.0.0.0:3022";
+    };
+    public_addr = mkOption {
+      type = types.str;
+      default = "";
+    };
+    permit_user_env = mkOption {
+      type = types.bool;
+      default = false;
+    };
+    pam = {
+      enabled = mkOption {
         type = types.bool;
         default = false;
-        description = "
-          Enable the Teleport Cluster SSH daemon.
-        ";
       };
-      cluster_name = mkOption {
+      service_name = mkOption {
         type = types.str;
-      };
-      listen_addr = mkOption {
-        type = types.str;
-      };
-      public_addr = mkOption {
-        type = types.str;
-      };
-      tokens = mkOption {
-        type = types.listOf types.str;
+        default = "sshd";
       };
     };
   };
-  telTypes.ssh_service = types.submodule {
-    options = {
-      enabled = mkEnableOption {
-        type = types.bool;
-        default = false;
-        description = "
-          Enable the Teleport Cluster SSH daemon.
-        ";
-      };
+  telTypes.proxy_service = {
+    enabled = mkOption {
+      type = types.str;
+      default = "off";
+    };
+    listen_addr = mkOption {
+      type = types.str;
+      default = "";
+    };
+    web_listen_addr = mkOption {
+      type = types.str;
+      default = "";
+    };
+    tunnel_listen_addr = mkOption {
+      type = types.str;
+      default = "";
+    };
+    https_key_file = mkOption {
+      type = types.str;
+      default = "";
+    };
+    https_cert_file = mkOption {
+      type = types.str;
+      default = "";
     };
   };
-  telTypes.proxy_service = types.submodule {
-    options = {
-      enabled = mkEnableOption {
-        type = types.bool;
-        default = false;
-        description = "
-          Enable the Teleport Cluster SSH daemon.
-        ";
-      };
-      listen_addr = mkOption {
-        type = types.str;
-      };
-      web_listen_addr = mkOption {
-        type = types.str;
-      };
-      tunnel_listen_addr = mkOption {
-        type = types.str;
-      };
-      https_key_file = mkOption {
-        type = types.str;
-      };
-      https_cert_file = mkOption {
-        type = types.str;
-      };
-    };
-  };
-
-in
-
-{
+  
+in {
   options = {
     services.teleport = {
-      enable = mkEnableOption {
-        type = types.bool;
-        default = false;
-        description = "
-          Enable the Teleport Cluster SSH daemon.
-        ";
-      };
+      enable = mkEnableOption "Teleport Cluster";
       dataDir = mkOption {
         type = types.path;
-        default = "/var/lib/teleport/";
-        description = "
-          Directory to store Teleport Service data.
-        ";
+        default = "/var/lib/teleport";
+        description = "Directory to store Teleport Service data";
       };
       configText = mkOption {
         type = types.nullOr types.lines;
         default = null;
-        description = "
-          If non-null, this option defines the text that is written to
-          teleport.yml.
-        ";
+        description = "If non-null, this option defines the text that is written to teleport.yml";
       };
       nodename = mkOption {
         type = types.str;
         default = "";
-        description = ''
-          The name of your teleport node.
-          This is what you `tsh ssh` to.
-        '';
       };
       auth_token = mkOption {
         type = types.str;
-        default = types.null;
-        description = ''
-          The auth token your teleport node authenticates with to your teleport auth nodes.
-        '';
+        default = "";
       };
       auth_servers = mkOption {
         type = types.listOf types.str;
-        description = ''
-          The set of Auth servers your Teleport node authenticates against.
-        '';
+        default = [ "" ];
+        description = "";
       };
-      auth_service = mkOption {
-        type = telTypes.auth_service;
-        default = {};
-        description = ''
-          Enable the Teleport SSH Auth service.
-        '';
+      advertise_ip = mkOption {
+        type = types.str;
+        default = "";
       };
-      ssh_service = mkOption {
-        type = telTypes.ssh_service;
-        default = {};
-        description = ''
-          Enable the Teleport SSH service.
-        '';
+      connection_limits = {
+        max_connection = mkOption {
+          type = types.int;
+          default = 1000;
+        };
+        max_users = mkOption {
+          type = types.int;
+          default = 250;
+        };
       };
-      proxy_service = mkOption {
-        type = telTypes.proxy_service;
-        default = {};
-        description = ''
-          Enable the Teleport SSH Proxy service.
-        '';
+      inherit (telTypes) ssh_service auth_service proxy_service;
+    };
+  };
+  
+  config = mkIf cfg.enable {
+    systemd.services.teleport = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.teleport}/bin/teleport start ${cmdlineArgs}";
+        ExecReload = "/run/current-system/sw/bin/kill -HUP $MAINPID";
+        PIDFile = "teleport.pid";
+        Restart = "on-failure";
+        WorkingDirectory = cfg.dataDir;
       };
     };
   };
-
-    config = mkIf cfg.enable {
-      systemd.services.teleport = {
-        wantedBy = [ "multi-user.target" ];
-        after    = [ "network.target" ];
-        serviceConfig = {
-          Type = "simple";
-          ExecStart = "${pkgs.teleport}/bin/teleport start ${cmdlineArgs}";
-          ExecReload = "/run/current-system/sw/bin/kill -HUP $MAINPID";
-          PIDFile = "run/teleport.pid";
-          Restart = "on-failure";
-          WorkingDirectory = cfg.dataDir;
-        };
-      };
-   };
 }

--- a/nixos/modules/services/networking/teleport.nix
+++ b/nixos/modules/services/networking/teleport.nix
@@ -13,6 +13,7 @@ let
   telConfig = {
     teleport = {
       nodename = cfg.nodename;
+      data_dir = cfg.dataDir;
       auth_token = cfg.auth_token;
       auth_servers = cfg.auth_servers;
       auth_service = cfg.auth_service;
@@ -45,53 +46,53 @@ let
       type = mkOption {
         type = types.str;
         default = "local";
-        description = "Set the authentication type for the Teleport Daemon.";
+        description = "Set the authentication type for the Teleport Auth Service.";
       };
       second_factor = mkOption {
         type = types.str;
         default = "otp";
-        description = "Set the authentication second factor type for the Teleport Daemon.";
+        description = "Set the authentication second factor type for the Teleport Auth Service.";
       };
     };
     listen_addr = mkOption {
       type = types.str;
       default = "0.0.0.0:3025";
-      description = "Set the address to listen on for the Teleport Daemon Auth Service.";
+      description = "Set the address to listen on for the Teleport Auth Service.";
     };
     public_addr = mkOption {
       type = types.str;
       default = "";
-      description = "Set the public address/dns entry to listen on for the Teleport Daemon Auth Service.";
+      description = "Set the public address/dns entry to listen on for the Teleport Auth Service.";
     };
     tokens = mkOption {
       type = types.listOf types.str;
       default = [ "" ];
-      description = "Set the tokens to authenticate nodes with for the Teleport Daemon.";
+      description = "Set the tokens to authenticate nodes with for the Teleport cluster.";
     };
     session_recording = mkOption {
       type = types.str;
       default = "node";
-      description = "Configure whether to enable session recording and for what node type for the Teleport Daemon.";
+      description = "Configure whether to enable session recording and for what node type for the Teleport cluster.";
     };
     client_idle_timeout = mkOption {
       type = types.str;
       default = "1hr";
-      description = "Set the client idle timeout before certs need to be reauthenticated for the Teleport Daemon.";
+      description = "Set the client idle timeout before certs need to be reauthenticated for the Teleport cluster.";
     };
     disconnect_expired_cert = mkOption {
       type = types.str;
       default = "yes";
-      description = "Set whether to disconnect a client when their cert expires for the Teleport Daemon.";
+      description = "Set whether to disconnect a client when their cert expires for the Teleport cluster.";
     };
     keep_alive_interval = mkOption {
       type = types.int;
       default = 15;
-      description = "Set the keep alive internal for the Teleport Daemon.";
+      description = "Set the keep alive internal for the Teleport cluster.";
     };
     keep_alive_count_max = mkOption {
       type = types.int;
       default = 3;
-      description = "Set the keep alive interval max count for the Teleport Daemon.";
+      description = "Set the keep alive interval max count for the Teleport cluster.";
     };
   };
   telTypes.ssh_service = {

--- a/nixos/modules/services/networking/teleport.nix
+++ b/nixos/modules/services/networking/teleport.nix
@@ -34,79 +34,97 @@ let
     enabled = mkOption {
       type = types.str;
       default = "off";
+      description = "Whether to enable the Teleport Daemon Auth Service";
     };
     cluster_name = mkOption {
       type = types.str;
       default = "";
+      description = "Set the name of the cluster for the Teleport Daemon.";
     };
     authentication = {
       type = mkOption {
         type = types.str;
         default = "local";
+        description = "Set the authentication type for the Teleport Daemon.";
       };
       second_factor = mkOption {
         type = types.str;
         default = "otp";
+        description = "Set the authentication second factor type for the Teleport Daemon.";
       };
     };
     listen_addr = mkOption {
       type = types.str;
-      default = "";
+      default = "0.0.0.0:3025";
+      description = "Set the address to listen on for the Teleport Daemon Auth Service.";
     };
     public_addr = mkOption {
       type = types.str;
       default = "";
+      description = "Set the public address/dns entry to listen on for the Teleport Daemon Auth Service.";
     };
     tokens = mkOption {
       type = types.listOf types.str;
       default = [ "" ];
+      description = "Set the tokens to authenticate nodes with for the Teleport Daemon.";
     };
     session_recording = mkOption {
       type = types.str;
       default = "node";
+      description = "Configure whether to enable session recording and for what node type for the Teleport Daemon.";
     };
     client_idle_timeout = mkOption {
       type = types.str;
       default = "1hr";
+      description = "Set the client idle timeout before certs need to be reauthenticated for the Teleport Daemon.";
     };
     disconnect_expired_cert = mkOption {
       type = types.str;
       default = "yes";
+      description = "Set whether to disconnect a client when their cert expires for the Teleport Daemon.";
     };
     keep_alive_interval = mkOption {
       type = types.int;
       default = 15;
+      description = "Set the keep alive internal for the Teleport Daemon.";
     };
     keep_alive_count_max = mkOption {
       type = types.int;
       default = 3;
+      description = "Set the keep alive interval max count for the Teleport Daemon.";
     };
   };
   telTypes.ssh_service = {
     enabled = mkOption {
       type = types.str;
       default = "on";
+      description = "Whether to enable the Teleport Daemon SSH Service";
     };
     listen_addr = mkOption {
       type = types.str;
       default = "0.0.0.0:3022";
+      description = "Set the address to listen on for the Teleport Daemon SSH Service.";
     };
     public_addr = mkOption {
       type = types.str;
       default = "";
+      description = "Set the public address/dns entry to listen on for the Teleport Daemon SSH Service.";
     };
     permit_user_env = mkOption {
       type = types.bool;
       default = false;
+      description = "Enable reading ~/.tsh/environment before creating a session.";
     };
     pam = {
       enabled = mkOption {
         type = types.bool;
         default = false;
+        description = "Whether to enable the pam integration for the Teleport Daemon.";
       };
       service_name = mkOption {
         type = types.str;
         default = "sshd";
+        description = "What service type to ape with the pam integration for the Teleport Daemon.";
       };
     };
   };
@@ -114,26 +132,37 @@ let
     enabled = mkOption {
       type = types.str;
       default = "off";
+      description = "Whether to enable the Teleport Daemon SSH Proxy Service";
     };
     listen_addr = mkOption {
       type = types.str;
+      default = "0.0.0.0:3023";
+      description = "Set the address to listen on for the Teleport Daemon SSH Proxy Service";
+    };
+    public_addr = mkOption {
+      type = types.str;
       default = "";
+      description = "Set the public address/dns entry to listen on for the Teleport Daemon SSH Proxy Web Service";
     };
     web_listen_addr = mkOption {
       type = types.str;
-      default = "";
+      default = "0.0.0.0:3008";
+      description = "Set the public address to listen on for the Teleport Daemon SSH Proxy Web Service";
     };
     tunnel_listen_addr = mkOption {
       type = types.str;
-      default = "";
+      default = "0.0.0.0:3024";
+      description = "Set the address to listen on for reverse tunneling for the Teleport Daemon SSH Proxy Web Service";
     };
     https_key_file = mkOption {
       type = types.str;
       default = "";
+      description = "Set the path to the ssl key file to enable https support for the Teleport Daemon SSH Proxy Web Service";
     };
     https_cert_file = mkOption {
       type = types.str;
       default = "";
+      description = "Set the path to the ssl certificate to enable https support for the Teleport Daemon SSH Proxy Web Service";
     };
   };
   
@@ -154,28 +183,33 @@ in {
       nodename = mkOption {
         type = types.str;
         default = "";
+        description = "Set the name of the node for the Teleport SSH Daemon";
       };
       auth_token = mkOption {
         type = types.str;
         default = "";
+        description = "The token to auth with to your teleport cluster.";
       };
       auth_servers = mkOption {
         type = types.listOf types.str;
         default = [ "" ];
-        description = "";
+        description = "Auth servers to use in your teleport cluster.";
       };
       advertise_ip = mkOption {
         type = types.str;
         default = "";
+        description = "IP of your node to advertise to your cluster, for NAT'd setups";
       };
       connection_limits = {
         max_connection = mkOption {
           type = types.int;
           default = 1000;
+          description = "Max amount of connections allowed to your teleport node at once.";
         };
         max_users = mkOption {
           type = types.int;
           default = 250;
+          description = "Max amount of users allowed to connect to your teleport node at once.";
         };
       };
       inherit (telTypes) ssh_service auth_service proxy_service;

--- a/nixos/modules/services/networking/teleport.nix
+++ b/nixos/modules/services/networking/teleport.nix
@@ -11,13 +11,15 @@ let
       echo '${builtins.toJSON x}' | ${pkgs.jq}/bin/jq . > $out
     ";
   # This becomes the main config file
-  # To be used in the future when I add seperate option sections for each part of teleport
-  # Rather then writing a single yaml file directly into your nix file.
   telConfig = {
-    global = cfg.globalConfig;
-    rule_files = cfg.ruleFiles ++ [
-      (pkgs.writeText "teleport.rules" (concatStringsSep "\n" cfg.rules))
-    ];
+    teleport = {
+      nodename = cfg.nodename;
+      auth_token = cfg.auth_token;
+      auth_servers = cfg.auth_servers;
+      auth_service = cfg.auth_service;
+      ssh_service = cfg.ssh_service;
+      proxy_service = cfg.proxy_service;
+    };
   };
 
   generatedTeleportYml = writePrettyJSON "teleport.yaml" telConfig;
@@ -28,6 +30,67 @@ let
     else generatedTeleportYml;
 
   cmdlineArgs = "-c ${teleportYml} --pid-file=/run/teleport.pid";
+
+  telTypes.auth_service = types.submodule {
+    options = {
+      enabled = mkEnableOption {
+        type = types.bool;
+        default = false;
+        description = "
+          Enable the Teleport Cluster SSH daemon.
+        ";
+      };
+      cluster_name = mkOption {
+        type = types.str;
+      };
+      listen_addr = mkOption {
+        type = types.str;
+      };
+      public_addr = mkOption {
+        type = types.str;
+      };
+      tokens = mkOption {
+        type = types.listOf types.str;
+      };
+    };
+  };
+  telTypes.ssh_service = types.submodule {
+    options = {
+      enabled = mkEnableOption {
+        type = types.bool;
+        default = false;
+        description = "
+          Enable the Teleport Cluster SSH daemon.
+        ";
+      };
+    };
+  };
+  telTypes.proxy_service = types.submodule {
+    options = {
+      enabled = mkEnableOption {
+        type = types.bool;
+        default = false;
+        description = "
+          Enable the Teleport Cluster SSH daemon.
+        ";
+      };
+      listen_addr = mkOption {
+        type = types.str;
+      };
+      web_listen_addr = mkOption {
+        type = types.str;
+      };
+      tunnel_listen_addr = mkOption {
+        type = types.str;
+      };
+      https_key_file = mkOption {
+        type = types.str;
+      };
+      https_cert_file = mkOption {
+        type = types.str;
+      };
+    };
+  };
 
 in
 
@@ -56,6 +119,48 @@ in
           teleport.yml.
         ";
       };
+      nodename = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          The name of your teleport node.
+          This is what you `tsh ssh` to.
+        '';
+      };
+      auth_token = mkOption {
+        type = types.str;
+        default = types.null;
+        description = ''
+          The auth token your teleport node authenticates with to your teleport auth nodes.
+        '';
+      };
+      auth_servers = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          The set of Auth servers your Teleport node authenticates against.
+        '';
+      };
+      auth_service = mkOption {
+        type = telTypes.auth_service;
+        default = {};
+        description = ''
+          Enable the Teleport SSH Auth service.
+        '';
+      };
+      ssh_service = mkOption {
+        type = telTypes.ssh_service;
+        default = {};
+        description = ''
+          Enable the Teleport SSH service.
+        '';
+      };
+      proxy_service = mkOption {
+        type = telTypes.proxy_service;
+        default = {};
+        description = ''
+          Enable the Teleport SSH Proxy service.
+        '';
+      };
     };
   };
 
@@ -69,7 +174,7 @@ in
           ExecReload = "/run/current-system/sw/bin/kill -HUP $MAINPID";
           PIDFile = "run/teleport.pid";
           Restart = "on-failure";
-          WorkingDirectory = ${cfg.dataDir};
+          WorkingDirectory = cfg.dataDir;
         };
       };
    };


### PR DESCRIPTION
###### Motivation for this change
Just a basic module for the clustered ssh daemon teleport since none existed.
Planning on a more nuanced module with a config section for each service that teleport offers/works with.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


I assume there's a doc that I'm missing, but where would I look to ensure documentation for the module is added to nixos.org?