### PR TITLE
cargo-deny: 0.7.0 -> 0.8.5

### DIFF
--- a/pkgs/development/tools/rust/cargo-deny/default.nix
+++ b/pkgs/development/tools/rust/cargo-deny/default.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-deny";
-  version = "0.7.0";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "EmbarkStudios";
     repo = pname;
     rev = version;
-    sha256 = "0mfccjcll7dxrhdi2bhfbggmkqdp8cmq5vf8vbb05qzpvlswvkf7";
+    sha256 = "01z3v1p8wv3h5x8mvwmfxwqii0kal9wsl0z8zkl5p803ffvv2r7c";
   };
 
-  cargoSha256 = "1gp5m432273mr0zwq1kdswdjgp0kajr0imymqyc4yj9i931by1xv";
+  cargoSha256 = "10q3w3pn7qmq7xk4mx1b9f9y7485icpz7m6gg5rplzpdjg38ill5";
 
   nativeBuildInputs = [ perl pkgconfig ];
 

--- a/pkgs/development/tools/rust/cargo-deny/default.nix
+++ b/pkgs/development/tools/rust/cargo-deny/default.nix
@@ -18,6 +18,8 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1d5vh6cifkvqxmbgc2z9259q8879fjw016z959hfivv38rragqbr";
 
+  doCheck = false;
+
   nativeBuildInputs = [ perl pkgconfig ];
 
   buildInputs = [ openssl  ]

--- a/pkgs/development/tools/rust/cargo-deny/default.nix
+++ b/pkgs/development/tools/rust/cargo-deny/default.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-deny";
-  version = "0.7.3";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner = "EmbarkStudios";
     repo = pname;
     rev = version;
-    sha256 = "1bvn75rg6b8f6k9379sj4vjz7z6b33zblnx290qsjgw7fhhmx3gz";
+    sha256 = "1qkg689ks4i665vk3qzyab1y955z5fshp2c6f0zjp618g84sd4ki";
   };
 
-  cargoSha256 = "1b1pnk0s99wcpqna2f4vp889crhf3lhmhia85kc25g6g03f86y2x";
+  cargoSha256 = "0nm6xy0nvv2nw6kkdbqq07ix48yd1vvkd06zmffh7gavw40lha9n";
 
   nativeBuildInputs = [ perl pkgconfig ];
 

--- a/pkgs/development/tools/rust/cargo-deny/default.nix
+++ b/pkgs/development/tools/rust/cargo-deny/default.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-deny";
-  version = "0.7.2";
+  version = "0.7.3";
 
   src = fetchFromGitHub {
     owner = "EmbarkStudios";
     repo = pname;
     rev = version;
-    sha256 = "01z3v1p8wv3h5x8mvwmfxwqii0kal9wsl0z8zkl5p803ffvv2r7c";
+    sha256 = "1bvn75rg6b8f6k9379sj4vjz7z6b33zblnx290qsjgw7fhhmx3gz";
   };
 
-  cargoSha256 = "10q3w3pn7qmq7xk4mx1b9f9y7485icpz7m6gg5rplzpdjg38ill5";
+  cargoSha256 = "1b1pnk0s99wcpqna2f4vp889crhf3lhmhia85kc25g6g03f86y2x";
 
   nativeBuildInputs = [ perl pkgconfig ];
 

--- a/pkgs/development/tools/rust/cargo-deny/default.nix
+++ b/pkgs/development/tools/rust/cargo-deny/default.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-deny";
-  version = "0.8.4";
+  version = "0.8.5";
 
   src = fetchFromGitHub {
     owner = "EmbarkStudios";
     repo = pname;
     rev = version;
-    sha256 = "18l3nl7db8s8c5yjr5n63qw49bl4qvbzcx1y3vdawfr5fvxj3535";
+    sha256 = "01czsnhlvs78fpx1kpi75386657jmlrqpsj4474nxmgcs75igncx";
   };
 
-  cargoSha256 = "00hqxr97lpz1999dkhain0np5yn42mqfrp84nasp4vxyvnmqngmx";
+  cargoSha256 = "1d5vh6cifkvqxmbgc2z9259q8879fjw016z959hfivv38rragqbr";
 
   nativeBuildInputs = [ perl pkgconfig ];
 

--- a/pkgs/development/tools/rust/cargo-deny/default.nix
+++ b/pkgs/development/tools/rust/cargo-deny/default.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-deny";
-  version = "0.8.2";
+  version = "0.8.4";
 
   src = fetchFromGitHub {
     owner = "EmbarkStudios";
     repo = pname;
     rev = version;
-    sha256 = "1qkg689ks4i665vk3qzyab1y955z5fshp2c6f0zjp618g84sd4ki";
+    sha256 = "18l3nl7db8s8c5yjr5n63qw49bl4qvbzcx1y3vdawfr5fvxj3535";
   };
 
-  cargoSha256 = "0nm6xy0nvv2nw6kkdbqq07ix48yd1vvkd06zmffh7gavw40lha9n";
+  cargoSha256 = "00hqxr97lpz1999dkhain0np5yn42mqfrp84nasp4vxyvnmqngmx";
 
   nativeBuildInputs = [ perl pkgconfig ];
 


### PR DESCRIPTION
Does not build for me though, tests fail.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
