### PR TITLE
nixos/mysql: add statements option to replace initialDatabases, ensureDatabases, and ensureUsers options

### DIFF
--- a/nixos/modules/services/mail/sympa.nix
+++ b/nixos/modules/services/mail/sympa.nix
@@ -570,12 +570,14 @@ in
     services.mysql = optionalAttrs mysqlLocal {
       enable = true;
       package = mkDefault pkgs.mariadb;
-      ensureDatabases = [ cfg.database.name ];
-      ensureUsers = [
-        { name = cfg.database.user;
-          ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; };
-        }
-      ];
+      statements =
+        let
+          unix_socket = if (lib.getName config.services.mysql.package == "mariadb-server") then "unix_socket" else "auth_socket";
+        in ''
+          create database if not exists `${cfg.database.name}`;
+          create user if not exists '${cfg.database.user}'@'localhost' identified with ${unix_socket};
+          grant all privileges on `${cfg.database.name}`.* to '${cfg.database.user}'@'localhost';
+        '';
     };
 
     services.postgresql = optionalAttrs pgsqlLocal {

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -347,13 +347,14 @@ in
     services.mysql = optionalAttrs (useMysql && cfg.database.createDatabase) {
       enable = mkDefault true;
       package = mkDefault pkgs.mariadb;
-
-      ensureDatabases = [ cfg.database.name ];
-      ensureUsers = [
-        { name = cfg.database.user;
-          ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; };
-        }
-      ];
+      statements =
+        let
+          unix_socket = if (lib.getName config.services.mysql.package == "mariadb-server") then "unix_socket" else "auth_socket";
+        in ''
+          create database if not exists `${cfg.database.name}`;
+          create user if not exists '${cfg.database.user}'@'localhost' identified with ${unix_socket};
+          grant all privileges on `${cfg.database.name}`.* to '${cfg.database.user}'@'localhost';
+        '';
     };
 
     systemd.tmpfiles.rules = [

--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -246,12 +246,14 @@ in
     services.mysql = mkIf mysqlLocal {
       enable = true;
       package = mkDefault pkgs.mariadb;
-      ensureDatabases = [ cfg.database.name ];
-      ensureUsers = [
-        { name = cfg.database.user;
-          ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; };
-        }
-      ];
+      statements =
+        let
+          unix_socket = if (lib.getName config.services.mysql.package == "mariadb-server") then "unix_socket" else "auth_socket";
+        in ''
+          create database if not exists `${cfg.database.name}`;
+          create user if not exists '${cfg.database.user}'@'localhost' identified with ${unix_socket};
+          grant all privileges on `${cfg.database.name}`.* to '${cfg.database.user}'@'localhost';
+        '';
     };
 
     services.postgresql = mkIf pgsqlLocal {

--- a/nixos/modules/services/misc/zoneminder.nix
+++ b/nixos/modules/services/misc/zoneminder.nix
@@ -213,11 +213,14 @@ in {
       mysql = lib.mkIf cfg.database.createLocally {
         enable = true;
         package = lib.mkDefault pkgs.mariadb;
-        ensureDatabases = [ cfg.database.name ];
-        ensureUsers = [{
-          name = cfg.database.username;
-          ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; };
-        }];
+        statements =
+          let
+            unix_socket = if (lib.getName config.services.mysql.package == "mariadb-server") then "unix_socket" else "auth_socket";
+          in ''
+            create database if not exists `${cfg.database.name}`;
+            create user if not exists '${cfg.database.user}'@'localhost' identified with ${unix_socket};
+            grant all privileges on `${cfg.database.name}`.* to '${cfg.database.user}'@'localhost';
+          '';
       };
 
       nginx = lib.mkIf useNginx {

--- a/nixos/modules/services/monitoring/zabbix-proxy.nix
+++ b/nixos/modules/services/monitoring/zabbix-proxy.nix
@@ -220,12 +220,14 @@ in
     services.mysql = optionalAttrs mysqlLocal {
       enable = true;
       package = mkDefault pkgs.mariadb;
-      ensureDatabases = [ cfg.database.name ];
-      ensureUsers = [
-        { name = cfg.database.user;
-          ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; };
-        }
-      ];
+      statements =
+        let
+          unix_socket = if (lib.getName config.services.mysql.package == "mariadb-server") then "unix_socket" else "auth_socket";
+        in ''
+          create database if not exists `${cfg.database.name}`;
+          create user if not exists '${cfg.database.user}'@'localhost' identified with ${unix_socket};
+          grant all privileges on `${cfg.database.name}`.* to '${cfg.database.user}'@'localhost';
+        '';
     };
 
     services.postgresql = optionalAttrs pgsqlLocal {

--- a/nixos/modules/services/web-apps/engelsystem.nix
+++ b/nixos/modules/services/web-apps/engelsystem.nix
@@ -90,11 +90,14 @@ in {
     services.mysql = mkIf cfg.createDatabase {
       enable = true;
       package = mkDefault pkgs.mysql;
-      ensureUsers = [{
-        name = "engelsystem";
-        ensurePermissions = { "engelsystem.*" = "ALL PRIVILEGES"; };
-      }];
-      ensureDatabases = [ "engelsystem" ];
+      statements =
+        let
+          unix_socket = if (lib.getName config.services.mysql.package == "mariadb-server") then "unix_socket" else "auth_socket";
+        in ''
+          create database if not exists `engelsystem`;
+          create user if not exists 'engelsystem'@'localhost' identified with ${unix_socket};
+          grant all privileges on `engelsystem`.* to 'engelsystem'@'localhost';
+        '';
     };
 
     environment.etc."engelsystem/config.php".source =

--- a/nixos/modules/services/web-apps/mediawiki.nix
+++ b/nixos/modules/services/web-apps/mediawiki.nix
@@ -375,12 +375,14 @@ in
     services.mysql = mkIf cfg.database.createLocally {
       enable = true;
       package = mkDefault pkgs.mariadb;
-      ensureDatabases = [ cfg.database.name ];
-      ensureUsers = [
-        { name = cfg.database.user;
-          ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; };
-        }
-      ];
+      statements =
+        let
+          unix_socket = if (lib.getName config.services.mysql.package == "mariadb-server") then "unix_socket" else "auth_socket";
+        in ''
+          create database if not exists `${cfg.database.name}`;
+          create user if not exists '${cfg.database.user}'@'localhost' identified with ${unix_socket};
+          grant all privileges on `${cfg.database.name}`.* to '${cfg.database.user}'@'localhost';
+        '';
     };
 
     services.phpfpm.pools.mediawiki = {

--- a/nixos/modules/services/web-apps/moodle.nix
+++ b/nixos/modules/services/web-apps/moodle.nix
@@ -203,14 +203,14 @@ in
     services.mysql = mkIf mysqlLocal {
       enable = true;
       package = mkDefault pkgs.mariadb;
-      ensureDatabases = [ cfg.database.name ];
-      ensureUsers = [
-        { name = cfg.database.user;
-          ensurePermissions = {
-            "${cfg.database.name}.*" = "SELECT, INSERT, UPDATE, DELETE, CREATE, CREATE TEMPORARY TABLES, DROP, INDEX, ALTER";
-          };
-        }
-      ];
+      statements =
+        let
+          unix_socket = if (lib.getName config.services.mysql.package == "mariadb-server") then "unix_socket" else "auth_socket";
+        in ''
+          create database if not exists `${cfg.database.name}`;
+          create user if not exists '${cfg.database.user}'@'localhost' identified with ${unix_socket};
+          grant select, insert, update, delete, create, create temporary tables, drop, index, alter on `${cfg.database.name}`.* to '${cfg.database.user}'@'localhost';
+        '';
     };
 
     services.postgresql = mkIf pgsqlLocal {

--- a/nixos/tests/mysql/mariadb-galera-mariabackup.nix
+++ b/nixos/tests/mysql/mariadb-galera-mariabackup.nix
@@ -38,14 +38,10 @@ in {
       services.mysql = {
         enable = true;
         package = pkgs.mariadb;
-        ensureDatabases = [ "testdb" ];
-        ensureUsers = [{
-          name = "testuser";
-          ensurePermissions = {
-            "testdb.*" = "ALL PRIVILEGES";
-          };
-        }];
-        initialScript = pkgs.writeText "mariadb-init.sql" ''
+        statements = ''
+          CREATE DATABASE IF NOT EXISTS `testdb`;
+          CREATE USER IF NOT EXISTS 'testuser'@'localhost' IDENTIFIED WITH unix_socket;
+          GRANT ALL PRIVILEGES ON `testdb`.* TO 'testuser'@'localhost';
           GRANT ALL PRIVILEGES ON *.* TO 'check_repl'@'localhost' IDENTIFIED BY 'check_pass' WITH GRANT OPTION;
           FLUSH PRIVILEGES;
         '';

--- a/nixos/tests/mysql/mariadb-galera-rsync.nix
+++ b/nixos/tests/mysql/mariadb-galera-rsync.nix
@@ -38,13 +38,11 @@ in {
       services.mysql = {
         enable = true;
         package = pkgs.mariadb;
-        ensureDatabases = [ "testdb" ];
-        ensureUsers = [{
-          name = "testuser";
-          ensurePermissions = {
-            "testdb.*" = "ALL PRIVILEGES";
-          };
-        }];
+        statements = ''
+          CREATE DATABASE IF NOT EXISTS `testdb`;
+          CREATE USER IF NOT EXISTS 'testuser'@'localhost' IDENTIFIED WITH unix_socket;
+          GRANT ALL PRIVILEGES ON `testdb`.* TO 'testuser'@'localhost';
+        '';
         settings = {
           mysqld = {
             bind_address = "0.0.0.0";

--- a/nixos/tests/mysql/mysql-autobackup.nix
+++ b/nixos/tests/mysql/mysql-autobackup.nix
@@ -9,8 +9,11 @@ import ./../make-test-python.nix ({ pkgs, lib, ... }:
     {
       services.mysql.enable = true;
       services.mysql.package = pkgs.mysql;
-      services.mysql.initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
-
+      services.mysql.statements = ''
+        create database if not exists `testdb`;
+        use `testdb`;
+        ${builtins.readFile ./testdb.sql}
+      '';
       services.automysqlbackup.enable = true;
     };
 

--- a/nixos/tests/mysql/mysql-backup.nix
+++ b/nixos/tests/mysql/mysql-backup.nix
@@ -9,8 +9,12 @@ import ./../make-test-python.nix ({ pkgs, ... } : {
     master = { pkgs, ... }: {
       services.mysql = {
         enable = true;
-        initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
         package = pkgs.mysql;
+        statements = ''
+          create database if not exists `testdb`;
+          use `testdb`;
+          ${builtins.readFile ./testdb.sql}
+        '';
       };
 
       services.mysqlBackup = {

--- a/nixos/tests/mysql/mysql-replication.nix
+++ b/nixos/tests/mysql/mysql-replication.nix
@@ -22,7 +22,11 @@ in
         services.mysql.replication.slaveHost = "%";
         services.mysql.replication.masterUser = replicateUser;
         services.mysql.replication.masterPassword = replicatePassword;
-        services.mysql.initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
+        services.mysql.statements = ''
+          create database if not exists `testdb`;
+          use `testdb`;
+          ${builtins.readFile ./testdb.sql}
+        '';
         networking.firewall.allowedTCPPorts = [ 3306 ];
       };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I would like to proceed with https://github.com/NixOS/nixpkgs/pull/84146 but the `mysql` module is more pressing to my immediate needs. Specifically I can't move ahead with https://github.com/NixOS/nixpkgs/pull/87712 using the `ensureDatabase` options as there is no ability to specify character sets, etc...

If this is merged I would follow up by rebasing https://github.com/NixOS/nixpkgs/pull/87712 and getting it in shape for merge as well.

NOTE: I haven't written release notes for this yet, waiting on general approval of this PR first.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
