### PR TITLE
ocamlPackages.hacl_x25519: 0.1.1 → 0.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/hacl_x25519/default.nix
+++ b/pkgs/development/ocaml-modules/hacl_x25519/default.nix
@@ -1,17 +1,18 @@
 { lib, buildDunePackage, fetchurl, benchmark, cstruct
-, eqaf, hex, ppx_blob, ppx_deriving_yojson, stdlib-shims, yojson }:
+, alcotest , eqaf, hex, ppx_blob, ppx_deriving_yojson, stdlib-shims, yojson }:
 
 buildDunePackage rec {
   pname = "hacl_x25519";
-  version = "0.1.1";
+  version = "0.2.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/hacl/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "187khbx1myh942c2v5f7wbms2hmhmgn57ik25djhnryln32c0874";
+    sha256 = "0ppq56i2yhxzz38w120aynnkx10kncl86zvqip9zx0v4974k3k4x";
   };
 
+  useDune2 = true;
   propagatedBuildInputs = [ eqaf cstruct ];
-  checkInputs = [ benchmark hex ppx_blob ppx_deriving_yojson stdlib-shims yojson ];
+  checkInputs = [ alcotest benchmark hex ppx_blob ppx_deriving_yojson stdlib-shims yojson ];
   doCheck = true;
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/mirage/hacl/releases/tag/v0.2.0>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
