### PR TITLE
dwm: add conf option

### DIFF
--- a/pkgs/applications/window-managers/dwm/default.nix
+++ b/pkgs/applications/window-managers/dwm/default.nix
@@ -1,4 +1,6 @@
-{stdenv, fetchurl, libX11, libXinerama, libXft, patches ? []}:
+{stdenv, fetchurl, libX11, libXinerama, libXft, writeText, patches ? [], conf ? null}:
+
+with stdenv.lib;
 
 let
   name = "dwm-6.2";
@@ -17,6 +19,10 @@ stdenv.mkDerivation {
 
   # Allow users set their own list of patches
   inherit patches;
+
+  # Allow users to set the config.def.h file containing the configuration
+  postPatch = let configFile = if isDerivation conf || builtins.isPath conf then conf else writeText "config.def.h" conf;
+  in optionalString (conf!=null) "cp ${configFile} config.def.h";
 
   buildPhase = " make ";
 

--- a/pkgs/applications/window-managers/dwm/default.nix
+++ b/pkgs/applications/window-managers/dwm/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation {
   postPatch = let configFile = if isDerivation conf || builtins.isPath conf then conf else writeText "config.def.h" conf;
   in optionalString (conf!=null) "cp ${configFile} config.def.h";
 
-  buildPhase = " make ";
-
   meta = {
     homepage = "https://suckless.org/";
     description = "Dynamic window manager for X";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This allows a user to set the config file, it's based on the [st derivation](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/st/default.nix) but also allows derivations and paths in a straightforward way.

For reference: There has been one previous issue (#44300) about adding this but that ended with someone using their own fork and thus not needing this functionality anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

**Edited:** Linked issue.