### PR TITLE
aliza: 1.48.10 -> 1.98.31

### DIFF
--- a/pkgs/applications/science/medicine/aliza/default.nix
+++ b/pkgs/applications/science/medicine/aliza/default.nix
@@ -3,11 +3,11 @@
 with stdenv.lib;
 stdenv.mkDerivation {
   pname = "aliza";
-  version = "1.48.10";
+  version = "1.98.31";
   src = fetchurl {
     # See https://www.aliza-dicom-viewer.com/download
-    url = "https://drive.google.com/uc?export=download&id=16WEScARaSrzJpJkyGuOUxDF95eUwGyET";
-    sha256 = "1ls16cwd0fmb5axxmy9lgf8cqrf7g7swm26f0gr2vqp4z9bw6qn3";
+    url = "https://drive.google.com/u/0/uc?id=1VPUi10jUm3SjylVokWNxkpzOsHyJTP6_&export=download";
+    sha256 = "0x2jr38s0rhl1jnsglay1vd1iyzlcwgi1njc5hb0m94xslrkqf9a";
     name = "aliza.rpm";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Newer aliza version available and the old build didn't download for me in 20.03 as well as unstable

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
