### PR TITLE
r-modules: add GitHub only r packages

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -3,7 +3,7 @@
 { R, pkgs, overrides }:
 
 let
-  inherit (pkgs) cacert fetchurl stdenv lib;
+  inherit (pkgs) cacert fetchurl fetchgit stdenv lib;
 
   buildRPackage = pkgs.callPackage ./generic-builder.nix {
     inherit R;
@@ -36,11 +36,31 @@ let
     meta.platforms = R.meta.platforms;
     meta.hydraPlatforms = hydraPlatforms;
     meta.broken = broken;
-  });
+    });
 
   # Templates for generating Bioconductor and CRAN packages
   # from the name, version, sha256, and optional per-package arguments above
   #
+  deriveGithub = args :
+    lib.makeOverridable ({
+      name, version, sha256, url, rev,
+        depends ? [],
+        doCheck ? true,
+        requireX ? false,
+        broken ? false,
+        hydraPlatforms ? R.meta.hydraPlatforms
+      }: buildRPackage {
+     name = "${name}-${version}";
+     src = pkgs.fetchgit { inherit url; rev = rev; inherit sha256; };
+    inherit doCheck requireX;
+    propagatedBuildInputs = depends;
+    nativeBuildInputs = depends;
+    meta.homepage = url;
+    meta.platforms = R.meta.platforms;
+    meta.hydraPlatforms = hydraPlatforms;
+    meta.broken = broken;
+    });
+
   deriveBioc = mkDerive {
     mkHomepage = {name, biocVersion, ...}: "https://bioconductor.org/packages/${biocVersion}/bioc/html/${name}.html";
     mkUrls = {name, version, biocVersion}: [ "mirror://bioc/${biocVersion}/bioc/src/contrib/${name}_${version}.tar.gz"
@@ -217,6 +237,7 @@ let
   # packages in `_self` may depends on overridden packages.
   self = (defaultOverrides _self self) // overrides;
   _self = { inherit buildRPackage; } //
+          import ./github-packages.nix { inherit self; derive = deriveGithub; } //
           import ./bioc-packages.nix { inherit self; derive = deriveBioc; } //
           import ./bioc-annotation-packages.nix { inherit self; derive = deriveBiocAnn; } //
           import ./bioc-experiment-packages.nix { inherit self; derive = deriveBiocExp; } //

--- a/pkgs/development/r-modules/generate-r-packages.R
+++ b/pkgs/development/r-modules/generate-r-packages.R
@@ -12,16 +12,60 @@ mirrorUrls <- list( bioc=paste0("http://bioconductor.statistik.tu-dortmund.de/pa
                   , cran=paste0("http://mran.revolutionanalytics.com/snapshot/", snapshotDate, "/src/contrib/")
                   )
 
-mirrorType <- commandArgs(trailingOnly=TRUE)[1]
-stopifnot(mirrorType %in% names(mirrorUrls))
+args <- commandArgs(trailingOnly=TRUE)
+mirrorType <- args[1]
+stopifnot(mirrorType %in% c(names(mirrorUrls), "github"))
 packagesFile <- paste(mirrorType, 'packages.nix', sep='-')
 readFormatted <- as.data.table(read.table(skip=8, sep='"', text=head(readLines(packagesFile), -1)))
 
 write(paste("downloading package lists"), stderr())
 knownPackages <- lapply(mirrorUrls, function(url) as.data.table(available.packages(url, filters=c("R_version", "OS_type", "duplicates")), method="libcurl"))
+
+if(mirrorType == "github"){
+
+    githubPkgsAndRef <-
+        lapply(strsplit(args[-1], "@"), function(splt){
+            if(length(splt) > 2) stop("Syntax Error: Please specify github packages as user/repo@commit")
+            if(length(splt) == 1)
+                splt <- c(splt, "HEAD")
+            splt
+        })
+
+    oldPkgs <- readFormatted$V8
+    newPkgsRegexes <- paste0(sapply(githubPkgsAndRef, function(x) x[1]), "$")
+    oldPkgsToUpdate <- Reduce(function(acc, r){ acc | grepl(r, oldPkgs) }
+                            , newPkgsRegexes, init = FALSE)
+    oldPkgs <- readFormatted[!oldPkgsToUpdate]
+
+    clusterExport(cl, c("readFormatted", "knownPackages"))
+
+    githubPackages <- parLapply(cl, githubPkgsAndRef, function(splt){
+        rp <- splt[1]
+        ref <- splt[2]
+        write(ref, stderr())
+        rpUrl <- paste0("https://raw.githubusercontent.com/", rp, "/", ref, "/DESCRIPTION")
+        conn <- url(rpUrl)
+        desc <- as.data.frame(read.dcf(conn))
+        close(conn)
+        repoUrl <- paste0("https://github.com/", rp)
+        cmd <- paste0("nix-prefetch-git --rev ", ref
+                    , " --url ", repoUrl
+                    , " | jq -r '.[\"sha256\", \"rev\"]'")
+        shaAndRev <- system(cmd, intern = TRUE)
+        desc$sha256 <- shaAndRev[1]
+        desc$rev <- shaAndRev[2]
+        desc$repoUrl <- repoUrl
+        desc
+    })
+
+    githubPackages <- as.data.table(rbindlist(githubPackages, fill = TRUE))
+
+   knownPackages$github <- githubPackages
+}
+
 pkgs <- knownPackages[mirrorType][[1]]
 setkey(pkgs, Package)
-knownPackages <- c(unique(do.call("rbind", knownPackages)$Package))
+knownPackages <- rbindlist(knownPackages, fill = TRUE)$Package
 knownPackages <- sapply(knownPackages, gsub, pattern=".", replacement="_", fixed=TRUE)
 
 mirrorUrl <- mirrorUrls[mirrorType][[1]]
@@ -29,7 +73,6 @@ nixPrefetch <- function(name, version) {
   prevV <- readFormatted$V2 == name & readFormatted$V4 == version
   if (sum(prevV) == 1)
     as.character(readFormatted$V6[ prevV ])
-
   else {
     # avoid nix-prefetch-url because it often fails to fetch/hash large files
     url <- paste0(mirrorUrl, name, "_", version, ".tar.gz")
@@ -43,7 +86,8 @@ nixPrefetch <- function(name, version) {
 
 }
 
-formatPackage <- function(name, version, sha256, depends, imports, linkingTo) {
+formatPackage <- function(name, version, sha256, depends, imports, linkingTo
+                        , repoUrl, rev) {
     name <- ifelse(name == "import", "r_import", name)
     attr <- gsub(".", "_", name, fixed=TRUE)
     options(warn=5)
@@ -59,17 +103,36 @@ formatPackage <- function(name, version, sha256, depends, imports, linkingTo) {
     depends <- lapply(depends, function(d) ifelse(d == "import", "r_import", d))
     depends <- paste(depends)
     depends <- paste(sort(unique(depends)), collapse=" ")
-    paste0("  ", attr, " = derive2 { name=\"", name, "\"; version=\"", version, "\"; sha256=\"", sha256, "\"; depends=[", depends, "]; };")
+    nix <- paste0("  ", attr, " = derive2 { name=\"", name, "\"; version=\"", version, "\"; sha256=\"", sha256, "\"; depends=[", depends, "];")
+    if(!is.na(repoUrl))
+        nix <- paste0(nix, " url = \"", repoUrl, "\";")
+    if(!is.na(rev))
+        nix <- paste0(nix, " rev = \"", rev, "\";")
+    nix <- paste0(nix, " };")
+    nix
 }
 
-clusterExport(cl, c("nixPrefetch","readFormatted", "mirrorUrl", "knownPackages"))
-
-pkgs <- as.data.table(available.packages(mirrorUrl, filters=c("R_version", "OS_type", "duplicates"), method="libcurl"))
-pkgs <- pkgs[order(Package)]
-
 write(paste("updating", mirrorType, "packages"), stderr())
-pkgs$sha256 <- parApply(cl, pkgs, 1, function(p) nixPrefetch(p[1], p[2]))
-nix <- apply(pkgs, 1, function(p) formatPackage(p[1], p[2], p[18], p[4], p[5], p[6]))
+
+if(mirrorType != "github"){
+    # Seems wasteful to redownload, maybe we should refactor above
+    pkgs <- as.data.table(available.packages(mirrorUrl, filters=c("R_version", "OS_type", "duplicates"), method="libcurl"))
+
+    clusterExport(cl, c("nixPrefetch","readFormatted", "mirrorUrl", "knownPackages", "pkgs"))
+
+    pkgs <- pkgs[order(Package)]
+    pkgs$sha256 <- parApply(cl, pkgs, 1, function(p){
+        nixPrefetch(p["Package"], p["Version"])
+    })
+} else {
+    pkgs <- githubPackages
+    pkgs <- pkgs[order(Package)]
+}
+
+nix <- apply(pkgs, 1, function(p){
+    formatPackage(p["Package"], p["Version"], p["sha256"]
+                , p["Depends"], p["Imports"], p["suggests"]
+                , p["repoUrl"], p["rev"])})
 write("done", stderr())
 
 cat("# This file is generated from generate-r-packages.R. DO NOT EDIT.\n")
@@ -79,11 +142,14 @@ cat(paste("# Rscript generate-r-packages.R", mirrorType, ">new && mv new", packa
 cat("\n\n")
 cat("{ self, derive }:\n")
 cat("let derive2 = derive ")
-if (mirrorType == "cran") { cat("{ snapshot = \"", paste(snapshotDate), "\"; }", sep="")
+if (mirrorType %in% c("cran", "github")) { cat("{ snapshot = \"", paste(snapshotDate), "\"; }", sep="")
 } else if (mirrorType == "irkernel") { cat("{}")
 } else { cat("{ biocVersion = \"", biocVersion, "\"; }", sep="") }
 cat(";\n")
 cat("in with self; {\n")
+if(mirrorType == "github" & exists("oldPkgs")){
+    cat(apply(oldPkgs, 1, paste0, collapse = '"'), sep = "\n")
+}
 cat(paste(nix, collapse="\n"), "\n", sep="")
 cat("}\n")
 

--- a/pkgs/development/r-modules/generate-shell.nix
+++ b/pkgs/development/r-modules/generate-shell.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
 
   buildCommand = "exit 1";
 
-  buildInputs = [ wget ];
+  buildInputs = [ wget jq ];
 
   nativeBuildInputs = [
     (rWrapper.override {

--- a/pkgs/development/r-modules/github-packages.nix
+++ b/pkgs/development/r-modules/github-packages.nix
@@ -1,0 +1,11 @@
+# This file is generated from generate-r-packages.R. DO NOT EDIT.
+# Execute the following command to update the file.
+#
+# Rscript generate-r-packages.R github >new && mv new github-packages.nix
+
+{ self, derive }:
+let derive2 = derive { snapshot = "2020-08-05"; };
+in with self; {
+ lgpr = derive2 { name="lgpr"; version="0.33.2"; sha256="14i1vf9119cypjnacy43flfzx3lsjhax5zg33h4kjsyjbfl68ngi"; depends=[MASS Rcpp bayesplot ggplot2 ggpubr rstan rstantools]; url = "https://github.com/jtimonen/lgpr"; rev = "5a25fa8a1b21a34f915461802e21f592184d6e67"; };
+  posterior = derive2 { name="posterior"; version="0.1.0"; sha256="08psb9cknkva4awbrz38pdr7ssic0za31hji4i90vjb0vdnjn4k0"; depends=[abind checkmate rlang tibble]; url = "https://github.com/stan-dev/posterior"; rev = "4794130b548511c9861fc0085ba5a677afeba6fe"; };
+}


### PR DESCRIPTION
##### Motivation for this change

Frequently for an analysis a package is required that isn't released on CRAN or bioconductor, but has a usable version on github. This PR adds the ability to integrate these packages with the `rPackages` set and adds two example packages https://github.com/jtimonen/lgpr and https://github.com/stan-dev/posterior. 

###### Things done

In order to do this I:

- Updated cran-packages.nix to ensure up to date dependencies
- Added a github-packages.nix file
- Modified generate-r-packages.R to accept the argument `github`
- When `github` is passed, a fixed list of github packages are traversed, using `nix-prefetch-git` to get the commit hash and sha256 for the current commit at HEAD. (This list is currently kept as an R vector in generate-R-packages.R, but could easily be made external as a text file).
- Modifies r-modules/default.nix to have a `deriveGithub` that constructs the homepage as the repo url and uses `fetchgit` to download the sources.
- Adds the github packages first to r-modules/default.nix so that a stable release on either bioconductor or CRAN would supersede the github version. 
- Tested with `nix-shell -p rPackages.posterior` works, `nix-shell -p rPackages.lgpr` fails to build due to failure to build `rPackages.StanHeaders`

---

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
