### PR TITLE
python3Packages.scikit-build: 0.10.0 -> 0.11.1

### DIFF
--- a/pkgs/development/python-modules/scikit-build/default.nix
+++ b/pkgs/development/python-modules/scikit-build/default.nix
@@ -26,11 +26,11 @@
 
 buildPythonPackage rec {
   pname = "scikit-build";
-  version = "0.10.0";
+  version = "0.11.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7342017cc82dd6178e3b19377389b8a8d1f8b429d9cdb315cfb1094e34a0f526";
+    sha256 = "0p4smkl2rbpl00m5va5qa8hp2hqb3284p2cs6k8zlmi4kgbdyh6s";
   };
 
   propagatedBuildInputs = [
@@ -59,15 +59,6 @@ buildPythonPackage rec {
 
   dontUseCmakeConfigure = true;
 
-  # scikit-build PR #458. Remove in version > 0.10.0
-  patches = [
-    (fetchpatch {
-      name = "python38-platform_linux_distribution-fix-458";
-      url = "https://github.com/scikit-build/scikit-build/commit/faa7284e5bc4c72bc8744987acdf3297b5d2e7e4.patch";
-      sha256 = "1hgl3cnkf266zaw534b64c88waxfz9721wha0m6j3hsnxk76ayjv";
-    })
-  ];
-
   disabledTests = lib.concatMapStringsSep " and " (s: "not " + s) ([
     "test_hello_develop" # tries setuptools develop install
     "test_source_distribution" # pip has no way to install missing dependencies
@@ -75,6 +66,7 @@ buildPythonPackage rec {
     "test_fortran_compiler" # passes if gfortran is available
     "test_install_command" # tries to alter out path
     "test_test_command" # tries to alter out path
+    "test_setup" # tries to install using distutils
   ]);
 
   checkPhase = ''


### PR DESCRIPTION
Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix broken build on Darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
