### PR TITLE
Update Vulkan, SPIR-V, glslang and shaderc

### DIFF
--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -5,7 +5,36 @@
 , python3
 , spirv-headers
 , spirv-tools
+, argSpirv-tools ? null
+, argSpirv-headers ? null
 }:
+# glslang requires custom versions of spirv-tools and spirb-headers.
+# The exact versions are taken from:
+# https://github.com/KhronosGroup/glslang/blob/master/known_good.json
+
+let
+  localSpirv-tools = if argSpirv-tools == null
+    then spirv-tools.overrideAttrs (_: {
+      src = fetchFromGitHub {
+        owner = "KhronosGroup";
+        repo = "SPIRV-Tools";
+        rev = "fd8e130510a6b002b28eee5885a9505040a9bdc9";
+        sha256 = "00b7xgyrcb2qq63pp3cnw5q1xqx2d9rfn65lai6n6r89s1vh3vg6";
+      };
+    })
+    else argSpirv-tools;
+
+  localSpirv-headers = if argSpirv-headers == null
+    then spirv-headers.overrideAttrs (_: {
+      src = fetchFromGitHub {
+        owner = "KhronosGroup";
+        repo = "SPIRV-Headers";
+        rev = "f8bf11a0253a32375c32cad92c841237b96696c0";
+        sha256 = "1znwjy02dl9rshqzl87rqsv9mfczw7gvwfhcirbl81idahgp4p6l";
+      };
+    })
+    else argSpirv-headers;
+in
 
 stdenv.mkDerivation rec {
   pname = "glslang";
@@ -20,22 +49,23 @@ stdenv.mkDerivation rec {
 
   # These get set at all-packages, keep onto them for child drvs
   passthru = {
-    inherit spirv-tools spirv-headers;
+    spirv-tools = localSpirv-tools;
+    spirv-headers = localSpirv-headers;
   };
 
   nativeBuildInputs = [ cmake python3 bison jq ];
   enableParallelBuilding = true;
 
   postPatch = ''
-    cp --no-preserve=mode -r "${spirv-tools.src}" External/spirv-tools
-    ln -s "${spirv-headers.src}" External/spirv-tools/external/spirv-headers
+    cp --no-preserve=mode -r "${localSpirv-tools.src}" External/spirv-tools
+    ln -s "${localSpirv-headers.src}" External/spirv-tools/external/spirv-headers
   '';
 
   # Ensure spirv-headers and spirv-tools match exactly to what is expected
   preConfigure = ''
     HEADERS_COMMIT=$(jq -r < known_good.json '.commits|map(select(.name=="spirv-tools/external/spirv-headers"))[0].commit')
     TOOLS_COMMIT=$(jq -r < known_good.json '.commits|map(select(.name=="spirv-tools"))[0].commit')
-    if [ "$HEADERS_COMMIT" != "${spirv-headers.src.rev}" ] || [ "$TOOLS_COMMIT" != "${spirv-tools.src.rev}" ]; then
+    if [ "$HEADERS_COMMIT" != "${localSpirv-headers.src.rev}" ] || [ "$TOOLS_COMMIT" != "${localSpirv-tools.src.rev}" ]; then
       echo "ERROR: spirv-tools commits do not match expected versions: expected tools at $TOOLS_COMMIT, headers at $HEADERS_COMMIT";
       exit 1;
     fi

--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "glslang";
-  version = "8.13.3559";
+  version = "8.13.3743";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
     rev = version;
-    sha256 = "0waamlh2vqh1k40m169294xdlm0iqjkx2vis4qyxfki0r0cnsmnk";
+    sha256 = "0d20wfpp2fmbnz1hnsjr9xc62lxpj86ik2qyviqbni0pqj212cry";
   };
 
   # These get set at all-packages, keep onto them for child drvs

--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -8,24 +8,24 @@ let
   glslang = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
-    rev = "3ed344dd784ecbbc5855e613786f3a1238823e56";
-    sha256 = "00s2arfvw78d9k9fmangqlkvkmkpqzrin3g91vfab4wr8srb09dx";
+    rev = "3ee5f2f1d3316e228916788b300d786bb574d337";
+    sha256 = "1l5h9d92mzd35pgs0wibqfg7vbl771lwnvdlcsyhf6999khn5dzv";
   };
   spirv-tools = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Tools";
