### PR TITLE
stdenv.mkDerivation: Support argument being a fixed-point function (self: { … }) instead of rec { … }

### DIFF
--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (self: {
   pname = "hello";
   version = "2.10";
 
   src = fetchurl {
-    url = "mirror://gnu/hello/${pname}-${version}.tar.gz";
+    url = "mirror://gnu/hello/${self.pname}-${self.version}.tar.gz";
     sha256 = "0ssi1wpaf7plaswqqjwigppsg5fyh99vdlb9kzl7c9lng89ndq1i";
   };
 
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
       It is fully customizable.
     '';
     homepage = "https://www.gnu.org/software/hello/manual/";
-    changelog = "https://git.savannah.gnu.org/cgit/hello.git/plain/NEWS?h=v${version}";
+    changelog = "https://git.savannah.gnu.org/cgit/hello.git/plain/NEWS?h=v${self.version}";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.eelco ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -354,6 +354,13 @@ in rec {
     attrs:
     let
       attrFun = if lib.isFunction attrs then attrs else (_: attrs);
-      overrideAttrs = f: mkDerivation (self: let super = attrFun self; in super // (f super));
+      overrideAttrs = f: mkDerivation (self:
+        let
+          super = attrFun self;
+          f' = f super;
+          feval = if lib.isFunction f'
+            then f self super # it's a new-style `self: super:` function
+            else f'; # it's an old-style `super:` function
+        in super // feval);
     in mkDerivation' (lib.fix attrFun) overrideAttrs;
 }


### PR DESCRIPTION
###### Motivation for this change
This came out of https://discourse.nixos.org/t/avoid-rec-expresions-in-nixpkgs/8293/6?u=lilyball as a proposed way to avoid using `rec { … }` with `mkDerivation`. The problem with `rec { … }` is it makes it harder to override, as any reference to an attribute from the set needs to be overridden. In particular, `version` tends to be re-used, requiring overriding it in multiple places, especially in the URLs given to `src` fetchers.

The approach taken here is to have `mkDerivation` detect if it's given a function instead of an attrset, and if it is a function, then it makes that function into a fixed point, calling it with a `self` value that's the fully-evaluated arguments (not the result of `mkDerivation`, just the arguments given to it). Switching to this style produces no changes in the resulting derivation, so it causes no rebuilds. But what it does is make `overrideAttrs` easier. Instead of saying

```nix
hello.overrideAttrs (super: {
  version = "2.9";
  src = fetchurl {
    url = "mirror://gnu/hello/hello-2.9.tar.gz";
    sha256 = "19qy37gkasc4csb1d3bdiz9snn8mir2p3aj0jgzmfv0r2hi7mfzc";
  };
  meta = super.meta // {
    changelog = "https://git.savannah.gnu.org/cgit/hello.git/plain/NEWS?h=v2.9";
  };
})
```

you can now write

```nix
hello.overrideAttrs (super: {
  version = "2.9";
  src = super.src.overrideAttrs (_: {
    outputHash = "19qy37gkasc4csb1d3bdiz9snn8mir2p3aj0jgzmfv0r2hi7mfzc";
  });
})
```

(sadly none of the fetchers I looked at, including `fetchurl`, allow you to override the arguments given to them directly, but overriding `outputHash` works for all the fetchers I inspected (`fetchurl`, `fetchFromGitHub`, and `fetchzip`)).

As a second step, this PR also updates `overrideAttrs` to support its argument as either `super: { … )}` or `self: super: { … }`, in case the `overrideAttrs` expects that it might be further customized and wants to introduce its own self-referential values.

This works by passing the `super` value to the argument and checking if it gets a function back; if so, it re-calls the argument with `self super` instead. I chose this approach because any existing `overrideAttrs` expects just `super` and must return an attrset, so if we get a function then it must be the new approach.

I also updated the stdenv adapters, though I haven't actually tested them.

### TODO

- [ ] Update [documentation on `stdenv.mkDerivation`](https://nixos.org/nixpkgs/manual/#sec-using-stdenv).
- [ ] Update [documentation on `overrideAttrs`](https://nixos.org/nixpkgs/manual/#sec-pkg-overrideAttrs).
- [ ] Go over all packages I maintain and convert any that use `rec { … }` to this new style.
- [ ] Determine if this impacts performance at all.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
