### PR TITLE
pythonPackages.binwalk: add dependencies

### DIFF
--- a/pkgs/development/python-modules/binwalk/default.nix
+++ b/pkgs/development/python-modules/binwalk/default.nix
@@ -9,6 +9,8 @@
 , gnutar
 , p7zip
 , cabextract
+, cramfsprogs
+, cramfsswap
 , lzma
 , nose
 , pycrypto
@@ -29,7 +31,7 @@ buildPythonPackage {
     sha256 = "1bxgj569fzwv6jhcbl864nmlsi9x1k1r20aywjxc8b9b1zgqrlvc";
   };
 
-  propagatedBuildInputs = [ zlib xz ncompress gzip bzip2 gnutar p7zip cabextract lzma pycrypto ]
+  propagatedBuildInputs = [ zlib xz ncompress gzip bzip2 gnutar p7zip cabextract cramfsswap cramfsprogs lzma pycrypto ]
   ++ stdenv.lib.optional visualizationSupport pyqtgraph;
 
   # setup.py only installs version.py during install, not test

--- a/pkgs/os-specific/linux/cramfsprogs/default.nix
+++ b/pkgs/os-specific/linux/cramfsprogs/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchurl
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cramfsprogs";
+  version = "1.1";
+
+  src = fetchurl {
+    url = "mirror://debian/pool/main/c/cramfs/cramfs_${version}.orig.tar.gz";
+    sha256 = "0s13sabykbkbp0pcw8clxddwzxckyq7ywm2ial343ip7qjiaqg0k";
+  };
+
+  # CramFs is unmaintained upstream: https://tracker.debian.org/pkg/cramfs.
+  # So patch the "missing include" bug ourselves.
+  patches = [ ./include-sysmacros.patch ];
+
+  installPhase = ''
+    install --target $out/bin -D cramfsck mkcramfs
+  '';
+
+  buildInputs = [ zlib ];
+
+  meta = with stdenv.lib; {
+    description = "Tools to create, check, and extract content of CramFs images";
+    homepage = "https://packages.debian.org/jessie/cramfsprogs";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ pamplemousse ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/cramfsprogs/include-sysmacros.patch
+++ b/pkgs/os-specific/linux/cramfsprogs/include-sysmacros.patch
@@ -1,0 +1,12 @@
+diff --git a/mkcramfs.c b/mkcramfs.c
+index a2ef018959d..bec83c112d1 100644
+--- a/mkcramfs.c
++++ b/mkcramfs.c
+@@ -22,6 +22,7 @@
+  * If you change the disk format of cramfs, please update fs/cramfs/README.
+  */
+ 
++#include <sys/sysmacros.h>
+ #include <sys/types.h>
+ #include <stdio.h>
+ #include <sys/stat.h>

--- a/pkgs/os-specific/linux/cramfsswap/builder.sh
+++ b/pkgs/os-specific/linux/cramfsswap/builder.sh
@@ -1,6 +1,0 @@
-source $stdenv/setup
-
-export DESTDIR=$out
-mkdir -p $out/usr/bin
-
-genericBuild

--- a/pkgs/os-specific/linux/cramfsswap/default.nix
+++ b/pkgs/os-specific/linux/cramfsswap/default.nix
@@ -1,17 +1,22 @@
 {stdenv, fetchurl, zlib}:
 
-stdenv.mkDerivation {
-  name = "cramfsswap-1.4.1";
-  builder = ./builder.sh;
+stdenv.mkDerivation rec {
+  pname = "cramfsswap";
+  version = "1.4.1";
+
   src = fetchurl {
-    url = "mirror://debian/pool/main/c/cramfsswap/cramfsswap_1.4.1.tar.gz";
+    url = "mirror://debian/pool/main/c/cramfsswap/${pname}_${version}.tar.gz";
     sha256 = "0c6lbx1inkbcvvhh3y6fvfaq3w7d1zv7psgpjs5f3zjk1jysi9qd";
   };
 
   buildInputs = [zlib];
 
+  installPhase = ''
+    install --target $out/bin -D cramfsswap
+  '';
+
   meta = with stdenv.lib; {
-    description = "swap endianess of a cram filesystem (cramfs)";
+    description = "Swap endianess of a cram filesystem (cramfs)";
     homepage = "https://packages.debian.org/sid/utils/cramfsswap";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16918,6 +16918,8 @@ in
 
   cryptsetup = callPackage ../os-specific/linux/cryptsetup { };
 
+  cramfsprogs = callPackage ../os-specific/linux/cramfsprogs { };
+
   cramfsswap = callPackage ../os-specific/linux/cramfsswap { };
 
   crda = callPackage ../os-specific/linux/crda { };


### PR DESCRIPTION
##### Motivation for this change

Allow `binwalk` to extract `CramFS` content.
Here is the error I get with the current version:
```
WARNING: Extractor.execute failed to run external extractor 'cramfsck -x 'cramfs-root' '%e'': [Errno 2] No such file or directory: 'cramfsck', 'cramfsck -x 'cramfs-root'
 '%e'' might not be installed correctly                                             

WARNING: Extractor.execute failed to run external extractor 'cramfsswap '%e' '%e.swap' && cramfsck -x 'cramfs-root' '%e.swap'': [Errno 2] No such file or directory: 'cra
mfsswap', 'cramfsswap '%e' '%e.swap' && cramfsck -x 'cramfs-root' '%e.swap'' might not be installed correctly
128           0x80            CramFS filesystem, little endian, size: 9912320, version 2, sorted_dirs, CRC 0xCA750C65, edition 0, 5736 blocks, 607 files
```

[This comment](https://github.com/ReFirmLabs/binwalk/issues/343#issuecomment-409606368) explicitly states that `cramfsck` and `cramfsswap` are required to work.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
