### PR TITLE
mate.atril: add support for more filetypes

### DIFF
--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -1,4 +1,25 @@
-{ stdenv, fetchurl, pkgconfig, gettext, gtk3, glib, libxml2, libsecret, poppler, itstool, hicolor-icon-theme, texlive, mate, wrapGAppsHook }:
+{ stdenv
+, fetchurl
+, pkgconfig
+, gettext
+, gtk3
+, glib
+, libxml2
+, libsecret
+, poppler
+, itstool
+, hicolor-icon-theme
+, texlive
+, mate
+, wrapGAppsHook
+, enableEpub ? true, webkitgtk
+, enableDjvu ? true, djvulibre
+, enablePostScript ? true, libspectre
+, enableXps ? true, libgxps
+, enableImages ? false
+}:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "atril";
@@ -26,7 +47,19 @@ stdenv.mkDerivation rec {
     mate.mate-desktop
     hicolor-icon-theme
     texlive.bin.core  # for synctex, used by the pdf back-end
-  ];
+  ]
+  ++ optionals enableDjvu [ djvulibre ]
+  ++ optionals enableEpub [ webkitgtk ]
+  ++ optionals enablePostScript [ libspectre ]
+  ++ optionals enableXps [ libgxps ]
+  ;
+
+  configureFlags = [ ]
+    ++ optionals (enableDjvu) [ "--enable-djvu" ]
+    ++ optionals (enableEpub) [ "--enable-epub" ]
+    ++ optionals (enablePostScript) [ "--enable-ps" ]
+    ++ optionals (enableXps) [ "--enable-xps" ]
+    ++ optionals (enableImages) [ "--enable-pixbuf" ];
 
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Atril was built without support for some filetypes.

This PR adds (enabled by default) support for djvu, epub, postscript and xps, plus (disabled by default) for images.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
