### PR TITLE
ft2-clone: add a test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -108,6 +108,7 @@ in
   fontconfig-default-fonts = handleTest ./fontconfig-default-fonts.nix {};
   freeswitch = handleTest ./freeswitch.nix {};
   fsck = handleTest ./fsck.nix {};
+  ft2-clone = handleTest ./ft2-clone.nix {};
   gerrit = handleTest ./gerrit.nix {};
   gotify-server = handleTest ./gotify-server.nix {};
   grocy = handleTest ./grocy.nix {};

--- a/nixos/tests/ft2-clone.nix
+++ b/nixos/tests/ft2-clone.nix
@@ -1,0 +1,35 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "ft2-clone";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ fgaz ];
+  };
+
+  machine = { config, pkgs, ... }: {
+    imports = [
+      ./common/x11.nix
+    ];
+
+    services.xserver.enable = true;
+    sound.enable = true;
+    environment.systemPackages = [ pkgs.ft2-clone ];
+  };
+
+  enableOCR = true;
+
+  testScript =
+    ''
+      machine.wait_for_x()
+      # Add a dummy sound card, or the program won't start
+      machine.execute("modprobe snd-dummy")
+
+      machine.execute("ft2-clone &")
+
+      machine.wait_for_window(r"Fasttracker")
+      machine.sleep(5)
+      # One of the few words that actually get recognized
+      if "Songlen" not in machine.get_screen_text():
+          raise Exception("Program did not start successfully")
+      machine.screenshot("screen")
+    '';
+})
+

--- a/pkgs/applications/audio/ft2-clone/default.nix
+++ b/pkgs/applications/audio/ft2-clone/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchFromGitHub
 , cmake
+, nixosTests
 , alsaLib
 , SDL2
 }:
@@ -18,6 +19,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ SDL2 ] ++ stdenv.lib.optional stdenv.isLinux alsaLib;
+
+  passthru.tests = {
+    ft2-clone-starts = nixosTests.ft2-clone;
+  };
 
   meta = with stdenv.lib; {
     description = "A highly accurate clone of the classic Fasttracker II software for MS-DOS";

--- a/pkgs/applications/audio/ft2-clone/default.nix
+++ b/pkgs/applications/audio/ft2-clone/default.nix
@@ -4,6 +4,7 @@
 , nixosTests
 , alsaLib
 , SDL2
+, libiconv
 }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +19,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ SDL2 ] ++ stdenv.lib.optional stdenv.isLinux alsaLib;
+  buildInputs = [ SDL2 ]
+    ++ stdenv.lib.optional stdenv.isLinux alsaLib
+    ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 
   passthru.tests = {
     ft2-clone-starts = nixosTests.ft2-clone;


### PR DESCRIPTION
###### Motivation for this change

New release, and a test because why not

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
