### PR TITLE
qutebrowser: fixup of 322d13e

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -4,7 +4,7 @@
 , libxslt, gst_all_1 ? null
 , withPdfReader      ? true
 , withMediaPlayback  ? true
-, backend            ? "webkit"
+, backend            ? "webengine"
 }:
 
 assert withMediaPlayback -> gst_all_1 != null;


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/NixOS/nixpkgs/pull/93336#issuecomment-664707718

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s)
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (qutebrowser)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @emmanuelrosa 