### PR TITLE
Bump swagger-codegen version to 3.0.20

### DIFF
--- a/pkgs/tools/networking/swagger-codegen/default.nix
+++ b/pkgs/tools/networking/swagger-codegen/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchurl, jre, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  version = "2.3.1";
-  pname = "swagger-codegen";
+  version = "3.0.20";
+  pname = "swagger-codegen-cli";
 
-  jarfilename = "${pname}-cli-${version}.jar";
+  jarfilename = "${pname}-${version}.jar";
 
   nativeBuildInputs = [
     makeWrapper
   ];
 
-  src = fetchurl {
-    url = "https://oss.sonatype.org/content/repositories/releases/io/swagger/${pname}-cli/${version}/${jarfilename}";
-    sha256 = "171qr0zx7i6cykv54vqjf3mplrf7w4a1fpq47wsj861lbf8xm322";
+  src = self.fetchurl {
+    url = "https://repo1.maven.org/maven2/io/swagger/codegen/v3/${pname}/${version}/${jarfilename}";
+    sha256 = "02jjxsg9lk5sp5052yzc9v3cvd6k3d7i475clvhsczswz1mmp08x";
   };
 
   phases = [ "installPhase" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bump swagger-codegen to 3.0.20
Update download URL to recommended from upstream: https://github.com/swagger-api/swagger-codegen#prerequisites

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
