### PR TITLE
llvm*: remove symlinks to llvm-diff, llvm-as and LLVM IR utilities

### DIFF
--- a/pkgs/development/compilers/llvm/10/bintools.nix
+++ b/pkgs/development/compilers/llvm/10/bintools.nix
@@ -11,7 +11,6 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
      ln -s $prog $out/bin/${prefix}$(basename $prog)
    done
    for prog in ${llvm}/bin/*; do
-     ln -s $prog $out/bin/${prefix}$(echo $(basename $prog) | sed -e "s|llvm-||")
      ln -sf $prog $out/bin/${prefix}$(basename $prog)
    done
    rm -f $out/bin/${prefix}cat

--- a/pkgs/development/compilers/llvm/7/bintools.nix
+++ b/pkgs/development/compilers/llvm/7/bintools.nix
@@ -11,7 +11,6 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
      ln -s $prog $out/bin/${prefix}$(basename $prog)
    done
    for prog in ${llvm}/bin/*; do
-     ln -s $prog $out/bin/${prefix}$(echo $(basename $prog) | sed -e "s|llvm-||")
      ln -sf $prog $out/bin/${prefix}$(basename $prog)
    done
    rm -f $out/bin/${prefix}cat

--- a/pkgs/development/compilers/llvm/8/bintools.nix
+++ b/pkgs/development/compilers/llvm/8/bintools.nix
@@ -11,7 +11,6 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
      ln -s $prog $out/bin/${prefix}$(basename $prog)
    done
    for prog in ${llvm}/bin/*; do
-     ln -s $prog $out/bin/${prefix}$(echo $(basename $prog) | sed -e "s|llvm-||")
      ln -sf $prog $out/bin/${prefix}$(basename $prog)
    done
    rm -f $out/bin/${prefix}cat

--- a/pkgs/development/compilers/llvm/9/bintools.nix
+++ b/pkgs/development/compilers/llvm/9/bintools.nix
@@ -11,7 +11,6 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
      ln -s $prog $out/bin/${prefix}$(basename $prog)
    done
    for prog in ${llvm}/bin/*; do
-     ln -s $prog $out/bin/${prefix}$(echo $(basename $prog) | sed -e "s|llvm-||")
      ln -sf $prog $out/bin/${prefix}$(basename $prog)
    done
    rm -f $out/bin/${prefix}cat


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

These llvm-prefixed utilities are not drop-in replacements for the utilities
with similar names, they are specifically for operating on LLVM IR files.
Symlinking these without the prefix causes incompatibilities with tools that
expect diff, as and others to behave normally.

Fixes #93523

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
