### PR TITLE
steam-runtime: 0.20200604.0 -> 0.20200720.0

### DIFF
--- a/pkgs/games/steam/runtime.nix
+++ b/pkgs/games/steam/runtime.nix
@@ -4,11 +4,11 @@ stdenv.mkDerivation rec {
 
   name = "steam-runtime";
   # from https://repo.steampowered.com/steamrt-images-scout/snapshots/
-  version = "0.20200604.0";
+  version = "0.20200720.0";
 
   src = fetchurl {
     url = "https://repo.steampowered.com/steamrt-images-scout/snapshots/${version}/steam-runtime.tar.xz";
-    sha256 = "04ficg3lnf6ijwkj08094vgcsskfncnlhk61v2csls3wfwvkrmhv";
+    sha256 = "03qdlr1xk84jb4c60ilis00vjhj70bxc0bbgk5g5b1883l2frljd";
     name = "scout-runtime-${version}.tar.gz";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Bump steam runtime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).