### PR TITLE
xbattbar: init at 1.4.9

### DIFF
--- a/pkgs/applications/misc/xbattbar/default.nix
+++ b/pkgs/applications/misc/xbattbar/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchgit, libX11, perl, ... }:
+
+stdenv.mkDerivation rec {
+  pname = "xbattbar";
+  version = "1.4.9";
+
+  # The current active upstream of xbattbar seems to be the Debian source
+  # repository.
+  src = fetchgit {
+    url = "https://salsa.debian.org/debian/xbattbar.git";
+    rev = "upstream/${version}";
+    sha256 = "10w7gs0l4hzhdn38yqyr3az7n4ncmfnd6hhhly6lk5dg7k441ck6";
+  };
+
+  buildInputs =  [ libX11 ];
+
+  # The following patches are applied:
+  # - sys-by-default: remove the APM checker binary, make the sys checker
+  #   script the default. Rationale: checking battery status by /proc/apm is
+  #   extremely oldschool and does not work on NixOS, while the sysfs script
+  #   does.
+  # - perl shebang patches for acpi/sys scripts
+  # - unhardcode path to checker scripts
+  patchPhase = ''
+    patch -p1 < ${./sys-by-default.patch}
+    sed -i -e "s,/usr/lib/xbattbar/,$out/libexec/," xbattbar.c
+    sed -i -e "s,/usr/bin/perl,${perl}/bin/perl," xbattbar-check-acpi
+    sed -i -e "s,/usr/bin/perl,${perl}/bin/perl," xbattbar-check-sys
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/libexec
+    install -m 0755 xbattbar $out/bin/
+    install -m 0755 xbattbar-check-acpi $out/libexec/
+    install -m 0755 xbattbar-check-sys $out/libexec/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Display battery status in X11";
+    homepage = "https://salsa.debian.org/debian/xbattbar";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.q3k ];
+  };
+}

--- a/pkgs/applications/misc/xbattbar/sys-by-default.patch
+++ b/pkgs/applications/misc/xbattbar/sys-by-default.patch
@@ -1,0 +1,26 @@
+diff --git a/xbattbar.c b/xbattbar.c
+index 1e26019..cb3eab5 100644
+--- a/xbattbar.c
++++ b/xbattbar.c
+@@ -75,9 +75,8 @@ char *ONOUT_C  = "olive drab";
+ char *OFFIN_C  = "blue";
+ char *OFFOUT_C = "red";
+ 
+-char *EXTERNAL_CHECK = "/usr/lib/xbattbar/xbattbar-check-apm";
++char *EXTERNAL_CHECK = "/usr/lib/xbattbar/xbattbar-check-sys";
+ char *EXTERNAL_CHECK_ACPI = "/usr/lib/xbattbar/xbattbar-check-acpi";
+-char *EXTERNAL_CHECK_SYS = "/usr/lib/xbattbar/xbattbar-check-sys";
+ 
+ int alwaysontop = False;
+ 
+@@ -245,10 +244,6 @@ main(int argc, char **argv)
+       EXTERNAL_CHECK = EXTERNAL_CHECK_ACPI;
+       break;
+ 
+-    case 'r':
+-      EXTERNAL_CHECK = EXTERNAL_CHECK_SYS;
+-      break;
+-
+     case 's':
+       EXTERNAL_CHECK = optarg;
+       break;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23430,6 +23430,8 @@ in
   xautomation = callPackage ../tools/X11/xautomation { };
 
   xawtv = callPackage ../applications/video/xawtv { };
+  
+  xbattbar = callPackage ../applications/misc/xbattbar { };
 
   xbindkeys = callPackage ../tools/X11/xbindkeys { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds xbattbar - an oldschool but nice X11 battery status tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
