### PR TITLE
python3Packages.sunpy: fix build

### DIFF
--- a/pkgs/development/python-modules/sunpy/default.nix
+++ b/pkgs/development/python-modules/sunpy/default.nix
@@ -2,27 +2,29 @@
 , lib
 , buildPythonPackage
 , fetchFromGitHub
-, numpy
-, scipy
-, matplotlib
-, pandas
-, astropy
-, parfive
 , pythonOlder
-, sqlalchemy
-, scikitimage
-, glymur
+
+, asdf
+, astropy
+, astropy-helpers
 , beautifulsoup4
 , drms
-, python-dateutil
-, zeep
-, tqdm
-, asdf
-, astropy-helpers
+, glymur
 , hypothesis
+, matplotlib
+, numpy
+, pandas
+, parfive
 , pytest-astropy
-, pytestcov
 , pytest-mock
+, pytestcov
+, python-dateutil
+, scikitimage
+, scipy
+, sqlalchemy
+, towncrier
+, tqdm
+, zeep
 }:
 
 buildPythonPackage rec {
@@ -47,6 +49,7 @@ buildPythonPackage rec {
     parfive
     sqlalchemy
     scikitimage
+    towncrier
     glymur
     beautifulsoup4
     drms

--- a/pkgs/development/python-modules/towncrier/default.nix
+++ b/pkgs/development/python-modules/towncrier/default.nix
@@ -1,0 +1,40 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, click
+, click-default-group
+, incremental
+, jinja2
+, pytestCheckHook
+, toml
+, twisted
+, git # shells out to git
+}:
+
+buildPythonPackage rec {
+  pname = "towncrier";
+  version = "19.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15l1gb0hhi9pf3mhhb9vpc93w6w3hrih2ljmzbkgfb3dwqd1l9a8";
+  };
+
+  propagatedBuildInputs = [
+    click
+    click-default-group
+    incremental
+    jinja2
+    toml
+  ];
+
+  # zope.interface collision
+  doCheck = !isPy27;
+  checkInputs = [ git twisted pytestCheckHook ];
+  pythonImportsCheck = [ "towncrier" ];
+
+  meta = with lib; {
+    description = "Utility to produce useful, summarised news files";
+    homepage = "https://github.com/twisted/towncrier/";
+    license = licenses.mit;
+    maintainers = with maintainers; [  ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1559,6 +1559,10 @@ in {
   tokenizers = disabledIf (!isPy3k)
     (toPythonModule (callPackage ../development/python-modules/tokenizers { }));
 
+  towncrier = callPackage ../development/python-modules/towncrier {
+    inherit (pkgs) git;
+  };
+
   transformers = callPackage ../development/python-modules/transformers { };
 
   transforms3d = callPackage ../development/python-modules/transforms3d { };


### PR DESCRIPTION
###### Motivation for this change
noticed it  was broken during a review

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
