### PR TITLE
stdenv/darwin: enable tapi support in cctools

### DIFF
--- a/pkgs/os-specific/darwin/libtapi/default.nix
+++ b/pkgs/os-specific/darwin/libtapi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, python3 }:
+{ lib, stdenv, fetchFromGitHub, cmake, python3, ncurses }:
 
 stdenv.mkDerivation {
   name = "libtapi-1000.10.8";
@@ -12,6 +12,10 @@ stdenv.mkDerivation {
   sourceRoot = "source/src/llvm";
 
   nativeBuildInputs = [ cmake python3 ];
+
+  # ncurses is required here to avoid a reference to bootstrap-tools, which is
+  # not allowed for the stdenv.
+  buildInputs = [ ncurses ];
 
   cmakeFlags = [ "-DLLVM_INCLUDE_TESTS=OFF" ];
 

--- a/pkgs/os-specific/darwin/libtapi/default.nix
+++ b/pkgs/os-specific/darwin/libtapi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, python3, clang_6 }:
+{ lib, stdenv, fetchFromGitHub, cmake, python3 }:
 
 stdenv.mkDerivation {
   name = "libtapi-1000.10.8";
@@ -9,22 +9,32 @@ stdenv.mkDerivation {
     sha256 = "1a19h39a48agvnmal99n9j1fjadiqwib7hfzmn342wmgh9z3vk0g";
   };
 
-  nativeBuildInputs = [ cmake python3 ];
-  buildInputs = [ clang_6.cc ];
+  sourceRoot = "source/src/llvm";
 
-  preConfigure = ''
-    cd src/llvm
-  '';
+  nativeBuildInputs = [ cmake python3 ];
 
   cmakeFlags = [ "-DLLVM_INCLUDE_TESTS=OFF" ];
 
-  buildFlags = [ "libtapi" ];
+  # fixes: fatal error: 'clang/Basic/Diagnostic.h' file not found
+  # adapted from upstream
+  # https://github.com/tpoechtrager/apple-libtapi/blob/3cb307764cc5f1856c8a23bbdf3eb49dfc6bea48/build.sh#L58-L60
+  preConfigure = ''
+    INCLUDE_FIX="-I $PWD/projects/clang/include"
+    INCLUDE_FIX+=" -I $PWD/build/projects/clang/include"
 
-  installTarget = "install-libtapi";
+    cmakeFlagsArray+=(-DCMAKE_CXX_FLAGS="$INCLUDE_FIX")
+  '';
+
+  buildFlags = [ "clangBasic" "libtapi" ];
+
+  installTargets = [ "install-libtapi" "install-tapi-headers" ];
+
+  postInstall = ''
+    install_name_tool -id $out/lib/libtapi.dylib $out/lib/libtapi.dylib
+  '';
 
   meta = with lib; {
     license = licenses.apsl20;
     maintainers = with maintainers; [ matthewbauer ];
   };
-
 }

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -198,12 +198,6 @@ in rec {
       python3 = super.python3Minimal;
 
       ninja = super.ninja.override { buildDocs = false; };
-
-      darwin = super.darwin // {
-        cctools = super.darwin.cctools.override {
-          enableTapiSupport = false;
-        };
-      };
     };
   in with prevStage; stageFun 1 prevStage {
     extraPreHook = "export NIX_CFLAGS_COMPILE+=\" -F${bootstrapTools}/Library/Frameworks\"";
@@ -305,7 +299,7 @@ in rec {
     persistent = self: super: with prevStage; {
       inherit
         gnumake gzip gnused bzip2 gawk ed xz patch bash python3
-        ncurses libffi zlib gmp pcre gnugrep
+        ncurses libffi zlib gmp pcre gnugrep cmake
         coreutils findutils diffutils patchutils ninja libxml2;
 
       # Hack to make sure we don't link ncurses in bootstrap tools. The proper
@@ -330,7 +324,6 @@ in rec {
       darwin = super.darwin // rec {
         inherit (darwin) dyld Libsystem libiconv locale;
 
-        cctools = super.darwin.cctools.override { enableTapiSupport = false; };
         CF = super.darwin.CF.override {
           inherit libxml2;
           python3 = prevStage.python3;
@@ -419,7 +412,7 @@ in rec {
       curl.out openssl.out libssh2.out nghttp2.lib libkrb5
       cc.expand-response-params libxml2.out
     ]) ++ (with pkgs.darwin; [
-      dyld Libsystem CF cctools ICU libiconv locale
+      dyld Libsystem CF cctools ICU libiconv locale libtapi
     ]);
 
     overrides = lib.composeExtensions persistent (self: super: {

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -100,6 +100,8 @@ in rec {
         cp ${cctools_}/bin/$i $out/bin
       done
 
+      cp -d ${darwin.libtapi}/lib/libtapi* $out/lib
+
       cp -rd ${pkgs.darwin.CF}/Library $out
 
       chmod -R u+w $out


### PR DESCRIPTION
###### Motivation for this change

Working towards #19906 with the overall goal of Big Sur compatibility via .tbd files.

~Comes with the unfortunate downside of requiring clang_6 to build the stdenv, which increases the time required.~

- [x] Tested:
  - [x] `nix-build -A hello`
  - [x] `nix-build pkgs/stdenv/darwin/make-bootstrap-tools.nix -A test`

cc @matthewbauer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
