### PR TITLE
untrunc-anthwlock: init at 2020.07.18

### DIFF
--- a/pkgs/tools/video/untrunc-anthwlock/default.nix
+++ b/pkgs/tools/video/untrunc-anthwlock/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, ffmpeg, libui }:
+
+stdenv.mkDerivation {
+  pname = "untrunc-anthwlock";
+  version = "2020.07.18";
+
+  src = fetchFromGitHub {
+    owner = "anthwlock";
+    repo = "untrunc";
+    rev = "a0bf2e8642ecdb7af5897ed9b0dd30a7d03520ae";
+    sha256 = "14i2lq68q990hnm2kkfamlsi67bcml85zl8yjsyxc5h8ncc2f3dp";
+  };
+
+  
+  buildInputs = [ ffmpeg libui ];
+
+  postBuild = ''
+    make untrunc-gui
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D -t $out/bin untrunc untrunc-gui
+    runHook postInstall
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Restore a truncated mp4/mov (improved version of ponchio/untrunc)";
+    homepage = "https://github.com/anthwlock/untrunc";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7372,6 +7372,8 @@ in
 
   untrunc = callPackage ../tools/video/untrunc { };
 
+  untrunc-anthwlock = callPackage ../tools/video/untrunc-anthwlock { };
+
   up = callPackage ../tools/misc/up { };
 
   upx = callPackage ../tools/compression/upx { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [anthwlock/untrunc](https://github.com/anthwlock/untrunc).

> Restore a damaged (truncated) mp4, m4v, mov, 3gp video. Provided you have a similar not broken video. And some luck.

This is an improved version of [ponchio/untrunc](https://github.com/ponchio/untrunc).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
