### PR TITLE
Pwntools + unicorn update

### DIFF
--- a/pkgs/development/libraries/unicorn-emu/default.nix
+++ b/pkgs/development/libraries/unicorn-emu/default.nix
@@ -1,17 +1,25 @@
-{ stdenv, fetchurl, pkgconfig, python }:
+{ stdenv, fetchurl, pkgconfig, python, cmocka, hexdump, writeScriptBin, binutils-unwrapped }:
 
 stdenv.mkDerivation rec {
   pname = "unicorn-emulator";
-  version = "1.0.1";
+  version = "1.0.2-rc4";
 
   src = fetchurl {
     url    = "https://github.com/unicorn-engine/unicorn/archive/${version}.tar.gz";
-    sha256 = "0z01apwmvhvdldm372ww9pjfn45awkw3m90c0h4v0nj0ihmlysis";
+    sha256 = "05w43jq3r97l3c8ggc745ai8m5l93p1b6q6cfp1zwzz6hl5kifiv";
   };
 
-  configurePhase = '' patchShebangs make.sh '';
-  buildPhase = '' ./make.sh '' + stdenv.lib.optionalString stdenv.isDarwin "macos-universal-no";
-  installPhase = '' env PREFIX=$out ./make.sh install '';
+  PREFIX = placeholder "out";
+  MACOS_UNIVERSAL = stdenv.lib.optionalString stdenv.isDarwin "no";
+  NIX_CFLAGS_COMPILE = "-Wno-error";
+
+  doCheck = !stdenv.isDarwin;
+
+  checkInputs = [
+    cmocka
+    hexdump
+    python.pkgs.setuptools
+  ];
 
   nativeBuildInputs = [ pkgconfig python ];
   enableParallelBuilding = true;

--- a/pkgs/development/python-modules/pwntools/default.nix
+++ b/pkgs/development/python-modules/pwntools/default.nix
@@ -1,19 +1,60 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy3k
-, Mako, packaging, pysocks, pygments, ROPGadget
-, capstone, paramiko, pip, psutil
-, pyelftools, pyserial, dateutil
-, requests, tox, unicorn, intervaltree, fetchpatch }:
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, Mako
+, packaging
+, pysocks
+, pygments
+, ROPGadget
+, capstone
+, paramiko
+, pip
+, psutil
+, pyelftools
+, pyserial
+, dateutil
+, requests
+, tox
+, unicorn
+, intervaltree
+, fetchpatch
+}:
 
 buildPythonPackage rec {
-  version = "4.1.1";
+  version = "4.2.1";
   pname = "pwntools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "694ce7a6cfca0ad40eae36c1d2663c44eb953f84785c63daa9752b4dfa7f39d8";
+    sha256 = "1fh7sq9wrcfvn44qryln9cyg99pilvyq9bp80758lgdd6ss6hdqd";
   };
 
-  propagatedBuildInputs = [ Mako packaging pysocks pygments ROPGadget capstone paramiko pip psutil pyelftools pyserial dateutil requests tox unicorn intervaltree ];
+  # Upstream has set an upper bound on unicorn because of https://github.com/Gallopsled/pwntools/issues/1538,
+  # but since that is a niche use case and it requires extra work to get unicorn 1.0.2rc3 to work we relax
+  # the bound here. Check if this is still necessary when updating!
+  postPatch = ''
+    sed -i 's/unicorn>=1.0.2rc1,<1.0.2rc4/unicorn>=1.0.2rc1/' setup.py
+  '';
+
+  propagatedBuildInputs = [
+    Mako
+    packaging
+    pysocks
+    pygments
+    ROPGadget
+    capstone
+    paramiko
+    pip
+    psutil
+    pyelftools
+    pyserial
+    dateutil
+    requests
+    tox
+    unicorn
+    intervaltree
+  ];
 
   doCheck = false; # no setuptools tests for the package
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Currently pwntools is broken because of incompatible package bounds. To fix it I updated unicorn-emulator, and since it is a pretty big update (even though they only bump patch/rc version numbers) I also added tests to make me more confident that it works.

I haven't tested that unicorn still works on macOS, and I'm unsure if we want doCheck to default to true, I couldn't find any consensus on that when searching.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