-    rev = "323a81fc5e30e43a04e5e22af4cba98ca2a161e6";
-    sha256 = "1kwyh95l02w3v1ra55c836wayzw8d0m14ab7wf0ynhhyp3k2p9hv";
+    rev = "b63f0e5ed3e818870968ebf6af73317127fd07b0";
+    sha256 = "1chv30azfp76nha428ivg4ixrij6d8pxj5kn3jam87gmkmgc9zhm";
   };
   spirv-headers = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
-    rev = "204cd131c42b90d129073719f2766293ce35c081";
-    sha256 = "1gp0mlbfccqnalaix97jxsa5i337xyzyr55wgssapy56p0q04wv2";
+    rev = "979924c8bc839e4cb1b69d03d48398551f369ce7";
+    sha256 = "07vyjlblpm4zhfds612h86lnz0qvrj5qqw5z2zzfa3m9fax7cm85";
   };
 in stdenv.mkDerivation rec {
   pname = "shaderc";
-  version = "2019.1";
+  version = "2020.2";
 
   outputs = [ "out" "lib" "bin" "dev" "static" ];
 
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
     owner = "google";
     repo = "shaderc";
     rev = "v${version}";
-    sha256 = "0x514rpignnb4vvl7wmijfakqc59986knjw3dh1zx0ah42xa7x37";
+    sha256 = "1sxz8872x3rdlrhmbn83r1vniq4j51jnk0ka3447fq68il4myf1w";
   };
 
   patchPhase = ''

--- a/pkgs/development/libraries/spirv-headers/default.nix
+++ b/pkgs/development/libraries/spirv-headers/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "spirv-headers";
-  version = "1.5.1";
+  version = "1.5.3";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
     rev = version;
-    sha256 = "1fnd8qwss6pxcch5j9qi1pdz70828zxsg4m8apgrhyj0p9lm0rbg";
+    sha256 = "069sivqajp7z4p44lmrz23lvf237xpkjxd4lzrg27836pwqcz9bj";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/vulkan-headers/default.nix
+++ b/pkgs/development/libraries/vulkan-headers/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake }:
 stdenv.mkDerivation rec {
   pname = "vulkan-headers";
-  version = "1.2.131.1";
+  version = "1.2.141.0";
 
   nativeBuildInputs = [ cmake ];
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "KhronosGroup";
     repo = "Vulkan-Headers";
     rev = "sdk-${version}";
-    sha256 = "1yf42c2cnhx1y4wkxsdl6g653xl2vvamhpkldz6jb4ca5wk03gxf";
+    sha256 = "10nmx6y4llllfcczyfz76amd0vkqv09dj952d19zkzmmgcval7zq";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-loader";
-  version = "1.2.131.2";
+  version = "1.2.141.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-Loader";
     rev = "sdk-${version}";
-    sha256 = "12n4mxc6db89258k8i47ql1zna7k94lkwv7lpxg39nm8ypa1ywrv";
+    sha256 = "10fyg71dza6qakz5zdchccfn0zcr8b1zpfi2rqir6jpzcbi28kcj";
   };
 
   nativeBuildInputs = [ pkgconfig cmake ];

--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, python3, spirv-headers }:
 let
   # Update spirv-headers rev in lockstep according to DEPs file
-  version = "2019.4";
+  version = "2020.2";
 in
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "KhronosGroup";
     repo = "SPIRV-Tools";
     rev = "v${version}";
-    sha256 = "17bbvhk4p42x4jlvcr5p9903xiiryw57c8yyfxmqik10s8601an9";
+    sha256 = "00b7xgyrcb2qq63pp3cnw5q1xqx2d9rfn65lai6n6r89s1vh3vg6";
   };
   enableParallelBuilding = true;
 

