### PR TITLE
pythonPackages.sentry-sdk: fix trytond dependency

### DIFF
--- a/pkgs/development/python-modules/sentry-sdk/default.nix
+++ b/pkgs/development/python-modules/sentry-sdk/default.nix
@@ -30,10 +30,10 @@ buildPythonPackage rec {
     sha256 = "0e5e947d0f7a969314aa23669a94a9712be5a688ff069ff7b9fc36c66adc160c";
   };
 
-  checkInputs = [ django flask tornado bottle rq falcon sqlalchemy werkzeug ]
+  checkInputs = [ django flask tornado bottle rq falcon sqlalchemy werkzeug trytond ]
   ++ stdenv.lib.optionals isPy3k [ celery pyramid sanic aiohttp ];
 
-  propagatedBuildInputs = [ urllib3 certifi trytond ];
+  propagatedBuildInputs = [ urllib3 certifi ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/getsentry/sentry-python";


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The `trytond` dependency of `sentry-sdk` causes a transitive dependency on `simplejson`, which then [makes `requests` behave differently](https://github.com/psf/requests/blob/2d39c0db054e158767ab4a755476844fe40787e7/requests/compat.py#L28-L31) in a way that can break error handling.

Tryton is an optional dependency of the Sentry SDK, if it is present, Sentry can integrate with it, but when it is not present, Sentry should not pull it in as a propagated build input, it is only required for the tests that test this specific integration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
