### PR TITLE
veusz: init at 3.3.1

### DIFF
--- a/pkgs/applications/graphics/veusz/default.nix
+++ b/pkgs/applications/graphics/veusz/default.nix
@@ -1,0 +1,71 @@
+{ python3Packages
+, qtbase
+, ghostscript
+, wrapQtAppsHook
+, lib
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "veusz";
+  version = "3.3.1";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "4ClgYwiU21wHDve2q9cItSAVb9hbR2F+fJc8znGI8OA=";
+  };
+
+  nativeBuildInputs = [ wrapQtAppsHook python3Packages.sip ];
+
+  buildInputs = [ qtbase ];
+
+  # veusz is a script and not an ELF-executable, so wrapQtAppsHook will not wrap
+  # it automatically -> we have to do it explicitly
+  dontWrapQtApps = true;
+  preFixup = ''
+    wrapQtApp "$out/bin/veusz"
+  '';
+
+  # For some reason, if sip5 is found on the PATH, the option --sip-dir is
+  # ignored in setupPyBuildFlags, see
+  # https://github.com/veusz/veusz/blob/53b99dffa999f2bc41fdc5335d7797ae857c761f/pyqtdistutils.py#L292
+  postPatch = ''
+    substituteInPlace pyqtdistutils.py \
+      --replace "'-I', pyqt5_include_dir," "'-I', '${python3Packages.pyqt5}/share/sip/PyQt5',"
+    patchShebangs tests/runselftest.py
+  '';
+
+  # you can find these options at
+  # https://github.com/veusz/veusz/blob/53b99dffa999f2bc41fdc5335d7797ae857c761f/pyqtdistutils.py#L71
+  setupPyBuildFlags = [
+    # --sip-dir does nothing here, but it should be the correct way to set the
+    # sip_dir, so I'm leaving it here for future versions
+    "--sip-dir=${python3Packages.pyqt5}/share/sip"
+    "--qt-include-dir=${qtbase.dev}/include"
+    # veusz tries to find a libinfix and fails without one
+    # but we simply don't need a libinfix, so set it to empty here
+    "--qt-libinfix="
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    numpy
+    pyqt5
+    # optional requirements:
+    dbus-python
+    h5py
+    # astropy -- fails to build on master
+    # optional TODO: add iminuit, pyemf and sampy
+  ];
+
+  installCheckPhase = ''
+    wrapQtApp "tests/runselftest.py"
+    QT_QPA_PLATFORM=minimal tests/runselftest.py
+  '';
+
+  meta = with lib; {
+    description = "A scientific plotting and graphing program with a GUI";
+    homepage = "https://veusz.github.io/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ laikq ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27214,6 +27214,8 @@ in
     inherit (gnome2) libgnomeui;
   };
 
+  veusz = libsForQt5.callPackage ../applications/graphics/veusz { };
+
   vim = callPackage ../applications/editors/vim {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
A friend of mine uses this program for everyday scientific plotting :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
