### PR TITLE
mailnag: enable to configure plugins

### DIFF
--- a/pkgs/applications/networking/mailreaders/mailnag/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailnag/default.nix
@@ -13,15 +13,13 @@
 , gsettings-desktop-schemas
 , glib
 , gobject-introspection
+# Available plugins (can be overriden)
+, availablePlugins
 # Plugins to install
 , plugins ? [ "goa" ]
 }:
 
 let
-  availablePlugins = {
-    # More are listed here: https://github.com/pulb/mailnag/#desktop-integration
-    goa = callPackage ./goa-plugin.nix { };
-  };
   # Get the list of plugins the user wants
   userPlugins = lib.attrVals plugins availablePlugins;
   # goa plugin requires gio's gnome-online-accounts which requires making sure

--- a/pkgs/applications/networking/mailreaders/mailnag/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailnag/default.nix
@@ -15,86 +15,91 @@
 , gobject-introspection
 # Available plugins (can be overriden)
 , availablePlugins
-# Plugins to install
-, plugins ? [ "goa" ]
+# Used in the withPlugins interface at passthru, can be overrided directly, or
+# prefarably via e.g: `mailnag.withPlugins(["goa"])`
+, mailnag
+, userPlugins ? [ ]
+, pluginsDeps ? [ ]
 }:
 
