### PR TITLE
mycli: 1.21.1 -> 1.22.1

### DIFF
--- a/pkgs/tools/admin/mycli/default.nix
+++ b/pkgs/tools/admin/mycli/default.nix
@@ -7,11 +7,11 @@ with python3.pkgs;
 
 buildPythonApplication rec {
   pname = "mycli";
-  version = "1.21.1";
+  version = "1.22.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1q9p0yik9cpvpxjs048anvhicfcna84mpl7axv9bwgr48w40lqwg";
+    sha256 = "18qxxrpdksg3s73va7nkbkwi34kg9m1pls7w4fh5f4jk4p434zsf";
   };
 
   propagatedBuildInputs = [
@@ -24,13 +24,8 @@ buildPythonApplication rec {
     export HOME=.
     export LC_ALL="en_US.UTF-8"
 
-    py.test
-  '';
-
-  # TODO: remove with next release
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "prompt_toolkit>=2.0.6,<3.0.0" "prompt_toolkit"
+    py.test \
+      --ignore=mycli/packages/paramiko_stub/__init__.py
   '';
 
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release (https://github.com/dbcli/mycli/compare/v1.21.1...v1.22.1). 

Need to skip `mycli/packages/paramiko_stub/__init__.py` in `pytest` because this causes the tests to abort immediately.

Tested SSH connection to localhost and performed some queries over this connection.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/hy4h2y0yqwrgb3567f1yg1zmr7h1i5bi-mycli-1.21.1	  172317832
/nix/store/agbvr6qkq1pxly40sf1g8n2mcbdhaabc-mycli-1.22.1	  172335720
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
