### PR TITLE
pythonPackages.jpylyzer: 1.18.0 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/jpylyzer/default.nix
+++ b/pkgs/development/python-modules/jpylyzer/default.nix
@@ -2,24 +2,24 @@
 , fetchFromGitHub
 , buildPythonPackage
 , six
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "jpylyzer";
-  version = "1.18.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "openpreserve";
     repo = pname;
     rev = version;
-    sha256 = "0vhrq15l6jd5fm6vj7mczjzjpl2ph1dk8jp89dw4vlccky8660ll";
+    sha256 = "01wfbb1bgby9b7m6q7483kvpyc1qhj80dg8d5a6smcxvmy8y6x5n";
   };
 
   propagatedBuildInputs = [ six ];
 
-  # there don't appear to be any in-tree tests as such, but the builder's automatic
-  # runner seems to be upset by the project layout
-  doCheck = false;
+  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "jpylyzer" ];
 
   meta = with lib; {
     description = "JP2 (JPEG 2000 Part 1) image validator and properties extractor";


### PR DESCRIPTION
###### Motivation for this change
Enabling tests at the same time.

This has a large list of reverse dependencies, but that is deceptive - it's merely that `jpylyzer` is a `checkInput` for `openjpeg`. So I haven't done the rebuild for this, but I'd argue that's ok because it's a purely transitive dependency.

Tested non-nixos linux x86_64, macos 10.14.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
