### PR TITLE
Add nplusone and pytest-pythonpath Python packages

### DIFF
--- a/pkgs/development/python-modules/nplusone/default.nix
+++ b/pkgs/development/python-modules/nplusone/default.nix
@@ -1,0 +1,49 @@
+{ blinker, buildPythonPackage, fetchFromGitHub, lib, isPy27, six, mock, pytest
+, webtest, pytestcov, pytest-django, pytest-pythonpath, flake8, sqlalchemy
+, flask_sqlalchemy, peewee }:
+
+buildPythonPackage rec {
+  pname = "nplusone";
+  version = "1.0.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "jmcarp";
+    repo = "nplusone";
+    rev = "v${version}";
+    sha256 = "0qdwpvvg7dzmksz3vqkvb27n52lq5sa8i06m7idnj5xk2dgjkdxg";
+  };
+
+  # The tests assume the source code is in an nplusone/ directory. When using
+  # the Nix sandbox, it will be in a source/ directory instead, making the
+  # tests fail.
+  prePatch = ''
+    substituteInPlace tests/conftest.py \
+      --replace nplusone/tests/conftest source/tests/conftest
+  '';
+
+  checkPhase = ''
+    pytest tests/
+  '';
+
+  propagatedBuildInputs = [ six blinker ];
+  checkInputs = [
+    mock
+    pytest
+    webtest
+    pytestcov
+    pytest-django
+    pytest-pythonpath
+    flake8
+    sqlalchemy
+    flask_sqlalchemy
+    peewee
+  ];
+
+  meta = with lib; {
+    description = "Detecting the n+1 queries problem in Python";
+    homepage = "https://github.com/jmcarp/nplusone";
+    maintainers = with maintainers; [ cript0nauta ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/pytest-pythonpath/default.nix
+++ b/pkgs/development/python-modules/pytest-pythonpath/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonPackage, fetchPypi, lib, pytest }:
+
+buildPythonPackage rec {
+  pname = "pytest-pythonpath";
+  version = "0.7.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qhxh0z2b3p52v3i0za9mrmjnb1nlvvyi2g23rf88b3xrrm59z33";
+  };
+
+  propagatedBuildInputs = [ pytest ];
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description =
+      "Pytest plugin for adding to the PYTHONPATH from command line or configs";
+    homepage = "https://github.com/bigsassy/pytest-pythonpath";
+    maintainers = with maintainers; [ cript0nauta ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2514,6 +2514,8 @@ in {
 
   mxnet = callPackage ../development/python-modules/mxnet { };
 
+  nplusone = callPackage ../development/python-modules/nplusone { };
+
   parsy = callPackage ../development/python-modules/parsy { };
 
   portalocker = callPackage ../development/python-modules/portalocker { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2655,6 +2655,8 @@ in {
 
   pytest-pep257 = callPackage ../development/python-modules/pytest-pep257 { };
 
+  pytest-pythonpath = callPackage ../development/python-modules/pytest-pythonpath { };
+
   pytest-raisesregexp = callPackage ../development/python-modules/pytest-raisesregexp { };
 
   pytest-random-order = callPackage ../development/python-modules/pytest-random-order { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add the `nplusone` Python package, which is a dependency of [Faraday](github.com/infobyte/faraday/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
