### PR TITLE
cascadia-code: 1911.21 -> 2007.01, opentype, variable weight, ...

### DIFF
--- a/pkgs/data/fonts/cascadia-code/default.nix
+++ b/pkgs/data/fonts/cascadia-code/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "cascadia-code";
-  version = "2005.15";
+  version = "2007.01";
 
   src = fetchzip {
-    url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/CascadiaCode_${version}.zip";
-    sha256 = "0wm8lqhgkz691w6ai6r45c7199p7bpr00rm8nz4ynafrb15fgm6v";
+    url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/CascadiaCode-${version}.zip";
+    sha256 = "0jqggqjqck0nkq301r217hv9k5xzcy6vqc4fqgdmh2d9divbja5m";
     stripRoot = false;
   };
 

--- a/pkgs/data/fonts/cascadia-code/default.nix
+++ b/pkgs/data/fonts/cascadia-code/default.nix
@@ -1,42 +1,19 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchzip }:
 
 stdenv.mkDerivation rec {
   pname = "cascadia-code";
-  version = "1911.21";
+  version = "2005.15";
 
-  srcs = [
-    (fetchurl {
-      url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/Cascadia.ttf";
-      sha256 = "1m5ymbngjg3n1g3p6vhcq7d825bwwln9afih651ar3jn7j9njnyg";
-     })
-    (fetchurl {
-      url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/CascadiaMono.ttf";
-      sha256 = "0vkhm6rhspzd1iayxrzaag099wsc94azfqa3ips7f4x9s8fmbp80";
-    })
-    (fetchurl {
-      url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/CascadiaMonoPL.ttf";
-      sha256 = "0xxqd8m2ydn97jngp1a3ik1mzpjbm65pfq02a82gfbbvajq5d673";
-    })
-    (fetchurl {
-      url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/CascadiaPL.ttf";
-      sha256 = "1s83c9flvifd05nbhnk8knwnik7p621sr7i94smknigc7d72wqav";
-    })
-  ];
-
-  unpackCmd = ''
-    ttfName=$(basename $(stripHash $curSrc))
-    cp $curSrc ./$ttfName
-  '';
-
-  sourceRoot = ".";
+  src = fetchzip {
+    url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/CascadiaCode_${version}.zip";
+    sha256 = "0wm8lqhgkz691w6ai6r45c7199p7bpr00rm8nz4ynafrb15fgm6v";
+    stripRoot = false;
+  };
 
   installPhase = ''
-    install -Dm444 -t $out/share/fonts/truetype *.ttf
+    install -Dm444 -t $out/share/fonts/truetype ttf/*.ttf
+    install -Dm444 -t $out/share/fonts/opentype otf/*.otf
   '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "1gkjs7qa409r4ykdy4ik8i0c3z49hzpklw6kyijhhifhyyyzhz4h";
 
   meta = with stdenv.lib; {
     description = "Monospaced font that includes programming ligatures and is designed to enhance the modern look and feel of the Windows Terminal";


### PR DESCRIPTION
###### Motivation for this change

* https://github.com/microsoft/cascadia-code/releases/tag/v2004.30 
* https://github.com/microsoft/cascadia-code/releases/tag/v2005.15
* https://github.com/microsoft/cascadia-code/releases/tag/v2007.01

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).