### PR TITLE
ocamlPackages.mustache: init at 3.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/mustache/default.nix
+++ b/pkgs/development/ocaml-modules/mustache/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, fetchFromGitHub, ezjsonm, menhir, ounit }:
+
+buildDunePackage rec {
+  pname = "mustache";
+  version = "3.1.0";
+  src = fetchFromGitHub {
+    owner = "rgrinberg";
+    repo = "ocaml-mustache";
+    rev = "v${version}";
+    sha256 = "19v8rk8d8lkfm2rmhdawfgadji6wa267ir5dprh4w9l1sfj8a1py";
+  };
+
+  buildInputs = [ ezjsonm ];
+  propagatedBuildInputs = [ menhir ];
+
+  doCheck = true;
+  checkInputs = [ ounit ];
+
+  meta = {
+    description = "Mustache logic-less templates in OCaml";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -569,6 +569,8 @@ let
 
     mtime =  callPackage ../development/ocaml-modules/mtime { };
 
+    mustache =  callPackage ../development/ocaml-modules/mustache { };
+
     nocrypto =  callPackage ../development/ocaml-modules/nocrypto { };
 
     notty = callPackage ../development/ocaml-modules/notty { };


### PR DESCRIPTION
###### Motivation for this change

mustache.js logic-less templates in OCaml

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
