### PR TITLE
hdhomerun-config-gui: init at 20200521

### DIFF
--- a/pkgs/applications/video/hdhomerun-config-gui/default.nix
+++ b/pkgs/applications/video/hdhomerun-config-gui/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, libhdhomerun, vlc, gcc, gnumake, pkg-config, gtk2 }:
+
+stdenv.mkDerivation rec {
+  pname = "hdhomerun-config-gui";
+  version = "20200521";
+
+  src = fetchurl {
+    url = "https://download.silicondust.com/hdhomerun/hdhomerun_config_gui_${version}.tgz";
+    sha256 = "1r1rwfgi714nwblyg8nqjzkpm4n2lg7kqqqas47hvbn5waimz1ja";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ gtk2 libhdhomerun ];
+
+  configureFlags = [ "CPPFLAGS=-I${libhdhomerun}/include/hdhomerun" ];
+  makeFlags = [ "SUBDIRS=src" ];
+
+  installPhase = ''
+    install -vDm 755 src/hdhomerun_config_gui $out/usr/bin/hdhomerun_config_gui
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GUI for configuring Silicondust HDHomeRun TV tuners";
+    homepage = "https://www.silicondust.com/support/linux";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.louisdk1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20399,6 +20399,8 @@ in
 
   hactool = callPackage ../tools/compression/hactool { };
 
+  hdhomerun-config-gui = callPackage ../applications/video/hdhomerun-config-gui { };
+
   heimer = libsForQt5.callPackage ../applications/misc/heimer { };
 
   hello = callPackage ../applications/misc/hello { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

Package does not build yet. I'll need to patch it to link to libhdhomerun.so from the libhdhomerun package and make sure it won't conflict.

###### Motivation for this change

hdhomerun_config_gui is currently not present in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
