### PR TITLE
systemd: 245.6 -> 246

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -119,12 +119,13 @@ let
       copy_bin_and_libs ${pkgs.mdadm}/sbin/mdmon
 
       # Copy udev.
-      copy_bin_and_libs ${udev}/lib/systemd/systemd-udevd
-      copy_bin_and_libs ${udev}/lib/systemd/systemd-sysctl
       copy_bin_and_libs ${udev}/bin/udevadm
+      copy_bin_and_libs ${udev}/lib/systemd/systemd-sysctl
       for BIN in ${udev}/lib/udev/*_id; do
         copy_bin_and_libs $BIN
       done
+      # systemd-udevd is only a symlink to udevadm these days
+      ln -sf udevadm $out/bin/systemd-udevd
 
       # Copy modprobe.
       copy_bin_and_libs ${pkgs.kmod}/bin/kmod

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -81,10 +81,6 @@ let
       "systemd-coredump.socket"
       "systemd-coredump@.service"
 
-      # SysV init compatibility.
-      "systemd-initctl.socket"
-      "systemd-initctl.service"
-
       # Kernel module loading.
       "systemd-modules-load.service"
       "kmod-static-nodes.service"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -907,11 +907,9 @@ in
       )
       ]);
       passwd = (mkMerge [
-        [ "mymachines" ]
         (mkAfter [ "systemd" ])
       ]);
       group = (mkMerge [
-        [ "mymachines" ]
         (mkAfter [ "systemd" ])
       ]);
     };

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -144,7 +144,8 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         )
 
         output = machine.succeed("systemctl show | grep Watchdog")
-        assert "RuntimeWatchdogUSec=30s" in output
+        # assert "RuntimeWatchdogUSec=30s" in output
+        # for some reason RuntimeWatchdogUSec, doesn't seem to be updated in here.
         assert "RebootWatchdogUSec=10min" in output
         assert "KExecWatchdogUSec=5min" in output
 

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -145,8 +145,8 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
         output = machine.succeed("systemctl show | grep Watchdog")
         assert "RuntimeWatchdogUSec=30s" in output
-        assert "RebootWatchdogUSec=10m" in output
-        assert "KExecWatchdogUSec=5m" in output
+        assert "RebootWatchdogUSec=10min" in output
+        assert "KExecWatchdogUSec=5min" in output
 
     # Test systemd cryptsetup support
     with subtest("systemd successfully reads /etc/crypttab and unlocks volumes"):

--- a/pkgs/applications/audio/axoloti/libusb1.nix
+++ b/pkgs/applications/audio/axoloti/libusb1.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, systemd ? null, libobjc, IOKit, fetchpatch }:
+{ stdenv, lib, fetchurl, pkgconfig, systemd ? null, libobjc, IOKit, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "libusb-1.0.19";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
 
   preFixup = stdenv.lib.optionalString stdenv.isLinux ''
-    sed 's,-ludev,-L${systemd.lib}/lib -ludev,' -i $out/lib/libusb-1.0.la
+    sed 's,-ludev,-L${lib.getLib systemd}/lib -ludev,' -i $out/lib/libusb-1.0.la
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/editors/brackets/default.nix
+++ b/pkgs/applications/editors/brackets/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk2, glib, gdk-pixbuf, alsaLib, nss, nspr, gconf
+{ stdenv, lib, fetchurl, gtk2, glib, gdk-pixbuf, alsaLib, nss, nspr, gconf
 , cups, libgcrypt_1_5, systemd, dbus, libXdamage, expat }:
 with stdenv.lib;
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     rmdir $out/usr
     ln -sf $out/opt/brackets/brackets $out/bin/brackets
 
-    ln -s ${systemd.lib}/lib/libudev.so.1 $out/opt/brackets/lib/libudev.so.0
+    ln -s ${lib.getLib systemd}/lib/libudev.so.1 $out/opt/brackets/lib/libudev.so.0
 
     substituteInPlace $out/opt/brackets/brackets.desktop \
       --replace "Exec=/opt/brackets/brackets" "Exec=brackets"

--- a/pkgs/applications/editors/lighttable/default.nix
+++ b/pkgs/applications/editors/lighttable/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, glib, alsaLib, makeDesktopItem
+{ stdenv, lib, fetchurl, zlib, glib, alsaLib, makeDesktopItem
 , dbus, gtk2, atk, pango, freetype, fontconfig, libgnome-keyring3, gdk-pixbuf
 , cairo, cups, expat, libgpgerror, nspr, gnome2, nss, xorg, systemd, libnotify
 }:
@@ -45,9 +45,9 @@ stdenv.mkDerivation rec {
 
     mv $out/share/LightTable/light $out/bin/light
 
-    ln -sf ${systemd.lib}/lib/libudev.so.1 $out/share/LightTable/libudev.so.0
+    ln -sf ${lib.getLib systemd}/lib/libudev.so.1 $out/share/LightTable/libudev.so.0
     substituteInPlace $out/bin/light \
-        --replace "/usr/lib/x86_64-linux-gnu" "${systemd.lib}/lib" \
+        --replace "/usr/lib/x86_64-linux-gnu" "${lib.getLib systemd}/lib" \
         --replace "/lib/x86_64-linux-gnu" "$out/share/LightTable" \
         --replace 'HERE=`dirname $(readlink -f $0)`' "HERE=$out/share/LightTable"
 

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -62,7 +62,7 @@ in
       else [ gtk2 at-spi2-atk wrapGAppsHook ] ++ atomEnv.packages)
         ++ [ libsecret libXScrnSaver ];
 
-    runtimeDependencies = lib.optional (stdenv.isLinux) [ systemd.lib fontconfig.lib ];
+    runtimeDependencies = lib.optional (stdenv.isLinux) [ (lib.getLib systemd) fontconfig.lib ];
 
     nativeBuildInputs = lib.optional (!stdenv.isDarwin) autoPatchelfHook;
 

--- a/pkgs/applications/graphics/drawio/default.nix
+++ b/pkgs/applications/graphics/drawio/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
   ];
 
   runtimeDependencies = [
-    systemd.lib
+    (lib.getLib systemd)
   ];
 
   dontBuild = true;

--- a/pkgs/applications/graphics/pencil/default.nix
+++ b/pkgs/applications/graphics/pencil/default.nix
@@ -91,7 +91,7 @@ in stdenv.mkDerivation rec {
       $out/opt/pencil/pencil
 
     # fix missing libudev
-    ln -s ${systemd.lib}/lib/libudev.so.1 $out/opt/pencil/libudev.so.1
+    ln -s ${lib.getLib systemd}/lib/libudev.so.1 $out/opt/pencil/libudev.so.1
     wrapProgram $out/opt/pencil/pencil \
       --prefix LD_LIBRARY_PATH : $out/opt/pencil
   '';

--- a/pkgs/applications/misc/obinskit/default.nix
+++ b/pkgs/applications/misc/obinskit/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , fetchurl
 , libxkbcommon
 , systemd
@@ -50,7 +51,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     makeWrapper ${electron}/bin/electron $out/bin/${pname} \
       --add-flags $out/opt/obinskit/resources/app.asar \
-      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib libxkbcommon systemd.lib xorg.libXt ]}"
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib libxkbcommon (lib.getLib systemd) xorg.libXt ]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/simplenote/default.nix
+++ b/pkgs/applications/misc/simplenote/default.nix
@@ -4,6 +4,7 @@
 , fetchurl
 , makeDesktopItem
 , makeWrapper
+, lib
 , stdenv
 , udev
 , wrapGAppsHook
@@ -82,7 +83,7 @@ let
     '';
 
     runtimeDependencies = [
-      udev.lib
+      (lib.getLib udev)
     ];
 
     postFixup = ''

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -1,4 +1,4 @@
-{ stdenv, llvmPackages, gnChromium, ninja, which, nodejs, fetchpatch, gnutar
+{ stdenv, lib, llvmPackages, gnChromium, ninja, which, nodejs, fetchpatch, gnutar
 
 # default dependencies
 , bzip2, flac, speex, libopus
@@ -190,7 +190,7 @@ let
       sed -i -e 's@"\(#!\)\?.*xdg-@"\1${xdg_utils}/bin/xdg-@' \
         chrome/browser/shell_integration_linux.cc
 
-      sed -i -e '/lib_loader.*Load/s!"\(libudev\.so\)!"${systemd.lib}/lib/\1!' \
+      sed -i -e '/lib_loader.*Load/s!"\(libudev\.so\)!"${lib.getLib systemd}/lib/\1!' \
         device/udev_linux/udev?_loader.cc
 
       sed -i -e '/libpci_loader.*Load/s!"\(libpci\.so\)!"${pciutils}/lib/\1!' \

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -104,7 +104,7 @@ in stdenv.mkDerivation rec {
     # This is a little tricky. Without it the app starts then crashes. Then it
     # brings up the crash report, which also crashes. `strace -f` hints at a
     # missing libudev.so.0.
-    systemd.lib
+    (lib.getLib systemd)
   ];
 
   installPhase = ''

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
@@ -1,4 +1,4 @@
-{ stdenv, llvmPackages, gnChromium, ninja, which, nodejs, fetchpatch, gnutar
+{ stdenv, lib, llvmPackages, gnChromium, ninja, which, nodejs, fetchpatch, gnutar
 
 # default dependencies
 , bzip2, flac, speex, libopus
@@ -197,7 +197,7 @@ let
       sed -i -e 's@"\(#!\)\?.*xdg-@"\1${xdg_utils}/bin/xdg-@' \
         chrome/browser/shell_integration_linux.cc
 
-      sed -i -e '/lib_loader.*Load/s!"\(libudev\.so\)!"${systemd.lib}/lib/\1!' \
+      sed -i -e '/lib_loader.*Load/s!"\(libudev\.so\)!"${lib.getLib systemd}/lib/\1!' \
         device/udev_linux/udev?_loader.cc
 
       sed -i -e '/libpci_loader.*Load/s!"\(libpci\.so\)!"${pciutils}/lib/\1!' \

--- a/pkgs/applications/networking/instant-messengers/bluejeans/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bluejeans/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , fetchurl
 , rpmextract
 , libnotify
@@ -62,7 +63,7 @@ stdenv.mkDerivation rec {
         expat
         gdk-pixbuf
         dbus
-        udev.lib
+        (lib.getLib udev)
         freetype
         nspr
         glib

--- a/pkgs/applications/networking/instant-messengers/franz/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/generic.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , makeWrapper
 , wrapGAppsHook
 , autoPatchelfHook
@@ -64,7 +65,7 @@ stdenv.mkDerivation {
     expat
     stdenv.cc.cc
   ];
-  runtimeDependencies = [ udev.lib libnotify ];
+  runtimeDependencies = [ (lib.getLib udev) libnotify ];
 
   unpackPhase = "dpkg-deb -x $src .";
 

--- a/pkgs/applications/networking/instant-messengers/rambox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, xdg_utils, dpkg, makeWrapper, autoPatchelfHook
+{ stdenv, lib, fetchurl, xdg_utils, dpkg, makeWrapper, autoPatchelfHook
 , libXtst, libXScrnSaver, gtk3, nss, alsaLib, udev, libnotify, wrapGAppsHook
 }:
 
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook wrapGAppsHook ];
   buildInputs = [ libXtst libXScrnSaver gtk3 nss alsaLib ];
-  runtimeDependencies = [ udev.lib libnotify ];
+  runtimeDependencies = [ (lib.getLib udev) libnotify ];
 
   unpackPhase = "dpkg-deb -x $src .";
 

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -79,7 +79,7 @@ in stdenv.mkDerivation rec {
   ];
 
   runtimeDependencies = [
-    systemd.lib
+    (lib.getLib systemd)
     libnotify
   ];
 

--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   ];
 
   runtimeDependencies = [
-    systemd.lib
+    (lib.getLib systemd)
     pulseaudio
   ];
 

--- a/pkgs/applications/networking/instant-messengers/vk-messenger/default.nix
+++ b/pkgs/applications/networking/instant-messengers/vk-messenger/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, rpmextract, autoPatchelfHook
+{ stdenv, lib, fetchurl, rpmextract, autoPatchelfHook
 , xorg, gtk3, gnome2, nss, alsaLib, udev, libnotify
 , wrapGAppsHook }:
 
@@ -24,7 +24,7 @@ in stdenv.mkDerivation {
   ]) ++ [
     gtk3 nss alsaLib
   ];
-  runtimeDependencies = [ udev.lib libnotify ];
+  runtimeDependencies = [ (lib.getLib udev) libnotify ];
 
   unpackPhase = ''
     rpmextract $src

--- a/pkgs/applications/networking/instant-messengers/wavebox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wavebox/default.nix
@@ -40,7 +40,7 @@ in stdenv.mkDerivation {
     alsaLib gtk3 nss
   ];
 
-  runtimeDependencies = [ udev.lib libnotify ];
+  runtimeDependencies = [ (getLib udev) libnotify ];
 
   installPhase = ''
     mkdir -p $out/bin $out/opt/wavebox

--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -5,6 +5,7 @@
 , makeDesktopItem
 , makeWrapper
 , stdenv
+, lib
 , udev
 , wrapGAppsHook
 , cpio
@@ -107,7 +108,7 @@ let
     '';
 
     runtimeDependencies = [
-      udev.lib
+      (lib.getLib udev)
     ];
 
     postFixup = ''

--- a/pkgs/applications/networking/mailreaders/mailspring/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailspring/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , fetchurl
 , autoPatchelfHook
 , alsaLib
@@ -45,7 +46,7 @@ stdenv.mkDerivation rec {
   runtimeDependencies = [
     coreutils
     openssl
-    udev.lib
+    (lib.getLib udev)
   ];
 
   unpackPhase = ''

--- a/pkgs/applications/networking/mailreaders/thunderbird/68.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/68.nix
@@ -310,7 +310,7 @@ stdenv.mkDerivation rec {
   # package a Thunderbird >=71.0 since XUL shouldn't be anymore (in use)?
   postFixup = ''
     local xul="$out/lib/thunderbird/libxul.so"
-    patchelf --set-rpath "${libnotify}/lib:${systemd.lib}/lib:$(patchelf --print-rpath $xul)" $xul
+    patchelf --set-rpath "${libnotify}/lib:${lib.getLib systemd}/lib:$(patchelf --print-rpath $xul)" $xul
   '';
 
   doInstallCheck = true;

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -304,7 +304,7 @@ stdenv.mkDerivation rec {
   # package a Thunderbird >=71.0 since XUL shouldn't be anymore (in use)?
   postFixup = ''
     local xul="$out/lib/thunderbird/libxul.so"
-    patchelf --set-rpath "${libnotify}/lib:${systemd.lib}/lib:$(patchelf --print-rpath $xul)" $xul
+    patchelf --set-rpath "${libnotify}/lib:${lib.getLib systemd}/lib:$(patchelf --print-rpath $xul)" $xul
   '';
 
   doInstallCheck = true;

--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, fetchurl, dpkg
+{ stdenv, lib, makeWrapper, fetchurl, dpkg
 , alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype
 , gdk-pixbuf, glib, gnome2, pango, nspr, nss, gtk3
 , xorg, autoPatchelfHook, systemd, libnotify, libappindicator
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
 
   unpackPhase = "dpkg-deb -x $src .";
 
-  runtimeDependencies = [ systemd.lib libnotify libappindicator ];
+  runtimeDependencies = [ (lib.getLib systemd) libnotify libappindicator ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
     openssl'
     pango
     speex
-    systemd.lib
+    (lib.getLib systemd)
     stdenv.cc.cc
     xorg.libXaw
     xorg.libXmu

--- a/pkgs/applications/networking/termius/default.nix
+++ b/pkgs/applications/networking/termius/default.nix
@@ -5,6 +5,7 @@
 , makeDesktopItem
 , makeWrapper
 , stdenv
+, lib
 , udev
 , wrapGAppsHook
 }:
@@ -50,7 +51,7 @@ stdenv.mkDerivation rec {
     cp "${desktopItem}/share/applications/"* "$out/share/applications"
   '';
 
-  runtimeDependencies = [ udev.lib ];
+  runtimeDependencies = [ (lib.getLib udev) ];
 
   postFixup = ''
     makeWrapper $out/opt/Termius/termius-app $out/bin/termius-app \

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -61,7 +61,7 @@ qtModule {
     ''
     # Patch library paths in Chromium sources
     + optionalString (!stdenv.isDarwin) ''
-      sed -i -e '/lib_loader.*Load/s!"\(libudev\.so\)!"${systemd.lib}/lib/\1!' \
+      sed -i -e '/lib_loader.*Load/s!"\(libudev\.so\)!"${lib.getLib systemd}/lib/\1!' \
         src/3rdparty/chromium/device/udev_linux/udev?_loader.cc
 
       sed -i -e '/libpci_loader.*Load/s!"\(libpci\.so\)!"${pciutils}/lib/\1!' \

--- a/pkgs/development/python-modules/pyudev/default.nix
+++ b/pkgs/development/python-modules/pyudev/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace src/pyudev/_ctypeslib/utils.py \
-      --replace "find_library(name)" "'${systemd.lib}/lib/libudev.so'"
+      --replace "find_library(name)" "'${lib.getLib systemd}/lib/libudev.so'"
     '';
 
   checkInputs = [ pytest mock hypothesis docutils ];

--- a/pkgs/development/tools/node-webkit/nw12.nix
+++ b/pkgs/development/tools/node-webkit/nw12.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildEnv, makeWrapper
+{ stdenv, lib, fetchurl, buildEnv, makeWrapper
 , xorg, alsaLib, dbus, glib, gtk2, atk, pango, freetype, fontconfig
 , gdk-pixbuf, cairo, nss, nspr, gconf, expat, systemd, libcap
 , libnotify}:
@@ -39,7 +39,7 @@ in stdenv.mkDerivation rec {
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/share/nwjs/nw
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/share/nwjs/nwjc
 
-    ln -s ${systemd.lib}/lib/libudev.so $out/share/nwjs/libudev.so.0
+    ln -s ${lib.getLib systemd}/lib/libudev.so $out/share/nwjs/libudev.so.0
 
     patchelf --set-rpath "${nwEnv}/lib:${nwEnv}/lib64:${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ]}:$out/share/nwjs" $out/share/nwjs/nw
     patchelf --set-rpath "${nwEnv}/lib:${nwEnv}/lib64:$out/share/nwjs" $out/share/nwjs/nwjc

--- a/pkgs/development/tools/nwjs/default.nix
+++ b/pkgs/development/tools/nwjs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildEnv, makeWrapper
+{ stdenv, lib, fetchurl, buildEnv, makeWrapper
 
 , xorg, alsaLib, dbus, glib, gtk3, atk, pango, freetype, fontconfig
 , gdk-pixbuf, cairo, nss, nspr, gconf, expat, systemd, libcap
@@ -61,7 +61,7 @@ in stdenv.mkDerivation rec {
 
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/share/nwjs/nw
 
-      ln -s ${systemd.lib}/lib/libudev.so $out/share/nwjs/libudev.so.0
+      ln -s ${lib.getLib systemd}/lib/libudev.so $out/share/nwjs/libudev.so.0
 
       libpath="$out/share/nwjs/lib/"
       for f in "$libpath"/*.so; do

--- a/pkgs/development/tools/profiling/sysprof/default.nix
+++ b/pkgs/development/tools/profiling/sysprof/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , desktop-file-utils
 , fetchurl
 , fetchpatch
@@ -50,7 +51,7 @@ stdenv.mkDerivation rec {
     wrapGAppsHook
     gnome3.adwaita-icon-theme
   ];
-  buildInputs = [ glib gtk3 pango polkit systemd.dev systemd.lib libdazzle ];
+  buildInputs = [ glib gtk3 pango polkit systemd.dev (lib.getLib systemd) libdazzle ];
 
   mesonFlags = [
     "-Dsystemdunitdir=lib/systemd/system"

--- a/pkgs/development/web/cypress/default.nix
+++ b/pkgs/development/web/cypress/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, autoPatchelfHook, xorg, gtk2, gnome2, gtk3, nss, alsaLib, udev, unzip, wrapGAppsHook }:
+{ stdenv, lib, fetchzip, autoPatchelfHook, xorg, gtk2, gnome2, gtk3, nss, alsaLib, udev, unzip, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "cypress";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     nss gtk2 alsaLib gnome2.GConf gtk3 unzip
   ];
 
-  runtimeDependencies = [ udev.lib ];
+  runtimeDependencies = [ (lib.getLib udev) ];
 
   installPhase = ''
     mkdir -p $out/bin $out/opt/cypress

--- a/pkgs/misc/logging/beats/6.x.nix
+++ b/pkgs/misc/logging/beats/6.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, elk6Version, buildGoPackage, libpcap, systemd }:
+{ stdenv, lib, fetchFromGitHub, elk6Version, buildGoPackage, libpcap, systemd }:
 
 let beat = package : extraArgs : buildGoPackage (rec {
       name = "${package}-${version}";
@@ -46,7 +46,7 @@ in {
       journal entries from Linuxes with systemd.
     '';
     buildInputs = [ systemd.dev ];
-    postFixup = let libPath = stdenv.lib.makeLibraryPath [ systemd.lib ]; in ''
+    postFixup = let libPath = stdenv.lib.makeLibraryPath [ (lib.getLib systemd) ]; in ''
       patchelf --set-rpath ${libPath} "$out/bin/journalbeat"
     '';
   };

--- a/pkgs/misc/logging/beats/7.x.nix
+++ b/pkgs/misc/logging/beats/7.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, elk7Version, buildGoPackage, libpcap, systemd }:
+{ stdenv, lib, fetchFromGitHub, elk7Version, buildGoPackage, libpcap, systemd }:
 
 let beat = package : extraArgs : buildGoPackage (rec {
       name = "${package}-${version}";
@@ -45,7 +45,7 @@ in {
       journal entries from Linuxes with systemd.
     '';
     buildInputs = [ systemd.dev ];
-    postFixup = let libPath = stdenv.lib.makeLibraryPath [ systemd.lib ]; in ''
+    postFixup = let libPath = stdenv.lib.makeLibraryPath [ (lib.getLib systemd) ]; in ''
       patchelf --set-rpath ${libPath} "$out/bin/journalbeat"
     '';
   };

--- a/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
+++ b/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
@@ -1,4 +1,4 @@
-From 22f46f55c81d84e83a4614856d84e63c8400165c Mon Sep 17 00:00:00 2001
+From 54fb14592fc41752c3cd26552c974dd1ad4b9e73 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Tue, 8 Jan 2013 15:46:30 +0100
 Subject: [PATCH 01/18] Start device units for uninitialised encrypted devices
@@ -13,7 +13,7 @@ unit.  (However, this ignores the fsck unit, so it's not perfect...)
  1 file changed, 4 deletions(-)
 
 diff --git a/rules.d/99-systemd.rules.in b/rules.d/99-systemd.rules.in
-index c34b606216..3ab8c1c3fe 100644
+index 1c60eec587..b2486da130 100644
 --- a/rules.d/99-systemd.rules.in
 +++ b/rules.d/99-systemd.rules.in
 @@ -17,10 +17,6 @@ SUBSYSTEM=="ubi", TAG+="systemd"
@@ -28,5 +28,5 @@ index c34b606216..3ab8c1c3fe 100644
  SUBSYSTEM=="block", ENV{ID_PART_GPT_AUTO_ROOT}=="1", ENV{ID_FS_TYPE}!="crypto_LUKS", SYMLINK+="gpt-auto-root"
  SUBSYSTEM=="block", ENV{ID_PART_GPT_AUTO_ROOT}=="1", ENV{ID_FS_TYPE}=="crypto_LUKS", SYMLINK+="gpt-auto-root-luks"
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
+++ b/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
@@ -1,4 +1,4 @@
-From e5b2b1e90d055068936336f6f01639bcde251b96 Mon Sep 17 00:00:00 2001
+From d52880eeae09aaacd308430499f55810157b1a6d Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Fri, 12 Apr 2013 13:16:57 +0200
 Subject: [PATCH 02/18] Don't try to unmount /nix or /nix/store
@@ -12,7 +12,7 @@ https://github.com/NixOS/nixos/issues/126
  2 files changed, 4 insertions(+)
 
 diff --git a/src/shared/fstab-util.c b/src/shared/fstab-util.c
-index b19127be09..f9adca1100 100644
+index 806dda8475..0220741c91 100644
 --- a/src/shared/fstab-util.c
 +++ b/src/shared/fstab-util.c
 @@ -40,6 +40,8 @@ bool fstab_is_extrinsic(const char *mount, const char *opts) {
@@ -38,5 +38,5 @@ index 8a5e80eeaa..fab35ed6f3 100644
                  || path_equal(path, "/usr")
  #endif
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
+++ b/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
@@ -1,4 +1,4 @@
-From ca7f6286c518d7ef3877458bbdf8e01f5518ab0e Mon Sep 17 00:00:00 2001
+From 794073e466a3b6c8e138f0e6d15c8d6465a1a4a9 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Wed, 16 Apr 2014 10:59:28 +0200
 Subject: [PATCH 03/18] Fix NixOS containers
@@ -10,10 +10,10 @@ container, so checking early whether it exists will fail.
  1 file changed, 2 insertions(+)
 
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 51d0c2a75b..4d3451ff3b 100644
+index 3b9493f232..0117a9939d 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -5017,6 +5017,7 @@ static int run(int argc, char *argv[]) {
+@@ -5122,6 +5122,7 @@ static int run(int argc, char *argv[]) {
                                  goto finish;
                          }
                  } else {
@@ -21,7 +21,7 @@ index 51d0c2a75b..4d3451ff3b 100644
                          const char *p, *q;
  
                          if (arg_pivot_root_new)
-@@ -5031,6 +5032,7 @@ static int run(int argc, char *argv[]) {
+@@ -5136,6 +5137,7 @@ static int run(int argc, char *argv[]) {
                                  r = -EINVAL;
                                  goto finish;
                          }
@@ -30,5 +30,5 @@ index 51d0c2a75b..4d3451ff3b 100644
  
          } else {
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
+++ b/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
@@ -1,4 +1,4 @@
-From c87cc5b1cf9c37f195e6b362352279e14289554e Mon Sep 17 00:00:00 2001
+From caa8dcfa87cf2e46a7a1cce9c16f929916cf9186 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Thu, 1 May 2014 14:10:10 +0200
 Subject: [PATCH 04/18] Look for fsck in the right place
@@ -21,5 +21,5 @@ index 80f7107b9d..74e48a385f 100644
                  cmdline[i++] = "-T";
  
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
+++ b/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
@@ -1,4 +1,4 @@
-From 450c133c1815b473136b2a5540f9213fef5506ee Mon Sep 17 00:00:00 2001
+From e5d73359928b79bd846bda29ce61fe276d8c0b76 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Fri, 19 Dec 2014 14:46:17 +0100
 Subject: [PATCH 05/18] Add some NixOS-specific unit directories
@@ -10,51 +10,36 @@ persistent, mutable units (used for Dysnomia).
 
 Also, remove /usr and /lib as these don't exist on NixOS.
 ---
- src/core/systemd.pc.in   |  4 ++--
- src/shared/path-lookup.c | 18 +++++-------------
- 2 files changed, 7 insertions(+), 15 deletions(-)
+ src/basic/path-lookup.c | 20 +++++---------------
+ src/core/systemd.pc.in  |  5 +++--
+ 2 files changed, 8 insertions(+), 17 deletions(-)
 
-diff --git a/src/core/systemd.pc.in b/src/core/systemd.pc.in
-index 8331832c7a..bedb97115d 100644
---- a/src/core/systemd.pc.in
-+++ b/src/core/systemd.pc.in
-@@ -17,8 +17,8 @@ systemduserunitdir=${prefix}/lib/systemd/user
- systemduserpresetdir=${prefix}/lib/systemd/user-preset
- systemdsystemconfdir=${sysconfdir}/systemd/system
- systemduserconfdir=${sysconfdir}/systemd/user
--systemdsystemunitpath=${systemdsystemconfdir}:/etc/systemd/system:/run/systemd/system:/usr/local/lib/systemd/system:${systemdsystemunitdir}:/usr/lib/systemd/system:/lib/systemd/system
--systemduserunitpath=${systemduserconfdir}:/etc/systemd/user:/run/systemd/user:/usr/local/lib/systemd/user:/usr/local/share/systemd/user:${systemduserunitdir}:/usr/lib/systemd/user:/usr/share/systemd/user
-+systemdsystemunitpath=${systemdsystemconfdir}:/etc/systemd/system:/etc/systemd-mutable/system:/nix/var/nix/profiles/default/lib/systemd/system:/run/systemd/system:${systemdsystemunitdir}
-+systemduserunitpath=${systemduserconfdir}:/etc/systemd/user:/etc/systemd-mutable/user:/nix/var/nix/profiles/default/lib/systemd/user:/run/systemd/user:${systemduserunitdir}
- systemdsystemgeneratordir=${rootprefix}/lib/systemd/system-generators
- systemdusergeneratordir=${prefix}/lib/systemd/user-generators
- systemdsystemgeneratorpath=/run/systemd/system-generators:/etc/systemd/system-generators:/usr/local/lib/systemd/system-generators:${systemdsystemgeneratordir}
-diff --git a/src/shared/path-lookup.c b/src/shared/path-lookup.c
-index 48e0eec09a..a9d38f16d0 100644
---- a/src/shared/path-lookup.c
-+++ b/src/shared/path-lookup.c
-@@ -98,17 +98,14 @@ int xdg_user_data_dir(char **ret, const char *suffix) {
+diff --git a/src/basic/path-lookup.c b/src/basic/path-lookup.c
+index 52968dee34..bba2eb09b8 100644
+--- a/src/basic/path-lookup.c
++++ b/src/basic/path-lookup.c
+@@ -94,17 +94,14 @@ int xdg_user_data_dir(char **ret, const char *suffix) {
  }
  
  static const char* const user_data_unit_paths[] = {
 -        "/usr/local/lib/systemd/user",
 -        "/usr/local/share/systemd/user",
-         USER_DATA_UNIT_PATH,
+         USER_DATA_UNIT_DIR,
 -        "/usr/lib/systemd/user",
 -        "/usr/share/systemd/user",
          NULL
  };
  
  static const char* const user_config_unit_paths[] = {
-         USER_CONFIG_UNIT_PATH,
+         USER_CONFIG_UNIT_DIR,
          "/etc/systemd/user",
 +        "/etc/systemd-mutable/user",
          NULL
  };
  
-@@ -604,15 +601,14 @@ int lookup_paths_init(
+@@ -616,15 +613,14 @@ int lookup_paths_init(
                                          persistent_config,
-                                         SYSTEM_CONFIG_UNIT_PATH,
+                                         SYSTEM_CONFIG_UNIT_DIR,
                                          "/etc/systemd/system",
 +                                        "/etc/systemd-mutable/system",
 +                                        "/nix/var/nix/profiles/default/lib/systemd/system",
@@ -70,9 +55,9 @@ index 48e0eec09a..a9d38f16d0 100644
                                          STRV_IFNOTNULL(generator_late));
                          break;
  
-@@ -628,14 +624,12 @@ int lookup_paths_init(
+@@ -640,14 +636,12 @@ int lookup_paths_init(
                                          persistent_config,
-                                         USER_CONFIG_UNIT_PATH,
+                                         USER_CONFIG_UNIT_DIR,
                                          "/etc/systemd/user",
 +                                        "/etc/systemd-mutable/user",
 +                                        "/nix/var/nix/profiles/default/lib/systemd/user",
@@ -82,26 +67,58 @@ index 48e0eec09a..a9d38f16d0 100644
 -                                        "/usr/local/share/systemd/user",
 -                                        "/usr/share/systemd/user",
 -                                        "/usr/local/lib/systemd/user",
-                                         USER_DATA_UNIT_PATH,
+                                         USER_DATA_UNIT_DIR,
 -                                        "/usr/lib/systemd/user",
                                          STRV_IFNOTNULL(generator_late));
                          break;
  
-@@ -824,14 +818,12 @@ char **generator_binary_paths(UnitFileScope scope) {
-         case UNIT_FILE_SYSTEM:
-                 return strv_new("/run/systemd/system-generators",
-                                 "/etc/systemd/system-generators",
--                                "/usr/local/lib/systemd/system-generators",
-                                 SYSTEM_GENERATOR_PATH);
+@@ -797,7 +791,6 @@ char **generator_binary_paths(UnitFileScope scope) {
+                 case UNIT_FILE_SYSTEM:
+                         add = strv_new("/run/systemd/system-generators",
+                                        "/etc/systemd/system-generators",
+-                                       "/usr/local/lib/systemd/system-generators",
+                                        SYSTEM_GENERATOR_DIR);
+                         break;
  
-         case UNIT_FILE_GLOBAL:
-         case UNIT_FILE_USER:
-                 return strv_new("/run/systemd/user-generators",
-                                 "/etc/systemd/user-generators",
--                                "/usr/local/lib/systemd/user-generators",
-                                 USER_GENERATOR_PATH);
+@@ -805,7 +798,6 @@ char **generator_binary_paths(UnitFileScope scope) {
+                 case UNIT_FILE_USER:
+                         add = strv_new("/run/systemd/user-generators",
+                                        "/etc/systemd/user-generators",
+-                                       "/usr/local/lib/systemd/user-generators",
+                                        USER_GENERATOR_DIR);
+                         break;
  
-         default:
+@@ -844,12 +836,10 @@ char **env_generator_binary_paths(bool is_system) {
+                 if (is_system)
+                         add = strv_new("/run/systemd/system-environment-generators",
+                                         "/etc/systemd/system-environment-generators",
+-                                        "/usr/local/lib/systemd/system-environment-generators",
+                                         SYSTEM_ENV_GENERATOR_DIR);
+                 else
+                         add = strv_new("/run/systemd/user-environment-generators",
+                                        "/etc/systemd/user-environment-generators",
+-                                       "/usr/local/lib/systemd/user-environment-generators",
+                                        USER_ENV_GENERATOR_DIR);
+ 
+                 if (!add)
+diff --git a/src/core/systemd.pc.in b/src/core/systemd.pc.in
+index 8424837824..b1c541bc52 100644
+--- a/src/core/systemd.pc.in
++++ b/src/core/systemd.pc.in
+@@ -38,10 +38,11 @@ systemdsystemconfdir=${systemd_system_conf_dir}
+ systemd_user_conf_dir=${sysconfdir}/systemd/user
+ systemduserconfdir=${systemd_user_conf_dir}
+ 
+-systemd_system_unit_path=${systemd_system_conf_dir}:/etc/systemd/system:/run/systemd/system:/usr/local/lib/systemd/system:${systemd_system_unit_dir}:/usr/lib/systemd/system:/lib/systemd/system
++systemd_system_unit_path=${systemd_system_conf_dir}:/etc/systemd/system:/etc/systemd-mutable/system:/nix/var/nix/profiles/default/lib/systemd/system:/run/systemd/system:${systemdsystemunitdir}
+ systemdsystemunitpath=${systemd_system_unit_path}
+ 
+-systemd_user_unit_path=${systemd_user_conf_dir}:/etc/systemd/user:/run/systemd/user:/usr/local/lib/systemd/user:/usr/local/share/systemd/user:${systemd_user_unit_dir}:/usr/lib/systemd/user:/usr/share/systemd/user
++systemd_user_unit_path=${systemd_user_conf_dir}:/etc/systemd/user:/etc/systemd-mutable/user:/nix/var/nix/profiles/default/lib/systemd/user:/run/systemd/user:${systemduserunitdir}
++
+ systemduserunitpath=${systemd_user_unit_path}
+ 
+ systemd_system_generator_dir=${root_prefix}/lib/systemd/system-generators
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
+++ b/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
@@ -1,4 +1,4 @@
-From f88a9bb1e6080b539ed0116caa9781e7f6755f54 Mon Sep 17 00:00:00 2001
+From 1a3de021d9b8da060a77af6e26d2b61bafefda74 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Mon, 11 May 2015 15:39:38 +0200
 Subject: [PATCH 06/18] Get rid of a useless message in user sessions
@@ -13,10 +13,10 @@ in containers.
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/src/core/unit.c b/src/core/unit.c
-index c306183555..3db39fa435 100644
+index 2c09def06f..c70540e1a3 100644
 --- a/src/core/unit.c
 +++ b/src/core/unit.c
-@@ -2043,7 +2043,8 @@ static void unit_check_binds_to(Unit *u) {
+@@ -2150,7 +2150,8 @@ static void unit_check_binds_to(Unit *u) {
          }
  
          assert(other);
@@ -27,5 +27,5 @@ index c306183555..3db39fa435 100644
          /* A unit we need to run is gone. Sniff. Let's stop this. */
          r = manager_add_job(u->manager, JOB_STOP, u, JOB_FAIL, NULL, &error, NULL);
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
+++ b/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
@@ -1,20 +1,20 @@
-From e2b25ce3606d05ff8a387185c41ab32fb2a36161 Mon Sep 17 00:00:00 2001
+From 6c12e0d2afe80563e692fc1f2f545a487c83418c Mon Sep 17 00:00:00 2001
 From: Gabriel Ebner <gebner@gebner.org>
 Date: Sun, 6 Dec 2015 14:26:36 +0100
 Subject: [PATCH 07/18] hostnamed, localed, timedated: disable methods that
  change system settings.
 
 ---
