### PR TITLE
ryujinx: init at 1.0.5160

### DIFF
--- a/pkgs/misc/emulators/ryujinx/default.nix
+++ b/pkgs/misc/emulators/ryujinx/default.nix
@@ -1,0 +1,106 @@
+{ stdenv, fetchFromGitHub, fetchurl, makeWrapper, makeDesktopItem, linkFarmFromDrvs
+, dotnet-sdk_3, dotnetPackages, dotnetCorePackages
+, SDL2, libX11, openal
+, gtk3, gobject-introspection, wrapGAppsHook
+}:
+
+let
+  runtimeDeps = [
+    SDL2
+    gtk3
+    libX11
+    openal
+  ];
+in stdenv.mkDerivation rec {
+  pname = "ryujinx";
+  version = "1.0.5160";
+
+  src = fetchFromGitHub {
+    owner = "Ryujinx";
+    repo = "Ryujinx";
+    rev = "58f65b6523fb25d989b011c51f963520c811f9f0";
+    sha256 = "19fizqmcr8i3axi3j5hg8p6dxr1pxnl5l58z4pws6nj1xbq8z5mi";
+  };
+
+  nativeBuildInputs = [ dotnet-sdk_3 dotnetPackages.Nuget makeWrapper wrapGAppsHook gobject-introspection ];
+
+  nugetDeps = linkFarmFromDrvs "${pname}-nuget-deps" (import ./deps.nix {
+    fetchNuGet = { name, version, sha256 }: fetchurl {
+      name = "nuget-${name}-${version}.nupkg";
+      url = "https://www.nuget.org/api/v2/package/${name}/${version}";
+      inherit sha256;
+    };
+  });
+
+  patches = [ ./log.patch ]; # Without this, Ryujinx tries to write logs to the nix store. This patch makes it write to "~/.config/Ryujinx/Logs" on Linux.
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export HOME=$(mktemp -d)
+    export DOTNET_CLI_TELEMETRY_OPTOUT=1
+    export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+    nuget sources Add -Name nixos -Source "$PWD/nixos"
+    nuget init "$nugetDeps" "$PWD/nixos"
+
+    # FIXME: https://github.com/NuGet/Home/issues/4413
+    mkdir -p $HOME/.nuget/NuGet
+    cp $HOME/.config/NuGet/NuGet.Config $HOME/.nuget/NuGet
+
+    dotnet restore --source nixos Ryujinx.sln
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    dotnet build Ryujinx.sln \
+      --no-restore \
+      --configuration Release \
+      -p:Version=${version}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    dotnet publish Ryujinx.sln \
+      --no-build \
+      --configuration Release \
+      --no-self-contained \
+      --output $out/lib/ryujinx
+    shopt -s extglob
+
+    makeWrapper $out/lib/ryujinx/Ryujinx $out/bin/Ryujinx \
+      --set DOTNET_ROOT "${dotnetCorePackages.netcore_3_1}" \
+      --suffix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath runtimeDeps}" \
+      ''${gappsWrapperArgs[@]}
+
+    for i in 16 32 48 64 96 128 256 512 1024; do
+      install -D ${src}/Ryujinx/Ui/assets/Icon.png $out/share/icons/hicolor/''${i}x$i/apps/ryujinx.png
+    done
+    cp -r ${makeDesktopItem {
+      desktopName = "Ryujinx";
+      name = "ryujinx";
+      exec = "Ryujinx";
+      icon = "ryujinx";
+      comment = meta.description;
+      type = "Application";
+      categories = "Game;";
+    }}/share/applications $out/share
+
+    runHook postInstall
+  '';
+
+  # Strip breaks the executable.
+  dontStrip = true;
+
+  meta = with stdenv.lib; {
+    description = "Experimental Nintendo Switch Emulator written in C#";
+    homepage = "https://ryujinx.org/";
+    license = licenses.mit;
+    maintainers = [ maintainers.ivar ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/misc/emulators/ryujinx/deps.nix
+++ b/pkgs/misc/emulators/ryujinx/deps.nix
@@ -1,0 +1,1317 @@
+{ fetchNuGet }: [
+  (fetchNuGet {
+    name = "AtkSharp";
+    version = "3.22.25.56";
+    sha256 = "069fm4wplxb4s1i6mdj00b22zqpz6pg9miglcj8mkf1b4lnn09g0";
+  })
+  (fetchNuGet {
+    name = "CairoSharp";
+    version = "3.22.25.56";
+    sha256 = "0b7p4yj88wgayh464j3rkbc4js8z57wxy3mprgvx86i3rc2v5jd9";
+  })
+  (fetchNuGet {
+    name = "Concentus";
+    version = "1.1.7";
+    sha256 = "0y5z444wrbhlmsqpy2sxmajl1fbf74843lvgj3y6vz260dn2q0l0";
+  })
+  (fetchNuGet {
+    name = "DiscordRichPresence";
+    version = "1.0.150";
+    sha256 = "0qmbi4sccia3w80q8xfvj3bw62nvz047wq198n2b2aflkf47bq79";
+  })
+  (fetchNuGet {
+    name = "FFmpeg.AutoGen";
+    version = "4.3.0";
+    sha256 = "03lb3xzgwxik8nljq87pr1b9bsxbsl3a4kvy0kqkw9f57n29ihvk";
+  })
+  (fetchNuGet {
+    name = "GdkSharp";
+    version = "3.22.25.56";
+    sha256 = "0f708dwy6i9hghxs711scwkww28lvfjd6gykk7xv921vich5xvy6";
+  })
+  (fetchNuGet {
+    name = "GioSharp";
+    version = "3.22.25.56";
+    sha256 = "1i7x1bakv5sq27ppl6w79c1wbvnfhf1713plc9ixaznh1fclcnwr";
+  })
+  (fetchNuGet {
+    name = "GLibSharp";
+    version = "3.22.25.56";
+    sha256 = "12czfm0lgjcy9hgqsiycwfv124dq619svrnsi036246i5hycj37w";
+  })
+  (fetchNuGet {
+    name = "GLWidget";
+    version = "1.0.2";
+    sha256 = "0nb46jiscnsywwdfy7zhx1bw4jfmca3s6l8dhbi99gc4bvp8ar7p";
+  })
+  (fetchNuGet {
+    name = "GtkSharp";
+    version = "3.22.25.56";
+    sha256 = "18dbn834wimdmxmgsqd81hyvjyyzgbnayzvz9f714cgw4yjkjyqs";
+  })
+  (fetchNuGet {
+    name = "GtkSharp.Dependencies";
+    version = "1.1.0";
+    sha256 = "1g1rhcn38ww97638rds6l5bysra43hkhv47fy71fvq89623zgyxn";
+  })
+  (fetchNuGet {
+    name = "LibHac";
+    version = "0.11.3";
+    sha256 = "0xj2ip3bjy29xwy4fn5fncjadwbbg59sa3580cmkj47aab9cddyn";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
+    version = "3.1.2";
+    sha256 = "19wfh9yg4n2khbl7pvf6ngx95m5p8lw4l9y935pv7nh4xgwk02p9";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.App.Runtime.osx-x64";
+    version = "3.1.2";
+    sha256 = "1v7i4f1k3j8xavbfwb7qr5f680gg5nblrmx5zcsj7l07q4wbnmwl";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.App.Runtime.win-x64";
+    version = "3.1.2";
+    sha256 = "1gciv56vzfpl86lb9gzvyfj8w2qd7jhdrbxph6l1aykwzqbxf7bd";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeCoverage";
+    version = "16.2.0";
+    sha256 = "07h1ylca2j7a4hznq4m4b8nrzv1lw7gcf848k2a3nbm6rapv61ki";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeCoverage";
+    version = "16.5.0";
+    sha256 = "0610wzn4qyywf9lb4538vwqhprxc4g0g7gjbmnjzvx97jr5nd5mf";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CSharp";
+    version = "4.0.1";
+    sha256 = "0zxc0apx1gcx361jlq8smc9pfdgmyjh6hpka8dypc9w23nlsh6yj";
+  })
+  (fetchNuGet {
+    name = "Microsoft.DotNet.InternalAbstractions";
+    version = "1.0.0";
+    sha256 = "0mp8ihqlb7fsa789frjzidrfjc1lrhk88qp3xm5qvr7vf4wy4z8x";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.App.Host.osx-x64";
+    version = "3.1.2";
+    sha256 = "0sy1h7ffq8s3bkvf1carf4rn9qf7hn0yv6dcjklgh3g9jhlsq34f";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.App.Host.win-x64";
+    version = "3.1.2";
+    sha256 = "1yqsnl4my2q1ps666162kn0h34wyfajiwqs6snhrww195b59msdv";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.App.Runtime.linux-x64";
+    version = "3.1.2";
+    sha256 = "0a332ia5pabnz7mdfc99a5hlc7drnwzlc7cj9b5c3an6dq636p66";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.App.Runtime.osx-x64";
+    version = "3.1.2";
+    sha256 = "1wb8h30di1mix8liz937snl1w8hbblixrpiazjskxclp3i7m1rg3";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.App.Runtime.win-x64";
+    version = "3.1.2";
+    sha256 = "0aj005mh57ynscf87cpfshc3ff22l4svf6lqz0hpqsi0hlidqwqx";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "1.0.1";
+    sha256 = "01al6cfxp68dscl15z7rxfw9zvhm64dncsw09a1vmdkacsa2v6lr";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "1.1.0";
+    sha256 = "08vh1r12g6ykjygq5d3vq09zylgb84l63k49jc4v8faw9g93iqqm";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "2.0.0";
+    sha256 = "1fk2fk2639i7nzy58m9dvpdnzql4vb8yl8vr19r2fp8lmj9w2jr0";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "3.1.0";
+    sha256 = "1gc1x8f95wk8yhgznkwsg80adk1lc65v9n5rx4yaa4bc5dva0z3j";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Targets";
+    version = "1.0.1";
+    sha256 = "0ppdkwy6s9p7x9jix3v4402wb171cdiibq7js7i13nxpdky7074p";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Targets";
+    version = "1.1.0";
+    sha256 = "193xwf33fbm0ni3idxzbr5fdq3i2dlfgihsac9jj7whj0gd902nh";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NET.Test.Sdk";
+    version = "16.2.0";
+    sha256 = "1nr5jxchdy3p7jm4fm73d5yivghjisdsyafma8fs5d1v49bhgckq";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NET.Test.Sdk";
+    version = "16.5.0";
+    sha256 = "19f5bvzci5mmfz81jwc4dax4qdf7w4k67n263383mn8mawf22bfq";
+  })
+  (fetchNuGet {
+    name = "Microsoft.TestPlatform.ObjectModel";
+    version = "16.2.0";
+    sha256 = "1ywzyx75d61wm75l7wglxzglg5k9nq66wd56m52hmmg8mf253z57";
+  })
+  (fetchNuGet {
+    name = "Microsoft.TestPlatform.ObjectModel";
+    version = "16.5.0";
+    sha256 = "02h7j1fr0fwcggn0wgddh59k8b2wmly3snckwhswzqvks5rvfnnw";
+  })
+  (fetchNuGet {
+    name = "Microsoft.TestPlatform.TestHost";
+    version = "16.2.0";
+    sha256 = "05dx9nv1skc5ji79ji5vz6c93b09w9xh70iyy6j5ca978ga92i6g";
+  })
+  (fetchNuGet {
+    name = "Microsoft.TestPlatform.TestHost";
+    version = "16.5.0";
+    sha256 = "08cvss66lqa92h55dxkbrzn796jckhlyj53zz22x3qyr6xi21v5v";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Primitives";
+    version = "4.0.1";
+    sha256 = "1n8ap0cmljbqskxpf8fjzn7kh1vvlndsa75k01qig26mbw97k2q7";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Primitives";
+    version = "4.3.0";
+    sha256 = "0j0c1wj4ndj21zsgivsc24whiya605603kxrbiw6wkfdync464wq";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Registry";
+    version = "4.0.0";
+    sha256 = "1spf4m9pikkc19544p29a47qnhcd885klncahz133hbnyqbkmz9k";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Registry";
+    version = "4.3.0";
+    sha256 = "1gxyzxam8163vk1kb6xzxjj4iwspjsz9zhgn1w9rjzciphaz0ig7";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Registry";
+    version = "4.5.0";
+    sha256 = "1zapbz161ji8h82xiajgriq6zgzmb1f3ar517p2h63plhsq5gh2q";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Registry";
+    version = "4.7.0";
+    sha256 = "0bx21jjbs7l5ydyw4p6cn07chryxpmchq2nl5pirzz4l3b0q4dgs";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.SystemEvents";
+    version = "4.5.0";
+    sha256 = "0fnkv3ky12227zqg4zshx4kw2mvysq2ppxjibfw02cc3iprv4njq";
+  })
+  (fetchNuGet {
+    name = "Mono.Posix.NETStandard";
+    version = "1.0.0";
+    sha256 = "0xlja36hwpjm837haq15mjh2prcf68lyrmn72nvgpz8qnf9vappw";
+  })
+  (fetchNuGet {
+    name = "MsgPack.Cli";
+    version = "1.0.1";
+    sha256 = "1dk2bs3g16lsxcjjm7gfx6jxa4667wccw94jlh2ql7y7smvh9z8r";
+  })
+  (fetchNuGet {
+    name = "NETStandard.Library";
+    version = "1.6.0";
+    sha256 = "0nmmv4yw7gw04ik8ialj3ak0j6pxa9spih67hnn1h2c38ba8h58k";
+  })
+  (fetchNuGet {
+    name = "NETStandard.Library";
+    version = "2.0.0";
+    sha256 = "1bc4ba8ahgk15m8k4nd7x406nhi0kwqzbgjk2dmw52ss553xz7iy";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "12.0.2";
+    sha256 = "0w2fbji1smd2y7x25qqibf1qrznmv4s6s0jvrbvr6alb7mfyqvh5";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "9.0.1";
+    sha256 = "0mcy0i7pnfpqm4pcaiyzzji4g0c8i3a5gjz28rrr28110np8304r";
+  })
+  (fetchNuGet {
+    name = "NuGet.Frameworks";
+    version = "5.0.0";
+    sha256 = "18ijvmj13cwjdrrm52c8fpq021531zaz4mj4b4zapxaqzzxf2qjr";
+  })
+  (fetchNuGet {
+    name = "NUnit";
+    version = "3.12.0";
+    sha256 = "1880j2xwavi8f28vxan3hyvdnph4nlh5sbmh285s4lc9l0b7bdk2";
+  })
+  (fetchNuGet {
+    name = "NUnit3TestAdapter";
+    version = "3.15.1";
+    sha256 = "1nhpvzxbxgymmkb3bd5ci40rg8k71bfx2ghbgc99znvnvhf2034y";
+  })
+  (fetchNuGet {
+    name = "NUnit3TestAdapter";
+    version = "3.16.1";
+    sha256 = "1pzhmapfdszsfza7zjr3zrlz4fssdxsyiwmlj76a40mbhxhfa4q9";
+  })
+  (fetchNuGet {
+    name = "OpenTK.NetStandard";
+    version = "1.0.5.12";
+    sha256 = "1n8j6k47189l5b6rnhyq391d84v6zkpiiqq41cccb6qizvrcgl69";
+  })
+  (fetchNuGet {
+    name = "PangoSharp";
+    version = "3.22.25.56";
+    sha256 = "12b0761nfsci4rvzcba4hrh5rcn6q24qaxwwz66myb82c999qj8w";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Collections";
+    version = "4.0.11";
+    sha256 = "1x44bm1cgv28zmrp095wf9mn8a6a0ivnzp9v14dcbhx06igxzgg0";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Collections";
+    version = "4.3.0";
+    sha256 = "0bv5qgm6vr47ynxqbnkc7i797fdi8gbjjxii173syrx14nmrkwg0";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Diagnostics.Tools";
+    version = "4.0.1";
+    sha256 = "0qcpm90hrm9gx9pmxlvfml65jm0bwpr5dg3r7l7xm9nvmibvc7n7";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Diagnostics.Tools";
+    version = "4.3.0";
+    sha256 = "1wl76vk12zhdh66vmagni66h5xbhgqq7zkdpgw21jhxhvlbcl8pk";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Diagnostics.Tracing";
+    version = "4.3.0";
+    sha256 = "00j6nv2xgmd3bi347k00m7wr542wjlig53rmj28pmw7ddcn97jbn";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Globalization";
+    version = "4.0.11";
+    sha256 = "0240rp66pi5bw1xklmh421hj7arwcdmjmgfkiq1cbc6nrm8ah286";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Globalization";
+    version = "4.3.0";
+    sha256 = "1daqf33hssad94lamzg01y49xwndy2q97i2lrb7mgn28656qia1x";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Globalization.Calendars";
+    version = "4.3.0";
+    sha256 = "1ghhhk5psqxcg6w88sxkqrc35bxcz27zbqm2y5p5298pv3v7g201";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.IO";
+    version = "4.1.0";
+    sha256 = "0kasfkjiml2kk8prnyn1990nhsahnjggvqwszqjdsfwfl43vpcb5";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.IO";
+    version = "4.3.0";
+    sha256 = "0l8xz8zn46w4d10bcn3l4yyn4vhb3lrj2zw8llvz7jk14k4zps5x";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Reflection";
+    version = "4.1.0";
+    sha256 = "06kcs059d5czyakx75rvlwa2mr86156w18fs7chd03f7084l7mq6";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Reflection";
+    version = "4.3.0";
+    sha256 = "02c9h3y35pylc0zfq3wcsvc5nqci95nrkq0mszifc0sjx7xrzkly";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Reflection.Extensions";
+    version = "4.0.1";
+    sha256 = "05k34ijz9g9csh0vbbv3g3lrxl163izwcfncmbcl7k073h32rzkr";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Reflection.Extensions";
+    version = "4.3.0";
+    sha256 = "0zyri97dfc5vyaz9ba65hjj1zbcrzaffhsdlpxc9bh09wy22fq33";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Reflection.Primitives";
+    version = "4.0.1";
+    sha256 = "1zxrpvixr5fqzkxpnin6g6gjq6xajy1snghz99ds2dwbhm276rhz";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Reflection.Primitives";
+    version = "4.3.0";
+    sha256 = "0x1mm8c6iy8rlxm8w9vqw7gb7s1ljadrn049fmf70cyh42vdfhrf";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Resources.ResourceManager";
+    version = "4.0.1";
+    sha256 = "1jmgs7hynb2rff48623wnyb37558bbh1q28k9c249j5r5sgsr5kr";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Resources.ResourceManager";
+    version = "4.3.0";
+    sha256 = "03kickal0iiby82wa5flar18kyv82s9s6d4xhk5h4bi5kfcyfjzl";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Runtime";
+    version = "4.1.0";
+    sha256 = "0mjr2bi7wvnkphfjqgkyf8vfyvy15a829jz6mivl6jmksh2bx40m";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Runtime";
+    version = "4.3.0";
+    sha256 = "1cqh1sv3h5j7ixyb7axxbdkqx6cxy00p4np4j91kpm492rf4s25b";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Runtime.Handles";
+    version = "4.0.1";
+    sha256 = "1kswgqhy34qvc49i981fk711s7knd6z13bp0rin8ms6axkh98nas";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Runtime.Handles";
+    version = "4.3.0";
+    sha256 = "0bh5bi25nk9w9xi8z23ws45q5yia6k7dg3i4axhfqlnj145l011x";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Runtime.InteropServices";
+    version = "4.1.0";
+    sha256 = "0gm8if0hcmp1qys1wmx4970k2x62pqvldgljsyzbjhiy5644vl8z";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Runtime.InteropServices";
+    version = "4.3.0";
+    sha256 = "0c3g3g3jmhlhw4klrc86ka9fjbl7i59ds1fadsb2l8nqf8z3kb19";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Text.Encoding";
+    version = "4.0.11";
+    sha256 = "0m4vgmzi1ky8xlj0r7xcyazxln3j9dlialnk6d2gmgrfnzf8f9m7";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Text.Encoding";
+    version = "4.3.0";
+    sha256 = "0aqqi1v4wx51h51mk956y783wzags13wa7mgqyclacmsmpv02ps3";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Text.Encoding.Extensions";
+    version = "4.0.11";
+    sha256 = "0d1rxxpvg9v7wlibsfgz0r4hwigpadas822qf8m8fs1gma9gs877";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Text.Encoding.Extensions";
+    version = "4.3.0";
+    sha256 = "0lqhgqi0i8194ryqq6v2gqx0fb86db2gqknbm0aq31wb378j7ip8";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Threading.Tasks";
+    version = "4.0.11";
+    sha256 = "1qzdp09qs8br5qxzlm1lgbjn4n57fk8vr1lzrmli2ysdg6x1xzvk";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Threading.Tasks";
+    version = "4.3.0";
+    sha256 = "03mnvkhskbzxddz4hm113zsch1jyzh2cs450dk3rgfjp8crlw1va";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Threading.Timer";
+    version = "4.3.0";
+    sha256 = "0aw4phrhwqz9m61r79vyfl5la64bjxj8l34qnrcwb28v49fg2086";
+  })
+  (fetchNuGet {
+    name = "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "16rnxzpk5dpbbl1x354yrlsbvwylrq456xzpsha1n9y3glnhyx9d";
+  })
+  (fetchNuGet {
+    name = "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0hkg03sgm2wyq8nqk6dbm9jh5vcq57ry42lkqdmfklrw89lsmr59";
+  })
+  (fetchNuGet {
+    name = "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0c2p354hjx58xhhz7wv6div8xpi90sc6ibdm40qin21bvi7ymcaa";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System";
+    version = "4.0.0";
+    sha256 = "1ppk69xk59ggacj9n7g6fyxvzmk1g5p4fkijm0d7xqfkig98qrkf";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System";
+    version = "4.3.0";
+    sha256 = "15hgf6zaq9b8br2wi1i3x0zvmk410nlmsmva9p0bbg73v6hml5k4";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.IO.Compression";
+    version = "4.1.0";
+    sha256 = "0d720z4lzyfcabmmnvh0bnj76ll7djhji2hmfh3h44sdkjnlkknk";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Net.Http";
+    version = "4.0.1";
+    sha256 = "1hgv2bmbaskx77v8glh7waxws973jn4ah35zysnkxmf0196sfxg6";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography";
+    version = "4.0.0";
+    sha256 = "0k57aa2c3b10wl3hfqbgrl7xq7g8hh3a3ir44b31dn5p61iiw3z9";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "18pzfdlwsg2nb1jjjjzyb5qlgy6xjxzmhnfaijq5s2jw3cm3ab97";
+  })
+  (fetchNuGet {
+    name = "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0qyynf9nz5i7pc26cwhgi8j62ps27sqmf78ijcfgzab50z9g8ay3";
+  })
+  (fetchNuGet {
+    name = "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "1klrs545awhayryma6l7g2pvnp9xy4z0r1i40r80zb45q3i9nbyf";
+  })
+  (fetchNuGet {
+    name = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0zcxjv5pckplvkg0r6mw3asggm7aqzbdjimhvsasb0cgm59x09l3";
+  })
+  (fetchNuGet {
+    name = "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0vhynn79ih7hw7cwjazn87rm9z9fj0rvxgzlab36jybgcpcgphsn";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "160p68l2c7cqmyqjwxydcvgw7lvl1cr0znkw8fp24d1by9mqc8p3";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "15zrc8fgd8zx28hdghcj5f5i34wf3l6bq5177075m2bc2j34jrqy";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "1p4dgxax6p7rlgj4q73k73rslcnz4wdcv8q2flg1s8ygwcm58ld5";
+  })
+  (fetchNuGet {
+    name = "runtime.unix.Microsoft.Win32.Primitives";
+    version = "4.3.0";
+    sha256 = "0y61k9zbxhdi0glg154v30kkq7f8646nif8lnnxbvkjpakggd5id";
+  })
+  (fetchNuGet {
+    name = "runtime.unix.System.Console";
+    version = "4.3.0";
+    sha256 = "1pfpkvc6x2if8zbdzg9rnc5fx51yllprl8zkm5npni2k50lisy80";
+  })
+  (fetchNuGet {
+    name = "runtime.unix.System.Diagnostics.Debug";
+    version = "4.0.11";
+    sha256 = "05ndbai4vpqrry0ghbfgqc8xblmplwjgndxmdn1zklqimczwjg2d";
+  })
+  (fetchNuGet {
+    name = "runtime.unix.System.Diagnostics.Debug";
+    version = "4.3.0";
+    sha256 = "1lps7fbnw34bnh3lm31gs5c0g0dh7548wfmb8zz62v0zqz71msj5";
+  })
+  (fetchNuGet {
+    name = "runtime.unix.System.IO.FileSystem";
+    version = "4.0.1";
+    sha256 = "02wnlydnbhai0zy7c3kihg0cis0l1b2z78kyi1ci47c5v0jklwha";
+  })
+  (fetchNuGet {
+    name = "runtime.unix.System.IO.FileSystem";
+    version = "4.3.0";
+    sha256 = "14nbkhvs7sji5r1saj2x8daz82rnf9kx28d3v2qss34qbr32dzix";
+  })
+  (fetchNuGet {
+    name = "runtime.unix.System.Net.Primitives";
+    version = "4.3.0";
+    sha256 = "0bdnglg59pzx9394sy4ic66kmxhqp8q8bvmykdxcbs5mm0ipwwm4";
+  })
+  (fetchNuGet {
+    name = "runtime.unix.System.Net.Sockets";
+    version = "4.3.0";
+    sha256 = "03npdxzy8gfv035bv1b9rz7c7hv0rxl5904wjz51if491mw0xy12";
+  })
+  (fetchNuGet {
+    name = "runtime.unix.System.Private.Uri";
+    version = "4.0.1";
+    sha256 = "0ic5dgc45jkhcr1g9xmmzjm7ffiw4cymm0fprczlx4fnww4783nm";
+  })
+  (fetchNuGet {
+    name = "runtime.unix.System.Private.Uri";
+    version = "4.3.0";
+    sha256 = "1jx02q6kiwlvfksq1q9qr17fj78y5v6mwsszav4qcz9z25d5g6vk";
+  })
+  (fetchNuGet {
+    name = "runtime.unix.System.Runtime.Extensions";
+    version = "4.1.0";
+    sha256 = "0x1cwd7cvifzmn5x1wafvj75zdxlk3mxy860igh3x1wx0s8167y4";
+  })
+  (fetchNuGet {
+    name = "runtime.unix.System.Runtime.Extensions";
+    version = "4.3.0";
+    sha256 = "0pnxxmm8whx38dp6yvwgmh22smknxmqs5n513fc7m4wxvs1bvi4p";
+  })
+  (fetchNuGet {
+    name = "runtime.win.Microsoft.Win32.Primitives";
+    version = "4.3.0";
+    sha256 = "0k1h8nnp1s0p8rjwgjyj1387cc1yycv0k22igxc963lqdzrx2z36";
+  })
+  (fetchNuGet {
+    name = "runtime.win.System.Console";
+    version = "4.3.0";
+    sha256 = "0x2yajfrbc5zc6g7nmlr44xpjk6p1hxjq47jn3xki5j7i33zw9jc";
+  })
+  (fetchNuGet {
+    name = "runtime.win.System.Diagnostics.Debug";
+    version = "4.0.11";
+    sha256 = "1ylkj4v7aq00svij7aq82d86afpwqgrqf2kpikabxl26p19ry9wm";
+  })
+  (fetchNuGet {
+    name = "runtime.win.System.Diagnostics.Debug";
+    version = "4.3.0";
+    sha256 = "16fbn4bcynad1ygdq0yk1wmckvs8jvrrf104xa5dc2hlc8y3x58f";
+  })
+  (fetchNuGet {
+    name = "runtime.win.System.IO.FileSystem";
+    version = "4.0.1";
+    sha256 = "1dn9k6x8h27b6vbqh72hsfxax4fwf30jj8lc5328rg52lw29cyn1";
+  })
+  (fetchNuGet {
+    name = "runtime.win.System.IO.FileSystem";
+    version = "4.3.0";
+    sha256 = "1c01nklbxywszsbfaxc76hsz7gdxac3jkphrywfkdsi3v4bwd6g8";
+  })
+  (fetchNuGet {
+    name = "runtime.win.System.Net.Primitives";
+    version = "4.3.0";
+    sha256 = "1dixh195bi7473n17hspll6i562gghdz9m4jk8d4kzi1mlzjk9cf";
+  })
+  (fetchNuGet {
+    name = "runtime.win.System.Net.Sockets";
+    version = "4.3.0";
+    sha256 = "0lr3zki831vs6qhk5wckv2b9qbfk9rcj0ds2926qvj1b9y9m6sck";
+  })
+  (fetchNuGet {
+    name = "runtime.win.System.Runtime.Extensions";
+    version = "4.1.0";
+    sha256 = "1zmx2msa04ka8mgh8viahi4pqpp86vdhzij2rg1jg131bwlv59yw";
+  })
+  (fetchNuGet {
+    name = "runtime.win.System.Runtime.Extensions";
+    version = "4.3.0";
+    sha256 = "1700famsxndccfbcdz9q14qb20p49lax67mqwpgy4gx3vja1yczr";
+  })
+  (fetchNuGet {
+    name = "Ryujinx.Graphics.Nvdec.Dependencies";
+    version = "4.3.0";
+    sha256 = "0szgbdhyhvzpw8nb9k2ww37p5qipab1pdll8idkk57y5xnl2f7ll";
+  })
+  (fetchNuGet {
+    name = "SkiaSharp";
+    version = "1.68.1.1";
+    sha256 = "013yzsk798dwxdf2y5yx675x96nagfapkri5k3pgsjnmyfp1lvzk";
+  })
+  (fetchNuGet {
+    name = "SkiaSharp.NativeAssets.Linux";
+    version = "1.68.1.1";
+    sha256 = "07448kn9x56pxlnkxp2dpr5jmwj62k48y5m4608mwci32vs675hn";
+  })
+  (fetchNuGet {
+    name = "SkiaSharp.Views.Desktop.Common";
+    version = "1.68.1.1";
+    sha256 = "0wkj952iha7w2i8mvl0mksz2wqkx7vi7xylh10xgddld8kkm03r7";
+  })
+  (fetchNuGet {
+    name = "SkiaSharp.Views.Gtk3";
+    version = "1.68.1.1";
+    sha256 = "19fgshim2i60p55j4jcr0biq6k2xwal5dsmbgvyrrajnssaj3r95";
+  })
+  (fetchNuGet {
+    name = "System.AppContext";
+    version = "4.1.0";
+    sha256 = "0fv3cma1jp4vgj7a8hqc9n7hr1f1kjp541s6z0q1r6nazb4iz9mz";
+  })
+  (fetchNuGet {
+    name = "System.Buffers";
+    version = "4.0.0";
+    sha256 = "13s659bcmg9nwb6z78971z1lr6bmh2wghxi1ayqyzl4jijd351gr";
+  })
+  (fetchNuGet {
+    name = "System.Buffers";
+    version = "4.3.0";
+    sha256 = "0fgns20ispwrfqll4q1zc1waqcmylb3zc50ys9x8zlwxh9pmd9jy";
+  })
+  (fetchNuGet {
+    name = "System.CodeDom";
+    version = "4.4.0";
+    sha256 = "1zgbafm5p380r50ap5iddp11kzhr9khrf2pnai6k593wjar74p1g";
+  })
+  (fetchNuGet {
+    name = "System.CodeDom";
+    version = "4.7.0";
+    sha256 = "1lch8gwmw420wsvbv9ir4v5g1ij2ag23cbgi3c9gramj1h4vhlz2";
+  })
+  (fetchNuGet {
+    name = "System.Collections";
+    version = "4.0.11";
+    sha256 = "1ga40f5lrwldiyw6vy67d0sg7jd7ww6kgwbksm19wrvq9hr0bsm6";
+  })
+  (fetchNuGet {
+    name = "System.Collections";
+    version = "4.3.0";
+    sha256 = "19r4y64dqyrq6k4706dnyhhw7fs24kpp3awak7whzss39dakpxk9";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Concurrent";
+    version = "4.0.12";
+    sha256 = "07y08kvrzpak873pmyxs129g1ch8l27zmg51pcyj2jvq03n0r0fc";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Immutable";
+    version = "1.2.0";
+    sha256 = "1jm4pc666yiy7af1mcf7766v710gp0h40p228ghj6bavx7xfa38m";
+  })
+  (fetchNuGet {
+    name = "System.Collections.NonGeneric";
+    version = "4.0.1";
+    sha256 = "19994r5y5bpdhj7di6w047apvil8lh06lh2c2yv9zc4fc5g9bl4d";
+  })
+  (fetchNuGet {
+    name = "System.Collections.NonGeneric";
+    version = "4.3.0";
+    sha256 = "07q3k0hf3mrcjzwj8fwk6gv3n51cb513w4mgkfxzm3i37sc9kz7k";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Specialized";
+    version = "4.0.1";
+    sha256 = "1wbv7y686p5x169rnaim7sln67ivmv6r57falrnx8aap9y33mam9";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Specialized";
+    version = "4.3.0";
+    sha256 = "1sdwkma4f6j85m3dpb53v9vcgd0zyc9jb33f8g63byvijcj39n20";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel";
+    version = "4.0.1";
+    sha256 = "0v4qpmqlzyfad2kswxxj2frnaqqhz9201c3yn8fmmarx5vlzg52z";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel";
+    version = "4.3.0";
+    sha256 = "0986b10ww3nshy30x9sjyzm0jx339dkjxjj3401r3q0f6fx2wkcb";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.EventBasedAsync";
+    version = "4.0.11";
+    sha256 = "07r5i7xwban347nsfw28hhjwpr78ywksjyhywvhj1yr0s7sr00wh";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.EventBasedAsync";
+    version = "4.3.0";
+    sha256 = "1rv9bkb8yyhqqqrx6x95njv6mdxlbvv527b44mrd93g8fmgkifl7";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.Primitives";
+    version = "4.1.0";
+    sha256 = "0wb5mnaag0w4fnyc40x19j8v2vshxp266razw64bcqfyj1whb1q0";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.Primitives";
+    version = "4.3.0";
+    sha256 = "1svfmcmgs0w0z9xdw2f2ps05rdxmkxxhf0l17xk9l1l8xfahkqr0";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.TypeConverter";
+    version = "4.1.0";
+    sha256 = "178cva9p1cs043h5n2fry5xkzr3wc9n0hwbxa8m3ymld9m6wcv0y";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.TypeConverter";
+    version = "4.3.0";
+    sha256 = "17ng0p7v3nbrg3kycz10aqrrlw4lz9hzhws09pfh8gkwicyy481x";
+  })
+  (fetchNuGet {
+    name = "System.Console";
+    version = "4.0.0";
+    sha256 = "0ynxqbc3z1nwbrc11hkkpw9skw116z4y9wjzn7id49p9yi7mzmlf";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Debug";
+    version = "4.0.11";
+    sha256 = "0gmjghrqmlgzxivd2xl50ncbglb7ljzb66rlx8ws6dv8jm0d5siz";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Debug";
+    version = "4.3.0";
+    sha256 = "00yjlf19wjydyr6cfviaph3vsjzg3d5nvnya26i2fvfg53sknh3y";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.DiagnosticSource";
+    version = "4.0.0";
+    sha256 = "1n6c3fbz7v8d3pn77h4v5wvsfrfg7v1c57lg3nff3cjyh597v23m";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Process";
+    version = "4.1.0";
+    sha256 = "061lrcs7xribrmq7kab908lww6kn2xn1w3rdc41q189y0jibl19s";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Process";
+    version = "4.3.0";
+    sha256 = "0g4prsbkygq8m21naqmcp70f24a1ksyix3dihb1r1f71lpi3cfj7";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.TextWriterTraceListener";
+    version = "4.0.0";
+    sha256 = "1xigiwkwyxak0dhm0p8i2zb7a9syly9cdb5s9zkr9rbad4f2fqhs";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tools";
+    version = "4.0.1";
+    sha256 = "19cknvg07yhakcvpxg3cxa0bwadplin6kyxd8mpjjpwnp56nl85x";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.TraceSource";
+    version = "4.0.0";
+    sha256 = "1mc7r72xznczzf6mz62dm8xhdi14if1h8qgx353xvhz89qyxsa3h";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tracing";
+    version = "4.1.0";
+    sha256 = "1d2r76v1x610x61ahfpigda89gd13qydz6vbwzhpqlyvq8jj6394";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tracing";
+    version = "4.3.0";
+    sha256 = "1m3bx6c2s958qligl67q7grkwfz3w53hpy7nc97mh6f7j5k168c4";
+  })
+  (fetchNuGet {
+    name = "System.Drawing.Common";
+    version = "4.5.0";
+    sha256 = "0knqa0zsm91nfr34br8gx5kjqq4v81zdhqkacvs2hzc8nqk0ddhc";
+  })
+  (fetchNuGet {
+    name = "System.Dynamic.Runtime";
+    version = "4.0.11";
+    sha256 = "1pla2dx8gkidf7xkciig6nifdsb494axjvzvann8g2lp3dbqasm9";
+  })
+  (fetchNuGet {
+    name = "System.Globalization";
+    version = "4.0.11";
+    sha256 = "070c5jbas2v7smm660zaf1gh0489xanjqymkvafcs4f8cdrs1d5d";
+  })
+  (fetchNuGet {
+    name = "System.Globalization";
+    version = "4.3.0";
+    sha256 = "1cp68vv683n6ic2zqh2s1fn4c2sd87g5hpp6l4d4nj4536jz98ki";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Calendars";
+    version = "4.0.1";
+    sha256 = "0bv0alrm2ck2zk3rz25lfyk9h42f3ywq77mx1syl6vvyncnpg4qh";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Extensions";
+    version = "4.0.1";
+    sha256 = "0hjhdb5ri8z9l93bw04s7ynwrjrhx2n0p34sf33a9hl9phz69fyc";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Extensions";
+    version = "4.3.0";
+    sha256 = "02a5zfxavhv3jd437bsncbhd2fp1zv4gxzakp1an9l6kdq1mcqls";
+  })
+  (fetchNuGet {
+    name = "System.IO";
+    version = "4.1.0";
+    sha256 = "1g0yb8p11vfd0kbkyzlfsbsp5z44lwsvyc0h3dpw6vqnbi035ajp";
+  })
+  (fetchNuGet {
+    name = "System.IO";
+    version = "4.3.0";
+    sha256 = "05l9qdrzhm4s5dixmx68kxwif4l99ll5gqmh7rqgw554fx0agv5f";
+  })
+  (fetchNuGet {
+    name = "System.IO.Compression";
+    version = "4.1.0";
+    sha256 = "0iym7s3jkl8n0vzm3jd6xqg9zjjjqni05x45dwxyjr2dy88hlgji";
+  })
+  (fetchNuGet {
+    name = "System.IO.Compression.ZipFile";
+    version = "4.0.1";
+    sha256 = "0h72znbagmgvswzr46mihn7xm7chfk2fhrp5krzkjf29pz0i6z82";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem";
+    version = "4.0.1";
+    sha256 = "0kgfpw6w4djqra3w5crrg8xivbanh1w9dh3qapb28q060wb9flp1";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem";
+    version = "4.3.0";
+    sha256 = "0z2dfrbra9i6y16mm9v1v6k47f0fm617vlb7s5iybjjsz6g1ilmw";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem.Primitives";
+    version = "4.0.1";
+    sha256 = "1s0mniajj3lvbyf7vfb5shp4ink5yibsx945k6lvxa96r8la1612";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem.Primitives";
+    version = "4.3.0";
+    sha256 = "0j6ndgglcf4brg2lz4wzsh1av1gh8xrzdsn9f0yznskhqn1xzj9c";
+  })
+  (fetchNuGet {
+    name = "System.Linq";
+    version = "4.1.0";
+    sha256 = "1ppg83svb39hj4hpp5k7kcryzrf3sfnm08vxd5sm2drrijsla2k5";
+  })
+  (fetchNuGet {
+    name = "System.Linq";
+    version = "4.3.0";
+    sha256 = "1w0gmba695rbr80l1k2h4mrwzbzsyfl2z4klmpbsvsg5pm4a56s7";
+  })
+  (fetchNuGet {
+    name = "System.Linq.Expressions";
+    version = "4.1.0";
+    sha256 = "1gpdxl6ip06cnab7n3zlcg6mqp7kknf73s8wjinzi4p0apw82fpg";
+  })
+  (fetchNuGet {
+    name = "System.Management";
+    version = "4.7.0";
+    sha256 = "0aw61jl6l78liiq04afxplz0ad5qbyg6vmyjaqrlnrv7whb58n66";
+  })
+  (fetchNuGet {
+    name = "System.Net.Http";
+    version = "4.1.0";
+    sha256 = "1i5rqij1icg05j8rrkw4gd4pgia1978mqhjzhsjg69lvwcdfg8yb";
+  })
+  (fetchNuGet {
+    name = "System.Net.NameResolution";
+    version = "4.3.0";
+    sha256 = "15r75pwc0rm3vvwsn8rvm2krf929mjfwliv0mpicjnii24470rkq";
+  })
+  (fetchNuGet {
+    name = "System.Net.Primitives";
+    version = "4.0.11";
+    sha256 = "10xzzaynkzkakp7jai1ik3r805zrqjxiz7vcagchyxs2v26a516r";
+  })
+  (fetchNuGet {
+    name = "System.Net.Sockets";
+    version = "4.1.0";
+    sha256 = "1385fvh8h29da5hh58jm1v78fzi9fi5vj93vhlm2kvqpfahvpqls";
+  })
+  (fetchNuGet {
+    name = "System.Numerics.Vectors";
+    version = "4.3.0";
+    sha256 = "05kji1mv4sl75iwmc613p873145nynm02xiajx8pn0h2kx53d23s";
+  })
+  (fetchNuGet {
+    name = "System.ObjectModel";
+    version = "4.0.12";
+    sha256 = "1sybkfi60a4588xn34nd9a58png36i0xr4y4v4kqpg8wlvy5krrj";
+  })
+  (fetchNuGet {
+    name = "System.Private.DataContractSerialization";
+    version = "4.1.1";
+    sha256 = "1xk9wvgzipssp1393nsg4n16zbr5481k03nkdlj954hzq5jkx89r";
+  })
+  (fetchNuGet {
+    name = "System.Private.Uri";
+    version = "4.0.1";
+    sha256 = "0k57qhawjysm4cpbfpc49kl4av7lji310kjcamkl23bwgij5ld9j";
+  })
+  (fetchNuGet {
+    name = "System.Private.Uri";
+    version = "4.3.0";
+    sha256 = "04r1lkdnsznin0fj4ya1zikxiqr0h6r6a1ww2dsm60gqhdrf0mvx";
+  })
+  (fetchNuGet {
+    name = "System.Reflection";
+    version = "4.1.0";
+    sha256 = "1js89429pfw79mxvbzp8p3q93il6rdff332hddhzi5wqglc4gml9";
+  })
+  (fetchNuGet {
+    name = "System.Reflection";
+    version = "4.3.0";
+    sha256 = "0xl55k0mw8cd8ra6dxzh974nxif58s3k1rjv1vbd7gjbjr39j11m";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit";
+    version = "4.0.1";
+    sha256 = "0ydqcsvh6smi41gyaakglnv252625hf29f7kywy2c70nhii2ylqp";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit";
+    version = "4.3.0";
+    sha256 = "11f8y3qfysfcrscjpjym9msk7lsfxkk4fmz9qq95kn3jd0769f74";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.ILGeneration";
+    version = "4.0.1";
+    sha256 = "1pcd2ig6bg144y10w7yxgc9d22r7c7ww7qn1frdfwgxr24j9wvv0";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.ILGeneration";
+    version = "4.3.0";
+    sha256 = "0w1n67glpv8241vnpz1kl14sy7zlnw414aqwj4hcx5nd86f6994q";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.Lightweight";
+    version = "4.0.1";
+    sha256 = "1s4b043zdbx9k39lfhvsk68msv1nxbidhkq6nbm27q7sf8xcsnxr";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.Lightweight";
+    version = "4.3.0";
+    sha256 = "0ql7lcakycrvzgi9kxz1b3lljd990az1x6c4jsiwcacrvimpib5c";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Extensions";
+    version = "4.0.1";
+    sha256 = "0m7wqwq0zqq9gbpiqvgk3sr92cbrw7cp3xn53xvw7zj6rz6fdirn";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Extensions";
+    version = "4.3.0";
+    sha256 = "02bly8bdc98gs22lqsfx9xicblszr2yan7v2mmw3g7hy6miq5hwq";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Metadata";
+    version = "1.3.0";
+    sha256 = "1y5m6kryhjpqqm2g3h3b6bzig13wkiw954x3b7icqjm6xypm1x3b";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Primitives";
+    version = "4.0.1";
+    sha256 = "1bangaabhsl4k9fg8khn83wm6yial8ik1sza7401621jc6jrym28";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Primitives";
+    version = "4.3.0";
+    sha256 = "04xqa33bld78yv5r93a8n76shvc8wwcdgr1qvvjh959g3rc31276";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.TypeExtensions";
+    version = "4.1.0";
+    sha256 = "1bjli8a7sc7jlxqgcagl9nh8axzfl11f4ld3rjqsyxc516iijij7";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.TypeExtensions";
+    version = "4.3.0";
+    sha256 = "0y2ssg08d817p0vdag98vn238gyrrynjdj4181hdg780sif3ykp1";
+  })
+  (fetchNuGet {
+    name = "System.Resources.ResourceManager";
+    version = "4.0.1";
+    sha256 = "0b4i7mncaf8cnai85jv3wnw6hps140cxz8vylv2bik6wyzgvz7bi";
+  })
+  (fetchNuGet {
+    name = "System.Resources.ResourceManager";
+    version = "4.3.0";
+    sha256 = "0sjqlzsryb0mg4y4xzf35xi523s4is4hz9q4qgdvlvgivl7qxn49";
+  })
+  (fetchNuGet {
+    name = "System.Runtime";
+    version = "4.1.0";
+    sha256 = "02hdkgk13rvsd6r9yafbwzss8kr55wnj8d5c7xjnp8gqrwc8sn0m";
+  })
+  (fetchNuGet {
+    name = "System.Runtime";
+    version = "4.3.0";
+    sha256 = "066ixvgbf2c929kgknshcxqj6539ax7b9m570cp8n179cpfkapz7";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Extensions";
+    version = "4.1.0";
+    sha256 = "0rw4rm4vsm3h3szxp9iijc3ksyviwsv6f63dng3vhqyg4vjdkc2z";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Extensions";
+    version = "4.3.0";
+    sha256 = "1ykp3dnhwvm48nap8q23893hagf665k0kn3cbgsqpwzbijdcgc60";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Handles";
+    version = "4.0.1";
+    sha256 = "1g0zrdi5508v49pfm3iii2hn6nm00bgvfpjq1zxknfjrxxa20r4g";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Handles";
+    version = "4.3.0";
+    sha256 = "0sw2gfj2xr7sw9qjn0j3l9yw07x73lcs97p8xfc9w1x9h5g5m7i8";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices";
+    version = "4.1.0";
+    sha256 = "01kxqppx3dr3b6b286xafqilv4s2n0gqvfgzfd4z943ga9i81is1";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices";
+    version = "4.3.0";
+    sha256 = "00hywrn4g7hva1b2qri2s6rabzwgxnbpw9zfxmz28z09cpwwgh7j";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices.RuntimeInformation";
+    version = "4.0.0";
+    sha256 = "0glmvarf3jz5xh22iy3w9v3wyragcm4hfdr17v90vs7vcrm7fgp6";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices.RuntimeInformation";
+    version = "4.3.0";
+    sha256 = "0q18r1sh4vn7bvqgd6dmqlw5v28flbpj349mkdish2vjyvmnb2ii";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Loader";
+    version = "4.0.0";
+    sha256 = "0lpfi3psqcp6zxsjk2qyahal7zaawviimc8lhrlswhip2mx7ykl0";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Numerics";
+    version = "4.0.1";
+    sha256 = "1y308zfvy0l5nrn46mqqr4wb4z1xk758pkk8svbz8b5ij7jnv4nn";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Serialization.Json";
+    version = "4.0.2";
+    sha256 = "08ypbzs0sb302ga04ds5b2wxa2gg0q50zpa0nvc87ipjhs0v66dn";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Serialization.Primitives";
+    version = "4.1.1";
+    sha256 = "042rfjixknlr6r10vx2pgf56yming8lkjikamg3g4v29ikk78h7k";
+  })
+  (fetchNuGet {
+    name = "System.Security.AccessControl";
+    version = "4.5.0";
+    sha256 = "1wvwanz33fzzbnd2jalar0p0z3x0ba53vzx1kazlskp7pwyhlnq0";
+  })
+  (fetchNuGet {
+    name = "System.Security.AccessControl";
+    version = "4.7.0";
+    sha256 = "0n0k0w44flkd8j0xw7g3g3vhw7dijfm51f75xkm1qxnbh4y45mpz";
+  })
+  (fetchNuGet {
+    name = "System.Security.Claims";
+    version = "4.3.0";
+    sha256 = "0jvfn7j22l3mm28qjy3rcw287y9h65ha4m940waaxah07jnbzrhn";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Algorithms";
+    version = "4.2.0";
+    sha256 = "148s9g5dgm33ri7dnh19s4lgnlxbpwvrw2jnzllq2kijj4i4vs85";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Cng";
+    version = "4.2.0";
+    sha256 = "118jijz446kix20blxip0f0q8mhsh9bz118mwc2ch1p6g7facpzc";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Csp";
+    version = "4.0.0";
+    sha256 = "1cwv8lqj8r15q81d2pz2jwzzbaji0l28xfrpw29kdpsaypm92z2q";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Encoding";
+    version = "4.0.0";
+    sha256 = "0a8y1a5wkmpawc787gfmnrnbzdgxmx1a14ax43jf3rj9gxmy3vk4";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.OpenSsl";
+    version = "4.0.0";
+    sha256 = "16sx3cig3d0ilvzl8xxgffmxbiqx87zdi8fc73i3i7zjih1a7f4q";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Primitives";
+    version = "4.0.0";
+    sha256 = "0i7cfnwph9a10bm26m538h5xcr8b36jscp9sy1zhgifksxz4yixh";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.X509Certificates";
+    version = "4.1.0";
+    sha256 = "0clg1bv55mfv5dq00m19cp634zx6inm31kf8ppbq1jgyjf2185dh";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal";
+    version = "4.3.0";
+    sha256 = "12cm2zws06z4lfc4dn31iqv7072zyi4m910d4r6wm8yx85arsfxf";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal.Windows";
+    version = "4.3.0";
+    sha256 = "00a0a7c40i3v4cb20s2cmh9csb5jv2l0frvnlzyfxh848xalpdwr";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal.Windows";
+    version = "4.5.0";
+    sha256 = "0rmj89wsl5yzwh0kqjgx45vzf694v9p92r4x4q6yxldk1cv1hi86";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal.Windows";
+    version = "4.7.0";
+    sha256 = "1a56ls5a9sr3ya0nr086sdpa9qv0abv31dd6fp27maqa9zclqq5d";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding";
+    version = "4.0.11";
+    sha256 = "1dyqv0hijg265dwxg6l7aiv74102d6xjiwplh2ar1ly6xfaa4iiw";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding";
+    version = "4.3.0";
+    sha256 = "1f04lkir4iladpp51sdgmis9dj4y8v08cka0mbmsy0frc9a4gjqr";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding.Extensions";
+    version = "4.0.11";
+    sha256 = "08nsfrpiwsg9x5ml4xyl3zyvjfdi4mvbqf93kjdh11j4fwkznizs";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding.Extensions";
+    version = "4.3.0";
+    sha256 = "11q1y8hh5hrp5a3kw25cb6l00v5l5dvirkz8jr3sq00h1xgcgrxy";
+  })
+  (fetchNuGet {
+    name = "System.Text.RegularExpressions";
+    version = "4.1.0";
+    sha256 = "1mw7vfkkyd04yn2fbhm38msk7dz2xwvib14ygjsb8dq2lcvr18y7";
+  })
+  (fetchNuGet {
+    name = "System.Text.RegularExpressions";
+    version = "4.3.0";
+    sha256 = "1bgq51k7fwld0njylfn7qc5fmwrk2137gdq7djqdsw347paa9c2l";
+  })
+  (fetchNuGet {
+    name = "System.Threading";
+    version = "4.0.11";
+    sha256 = "19x946h926bzvbsgj28csn46gak2crv2skpwsx80hbgazmkgb1ls";
+  })
+  (fetchNuGet {
+    name = "System.Threading";
+    version = "4.3.0";
+    sha256 = "0rw9wfamvhayp5zh3j7p1yfmx9b5khbf4q50d8k5rk993rskfd34";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Overlapped";
+    version = "4.0.1";
+    sha256 = "0fi79az3vmqdp9mv3wh2phblfjls89zlj6p9nc3i9f6wmfarj188";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Overlapped";
+    version = "4.3.0";
+    sha256 = "1nahikhqh9nk756dh8p011j36rlcp1bzz3vwi2b4m1l2s3vz8idm";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks";
+    version = "4.0.11";
+    sha256 = "0nr1r41rak82qfa5m0lhk9mp0k93bvfd7bbd9sdzwx9mb36g28p5";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks";
+    version = "4.3.0";
+    sha256 = "134z3v9abw3a6jsw17xl3f6hqjpak5l682k2vz39spj4kmydg6k7";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks.Extensions";
+    version = "4.0.0";
+    sha256 = "1cb51z062mvc2i8blpzmpn9d9mm4y307xrwi65di8ri18cz5r1zr";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks.Extensions";
+    version = "4.3.0";
+    sha256 = "1xxcx2xh8jin360yjwm4x4cf5y3a2bwpn2ygkfkwkicz7zk50s2z";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Thread";
+    version = "4.0.0";
+    sha256 = "1gxxm5fl36pjjpnx1k688dcw8m9l7nmf802nxis6swdaw8k54jzc";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Thread";
+    version = "4.3.0";
+    sha256 = "0y2xiwdfcph7znm2ysxanrhbqqss6a3shi1z3c779pj2s523mjx4";
+  })
+  (fetchNuGet {
+    name = "System.Threading.ThreadPool";
+    version = "4.0.10";
+    sha256 = "0fdr61yjcxh5imvyf93n2m3n5g9pp54bnw2l1d2rdl9z6dd31ypx";
+  })
+  (fetchNuGet {
+    name = "System.Threading.ThreadPool";
+    version = "4.3.0";
+    sha256 = "027s1f4sbx0y1xqw2irqn6x161lzj8qwvnh2gn78ciiczdv10vf1";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Timer";
+    version = "4.0.1";
+    sha256 = "15n54f1f8nn3mjcjrlzdg6q3520571y012mx7v991x2fvp73lmg6";
+  })
+  (fetchNuGet {
+    name = "System.Xml.ReaderWriter";
+    version = "4.0.11";
+    sha256 = "0c6ky1jk5ada9m94wcadih98l6k1fvf6vi7vhn1msjixaha419l5";
+  })
+  (fetchNuGet {
+    name = "System.Xml.ReaderWriter";
+    version = "4.3.0";
+    sha256 = "0c47yllxifzmh8gq6rq6l36zzvw4kjvlszkqa9wq3fr59n0hl3s1";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XDocument";
+    version = "4.0.11";
+    sha256 = "0n4lvpqzy9kc7qy1a4acwwd7b7pnvygv895az5640idl2y9zbz18";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XmlDocument";
+    version = "4.0.1";
+    sha256 = "0ihsnkvyc76r4dcky7v3ansnbyqjzkbyyia0ir5zvqirzan0bnl1";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XmlDocument";
+    version = "4.3.0";
+    sha256 = "0bmz1l06dihx52jxjr22dyv5mxv6pj4852lx68grjm7bivhrbfwi";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XmlSerializer";
+    version = "4.0.11";
+    sha256 = "01nzc3gdslw90qfykq4qzr2mdnqxjl4sj0wp3fixiwdmlmvpib5z";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XPath";
+    version = "4.0.1";
+    sha256 = "0fjqgb6y66d72d5n8qq1h213d9nv2vi8mpv8p28j3m9rccmsh04m";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XPath";
+    version = "4.3.0";
+    sha256 = "1cv2m0p70774a0sd1zxc8fm8jk3i5zk2bla3riqvi8gsm0r4kpci";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XPath.XmlDocument";
+    version = "4.0.1";
+    sha256 = "0l7yljgif41iv5g56l3nxy97hzzgck2a7rhnfnljhx9b0ry41bvc";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XPath.XmlDocument";
+    version = "4.3.0";
+    sha256 = "1h9lh7qkp0lff33z847sdfjj8yaz98ylbnkbxlnsbflhj9xyfqrm";
+  })
+]

--- a/pkgs/misc/emulators/ryujinx/fetch-deps.sh
+++ b/pkgs/misc/emulators/ryujinx/fetch-deps.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts dotnet-sdk_3
+set -eo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+deps_file="$(realpath "./deps.nix")"
+
+# Setup empty nuget package folder to force reinstall.
+mkdir ./nuget_tmp.packages
+cat >./nuget_tmp.config <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <config>
+    <add key="globalPackagesFolder" value="$(realpath ./nuget_tmp.packages)" />
+  </config>
+</configuration>
+EOF
+
+dotnet restore Ryujinx.sln --configfile ./nuget_tmp.config
+
+echo "{ fetchNuGet }: [" >"$deps_file"
+while read pkg_spec; do
+  { read pkg_name; read pkg_version; } < <(
+    # Build version part should be ignored: `3.0.0-beta2.20059.3+77df2220` -> `3.0.0-beta2.20059.3`
+    sed -nE 's/.*<id>([^<]*).*/\1/p; s/.*<version>([^<+]*).*/\1/p' "$pkg_spec")
+  pkg_sha256="$(nix-hash --type sha256 --flat --base32 "$(dirname "$pkg_spec")"/*.nupkg)"
+  cat >>"$deps_file" <<EOF
+  (fetchNuGet {
+    name = "$pkg_name";
+    version = "$pkg_version";
+    sha256 = "$pkg_sha256";
+  })
+EOF
+done < <(find ./nuget_tmp.packages -name '*.nuspec' | sort)
+echo "]" >>"$deps_file"
+
+popd
+rm -r "$src"

--- a/pkgs/misc/emulators/ryujinx/log.patch
+++ b/pkgs/misc/emulators/ryujinx/log.patch
@@ -1,0 +1,13 @@
+diff --git a/Ryujinx.Common/Configuration/LoggerModule.cs b/Ryujinx.Common/Configuration/LoggerModule.cs
+index 20c0fb46..ce933730 100644
+--- a/Ryujinx.Common/Configuration/LoggerModule.cs
++++ b/Ryujinx.Common/Configuration/LoggerModule.cs
+@@ -75,7 +75,7 @@ namespace Ryujinx.Configuration
+             if (e.NewValue)
+             {
+                 Logger.AddTarget(new AsyncLogTargetWrapper(
+-                    new FileLogTarget(AppDomain.CurrentDomain.BaseDirectory, "file"),
++		      new FileLogTarget(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Ryujinx"), "file"),
+                     1000,
+                     AsyncLogTargetOverflowAction.Block
+                 ));

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2231,6 +2231,8 @@ in
 
   remarkable-mouse = python3Packages.callPackage ../applications/misc/remarkable/remarkable-mouse { };
 
+  ryujinx = callPackage ../misc/emulators/ryujinx { };
+
   scour = with python3Packages; toPythonApplication scour;
 
   s2png = callPackage ../tools/graphics/s2png { };


### PR DESCRIPTION
###### Motivation for this change
Adds [Ryujinx](https://github.com/Ryujinx/Ryujinx), a Nintendo Switch emulator written in C#.

This is my first time doing any dotnet packaging, so I've mainly based this off of [osu-lazer](https://github.com/NixOS/nixpkgs/tree/1d859196574ff05ceb5992c098818a1aedc731e7/pkgs/games/osu-lazer). 

The update script for that uses some checks to see if it already has the latest dependencies (for the `deps.nix`), however i could not get that to work here as there are no stable builds.

Upstream does not have stable releases, however dotnet fails when using the regular `unstable-${date}` version convention for git revs. The current versioning is based off of [the official appveyor builds](https://ci.appveyor.com/project/gdkchan/ryujinx?branch=master).

Ryujinx normally tries to write logs next to the executable, so to the nix store. I've added a patch which just puts those in the directory you're launching it from.

Edit: Patch now writes logs to `~/.config/Ryujinx/Logs/` on Linux, and the appropriate directory on other platforms as well.

Closes: #85684

![image](https://user-images.githubusercontent.com/41924494/89032044-0d1d3700-d334-11ea-9e5e-8f33e74c51a0.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
 