### PR TITLE
dual-function-keys: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8577,6 +8577,12 @@
     githubId = 1040871;
     name = "Mathis Antony";
   };
+  svend = {
+    email = "svend@svends.net";
+    github = "svend";
+    githubId = 306190;
+    name = "Svend Sorensen";
+  };
   svrana = {
     email = "shaw@vranix.com";
     github = "svrana";

--- a/pkgs/tools/inputmethods/interception-tools/dual-function-keys.nix
+++ b/pkgs/tools/inputmethods/interception-tools/dual-function-keys.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitLab, pkg-config, libyamlcpp, libevdev }:
+
+stdenv.mkDerivation rec {
+  pname = "dual-function-keys";
+  version = "1.1.0";
+
+  src = fetchFromGitLab {
+    owner = "interception/linux/plugins";
+    repo = pname;
+    rev = version;
+    sha256 = "07hksca4g7v4zsvhmhc9j725j3n63fzrkx9sb4a0wrd7rwgr25rz";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libevdev libyamlcpp ];
+
+  prePatch = ''
+    substituteInPlace config.mk --replace \
+      '/usr/include/libevdev-1.0' \
+      "$(pkg-config --cflags libevdev | cut -c 3-)"
+  '';
+
+  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://gitlab.com/interception/linux/plugins/dual-function-keys";
+    description = "Tap for one key, hold for another.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ svend ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/interception-tools/dual-function-keys.nix
+++ b/pkgs/tools/inputmethods/interception-tools/dual-function-keys.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, pkg-config, libyamlcpp, libevdev }:
+{ stdenv, lib, fetchFromGitLab, pkg-config, libyamlcpp, libevdev }:
 
 stdenv.mkDerivation rec {
   pname = "dual-function-keys";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://gitlab.com/interception/linux/plugins/dual-function-keys";
     description = "Tap for one key, hold for another.";
     license = licenses.mit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3118,6 +3118,7 @@ in
   interception-tools = callPackage ../tools/inputmethods/interception-tools { };
   interception-tools-plugins = {
     caps2esc = callPackage ../tools/inputmethods/interception-tools/caps2esc.nix { };
+    dual-function-keys = callPackage ../tools/inputmethods/interception-tools/dual-function-keys.nix { };
   };
 
   age = callPackage ../tools/security/age { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add dual-function-keys interception-tools plugin. This allows for modifier keys like: hold for ctrl, tap for delete.

See https://gitlab.com/interception/linux/plugins/dual-function-keys

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
