### PR TITLE
Add build version to open-policy-agent package

### DIFF
--- a/pkgs/development/tools/open-policy-agent/default.nix
+++ b/pkgs/development/tools/open-policy-agent/default.nix
@@ -13,6 +13,11 @@ buildGoPackage rec {
   };
   goDeps = ./deps.nix;
 
+  buildFlagsArray = ''
+    -ldflags=
+      -X ${goPackagePath}/version.Version=${version}
+  '';
+
   meta = with lib; {
     description = "General-purpose policy engine";
     homepage = "https://www.openpolicyagent.org";


### PR DESCRIPTION
###### Motivation for this change

I recently installed [Open Policy Agent](https://openpolicyagent.org) using Nix and realized that the OPA version is not currently built into the `opa` executable. This PR updates the build process to supply the version via `ldflags`.

cc @nlewo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
