### PR TITLE
pythonPackages.cot: init at 2.2.1

### DIFF
--- a/pkgs/development/python-modules/cot/default.nix
+++ b/pkgs/development/python-modules/cot/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, isPy3k
+, argcomplete, colorlog, pyvmomi, requests, verboselogs
+, psutil, pyopenssl, setuptools
+, mock, pytest, pytest-mock, pytestCheckHook, qemu
+}:
+
+buildPythonPackage rec {
+  pname = "cot";
+  version = "2.2.1";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f4b3553415f90daac656f89d3e82e79b3d751793239bb173a683b4cc0ceb2635";
+  };
+
+  propagatedBuildInputs = [ colorlog pyvmomi requests verboselogs pyopenssl setuptools ]
+  ++ stdenv.lib.optional (pythonOlder "3.3") psutil;
+
+  checkInputs = [ mock pytestCheckHook pytest-mock qemu ];
+
+  # Many tests require network access and/or ovftool (https://code.vmware.com/web/tool/ovf)
+  # try enabling these tests with ovftool once/if it is added to nixpkgs
+  disabledTests = [
+    "HelperGenericTest"
+    "TestCOTAddDisk"
+    "TestCOTAddFile"
+    "TestCOTEditHardware"
+    "TestCOTEditProduct"
+    "TestCOTEditProperties"
+    "TestCOTInjectConfig"
+    "TestISO"
+    "TestOVFAPI"
+    "TestQCOW2"
+    "TestRAW"
+    "TestVMDKConversion"
+  ];
+
+
+  # argparse is part of the standardlib
+  prePatch = ''
+    substituteInPlace setup.py --replace "'argparse'," ""
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Common OVF Tool";
+    longDescription = ''
+      COT (the Common OVF Tool) is a tool for editing Open Virtualization Format (.ovf, .ova) virtual appliances,
+      with a focus on virtualized network appliances such as the Cisco CSR 1000V and Cisco IOS XRv platforms.
+    '';
+    homepage = "https://github.com/glennmatthews/cot";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evanjs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1619,6 +1619,8 @@ in
 
   compsize = callPackage ../os-specific/linux/compsize { };
 
+  cot = with python3Packages; toPythonApplication cot;
+
   coturn = callPackage ../servers/coturn { };
 
   coursier = callPackage ../development/tools/coursier {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -627,6 +627,8 @@ in {
 
   convertdate = callPackage ../development/python-modules/convertdate { };
 
+  cot = callPackage ../development/python-modules/cot { };
+
   crc32c = callPackage ../development/python-modules/crc32c { };
 
   curio = callPackage ../development/python-modules/curio { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
> [COT ](https://github.com/glennmatthews/cot) (the Common OVF Tool) is a tool for editing Open Virtualization Format (.ovf, .ova) virtual appliances, with a focus on virtualized network appliances such as the Cisco CSR 1000V and Cisco IOS XRv platforms.

I figured this might be more accessible/helpful than e.g. https://code.vmware.com/tool/ovf

This might prove useful in adding [ESXi virtualization support](https://github.com/NixOS/nixpkgs/issues/94104) ([Discourse post](https://discourse.nixos.org/t/virtualization-ova-ovf-esxi-support-extended-ova-customization/7536)) if/once https://github.com/glennmatthews/cot/issues/80 is resolved.

Until then, I think this might still be useful for managing OVF appliances, either during or after their generation, via the `virtualbox-image` and related expressions (`VBoxManage export`, etc).
___
###### Things done
- Added `cot` to python-modules (>=python3)
- Added `cot` to `top-level/pythonPackages`
- Added `cot` to `top-level/all-packages` (via `toPythonApplication`)
___
##### Many tests are currently disabled
Without any filters, this is the output from a normal build (with all tests enabled):
```
python3.8-cot> =========== 189 failed, 380 passed, 24 warnings, 17 errors in 25.32s ===========
builder for '/nix/store/lakc1ns9f44l1hxw778207danhr37fim-python3.8-cot-2.2.0.drv' failed with exit code 1; last 10 log lines:
  ERROR COT/ui/tests/test_cli.py::TestCLIAddDisk::test_invalid_args - Assertion...
  ERROR COT/ui/tests/test_cli.py::TestCLIAddDisk::test_nonexistent_file - Asser...
  ERROR COT/ui/tests/test_cli.py::TestCLIEditHardware::test_args_append - Asser...
  ERROR COT/ui/tests/test_cli.py::TestCLIEditProperties::test_set_property_valid
  ERROR COT/vm_description/ovf/tests/test_item.py::TestOVFItem::test_set_property
  ERROR COT/vm_description/ovf/tests/test_item.py::TestOVFItem::test_set_property_no_modification
  ERROR COT/vm_description/ovf/tests/test_ovf.py::TestOVFInputOutput::test_input_output_bad_file
  ERROR COT/vm_description/ovf/tests/test_ovf.py::TestOVFInputOutput::test_tar_links
  ERROR COT/vm_description/ovf/tests/test_ovf.py::TestOVFInputOutput::test_tar_untar
  =========== 189 failed, 380 passed, 24 warnings, 17 errors in 25.32s ===========
[0 built (1 failed), 0.0 MiB DL]
error: build of '/nix/store/lakc1ns9f44l1hxw778207danhr37fim-python3.8-cot-2.2.0.drv' failed
```

I ignored any files with failing tests, vs disabling each test that was failing.
This results in 19 lines of `--ignore` vs ~189.

Note that this package needs `py3k`  and up, and is disabled `if !isPy3k` in the expression.
I noticed that some packages do this checking earlier (e.g. in `python-packages.nix`), and while I'm not sure which is a best practice, the `disabled` attribute does prevent `cot` from being built with `python2` (`error: cot-2.2.1 not supported for interpreter python2.7`)