### PR TITLE
 pythonPackages.recommonmark: mark broken

### DIFF
--- a/pkgs/development/python-modules/recommonmark/default.nix
+++ b/pkgs/development/python-modules/recommonmark/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/rtfd/recommonmark";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fridh ];
+    broken = true; #broke until it works with sphinx 3
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

# recommonmark marked broken (rest of this text is outdated)

###### Motivation for this change
Adds sphinx2, because recommonmark doesn't support sphinx 3 (this fixes #93117).
To add sphinx2 the file `pkgs/development/python-modules/sphinx/2.nix` has been renamed to 1.nix, since it contains sphinx 1.8.5 (which still uses python2).

`altair` is also setup to use sphinx2, otherwise it fails because of multiple sphinx versions.

The second commit updates sphinx2 from 2.3.1 to 2.4.4.

All packages that failed to build did so for unrelated reason.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
