### PR TITLE
python37Packages.azure-identity: fix build

### DIFF
--- a/pkgs/development/python-modules/azure-identity/default.nix
+++ b/pkgs/development/python-modules/azure-identity/default.nix
@@ -38,6 +38,13 @@ buildPythonPackage rec {
     msrestazure
   ];
 
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace msal-extensions~=0.1.3 msal-extensions
+  '';
+
+  pythonImportsCheck = [ "azure.identity" ];
+
   # Requires checkout from mono-repo and a mock account:
   #   https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/identity/tests.yml
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken, relaxing the version bounds seems to fix the build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/94194
1 package built:
python37Packages.azure-identity
```