### PR TITLE
pythonPackages.webdavclient3: init at 3.14.5

### DIFF
--- a/pkgs/development/python-modules/webdavclient3/default.nix
+++ b/pkgs/development/python-modules/webdavclient3/default.nix
@@ -1,0 +1,30 @@
+{ buildPythonPackage, fetchPypi, isPy27, lib, dateutil, lxml, requests
+, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "webdavclient3";
+  version = "3.14.5";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0yw3n5m70ysjn1ch48znpn4zr4a1bd0lsm7q2grqz7q5hfjzjwk0";
+  };
+
+  propagatedBuildInputs = [ dateutil lxml requests ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  # disable tests completely, as most of them fail due to urllib3 not being able to establish a http connection
+  doCheck = false;
+
+  pythonImportsCheck = [ "webdav3.client" ];
+
+  meta = with lib; {
+    description = "Easy to use WebDAV Client for Python 3.x";
+    homepage = "https://github.com/ezhov-evgeny/webdav-client-python-3";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dmrauh ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1713,6 +1713,8 @@ in {
 
   webapp2 = callPackage ../development/python-modules/webapp2 { };
 
+  webdavclient3 = callPackage ../development/python-modules/webdavclient3 { };
+
   wordcloud = callPackage ../development/python-modules/wordcloud { };
 
   wrf-python = callPackage ../development/python-modules/wrf-python { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I needed a Python-based WebDAV client library, that can be imported as a module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) 0 -> 127593712
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
