### PR TITLE
kitty: 0.18.1 → 0.18.2

### DIFF
--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -20,14 +20,14 @@
 with python3Packages;
 buildPythonApplication rec {
   pname = "kitty";
-  version = "0.18.1";
+  version = "0.18.2";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "kovidgoyal";
     repo = "kitty";
     rev = "v${version}";
-    sha256 = "1g4mfgygyl143k0k6d3cb8b2l05ahiamlcqs1iqi66pc73cax4z6";
+    sha256 = "0x6h8g017mbpjkpkb1y8asyfdc48bgjzmj5gachsp5cf5jcqwir2";
   };
 
   buildInputs = [
@@ -85,9 +85,15 @@ buildPythonApplication rec {
 
   checkInputs = [ pillow ];
 
-  checkPhase = ''
-    ${python.interpreter} test.py
-  '';
+  checkPhase =
+    let buildBinPath =
+      if stdenv.isDarwin
+        then "kitty.app/Contents/MacOS"
+        else "linux-package/bin";
+    in
+    ''
+      env PATH="${buildBinPath}:$PATH" ${python.interpreter} test.py
+    '';
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/kovidgoyal/kitty/releases/tag/v0.18.2>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
