### PR TITLE
finalfusion-utils: init at 0.11.2

### DIFF
--- a/pkgs/applications/science/machine-learning/finalfusion-utils/default.nix
+++ b/pkgs/applications/science/machine-learning/finalfusion-utils/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, installShellFiles
+, blas
+, gfortran
+, lapack
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "finalfusion-utils";
+  version = "0.11.2";
+
+  src = fetchFromGitHub {
+    owner = "finalfusion";
+    repo = pname;
+    rev = version;
+    sha256 = "1y2ik3qj2wbjnnk7bbglwbvyvbm5zfk7mbd1gpxg4495nzlf2jhf";
+  };
+
+  cargoSha256 = "19yay31f76ns1d6b6k9mgw5mrl8zg69y229ca6ssyb2z82gyhsnw";
+
+  # Enables build against a generic BLAS.
+  cargoBuildFlags = [
+    "--features"
+    "netlib"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = [
+    blas
+    gfortran.cc.lib
+    lapack
+  ] ++ lib.optionals stdenv.isDarwin [
+    Security
+  ];
+
+  postInstall = ''
+    # Install shell completions
+    for shell in bash fish zsh; do
+      $out/bin/finalfusion completions $shell > finalfusion.$shell
+    done
+    installShellCompletion finalfusion.{bash,fish,zsh}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Utility for converting, quantizing, and querying word embeddings";
+    homepage = "https://github.com/finalfusion/finalfusion-utils/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19835,6 +19835,10 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  finalfusion-utils = callPackage ../applications/science/machine-learning/finalfusion-utils {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   flacon = libsForQt5.callPackage ../applications/audio/flacon { };
 
   flexget = callPackage ../applications/networking/flexget { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Utility for converting, quantizing, and inspecting word embeddings.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
