### PR TITLE
python38Packages.ihatemoney: enable on darwin

### DIFF
--- a/pkgs/development/python-modules/flask-testing/default.nix
+++ b/pkgs/development/python-modules/flask-testing/default.nix
@@ -1,7 +1,4 @@
-{ stdenv, fetchPypi, buildPythonPackage, pythonOlder
-, flask, blinker, twill }:
-
-with stdenv.lib;
+{ stdenv, fetchPypi, buildPythonPackage, isPy3k, flask, blinker, twill }:
 
 buildPythonPackage rec {
   pname = "Flask-Testing";
@@ -13,13 +10,20 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    sed -i -e 's/twill==0.9.1/twill/' setup.py
+    substituteInPlace setup.py --replace "twill==0.9.1" "twill"
   '';
 
-  buildInputs = optionals (pythonOlder "3.0") [ twill ];
-  propagatedBuildInputs = [ flask blinker ];
+  propagatedBuildInputs = [ flask ];
 
-  meta = {
+  checkInputs = [ blinker ] ++ stdenv.lib.optionals (!isPy3k) [ twill ];
+
+  # twill integration is outdated in Python 2, hence it the tests fails.
+  # Some of the tests use localhost networking on darwin.
+  doCheck = isPy3k && !stdenv.isDarwin;
+
+  pythonImportsCheck = [ "flask_testing" ];
+
+  meta = with stdenv.lib; {
     description = "Flask unittest integration.";
     homepage = "https://pythonhosted.org/Flask-Testing/";
     license = licenses.bsd3;

--- a/pkgs/development/python-modules/ihatemoney/default.nix
+++ b/pkgs/development/python-modules/ihatemoney/default.nix
@@ -122,7 +122,6 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://ihatemoney.org";
     description = "A simple shared budget manager web application";
-    platforms = platforms.linux;
     license = licenses.beerware;
     maintainers = [ maintainers.symphorien ];
   };

--- a/pkgs/development/python-modules/twill/default.nix
+++ b/pkgs/development/python-modules/twill/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   doCheck = false; # pypi package comes without tests, other homepage does not provide all verisons
 
   meta = with lib; {
-    homepage = "http://twill.idyll.org/";
+    homepage = "https://twill-tools.github.io/twill/";
     description = "A simple scripting language for Web browsing";
     license     = licenses.mit;
     maintainers = with maintainers; [ mic92 ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
