### PR TITLE
python.pkgs.decorator: 4.4.1 -> 4.4.2

### DIFF
--- a/pkgs/development/python-modules/decorator/default.nix
+++ b/pkgs/development/python-modules/decorator/default.nix
@@ -1,24 +1,16 @@
 { lib
 , buildPythonPackage
-, fetchpatch
 , fetchPypi
 }:
 
 buildPythonPackage rec {
   pname = "decorator";
-  version = "4.4.1";
+  version = "4.4.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce";
+    sha256 = "1rxzhk5zwiggk45hl53zydvy70lk654kg0nc1p54090p402jz9p3";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/micheles/decorator/commit/3265f2755d16c0a3dfc9f1feee39722ddc11ee80.patch";
-      sha256 = "1q5nmff30vccqq5swf2ivm8cn7x3lhz8c9qpj0zddgs2y7fw8syz";
-    })
-  ];
 
   meta = with lib; {
     homepage = "https://pypi.python.org/pypi/decorator";


### PR DESCRIPTION
###### Motivation for this change
This should fix the build of python39.pkgs.decorator.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
