### PR TITLE
datefudge: work correctly even if GNU date is not in PATH

### DIFF
--- a/pkgs/tools/system/datefudge/default.nix
+++ b/pkgs/tools/system/datefudge/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchgit, fetchpatch, makeWrapper, coreutils ? null }:
+{ stdenv, lib, fetchgit, fetchpatch, makeWrapper, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "datefudge";
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
     rev = "debian/${version}";
     sha256 = "1nh433yx4y4djp0bs6aawqbwk7miq7fsbs9wpjlyh2k9dvil2lrm";
   };
-  nativeBuildInputs = lib.optional (coreutils != null) makeWrapper;
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ coreutils ];
 
   postPatch = ''
     substituteInPlace Makefile \
@@ -23,7 +25,6 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     chmod +x $out/lib/datefudge/datefudge.so
-  '' + lib.optionalString (coreutils != null) ''
     wrapProgram $out/bin/datefudge --prefix PATH : ${coreutils}/bin
   '';
 

--- a/pkgs/tools/system/datefudge/default.nix
+++ b/pkgs/tools/system/datefudge/default.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     rev = "debian/${version}";
     sha256 = "1nh433yx4y4djp0bs6aawqbwk7miq7fsbs9wpjlyh2k9dvil2lrm";
   };
+
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [ coreutils ];

--- a/pkgs/tools/system/datefudge/default.nix
+++ b/pkgs/tools/system/datefudge/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit, fetchpatch }:
+{ stdenv, lib, fetchgit, fetchpatch, makeWrapper, coreutils ? null }:
 
 stdenv.mkDerivation rec {
   pname = "datefudge";
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     rev = "debian/${version}";
     sha256 = "1nh433yx4y4djp0bs6aawqbwk7miq7fsbs9wpjlyh2k9dvil2lrm";
   };
+  nativeBuildInputs = lib.optional (coreutils != null) makeWrapper;
 
   postPatch = ''
     substituteInPlace Makefile \
@@ -20,7 +21,11 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "DESTDIR=$(out)" ];
 
-  postInstall = "chmod +x $out/lib/datefudge/datefudge.so";
+  postInstall = ''
+    chmod +x $out/lib/datefudge/datefudge.so
+  '' + lib.optionalString (coreutils != null) ''
+    wrapProgram $out/bin/datefudge --prefix PATH : ${coreutils}/bin
+  '';
 
   meta = with lib; {
     description = "Fake the system date";


### PR DESCRIPTION
Examples in manual assumes advanced features from date(1) like "last
Friday", which only available in GNU coreutils version of date(1)
utility. Without this patch, most examples from datefudge(1) manual will
fail in busybox environment, which is confusing.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).