### PR TITLE
multipath-tools: Fix build with multiple-output lvm2

### DIFF
--- a/pkgs/os-specific/linux/multipath-tools/default.nix
+++ b/pkgs/os-specific/linux/multipath-tools/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    substituteInPlace libmultipath/Makefile --replace /usr/include/libdevmapper.h ${lvm2}/include/libdevmapper.h
+    substituteInPlace libmultipath/Makefile --replace /usr/include/libdevmapper.h ${stdenv.lib.getDev lvm2}/include/libdevmapper.h
     sed -i -re '
       s,^( *#define +DEFAULT_MULTIPATHDIR\>).*,\1 "'"$out/lib/multipath"'",
     ' libmultipath/defaults.h


### PR DESCRIPTION
###### Motivation for this change

It was broken by commit d3a991d41028c5d2a5af2796c0bb542836457822 (#93024).

```
gcc -O2 -g -pipe -Wall -Wextra -Wformat=2 -Werror=implicit-int -Werror=implicit-function-declaration -Werror=format-security -Wno-sign-compare -Wno-unused-parameter -Wno-clobbered -Werror=cast-qual -Werror=discarded-qualifiers -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong --param=ssp-buffer-size=4 -DBIN_DIR=\"/nix/store/k6c2lqi2rm1ara0sa7zm4j1kadmyzn3d-multipath-tools-0.8.3/sbin\" -DLIB_STRING=\"lib\" -DRUN_DIR=\"run\" -MMD -MP  -fPIC -I../libmpathcmd -I../libmpathpersist -I../libmultipath/nvme -DUSE_SYSTEMD=245 -c -o devmapper.o devmapper.c
devmapper.c:47:19: error: conflicting types for 'dm_task_set_cookie'
   47 | static inline int dm_task_set_cookie(struct dm_task *dmt, uint32_t *c, int a)
      |                   ^~~~~~~~~~~~~~~~~~
In file included from devmapper.c:11:
/nix/store/my4c6x9r0ghgq0cd3y0yss5xz81d9m2l-lvm2-2.03.09-dev/include/libdevmapper.h:225:5: note: previous declaration of 'dm_task_set_cookie' was here
  225 | int dm_task_set_cookie(struct dm_task *dmt, uint32_t *cookie, uint16_t flags);
      |     ^~~~~~~~~~~~~~~~~~
devmapper.c:52:6: error: conflicting types for 'dm_udev_wait'
   52 | void dm_udev_wait(unsigned int c)
      |      ^~~~~~~~~~~~
In file included from devmapper.c:11:
/nix/store/my4c6x9r0ghgq0cd3y0yss5xz81d9m2l-lvm2-2.03.09-dev/include/libdevmapper.h:3744:5: note: previous declaration of 'dm_udev_wait' was here
 3744 | int dm_udev_wait(uint32_t cookie);
      |     ^~~~~~~~~~~~
make[1]: *** [../Makefile.inc:137: devmapper.o] Error 1
make[1]: Leaving directory '/build/multipath-tools-0.8.3/libmultipath'
make: *** [Makefile:25: recurse] Error 2
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
