### PR TITLE
the-powder-toy: 94.1 -> 95.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7462,6 +7462,12 @@
     githubId = 2770647;
     name = "Simon Vandel Sillesen";
   };
+  siraben = {
+    email = "bensiraphob@gmail.com";
+    github = "siraben";
+    githubId = 8219659;
+    name = "Siraphob Phipathananunth";
+  };
   siriobalmelli = {
     email = "sirio@b-ad.ch";
     github = "siriobalmelli";

--- a/pkgs/games/the-powder-toy/default.nix
+++ b/pkgs/games/the-powder-toy/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchFromGitHub, scons, pkgconfig, SDL2, lua, fftwFloat,
-  zlib, bzip2, curl }:
+  zlib, bzip2, curl, darwin }:
 
+with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "the-powder-toy";
   version = "95.0";
@@ -13,7 +14,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ scons pkgconfig ];
-
+  
+  propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin 
+    [ (darwin.apple_sdk.frameworks.Cocoa) ];
+  
   buildInputs = [ SDL2 lua fftwFloat zlib bzip2 curl ];
 
   installPhase = ''

--- a/pkgs/games/the-powder-toy/default.nix
+++ b/pkgs/games/the-powder-toy/default.nix
@@ -1,7 +1,6 @@
 { stdenv, fetchFromGitHub, scons, pkgconfig, SDL2, lua, fftwFloat,
   zlib, bzip2, curl, darwin }:
 
-with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "the-powder-toy";
   version = "95.0";
@@ -16,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ scons pkgconfig ];
   
   propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin 
-    [ (darwin.apple_sdk.frameworks.Cocoa) ];
+    [ darwin.apple_sdk.frameworks.Cocoa ];
   
   buildInputs = [ SDL2 lua fftwFloat zlib bzip2 curl ];
 

--- a/pkgs/games/the-powder-toy/default.nix
+++ b/pkgs/games/the-powder-toy/default.nix
@@ -1,21 +1,20 @@
-{ stdenv, fetchFromGitHub, scons, pkgconfig, SDL2, lua, fftwFloat, zlib, bzip2 }:
+{ stdenv, fetchFromGitHub, scons, pkgconfig, SDL2, lua, fftwFloat,
+  zlib, bzip2, curl }:
 
 stdenv.mkDerivation rec {
   pname = "the-powder-toy";
-  version = "94.1";
+  version = "95.0";
 
   src = fetchFromGitHub {
-    owner = "ThePowderToy";
+    owner = "The-Powder-Toy";
     repo = "The-Powder-Toy";
     rev = "v${version}";
-    sha256 = "0w3i4zjkw52qbv3s9cgcwxrdbb1npy0ka7wygyb76xcb17bj0l0b";
+    sha256 = "18rp2g1mj0gklra06wm9dm57h73hmm301npndh0y8ap192i5s8sa";
   };
 
   nativeBuildInputs = [ scons pkgconfig ];
 
-  buildInputs = [ SDL2 lua fftwFloat zlib bzip2 ];
-
-  sconsFlags = "--tool=";
+  buildInputs = [ SDL2 lua fftwFloat zlib bzip2 curl ];
 
   installPhase = ''
     install -Dm 755 build/powder* "$out/bin/powder"
@@ -28,6 +27,6 @@ stdenv.mkDerivation rec {
     homepage = "http://powdertoy.co.uk/";
     platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
     license = licenses.gpl3;
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with maintainers; [ abbradar siraben ];
   };
 }

--- a/pkgs/games/the-powder-toy/default.nix
+++ b/pkgs/games/the-powder-toy/default.nix
@@ -13,10 +13,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ scons pkgconfig ];
-  
-  propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin 
+
+  propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin
     [ darwin.apple_sdk.frameworks.Cocoa ];
-  
+
   buildInputs = [ SDL2 lua fftwFloat zlib bzip2 curl ];
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Update the-powder-toy from 94.1 to 95.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