--- a/pkgs/development/tools/vulkan-validation-layers/default.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/default.nix
@@ -1,23 +1,39 @@
 { stdenv, fetchFromGitHub, cmake, writeText, python3
-, vulkan-headers, vulkan-loader, glslang
+, vulkan-headers, vulkan-loader, glslang, spirv-headers
 , pkgconfig, xlibsWrapper, libxcb, libXrandr, wayland }:
 
 stdenv.mkDerivation rec {
   pname = "vulkan-validation-layers";
-  version = "1.2.131.2";
+  version = "1.2.141.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-ValidationLayers";
     rev = "sdk-${version}";
-    sha256 = "1sz0388cr018ldx6ziplvk4v3zbg44pww77kv6kv5wxl69plwfcn";
+    sha256 = "1yfas7q122kx74nbjk3wxlyacysgncvlvq081a5dp238m88vkmbj";
   };
 
-  nativeBuildInputs = [ pkgconfig cmake python3  ];
-  buildInputs = [ vulkan-headers vulkan-loader libxcb libXrandr wayland ];
+  nativeBuildInputs = [
+    pkgconfig
+    cmake
+    python3
+  ];
+
+  buildInputs = [
+    glslang
+    spirv-headers
+    vulkan-headers
+    vulkan-loader
+    libxcb
+    libXrandr
+    wayland
+  ];
+
   enableParallelBuilding = true;
 
-  cmakeFlags = [ "-DGLSLANG_INSTALL_DIR=${glslang}" ];
+  cmakeFlags = [
+    "-DGLSLANG_INSTALL_DIR=${glslang}"
+  ];
 
   # Help vulkan-loader find the validation layers
   setupHook = writeText "setup-hook" ''

