### PR TITLE
inform6: init at 6.34-6.12.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1918,6 +1918,12 @@
     githubId = 14032;
     name = "Daniel Brockman";
   };
+  ddelabru = {
+    email = "ddelabru@redhat.com";
+    github = "ddelabru";
+    githubId = 39909293;
+    name = "Dominic Delabruere";
+  };
   dduan = {
     email = "daniel@duan.ca";
     github = "dduan";

--- a/pkgs/development/compilers/inform6/default.nix
+++ b/pkgs/development/compilers/inform6/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, perl }:
+
+stdenv.mkDerivation rec {
+  pname = "inform6";
+  version = "6.34-6.12.2";
+
+  src = fetchurl  {
+    url = "https://ifarchive.org/if-archive/infocom/compilers/inform6/source/inform-${version}.tar.gz";
+    sha256 = "c149f143f2c29a4cb071e578afef8097647cc9e823f7fcfab518ac321d9d259f";
+  };
+
+  buildInputs = [ perl ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  meta = with stdenv.lib; {
+    description = "Interactive fiction compiler and libraries";
+    longDescription = ''
+      Inform 6 is a C-like programming language for writing interactive fiction
+      (text adventure) games.
+    '';
+    homepage = "https://gitlab.com/DavidGriffith/inform6unix";
+    changelog = "https://gitlab.com/DavidGriffith/inform6unix/-/raw/${version}/NEWS";
+    license = licenses.artistic2;
+    maintainers = with stdenv.lib.maintainers; [ ddelabru ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4370,6 +4370,8 @@ in
 
   inetutils = callPackage ../tools/networking/inetutils { };
 
+  inform6 = callPackage ../development/compilers/inform6 { };
+
   inform7 = callPackage ../development/compilers/inform7 { };
 
   infamousPlugins = callPackage ../applications/audio/infamousPlugins { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

nixpkgs already has Inform 7, which is a lovely design system for creating interactive fiction (text adventures) using a natural language compiler and a rich IDE. However, underlying Inform 7 is a C-like language, Inform 6, which has a much simpler toolchain and its own compiler and standard libraries, which I have packaged for nix here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
