### PR TITLE
dockertools: fix buildLayeredImage nix-store permissions

### DIFF
--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -79,6 +79,16 @@ import ./make-test-python.nix ({ pkgs, ... }: {
             "docker rmi ${examples.nix.imageName}",
         )
 
+    with subtest(
+        "Ensure (layered) nix store has correct permissions "
+        "and that the container starts when its process does not have uid 0"
+    ):
+        docker.succeed(
+            "docker load --input='${examples.bashLayeredWithUser}'",
+            "docker run -u somebody --rm ${examples.bashLayeredWithUser.imageName} ${pkgs.bash}/bin/bash -c 'test 555 == $(stat --format=%a /nix) && test 555 == $(stat --format=%a /nix/store)'",
+            "docker rmi ${examples.bashLayeredWithUser.imageName}",
+        )
+
     with subtest("The nix binary symlinks are intact"):
         docker.succeed(
             "docker load --input='${examples.nix}'",

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -382,4 +382,40 @@ rec {
     contents = pkgs.bashInteractive;
   };
 
+  # buildLayeredImage with non-root user
+  bashLayeredWithUser =
+  let
+    nonRootShadowSetup = { user, uid, gid ? uid }: with pkgs; [
+      (
+      writeTextDir "etc/shadow" ''
+        root:!x:::::::
+        ${user}:!:::::::
+      ''
+      )
+      (
+      writeTextDir "etc/passwd" ''
+        root:x:0:0::/root:${runtimeShell}
+        ${user}:x:${toString uid}:${toString gid}::/home/${user}:
+      ''
+      )
+      (
+      writeTextDir "etc/group" ''
+        root:x:0:
+        ${user}:x:${toString gid}:
+      ''
+      )
+      (
+      writeTextDir "etc/gshadow" ''
+        root:x::
+        ${user}:x::
+      ''
+      )
+    ];
+  in
+    pkgs.dockerTools.buildLayeredImage {
+      name = "bash-layered-with-user";
+      tag = "latest";
+      contents = [ pkgs.bash pkgs.coreutils (nonRootShadowSetup { uid = 999; user = "somebody"; }) ];
+    };
+
 }

--- a/pkgs/build-support/docker/stream_layered_image.py
+++ b/pkgs/build-support/docker/stream_layered_image.py
@@ -74,6 +74,10 @@ def archive_paths_to(obj, paths, mtime, add_nix, filter=None):
         ti.gname = "root"
         return filter(ti)
 
+    def nix_root(ti):
+        ti.mode = 0o0555  # r-xr-xr-x
+        return ti
+
     def dir(path):
         ti = tarfile.TarInfo(path)
         ti.type = tarfile.DIRTYPE
@@ -84,8 +88,8 @@ def archive_paths_to(obj, paths, mtime, add_nix, filter=None):
         # these directories first when building layer tarballs. But
         # we don't need them on the customisation layer.
         if add_nix:
-            tar.addfile(apply_filters(dir("/nix")))
-            tar.addfile(apply_filters(dir("/nix/store")))
+            tar.addfile(apply_filters(nix_root(dir("/nix"))))
+            tar.addfile(apply_filters(nix_root(dir("/nix/store"))))
 
         for path in paths:
             path = pathlib.Path(path)


### PR DESCRIPTION

###### Motivation for this change
Fix bug in `dockerTools.buildLayeredImage` that causes non-root containers to be not runnable.

Pardon my python, but I was unsure how - in the prettiest way - to hook into the existing logic around /nix/store dir-creation.

example docker error message:
```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/nix/store/3avafdzgh694z5m3rgw2vvlgsfz2gmkl-coredns-1.6.6/bin/coredns\": stat /nix/store/3avafdzgh694z5m3rgw2vvlgsfz2gmkl-coredns-1.6.6/bin/coredns: permission denied": unknown.
```

The cause of the error is that `/nix` and `/nix/store` has wrong permissions inside the final image, i.e.:
```
bash-4.4# ls -dl /nix/store/
drw-r--r-- 32 root root 34 Jan  1  1970 /nix/store/
```
The top-level directories lack world execute permissions, which, is ok as long we run the image as root, but fails when the image is run as an unprivileged user.

###### Steps to reproduce

1. cherry-pick 4fc255e from my branch onto master
2. `docker load <$(nix-build . -A dockerTools.examples.bashLayeredWithUser)`
3. `docker run --rm -it -u somebody bash-layered-with-user /bin/echo "it works"`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @LnL7 @utdemir 