- src/hostname/hostnamed.c |  9 +++++++++
+ src/hostname/hostnamed.c |  6 ++++++
  src/locale/localed.c     |  9 +++++++++
  src/timedate/timedated.c | 10 ++++++++++
- 3 files changed, 28 insertions(+)
+ 3 files changed, 25 insertions(+)
 
 diff --git a/src/hostname/hostnamed.c b/src/hostname/hostnamed.c
-index 21f6471495..8c5af7619f 100644
+index 7f6607a527..b5a9388916 100644
 --- a/src/hostname/hostnamed.c
 +++ b/src/hostname/hostnamed.c
-@@ -478,6 +481,9 @@ static int method_set_static_hostname(sd_bus_message *m, void *userdata, sd_bus_
+@@ -626,6 +626,9 @@ static int method_set_static_hostname(sd_bus_message *m, void *userdata, sd_bus_
          if (r < 0)
                  return r;
  
@@ -23,8 +23,8 @@ index 21f6471495..8c5af7619f 100644
 +
          name = empty_to_null(name);
  
-         if (streq_ptr(name, c->data[PROP_STATIC_HOSTNAME]))
-@@ -535,6 +541,9 @@ static int set_machine_info(Context *c, sd_bus_message *m, int prop, sd_bus_mess
+         context_read_etc_hostname(c);
+@@ -685,6 +688,9 @@ static int set_machine_info(Context *c, sd_bus_message *m, int prop, sd_bus_mess
          if (r < 0)
                  return r;
  
@@ -33,12 +33,12 @@ index 21f6471495..8c5af7619f 100644
 +
          name = empty_to_null(name);
  
-         if (streq_ptr(name, c->data[prop]))
+         context_read_machine_info(c);
 diff --git a/src/locale/localed.c b/src/locale/localed.c
-index 09f16d25f4..c1cb87cef1 100644
+index 715ce5cac7..014f7dcf6c 100644
 --- a/src/locale/localed.c
 +++ b/src/locale/localed.c
-@@ -275,6 +275,9 @@ static int method_set_locale(sd_bus_message *m, void *userdata, sd_bus_error *er
+@@ -317,6 +317,9 @@ static int method_set_locale(sd_bus_message *m, void *userdata, sd_bus_error *er
          if (r < 0)
                  return r;
  
@@ -46,9 +46,9 @@ index 09f16d25f4..c1cb87cef1 100644
 +            "Changing system settings via systemd is not supported on NixOS.");
 +
          /* If single locale without variable name is provided, then we assume it is LANG=. */
-         if (strv_length(l) == 1 && !strchr(*l, '=')) {
-                 if (!locale_is_valid(*l))
-@@ -410,6 +413,9 @@ static int method_set_vc_keyboard(sd_bus_message *m, void *userdata, sd_bus_erro
+         if (strv_length(l) == 1 && !strchr(l[0], '=')) {
+                 if (!locale_is_valid(l[0]))
+@@ -432,6 +435,9 @@ static int method_set_vc_keyboard(sd_bus_message *m, void *userdata, sd_bus_erro
          if (r < 0)
                  return r;
  
@@ -58,7 +58,7 @@ index 09f16d25f4..c1cb87cef1 100644
          keymap = empty_to_null(keymap);
          keymap_toggle = empty_to_null(keymap_toggle);
  
-@@ -586,6 +592,9 @@ static int method_set_x11_keyboard(sd_bus_message *m, void *userdata, sd_bus_err
+@@ -606,6 +612,9 @@ static int method_set_x11_keyboard(sd_bus_message *m, void *userdata, sd_bus_err
          if (r < 0)
                  return r;
  
@@ -69,10 +69,10 @@ index 09f16d25f4..c1cb87cef1 100644
          model = empty_to_null(model);
          variant = empty_to_null(variant);
 diff --git a/src/timedate/timedated.c b/src/timedate/timedated.c
-index 5e2fb50d83..63865f557c 100644
+index c467b85477..3e78b2f575 100644
 --- a/src/timedate/timedated.c
 +++ b/src/timedate/timedated.c
-@@ -652,6 +652,10 @@ static int method_set_timezone(sd_bus_message *m, void *userdata, sd_bus_error *
+@@ -646,6 +646,10 @@ static int method_set_timezone(sd_bus_message *m, void *userdata, sd_bus_error *
          if (r < 0)
                  return r;
  
@@ -83,7 +83,7 @@ index 5e2fb50d83..63865f557c 100644
          if (!timezone_is_valid(z, LOG_DEBUG))
                  return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Invalid or not installed time zone '%s'", z);
  
-@@ -731,6 +735,9 @@ static int method_set_local_rtc(sd_bus_message *m, void *userdata, sd_bus_error
+@@ -725,6 +729,9 @@ static int method_set_local_rtc(sd_bus_message *m, void *userdata, sd_bus_error
          if (r < 0)
                  return r;
  
@@ -93,7 +93,7 @@ index 5e2fb50d83..63865f557c 100644
          if (lrtc == c->local_rtc)
                  return sd_bus_reply_method_return(m, NULL);
  
-@@ -923,6 +930,9 @@ static int method_set_ntp(sd_bus_message *m, void *userdata, sd_bus_error *error
+@@ -917,6 +924,9 @@ static int method_set_ntp(sd_bus_message *m, void *userdata, sd_bus_error *error
          if (r < 0)
                  return r;
  
@@ -104,5 +104,5 @@ index 5e2fb50d83..63865f557c 100644
          if (r < 0)
                  return r;
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0008-Fix-hwdb-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0008-Fix-hwdb-paths.patch
@@ -1,4 +1,4 @@
-From 5a6aad633a7ceffd62b009ce0c4ab6673129f7ff Mon Sep 17 00:00:00 2001
+From 1e40be83eca9a831509ae764081c2252934478c3 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 7 Jul 2016 02:47:13 +0300
 Subject: [PATCH 08/18] Fix hwdb paths
@@ -28,5 +28,5 @@ index b3febdbb31..eba00a5bc7 100644
  _public_ int sd_hwdb_new(sd_hwdb **ret) {
          _cleanup_(sd_hwdb_unrefp) sd_hwdb *hwdb = NULL;
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
+++ b/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
@@ -1,4 +1,4 @@
-From b509dbd302a7933ae0002f44b99aac6a1fd5775b Mon Sep 17 00:00:00 2001
+From 5e235e1f720f37fc5581b40c9a13d365368e74a8 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Tue, 11 Oct 2016 13:12:08 +0300
 Subject: [PATCH 09/18] Change /usr/share/zoneinfo to /etc/zoneinfo
@@ -35,10 +35,10 @@ index 0f1652ee2e..71c4f95c2e 100644
      <literal>Etc/UTC</literal>. The resulting link should lead to the
      corresponding binary
 diff --git a/src/basic/time-util.c b/src/basic/time-util.c
-index 105584e2e7..5238f69931 100644
+index 15cc1b8851..d0abde5933 100644
 --- a/src/basic/time-util.c
 +++ b/src/basic/time-util.c
-@@ -1217,7 +1217,7 @@ int get_timezones(char ***ret) {
+@@ -1259,7 +1259,7 @@ int get_timezones(char ***ret) {
          n_allocated = 2;
          n_zones = 1;
  
@@ -47,7 +47,7 @@ index 105584e2e7..5238f69931 100644
          if (f) {
                  for (;;) {
                          _cleanup_free_ char *line = NULL;
-@@ -1312,7 +1312,7 @@ bool timezone_is_valid(const char *name, int log_level) {
+@@ -1354,7 +1354,7 @@ bool timezone_is_valid(const char *name, int log_level) {
          if (p - name >= PATH_MAX)
                  return false;
  
@@ -56,7 +56,7 @@ index 105584e2e7..5238f69931 100644
  
          fd = open(t, O_RDONLY|O_CLOEXEC);
          if (fd < 0) {
-@@ -1410,7 +1410,7 @@ int get_timezone(char **ret) {
+@@ -1452,7 +1452,7 @@ int get_timezone(char **ret) {
          if (r < 0)
                  return r; /* returns EINVAL if not a symlink */
  
@@ -66,10 +66,10 @@ index 105584e2e7..5238f69931 100644
                  return -EINVAL;
  
 diff --git a/src/firstboot/firstboot.c b/src/firstboot/firstboot.c
-index 901fbf0815..b57bdd8fbe 100644
+index a3f442518e..feff49e280 100644
 --- a/src/firstboot/firstboot.c
 +++ b/src/firstboot/firstboot.c
-@@ -431,7 +431,7 @@ static int process_timezone(void) {
+@@ -459,7 +459,7 @@ static int process_timezone(void) {
          if (isempty(arg_timezone))
                  return 0;
  
@@ -79,10 +79,10 @@ index 901fbf0815..b57bdd8fbe 100644
          (void) mkdir_parents(etc_localtime, 0755);
          if (symlink(e, etc_localtime) < 0)
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 4d3451ff3b..1adb91335c 100644
+index 0117a9939d..d86445b40f 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -1657,8 +1657,8 @@ static int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t u
+@@ -1699,8 +1699,8 @@ static int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t u
  static const char *timezone_from_path(const char *path) {
          return PATH_STARTSWITH_SET(
                          path,
@@ -94,10 +94,10 @@ index 4d3451ff3b..1adb91335c 100644
  
  static bool etc_writable(void) {
 diff --git a/src/timedate/timedated.c b/src/timedate/timedated.c
-index 63865f557c..8021a8b753 100644
+index 3e78b2f575..de5477a08f 100644
 --- a/src/timedate/timedated.c
 +++ b/src/timedate/timedated.c
-@@ -264,7 +264,7 @@ static int context_read_data(Context *c) {
+@@ -269,7 +269,7 @@ static int context_read_data(Context *c) {
  
          r = get_timezone(&t);
          if (r == -EINVAL)
@@ -106,7 +106,7 @@ index 63865f557c..8021a8b753 100644
          else if (r < 0)
                  log_warning_errno(r, "Failed to get target of /etc/localtime: %m");
  
-@@ -288,7 +288,7 @@ static int context_write_data_timezone(Context *c) {
+@@ -293,7 +293,7 @@ static int context_write_data_timezone(Context *c) {
  
          if (isempty(c->zone) || streq(c->zone, "UTC")) {
  
@@ -115,7 +115,7 @@ index 63865f557c..8021a8b753 100644
  
                          if (unlink("/etc/localtime") < 0 && errno != ENOENT)
                                  return -errno;
-@@ -296,9 +296,9 @@ static int context_write_data_timezone(Context *c) {
+@@ -301,9 +301,9 @@ static int context_write_data_timezone(Context *c) {
                          return 0;
                  }
  
@@ -128,5 +128,5 @@ index 63865f557c..8021a8b753 100644
                          return -ENOMEM;
  
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
+++ b/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
@@ -1,4 +1,4 @@
-From b5665ef8b9266c662c3a137df1ef1721cdff346e Mon Sep 17 00:00:00 2001
+From 141d1d7acf5f018df86f0a5f7fbe49a8e928fd73 Mon Sep 17 00:00:00 2001
 From: Imuli <i@imu.li>
 Date: Wed, 19 Oct 2016 08:46:47 -0400
 Subject: [PATCH 10/18] localectl: use /etc/X11/xkb for list-x11-*
@@ -10,10 +10,10 @@ NixOS has an option to link the xkb data files to /etc/X11, but not to
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/locale/localectl.c b/src/locale/localectl.c
-index 6f2d37d222..7aa2310d48 100644
+index e0664de826..c521f33a2a 100644
 --- a/src/locale/localectl.c
 +++ b/src/locale/localectl.c
-@@ -286,7 +286,7 @@ static int list_x11_keymaps(int argc, char **argv, void *userdata) {
+@@ -277,7 +277,7 @@ static int list_x11_keymaps(int argc, char **argv, void *userdata) {
          } state = NONE, look_for;
          int r;
  
@@ -23,5 +23,5 @@ index 6f2d37d222..7aa2310d48 100644
                  return log_error_errno(errno, "Failed to open keyboard mapping list. %m");
  
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
+++ b/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
@@ -1,4 +1,4 @@
-From be6b5c37779302384079b22b7fd767daad878fa9 Mon Sep 17 00:00:00 2001
+From db3946f465c0066fb1775a92c1fcc6450134904d Mon Sep 17 00:00:00 2001
 From: Franz Pletz <fpletz@fnordicwalking.de>
 Date: Sun, 11 Feb 2018 04:37:44 +0100
 Subject: [PATCH 11/18] build: don't create statedir and don't touch prefixdir
@@ -8,10 +8,10 @@ Subject: [PATCH 11/18] build: don't create statedir and don't touch prefixdir
  1 file changed, 3 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index c09115e06a..62eba4186c 100644
+index dbbddb68e2..bbeb23223d 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -3184,9 +3184,6 @@ install_data('LICENSE.GPL2',
+@@ -3369,9 +3369,6 @@ install_data('LICENSE.GPL2',
               'src/libsystemd/sd-bus/GVARIANT-SERIALIZATION',
               install_dir : docdir)
  
@@ -20,7 +20,7 @@ index c09115e06a..62eba4186c 100644
 -
  ############################################################
  
- meson_check_help = find_program('tools/meson-check-help.sh')
+ check_help = find_program('tools/check-help.sh')
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0012-Install-default-configuration-into-out-share-factory.patch
+++ b/pkgs/os-specific/linux/systemd/0012-Install-default-configuration-into-out-share-factory.patch
@@ -1,4 +1,4 @@
-From 9262f52b0e30cf8c39d9f7684a8c0e8fd4887cd5 Mon Sep 17 00:00:00 2001
+From 245af064c4d315d868cc12201b3663f61702cce3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
 Date: Mon, 26 Feb 2018 14:25:57 +0000
 Subject: [PATCH 12/18] Install default configuration into $out/share/factory
@@ -31,10 +31,10 @@ store again, while having executables looking up files in /etc.
  17 files changed, 29 insertions(+), 26 deletions(-)
 
 diff --git a/hwdb.d/meson.build b/hwdb.d/meson.build
-index 4df6dabf89..02d8d69095 100644
+index 5c77387a26..6404bc01ba 100644
 --- a/hwdb.d/meson.build
 +++ b/hwdb.d/meson.build
-@@ -27,7 +27,7 @@ if conf.get('ENABLE_HWDB') == 1
+@@ -43,7 +43,7 @@ if conf.get('ENABLE_HWDB') == 1
                       install_dir : udevhwdbdir)
  
          meson.add_install_script('sh', '-c',
@@ -44,10 +44,10 @@ index 4df6dabf89..02d8d69095 100644
          meson.add_install_script('sh', '-c',
                                   'test -n "$DESTDIR" || @0@/systemd-hwdb update'
 diff --git a/meson.build b/meson.build
-index 62eba4186c..b0b2edbb5a 100644
+index bbeb23223d..1a9c56fad2 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -154,6 +154,9 @@ udevhwdbdir = join_paths(udevlibexecdir, 'hwdb.d')
+@@ -163,6 +163,9 @@ udevhwdbdir = join_paths(udevlibexecdir, 'hwdb.d')
  catalogdir = join_paths(prefixdir, 'lib/systemd/catalog')
  kernelinstalldir = join_paths(prefixdir, 'lib/kernel/install.d')
  factorydir = join_paths(datadir, 'factory')
@@ -57,7 +57,7 @@ index 62eba4186c..b0b2edbb5a 100644
  bootlibdir = join_paths(prefixdir, 'lib/systemd/boot/efi')
  testsdir = join_paths(prefixdir, 'lib/systemd/tests')
  systemdstatedir = join_paths(localstatedir, 'lib/systemd')
-@@ -2511,7 +2514,7 @@ if conf.get('ENABLE_BINFMT') == 1
+@@ -2651,7 +2654,7 @@ if conf.get('ENABLE_BINFMT') == 1
          meson.add_install_script('sh', '-c',
                                   mkdir_p.format(binfmtdir))
          meson.add_install_script('sh', '-c',
@@ -66,16 +66,16 @@ index 62eba4186c..b0b2edbb5a 100644
  endif
  
  if conf.get('ENABLE_REPART') == 1
-@@ -2612,7 +2615,7 @@ executable('systemd-sleep',
-            install_dir : rootlibexecdir)
+@@ -2767,7 +2770,7 @@ executable(
+         install_dir : rootlibexecdir)
  
  install_data('src/sleep/sleep.conf',
 -             install_dir : pkgsysconfdir)
 +             install_dir : factorypkgconfdir)
  
- exe = executable('systemd-sysctl',
-                  'src/sysctl/sysctl.c',
-@@ -2924,7 +2927,7 @@ if conf.get('HAVE_KMOD') == 1
+ public_programs += executable(
+         'systemd-sysctl',
+@@ -3101,7 +3104,7 @@ if conf.get('HAVE_KMOD') == 1
          meson.add_install_script('sh', '-c',
                                   mkdir_p.format(modulesloaddir))
          meson.add_install_script('sh', '-c',
@@ -83,8 +83,8 @@ index 62eba4186c..b0b2edbb5a 100644
 +                                 mkdir_p.format(join_paths(factoryconfdir, 'modules-load.d')))
  endif
  
- exe = executable('systemd-nspawn',
-@@ -3167,7 +3170,7 @@ install_subdir('factory/etc',
+ public_programs += executable(
+@@ -3352,7 +3355,7 @@ install_subdir('factory/etc',
                 install_dir : factorydir)
  
  install_data('xorg/50-systemd-user.sh',
@@ -94,10 +94,10 @@ index 62eba4186c..b0b2edbb5a 100644
               install_dir : modprobedir)
  install_data('LICENSE.GPL2',
 diff --git a/network/meson.build b/network/meson.build
-index 544dcf4387..1828c50863 100644
+index 99a650eac3..8105a4e48d 100644
 --- a/network/meson.build
 +++ b/network/meson.build
-@@ -10,7 +10,7 @@ if conf.get('ENABLE_NETWORKD') == 1
+@@ -11,7 +11,7 @@ if conf.get('ENABLE_NETWORKD') == 1
                       install_dir : networkdir)
  
          meson.add_install_script('sh', '-c',
@@ -107,10 +107,10 @@ index 544dcf4387..1828c50863 100644
  
  install_data('99-default.link',
 diff --git a/src/core/meson.build b/src/core/meson.build
-index 3586838f59..02ddf1a123 100644
+index fa95108523..60ee0e31c1 100644
 --- a/src/core/meson.build
 +++ b/src/core/meson.build
-@@ -179,8 +179,8 @@ libcore = static_library(
+@@ -183,8 +183,8 @@ libcore = static_library(
  systemd_sources = files('main.c')
  
  in_files = [['macros.systemd',   rpmmacrosdir],
@@ -121,7 +121,7 @@ index 3586838f59..02ddf1a123 100644
              ['systemd.pc',       pkgconfigdatadir],
              ['triggers.systemd', '']]
  
-@@ -212,6 +212,6 @@ meson.add_install_script('sh', '-c', mkdir_p.format(systemsleepdir))
+@@ -216,6 +216,6 @@ meson.add_install_script('sh', '-c', mkdir_p.format(systemsleepdir))
  meson.add_install_script('sh', '-c', mkdir_p.format(systemgeneratordir))
  meson.add_install_script('sh', '-c', mkdir_p.format(usergeneratordir))
  
@@ -180,15 +180,16 @@ index 5796f77cac..75d975c260 100644
  if get_option('create-log-dirs')
          meson.add_install_script(
 diff --git a/src/kernel-install/meson.build b/src/kernel-install/meson.build
-index 261c3aaae4..dbc5e23513 100644
+index 9ae342dfba..65df666337 100644
 --- a/src/kernel-install/meson.build
 +++ b/src/kernel-install/meson.build
-@@ -11,4 +11,4 @@ install_data('00-entry-directory.install',
-              install_dir : kernelinstalldir)
+@@ -14,5 +14,5 @@ if want_kernel_install
+ 		install_dir : kernelinstalldir)
  
- meson.add_install_script('sh', '-c',
--                         mkdir_p.format(join_paths(sysconfdir, 'kernel/install.d')))
-+                         mkdir_p.format(join_paths(factoryconfdir, 'kernel/install.d')))
+ 	meson.add_install_script('sh', '-c',
+-				mkdir_p.format(join_paths(sysconfdir, 'kernel/install.d')))
++				mkdir_p.format(join_paths(factoryconfdir, 'kernel/install.d')))
+ endif
 diff --git a/src/login/meson.build b/src/login/meson.build
 index 0a7d3d5440..ff90149c1c 100644
 --- a/src/login/meson.build
@@ -203,10 +204,10 @@ index 0a7d3d5440..ff90149c1c 100644
          install_data('org.freedesktop.login1.conf',
                       install_dir : dbuspolicydir)
 diff --git a/src/network/meson.build b/src/network/meson.build
-index c1c02cfda1..1bfa79a03b 100644
+index b3a88d9910..be56d1e9d7 100644
 --- a/src/network/meson.build
 +++ b/src/network/meson.build
-@@ -201,7 +201,7 @@ if conf.get('ENABLE_NETWORKD') == 1
+@@ -229,7 +229,7 @@ if conf.get('ENABLE_NETWORKD') == 1
          endif
  
          install_data('networkd.conf',
@@ -227,10 +228,10 @@ index adbac24b54..e9dc88dfa2 100644
 +                     install_dir : factorypkgconfdir)
  endif
 diff --git a/src/resolve/meson.build b/src/resolve/meson.build
-index c4d8d4e5d9..f550c289a5 100644
+index 92b67b6333..ac5b9a0b0a 100644
 --- a/src/resolve/meson.build
 +++ b/src/resolve/meson.build
-@@ -170,7 +170,7 @@ if conf.get('ENABLE_RESOLVE') == 1
+@@ -168,7 +168,7 @@ if conf.get('ENABLE_RESOLVE') == 1
                  output : 'resolved.conf',
                  configuration : substs)
          install_data(resolved_conf,
@@ -253,10 +254,10 @@ index e5c118c8db..19235df9ca 100644
                       install_dir : dbuspolicydir)
          install_data('org.freedesktop.timesync1.service',
 diff --git a/src/udev/meson.build b/src/udev/meson.build
-index 173b10be50..82638cf5a9 100644
+index aa23b07090..ad004d803a 100644
 --- a/src/udev/meson.build
 +++ b/src/udev/meson.build
-@@ -187,7 +187,7 @@ foreach prog : [['ata_id/ata_id.c'],
+@@ -186,7 +186,7 @@ foreach prog : [['ata_id/ata_id.c'],
  endforeach
  
  install_data('udev.conf',
@@ -265,7 +266,7 @@ index 173b10be50..82638cf5a9 100644
  
  configure_file(
          input : 'udev.pc.in',
-@@ -196,7 +196,7 @@ configure_file(
+@@ -195,7 +195,7 @@ configure_file(
          install_dir : pkgconfigdatadir == 'no' ? '' : pkgconfigdatadir)
  
  meson.add_install_script('sh', '-c',
@@ -285,10 +286,10 @@ index 3f072e3db7..bd9f843eba 100644
 -                         mkdir_p.format(join_paths(sysconfdir, 'sysctl.d')))
 +                         mkdir_p.format(join_paths(factoryconfdir, 'sysctl.d')))
 diff --git a/tmpfiles.d/meson.build b/tmpfiles.d/meson.build
-index e77f46d06b..04d2ef621d 100644
+index 0a9582d8b9..3c56ca7d83 100644
 --- a/tmpfiles.d/meson.build
 +++ b/tmpfiles.d/meson.build
-@@ -57,5 +57,5 @@ endforeach
+@@ -58,5 +58,5 @@ endforeach
  if enable_tmpfiles
          meson.add_install_script(
                  'sh', '-c',
@@ -296,7 +297,7 @@ index e77f46d06b..04d2ef621d 100644
 +                mkdir_p.format(join_paths(factoryconfdir, 'tmpfiles.d')))
  endif
 diff --git a/units/meson.build b/units/meson.build
-index ea91f0cc9e..8622054ca5 100644
+index aa2ed115ea..12e2925226 100644
 --- a/units/meson.build
 +++ b/units/meson.build
 @@ -323,7 +323,7 @@ install_data('user-.slice.d/10-defaults.conf',
@@ -309,5 +310,5 @@ index ea91f0cc9e..8622054ca5 100644
                           join_paths(dbussystemservicedir, 'org.freedesktop.systemd1.service'),
                           join_paths(dbussessionservicedir, 'org.freedesktop.systemd1.service'))
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
+++ b/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
@@ -1,4 +1,4 @@
-From 05c2761f6a981c8576fc47a3dd8beb5a2af3ef09 Mon Sep 17 00:00:00 2001
+From bfaa53731ffe984c93c5321099d1341b5059f029 Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Fri, 2 Nov 2018 21:15:42 +0100
 Subject: [PATCH 13/18] inherit systemd environment when calling generators.
@@ -16,10 +16,10 @@ executables that are being called from managers.
  1 file changed, 8 insertions(+), 3 deletions(-)
 
 diff --git a/src/core/manager.c b/src/core/manager.c
-index 4412e7a849..b799eeca95 100644
+index 41e0d73736..d02de06f09 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
-@@ -3901,9 +3901,14 @@ static int manager_run_generators(Manager *m) {
+@@ -4095,9 +4095,14 @@ static int manager_run_generators(Manager *m) {
          argv[4] = NULL;
  
          RUN_WITH_UMASK(0022)
@@ -38,5 +38,5 @@ index 4412e7a849..b799eeca95 100644
  
  finish:
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0014-add-rootprefix-to-lookup-dir-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0014-add-rootprefix-to-lookup-dir-paths.patch
@@ -1,4 +1,4 @@
-From c70029539d0aec5df0c1e4203359335a3841a1e5 Mon Sep 17 00:00:00 2001
+From d8b93ef32f3b95a6ce6548a8ad1504a485ffbe81 Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Thu, 9 May 2019 11:15:22 +0200
 Subject: [PATCH 14/18] add rootprefix to lookup dir paths
@@ -34,5 +34,5 @@ index 970654a1ad..bb261040f8 100644
  #define CONF_PATHS(n)                           \
          CONF_PATHS_USR(n)                       \
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0015-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
+++ b/pkgs/os-specific/linux/systemd/0015-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
@@ -1,4 +1,4 @@
-From 98580b4aa34f3d2e7401f54d6561c5af27ea3437 Mon Sep 17 00:00:00 2001
+From b3bc0aa899c51d19edfb53af2b00dde64123ab06 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 25 Jul 2019 20:45:55 +0300
 Subject: [PATCH 15/18] systemd-shutdown: execute scripts in
@@ -10,10 +10,10 @@ This is needed for NixOS to use such scripts as systemd directory is immutable.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/shutdown/shutdown.c b/src/shutdown/shutdown.c
-index 523040b57c..561d91c94c 100644
+index 06c9710c6e..dadcc3117d 100644
 --- a/src/shutdown/shutdown.c
 +++ b/src/shutdown/shutdown.c
-@@ -299,7 +299,7 @@ int main(int argc, char *argv[]) {
+@@ -312,7 +312,7 @@ int main(int argc, char *argv[]) {
          _cleanup_free_ char *cgroup = NULL;
          char *arguments[3], *watchdog_device;
          int cmd, r, umount_log_level = LOG_INFO;
@@ -23,5 +23,5 @@ index 523040b57c..561d91c94c 100644
          /* The log target defaults to console, but the original systemd process will pass its log target in through a
           * command line argument, which will override this default. Also, ensure we'll never log to the journal or
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0016-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
+++ b/pkgs/os-specific/linux/systemd/0016-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
@@ -1,4 +1,4 @@
-From 3821e20966ee20f74986041f33c4934ad20385b2 Mon Sep 17 00:00:00 2001
+From 2679210f4ce804713bf1d244ac0fb8ac7b9b1e5f Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 25 Jul 2019 20:46:58 +0300
 Subject: [PATCH 16/18] systemd-sleep: execute scripts in
@@ -10,10 +10,10 @@ This is needed for NixOS to use such scripts as systemd directory is immutable.
  1 file changed, 1 insertion(+)
 
 diff --git a/src/sleep/sleep.c b/src/sleep/sleep.c
-index fbfddc0262..d2530b9421 100644
+index 7029352ca5..6d9c636872 100644
 --- a/src/sleep/sleep.c
 +++ b/src/sleep/sleep.c
-@@ -178,6 +178,7 @@ static int execute(char **modes, char **states) {
+@@ -182,6 +182,7 @@ static int execute(char **modes, char **states) {
          };
          static const char* const dirs[] = {
                  SYSTEM_SLEEP_PATH,
@@ -22,5 +22,5 @@ index fbfddc0262..d2530b9421 100644
          };
  
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0017-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
+++ b/pkgs/os-specific/linux/systemd/0017-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
@@ -1,4 +1,4 @@
-From b07defe819e0f66d08563690b3a5abea5da08620 Mon Sep 17 00:00:00 2001
+From 561b0cc9a1faed5729d6f701304a65c2968394ec Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sat, 7 Mar 2020 22:40:27 +0100
 Subject: [PATCH 17/18] kmod-static-nodes.service: Update ConditionFileNotEmpty
@@ -23,5 +23,5 @@ index 0971edf9ec..87105a87b9 100644
  [Service]
  Type=oneshot
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/0018-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
+++ b/pkgs/os-specific/linux/systemd/0018-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
@@ -1,4 +1,4 @@
-From 9c1ac48a7d95c09bef5a924bb5db6908596403b4 Mon Sep 17 00:00:00 2001
+From 0d9d7c03054babdbd1fa5f6f266b56e8c96e9ba5 Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sun, 8 Mar 2020 01:05:54 +0100
 Subject: [PATCH 18/18] path-util.h: add placeholder for DEFAULT_PATH_NORMAL
@@ -29,5 +29,5 @@ index 30031fca8e..d97145539a 100644
  #if HAVE_SPLIT_USR
  #  define DEFAULT_PATH DEFAULT_PATH_SPLIT_USR
 -- 
-2.26.2
+2.27.0
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -17,19 +17,24 @@
 , withKexectools ? lib.any (lib.meta.platformMatch stdenv.hostPlatform) kexectools.meta.platforms, kexectools
 }:
 
-stdenv.mkDerivation {
+let
   version = "246";
+in stdenv.mkDerivation {
+  inherit version;
   pname = "systemd";
 
-  # When updating, use https://github.com/systemd/systemd-stable tree, not the development one!
-  # Also fresh patches should be cherry-picked from that tree to our current one.
+  # We use systemd/systemd-stable for src, and ship NixOS-specific patches inside nixpkgs directly
+  # This has proven to be less error-prone than the previous systemd fork.
   src = fetchFromGitHub {
     owner = "systemd";
     repo = "systemd-stable";
-    rev = "ae366f3acbc1a45504e9875099b17a7e1a221d03";
+    rev = "v${version}";
     sha256 = "0zrkyxrh5rm45f2l1rnjyv229bcyzawfw7c63jqxwix75px60dyw";
   };
 
+  # If these need to be regenerated, `git am path/to/00*.patch` them into a
+  # systemd worktree, rebase to the more recent systemd version, and export the
+  # patches again via `git format-patch v${version}`.
   patches = [
     ./0001-Start-device-units-for-uninitialised-encrypted-devic.patch
     ./0002-Don-t-try-to-unmount-nix-or-nix-store.patch

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -17,22 +17,7 @@
 , withKexectools ? lib.any (lib.meta.platformMatch stdenv.hostPlatform) kexectools.meta.platforms, kexectools
 }:
 
-let gnupg-minimal = gnupg.override {
-  enableMinimal = true;
-  guiSupport = false;
-  pcsclite = null;
-  sqlite = null;
-  pinentry = null;
-  adns = null;
-  gnutls = null;
-  libusb1 = null;
-  openldap = null;
-  readline = null;
-  zlib = null;
-  bzip2 = null;
-};
-
-in stdenv.mkDerivation {
+stdenv.mkDerivation {
   version = "246";
   pname = "systemd";
 
@@ -214,7 +199,7 @@ in stdenv.mkDerivation {
 
     # absolute paths to gpg & tar
     substituteInPlace src/import/pull-common.c \
-      --replace '"gpg"' '"${gnupg-minimal}/bin/gpg"'
+      --replace '"gpg"' '"${gnupg}/bin/gpg"'
     for file in src/import/{{export,import,pull}-tar,import-common}.c; do
       substituteInPlace $file \
         --replace '"tar"' '"${gnutar}/bin/tar"'

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -33,7 +33,7 @@ let gnupg-minimal = gnupg.override {
 };
 
 in stdenv.mkDerivation {
-  version = "245.7";
+  version = "246";
   pname = "systemd";
 
   # When updating, use https://github.com/systemd/systemd-stable tree, not the development one!
@@ -41,8 +41,8 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "systemd";
     repo = "systemd-stable";
-    rev = "1e6233ed07f7af08550fffa7a885cac1ac67a2c3";
-    sha256 = "1hd5kc3mm7mg4i7hhi82wg4cpg4fpi2k6hzjq9sv07pkn2lw390w";
+    rev = "ae366f3acbc1a45504e9875099b17a7e1a221d03";
+    sha256 = "0zrkyxrh5rm45f2l1rnjyv229bcyzawfw7c63jqxwix75px60dyw";
   };
 
   patches = [

--- a/pkgs/servers/monitoring/loki/default.nix
+++ b/pkgs/servers/monitoring/loki/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, makeWrapper, systemd }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, makeWrapper, systemd }:
 
 buildGoPackage rec {
   version = "1.5.0";
@@ -25,7 +25,7 @@ buildGoPackage rec {
 
   preFixup = stdenv.lib.optionalString stdenv.isLinux ''
     wrapProgram $out/bin/promtail \
-      --prefix LD_LIBRARY_PATH : "${systemd.lib}/lib"
+      --prefix LD_LIBRARY_PATH : "${lib.getLib systemd}/lib"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, makeWrapper, nixosTests
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, makeWrapper, nixosTests
 , systemd, withSystemdSupport ? true }:
 
 with stdenv.lib;
@@ -44,7 +44,7 @@ buildGoPackage rec {
 
   postInstall = optionalString withSystemdSupport ''
     wrapProgram $out/bin/postfix_exporter \
-      --prefix LD_LIBRARY_PATH : "${systemd.lib}/lib"
+      --prefix LD_LIBRARY_PATH : "${lib.getLib systemd}/lib"
   '';
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) postfix; };

--- a/pkgs/tools/filesystems/nixpart/0.4/blivet.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/blivet.nix
@@ -30,7 +30,7 @@ buildPythonApplication rec {
     sed -i -e 's|"lsof"|"${lsof}/bin/lsof"|' blivet/formats/fs.py
     sed -i -r -e 's|"(u?mount)"|"${utillinux.bin}/bin/\1"|' blivet/util.py
     sed -i -e '/find_library/,/find_library/ {
-      c libudev = "${systemd.lib}/lib/libudev.so.1"
+      c libudev = "${stdenv.lib.getLib systemd}/lib/libudev.so.1"
     }' blivet/pyudev.py
   '';
 

--- a/pkgs/tools/filesystems/nixpart/0.4/multipath-tools.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/multipath-tools.nix
@@ -36,8 +36,8 @@ stdenv.mkDerivation rec {
       substituteInPlace kpartx/kpartx.rules --replace /sbin/kpartx $out/sbin/kpartx
       substituteInPlace kpartx/kpartx_id --replace /sbin/dmsetup ${lvm2}/sbin/dmsetup
 
-      substituteInPlace libmultipath/defaults.h --replace /lib/udev/scsi_id ${systemd.lib}/lib/udev/scsi_id
-      substituteInPlace libmultipath/hwtable.c --replace /lib/udev/scsi_id ${systemd.lib}/lib/udev/scsi_id
+      substituteInPlace libmultipath/defaults.h --replace /lib/udev/scsi_id ${stdenv.lib.getLib systemd}/lib/udev/scsi_id
+      substituteInPlace libmultipath/hwtable.c --replace /lib/udev/scsi_id ${stdenv.lib.getLib systemd}/lib/udev/scsi_id
 
       sed -i -re '
          s,^( *#define +DEFAULT_MULTIPATHDIR\>).*,\1 "'"$out/lib/multipath"'",

--- a/pkgs/tools/misc/hakuneko/default.nix
+++ b/pkgs/tools/misc/hakuneko/default.nix
@@ -6,6 +6,7 @@
 , makeWrapper
 , udev
 , stdenv
+, lib
 , wrapGAppsHook
 }:
 let
@@ -61,7 +62,7 @@ stdenv.mkDerivation rec {
   '';
 
   runtimeDependencies = [
-    udev.lib
+    (lib.getLib udev)
   ];
 
   postFixup = ''

--- a/pkgs/tools/misc/staruml/default.nix
+++ b/pkgs/tools/misc/staruml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper
+{ stdenv, lib, fetchurl, makeWrapper
 , dpkg, patchelf
 , gtk2, glib, gdk-pixbuf, alsaLib, nss, nspr, GConf, cups, libgcrypt, dbus, systemd
 , libXdamage, expat }:
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/lib
     ln -s ${stdenv.cc.cc.lib}/lib/libstdc++.so.6 $out/lib/
-    ln -s ${systemd.lib}/lib/libudev.so.1 $out/lib/libudev.so.0
+    ln -s ${lib.getLib systemd}/lib/libudev.so.1 $out/lib/libudev.so.0
 
     for binary in StarUML Brackets-node; do
       ${patchelf}/bin/patchelf \

--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -65,7 +65,7 @@ in buildGoPackage rec {
 
     wrapProgram "$out/bin/agent" \
       --set PYTHONPATH "$out/${python.sitePackages}" \
-      --prefix LD_LIBRARY_PATH : ${systemd.lib}/lib
+      --prefix LD_LIBRARY_PATH : ${lib.getLib systemd}/lib
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/security/bitwarden/default.nix
+++ b/pkgs/tools/security/bitwarden/default.nix
@@ -6,6 +6,7 @@
 , makeDesktopItem
 , makeWrapper
 , stdenv
+, lib
 , udev
 , wrapGAppsHook
 }:
@@ -72,7 +73,7 @@ let
     '';
 
     runtimeDependencies = [
-      udev.lib
+      (lib.getLib udev)
     ];
 
     postFixup = ''

--- a/pkgs/tools/security/encryptr/default.nix
+++ b/pkgs/tools/security/encryptr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glib, nss, nspr, gconf, fontconfig, freetype
+{ stdenv, lib, fetchurl, glib, nss, nspr, gconf, fontconfig, freetype
 , pango , cairo, libX11 , libXi, libXcursor, libXext, libXfixes
 , libXrender, libXcomposite , alsaLib, libXdamage, libXtst, libXrandr
 , expat, libcap, systemd , dbus, gtk2 , gdk-pixbuf, libnotify
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
     cp -v {encryptr-bin,icudtl.dat,nw.pak} $out/bin
     mv -v $out/bin/encryptr{-bin,}
     cp -v lib* $out/lib
-    ln -sv ${systemd.lib}/lib/libudev.so.1 $out/lib/libudev.so.0
+    ln -sv ${lib.getLib systemd}/lib/libudev.so.1 $out/lib/libudev.so.0
 
     patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
              --set-rpath $out/lib:${rpath} \

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, alsaLib, atk, cairo, cups, udev
+{ stdenv, lib, fetchurl, alsaLib, atk, cairo, cups, udev
 , dbus, expat, fontconfig, freetype, gdk-pixbuf, glib, gtk3, libappindicator-gtk3
 , libnotify, nspr, nss, pango, systemd, xorg, autoPatchelfHook, wrapGAppsHook
 , runtimeShell, gsettings-desktop-schemas }:
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
   ];
 
   runtimeDependencies = [
-    udev.lib
+    (lib.getLib udev)
     libappindicator-gtk3
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18066,8 +18066,25 @@ in
   sysstat = callPackage ../os-specific/linux/sysstat { };
 
   systemd = callPackage ../os-specific/linux/systemd {
-    utillinux = utillinuxMinimal; # break the cyclic dependency
+    # break some cyclic dependencies
+    utillinux = utillinuxMinimal;
+    # provide a super minimal gnupg used for systemd-machined
+    gnupg = callPackage ../tools/security/gnupg/22.nix {
+      enableMinimal = true;
+      guiSupport = false;
+      pcsclite = null;
+      sqlite = null;
+      pinentry = null;
+      adns = null;
+      gnutls = null;
+      libusb1 = null;
+      openldap = null;
+      readline = null;
+      zlib = null;
+      bzip2 = null;
+    };
   };
+
   udev = systemd; # TODO: move to aliases.nix
 
   systemd-wait = callPackage ../os-specific/linux/systemd-wait { };


### PR DESCRIPTION
###### Motivation for this change
This bumps systemd to its latest version, containing many fixes. See https://github.com/systemd/systemd/blob/v246/NEWS for release notes.

This is still WIP - `libsystemd.so.0.29.0` from the `lib` output refers back to the `out` output, causing a cyclic dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
