### PR TITLE
convos: 4.23 -> 4.29

### DIFF
--- a/pkgs/applications/networking/irc/convos/default.nix
+++ b/pkgs/applications/networking/irc/convos/default.nix
@@ -6,13 +6,13 @@ with stdenv.lib;
 
 perlPackages.buildPerlPackage rec {
   pname = "convos";
-  version = "4.23";
+  version = "4.29";
 
-  src = fetchFromGitHub rec {
+  src = fetchFromGitHub {
     owner = "Nordaaker";
     repo = pname;
     rev = version;
-    sha256 = "0py9dvqf67vhgdlx20jzwnh313ns1d29yiiqgijydyfj2lflyz12";
+    sha256 = "07m9lhwgqq77hi4n2zrya7n8apkjv8xi166bxa0n7pnlknlp74ar";
   };
 
   nativeBuildInputs = [ makeWrapper ]
@@ -38,16 +38,6 @@ perlPackages.buildPerlPackage rec {
     #
     substituteInPlace t/web-register-open-to-public.t \
       --replace '!127.0.0.1!' '!localhost!'
-
-    # Time-impurity in test, (fixed in master)
-    #
-    substituteInPlace t/web-load-user.t \
-      --replace '400' '410'
-
-    # Disk-space check fails on zfs, (fixed in master)
-    #
-    substituteInPlace t/web-admin.t \
-      --replace 'qr{/dev/}' 'qr{\w}'
 
     # Module::Install is a runtime dependency not covered by the tests, so we add
     # a test for it.


### PR DESCRIPTION
https://github.com/Nordaaker/convos/blob/4.29/Changes

- removed unnecessary `rec`
- removed fixes for tests that are fixed in this version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
