### PR TITLE
mgit: Init at 0.1.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4368,9 +4368,9 @@
   };
   koozz = {
     name = "Jan van den Berg";
-    email = "264371+koozz@users.noreply.github.com";
+    email = "264372+koozz@users.noreply.github.com";
     github = "koozz";
-    githubId = 264371;
+    githubId = 264372;
   };
   koral = {
     email = "koral@mailoo.org";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9257,4 +9257,10 @@
     github = "deifactor";
     githubId = 30192992;
   };
+  koozz = {
+    name = "Jan van den Berg";
+    email = "264372+koozz@users.noreply.github.com";
+    github = "koozz";
+    githubId = 264372;
+  };
 }

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4366,6 +4366,12 @@
     githubId = 15692230;
     name = "Muhammad Herdiansyah";
   };
+  koozz = {
+    name = "Jan van den Berg";
+    email = "264371+koozz@users.noreply.github.com";
+    github = "koozz";
+    githubId = 264371;
+  };
   koral = {
     email = "koral@mailoo.org";
     github = "k0ral";
@@ -9256,11 +9262,5 @@
     email = "ext0l@riseup.net";
     github = "deifactor";
     githubId = 30192992;
-  };
-  koozz = {
-    name = "Jan van den Berg";
-    email = "264372+koozz@users.noreply.github.com";
-    github = "koozz";
-    githubId = 264372;
   };
 }

--- a/pkgs/development/tools/misc/mgit/default.nix
+++ b/pkgs/development/tools/misc/mgit/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mgit";
+  version = "0.1.10";
+
+  src = fetchFromGitHub {
+    owner = "koozz";
+    repo = pname;
+    rev = version;
+    sha256 = "0lsph259vwxrj8nprkz6dr2nahbl7h037zi6z8w8zgpcg0fs17y6";
+  };
+
+  cargoSha256 = "1a0sznzn1vmavs4l3wmpx3qjh98sknz3fjybsmicch25z3j75iyi";
+
+  meta = with stdenv.lib; {
+    description = "A utility that performs git actions on multiple directories within the current tree";
+    homepage = "https://github.com/koozz/mgit";
+    license = licenses.mit;
+    maintainers = with maintainers; [ koozz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2120,6 +2120,8 @@ in
 
   metabase = callPackage ../servers/metabase { };
 
+  mgit = callPackage ../development/tools/misc/mgit { };
+
   midicsv = callPackage ../tools/audio/midicsv { };
 
   mididings = callPackage ../tools/audio/mididings { };


### PR DESCRIPTION
###### Motivation for this change

Commandline tool written in Rust by myself.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
