### PR TITLE
iosevka-bin: 3.2.2 -> 3.3.1

### DIFF
--- a/pkgs/data/fonts/iosevka/bin.nix
+++ b/pkgs/data/fonts/iosevka/bin.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchzip }:
 
 let
-  version = "3.2.2";
+  version = "3.3.1";
 in fetchzip {
   name = "iosevka-bin-${version}";
 
@@ -12,7 +12,7 @@ in fetchzip {
     unzip -j $downloadedFile \*.ttc -d $out/share/fonts/iosevka
   '';
 
-  sha256 = "11966fvqamlg88vlgs47fl3ambi48h0mjj4a758i5y8myb2hk6bd";
+  sha256 = "1hfccivk5f7i489s78yh2x96ic6rf5ncbsjqnrxqmfs9n1gjhfbj";
 
   meta = with stdenv.lib; {
     homepage = "https://be5invis.github.io/Iosevka/";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/be5invis/Iosevka/releases/tag/v3.3.1


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).