### PR TITLE
chromium: 84.0.4147.89 -> 84.0.4147.105

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -11,8 +11,8 @@
     version = "86.0.4209.2";
   };
   stable = {
-    sha256 = "0yf6j0459qzr677zsa2apmfz0x0ndlscvwj1a5v40nqjijchv5qp";
-    sha256bin64 = "1hzhgvs2ykqsncpnbnhzh09sw1vlsdfjhs06z5gc80l47brdi3wz";
-    version = "84.0.4147.89";
+    sha256 = "1b6cqnwx76pp4y5hvz3qm8lm1ayaxr5578k76164acr35bmypx6a";
+    sha256bin64 = "0znxq5ncyvyysx3p8xikzg8jm8jr51k478y29m985x6c5p5a4zyw";
+    version = "84.0.4147.105";
   };
 }


### PR DESCRIPTION
https://chromereleases.googleblog.com/2020/07/stable-channel-update-for-desktop_27.html

This update includes 8 security fixes.

CVEs:
CVE-2020-6537 CVE-2020-6538 CVE-2020-6532 CVE-2020-6539 CVE-2020-6540
CVE-2020-6541

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Testing status

| platform | attribute | status | tester |
| --- | --- | --- | --- |
| x86_64 | chromium | | @danielfullmer |
| x86_64 | nixosTests.chromium | | @danielfullmer  |
| x86_64 | google-chrome | | |
| aarch64 | chromium | | @thefloweringash |


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
