### PR TITLE
haskellPackages.haskell-language-server+hls-ide: fix lsp-test override

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1342,7 +1342,7 @@ self: super: {
         })).override {
           # we are faster than stack here
           hie-bios = dontCheck self.hie-bios_0_6_1;
-          lsp-test = dontCheck self.lsp-test_0_11_0_2;
+          lsp-test = dontCheck self.lsp-test_0_11_0_3;
         });
 
   haskell-language-server = (overrideCabal super.haskell-language-server
@@ -1362,7 +1362,7 @@ self: super: {
       ghcide = self.hls-ghcide;
       # we are faster than stack here
       hie-bios = dontCheck self.hie-bios_0_6_1;
-      lsp-test = dontCheck self.lsp-test_0_11_0_2;
+      lsp-test = dontCheck self.lsp-test_0_11_0_3;
     };
 
   # https://github.com/kowainik/policeman/issues/57


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix for `attribute 'lsp-test_0_11_0_2' missing`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
