### PR TITLE
nixos/evdevremapkeys: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -344,6 +344,7 @@
   ./services/hardware/bluetooth.nix
   ./services/hardware/bolt.nix
   ./services/hardware/brltty.nix
+  ./services/hardware/evdevremapkeys.nix
   ./services/hardware/fancontrol.nix
   ./services/hardware/freefall.nix
   ./services/hardware/fwupd.nix

--- a/nixos/modules/services/hardware/evdevremapkeys.nix
+++ b/nixos/modules/services/hardware/evdevremapkeys.nix
@@ -1,0 +1,82 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.evdevremapkeys;
+
+  fullConfig = {
+    devices = cfg.devices;
+  };
+
+  cfgFile = pkgs.writeText "config.yaml" (builtins.toJSON fullConfig);
+in {
+
+  options.services.evdevremapkeys = {
+
+    # Note: this corresponds to the YAML configuration that evdevremap keys
+    # expects.
+    devices = mkOption {
+      default = {};
+      description = "Input devices to remap using evdevremapkeys";
+      type = with types; listOf (submodule {
+        options = {
+
+          input_name = mkOption {
+            type = str;
+            description = ''
+              Name of device to be remapped (from `xinput list`).
+            '';
+          };
+
+          output_name = mkOption {
+            type = str;
+            description = ''
+              Name of virtual device that will output remapped events.
+            '';
+          };
+
+          remappings = mkOption {
+            type = attrsOf (listOf str);
+            description = ''
+              Attrset of inputted event name to list of events that will be
+              fired instead. The event names are standard Linux input event
+              names, for a list see include/uapi/linux/input-event-codes.h in
+              the Linux source tree.
+
+              For example:
+                remappings = {
+                  KEY_ESC = [
+                    "KEY_A"
+                    "KEY_B"
+                  ];
+                };
+              will remap the escape key to instead fire an A and B keypress
+              simultaneously when pressed.
+            '';
+          };
+        };
+      });
+    };
+
+  };
+
+  config = mkIf (cfg.devices != []) {
+
+    systemd.services.evdevremapkeys = {
+      description = "Remap Evdev Input";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.evdevremapkeys}/bin/evdevremapkeys -f ${cfgFile}";
+        WorkingDirectory = "/tmp";
+        Restart = "always";
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+      };
+    };
+
+  };
+
+  meta.maintainers = with maintainers; [ maintainers.q3k ];
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Implement a basic [evdevremapkeys](https://github.com/philipl/evdevremapkeys) service. The tool itself already exists as  a derivation, this merely adds a module to turn it into a service.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
