### PR TITLE
nvidia-docker: remove ldconf patch (fixes #93511)

### DIFF
--- a/pkgs/applications/virtualization/nvidia-docker/default.nix
+++ b/pkgs/applications/virtualization/nvidia-docker/default.nix
@@ -3,18 +3,6 @@
 
 with lib; let
 
-  glibc-ldconf = glibc.overrideAttrs (oldAttrs: {
-    # ldconfig needs help reading libraries that have been patchelf-ed, as the
-    # .dynstr section is no longer in the first LOAD segment. See also
-    # https://sourceware.org/bugzilla/show_bug.cgi?id=23964 and
-    # https://github.com/NixOS/patchelf/issues/44
-    patches = oldAttrs.patches ++ [ (fetchpatch {
-      name = "ldconfig-patchelf.patch";
-      url = "https://sourceware.org/bugzilla/attachment.cgi?id=11444";
-      sha256 = "0nzzmq7pli37iyjrgcmvcy92piiwjybpw245ds7q43pbgdm7lc3s";
-    })];
-  });
-
   libnvidia-container = callPackage ./libnvc.nix { };
 
   nvidia-container-runtime = fetchFromGitHub {
@@ -72,7 +60,7 @@ in stdenv.mkDerivation rec {
     wrapProgram $out/bin/nvidia-container-cli \
       --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:/run/opengl-driver-32/lib
     cp ${./config.toml} $out/etc/config.toml
-    substituteInPlace $out/etc/config.toml --subst-var-by glibcbin ${lib.getBin glibc-ldconf}
+    substituteInPlace $out/etc/config.toml --subst-var-by glibcbin ${lib.getBin glibc}
   '';
 
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
#93511 
The [bug](https://sourceware.org/bugzilla/show_bug.cgi?id=23964) listed in https://github.com/NixOS/nixpkgs/blob/5ad1cdafe15d4ea79ae6abcddc360dd2de35b44e/pkgs/applications/virtualization/nvidia-docker/default.nix#L9 was fixed by https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=58e8f5fd2ba47b6dc47fd4d0a35e4175c7c87aaa

Thus the applied patch isn't necessary anymore (and breaks this package)

###### Things done

Removed the redundant patch.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
