### PR TITLE
Partial revert of #76542's strict hostname checks

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -216,7 +216,7 @@ class Machine:
             if cmd:
                 match = re.search("run-(.+)-vm$", cmd)
                 if match:
-                    self.name = match.group(1)
+                    self.name = match.group(1).replace(".", "_")
 
         self.script = args.get("startCommand", self.create_startcommand(args))
 

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -376,20 +376,10 @@ in
 
     networking.hostName = mkOption {
       default = "nixos";
-      # Only allow hostnames without the domain name part (i.e. no FQDNs, see
-      # e.g. "man 5 hostname") and require valid DNS labels (recommended
-      # syntax). Note: We also allow underscores for compatibility/legacy
-      # reasons (as undocumented feature):
-      type = types.strMatching
-        "^$|^[[:alpha:]]([[:alnum:]_-]{0,61}[[:alnum:]])?$";
+      type = types.str;
       description = ''
-        The name of the machine. Leave it empty if you want to obtain it from a
-        DHCP server (if using DHCP). The hostname must be a valid DNS label (see
-        RFC 1035 section 2.3.1: "Preferred name syntax") and as such must not
-        contain the domain part. This means that the hostname must start with a
-        letter, end with a letter or digit, and have as interior characters only
-        letters, digits, and hyphen. The maximum length is 63 characters.
-        Additionally it is recommended to only use lower-case characters.
+        The name of the machine.  Leave it empty if you want to obtain
+        it from a DHCP server (if using DHCP).
       '';
     };
 


### PR DESCRIPTION
###### Motivation for this change

See #94011 for context, but in general this check is a bit too strict.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
