### PR TITLE
texlive: new mirror with upstream revisions

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -110,6 +110,8 @@ let
       # should be switching to the tlnet-final versions
       # (https://tug.org/historic/).
       urlPrefixes = args.urlPrefixes or [
+        # revisions are used by upstream
+        "https://ftp.heanet.ie/mirrors/ctan.org/tex/systems/texlive/tlnet/archive"
         # tlnet-final snapshot
         "http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2019/tlnet-final/archive"
         "ftp://tug.org/texlive/historic/2019/tlnet-final/archive"


### PR DESCRIPTION
###### Motivation for this change
Provided mirrors do not contain revisions used by upstream. As a result we have a lot 404 error and long time waiting during i/o operations. New mirror allows to speed up build process and eliminates 404 errors related to texlive. Repo is managed by HEAnet. HEAnet is the national education and research network of Ireland. HEAnet's e-infrastructure services support approximately 210,000 students and staff (third-level) in Ireland, and approximately 800,000 students and staff (first and second-level) relying on the HEAnet network. In total, the network supports approximately 1 million users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
