### PR TITLE
yubikey-agent: fix on darwin

### DIFF
--- a/pkgs/tools/security/yubikey-agent/default.nix
+++ b/pkgs/tools/security/yubikey-agent/default.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
     substituteInPlace main.go --replace 'notify-send' ${libnotify}/bin/notify-send
   '';
 
-  vendorSha256 = "1x7934p6522i0yyv08xzb4134d0kr5x6igsrp26vh79d8fndbywr";
+  vendorSha256 = "128mlsagj3im6h0p0ndhzk29ya47g19im9dldx3nmddf2jlccj2h";
 
   subPackages = [ "." ];
 

--- a/pkgs/tools/security/yubikey-agent/use-piv-go-75.patch
+++ b/pkgs/tools/security/yubikey-agent/use-piv-go-75.patch
@@ -1,24 +1,22 @@
-From 56a465d463273b2a2a24cf668c4c33938b198b16 Mon Sep 17 00:00:00 2001
+From 547695fff9cbfc4037168cdeb07cfe16bd89b6db Mon Sep 17 00:00:00 2001
 From: Philip Potter <philip.g.potter@gmail.com>
-Date: Sun, 12 Jul 2020 16:54:57 +0100
-Subject: [PATCH] Pull in go-piv/piv-go#75
+Date: Sat, 25 Jul 2020 21:59:50 +0100
+Subject: [PATCH] Pull in piv-go#75
 
 ---
- go.mod | 1 +
- 1 file changed, 1 insertion(+)
+ go.mod | 2 ++
+ 1 file changed, 2 insertions(+)
 
 diff --git a/go.mod b/go.mod
-index d4d13c8..e24d53d 100644
+index d4d13c8..f75be2d 100644
 --- a/go.mod
 +++ b/go.mod
-@@ -2,6 +2,7 @@ module filippo.io/yubikey-agent
- 
- go 1.14
- 
-+replace github.com/go-piv/piv-go => github.com/rawkode/piv-go v1.5.1-0.20200711221619-a4158f9b8204
- require (
- 	github.com/go-piv/piv-go v1.5.1-0.20200523071327-a3e5767e8b72
+@@ -7,3 +7,5 @@ require (
  	github.com/gopasspw/gopass v1.9.1
+ 	golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79
+ )
++
++replace github.com/go-piv/piv-go => github.com/rawkode/piv-go v1.5.1-0.20200725154545-1c3200c75a28
 -- 
 2.27.0
 


### PR DESCRIPTION
###### Motivation for this change

Mea culpa: in #92936, I did originally test on macOS but I forgot to
retest after adding the piv-go patch.  Unfortunately, the piv-go patch
was broken on macOS.  This pulls in the latest version of
go-piv/piv-go#75 which works on macOS now.

(This is a repeat of #93769 which went a bit wrong)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
