### PR TITLE
cfssl: 1.3.2 -> 1.4.1

### DIFF
--- a/pkgs/tools/misc/go.rice/default.nix
+++ b/pkgs/tools/misc/go.rice/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go.rice";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "GeertJohan";
+    repo = "go.rice";
+    rev = "v${version}";
+    sha256 = "0m1pkqnx9glf3mlx5jdaby9yxccbl02jpjgpi4m7x1hb4s2gn6vx";
+  };
+
+  vendorSha256 = "0cb5phyl2zm1xnkhvisv0lzgknsi93yzmpayg30w7jc6z4icwnw7";
+
+  subPackages = [ "." "rice" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/GeertJohan/go.rice";
+    description = "A Go package that makes working with resources such as html, js, css, images, templates very easy.";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ blaggacao ];
+  };
+}
+

--- a/pkgs/tools/security/cfssl/default.nix
+++ b/pkgs/tools/security/cfssl/default.nix
@@ -1,34 +1,59 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, fetchpatch }:
+{ stdenv, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+let
+  # Embed static files in the built-in webserver
+  rice = buildGoModule rec {
+    name = "rice";
+    src = fetchFromGitHub {
+      owner = "GeertJohan";
+      repo = "go.rice";
+      rev = "v1.0.0";
+      sha256 = "0m1pkqnx9glf3mlx5jdaby9yxccbl02jpjgpi4m7x1hb4s2gn6vx";
+    };
+    vendorSha256 = "0cb5phyl2zm1xnkhvisv0lzgknsi93yzmpayg30w7jc6z4icwnw7";
+    subPackages = [ "rice" ];
+  };
+in
+buildGoModule rec {
   pname = "cfssl";
-  version = "1.3.2";
-
-  goPackagePath = "github.com/cloudflare/cfssl";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "cloudflare";
     repo = "cfssl";
-    rev = version;
-    sha256 = "0j2gz2vl2pf7ir7sc7jrwmjnr67hk4qhxw09cjx132jbk337jc9x";
+    rev = "v${version}";
+    sha256 = "07qacg95mbh94fv64y577zyr4vk986syf8h5l8lbcmpr0zcfk0pd";
   };
 
-  # The following patch ensures that the auth-key decoder doesn't break,
-  # if the auth-key file contains leading or trailing whitespaces.
-  # https://github.com/cloudflare/cfssl/pull/923 is merged
-  # remove patch when it becomes part of a release.
-  patches = [
-    (fetchpatch {
-      url    = "https://github.com/cloudflare/cfssl/commit/7e13f60773c96644db9dd8d342d42fe3a4d26f36.patch";
-      sha256 = "1z2v2i8yj7qpj8zj5f2q739nhrr9s59jwzfzk52wfgssl4vv5mn5";
-    })
+  subPackages = [
+    "cmd/cfssl"
+    "cmd/cfssljson"
+    "cmd/cfssl-bundle"
+    "cmd/cfssl-certinfo"
+    "cmd/cfssl-newkey"
+    "cmd/cfssl-scan"
+    "cmd/multirootca"
+    "cmd/mkbundle"
   ];
+
+  vendorSha256 = null;
+
+  preBuild = ''
+    pushd cli/serve
+    ${rice}/bin/rice embed-go
+    popd
+  '';
+
+  buildFlagsArray = ''
+    -ldflags=
+      -s -w
+      -X github.com/cloudflare/cfssl/cli/version.version=v${version}
+  '';
 
   meta = with stdenv.lib; {
     homepage = "https://cfssl.org/";
     description = "Cloudflare's PKI and TLS toolkit";
     license = licenses.bsd2;
     maintainers = with maintainers; [ mbrgm ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/security/cfssl/default.nix
+++ b/pkgs/tools/security/cfssl/default.nix
@@ -1,19 +1,5 @@
-{ stdenv, buildGoModule, fetchFromGitHub }:
+{ stdenv, buildGoModule, fetchFromGitHub, go-rice }:
 
-let
-  # Embed static files in the built-in webserver
-  rice = buildGoModule rec {
-    name = "rice";
-    src = fetchFromGitHub {
-      owner = "GeertJohan";
-      repo = "go.rice";
-      rev = "v1.0.0";
-      sha256 = "0m1pkqnx9glf3mlx5jdaby9yxccbl02jpjgpi4m7x1hb4s2gn6vx";
-    };
-    vendorSha256 = "0cb5phyl2zm1xnkhvisv0lzgknsi93yzmpayg30w7jc6z4icwnw7";
-    subPackages = [ "rice" ];
-  };
-in
 buildGoModule rec {
   pname = "cfssl";
   version = "1.4.1";
@@ -38,9 +24,11 @@ buildGoModule rec {
 
   vendorSha256 = null;
 
+  nativeBuildInputs = [ go-rice ];
+
   preBuild = ''
     pushd cli/serve
-    ${rice}/bin/rice embed-go
+    rice embed-go
     popd
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1911,6 +1911,8 @@ in
 
   gdrive = callPackage ../applications/networking/gdrive { };
 
+  go-rice = callPackage ../tools/misc/go.rice {};
+
   go-2fa = callPackage ../tools/security/2fa {};
 
   go-dependency-manager = callPackage ../development/tools/gdm { };
@@ -7344,7 +7346,7 @@ in
   uget = callPackage ../tools/networking/uget { };
 
   uget-integrator = callPackage ../tools/networking/uget-integrator { };
-  
+
   ugrep = callPackage ../tools/text/ugrep { };
 
   uif2iso = callPackage ../tools/cd-dvd/uif2iso { };


### PR DESCRIPTION
- [x] Jep, cfssl server works (now) with embedded static files
- [x] All built commandos tested manually for `--help`

`nix-review` outputs in comment below.

![image](https://user-images.githubusercontent.com/7548295/88750314-d4564580-d11a-11ea-9538-3c129cc729ce.png)
