### PR TITLE
openbgpd: init at 6.7p0

### DIFF
--- a/pkgs/servers/openbgpd/default.nix
+++ b/pkgs/servers/openbgpd/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, autoconf, automake
+, libtool, m4, yacc }:
+
+let
+  openbsd_version = "OPENBSD_6_7"; # This has to be equal to ${src}/OPENBSD_BRANCH
+  openbsd = fetchFromGitHub {
+    owner = "openbgpd-portable";
+    repo = "openbgpd-openbsd";
+    rev = openbsd_version;
+    sha256 = "sha256-YJTHUsn6s4xLcLQuxCLmEkIE8ozxzooj71cJ5Wl+0lI=";
+  };
+in stdenv.mkDerivation rec {
+  pname = "opengpd";
+  version = "6.7p0";
+
+  src = fetchFromGitHub {
+    owner = "openbgpd-portable";
+    repo = "openbgpd-portable";
+    rev = version;
+    sha256 = "sha256-10DfK45BsSHeyANB0OJLKog1mEj0mydXSDAT9G6u1gM";
+  };
+
+  nativeBuildInputs =
+    [  autoconf automake libtool m4 yacc ];
+
+  preConfigure = ''
+    mkdir ./openbsd
+    cp -r ${openbsd}/* ./openbsd/
+    chmod -R +w ./openbsd
+    openbsd_version=$(cat ./OPENBSD_BRANCH)
+    if [ "$openbsd_version" != "${openbsd_version}" ]; then
+      echo "OPENBSD VERSION does not match"
+      exit 1
+    fi
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "OpenBGPD is a FREE implementation of the Border Gateway Protocol, Version 4. It allows ordinary machines to be used as routers exchanging routes with other systems speaking the BGP protocol.";
+    license = licenses.isc;
+    homepage = "http://www.openbgpd.org/";
+    maintainers = with maintainers; [ kloenk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16189,6 +16189,8 @@ in
 
   oauth2_proxy = callPackage ../servers/oauth2_proxy { };
 
+  openbgpd = callPackage ../servers/openbgpd { };
+
   openafs = callPackage ../servers/openafs/1.6 { tsmbac = null; ncurses = null; };
   openafs_1_8 = callPackage ../servers/openafs/1.8 { tsmbac = null; ncurses = null; };
 


### PR DESCRIPTION
###### Motivation for this change
Packaging openbgpd

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
