### PR TITLE
coq_8_12: 8.12+β1 → 8.12.0; coqPackages.equations: 1.2.2 → 1.2.3

### DIFF
--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -35,7 +35,7 @@ let
    "8.11.0" = "1rfdic6mp7acx2zfwz7ziqk12g95bl9nyj68z4n20a5bcjv2pxpn";
    "8.11.1" = "0qriy9dy36dajsv5qmli8gd6v55mah02ya334nw49ky19v7518m0";
    "8.11.2" = "0f77ccyxdgbf1nrj5fa8qvrk1cyfy06fv8gj9kzfvlcgn0cf48sa";
-   "8.12+beta1" = "0jbm8am9j926s0h4fi0cjl95l37l6p7i03spcryyrd4sg5xrddr7";
+   "8.12.0" = "18dc7k0piv6v064zgdadpw6mkkxk7j663hb3svgj5236fihjr0cz";
   }.${version};
   coq-version = stdenv.lib.versions.majorMinor version;
   versionAtLeast = stdenv.lib.versionAtLeast coq-version;
@@ -112,12 +112,14 @@ self = stdenv.mkDerivation {
   ;
   buildInputs = [ ncurses ocamlPackages.ocaml ocamlPackages.findlib ]
   ++ stdenv.lib.optional (!versionAtLeast "8.10") ocamlPackages.camlp5
-  ++ [ ocamlPackages.num ]
+  ++ stdenv.lib.optional (!versionAtLeast "8.12") ocamlPackages.num
   ++ stdenv.lib.optionals buildIde
     (if versionAtLeast "8.10"
      then [ ocamlPackages.lablgtk3-sourceview3 glib gnome3.defaultIconTheme wrapGAppsHook ]
      ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Cocoa
      else [ ocamlPackages.lablgtk ]);
+
+  propagatedBuildInputs = stdenv.lib.optional (versionAtLeast "8.12") ocamlPackages.num;
 
   postPatch = ''
     UNAME=$(type -tp uname)

--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -33,15 +33,15 @@ let
     };
 
     "8.11" = {
-      version = "1.2.2";
-      rev = "v1.2.2-8.11";
-      sha256 = "0g2y0s8kb2imbqyrx9hmvjzpwmicid7shv7ma10fnb8dgk2dqkf9";
+      version = "1.2.3";
+      rev = "v1.2.3-8.11";
+      sha256 = "1srxz1rws8jsh7402g2x2vcqgjbbsr64dxxj5d2zs48pmhb20csf";
     };
 
     "8.12" = {
-      version = "1.2.2";
-      rev = "v1.2.2-8.12";
-      sha256 = "0fkz78i2gn9x9scfa7n8fl2sq7czppsicy7w5mq919qqfp0w1aj0";
+      version = "1.2.3";
+      rev = "v1.2.3-8.12";
+      sha256 = "1y0jkvzyz5ssv5vby41p1i8zs7nsdc8g3pzyq73ih9jz8h252643";
     };
   };
   param = params.${coq.coq-version};

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -118,7 +118,7 @@ in rec {
     version = "8.11.2";
   };
   coq_8_12 = callPackage ../applications/science/logic/coq {
-    version = "8.12+beta1";
+    version = "8.12.0";
   };
 
   coqPackages_8_5 = mkCoqPackages coq_8_5;


### PR DESCRIPTION
###### Motivation for this change

New release: https://github.com/coq/coq/releases/tag/V8.12.0

Also update the `equations` package for compatibility with Coq 8.12.0

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
