### PR TITLE
xmenu: init at 4.3.1

### DIFF
--- a/pkgs/applications/misc/xmenu/default.nix
+++ b/pkgs/applications/misc/xmenu/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, imlib2, libX11, libXft, libXinerama }:
+
+stdenv.mkDerivation rec {
+  pname = "xmenu";
+  version = "4.3.1";
+
+  src = fetchFromGitHub {
+    owner = "phillbush";
+    repo = "xmenu";
+    rev = "v${version}";
+    sha256 = "0m97w1nwak5drcxxlyisqb73fxkapy2rlph9mg531kbx3k2h30r1";
+  };
+
+  buildInputs = [ imlib2 libX11 libXft libXinerama ];
+
+  postPatch = "sed -i \"s:/usr/local:$out:\" config.mk";
+
+  meta = with stdenv.lib; {
+    description = "XMenu is a menu utility for X";
+    homepage = "https://github.com/phillbush/xmenu";
+    license = licenses.publicDomain;
+    maintainers = with maintainers; [ neonfuz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23836,6 +23836,8 @@ in
 
   xmacro = callPackage ../tools/X11/xmacro { };
 
+  xmenu = callPackage ../applications/misc/xmenu { };
+
   xmlcopyeditor = callPackage ../applications/editors/xmlcopyeditor { };
 
   xmp = callPackage ../applications/audio/xmp { };


### PR DESCRIPTION
###### Motivation for this change
Added package xmenu

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
