### PR TITLE
dict: look for config in /etc

### DIFF
--- a/pkgs/servers/dict/default.nix
+++ b/pkgs/servers/dict/default.nix
@@ -13,23 +13,26 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ bison flex libtool which ];
 
-  # Makefile(.in) contains "clientparse.c clientparse.h: clientparse.y" which
-  # causes bison to run twice, and break the build when this happens in
-  # parallel.  Test with "make -j clientparse.c clientparse.h".  The error
-  # message may be "mv: cannot move 'y.tab.c' to 'clientparse.c'".
-  enableParallelBuilding = false;
+  # In earlier versions, parallel building was not supported but it's OK with 1.13
+  enableParallelBuilding = true;
 
   patchPhase = "patch -p0 < ${./buildfix.diff}";
+
   configureFlags = [
     "--enable-dictorg"
     "--datadir=/run/current-system/sw/share/dictd"
+    "--sysconfdir=/etc"
   ];
+
+  postInstall = ''
+    install -Dm444 -t $out/share/doc/${pname} NEWS README
+  '';
 
   meta = with stdenv.lib; {
     description = "Dict protocol server and client";
-    homepage    = "http://www.dict.org";
-    license     = licenses.gpl2;
+    homepage = "http://www.dict.org";
+    license = licenses.gpl2;
     maintainers = with maintainers; [ ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Previously it was impossible to configure dict/dictd system-wide as it
was looking for a config file in the nix store. Instead use /etc so it
becomes usable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).