### PR TITLE
cmusfm: 2018-10-11 -> 2020-07-23

### DIFF
--- a/pkgs/applications/audio/cmusfm/default.nix
+++ b/pkgs/applications/audio/cmusfm/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, curl, libnotify, gdk-pixbuf }:
 
 stdenv.mkDerivation {
-  version = "2018-10-11";
+  version = "2020-07-23";
   pname = "cmusfm-unstable";
   src = fetchFromGitHub {
     owner = "Arkq";
     repo = "cmusfm";
-    rev = "ad2fd0aad3f4f1a25add1b8c2f179e8859885873";
-    sha256 = "0wpwdwgyrp64nvwc6shy0n387p31j6aw6cnmfi9x2y1jhl5hbv6b";
+    rev = "73df3e64d8aa3b5053b639615b8f81d512420e52";
+    sha256 = "1p9i65v8hda9bsps4hm9m2b7aw9ivk4ncllg8svyp455gn5v8xx6";
   };
   # building
   configureFlags = [ "--enable-libnotify" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Minor update, which prevents cmusfm from building against curl 7.71.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
