### PR TITLE
librespot: 0.1.1 -> 0.1.3

### DIFF
--- a/pkgs/applications/audio/librespot/cargo-lock.patch
+++ b/pkgs/applications/audio/librespot/cargo-lock.patch
@@ -1,0 +1,137 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 533b47d..9c9c2f6 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -932,7 +932,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "librespot"
+-version = "0.1.2"
++version = "0.1.3"
+ dependencies = [
+  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -940,12 +940,12 @@ dependencies = [
+  "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
+- "librespot-audio 0.1.2",
+- "librespot-connect 0.1.2",
+- "librespot-core 0.1.2",
+- "librespot-metadata 0.1.2",
+- "librespot-playback 0.1.2",
+- "librespot-protocol 0.1.2",
++ "librespot-audio 0.1.3",
++ "librespot-connect 0.1.3",
++ "librespot-core 0.1.3",
++ "librespot-metadata 0.1.3",
++ "librespot-playback 0.1.3",
++ "librespot-protocol 0.1.3",
+  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "protobuf 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -961,7 +961,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "librespot-audio"
+-version = "0.1.2"
++version = "0.1.3"
+ dependencies = [
+  "aes-ctr 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "bit-set 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -969,7 +969,7 @@ dependencies = [
+  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lewton 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "librespot-core 0.1.2",
++ "librespot-core 0.1.3",
+  "librespot-tremor 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -980,7 +980,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "librespot-connect"
+-version = "0.1.2"
++version = "0.1.3"
+ dependencies = [
+  "aes-ctr 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -990,9 +990,9 @@ dependencies = [
+  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libmdns 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "librespot-core 0.1.2",
+- "librespot-playback 0.1.2",
+- "librespot-protocol 0.1.2",
++ "librespot-core 0.1.3",
++ "librespot-playback 0.1.3",
++ "librespot-protocol 0.1.3",
+  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "protobuf 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1007,7 +1007,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "librespot-core"
+-version = "0.1.2"
++version = "0.1.3"
+ dependencies = [
+  "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1020,7 +1020,7 @@ dependencies = [
+  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
+  "hyper-proxy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "librespot-protocol 0.1.2",
++ "librespot-protocol 0.1.3",
+  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1043,12 +1043,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "librespot-metadata"
+-version = "0.1.2"
++version = "0.1.3"
+ dependencies = [
+  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+- "librespot-core 0.1.2",
+- "librespot-protocol 0.1.2",
++ "librespot-core 0.1.3",
++ "librespot-protocol 0.1.3",
+  "linear-map 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "protobuf 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1056,7 +1056,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "librespot-playback"
+-version = "0.1.2"
++version = "0.1.3"
+ dependencies = [
+  "alsa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1068,9 +1068,9 @@ dependencies = [
+  "jack 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.73 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libpulse-sys 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "librespot-audio 0.1.2",
+- "librespot-core 0.1.2",
+- "librespot-metadata 0.1.2",
++ "librespot-audio 0.1.3",
++ "librespot-core 0.1.3",
++ "librespot-metadata 0.1.3",
+  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "portaudio-rs 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rodio 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1081,7 +1081,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "librespot-protocol"
+-version = "0.1.2"
++version = "0.1.3"
+ dependencies = [
+  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "protobuf 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/pkgs/applications/audio/librespot/default.nix
+++ b/pkgs/applications/audio/librespot/default.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl
-, withRodio ? true
-, withALSA ? true, alsaLib ? null
-, withPulseAudio ? false, libpulseaudio ? null
-, withPortAudio ? false, portaudio ? null
-}:
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl, withRodio ? true
+, withALSA ? true, alsaLib ? null, withPulseAudio ? false, libpulseaudio ? null
+, withPortAudio ? false, portaudio ? null }:
 
 rustPlatform.buildRustPackage rec {
   pname = "librespot";
-  version = "0.1.1";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "librespot-org";
     repo = "librespot";
     rev = "v${version}";
-    sha256 = "1sdbjv8w2mfpv82rx5iy4s532l1767vmlrg9d8khnvh8vrm2lshy";
+    sha256 = "1ixh47yvaamrpzagqsiimc3y6bi4nbym95843d23am55zkrgnmy5";
   };
 
-  cargoSha256 = "0zi50imjvalwl6pxl35qrmbg74j5xdfaws8v69am4g9agbfjvlms";
+  cargoSha256 = "1csls8kzzx28ng6w9vdwhnnav5sqp2m5fj430db5z306xh5acg3d";
+
+  cargoPatches = [ ./cargo-lock.patch ];
 
   cargoBuildFlags = with stdenv.lib; [
     "--no-default-features"
@@ -32,8 +31,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ openssl ]
-    ++ stdenv.lib.optional withALSA alsaLib
+  buildInputs = [ openssl ] ++ stdenv.lib.optional withALSA alsaLib
     ++ stdenv.lib.optional withPulseAudio libpulseaudio
     ++ stdenv.lib.optional withPortAudio portaudio;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New release available: https://github.com/librespot-org/librespot/releases/tag/v0.1.2

I applied nixfmt on the file, hence the multiple lines changed: let me know if this is not desirable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
