### PR TITLE
.github/workflows/wait-ofborg.yml: 260 -> 360

### DIFF
--- a/.github/workflows/wait-ofborg.yml
+++ b/.github/workflows/wait-ofborg.yml
@@ -9,7 +9,7 @@ jobs:
       run: |
         # wait for ~30min...
         # ..in future a better fix would be to make ofborg mark CI as pending right away.
-        for i in $(seq 260); do
+        for i in $(seq 360); do
           res=$(curl --silent \
             -H "Accept: application/vnd.github.antiope-preview+json" \
             -H "Authorization: token ${GITHUB_TOKEN}" \


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/blob/e3d45be66fcd7abbafb6f47e7890f60320905eed/.github/workflows/wait-ofborg.yml#L10

Currently this isn't waiting for 30min.