--- a/pkgs/development/tools/vulkan-validation-layers/default.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/default.nix
@@ -1,6 +1,51 @@
-{ stdenv, fetchFromGitHub, cmake, writeText, python3
-, vulkan-headers, vulkan-loader, glslang, spirv-headers
-, pkgconfig, xlibsWrapper, libxcb, libXrandr, wayland }:
+{ stdenv
+, fetchFromGitHub
+, cmake
+, writeText
+, python3
+, spirv-headers
+, spirv-tools
+, vulkan-headers
+, vulkan-loader
+, glslang
+, pkgconfig
+, xlibsWrapper
+, libxcb
+, libXrandr
+, wayland
+}:
+# vulkan-validation-layers requires a custom glslang version, while glslang requires
+# custom versions for spirv-tools and spirv-headers. The git hashes required for all
+# of these deps is documented upstream here:
+# https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/scripts/known_good.json
+
+let
+  localGlslang = (glslang.override {
+    argSpirv-tools = spirv-tools.overrideAttrs (_: {
+      src = fetchFromGitHub {
+        owner = "KhronosGroup";
+        repo = "SPIRV-Tools";
+        rev = "e128ab0d624ce7beb08eb9656bb260c597a46d0a";
+        sha256 = "0jj8zrl3dh9fq71jc8msx3f3ifb2vjcb37nl0w4sa8sdhfff74pv";
+      };
+    });
+    argSpirv-headers = spirv-headers.overrideAttrs (_: {
+      src = fetchFromGitHub {
+        owner = "KhronosGroup";
+        repo = "SPIRV-Headers";
+        rev = "ac638f1815425403e946d0ab78bac71d2bdbf3be";
+        sha256 = "1lkhs7pxcrfkmiizcxl0w5ajx6swwjv7w3iq586ipgh571fc75gx";
+      };
+    });
+  }).overrideAttrs (_: {
+    src = fetchFromGitHub {
+      owner = "KhronosGroup";
+      repo = "glslang";
+      rev = "e00d27c6d65b7d3e72506a311d7f053da4051295";
+      sha256 = "00lzvzk613gpm1vsdxffmx52z3c52ijwvzk4sfhh95p71kdydhgv";
+    };
+  });
+in
 
 stdenv.mkDerivation rec {
   pname = "vulkan-validation-layers";
@@ -20,8 +65,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    glslang
-    spirv-headers
+    localGlslang
+    localGlslang.spirv-headers
     vulkan-headers
     vulkan-loader
     libxcb
@@ -32,7 +77,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   cmakeFlags = [
-    "-DGLSLANG_INSTALL_DIR=${glslang}"
+    "-DGLSLANG_INSTALL_DIR=${localGlslang}"
   ];
 
   # Help vulkan-loader find the validation layers

--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -1,22 +1,33 @@
-{ stdenv, fetchFromGitHub, cmake, python3, vulkan-loader, vulkan-headers,
-  glslang, pkgconfig, xlibsWrapper, libxcb, libXrandr, wayland }:
+{ stdenv, lib, fetchFromGitHub, cmake, python3, vulkan-loader,
+ vulkan-headers, glslang, pkgconfig, xlibsWrapper, libxcb,
+ libXrandr, wayland }:
 
 stdenv.mkDerivation rec {
   pname = "vulkan-tools";
-  version = "1.2.131.1";
+  version = "1.2.141.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-Tools";
     rev = "sdk-${version}";
-    sha256 = "0ws47ansrr8cq4qjf6k4q0ygm9wwd3w7mhwqcl1qxms8lh5vmhfq";
+    sha256 = "1ch56ihm7rmilipfyc4i4ww7l6i20fb3qikkpm1ch43kzn42zjaw";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ python3 vulkan-headers vulkan-loader xlibsWrapper libxcb libXrandr wayland ];
   enableParallelBuilding = true;
 
-  cmakeFlags = [ "-DBUILD_ICD=OFF" "-DGLSLANG_INSTALL_DIR=${glslang}" ];
+  libraryPath = lib.strings.makeLibraryPath [ vulkan-loader ];
+
+  dontPatchELF = true;
+
+  cmakeFlags = [
+    # Don't build the mock ICD as it may get used instead of other drivers, if installed
+    "-DBUILD_ICD=OFF"
+    "-DGLSLANG_INSTALL_DIR=${glslang}"
+    # vulkaninfo loads libvulkan using dlopen, so we have to add it manually to RPATH
+    "-DCMAKE_INSTALL_RPATH=${libraryPath}"
+  ];
 
   meta = with stdenv.lib; {
     description = "LunarG Vulkan loader";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9099,16 +9099,16 @@ in
       src = fetchFromGitHub {
         owner = "KhronosGroup";
         repo = "SPIRV-Tools";
-        rev = "5c019b5923c1f6bf00a3ac28114ec4a7b1faa0e2";
-        sha256 = "17a0kiyb7zjsg7ws12diip84vds1ajl98ni9c2wria6ymcvbvsvz";
+        rev = "fd8e130510a6b002b28eee5885a9505040a9bdc9";
+        sha256 = "00b7xgyrcb2qq63pp3cnw5q1xqx2d9rfn65lai6n6r89s1vh3vg6";
       };
     });
     spirv-headers = spirv-headers.overrideAttrs (_: {
       src = fetchFromGitHub {
         owner = "KhronosGroup";
         repo = "SPIRV-Headers";
-        rev = "204cd131c42b90d129073719f2766293ce35c081";
-        sha256 = "1gp0mlbfccqnalaix97jxsa5i337xyzyr55wgssapy56p0q04wv2";
+        rev = "f8bf11a0253a32375c32cad92c841237b96696c0";
+        sha256 = "1znwjy02dl9rshqzl87rqsv9mfczw7gvwfhcirbl81idahgp4p6l";
       };
     });
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15824,24 +15824,24 @@ in
         src = fetchFromGitHub {
           owner = "KhronosGroup";
           repo = "SPIRV-Tools";
-          rev = "323a81fc5e30e43a04e5e22af4cba98ca2a161e6";
-          sha256 = "1kwyh95l02w3v1ra55c836wayzw8d0m14ab7wf0ynhhyp3k2p9hv";
+          rev = "e128ab0d624ce7beb08eb9656bb260c597a46d0a";
+          sha256 = "0jj8zrl3dh9fq71jc8msx3f3ifb2vjcb37nl0w4sa8sdhfff74pv";
         };
       });
       spirv-headers = spirv-tools.overrideAttrs (_: {
         src = fetchFromGitHub {
           owner = "KhronosGroup";
           repo = "SPIRV-Headers";
-          rev = "204cd131c42b90d129073719f2766293ce35c081";
-          sha256 = "1gp0mlbfccqnalaix97jxsa5i337xyzyr55wgssapy56p0q04wv2";
+          rev = "ac638f1815425403e946d0ab78bac71d2bdbf3be";
+          sha256 = "1lkhs7pxcrfkmiizcxl0w5ajx6swwjv7w3iq586ipgh571fc75gx";
         };
       });
     }).overrideAttrs (_: {
       src = fetchFromGitHub {
         owner = "KhronosGroup";
         repo = "glslang";
-        rev = "4fc7a33910fb8e40b970d160e1b38ab3f67fe0f3";
-        sha256 = "1dghz8zl774dx2xpa4dv8xhxirbylgyn6kx18ib4qirna1njp0zg";
+        rev = "e00d27c6d65b7d3e72506a311d7f053da4051295";
+        sha256 = "00lzvzk613gpm1vsdxffmx52z3c52ijwvzk4sfhh95p71kdydhgv";
       };
     });
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9094,24 +9094,7 @@ in
 
   dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix {});
 
