### PR TITLE
sd-switch: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/os-specific/linux/sd-switch/default.nix
+++ b/pkgs/os-specific/linux/sd-switch/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sd-switch";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitLab {
     owner = "rycee";
     repo = pname;
     rev = version;
-    sha256 = "0njihfqvvp4lm2572sw5xadwg3nrvx2i1qrfm7fi0i3v5pxdc7g0";
+    sha256 = "1bhks4ma3sn95bsszs6lj9cwfr8zgmja0hqfp8xr5iq77ww2p6k3";
   };
 
-  cargoSha256 = "0ba2j0v2z90fivwdr5akdrsz9f479gz20yh85yiy05rkjhjy8cvv";
+  cargoSha256 = "0lskxakzh3yji0rzk8jcfz1sv4j19b5kmdsaj7401m5w84s1cbjw";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dbus ];


### PR DESCRIPTION
###### Motivation for this change

Bump sd-switch to version 0.2.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
