### PR TITLE
OpenJDK: Update 11 and 14 per July 2020 CPU

### DIFF
--- a/pkgs/development/compilers/openjdk/default.nix
+++ b/pkgs/development/compilers/openjdk/default.nix
@@ -10,7 +10,7 @@
 
 let
   major = "14";
-  update = ".0.1";
+  update = ".0.2";
   build = "-ga";
 
   openjdk = stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ let
 
     src = fetchurl {
       url = "http://hg.openjdk.java.net/jdk-updates/jdk${major}u/archive/jdk-${version}.tar.gz";
-      sha256 = "0ic7dcrzk62jc65yrshs6xlclmsha7z52bia5s2bkllw1zpmdmip";
+      sha256 = "1s1pc6ihzf0awp4hbaqfxmbica0hnrg8nr7s0yd2hfn7nan8xmf3";
     };
 
     nativeBuildInputs = [ pkgconfig autoconf ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Among other things, this fixes a build failure in 14 caused by updating to gnumake 4.3 (0cfe9f3ae25f5c4627664476bececb31e8b0143e):

```
Building target 'all' in configuration 'linux-x86_64-server-release'
make[3]: *** No rule to make target '/build/jdk14u-jdk-14.0.1-ga/build/linux-x86_64-server-release/buildtools/langtools_tools_classes/_the.BUILD_TOOLS_LANGTOOLS.vardeps', needed by '/build/jdk14u-jdk-14.0.1-ga/build/linux-x86_64-server-release/buildtools/langtools_tools_classes/_the.BUILD_TOOLS_LANGTOOLS_batch'.  Stop.
make[3]: *** Waiting for unfinished jobs....
Warning: No SCM configuration present and no .src-rev
make[2]: *** [make/Main.gmk:70: buildtools-langtools] Error 2
make[2]: *** Waiting for unfinished jobs....
make[3]: *** No rule to make target '/build/jdk14u-jdk-14.0.1-ga/build/linux-x86_64-server-release/make-support/vardeps/make/ModuleWrapper.gmk/java.base/ORDERED_CFG_VARIANTS.vardeps', needed by '/build/jdk14u-jdk-14.0.1-ga/build/linux-x86_64-server-release/support/modules_libs/java.base/jvm.cfg'.  Stop.
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [make/Main.gmk:158: java.base-copy] Error 2
make[3]: *** No rule to make target '/build/jdk14u-jdk-14.0.1-ga/build/linux-x86_64-server-release/make-support/vardeps/make/ReleaseFile.gmk/create-info-file.vardeps', needed by '/build/jdk14u-jdk-14.0.1-ga/build/linux-x86_64-server-release/jdk/release'.  Stop.
make[2]: *** [make/Main.gmk:405: release-file] Error 2

ERROR: Build failed for target 'all' in configuration 'linux-x86_64-server-release' (exit code 2)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
