### PR TITLE
agave: 16 -> 22

### DIFF
--- a/pkgs/data/fonts/agave/default.nix
+++ b/pkgs/data/fonts/agave/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "agave";
-  version = "16";
+  version = "17";
 in fetchurl {
   name = "${pname}-${version}";
   url = "https://github.com/agarick/agave/releases/download/v${version}/Agave-Regular.ttf";
@@ -13,7 +13,7 @@ in fetchurl {
     install -D $downloadedFile $out/share/fonts/truetype/Agave-Regular.ttf
   '';
 
-  sha256 = "108jvcijnx06v1jzhnb28ql9nvmwqd83309834wcd4aii6bgf9ka";
+  sha256 = "1h61j1nbiwip71gxmz8my6xwy0j8ahf2p39hmrl1rxpsqvsj6dlz";
 
   meta = with lib; {
     description = "truetype monospaced typeface designed for X environments";

--- a/pkgs/data/fonts/agave/default.nix
+++ b/pkgs/data/fonts/agave/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "agave";
-  version = "17";
+  version = "21";
 in fetchurl {
   name = "${pname}-${version}";
   url = "https://github.com/agarick/agave/releases/download/v${version}/Agave-Regular.ttf";
@@ -13,7 +13,7 @@ in fetchurl {
     install -D $downloadedFile $out/share/fonts/truetype/Agave-Regular.ttf
   '';
 
-  sha256 = "1h61j1nbiwip71gxmz8my6xwy0j8ahf2p39hmrl1rxpsqvsj6dlz";
+  sha256 = "1q91h8p848i789jcnazx9pmhv2drypsb4b2bnxca2lcjpyn1wscr";
 
   meta = with lib; {
     description = "truetype monospaced typeface designed for X environments";

--- a/pkgs/data/fonts/agave/default.nix
+++ b/pkgs/data/fonts/agave/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "agave";
-  version = "21";
+  version = "22";
 in fetchurl {
   name = "${pname}-${version}";
   url = "https://github.com/agarick/agave/releases/download/v${version}/Agave-Regular.ttf";
@@ -13,7 +13,7 @@ in fetchurl {
     install -D $downloadedFile $out/share/fonts/truetype/Agave-Regular.ttf
   '';
 
-  sha256 = "1q91h8p848i789jcnazx9pmhv2drypsb4b2bnxca2lcjpyn1wscr";
+  sha256 = "1jb8f0xcv5z0l5nyx733b6zclswi82vrh2nwyyhbqzgqrl4y1h6s";
 
   meta = with lib; {
     description = "truetype monospaced typeface designed for X environments";


### PR DESCRIPTION
###### Motivation for this change

* https://github.com/agarick/agave/releases/tag/v17
* https://github.com/agarick/agave/releases/tag/v18
* https://github.com/agarick/agave/releases/tag/v19
* https://github.com/agarick/agave/releases/tag/v20
* https://github.com/agarick/agave/releases/tag/v21
* https://github.com/agarick/agave/releases/tag/v22

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
     - Using in terminal to write this right now! :grin:
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).