### PR TITLE
kdiamond: init 20.04.3

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -111,6 +111,7 @@ let
       kdepim-apps-libs = callPackage ./kdepim-apps-libs {};
       kdf = callPackage ./kdf.nix {};
       kdialog = callPackage ./kdialog.nix {};
+      kdiamond = callPackage ./kdiamond.nix {};
       keditbookmarks = callPackage ./keditbookmarks.nix {};
       kfind = callPackage ./kfind.nix {};
       kfloppy = callPackage ./kfloppy.nix {};

--- a/pkgs/applications/kde/kdiamond.nix
+++ b/pkgs/applications/kde/kdiamond.nix
@@ -6,7 +6,7 @@ mkDerivation {
     homepage = "https://kde.org/applications/en/games/org.kde.kdiamond";
     description = "KDiamond is a single player puzzle game";
     maintainers = with maintainers; [ freezeboy ];
-    license = licences.gpl2Plus;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };
   nativeBuildInputs = [

--- a/pkgs/applications/kde/kdiamond.nix
+++ b/pkgs/applications/kde/kdiamond.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, libkdegames, kconfig, knotifyconfig }:
+
+mkDerivation {
+  name = "kdiamond";
+  meta = with lib; {
+    homepage = "https://kde.org/applications/en/games/org.kde.kdiamond";
+    description = "KDiamond is a single player puzzle game";
+    maintainers = with maintainers; [ freezeboy ];
+    licence = licences.gpl2Plus;
+    platforms = platforms.linux;
+  };
+  nativeBuildInputs = [
+    extra-cmake-modules
+  ];
+  buildInputs = [
+    libkdegames
+    knotifyconfig
+    kconfig
+    kdoctools
+    ki18n
+    kio
+  ];
+}

--- a/pkgs/applications/kde/kdiamond.nix
+++ b/pkgs/applications/kde/kdiamond.nix
@@ -6,7 +6,7 @@ mkDerivation {
     homepage = "https://kde.org/applications/en/games/org.kde.kdiamond";
     description = "KDiamond is a single player puzzle game";
     maintainers = with maintainers; [ freezeboy ];
-    licence = licences.gpl2Plus;
+    license = licences.gpl2Plus;
     platforms = platforms.linux;
   };
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

new package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
