### PR TITLE
openexr, ilmbase: Fix compilation on non-glibc.

### DIFF
--- a/pkgs/development/libraries/ilmbase/default.nix
+++ b/pkgs/development/libraries/ilmbase/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , buildPackages
 , cmake
 , libtool
@@ -20,7 +21,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake libtool ];
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-  patches = [ ./cross.patch ];
+  patches = [
+    ./cross.patch
+  ] ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.libc != "glibc") [
+    openexr.non_glibc_fpstate_patch # see description of this patch in `openexr`
+  ];
 
   # fails 1 out of 1 tests with
   # "lt-ImathTest: testBoxAlgo.cpp:892: void {anonymous}::boxMatrixTransform(): Assertion `b21 == b2' failed"

--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -4,10 +4,24 @@
 , fetchFromGitHub
 , zlib
 , ilmbase
-, fetchpatch 
+, fetchpatch
 , cmake
 , libtool
 }:
+
+let
+  non_glibc_fpstate_patch =
+    # Fix ilmbase/openexr using glibc-only fpstate.
+    # Found via https://git.alpinelinux.org/aports/tree/community/openexr/10-musl-_fpstate.patch?id=80d9611b7b8e406a554c6f511137e03ff26acbae,
+    # TODO Remove when https://github.com/AcademySoftwareFoundation/openexr/pull/798 is merged and available.
+    #      Remove it from `ilmbase` as well then.
+    (fetchpatch {
+      name = "ilmbase-musl-_fpstate.patch.patch";
+      url = "https://raw.githubusercontent.com/void-linux/void-packages/80bbc168faa25448bd3399f4df331b836e74b85c/srcpkgs/ilmbase/patches/musl-_fpstate.patch";
+      sha256 = "0appzbs9pd6dia5pzxmrs9ww35shlxi329ks6lchwzw4f2a81arz";
+    });
+in
+
 stdenv.mkDerivation rec {
   pname = "openexr";
   version = "2.4.1";
@@ -23,7 +37,20 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake libtool ];
   propagatedBuildInputs = [ ilmbase zlib ];
 
+  postPatch =
+    if (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.libc != "glibc")
+      then
+        ''
+          patch -p0 < ${non_glibc_fpstate_patch}
+        ''
+      else null; # `null` avoids rebuild on glibc
+
   enableParallelBuilding = true;
+
+  passthru = {
+    # So that ilmbase (sharing the same source code) can re-use this patch.
+    inherit non_glibc_fpstate_patch;
+  };
 
   meta = with stdenv.lib; {
     description = "A high dynamic-range (HDR) image file format";


### PR DESCRIPTION
###### Motivation for this change

musl compatibility via https://github.com/nh2/static-haskell-nix/pull/98.

Tested with musl.

I PRd the patch upstream: https://github.com/AcademySoftwareFoundation/openexr/pull/798

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
