### PR TITLE
pythonPackages.django_silk: 3.0.4 -> 4.0.1

### DIFF
--- a/pkgs/development/python-modules/django_silk/default.nix
+++ b/pkgs/development/python-modules/django_silk/default.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "django-silk";
-  version = "3.0.4";
+  version = "4.0.1";
 
   # pypi tarball doesn't include test project
   src = fetchFromGitHub {
     owner = "jazzband";
     repo = "django-silk";
     rev = version;
-    sha256 = "10542yvbchcy8hik2hw3jclb4ic89mxkw0sykag4bw9sv43xv7vx";
+    sha256 = "0yy9rzxvwlp2xvnw76r9hnqajlp417snam92xpb6ay0hxwslwqyb";
   };
   # "test_time_taken" tests aren't suitable for reproducible execution, but django's
   # test runner doesn't have an easy way to ignore tests - so instead prevent it from picking
@@ -38,6 +38,8 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace project/tests/test_silky_profiler.py \
       --replace "def test_time_taken" "def _test_time_taken"
+    substituteInPlace setup.py \
+      --replace 'use_scm_version=True' 'version="${version}"'
   '';
 
   buildInputs = [ mock ];
@@ -54,7 +56,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Silky smooth profiling for the Django Framework";
-    homepage = "https://github.com/mtford90/silk";
+    homepage = "https://github.com/jazzband/django-silk";
     license = licenses.mit;
     maintainers = with maintainers; [ ris ];
   };


### PR DESCRIPTION
###### Motivation for this change
Standard bumpage. Required workaround for `use_scm_version` :roll_eyes: 

Tested non-nixos linux x86_64, macos 10.14. Leaf package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
