### PR TITLE
treewide: fix typo on word environment

### DIFF
--- a/nixos/modules/hardware/video/uvcvideo/default.nix
+++ b/nixos/modules/hardware/video/uvcvideo/default.nix
@@ -26,7 +26,7 @@ in
           Whether to enable <command>uvcvideo</command> dynamic controls.
 
           Note that enabling this brings the <command>uvcdynctrl</command> tool
-          into your environement and register all dynamic controls from
+          into your environment and register all dynamic controls from
           specified <command>packages</command> to the <command>uvcvideo</command> driver.
         '';
       };

--- a/nixos/modules/services/networking/skydns.nix
+++ b/nixos/modules/services/networking/skydns.nix
@@ -64,7 +64,7 @@ in {
     extraConfig = mkOption {
       default = {};
       type = types.attrsOf types.str;
-      description = "Skydns attribute set of extra config options passed as environemnt variables.";
+      description = "Skydns attribute set of extra config options passed as environment variables.";
     };
   };
 

--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     ++ optionals withBluez [ bluez.dev pkgconfig ];
 
   # We need to force the autodetection because detection doesn't
-  # work in pure build enviroments.
+  # work in pure build environments.
   configureFlags = [
     ("--with-pcap=" + {
       linux = "linux";

--- a/pkgs/tools/graphics/lprof/keep-environment.patch
+++ b/pkgs/tools/graphics/lprof/keep-environment.patch
@@ -3,7 +3,7 @@
 @@ -22,12 +22,7 @@
  # opts.Add(BoolOption('qt-mt-lib', 'Flag used to set QT library to either qt-mt or qt. Value of 1 = qt-mt, 0 = qt.', 'yes'))
  
- # setup base environemnt 
+ # setup base environment 
 -env = Environment(
 -    ENV = {
 -      'PATH' : os.environ[ 'PATH' ],


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fast-typing fails on that word, please ping if I need to name commit differently

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
