### PR TITLE
python2Packages.statsmodels: disable py27, abandoned

### DIFF
--- a/pkgs/development/python-modules/statsmodels/default.nix
+++ b/pkgs/development/python-modules/statsmodels/default.nix
@@ -14,6 +14,7 @@
 buildPythonPackage rec {
   pname = "statsmodels";
   version = "0.11.1";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change
```
  Processing ./statsmodels-0.11.1-cp27-cp27mu-linux_x86_64.whl
  ERROR: Package 'statsmodels' requires a different Python: 2.7.18 not in '>=3.5'
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
2 packages removed:
python2.7-cufflinks (†0.17.3) python2.7-statsmodels (†0.11.1)

Nothing changed
https://github.com/NixOS/nixpkgs/pull/94302
$ nix-shell /home/jon/.cache/nixpkgs-review/pr-94302/shell.nix
```