### PR TITLE
tvheadend: include dtv scan tables

### DIFF
--- a/pkgs/servers/tvheadend/default.nix
+++ b/pkgs/servers/tvheadend/default.nix
@@ -1,10 +1,22 @@
 { stdenv, fetchFromGitHub, cmake, makeWrapper, pkgconfig
 , avahi, dbus, gettext, git, gnutar, gzip, bzip2, ffmpeg_3, libiconv, openssl, python
-, which, zlib }:
+, v4l-utils, which, zlib }:
 
 let
   version = "4.2.8";
 
+  dtv-scan-tables = stdenv.mkDerivation {
+    pname = "dtv-scan-tables";
+    version = "2020-05-18";
+    src = fetchFromGitHub {
+      owner = "tvheadend";
+      repo = "dtv-scan-tables";
+      rev = "e3138a506a064f6dfd0639d69f383e8e576609da";
+      sha256 = "19ac9ds3rfc2xrqcywsbd1iwcpv7vmql7gp01iikxkzcgm2g2b6w";
+    };
+    nativeBuildInputs = [ v4l-utils ];
+    installFlags = [ "DATADIR=$(out)" ];
+  };
 in stdenv.mkDerivation {
   pname = "tvheadend";
   inherit version;
@@ -28,7 +40,7 @@ in stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = [ "-Wno-error=format-truncation" "-Wno-error=stringop-truncation" ];
 
   # disable dvbscan, as having it enabled causes a network download which
-  # cannot happen during build.
+  # cannot happen during build.  We now include the dtv-scan-tables ourselves
   configureFlags = [
     "--disable-dvbscan"
     "--disable-bintray_cache"
@@ -44,6 +56,9 @@ in stdenv.mkDerivation {
 
     substituteInPlace src/config.c \
       --replace /usr/bin/tar ${gnutar}/bin/tar
+
+    substituteInPlace src/input/mpegts/scanfile.c \
+      --replace /usr/share/dvb ${dtv-scan-tables}/dvbv5
 
     # the version detection script `support/version` reads this file if it
     # exists, so let's just use that


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I'm not regularly using tvheadend, just trying it out with an old DVB tuner I had lying around. However, when setting up the tuner, it needs to know what frequencies it should try to scan for TV service.  Normally, the tvheadend build process fetches these tables itself, however, this would not work for us with nix.   This PR makes those "dtv scan tables" available.

Before: (there are no available "predefined muxes")
![dvb](https://user-images.githubusercontent.com/1298344/88765109-dd4f1300-d12a-11ea-88e3-55b56ad8c89e.png)

After:
![dvb-new](https://user-images.githubusercontent.com/1298344/88765119-e04a0380-d12a-11ea-9812-a5dd18547c0c.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
