### PR TITLE
LottieConverter: init at r0.1.1 & rlottie: init at v0.1

### DIFF
--- a/pkgs/development/libraries/rlottie/default.nix
+++ b/pkgs/development/libraries/rlottie/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "rlottie";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "Samsung";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-8KQ0ZnVg5rTb44IYnn02WBSe2SA5UGUOSLEdmmscUDs=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Samsung/rlottie";
+    description = "A platform independent standalone c++ library for rendering vector based animations and art in realtime.";
+    license = licenses.unfree; # Mixed, see https://github.com/Samsung/rlottie/blob/master/COPYING
+    platforms = platforms.all;
+    maintainers = with maintainers; [ CRTified ];
+  };
+}

--- a/pkgs/tools/misc/lottieconverter/default.nix
+++ b/pkgs/tools/misc/lottieconverter/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, libpng, rlottie, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "LottieConverter";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "sot-tech";
+    repo = pname;
+    rev = "r${version}";
+    hash = "sha256-lAGzh6B2js2zDuN+1U8CZnse09RJGZRXbtmsheGKuYU=";
+  };
+
+  buildInputs = [ libpng rlottie zlib ];
+  makeFlags = [ "CONF=Release" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -v dist/Release/GNU-Linux/lottieconverter $out/bin/
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/sot-tech/LottieConverter/";
+    description = "Lottie converter utility";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ CRTified ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4735,6 +4735,8 @@ in
 
   lolcat = callPackage ../tools/misc/lolcat { };
 
+  lottieconverter = callPackage ../tools/misc/lottieconverter { };
+
   lsd = callPackage ../tools/misc/lsd { };
 
   lsdvd = callPackage ../tools/cd-dvd/lsdvd {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14757,6 +14757,8 @@ in
 
   rlog = callPackage ../development/libraries/rlog { };
 
+  rlottie = callPackage ../development/libraries/rlottie { };
+
   rocksdb = callPackage ../development/libraries/rocksdb { };
 
   rocksdb_lite = rocksdb.override { enableLite = true; };


### PR DESCRIPTION
## Motivation for this change

According to the [source of mautrix-telegram](https://github.com/tulir/mautrix-telegram/blob/master/mautrix_telegram/util/tgs_converter.py#L36), this binary (and indirectly `rlottie` as a library) is required to convert animated telegram stickers to a different format. As `mautrix-telegram` has a module (#63589 ) in unstable, it would make sense to care for this feature.

I'm unsure whether the derivation for `rlottie` is written correctly. The cmake script seems a bit broken, as most variables are not used. It also has a very mixed license usage (from MIT over custom unfree licenses), so I was unsure whether I should list all of them, and went the most restrictive path.
LottieConverter has its license written in the code file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
