### PR TITLE
lightburn: init at 0.9.15

### DIFF
--- a/pkgs/applications/graphics/lightburn/default.nix
+++ b/pkgs/applications/graphics/lightburn/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, patchelf, fetchurl, p7zip
+, nss, nspr, libusb1
+, qtbase, qtmultimedia, qtserialport
+, autoPatchelfHook, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lightburn";
+  version = "0.9.15";
+
+  nativeBuildInputs = [
+    p7zip
+    autoPatchelfHook
+    wrapQtAppsHook
+  ];
+
+  src = fetchurl {
+    url = "https://github.com/LightBurnSoftware/deployment/releases/download/${version}/LightBurn-Linux64-v${version}.7z";
+    sha256 = "1dwmrili4jfw55gnlnda3imgli7f4jqz9smwlynf7k87lxrhppmh";
+  };
+
+  buildInputs = [
+    nss nspr libusb1
+    qtbase qtmultimedia qtserialport
+  ];
+
+  # We nuke the vendored Qt5 libraries that LightBurn ships and instead use our
+  # own.
+  unpackPhase = ''
+    7z x $src
+    rm -rf LightBurn/lib LightBurn/plugins
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share $out/bin
+    cp -ar LightBurn $out/share/LightBurn
+    ln -s $out/share/LightBurn/LightBurn $out/bin
+
+    wrapQtApp $out/bin/LightBurn
+  '';
+
+  meta = {
+    description = "LightBurn is layout, editing, and control software for your laser cutter.";
+    homepage = "https://lightburnsoftware.com/";
+    license = stdenv.lib.licenses.unfree;
+    maintainers = with stdenv.lib.maintainers; [ q3k ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21056,6 +21056,8 @@ in
   ledger-autosync = callPackage  ../applications/office/ledger-autosync { };
 
   ledger-web = callPackage ../applications/office/ledger-web { };
+  
+  lightburn = libsForQt5.callPackage ../applications/graphics/lightburn { };
 
   lighthouse = callPackage ../applications/misc/lighthouse { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This implements a derivation for LightBurn, a laser control software. It's binary and non-free, so we wrap it appropriately.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
