### PR TITLE
python3Packages.wxPython_4_0: remove unused dependencies

### DIFF
--- a/pkgs/development/python-modules/wxPython/4.0.nix
+++ b/pkgs/development/python-modules/wxPython/4.0.nix
@@ -29,8 +29,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [ pkgconfig which doxygen wxGTK ];
   buildInputs = [ ncurses wxGTK.gtk ];
 
-  hardeningDisable = [ "format" ];
-
   DOXYGEN = "${doxygen}/bin/doxygen";
 
   preConfigure = lib.optionalString (!stdenv.isDarwin) ''

--- a/pkgs/development/python-modules/wxPython/4.0.nix
+++ b/pkgs/development/python-modules/wxPython/4.0.nix
@@ -48,7 +48,6 @@ buildPythonPackage rec {
 
   installPhase = ''
     ${python.interpreter} setup.py install --skip-build --prefix=$out
-    wrapPythonPrograms
   '';
 
   passthru = { inherit wxGTK; };

--- a/pkgs/development/python-modules/wxPython/4.0.nix
+++ b/pkgs/development/python-modules/wxPython/4.0.nix
@@ -1,29 +1,18 @@
 { lib
 , stdenv
-, openglSupport ? true
-, libX11
-, pyopengl
 , buildPythonPackage
 , fetchPypi
 , pkgconfig
-, libjpeg
-, libtiff
-, SDL
-, gst-plugins-base
-, libnotify
-, freeglut
-, xorg
 , which
 , cairo
-, requests
 , pango
-, pathlib2
 , python
 , doxygen
 , ncurses
-, libpng
-, gstreamer
 , wxGTK
+, numpy
+, pillow
+, six
 }:
 
 buildPythonPackage rec {
@@ -38,14 +27,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   nativeBuildInputs = [ pkgconfig which doxygen wxGTK ];
-
-  buildInputs = [ libjpeg libtiff SDL
-      gst-plugins-base libnotify freeglut xorg.libSM ncurses
-      requests libpng gstreamer libX11
-      pathlib2
-      (wxGTK.gtk)
-  ]
-    ++ lib.optional openglSupport pyopengl;
+  buildInputs = [ ncurses wxGTK.gtk ];
 
   hardeningDisable = [ "format" ];
 
@@ -71,7 +53,7 @@ buildPythonPackage rec {
     wrapPythonPrograms
   '';
 
-  passthru = { inherit wxGTK openglSupport; };
+  passthru = { inherit wxGTK; };
 
 
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`wxPython_4_0` is currently broken because GStreamer 0.1 is broken. `wxPython_4_0` [apparently supports GStreamer 1.0](https://github.com/wxWidgets/Phoenix/issues/214), but looking closer at the package, I realized that the GStreamer dependency, along with many others, are not actually used.

The build still succeeds even after removing many of the dependencies, and there is no way they are needed at runtime because the package retains no references to them.

I also re-enabled format hardening, because that appears to have been unnecessarily inherited from wxPython 3, and the build still succeeds.

I have not tested this on macOS.

cc @FRidh @tbenst @evils

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
