### PR TITLE
chruby-fish: init at 0.8.2

### DIFF
--- a/pkgs/development/tools/misc/chruby-fish/default.nix
+++ b/pkgs/development/tools/misc/chruby-fish/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchFromGitHub, chruby }:
+
+stdenv.mkDerivation rec {
+  pname = "chruby-fish";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "JeanMertz";
+    repo = "chruby-fish";
+    rev = "v${version}";
+    sha256 = "15q0ywsn9pcypbpvlq0wb41x4igxm9bsvhg9a05dqw1n437qjhyb";
+  };
+
+  postInstall = ''
+    sed -i -e '1iset CHRUBY_ROOT ${chruby}' $out/share/chruby/auto.fish
+    sed -i -e '1iset CHRUBY_ROOT ${chruby}' $out/share/chruby/chruby.fish
+  '';
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "Thin wrapper around chruby to make it work with the Fish shell";
+    homepage = "https://github.com/JeanMertz/chruby-fish";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.cohei ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10753,6 +10753,8 @@ in
 
   chruby = callPackage ../development/tools/misc/chruby { rubies = null; };
 
+  chruby-fish = callPackage ../development/tools/misc/chruby-fish { };
+
   cl-launch = callPackage ../development/tools/misc/cl-launch {};
 
   cloud-nuke = callPackage ../development/tools/cloud-nuke { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add chruby-fish to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] ~~Tested execution of all binary files (usually in `./result/bin/`)~~ no binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
