### PR TITLE
datefudge: 1.23 -> 1.24

### DIFF
--- a/pkgs/tools/system/datefudge/default.nix
+++ b/pkgs/tools/system/datefudge/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchgit, fetchpatch }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "datefudge";
   version = "1.24";
 
   src = fetchgit {
-    url = "https://salsa.debian.org/debian/datefudge.git";
-    rev = "6a1b132c14cd7eff58b4fdbbc6ca110cba53d7c6";
+    url = "https://salsa.debian.org/debian/${pname}.git";
+    rev = "debian/${version}";
     sha256 = "1nh433yx4y4djp0bs6aawqbwk7miq7fsbs9wpjlyh2k9dvil2lrm";
   };
 

--- a/pkgs/tools/system/datefudge/default.nix
+++ b/pkgs/tools/system/datefudge/default.nix
@@ -2,20 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "datefudge";
-  version = "1.23";
+  version = "1.24";
 
   src = fetchgit {
     url = "https://salsa.debian.org/debian/datefudge.git";
-    rev = "090d3aace17640478f7f5119518b2f4196f62617";
-    sha256 = "0r9g8v9xnv60hq3j20wqy34kyig3sc2pisjxl4irn7jjx85f1spv";
+    rev = "6a1b132c14cd7eff58b4fdbbc6ca110cba53d7c6";
+    sha256 = "1nh433yx4y4djp0bs6aawqbwk7miq7fsbs9wpjlyh2k9dvil2lrm";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/datefudge/raw/master/f/datefudge_1.23-tz.patch";
-      sha256 = "19c2fvhm06wnp3059b0rnd7dqdchkan8iycjh8jk8y25j870zkvn";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace Makefile \


### PR DESCRIPTION
###### Motivation for this change

Simple version bump.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
