### PR TITLE
MIDIVisualizer: init at 5.1

### DIFF
--- a/pkgs/applications/audio/midi-visualizer/default.nix
+++ b/pkgs/applications/audio/midi-visualizer/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, cmake, pkg-config, libX11, glfw, makeWrapper,
+  libXrandr, libXinerama, libXcursor, gtk3, ffmpeg-full, ...}:
+
+stdenv.mkDerivation rec {
+  pname = "MIDIVisualizer";
+  version = "5.1";
+
+  src = fetchFromGitHub {
+    owner = "kosua20";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1fjlfa0qjpnjxl3bx5cq3dkswv9wihxmgfpkjijqp7kvf3q127rq";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config makeWrapper];
+
+  buildInputs = [
+    libX11
+    glfw
+    libXrandr
+    libXinerama
+    libXcursor
+    gtk3
+    ffmpeg-full
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp MIDIVisualizer $out/bin
+
+    wrapProgram $out/bin/MIDIVisualizer \
+      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A small MIDI visualizer tool, using OpenGL";
+    homepage = "https://github.com/kosua20/MIDIVisualizer";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.ericdallo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14020,6 +14020,8 @@ in
 
   micropython = callPackage ../development/interpreters/micropython { };
 
+  MIDIVisualizer = callPackage ../applications/audio/midi-visualizer { };
+
   mimalloc = callPackage ../development/libraries/mimalloc { };
 
   minizip = callPackage ../development/libraries/minizip { };


### PR DESCRIPTION
###### Motivation for this change
Add MIDIVisualizer application.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
