### PR TITLE
qdirstat: 1.6.1 -> 1.7

### DIFF
--- a/pkgs/applications/misc/qdirstat/default.nix
+++ b/pkgs/applications/misc/qdirstat/default.nix
@@ -3,7 +3,7 @@
 , makeWrapper, perlPackages, mkDerivation }:
 
 let
-  version = "1.6.1";
+  version = "1.7";
 in mkDerivation rec {
   pname = "qdirstat";
   inherit version;
@@ -12,7 +12,7 @@ in mkDerivation rec {
     owner = "shundhammer";
     repo = "qdirstat";
     rev = version;
-    sha256 = "0q77a347qv1aka6sni6l03zh5jzyy9s74aygg554r73g01kxczpb";
+    sha256 = "163x3fxra0l3vvrzm25mh7jvcwjbmwsqlpppkxx76mkz9a1769fy";
   };
 
   nativeBuildInputs = [ qmake makeWrapper ];

--- a/pkgs/applications/misc/qdirstat/default.nix
+++ b/pkgs/applications/misc/qdirstat/default.nix
@@ -3,17 +3,19 @@
 , makeWrapper, perlPackages, mkDerivation }:
 
 let
-  version = "1.7";
-in mkDerivation rec {
   pname = "qdirstat";
-  inherit version;
+  version = "1.7";
 
   src = fetchFromGitHub {
     owner = "shundhammer";
-    repo = "qdirstat";
+    repo = pname;
     rev = version;
     sha256 = "163x3fxra0l3vvrzm25mh7jvcwjbmwsqlpppkxx76mkz9a1769fy";
   };
+in
+
+mkDerivation {
+  inherit pname version src;
 
   nativeBuildInputs = [ qmake makeWrapper ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/shundhammer/qdirstat/releases/tag/1.7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
