### PR TITLE
synergy: Add patch to fix CVE-2020-15117

### DIFF
--- a/pkgs/applications/misc/synergy/default.nix
+++ b/pkgs/applications/misc/synergy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, cmake, openssl, qttools
+{ stdenv, lib, fetchpatch, fetchFromGitHub, cmake, openssl, qttools
 , ApplicationServices, Carbon, Cocoa, CoreServices, ScreenSaver
 , xlibsWrapper, libX11, libXi, libXtst, libXrandr, xinput, avahi-compat
 , withGUI ? true, wrapQtAppsHook }:
@@ -14,7 +14,14 @@ stdenv.mkDerivation rec {
     sha256 = "1jk60xw4h6s5crha89wk4y8rrf1f3bixgh5mzh3cq3xyrkba41gh";
   };
 
-  patches = [ ./build-tests.patch
+  patches = [
+    ./build-tests.patch
+    (fetchpatch {
+      name = "CVE-2020-15117.patch";
+      url = "https://github.com/symless/synergy-core/commit/"
+          + "0a97c2be0da2d0df25cb86dfd642429e7a8bea39.patch";
+      sha256 = "03q8m5n50fms7fjfjgmqrgy9mrxwi9kkz3f3vlrs2x5h21dl6bmj";
+    })
   ] ++ lib.optional stdenv.isDarwin ./macos_build_fix.patch;
 
   # Since the included gtest and gmock don't support clang and the


### PR DESCRIPTION
From the description of CVE-2020-15117:

> In Synergy before version 1.12.0, a Synergy server can be crashed by receiving a kMsgHelloBack packet with a client name length set to 0xffffffff (4294967295) if the servers memory is less than 4 GB. It was verified that this issue does not cause a crash through the exception handler if the available memory of the Server is more than 4GB.

While I personally would consider this a pretty low-priority issue since Synergy usually is only used in local environment, it's nevertheless better to patch known issues.

Since the fix is part of version 1.12, which doesn't have a stable release yet, I'm including the fix as a patch cherry-picked from the
upstream commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).