### PR TITLE
python3Packages.requests: set default system certificate path

### DIFF
--- a/pkgs/development/python-modules/requests/default.nix
+++ b/pkgs/development/python-modules/requests/default.nix
@@ -11,6 +11,10 @@ buildPythonPackage rec {
     sha256 = "1rhpg0jb08v0gd7f19jjiwlcdnxpmqi1fhvw7r4s9avddi4kvx5k";
   };
 
+  patches = [
+    ./default_ca_bundle.patch
+  ];
+
   nativeBuildInputs = [ pytest ];
   propagatedBuildInputs = [ urllib3 idna chardet certifi ];
   # sadly, tests require networking

--- a/pkgs/development/python-modules/requests/default_ca_bundle.patch
+++ b/pkgs/development/python-modules/requests/default_ca_bundle.patch
@@ -1,0 +1,15 @@
+diff --git a/requests/sessions.py b/requests/sessions.py
+index e8e2d609..3d728851 100644
+--- a/requests/sessions.py
++++ b/requests/sessions.py
+@@ -704,7 +704,9 @@ class Session(SessionRedirectMixin):
+             # with cURL.
+             if verify is True or verify is None:
+                 verify = (os.environ.get('REQUESTS_CA_BUNDLE') or
+-                          os.environ.get('CURL_CA_BUNDLE'))
++                          os.environ.get('CURL_CA_BUNDLE') or
++                          "/etc/ssl/certs/ca-bundle.crt"
++                          )
+ 
+         # Merge all the kwargs.
+         proxies = merge_setting(proxies, self.proxies)


### PR DESCRIPTION
##### Motivation for this change


The next version of ihatemoney will use requests in a system service to connect to a https third party. In the nixos test, I mock this api with nginx and a self signed certificate which I add to the system certificate store. The mock certificated it accepted by curl but not by requests. The reason is that requests seems to ignore the system certificate store. This patch makes it use it.

I don't know if it's the best way to do so, or if there is a better way. In any case:
* this does not contradict the doc https://requests.readthedocs.io/en/stable/user/advanced/#ssl-cert-verification
* this can be overriden by users by passing an environment variable


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
