### PR TITLE
nss: switch the default to 3.44

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -1,11 +1,11 @@
-{ config, stdenv, lib, callPackage, fetchurl, nss_3_44 }:
+{ config, stdenv, lib, callPackage, fetchurl, nss_3_44, nss_latest }:
 
 let
   common = opts: callPackage (import ./common.nix opts) {};
 in
 
 rec {
-  firefox = common rec {
+  firefox = (common rec {
     pname = "firefox";
     ffversion = "78.0.1";
     src = fetchurl {
@@ -31,6 +31,8 @@ rec {
       attrPath = "firefox-unwrapped";
       versionKey = "ffversion";
     };
+  }).override {
+    nss = nss_latest;
   };
 
   firefox-esr-68 = (common rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14152,7 +14152,8 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
-  nss = lowPrio (callPackage ../development/libraries/nss { });
+  nss = nss_3_44; # various packages had problems with 3.54: #93955
+  nss_latest = lowPrio (callPackage ../development/libraries/nss { });
   nss_3_44 = lowPrio (callPackage ../development/libraries/nss/3.44.nix { });
   nssTools = nss.tools;
 
@@ -18181,7 +18182,9 @@ in
 
   inherit (kdeFrameworks) breeze-icons;
 
-  cacert = callPackage ../data/misc/cacert { };
+  cacert = callPackage ../data/misc/cacert {
+    nss = nss_latest;
+  };
 
   caladea = callPackage ../data/fonts/caladea {};
 


### PR DESCRIPTION
- newest Firefox needs newer version
- cacert keeps being built from newer version
This isn't such a large rebuild, perhaps surprisingly.

This is meant as a quick work-around for various packages having problems (#93955), at least until we know more about what's going on in there.  I'd like fast merge, but I wanted to post this as a PR at least for a while.