### PR TITLE
as-tree: init at 0.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4284,6 +4284,12 @@
     githubId = 16374374;
     name = "Joshua Campbell";
   };
+  jshholland = {
+    email = "josh@inv.alid.pw";
+    github = "jshholland";
+    githubId = 107689;
+    name = "Josh Holland";
+  };
   jtcoolen = {
     email = "jtcoolen@pm.me";
     name = "Julien Coolen";

--- a/pkgs/tools/misc/as-tree/cargo-lock.patch
+++ b/pkgs/tools/misc/as-tree/cargo-lock.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 991ecd8..9e94574 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -11,7 +11,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "as-tree"
+-version = "0.11.1"
++version = "0.12.0"
+ dependencies = [
+  "ansi_term",
+  "atty",

--- a/pkgs/tools/misc/as-tree/default.nix
+++ b/pkgs/tools/misc/as-tree/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "as-tree";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "jez";
+    repo = pname;
+    rev = version;
+    sha256 = "0c0g32pkyhyvqpgvzlw9244c80npq6s8mxy3may7q4qyd7hi3dz5";
+  };
+
+  cargoSha256 = "0yhd9svdxg7akv61msn7rf3rfblb7kxnyn955dfdwyxbxq48qwpr";
+  # the upstream 0.12.0 release didn't update the Cargo.lock file properly
+  # they have updated their release script, so this patch can be removed
+  # when the next version is released.
+  cargoPatches = [ ./cargo-lock.patch ];
+
+  meta = with lib; {
+    description = "Print a list of paths as a tree of paths";
+    homepage = "https://github.com/jez/as-tree";
+    license = with licenses; [ blueOak100 ];
+    maintainers = with maintainers; [ jshholland ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1338,6 +1338,8 @@ in
   };
   aria = aria2;
 
+  as-tree = callPackage ../tools/misc/as-tree { };
+
   asmfmt = callPackage ../development/tools/asmfmt { };
 
   aspcud = callPackage ../tools/misc/aspcud { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add new package as-tree.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
