### PR TITLE
cmake: 3.17.3 -> 3.18.0

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/application-services.patch
+++ b/pkgs/development/tools/build-managers/cmake/application-services.patch
@@ -1,11 +1,8 @@
 diff --git a/Source/CMakeLists.txt b/Source/CMakeLists.txt
-index 8aff8f6..af1852d 100644
+index 1b6bb00d4c..487114daa8 100644
 --- a/Source/CMakeLists.txt
 +++ b/Source/CMakeLists.txt
-@@ -791,12 +791,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "sparc"
-   endif()
- endif()
- 
+@@ -893,7 +893,6 @@ endif()
  # On Apple we need CoreFoundation and CoreServices
  if(APPLE)
    target_link_libraries(CMakeLib "-framework CoreFoundation")
@@ -13,13 +10,11 @@ index 8aff8f6..af1852d 100644
  endif()
  
  if(WIN32 AND NOT UNIX)
-   # We need the rpcrt4 library on Windows.
-   # We need the crypt32 library on Windows for crypto/cert APIs.
 diff --git a/Source/cmGlobalXCodeGenerator.cxx b/Source/cmGlobalXCodeGenerator.cxx
-index e353a37..b06f842 100644
+index a5ce5d18f4..3d6838ce82 100644
 --- a/Source/cmGlobalXCodeGenerator.cxx
 +++ b/Source/cmGlobalXCodeGenerator.cxx
-@@ -35,11 +35,6 @@
+@@ -43,11 +43,6 @@
  
  struct cmLinkImplementation;
  
@@ -32,12 +27,12 @@ index e353a37..b06f842 100644
  #  include "cmXMLParser.h"
  
 diff --git a/Utilities/cmlibarchive/CMakeLists.txt b/Utilities/cmlibarchive/CMakeLists.txt
-index d7af6e2..d4808fc 100644
+index bfcaf30bb7..1da540aee5 100644
 --- a/Utilities/cmlibarchive/CMakeLists.txt
 +++ b/Utilities/cmlibarchive/CMakeLists.txt
-@@ -1662,11 +1662,6 @@ IF(MSVC)
-   ADD_DEFINITIONS(-D_CRT_SECURE_NO_DEPRECATE)
- ENDIF(MSVC)
+@@ -2007,11 +2007,6 @@ IF(ENABLE_TEST)
+ ENDIF(ENABLE_TEST)
+ ENDIF()
  
 -# We need CoreServices on Mac OS.
 -IF(APPLE)
@@ -45,16 +40,5 @@ index d7af6e2..d4808fc 100644
 -ENDIF(APPLE)
 -
  add_subdirectory(libarchive)
