### PR TITLE
bloaty: 1.0 -> 1.1

### DIFF
--- a/pkgs/development/tools/bloaty/default.nix
+++ b/pkgs/development/tools/bloaty/default.nix
@@ -1,14 +1,14 @@
 { stdenv, cmake, zlib, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "1.0";
+  version = "1.1";
   pname = "bloaty";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "bloaty";
     rev = "v${version}";
-    sha256 = "0fck83zyh9bwlwdk3fkhv3337g9nii6rzf96gyghmnrsp9rzxs3l";
+    sha256 = "1556gb8gb8jwf5mwxppcqz3mp269b5jhd51kj341iqkbn27zzngk";
     fetchSubmodules = true;
   };
 
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/google/bloaty";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = [ maintainers.dtzWill ];
+    maintainers = with maintainers; [ dtzWill ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/google/bloaty/releases/tag/v1.1


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).