### PR TITLE
cmake-language-server: fix test error on macOS

### DIFF
--- a/pkgs/development/tools/cmake-language-server/default.nix
+++ b/pkgs/development/tools/cmake-language-server/default.nix
@@ -1,6 +1,7 @@
 { stdenv, buildPythonApplication, fetchFromGitHub
 , poetry, pygls, pyparsing
 , cmake, pytest, pytest-datadir
+, fetchpatch
 }:
 
 buildPythonApplication rec {
@@ -14,6 +15,12 @@ buildPythonApplication rec {
     rev = "v${version}";
     sha256 = "0vz7bjxkk0phjhz3h9kj6yr7wnk3g7lqmkqraa0kw12mzcfck837";
   };
+
+  # can be removed after v0.1.2
+  patches = stdenv.lib.optional stdenv.isDarwin (fetchpatch {
+    url = "https://github.com/regen100/cmake-language-server/pull/24.patch";
+    sha256 = "1id8wpmyc7djyqasb5g9z9i3jipcdb4sirn4cpx2v8xmdn9khdnz";
+  });
 
   postPatch = ''
     substituteInPlace pyproject.toml \

--- a/pkgs/development/tools/cmake-language-server/default.nix
+++ b/pkgs/development/tools/cmake-language-server/default.nix
@@ -18,8 +18,8 @@ buildPythonApplication rec {
 
   # can be removed after v0.1.2
   patches = stdenv.lib.optional stdenv.isDarwin (fetchpatch {
-    url = "https://github.com/regen100/cmake-language-server/pull/24.patch";
-    sha256 = "1id8wpmyc7djyqasb5g9z9i3jipcdb4sirn4cpx2v8xmdn9khdnz";
+    url = "https://github.com/regen100/cmake-language-server/commit/0ec120f39127f25898ab110b43819e3e9becb8a3.patch";
+    sha256 = "1xbmarvsvzd61fnlap4qscnijli2rw2iqr7cyyvar2jd87z6sfp0";
   });
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

This should fix Hydra's Darwin test failures for this package.
See https://github.com/regen100/cmake-language-server/pull/24

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
