### PR TITLE
autotiling: init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -833,6 +833,12 @@
     githubId = 135230;
     name = "Aycan iRiCAN";
   };
+  artturin = {
+    email = "artturin@artturin.com";
+    github = "artturin";
+    githubId = 56650223;
+    name = "Artturi N";
+  };
   b4dm4n = {
     email = "fabianm88@gmail.com";
     github = "B4dM4n";

--- a/pkgs/misc/autotiling/default.nix
+++ b/pkgs/misc/autotiling/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonApplication, fetchPypi, i3ipc, importlib-metadata }:
+
+buildPythonApplication rec {
+  pname = "autotiling";
+  version = "1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hwvy9bxwv9fakqqiyrkmpckxgm0z85c240p84ibdhja9sm086v0";
+  };
+
+  propagatedBuildInputs = [ i3ipc importlib-metadata ];
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/nwg-piotr/autotiling";
+    description = "Script for sway and i3 to automatically switch the horizontal / vertical window split orientation";
+    license = licenses.gpl3Plus;
+    platforms= platforms.linux;
+    maintainers = with maintainers; [ artturin ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25881,6 +25881,8 @@ in
 
   attract-mode = callPackage ../misc/emulators/attract-mode { };
 
+  autotiling = python3Packages.callPackage ../misc/autotiling { };
+
   beep = callPackage ../misc/beep { };
 
   bees = callPackage ../tools/filesystems/bees { };


### PR DESCRIPTION
autotiling for i3 & sway
###### Motivation for this change
I use it and i think it will be useful for other people too

closes: #91244
###### Things done


- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
