### PR TITLE
nixos/nixos-rebuild.sh: Add --path-to-built-config

### DIFF
--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -83,6 +83,10 @@
     <option>--flake</option> <replaceable>flake-uri</replaceable>
    </arg>
 
+   <arg>
+    <option>--path-to-built-config</option> <replaceable>path-to-built-config</replaceable>
+   </arg>
+
    <sbr />
 
    <arg>
@@ -532,6 +536,17 @@
       <literal>nixosConfigurations.<replaceable>name</replaceable></literal>. If
       <replaceable>name</replaceable> is omitted, it default to the
       current host name.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term>
+     <option>--path-to-built-config</option> <replaceable>path-to-built-config</replaceable>
+    </term>
+    <listitem>
+     <para>
+      Switch the NixOS system to the specified already built system config.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Added --path-to-built-config option to nixos-rebuild.sh to allow for building the system config manually, and then switching to it.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I wanted to experiment with using `nix build` to build my system image, but did not have a way to pass in the built system to `nixos-rebuild` without it redoing the work of the build.

###### Things done

Added `--path-to-built-config` option to nixos-rebuild.sh. Does not build the system image when executing either `boot` or `switch`, instead uses the supplied path.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
