### PR TITLE
obs: gstreamer plugin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8919,6 +8919,16 @@
     githubId = 687198;
     name = "Yuri Aisaka";
   };
+  yurkobb = {
+    name = "Yury Bulka";
+    email = "setthemfree@privacyrequired.com";
+    github = "yurkobb";
+    githubId = 479389;
+    keys = [{
+      longkeyid = "rsa4096/0xD834635CA9470CA2";
+      fingerprint = "36DD 7515 B47D E2C9 9057  D440 D834 635C A947 0CA2";
+    }];
+  };
   yurrriq = {
     email = "eric@ericb.me";
     github = "yurrriq";

--- a/pkgs/applications/video/obs-studio/obs-gstreamer.nix
+++ b/pkgs/applications/video/obs-studio/obs-gstreamer.nix
@@ -11,12 +11,12 @@
 
 stdenv.mkDerivation rec {
   pname = "obs-gstreamer";
-  version = "v0.1.0";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "fzwoch";
     repo = "obs-gstreamer";
-    rev = version;
+    rev = "v${version}";
     sha256 = "1szfx5p2lb953blzw7prfd0nngjlwv2wn7jmnwvlssc9ci6jl6s8";
   };
 

--- a/pkgs/applications/video/obs-studio/obs-gstreamer.nix
+++ b/pkgs/applications/video/obs-studio/obs-gstreamer.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     description = "GStreamer OBS Studio plugin";
     homepage = "https://github.com/fzwoch/obs-gstreamer";
     license = licenses.gpl2;
+    maintainers = with maintainers; [ yurkobb ];
     platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }

--- a/pkgs/applications/video/obs-studio/obs-gstreamer.nix
+++ b/pkgs/applications/video/obs-studio/obs-gstreamer.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gstreamer
+, gst-plugins-base
+, pkgconfig
+, meson
+, ninja
+, obs-studio
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-gstreamer";
+  version = "v0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "fzwoch";
+    repo = "obs-gstreamer";
+    rev = version;
+    sha256 = "1szfx5p2lb953blzw7prfd0nngjlwv2wn7jmnwvlssc9ci6jl6s8";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs = [ obs-studio gstreamer gst-plugins-base ];
+
+  meta = with lib; {
+    description = "GStreamer OBS Studio plugin";
+    homepage = "https://github.com/fzwoch/obs-gstreamer";
+    license = licenses.gpl2;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21727,6 +21727,10 @@ in
     inherit (gnome2) libglade;
   };
 
+  obs-gstreamer = callPackage ../applications/video/obs-studio/obs-gstreamer.nix {
+    inherit (gst_all_1) gstreamer gst-plugins-base;
+  };
+
   obs-linuxbrowser = callPackage ../applications/video/obs-studio/linuxbrowser.nix { };
 
   obs-studio = libsForQt5.callPackage ../applications/video/obs-studio { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add the [obs-gstreamer](https://github.com/fzwoch/obs-gstreamer) OBS plugin (useful for things like attaching sources OBS doesn't support natively, but gstreamer does, like firewire (H)DV cameras, among other things).

###### Need help with
Currently there are two issues with path lookup:
1. [obs doesn't know about plugins outside its own package](https://github.com/NixOS/nixpkgs/issues/77627) - can be worked around by `ln -s ~/.nix-profile/lib/obs-plugins/obs-gstreamer.so ~/.config/obs-studio/plugin/obs-gstreamer/bin/64bit/`
2. obs doesn't know where to look for gstreamer plugins, required by this package. Can be worked around by looking up the store path of gstreamer and gstreamer-plugins and doing
```
export GST_PLUGIN_SYSTEM_PATH_1_0=/nix/store/789ac60d8hdyhgbi5arx26m34zp410ik-gst-plugins-base-1.16.2/lib/:/nix/store/2j71zkvld1r8vhyk44xilcid9sybjpqw-gstreamer-1.16.2/lib
```

I am not sure if #1 needs patching OBS to support loading plugins from the system and user profiles (at least i can't find any environment variables to tweak [by searching for getenv calls](https://github.com/obsproject/obs-studio/search?q=getenv&unscoped_q=getenv) in its source code).

About #2 - have no idea how to fix this... Still a nixpkgs newbie...

(cc @jb55 @MP2E from `default.nix` maintainers).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
