### PR TITLE
linuxPackages.xpadneo: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/os-specific/linux/xpadneo/default.nix
+++ b/pkgs/os-specific/linux/xpadneo/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "xpadneo";
-  version = "0.8.1";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner = "atar-axis";
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
 
   setSourceRoot = ''
     export sourceRoot=$(pwd)/source/hid-xpadneo/src
+  '';
+
+  postPatch = ''
+    # Set kernel module version
+    substituteInPlace hid-xpadneo.c \
+      --subst-var-by DO_NOT_CHANGE ${version}
   '';
 
   nativeBuildInputs = kernel.moduleBuildDependencies;


### PR DESCRIPTION
Also fixes kernel module version: `@DO_NOT_CHANGE@` -> `0.8.2`

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade to the latest release: https://github.com/atar-axis/xpadneo/releases/tag/v0.8.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  
  No binary files. Enabled with `hardware.xpadneo.enable = true` & tested through use of Xbox One controller.

  Tested:
  - Bluetooth connectivity
  - All buttons
  - Rumble support
  <br/>

  ```
  > modinfo hid_xpadneo
  filename:       /run/current-system/kernel-modules/lib/modules/5.7.9/extra/hid-xpadneo.ko.xz
  version:        0.8.2
  description:    Linux kernel driver for Xbox ONE S+ gamepads (BT), incl. FF
  author:         Florian Dollinger <dollinger.florian@gmx.de>
  license:        GPL
  srcversion:     3D77A9FCE33246E56A7AE59
  alias:          hid:b0005g*v0000045Ep00000B05
  alias:          hid:b0005g*v0000045Ep000002E0
  alias:          hid:b0005g*v0000045Ep000002FD
  depends:        hid,ff-memless
  retpoline:      Y
  name:           hid_xpadneo
  vermagic:       5.7.9 SMP mod_unload
  parm:           debug_level:(u8) Debug information level: 0 (none) to 3+ (most verbose). (byte)
  parm:           combined_z_axis:(bool) Combine the triggers to form a single axis. 1: combine, 0: do not combine. (bool)
  parm:           trigger_rumble_mode:(u8) Trigger rumble mode. 0: pressure, 1: directional, 2: disable. (byte)
  parm:           rumble_attenuation:(u8) Attenuate the rumble strength: all[,triggers] 0 (none, full rumble) to 100 (max, no rumble). (array of byte)
  parm:           ff_connect_notify:(bool) Connection notification using force feedback. 1: enable, 0: disable. (bool)
  parm:           gamepad_compliance:(bool) Adhere to Linux Gamepad Specification by using signed axis values. 1: enable, 0: disable. (bool)
  parm:           quirks:array of charp
  parm:           quriks:(string) Override device quirks, specify as: "MAC1:quirks1[,...16]", MAC format = 11:22:33:44:55:66, no pulse parameters = 1, no trigger rumble = 2, no motor masking = 4
  ```
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
