### PR TITLE
cloudfoundry-cli: 6.51.0 -> 7.0.1

### DIFF
--- a/pkgs/development/tools/cloudfoundry-cli/default.nix
+++ b/pkgs/development/tools/cloudfoundry-cli/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, installShellFiles }:
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchurl, installShellFiles }:
 
 buildGoPackage rec {
   pname = "cloudfoundry-cli";
-  version = "6.51.0";
+  version = "7.0.1";
 
   goPackagePath = "code.cloudfoundry.org/cli";
 
@@ -12,7 +12,14 @@ buildGoPackage rec {
     owner = "cloudfoundry";
     repo = "cli";
     rev = "v${version}";
-    sha256 = "189cqng7y12knqm4n1bfajbc2lx027rwb44wddmj5iya27i7fv8f";
+    sha256 = "0jh4x7xlijp1naak5qyc256zkzlrczl6g4iz94s8wx2zj7np0q5l";
+  };
+
+  # upstream have helpfully moved the bash completion script to a separate
+  # repo which receives no releases or even tags
+  bashCompletionScript = fetchurl {
+    url = "https://raw.githubusercontent.com/cloudfoundry/cli-ci/6087781a0e195465a35c79c8e968ae708c6f6351/ci/installers/completion/cf7";
+    sha256 = "1vhg9jcgaxcvvb4pqnhkf27b3qivs4d3w232j0gbh9393m3qxrvy";
   };
 
   nativeBuildInputs = [ installShellFiles ];
@@ -35,7 +42,7 @@ buildGoPackage rec {
 
   installPhase = ''
     install -Dm555 out/cf "$out/bin/cf"
-    installShellCompletion --bash "$src/ci/installers/completion/cf"
+    installShellCompletion --bash $bashCompletionScript
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Bump to 7.0.1. Required some fiddling with the bash completion scripts.

Tested non-nixos linux & macos 10.14.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
