### PR TITLE
qgis: 3.10.7 -> 3.10.8

### DIFF
--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake, ninja, flex, bison, proj, geos, xlibsWrapper, sqlite, gsl
+{ mkDerivation, lib, fetchFromGitHub, fetchpatch, cmake, ninja, flex, bison, proj, geos, xlibsWrapper, sqlite, gsl
 , qwt, fcgi, python3Packages, libspatialindex, libspatialite, postgresql
 , txt2tags, openssl, libzip, hdf5, netcdf, exiv2
 , qtbase, qtwebkit, qtsensors, qca-qt5, qtkeychain, qscintilla, qtserialport, qtxmlpatterns
@@ -20,6 +20,16 @@ in mkDerivation rec {
     rev = "final-${lib.replaceStrings ["."] ["_"] version}";
     sha256 = "043jd81q8yps5z6sxmiizkfy0h4ni2y16lmvqnc1gb69nbnxgq71";
   };
+
+  patches = [
+    # backport fix for https://github.com/NixOS/nixpkgs/issues/37042
+    # This is in QGIS master, so will be removed as soon as it is is backported
+    # to the LTS branch.
+    (fetchpatch {
+      url = "https://github.com/qgis/QGIS/commit/3cdd03c7172476113308c3b5c89a7341b87f13c2.patch";
+      sha256 = "1bh3yihwrg8q4vbd5pn9z9am09zg4d962f5bah115h1pzp3fn7xy";
+    })
+  ];
 
   passthru = {
     inherit pythonBuildInputs;

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -10,7 +10,7 @@ let
     [ qscintilla-qt5 gdal jinja2 numpy psycopg2
       chardet dateutil pyyaml pytz requests urllib3 pygments pyqt5 sip owslib six ];
 in mkDerivation rec {
-  version = "3.10.7";
+  version = "3.10.8";
   pname = "qgis";
   name = "${pname}-unwrapped-${version}";
 
@@ -18,7 +18,7 @@ in mkDerivation rec {
     owner = "qgis";
     repo = "QGIS";
     rev = "final-${lib.replaceStrings ["."] ["_"] version}";
-    sha256 = "0z593n5g3zwhlzhs0z7nlpblz6z2rl3y7y3j1wf1rdx76i8p3qgf";
+    sha256 = "043jd81q8yps5z6sxmiizkfy0h4ni2y16lmvqnc1gb69nbnxgq71";
   };
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

Update qo 3.10.8 and properly fix #37042 (again).

I’ll backport to release-20.03 once accepted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
