### PR TITLE
kak-prelude: init at 2020-03-15

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/default.nix
+++ b/pkgs/applications/editors/kakoune/plugins/default.nix
@@ -9,5 +9,6 @@
   kak-fzf = pkgs.callPackage ./kak-fzf.nix { };
   kak-plumb = pkgs.callPackage ./kak-plumb.nix { };
   kak-powerline = pkgs.callPackage ./kak-powerline.nix { };
+  kak-prelude = pkgs.callPackage ./kak-prelude.nix { };
   kak-vertical-selection = pkgs.callPackage ./kak-vertical-selection.nix { };
 }

--- a/pkgs/applications/editors/kakoune/plugins/kak-prelude.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-prelude.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation {
+  name = "kak-prelude";
+  version = "2020-03-15";
+
+  src = fetchFromGitHub {
+    owner = "alexherbo2";
+    repo = "prelude.kak";
+    rev = "05b2642b1e014bd46423f9d738cc38a624947b63";
+    sha256 = "180p8hq8z7mznzd9w9ma5as3ijs7zbzcj96prcpswqg263a0b329";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/kak/autoload/plugins
+    cp -r rc $out/share/kak/autoload/plugins/auto-pairs
+  '';
+
+  meta = with stdenv.lib;
+  { description = "Prelude of shell blocks for Kakoune.";
+    homepage = "https://github.com/alexherbo2/prelude.kak";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ buffet ];
+    platform = platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This is a dependency for some other plugins (like newer versions of auto-pairs.kak).


###### Things done2019-07-27

<!-- Please check what applies. Note tha2019-07-27t these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files [the plugin] (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
