### PR TITLE
nixos/postgres Add syslog option

### DIFF
--- a/nixos/tests/postgresql.nix
+++ b/nixos/tests/postgresql.nix
@@ -32,6 +32,7 @@ let
         services.postgresql = {
           enable = true;
           package = postgresql-package;
+          enableSystemLogging = true; # makes sense for the test I suppose
         };
 
         services.postgresqlBackup = {

--- a/nixos/tests/postgresql.nix
+++ b/nixos/tests/postgresql.nix
@@ -32,7 +32,13 @@ let
         services.postgresql = {
           enable = true;
           package = postgresql-package;
-          enableSystemLogging = true; # makes sense for the test I suppose
+          log = {
+            connections = true;
+            disconnections = true;
+            statement = "all";
+            collector = true;
+            destination = ["syslog"];
+          };
         };
 
         services.postgresqlBackup = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Having the option to use postgres to log all your queries should
be quite valuable to many users.

Doing this at application level is usually less reliable and slower.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
