### PR TITLE
ip,bytebuild: disable test suites.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -460,6 +460,9 @@ self: super: {
   bytestring-strict-builder = dontCheck super.bytestring-strict-builder;
   bytestring-tree-builder = dontCheck super.bytestring-tree-builder;
 
+  # https://github.com/byteverse/bytebuild/issues/19
+  bytebuild = dontCheck super.bytebuild;
+
   # https://github.com/ndmitchell/shake/issues/206
   # https://github.com/ndmitchell/shake/issues/267
   shake = overrideCabal super.shake (drv: { doCheck = !pkgs.stdenv.isDarwin && false; });

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -463,6 +463,9 @@ self: super: {
   # https://github.com/byteverse/bytebuild/issues/19
   bytebuild = dontCheck super.bytebuild;
 
+  # https://github.com/andrewthad/haskell-ip/issues/67
+  ip = dontCheck super.ip;
+
   # https://github.com/ndmitchell/shake/issues/206
   # https://github.com/ndmitchell/shake/issues/267
   shake = overrideCabal super.shake (drv: { doCheck = !pkgs.stdenv.isDarwin && false; });

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6825,7 +6825,6 @@ broken-packages:
   - iostring
   - iothread
   - iotransaction
-  - ip
   - ip2location
   - ip2proxy
   - ipatch

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3561,7 +3561,6 @@ broken-packages:
   - bv-sized
   - bytable
   - bytearray-parsing
-  - bytebuild
   - bytelog
   - bytestring-arbitrary
   - bytestring-builder-varword


### PR DESCRIPTION
###### Motivation for this change

ip and bytebuild are currently marked broken because of broken test suites.

###### Things done

Disabled tests and ran
`nix-build --no-out-link -A haskellPackages.ip --arg config '{ allowBroken = true; }' `
`nix-build --no-out-link -A haskellPackages.bytebuild --arg config '{ allowBroken = true; }' `
successfully.
