### PR TITLE
humioctl: init at 0.25.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4769,6 +4769,12 @@
     githubId = 59375051;
     name = "Lucas Ransan";
   };
+  lucperkins = {
+    email = "lucperkins@gmail.com";
+    github = "lucperkins";
+    githubId = 1523104;
+    name = "Luc Perkins";
+  };
   lucus16 = {
     email = "lars.jellema@gmail.com";
     github = "Lucus16";

--- a/pkgs/applications/logging/humioctl/default.nix
+++ b/pkgs/applications/logging/humioctl/default.nix
@@ -1,0 +1,38 @@
+{ buildGoModule, fetchFromGitHub, installShellFiles, stdenv }:
+
+let
+  humioCtlVersion = "0.25.0";
+  sha256 = "1x8354m410nf9g167v0i1c77s5w2by7smdlyjwl89ixgdjw04ay3";
+  vendorSha256 = "14bysjgvahr56hvd8walym11hh721i1q2g503n8m68wdzrrym4qy";
+in buildGoModule {
+    name = "humioctl-${humioCtlVersion}";
+    pname = "humioctl";
+    version = humioCtlVersion;
+
+    vendorSha256 = vendorSha256;
+
+    src = fetchFromGitHub {
+      owner = "humio";
+      repo = "cli";
+      rev = "v${humioCtlVersion}";
+      sha256 = sha256;
+    };
+
+    buildFlagsArray = "-ldflags=-X main.version=${humioCtlVersion}";
+
+    nativeBuildInputs = [ installShellFiles ];
+
+    postInstall = ''
+      mv $out/bin/cli $out/bin/humioctl
+      $out/bin/humioctl completion bash > humioctl.bash
+      $out/bin/humioctl completion zsh > humioctl.zsh
+      installShellCompletion humioctl.{bash,zsh}
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = "https://github.com/humio/cli";
+      description = "A CLI for managing and sending data to Humio";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ lucperkins ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2011,6 +2011,8 @@ in
 
   hr = callPackage ../applications/misc/hr { };
 
+  humioctl = callPackage ../applications/logging/humioctl {};
+
   hyx = callPackage ../tools/text/hyx { };
 
   icdiff = callPackage ../tools/text/icdiff {};
@@ -7345,7 +7347,7 @@ in
   uget = callPackage ../tools/networking/uget { };
 
   uget-integrator = callPackage ../tools/networking/uget-integrator { };
-  
+
   ugrep = callPackage ../tools/text/ugrep { };
 
   uif2iso = callPackage ../tools/cd-dvd/uif2iso { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds the CLI for [Humio](https://www.humio.com/), `humioctl`, to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
