### PR TITLE
dex: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/tools/X11/dex/default.nix
+++ b/pkgs/tools/X11/dex/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   program = "dex";
   name = "${program}-${version}";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "jceb";
     repo = program;
     rev = "v${version}";
-    sha256 = "13dkjd1373mbvskrdrp0865llr3zvdr90sc6a6jqswh3crmgmz4k";
+    sha256 = "03aapcywnz4kl548cygpi25m8adwbmqlmwgxa66v4156ax9dqs86";
   };
 
   propagatedBuildInputs = [ python3 ];

--- a/pkgs/tools/X11/dex/default.nix
+++ b/pkgs/tools/X11/dex/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3, fetchpatch }:
+{ stdenv, fetchFromGitHub, python3 }:
 
 stdenv.mkDerivation rec {
   program = "dex";
@@ -15,13 +15,6 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ python3 ];
   nativeBuildInputs = [ python3.pkgs.sphinx ];
   makeFlags = [ "PREFIX=$(out)" "VERSION=$(version)" ];
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/jceb/dex/commit/107358ddf5e1ca4fa56ef1a7ab161dc3b6adc45a.patch";
-      sha256 = "06dfkfzxp8199by0jc5wim8g8qw38j09dq9p6n9w4zaasla60pjq";
-    })
-  ];
 
   meta = with stdenv.lib; {
     description = "A program to generate and execute DesktopEntry files of the Application type";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/jceb/dex/compare/v0.8.0...v0.9.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).