### PR TITLE
newsflash: fix loading external https content

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsflash/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsflash/default.nix
@@ -7,6 +7,7 @@
 , ninja
 , pkg-config
 , wrapGAppsHook
+, glib-networking
 , gsettings-desktop-schemas
 , gtk3
 , libhandy
@@ -54,6 +55,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     gdk-pixbuf
     glib
+    glib-networking # TLS support for loading external content in webkitgtk WebView (eg. images)
     gsettings-desktop-schemas # used to get system default font in src/article_view/mod.rs
     gtk3
     libhandy


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Images hosted through https weren't loading properly

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

**Before:**
---

<img src="https://user-images.githubusercontent.com/382041/88466736-71a44600-ce9d-11ea-9b9b-fcd605abcbb6.png" width="673">

**After:**
---
<img src="https://user-images.githubusercontent.com/382041/88466737-75d06380-ce9d-11ea-897d-ca82117a2f16.png" width="673">