### PR TITLE
spleen: 1.8.0 -> 1.8.1

### DIFF
--- a/pkgs/data/fonts/spleen/default.nix
+++ b/pkgs/data/fonts/spleen/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "spleen";
-  version = "1.8.0";
+  version = "1.8.1";
 in fetchurl {
   name = "${pname}-${version}";
   url = "https://github.com/fcambus/spleen/releases/download/${version}/spleen-${version}.tar.gz";
@@ -19,7 +19,7 @@ in fetchurl {
     # create fonts.dir so NixOS xorg module adds to fp
     ${mkfontscale}/bin/mkfontdir "$d"
   '';
-  sha256 = "0vaawnav4k2gpwsgxn5rmkd8wyxnwsrbd0ksp749sb7rwfd3nphc";
+  sha256 = "0m70gz1ywrhw8xfff9bgx1wv52z9fibdsmjcwhjhpd826zbz05w8";
 
   meta = with lib; {
     description = "Monospaced bitmap fonts";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/fcambus/spleen/blob/1.8.1/ChangeLog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).