-let
-  # Get the list of plugins the user wants
-  userPlugins = lib.attrVals plugins availablePlugins;
-  # goa plugin requires gio's gnome-online-accounts which requires making sure
-  # mailnag runs with GI_TYPELIB_PATH containing the path to Goa-1.0.typelib.
-  # This is handled best by adding the plugins' deps to buildInputs and let
-  # wrapGAppsHook handle that.
-  pluginsDeps = lib.flatten (lib.catAttrs "buildInputs" userPlugins);
-in
-  python3Packages.buildPythonApplication rec {
-    pname = "mailnag";
-    version = "2.0.0";
+python3Packages.buildPythonApplication rec {
+  pname = "mailnag";
+  version = "2.0.0";
 
-    src = fetchFromGitHub {
-      owner = "pulb";
-      repo = "mailnag";
-      rev = "v${version}";
-      sha256 = "0q97v9i96br22z3h6r2mz79i68ib8m8x42yxky78szfrf8j60i30";
-    };
+  src = fetchFromGitHub {
+    owner = "pulb";
+    repo = "mailnag";
+    rev = "v${version}";
+    sha256 = "0q97v9i96br22z3h6r2mz79i68ib8m8x42yxky78szfrf8j60i30";
+  };
 
-    buildInputs = [
-      gtk3
-      gdk-pixbuf
-      glib
-      libnotify
-      gst_all_1.gstreamer
-      gst_all_1.gst-plugins-base
-      gst_all_1.gst-plugins-good
-      gst_all_1.gst-plugins-bad
-      gobject-introspection
-      libsecret
-    ] ++ pluginsDeps;
+  buildInputs = [
+    gtk3
+    gdk-pixbuf
+    glib
+    libnotify
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gobject-introspection
+    libsecret
+  ] ++ pluginsDeps;
 
-    nativeBuildInputs = [
-      gettext
-      wrapGAppsHook
-      # To later add plugins to 
-      xorg.lndir
-    ];
+  nativeBuildInputs = [
+    gettext
+    wrapGAppsHook
+    # To later add plugins to 
+    xorg.lndir
+  ];
 
-    propagatedBuildInputs = with python3Packages; [
-      gsettings-desktop-schemas
-      pygobject3
-      dbus-python
-      pyxdg
-    ];
+  propagatedBuildInputs = with python3Packages; [
+    gsettings-desktop-schemas
+    pygobject3
+    dbus-python
+    pyxdg
+  ];
 
-    passthru = {
-      inherit availablePlugins;
-    };
+  passthru = {
+    inherit availablePlugins;
+    withPlugins =
+      plugs:
+      let
+        # goa plugin requires gio's gnome-online-accounts which requires making sure
+        # mailnag runs with GI_TYPELIB_PATH containing the path to Goa-1.0.typelib.
+        # This is handled best by adding the plugins' deps to buildInputs and let
+        # wrapGAppsHook handle that.
+        pluginsDeps = lib.flatten (lib.catAttrs "buildInputs" plugs);
+        self = mailnag;
+      in
+        self.override { userPlugins = plugs; };
+  };
 
-    # See https://nixos.org/nixpkgs/manual/#ssec-gnome-common-issues-double-wrapped
-    dontWrapGApps = true;
+  # See https://nixos.org/nixpkgs/manual/#ssec-gnome-common-issues-double-wrapped
+  dontWrapGApps = true;
 
-    preFixup = ''
-      substituteInPlace $out/${python3Packages.python.sitePackages}/Mailnag/common/dist_cfg.py \
-        --replace "/usr/" $out/
-      for desktop_file in $out/share/applications/*.desktop; do
-        substituteInPlace "$desktop_file" \
-        --replace "/usr/bin" $out/bin
-      done
-      makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
-    '';
+  preFixup = ''
+    substituteInPlace $out/${python3Packages.python.sitePackages}/Mailnag/common/dist_cfg.py \
+      --replace "/usr/" $out/
+    for desktop_file in $out/share/applications/*.desktop; do
+      substituteInPlace "$desktop_file" \
+      --replace "/usr/bin" $out/bin
+    done
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
 
-    # Actually install plugins
-    postInstall = ''
-      for plug in ${builtins.toString userPlugins}; do
-        lndir $plug/${python3Packages.python.sitePackages} $out/${python3Packages.python.sitePackages}
-      done
-    '';
+  # Actually install plugins
+  postInstall = ''
+    for plug in ${builtins.toString userPlugins}; do
+      lndir $plug/${python3Packages.python.sitePackages} $out/${python3Packages.python.sitePackages}
+    done
+  '';
 
-    meta = with lib; {
-      description = "An extensible mail notification daemon";
-      homepage = "https://github.com/pulb/mailnag";
-      license = licenses.gpl2;
-      platforms = platforms.linux;
-      maintainers = with maintainers; [ doronbehar ];
-    };
-  }
+  meta = with lib; {
+    description = "An extensible mail notification daemon";
+    homepage = "https://github.com/pulb/mailnag";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/applications/networking/mailreaders/mailnag/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailnag/default.nix
@@ -1,8 +1,10 @@
-{ stdenv
+{ lib
+, callPackage
 , fetchFromGitHub
 , gettext
+, xorg # for lndir
 , gtk3
-, pythonPackages
+, python3Packages
 , gdk-pixbuf
 , libnotify
 , gst_all_1
@@ -11,57 +13,90 @@
 , gsettings-desktop-schemas
 , glib
 , gobject-introspection
+# Plugins to install
+, plugins ? [ "goa" ]
 }:
 
-pythonPackages.buildPythonApplication rec {
-  pname = "mailnag";
-  version = "2.0.0";
-
-  src = fetchFromGitHub {
-    owner = "pulb";
-    repo = "mailnag";
-    rev = "v${version}";
-    sha256 = "0q97v9i96br22z3h6r2mz79i68ib8m8x42yxky78szfrf8j60i30";
+let
+  availablePlugins = {
+    # More are listed here: https://github.com/pulb/mailnag/#desktop-integration
+    goa = callPackage ./goa-plugin.nix { };
   };
-  preFixup = ''
-    substituteInPlace $out/${pythonPackages.python.sitePackages}/Mailnag/common/dist_cfg.py \
-      --replace "/usr/" $out/
-    for desktop_file in $out/share/applications/*.desktop; do
-      substituteInPlace "$desktop_file" \
-      --replace "/usr/bin" $out/bin
-    done
-  '';
+  # Get the list of plugins the user wants
+  userPlugins = lib.attrVals plugins availablePlugins;
+  # goa plugin requires gio's gnome-online-accounts which requires making sure
+  # mailnag runs with GI_TYPELIB_PATH containing the path to Goa-1.0.typelib.
+  # This is handled best by adding the plugins' deps to buildInputs and let
+  # wrapGAppsHook handle that.
+  pluginsDeps = lib.flatten (lib.catAttrs "buildInputs" userPlugins);
+in
+  python3Packages.buildPythonApplication rec {
+    pname = "mailnag";
+    version = "2.0.0";
 
-  buildInputs = [
-    gtk3
-    gdk-pixbuf
-    glib
-    libnotify
-    gst_all_1.gstreamer
-    gst_all_1.gst-plugins-base
-    gst_all_1.gst-plugins-good
-    gst_all_1.gst-plugins-bad
-    gobject-introspection
-    libsecret
-  ];
+    src = fetchFromGitHub {
+      owner = "pulb";
+      repo = "mailnag";
+      rev = "v${version}";
+      sha256 = "0q97v9i96br22z3h6r2mz79i68ib8m8x42yxky78szfrf8j60i30";
+    };
 
-  nativeBuildInputs = [
-    gettext
-    wrapGAppsHook
-  ];
+    buildInputs = [
+      gtk3
+      gdk-pixbuf
+      glib
+      libnotify
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+      gst_all_1.gst-plugins-bad
+      gobject-introspection
+      libsecret
+    ] ++ pluginsDeps;
 
-  propagatedBuildInputs = with pythonPackages; [
-    gsettings-desktop-schemas
-    pygobject3
-    dbus-python
-    pyxdg
-  ];
+    nativeBuildInputs = [
+      gettext
+      wrapGAppsHook
+      # To later add plugins to 
+      xorg.lndir
+    ];
 
-  meta = with stdenv.lib; {
-    description = "An extensible mail notification daemon";
-    homepage = "https://github.com/pulb/mailnag";
-    license = licenses.gpl2;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ doronbehar ];
-  };
-}
+    propagatedBuildInputs = with python3Packages; [
+      gsettings-desktop-schemas
+      pygobject3
+      dbus-python
+      pyxdg
+    ];
+
+    passthru = {
+      inherit availablePlugins;
+    };
+
+    # See https://nixos.org/nixpkgs/manual/#ssec-gnome-common-issues-double-wrapped
+    dontWrapGApps = true;
+
+    preFixup = ''
+      substituteInPlace $out/${python3Packages.python.sitePackages}/Mailnag/common/dist_cfg.py \
+        --replace "/usr/" $out/
+      for desktop_file in $out/share/applications/*.desktop; do
+        substituteInPlace "$desktop_file" \
+        --replace "/usr/bin" $out/bin
+      done
+      makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    '';
+
+    # Actually install plugins
+    postInstall = ''
+      for plug in ${builtins.toString userPlugins}; do
+        lndir $plug/${python3Packages.python.sitePackages} $out/${python3Packages.python.sitePackages}
+      done
+    '';
+
+    meta = with lib; {
+      description = "An extensible mail notification daemon";
+      homepage = "https://github.com/pulb/mailnag";
+      license = licenses.gpl2;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ doronbehar ];
+    };
+  }

--- a/pkgs/applications/networking/mailreaders/mailnag/goa-plugin.nix
+++ b/pkgs/applications/networking/mailreaders/mailnag/goa-plugin.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, fetchFromGitHub
+, python3Packages
+, gobject-introspection
+, gnome-online-accounts
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "mailnag-goa-plugin";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "pulb";
+    repo = "mailnag-goa-plugin";
+    rev = "v${version}";
+    sha256 = "0bij6cy96nhq7xzslx0fnhmiac629h0x4wgy67k4i4npwqw10680";
+  };
+
+  buildInputs = [
+    gobject-introspection
+    gnome-online-accounts
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Mailnag GNOME Online Accounts plugin.";
+    homepage = "https://github.com/pulb/mailnag-goa-plugin";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5153,9 +5153,7 @@ in
 
   mailhog = callPackage ../servers/mail/mailhog {};
 
-  mailnag = callPackage ../applications/networking/mailreaders/mailnag {
-    pythonPackages = python3Packages;
-  };
+  mailnag = callPackage ../applications/networking/mailreaders/mailnag { };
 
   mailsend = callPackage ../tools/networking/mailsend { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5153,7 +5153,13 @@ in
 
   mailhog = callPackage ../servers/mail/mailhog {};
 
-  mailnag = callPackage ../applications/networking/mailreaders/mailnag { };
+  mailnag = callPackage ../applications/networking/mailreaders/mailnag {
+    availablePlugins = {
+      # More are listed here: https://github.com/pulb/mailnag/#desktop-integration
+      # Use the attributes here as arguments to `plugins` list
+      goa = callPackage ../applications/networking/mailreaders/mailnag/goa-plugin.nix { };
+    };
+  };
 
   mailsend = callPackage ../tools/networking/mailsend { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5160,6 +5160,9 @@ in
       goa = callPackage ../applications/networking/mailreaders/mailnag/goa-plugin.nix { };
     };
   };
+  mailnagWithPlugins = mailnag.withPlugins(
+    builtins.attrValues mailnag.availablePlugins
+  );
 
   mailsend = callPackage ../tools/networking/mailsend { };
 


### PR DESCRIPTION
###### Motivation for this change

Make mailnag more usable for Gnome users - make the gnome online accounts mailnag extension usable via Nix arguments to the derivation. Mailnag's Goa plugin is https://github.com/pulb/mailnag-goa-plugin . This PR also makes it easy enough for future us add [other plugins](https://github.com/pulb/mailnag#desktop-integration) that will be added to the derivation.

###### Things done

See commit message. I'm currently using it and it works great for me + plus the gnome shell extension: https://extensions.gnome.org/extension/886/mailnag/

![Screenshot from 2020-07-30 03-00-04](https://user-images.githubusercontent.com/10998835/88865537-ae52a300-d1f7-11ea-86b7-fc2bf959e80b.png)

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).