### PR TITLE
cmake: fix CMAKE_FIND_FRAMEWORK

### DIFF
--- a/pkgs/applications/gis/openorienteering-mapper/default.nix
+++ b/pkgs/applications/gis/openorienteering-mapper/default.nix
@@ -56,8 +56,6 @@ mkDerivation rec {
     "-DLICENSING_PROVIDER:BOOL=OFF"
     "-DMapper_MANUAL_QTHELP:BOOL=OFF"
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
-    # Usually enabled on Darwin
-    "-DCMAKE_FIND_FRAMEWORK=never"
     # FindGDAL is broken and always finds /Library/Framework unless this is
     # specified
     "-DGDAL_INCLUDE_DIR=${gdal}/include"

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -44,7 +44,7 @@ let
         "-DENABLE_JAVASCRIPT=OFF"  # Requires v8 <= 3.24.3, https://github.com/weechat/weechat/issues/360
         "-DENABLE_PHP=OFF"
       ]
-        ++ optionals stdenv.isDarwin ["-DICONV_LIBRARY=${libiconv}/lib/libiconv.dylib" "-DCMAKE_FIND_FRAMEWORK=LAST"]
+        ++ optionals stdenv.isDarwin ["-DICONV_LIBRARY=${libiconv}/lib/libiconv.dylib"]
         ++ map (p: "-D${p.cmakeFlag}=" + (if p.enabled then "ON" else "OFF")) plugins
         ;
 

--- a/pkgs/development/compilers/mozart/default.nix
+++ b/pkgs/development/compilers/mozart/default.nix
@@ -61,7 +61,7 @@ in stdenv.mkDerivation rec {
     # gcc together as compilers and we need clang for the sources generation.
     # However, clang emits tons of warnings about gcc's atomic-base library.
     "-DCMAKE_CXX_FLAGS=-Wno-braced-scalar-init"
-  ] ++ lib.optional stdenv.isDarwin "-DCMAKE_FIND_FRAMEWORK=LAST";
+  ];
 
   fixupPhase = ''
     wrapProgram $out/bin/oz --set OZEMACS ${emacs}/bin/emacs

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -48,7 +48,7 @@ cmakeConfigurePhase() {
 
     # on macOS we want to prefer Unix-style headers to Frameworks
     # because we usually do not package the framework
-    cmakeFlags="-DCMAKE_FIND_FRAMEWORK=last $cmakeFlags"
+    cmakeFlags="-DCMAKE_FIND_FRAMEWORK=LAST $cmakeFlags"
 
     # on macOS i686 was only relevant for 10.5 or earlier.
     cmakeFlags="-DCMAKE_OSX_ARCHITECTURES=x86_64 $cmakeFlags"


### PR DESCRIPTION
###### Motivation for this change
#37015 introduced new macOS specific default CMake flag: `CMAKE_FIND_FRAMEWORK=last`. But it has no effect since the flag value is case sensitive and should be `CMAKE_FIND_FRAMEWORK=LAST`, see [CMake documentation](https://cmake.org/cmake/help/v3.18/variable/CMAKE_FIND_FRAMEWORK.html).

`CMAKE_FIND_FRAMEWORK` removed as not needed anymore for these derivations:
* openorienteering-mapper
* weechat
* mozart

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
