### PR TITLE
obsidian: 0.8.2 -> 0.8.12

### DIFF
--- a/pkgs/applications/misc/obsidian/default.nix
+++ b/pkgs/applications/misc/obsidian/default.nix
@@ -1,32 +1,74 @@
-{ appimageTools, fetchurl, lib, gsettings-desktop-schemas, gtk3}:
+{ stdenv, fetchurl, lib, makeWrapper, electron, makeDesktopItem, graphicsmagick
+, writeScript }:
 
 let
-  pname = "obsidian";
-  version = "0.8.2";
-in
-
-appimageTools.wrapType2 rec {
-
-  name = "${pname}-${version}";
-
-  src = fetchurl {
-    url = "https://github.com/obsidianmd/obsidian-releases/releases/download/v${version}/Obsidian-${version}.AppImage";
-    sha256 = "04jgsd97ivdm84diiafwqxzc9vvga1gsr7xicmqhdq05ns3xsfyz";
+  icon = fetchurl {
+    url =
+      "https://forum.obsidian.md/uploads/default/original/1X/bf119bd48f748f4fd2d65f2d1bb05d3c806883b5.png";
+    sha256 = "18ylnbvxr6k4x44c4i1d55wxy2dq4fdppp43a4wl6h6zar0sc9s2";
   };
 
-  profile = ''
-    export LC_ALL=C.UTF-8
-    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+  desktopItem = makeDesktopItem {
+    name = "obsidian";
+    desktopName = "Obsidian";
+    comment = "Knowledge base";
+    icon = "obsidian";
+    exec = "obsidian";
+    categories = "Office";
+  };
+
+  updateScript = writeScript "obsidian-updater" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq common-updater-scripts
+
+    set -eu -o pipefail
+
+    latestVersion="$(curl -sS https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/desktop-releases.json | jq -r '.latestVersion')"
+
+    update-source-version obsidian "$latestVersion"
   '';
 
-  # Strip version from binary name.
-  extraInstallCommands = "mv $out/bin/{${name},${pname}}";
+in stdenv.mkDerivation rec {
+  pname = "obsidian";
+  version = "0.8.12";
+
+  src = fetchurl {
+    url =
+      "https://github.com/obsidianmd/obsidian-releases/releases/download/v${version}/obsidian-${version}.asar.gz";
+    sha256 = "1rvdxdxrfhw0ldslbnmx26znlvznb1iqpk95c0rh12hlzh4nlgxm";
+  };
+
+  nativeBuildInputs = [ makeWrapper graphicsmagick ];
+
+  unpackPhase = ''
+    gzip -dc $src > obsidian.asar
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    makeWrapper ${electron}/bin/electron $out/bin/obsidian \
+      --add-flags $out/share/electron/obsidian.asar
+
+    install -m 444 -D obsidian.asar $out/share/electron/obsidian.asar
+
+    install -m 444 -D "${desktopItem}/share/applications/"* \
+      -t $out/share/applications/
+
+    for size in 16 24 32 48 64 128 256 512; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      gm convert -resize "$size"x"$size" ${icon} $out/share/icons/hicolor/"$size"x"$size"/apps/obsidian.png
+    done
+  '';
+
+  passthru.updateScript = updateScript;
 
   meta = with lib; {
-    description = "Obsidian is a powerful knowledge base that works on top of a local folder of plain text Markdown files.";
+    description =
+      "Obsidian is a powerful knowledge base that works on top of a local folder of plain text Markdown files";
     homepage = "https://obsidian.md";
     license = licenses.obsidian;
-    maintainers = with maintainers; [ conradmearns ];
+    maintainers = with maintainers; [ conradmearns zaninime ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Updating Obsidian to 0.8.12, while reducing the final closure size. Since the app is based on Electron (without extra native dependencies), I replaced the AppImage with an Electron wrapper.

~~I still rely on the AppImage for building the derivation as it includes both the `.asar` file and the icon file.~~ I found an icon in their official forum. This will reduce the required bandwith for building too.

I also added an `updateScript`.

cc @conradmearns

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
