### PR TITLE
ibm-plex: 5.0.0 -> 5.1.0

### DIFF
--- a/pkgs/data/fonts/ibm-plex/default.nix
+++ b/pkgs/data/fonts/ibm-plex/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip }:
 
 let
-  version = "5.0.0";
+  version = "5.1.0";
 
 in fetchzip {
   name = "ibm-plex-${version}";
@@ -13,7 +13,7 @@ in fetchzip {
     unzip -j $downloadedFile "OpenType/*/*.otf" -d $out/share/fonts/opentype
   '';
 
-  sha256 = "1m8a9p0bryrj05v7sg9kqvyp0ddhgdwd0zjbn0i4l296cj5s2k97";
+  sha256 = "1lcbj6zkpnsq38s2xkx3z4d7bd43k630lmzmgdcv1w05gjij0pw5";
 
   meta = with lib; {
     description = "IBM Plex Typeface";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/IBM/plex/releases/tag/v5.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).