### PR TITLE
pythonPackages.qds_sdk: 1.12.0 -> 1.15.2

### DIFF
--- a/pkgs/development/python-modules/qds_sdk/default.nix
+++ b/pkgs/development/python-modules/qds_sdk/default.nix
@@ -11,29 +11,29 @@
 
 buildPythonPackage rec {
   pname = "qds_sdk";
-  version = "1.12.0";
+  version = "1.15.2";
 
   # pypi does not contain tests, using github sources instead
   src = fetchFromGitHub {
     owner = "qubole";
     repo = "qds-sdk-py";
     rev = "V${version}";
-    sha256 = "18xhvlcfki8llv7fw2r5yfk20zds3gr78b4klwm9mkvhlhwds9rx";
+    sha256 = "0xxg9s0y6fz7vb1kab4q93q7ryi71z8x6q9qspm6s506yr3mc67l";
   };
 
-  propagatedBuildInputs = [ 
+  propagatedBuildInputs = [
     boto
     inflection
     requests
-    six 
-    urllib3 
+    six
+    urllib3
   ];
 
   checkInputs = [ pytest mock ];
   checkPhase = ''
     py.test --disable-pytest-warnings tests
   '';
- 
+
   meta = with lib; {
     description = "A Python module that provides the tools you need to authenticate with, and use the Qubole Data Service API";
     homepage = "https://github.com/qubole/qds-sdk-py";


### PR DESCRIPTION
##### Motivation for this change

Add version `1.15.2` of `qds_sdk` to Nix OSS.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
