### PR TITLE
sublime-music: 0.11.0 -> 0.11.7

### DIFF
--- a/pkgs/applications/audio/sublime-music/default.nix
+++ b/pkgs/applications/audio/sublime-music/default.nix
@@ -9,11 +9,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "sublime-music";
-  version = "0.11.0";
+  version = "0.11.7";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1rnjc8pjfaq67mq10gy939g77azc80lxf77s9nsaxds4q5j1yrl2";
+    sha256 = "1x6b02gw46gp6qcgv67j7k3gr1dpfczbyma6dxanag8pnpqrj8qi";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Update to recent release 0.11.7

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