- 
- install(FILES COPYING DESTINATION ${CMAKE_DOC_DIR}/cmlibarchive)
-index e505bdd..f45557d 100644
---- a/Utilities/cmlibuv/src/unix/darwin-proctitle.c
-+++ b/Utilities/cmlibuv/src/unix/darwin-proctitle.c
-@@ -30,7 +30,6 @@
-
- #if !TARGET_OS_IPHONE
- # include <CoreFoundation/CoreFoundation.h>
--# include <ApplicationServices/ApplicationServices.h>
- #endif
-
- #define S(s) pCFStringCreateWithCString(NULL, (s), kCFStringEncodingUTF8)
+ IF(0) # CMake does not build libarchive's command-line tools.
+ add_subdirectory(cat)

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -19,12 +19,12 @@ stdenv.mkDerivation rec {
           + lib.optionalString useNcurses "-cursesUI"
           + lib.optionalString withQt5 "-qt5UI"
           + lib.optionalString useQt4 "-qt4UI";
-  version = "3.17.3";
+  version = "3.18.0";
 
   src = fetchurl {
     url = "${meta.homepage}files/v${lib.versions.majorMinor version}/cmake-${version}.tar.gz";
     # compare with https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}-SHA-256.txt
-    sha256 = "0h4c3nwk7wmzcmmlwyb16zmjqr44l4k591m2y9p9zp3m498hvmhb";
+    sha256 = "0aby67jn3i0rqhj6cvpm0f7idw3dl7jayaqxa9hkk9w2jk5zzd43";
   };
 
   patches = [

--- a/pkgs/development/tools/build-managers/cmake/libuv-application-services.patch
+++ b/pkgs/development/tools/build-managers/cmake/libuv-application-services.patch
@@ -1,7 +1,8 @@
-diff -ur cmake-3.12.1/Utilities/cmlibuv/CMakeLists.txt cmake-3.12.1-patched/Utilities/cmlibuv/CMakeLists.txt
---- cmake-3.12.1/Utilities/cmlibuv/CMakeLists.txt	2018-08-09 21:14:08.000000000 +0900
-+++ cmake-3.12.1-patched/Utilities/cmlibuv/CMakeLists.txt	2018-08-13 10:14:53.000000000 +0900
-@@ -173,6 +173,22 @@
+diff --git a/Utilities/cmlibuv/CMakeLists.txt b/Utilities/cmlibuv/CMakeLists.txt
+index 7625cf65d9..167903e309 100644
+--- a/Utilities/cmlibuv/CMakeLists.txt
++++ b/Utilities/cmlibuv/CMakeLists.txt
+@@ -193,6 +193,22 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
      src/unix/kqueue.c
      src/unix/proctitle.c
      )
@@ -24,9 +25,10 @@ diff -ur cmake-3.12.1/Utilities/cmlibuv/CMakeLists.txt cmake-3.12.1-patched/Util
  endif()
  
  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-diff -ur cmake-3.12.1/Utilities/cmlibuv/src/unix/fsevents.c cmake-3.12.1-patched/Utilities/cmlibuv/src/unix/fsevents.c
---- cmake-3.12.1/Utilities/cmlibuv/src/unix/fsevents.c	2018-08-09 21:14:08.000000000 +0900
-+++ cmake-3.12.1-patched/Utilities/cmlibuv/src/unix/fsevents.c	2018-08-13 10:01:29.000000000 +0900
+diff --git a/Utilities/cmlibuv/src/unix/fsevents.c b/Utilities/cmlibuv/src/unix/fsevents.c
+index a51f29b3f6..3f6bf01968 100644
+--- a/Utilities/cmlibuv/src/unix/fsevents.c
++++ b/Utilities/cmlibuv/src/unix/fsevents.c
 @@ -21,7 +21,7 @@
  #include "uv.h"
  #include "internal.h"
@@ -35,17 +37,17 @@ diff -ur cmake-3.12.1/Utilities/cmlibuv/src/unix/fsevents.c cmake-3.12.1-patched
 +#if !HAVE_CORESERVICES_CORESERVICES_H || MAC_OS_X_VERSION_MAX_ALLOWED < 1070
  
  /* iOS (currently) doesn't provide the FSEvents-API (nor CoreServices) */
- 
-@@ -38,7 +38,7 @@
+ /* macOS prior to 10.7 doesn't provide the full FSEvents API so use kqueue */
+@@ -39,7 +39,7 @@ int uv__fsevents_close(uv_fs_event_t* handle) {
  void uv__fsevents_loop_delete(uv_loop_t* loop) {
  }
  
 -#else /* TARGET_OS_IPHONE */
 +#else /* !HAVE_CORESERVICES_CORESERVICES_H */
  
- #include <dlfcn.h>
- #include <assert.h>
-@@ -916,4 +916,4 @@
+ #include "darwin-stub.h"
+ 
+@@ -920,4 +920,4 @@ int uv__fsevents_close(uv_fs_event_t* handle) {
    return 0;
  }
  

--- a/pkgs/development/tools/build-managers/cmake/search-path.patch
+++ b/pkgs/development/tools/build-managers/cmake/search-path.patch
@@ -1,9 +1,10 @@
-diff -ur cmake-3.9.1/Modules/Platform/UnixPaths.cmake cmake-3.9.1-mod/Modules/Platform/UnixPaths.cmake
---- cmake-3.9.1/Modules/Platform/UnixPaths.cmake	2017-08-10 13:36:32.000000000 +0000
-+++ cmake-3.9.1-mod/Modules/Platform/UnixPaths.cmake	2017-09-03 01:24:31.901473539 +0000
-@@ -22,9 +22,6 @@
- # List common installation prefixes.  These will be used for all
- # search types.
+diff --git a/Modules/Platform/UnixPaths.cmake b/Modules/Platform/UnixPaths.cmake
+index b9381c3d7d..cecc40a89e 100644
+--- a/Modules/Platform/UnixPaths.cmake
++++ b/Modules/Platform/UnixPaths.cmake
+@@ -26,9 +26,6 @@ get_filename_component(_CMAKE_INSTALL_DIR "${_CMAKE_INSTALL_DIR}" PATH)
+ # please make sure to keep Help/variable/CMAKE_SYSTEM_PREFIX_PATH.rst
+ # synchronized
  list(APPEND CMAKE_SYSTEM_PREFIX_PATH
 -  # Standard
 -  /usr/local /usr /
@@ -11,7 +12,7 @@ diff -ur cmake-3.9.1/Modules/Platform/UnixPaths.cmake cmake-3.9.1-mod/Modules/Pl
    # CMake install location
    "${_CMAKE_INSTALL_DIR}"
    )
-@@ -43,31 +40,26 @@
+@@ -47,24 +44,19 @@ endif()
  
  # Non "standard" but common install prefixes
  list(APPEND CMAKE_SYSTEM_PREFIX_PATH
@@ -39,12 +40,7 @@ diff -ur cmake-3.9.1/Modules/Platform/UnixPaths.cmake cmake-3.9.1-mod/Modules/Pl
    )
  
  if(CMAKE_SYSROOT_COMPILE)
-   set(_cmake_sysroot_compile "${CMAKE_SYSROOT_COMPILE}")
- else()
-   set(_cmake_sysroot_compile "${CMAKE_SYSROOT}")
- endif()
- 
- # Default per-language values.  These may be later replaced after
+@@ -77,15 +69,15 @@ endif()
  # parsing the implicit directory information from compiler output.
  set(_CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES_INIT
    ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}
@@ -62,11 +58,12 @@ diff -ur cmake-3.9.1/Modules/Platform/UnixPaths.cmake cmake-3.9.1-mod/Modules/Pl
 +  @libc_dev@/include
    )
  
- # Enable use of lib32 and lib64 search path variants by default.
-diff -ur cmake-3.9.1/Modules/Platform/WindowsPaths.cmake cmake-3.9.1-mod/Modules/Platform/WindowsPaths.cmake
---- cmake-3.9.1/Modules/Platform/WindowsPaths.cmake	2017-08-10 13:36:32.000000000 +0000
-+++ cmake-3.9.1-mod/Modules/Platform/WindowsPaths.cmake	2017-09-03 01:19:32.808355986 +0000
-@@ -66,7 +66,7 @@
+ unset(_cmake_sysroot_compile)
+diff --git a/Modules/Platform/WindowsPaths.cmake b/Modules/Platform/WindowsPaths.cmake
+index b9e2f17979..ab517cd4a7 100644
+--- a/Modules/Platform/WindowsPaths.cmake
++++ b/Modules/Platform/WindowsPaths.cmake
+@@ -70,7 +70,7 @@ endif()
  
  if(CMAKE_CROSSCOMPILING AND NOT CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
    # MinGW (useful when cross compiling from linux with CMAKE_FIND_ROOT_PATH set)


### PR DESCRIPTION
###### Motivation for this change
New CMake version 3.18 available
https://cmake.org/cmake/help/v3.18/release/3.18.html

###### Things done

Patches had some conflicts, but they seemed to be trivial to resolve. Did that via `git apply` and merge on the cmake git itself - let me know if there's a more nixy way to do that.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions (Arch Linux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