-  glslang = callPackage ../development/compilers/glslang {
-    spirv-tools = spirv-tools.overrideAttrs (_: {
-      src = fetchFromGitHub {
-        owner = "KhronosGroup";
-        repo = "SPIRV-Tools";
-        rev = "fd8e130510a6b002b28eee5885a9505040a9bdc9";
-        sha256 = "00b7xgyrcb2qq63pp3cnw5q1xqx2d9rfn65lai6n6r89s1vh3vg6";
-      };
-    });
-    spirv-headers = spirv-headers.overrideAttrs (_: {
-      src = fetchFromGitHub {
-        owner = "KhronosGroup";
-        repo = "SPIRV-Headers";
-        rev = "f8bf11a0253a32375c32cad92c841237b96696c0";
-        sha256 = "1znwjy02dl9rshqzl87rqsv9mfczw7gvwfhcirbl81idahgp4p6l";
-      };
-    });
-  };
+  glslang = callPackage ../development/compilers/glslang { };
 
   go_bootstrap = if stdenv.isAarch64 then
     srcOnly {
@@ -15818,33 +15801,7 @@ in
   vulkan-headers = callPackage ../development/libraries/vulkan-headers { };
   vulkan-loader = callPackage ../development/libraries/vulkan-loader { };
   vulkan-tools = callPackage ../tools/graphics/vulkan-tools { };
-  vulkan-validation-layers = callPackage ../development/tools/vulkan-validation-layers {
-    glslang = (glslang.override {
-      spirv-tools = spirv-tools.overrideAttrs (_: {
-        src = fetchFromGitHub {
-          owner = "KhronosGroup";
-          repo = "SPIRV-Tools";
-          rev = "e128ab0d624ce7beb08eb9656bb260c597a46d0a";
-          sha256 = "0jj8zrl3dh9fq71jc8msx3f3ifb2vjcb37nl0w4sa8sdhfff74pv";
-        };
-      });
-      spirv-headers = spirv-tools.overrideAttrs (_: {
-        src = fetchFromGitHub {
-          owner = "KhronosGroup";
-          repo = "SPIRV-Headers";
-          rev = "ac638f1815425403e946d0ab78bac71d2bdbf3be";
-          sha256 = "1lkhs7pxcrfkmiizcxl0w5ajx6swwjv7w3iq586ipgh571fc75gx";
-        };
-      });
-    }).overrideAttrs (_: {
-      src = fetchFromGitHub {
-        owner = "KhronosGroup";
-        repo = "glslang";
-        rev = "e00d27c6d65b7d3e72506a311d7f053da4051295";
-        sha256 = "00lzvzk613gpm1vsdxffmx52z3c52ijwvzk4sfhh95p71kdydhgv";
-      };
-    });
-  };
+  vulkan-validation-layers = callPackage ../development/tools/vulkan-validation-layers { };
 
   vtkWithQt5 = vtk.override { qtLib = qt514; };
 


### PR DESCRIPTION
###### Motivation for this change
Keeping master up to date with recent developments in upstream projects

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
