### PR TITLE
haskell-generic-builder: Use args ? attr for passthru (closes #94246)

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -21,7 +21,7 @@ in
 , configureFlags ? []
 , buildFlags ? []
 , haddockFlags ? []
-, description ? ""
+, description ? null
 , doCheck ? !isCross && stdenv.lib.versionOlder "7.4" ghc.version
 , doBenchmark ? false
 , doHoogle ? true
@@ -50,7 +50,7 @@ in
 , jailbreak ? false
 , license
 , enableParallelBuilding ? true
-, maintainers ? []
+, maintainers ? null
 , doCoverage ? false
 , doHaddock ? !(ghc.isHaLVM or false)
 , passthru ? {}
@@ -59,14 +59,14 @@ in
 , benchmarkDepends ? [], benchmarkHaskellDepends ? [], benchmarkSystemDepends ? [], benchmarkFrameworkDepends ? []
 , testTarget ? ""
 , broken ? false
-, preCompileBuildDriver ? "", postCompileBuildDriver ? ""
-, preUnpack ? "", postUnpack ? ""
-, patches ? [], patchPhase ? "", prePatch ? "", postPatch ? ""
-, preConfigure ? "", postConfigure ? ""
-, preBuild ? "", postBuild ? ""
-, installPhase ? "", preInstall ? "", postInstall ? ""
-, checkPhase ? "", preCheck ? "", postCheck ? ""
-, preFixup ? "", postFixup ? ""
+, preCompileBuildDriver ? null, postCompileBuildDriver ? null
+, preUnpack ? null, postUnpack ? null
+, patches ? null, patchPhase ? null, prePatch ? "", postPatch ? ""
+, preConfigure ? null, postConfigure ? null
+, preBuild ? null, postBuild ? null
+, installPhase ? null, preInstall ? null, postInstall ? null
+, checkPhase ? null, preCheck ? null, postCheck ? null
+, preFixup ? null, postFixup ? null
 , shellHook ? ""
 , coreSetup ? false # Use only core packages to build Setup.hs.
 , useCpphs ? false
@@ -636,34 +636,34 @@ stdenv.mkDerivation ({
   };
 
   meta = { inherit homepage license platforms; }
-         // optionalAttrs broken               { inherit broken; }
-         // optionalAttrs (description != "")  { inherit description; }
-         // optionalAttrs (maintainers != [])  { inherit maintainers; }
-         // optionalAttrs (hydraPlatforms != null) { inherit hydraPlatforms; }
+         // optionalAttrs (args ? broken)         { inherit broken; }
+         // optionalAttrs (args ? description)    { inherit description; }
+         // optionalAttrs (args ? maintainers)    { inherit maintainers; }
+         // optionalAttrs (args ? hydraPlatforms) { inherit hydraPlatforms; }
          ;
 
 }
-// optionalAttrs (preCompileBuildDriver != "")  { inherit preCompileBuildDriver; }
-// optionalAttrs (postCompileBuildDriver != "") { inherit postCompileBuildDriver; }
-// optionalAttrs (preUnpack != "")      { inherit preUnpack; }
-// optionalAttrs (postUnpack != "")     { inherit postUnpack; }
-// optionalAttrs (patches != [])        { inherit patches; }
-// optionalAttrs (patchPhase != "")     { inherit patchPhase; }
-// optionalAttrs (preConfigure != "")   { inherit preConfigure; }
-// optionalAttrs (postConfigure != "")  { inherit postConfigure; }
-// optionalAttrs (preBuild != "")       { inherit preBuild; }
-// optionalAttrs (postBuild != "")      { inherit postBuild; }
-// optionalAttrs (doBenchmark)          { inherit doBenchmark; }
-// optionalAttrs (checkPhase != "")     { inherit checkPhase; }
-// optionalAttrs (preCheck != "")       { inherit preCheck; }
-// optionalAttrs (postCheck != "")      { inherit postCheck; }
-// optionalAttrs (preInstall != "")     { inherit preInstall; }
-// optionalAttrs (installPhase != "")   { inherit installPhase; }
-// optionalAttrs (postInstall != "")    { inherit postInstall; }
-// optionalAttrs (preFixup != "")       { inherit preFixup; }
-// optionalAttrs (postFixup != "")      { inherit postFixup; }
-// optionalAttrs (dontStrip)            { inherit dontStrip; }
-// optionalAttrs (hardeningDisable != []) { inherit hardeningDisable; }
+// optionalAttrs (args ? preCompileBuildDriver)  { inherit preCompileBuildDriver; }
+// optionalAttrs (args ? postCompileBuildDriver) { inherit postCompileBuildDriver; }
+// optionalAttrs (args ? preUnpack)              { inherit preUnpack; }
+// optionalAttrs (args ? postUnpack)             { inherit postUnpack; }
+// optionalAttrs (args ? patches)                { inherit patches; }
+// optionalAttrs (args ? patchPhase)             { inherit patchPhase; }
+// optionalAttrs (args ? preConfigure)           { inherit preConfigure; }
+// optionalAttrs (args ? postConfigure)          { inherit postConfigure; }
+// optionalAttrs (args ? preBuild)               { inherit preBuild; }
+// optionalAttrs (args ? postBuild)              { inherit postBuild; }
+// optionalAttrs (args ? doBenchmark)            { inherit doBenchmark; }
+// optionalAttrs (args ? checkPhase)             { inherit checkPhase; }
+// optionalAttrs (args ? preCheck)               { inherit preCheck; }
+// optionalAttrs (args ? postCheck)              { inherit postCheck; }
+// optionalAttrs (args ? preInstall)             { inherit preInstall; }
+// optionalAttrs (args ? installPhase)           { inherit installPhase; }
+// optionalAttrs (args ? postInstall)            { inherit postInstall; }
+// optionalAttrs (args ? preFixup)               { inherit preFixup; }
+// optionalAttrs (args ? postFixup)              { inherit postFixup; }
+// optionalAttrs (args ? dontStrip)              { inherit dontStrip; }
+// optionalAttrs (args ? hardeningDisable)       { inherit hardeningDisable; }
 // optionalAttrs (stdenv.buildPlatform.libc == "glibc"){ LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive"; }
 )
 )


### PR DESCRIPTION
Comparing to a default value to detect if an argument was provided forces it to at least WHNF, which can cause failure (e.g., if the argument is a string with a quoted path from a broken package). Replaced with `args ? attr` as the `args` set does not contain defaulted values.

###### Motivation for this change

Closes  #94246.

###### Things done

Besides verifying that accessing the derivation no longer forces any provided phase override strings, I rebuild a random haskell project I had after apply this change. The nix environment produced all the required packages and the program ran, so I presume all is still good.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
