### PR TITLE
oci-tools: Adds additional arguments and fixes a bug

### DIFF
--- a/pkgs/build-support/oci-tools/default.nix
+++ b/pkgs/build-support/oci-tools/default.nix
@@ -3,76 +3,78 @@
 {
   buildContainer =
     { args
-    , mounts ? {}
+    , mounts ? { }
     , os ? "linux"
     , arch ? "x86_64"
     , readonly ? false
     }:
-  let
-    sysMounts = {
-      "/proc" = {
-        type = "proc";
-        source = "proc";
+    let
+      sysMounts = {
+        "/proc" = {
+          type = "proc";
+          source = "proc";
+        };
+        "/dev" = {
+          type = "tmpfs";
+          source = "tmpfs";
+          options = [ "nosuid" "strictatime" "mode=755" "size=65536k" ];
+        };
+        "/dev/pts" = {
+          type = "devpts";
+          source = "devpts";
+          options = [ "nosuid" "noexec" "newinstance" "ptmxmode=0666" "mode=755" "gid=5" ];
+        };
+        "/dev/shm" = {
+          type = "tmpfs";
+          source = "shm";
+          options = [ "nosuid" "noexec" "nodev" "mode=1777" "size=65536k" ];
+        };
+        "/dev/mqueue" = {
+          type = "mqueue";
+          source = "mqueue";
+          options = [ "nosuid" "noexec" "nodev" ];
+        };
+        "/sys" = {
+          type = "sysfs";
+          source = "sysfs";
+          options = [ "nosuid" "noexec" "nodev" "ro" ];
+        };
+        "/sys/fs/cgroup" = {
+          type = "cgroup";
+          source = "cgroup";
+          options = [ "nosuid" "noexec" "nodev" "realatime" "ro" ];
+        };
       };
-      "/dev" = {
-        type = "tmpfs";
-        source = "tmpfs";
-        options = [ "nosuid" "strictatime" "mode=755" "size=65536k" ];
-      };
-      "/dev/pts" = {
-        type = "devpts";
-        source = "devpts";
-        options = [ "nosuid" "noexec" "newinstance" "ptmxmode=0666" "mode=755" "gid=5" ];
-      };
-      "/dev/shm" = {
-        type = "tmpfs";
-        source = "shm";
-        options = [ "nosuid" "noexec" "nodev" "mode=1777" "size=65536k" ];
-      };
-      "/dev/mqueue" = {
-        type = "mqueue";
-        source = "mqueue";
-        options = [ "nosuid" "noexec" "nodev" ];
-      };
-      "/sys" = {
-        type = "sysfs";
-        source = "sysfs";
-        options = [ "nosuid" "noexec" "nodev" "ro" ];
-      };
-      "/sys/fs/cgroup" = {
-        type = "cgroup";
-        source = "cgroup";
-        options = [ "nosuid" "noexec" "nodev" "realatime" "ro" ];
-      };
-    };
-    config = writeText "config.json" (builtins.toJSON {
-      ociVersion = "1.0.0";
-      platform = {
-        inherit os arch;
-      };
+      config = writeText "config.json" (builtins.toJSON {
+        ociVersion = "1.0.0";
+        platform = {
+          inherit os arch;
+        };
 
-      linux = {
-        namespaces = map (type: { inherit type; }) [ "pid" "network" "mount" "ipc" "uts" ];
-      };
+        linux = {
+          namespaces = map (type: { inherit type; }) [ "pid" "network" "mount" "ipc" "uts" ];
+        };
 
-      root = { path = "rootfs"; inherit readonly; };
+        root = { path = "rootfs"; inherit readonly; };
 
-      process = {
-        inherit args;
-        user = { uid = 0; gid = 0; };
-        cwd = "/";
-      };
+        process = {
+          inherit args;
+          user = { uid = 0; gid = 0; };
+          cwd = "/";
+        };
 
-      mounts = lib.mapAttrsToList (destination: { type, source, options ? null }: {
-        inherit destination type source options;
-      }) sysMounts;
-    });
-  in
-    runCommand "join" {} ''
+        mounts = lib.mapAttrsToList
+          (destination: { type, source, options ? null }: {
+            inherit destination type source options;
+          })
+          sysMounts;
+      });
+    in
+    runCommand "join"
+      { } ''
       set -o pipefail
       mkdir -p $out/rootfs/{dev,proc,sys}
       cp ${config} $out/config.json
       xargs tar c < ${writeReferencesToFile args} | tar -xC $out/rootfs/
     '';
 }
-

--- a/pkgs/build-support/oci-tools/default.nix
+++ b/pkgs/build-support/oci-tools/default.nix
@@ -67,7 +67,7 @@
           (destination: { type, source, options ? null }: {
             inherit destination type source options;
           })
-          sysMounts;
+          (sysMounts // mounts);
       });
     in
     runCommand "join"


### PR DESCRIPTION
##### Motivation for this change

This improves the `pkgs.ociTools.buildContainer` with some additional arguments. It also formats the file and fixes a bug where one of the arguments was unused.

Assuming the new arguments are left with default values, the derivation is almost identical to what it was before this commit. The only different is that the key `process.env` in `config.json` was not present before, while after this commit it will be an empty dictionary.

I am currently using this improved `ociTools` on my machine to build an ephemeral tor-browser inside a container, which is then started with `runc`.

The added arguments are:

* `uid` => put into `process.user.uid` in `config.json`
* `gid` => put into `process.user.gid` in `config.json`
* `processEnv` => mapped to the right format and put into `process.env` in `config.json`.
* `namespaces` => mapped to the right format and put into `linux.namespaces` in `config.json`.
* `shm-size` => put into the mount options for the `/dev/shm` mount entry in `config.json`.
* `extraConfig` => merged with the existing attributes in `config.json`.
* `extraSetupCommands` => run as part of the command to build the derivation. Useful for e.g. creating extra directories in the resulting rootfs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
