### PR TITLE
doas: add enablePAM option

### DIFF
--- a/pkgs/tools/security/doas/default.nix
+++ b/pkgs/tools/security/doas/default.nix
@@ -4,6 +4,7 @@
 , bison
 , pam
 
+, withPAM ? true
 , withTimestamp ? true
 }:
 
@@ -23,6 +24,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     (lib.optionalString withTimestamp "--with-timestamp") # to allow the "persist" setting
+    (lib.optionalString (!withPAM) "--without-pam")
     "--pamdir=${placeholder "out"}/etc/pam.d"
   ];
 


### PR DESCRIPTION
New option "enablePAM" controls whether to build support for pluggable
authetincation modules. Default value is "true", which correspond to
existing behaviour. Futhermore, with default configuration, this change
do not cause rebuild.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).