### PR TITLE
systemd: disable remote support

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, pkgconfig, intltool, gperf, libcap
 , curl, kmod, gnupg, gnutar, xz, pam, acl, libuuid, m4, utillinux, libffi
 , glib, kbd, libxslt, coreutils, libgcrypt, libgpgerror, libidn2, libapparmor
-, audit, lz4, bzip2, libmicrohttpd, pcre2
+, audit, lz4, bzip2, pcre2
 , linuxHeaders ? stdenv.cc.libc.linuxHeaders
 , iptables, gnu-efi, bashInteractive
 , gettext, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_45
@@ -90,7 +90,7 @@ in stdenv.mkDerivation {
   buildInputs =
     [ linuxHeaders libcap curl.dev kmod xz pam acl
       /* cryptsetup */ libuuid glib libgcrypt libgpgerror libidn2
-      libmicrohttpd pcre2 ] ++
+      pcre2 ] ++
       stdenv.lib.optional withKexectools kexectools ++
       stdenv.lib.optional withLibseccomp libseccomp ++
     [ libffi audit lz4 bzip2 libapparmor
@@ -120,6 +120,7 @@ in stdenv.mkDerivation {
     "-Dhostnamed=true"
     "-Dnetworkd=true"
     "-Dportabled=false"
+    "-Dremote=false"
     "-Dsysusers=false"
     "-Dtimedated=true"
     "-Dtimesyncd=true"


### PR DESCRIPTION
This disabled systemd-journal-upload and systemd-journal-remote.

We didn't install the unit files anyways, so this was probably not used
at all, and currently fails to build due to libmicrohttpd and systemd
code being incompatible:

```
../src/journal-remote/journal-remote-main.c: In function ‘setup_microhttpd_server’:
../src/journal-remote/journal-remote-main.c:431:38: error: passing argument 5 of ‘MHD_start_daemon’ from incompatible pointer type [-Werror=incompatible-pointer-types]
```

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/94296#issuecomment-667077848

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
