### PR TITLE
Update Haskell package set to LTS 16.7 (plus other fixes)

### DIFF
--- a/pkgs/data/misc/hackage/default.nix
+++ b/pkgs/data/misc/hackage/default.nix
@@ -1,6 +1,6 @@
 { fetchurl }:
 
 fetchurl {
-  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/8af27e77a015d06c7a8fe49a430fd5334a93ebf7.tar.gz";
-  sha256 = "1w5cfcvliy1ly8iq42l76ai5wgfnrwxf6hw5kq6p913qhhrcn5wr";
+  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/edb0920a8dbbd592d67a781d0b905728515ab623.tar.gz";
+  sha256 = "08yvpwzw7c3xw3w970ysykj44vglqfiq057kx0axk81s68v83rcy";
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1393,9 +1393,6 @@ self: super: {
     sha256 = "1c5ck2ibag2gcyag6rjivmlwdlp5k0dmr8nhk7wlkzq2vh7zgw63";
   });
 
-  # The current LTS 15.x version has a bug in the test suite.
-  streaming-commons = self.streaming-commons_0_2_2_1;
-
   # Version bumps have not been merged by upstream yet.
   # https://github.com/obsidiansystems/dependent-sum-aeson-orphans/pull/5
   dependent-sum-aeson-orphans = appendPatch super.dependent-sum-aeson-orphans (pkgs.fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -460,6 +460,9 @@ self: super: {
   bytestring-strict-builder = dontCheck super.bytestring-strict-builder;
   bytestring-tree-builder = dontCheck super.bytestring-tree-builder;
 
+  # https://github.com/byteverse/bytebuild/issues/19
+  bytebuild = dontCheck super.bytebuild;
+
   # https://github.com/ndmitchell/shake/issues/206
   # https://github.com/ndmitchell/shake/issues/267
   shake = overrideCabal super.shake (drv: { doCheck = !pkgs.stdenv.isDarwin && false; });

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1348,7 +1348,7 @@ self: super: {
         })).override {
           # we are faster than stack here
           hie-bios = dontCheck self.hie-bios_0_6_1;
-          lsp-test = dontCheck self.lsp-test_0_11_0_2;
+          lsp-test = dontCheck self.lsp-test_0_11_0_3;
         });
 
   haskell-language-server = (overrideCabal super.haskell-language-server
@@ -1368,7 +1368,7 @@ self: super: {
       ghcide = self.hls-ghcide;
       # we are faster than stack here
       hie-bios = dontCheck self.hie-bios_0_6_1;
-      lsp-test = dontCheck self.lsp-test_0_11_0_2;
+      lsp-test = dontCheck self.lsp-test_0_11_0_3;
     };
 
   # https://github.com/kowainik/policeman/issues/57

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -463,6 +463,9 @@ self: super: {
   # https://github.com/byteverse/bytebuild/issues/19
   bytebuild = dontCheck super.bytebuild;
 
+  # https://github.com/andrewthad/haskell-ip/issues/67
+  ip = dontCheck super.ip;
+
   # https://github.com/ndmitchell/shake/issues/206
   # https://github.com/ndmitchell/shake/issues/267
   shake = overrideCabal super.shake (drv: { doCheck = !pkgs.stdenv.isDarwin && false; });

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1451,4 +1451,7 @@ self: super: {
     };
   };
 
+  # Testsuite trying to run `which haskeline-examples-Test`
+  haskeline_0_8_0_0 = dontCheck super.haskeline_0_8_0_0;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1454,4 +1454,11 @@ self: super: {
   # Testsuite trying to run `which haskeline-examples-Test`
   haskeline_0_8_0_0 = dontCheck super.haskeline_0_8_0_0;
 
+  # Requires repline 0.4 which is the default only for ghc8101, override for the rest
+  zre = super.zre.override {
+    repline = self.repline_0_4_0_0.override {
+      haskeline = self.haskeline_0_8_0_0;
+    };
+  };
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -111,6 +111,10 @@ self: super: {
   });
 
   # hnix 0.9.0 does not provide an executable for ghc < 8.10, so define completions here for now.
-  hnix = generateOptparseApplicativeCompletion "hnix" super.hnix;
+  hnix = generateOptparseApplicativeCompletion "hnix"
+    (overrideCabal super.hnix (drv: {
+      # executable is allowed for ghc >= 8.10 and needs repline
+      executableHaskellDepends = drv.executableToolDepends or [] ++ [ self.repline ];
+    }));
 
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6829,7 +6829,6 @@ broken-packages:
   - iostring
   - iothread
   - iotransaction
-  - ip
   - ip2location
   - ip2proxy
   - ipatch

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5904,7 +5904,6 @@ broken-packages:
   - hasql-dynamic-statements
   - hasql-generic
   - hasql-implicits
-  - hasql-migration
   - hasql-optparse-applicative
   - hasql-postgres
   - hasql-postgres-options

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3562,7 +3562,6 @@ broken-packages:
   - byline
   - bytable
   - bytearray-parsing
-  - bytebuild
   - bytelog
   - bytestring-arbitrary
   - bytestring-builder-varword

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -1,6 +1,6 @@
 # pkgs/development/haskell-modules/configuration-hackage2nix.yaml
 
-compiler: ghc-8.8.3
+compiler: ghc-8.8.4
 
 core-packages:
   - array-0.5.4.0

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2646,10 +2646,8 @@ package-maintainers:
     - streaming-wai
   kiwi:
     - glirc
-    - matterhorn
     - mattermost-api
     - mattermost-api-qc
-    - Unique
   psibi:
     - path-pieces
     - persistent
@@ -3557,9 +3555,11 @@ broken-packages:
   - buster
   - buster-gtk
   - buster-network
+  - bustle
   - butter
   - butterflies
   - bv-sized
+  - byline
   - bytable
   - bytearray-parsing
   - bytebuild
@@ -4668,6 +4668,7 @@ broken-packages:
   - elm-websocket
   - elynx
   - elynx-markov
+  - elynx-nexus
   - elynx-seq
   - elynx-tools
   - elynx-tree
@@ -6620,6 +6621,7 @@ broken-packages:
   - hw-json-simple-cursor
   - hw-json-standard-cursor
   - hw-kafka-avro
+  - hw-prim-bits
   - hw-rankselect
   - hw-simd
   - hw-succinct
@@ -6799,6 +6801,7 @@ broken-packages:
   - integer-pure
   - integreat
   - intel-aes
+  - intensional-datatys
   - interlude-l
   - InternedData
   - internetmarke
@@ -7341,7 +7344,15 @@ broken-packages:
   - lio-simple
   - lipsum-gen
   - liquid
+  - liquid-base
+  - liquid-bytestring
+  - liquid-containers
   - liquid-fixpoint
+  - liquid-ghc-prim
+  - liquid-parallel
+  - liquid-platform
+  - liquid-prelude
+  - liquid-vector
   - liquidhaskell
   - liquidhaskell-cabal
   - Liquorice
@@ -7581,6 +7592,7 @@ broken-packages:
   - matrix-market
   - matrix-sized
   - matsuri
+  - matterhorn
   - maude
   - maxent
   - maxent-learner-hw
@@ -7885,6 +7897,7 @@ broken-packages:
   - multibase
   - multifocal
   - multihash
+  - multihash-cryptonite
   - multihash-serialise
   - multilinear
   - multilinear-io
@@ -8605,6 +8618,7 @@ broken-packages:
   - polydata
   - polydata-core
   - polynomial
+  - polysemy-optics
   - polysemy-RandomFu
   - polysemy-webserver
   - polysemy-zoo
@@ -9980,6 +9994,7 @@ broken-packages:
   - streaming-png
   - streaming-process
   - streaming-sort
+  - streamly-archive
   - streamly-lmdb
   - streamproc
   - strelka
@@ -10408,6 +10423,7 @@ broken-packages:
   - trackit
   - traction
   - tracy
+  - trade-journal
   - traildb
   - trajectory
   - transactional-events
@@ -10488,6 +10504,7 @@ broken-packages:
   - turingMachine
   - turtle-options
   - tweak
+  - twee
   - tweet-hs
   - twentefp-eventloop-graphics
   - twentefp-eventloop-trees
@@ -10577,6 +10594,7 @@ broken-packages:
   - UMM
   - unagi-bloomfilter
   - unamb-custom
+  - unbeliever
   - unbound
   - unbound-generics
   - unbound-kind-generics
@@ -10600,6 +10618,7 @@ broken-packages:
   - uniform-io
   - union
   - union-map
+  - Unique
   - uniqueid
   - uniquely-represented-sets
   - units-attoparsec
@@ -10763,6 +10782,7 @@ broken-packages:
   - views
   - vigilance
   - Villefort
+  - vimeta
   - vimus
   - vintage-basic
   - vinyl-gl

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -72,7 +72,7 @@ default-package-overrides:
   # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
   # not yet available in Nixpkgs
   - gi-gdkx11 < 4
-  # LTS Haskell 16.6
+  # LTS Haskell 16.7
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
   - AC-Angle ==1.0
@@ -262,7 +262,7 @@ default-package-overrides:
   - attoparsec-path ==0.0.0.1
   - audacity ==0.0.2
   - aur ==7.0.3
-  - aura ==3.1.5
+  - aura ==3.1.6
   - authenticate ==1.3.5
   - authenticate-oauth ==1.6.0.1
   - auto ==0.4.3.1
@@ -430,7 +430,7 @@ default-package-overrides:
   - chimera ==0.3.1.0
   - chiphunk ==0.1.2.1
   - choice ==0.2.2
-  - chronologique ==0.3.1.1
+  - chronologique ==0.3.1.3
   - chronos ==1.1.1
   - chronos-bench ==0.2.0.2
   - chunked-data ==0.3.1
@@ -912,7 +912,7 @@ default-package-overrides:
   - ghc-syntax-highlighter ==0.0.6.0
   - ghc-tcplugins-extra ==0.4
   - ghc-typelits-extra ==0.4
-  - ghc-typelits-knownnat ==0.7.2
+  - ghc-typelits-knownnat ==0.7.3
   - ghc-typelits-natnormalise ==0.7.2
   - ghc-typelits-presburger ==0.3.0.1
   - ghost-buster ==0.1.1.0
@@ -1135,7 +1135,7 @@ default-package-overrides:
   - http-client-openssl ==0.3.1.0
   - http-client-overrides ==0.1.1.0
   - http-client-tls ==0.3.5.3
-  - http-common ==0.8.2.0
+  - http-common ==0.8.2.1
   - http-conduit ==2.3.7.3
   - http-date ==0.0.8
   - http-directory ==0.1.8
@@ -1338,7 +1338,7 @@ default-package-overrides:
   - libyaml ==0.1.2
   - LibZip ==1.0.1
   - life-sync ==1.1.1.0
-  - lifted-async ==0.10.1.1
+  - lifted-async ==0.10.1.2
   - lifted-base ==0.2.3.12
   - lift-generics ==0.1.3
   - line ==4.0.1
@@ -1397,6 +1397,7 @@ default-package-overrides:
   - matplotlib ==0.7.5
   - matrices ==0.5.0
   - matrix ==0.3.6.1
+  - matrix-as-xyz ==0.1.1.3
   - matrix-market-attoparsec ==0.1.1.3
   - matrix-static ==0.3
   - maximal-cliques ==0.1.1
@@ -1754,7 +1755,7 @@ default-package-overrides:
   - profunctors ==5.5.2
   - projectroot ==0.2.0.1
   - project-template ==0.2.1.0
-  - prometheus-client ==1.0.0.1
+  - prometheus-client ==1.0.1
   - promises ==0.3
   - prompt ==0.1.1.2
   - prospect ==0.1.0.0
@@ -2096,7 +2097,7 @@ default-package-overrides:
   - stratosphere ==0.53.0
   - streaming ==0.2.3.0
   - streaming-bytestring ==0.1.6
-  - streaming-commons ==0.2.2.0
+  - streaming-commons ==0.2.2.1
   - streamly ==0.7.2
   - streamly-bytestring ==0.1.2
   - streams ==3.3


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2020-07-31 20:00 +02:00. You can watch this live on Twitch at https://www.twitch.tv/peti343. In addition to the chat features offered by Twitch, there is also a voice conference at https://discord.gg/YTEa3XR that viewers can use to chat with me and with each other.