### PR TITLE
lorri: 1.1 -> 1.1.1

### DIFF
--- a/pkgs/tools/misc/lorri/default.nix
+++ b/pkgs/tools/misc/lorri/default.nix
@@ -12,9 +12,9 @@
 , Security
 }:
 
-rustPlatform.buildRustPackage rec {
+(rustPlatform.buildRustPackage rec {
   pname = "lorri";
-  version = "1.1";
+  version = "1.1.1";
 
   meta = with stdenv.lib; {
     description = "Your project's nix-env";
@@ -28,11 +28,11 @@ rustPlatform.buildRustPackage rec {
     repo = pname;
     # Run `eval $(nix-build -A lorri.updater)` after updating the revision!
     # ALSO don’t forget to update the cargoSha256!
-    rev = "93d93013217cd9aa09d2bd316d6c3abf827a6601";
-    sha256 = "0wbkx8hmikngfp6fp0y65yla22f3k0jszq8a6pas80q0b33llwm5";
+    rev = "05ea21170a18800e83b3dcf1e3d347f83a9fa992";
+    sha256 = "1lgig5q1anmmmc1i1qnbx8rd8mqvm5csgnlaxlj4l4rxjmgiv06n";
   };
 
-  cargoSha256 = "1a3n1ylyp63x6v7b07nnqpfxjzmsgwmgraza23lx8z4gh167gv46";
+  cargoSha256 = "16asbpq47f3zcv4j9rzqx9v1317qz7xjr7dxd019vpr88zyk4fi1";
   doCheck = false;
 
   BUILD_REV_COUNT = src.revCount or 1;
@@ -41,6 +41,17 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = with pkgs; [ rustPackages.rustfmt ];
   buildInputs =
     stdenv.lib.optionals stdenv.isDarwin [ CoreServices Security ];
+
+  # copy the docs to the $man and $doc outputs
+  postInstall = ''
+    install -Dm644 lorri.1 $man/share/man/man1/lorri.1
+    install -Dm644 -t $doc/share/doc/lorri/ \
+      README.md \
+      CONTRIBUTING.md \
+      LICENSE \
+      MAINTAINERS.md
+    cp -r contrib/ $doc/share/doc/lorri/contrib
+  '';
 
   passthru = {
     updater = writers.writeBash "copy-runtime-nix.sh" ''
@@ -52,4 +63,7 @@ rustPlatform.buildRustPackage rec {
       nixos = nixosTests.lorri;
     };
   };
-}
+}).overrideAttrs (old: {
+  # add man and doc outputs to put our documentation into
+  outputs = old.outputs or [ "out" ] ++ [ "man" "doc" ];
+})


### PR DESCRIPTION
Patch release which adds a manpage.

Adding a `man` and a `doc` output, and copying the files to the
corresponding directories.

The `overrideAttrs` is necessary because `buildRustPackage` does not
allow adding outputs.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @curiousleo 
