### PR TITLE
input-fonts: 2019-11-25 -> 2020-07-24

### DIFF
--- a/pkgs/data/fonts/input-fonts/default.nix
+++ b/pkgs/data/fonts/input-fonts/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "input-fonts";
-  version = "2019-11-25"; # date of the download and checksum
+  version = "2020-07-24"; # date of the download and checksum
 
   src = requireFile {
     name = "Input-Font.zip";
     url = "https://input.fontbureau.com/download/";
-    sha256 = "10rax2a7vzidcs7kyfg5lv5bwp9i7kvjpdcsd10p0517syijkp3b";
+    sha256 = "1wacfy12ykgx33dvggcbivji6671vl5qnp4m8kpjipydffzaxqdr";
   };
 
   nativeBuildInputs = [ unzip ];
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "15sdhqqqd4jgk80fw7ncx49avi9cxbdgyrvnrfya0066x4q4r6lv";
+  outputHash = "1dda1dw2p56v1yp2qdzq38y1nksxgvcss48n5gp019imxjkrkg94";
 
   meta = with stdenv.lib; {
     description = "Fonts for Code, from Font Bureau";


### PR DESCRIPTION
###### Motivation for this change

The previous version of the zip file needed to install these fonts is no longer downloadable.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).