### PR TITLE
tig: Don't install the broken ZSH completion

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/tig/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/tig/default.nix
@@ -34,12 +34,13 @@ stdenv.mkDerivation rec {
     # fixes tig-completion __git-complete dependency
     sed -i '1s;^;source ${git}/share/bash-completion/completions/git\n;' contrib/tig-completion.bash
 
-    substituteInPlace contrib/tig-completion.zsh \
-      --replace 'e=$(dirname ''${funcsourcetrace[1]%:*})/tig-completion.bash' "e=$out/share/bash-completion/completions/tig"
-
     install -D contrib/tig-completion.bash $out/share/bash-completion/completions/tig
-    install -D contrib/tig-completion.zsh $out/share/zsh/site-functions/_tig
     cp contrib/vim.tigrc $out/etc/
+
+    # Note: Until https://github.com/jonas/tig/issues/940 is resolved it is best
+    # not to install the ZSH completion so that the fallback implemenation from
+    # ZSH can be used (Completion/Unix/Command/_git: "_tig () { _git-log }"):
+    #install -D contrib/tig-completion.zsh $out/share/zsh/site-functions/_tig
 
     wrapProgram $out/bin/tig \
       --prefix PATH ':' "${git}/bin"


### PR DESCRIPTION
There are some Nixpkgs specific issues that we could fix but due to
changes in Git it currently isn't possible to source git-completion.bash
from ZSH (at least not how tig-completion.bash expects it).
Upstream issue: https://github.com/jonas/tig/issues/940

For the meantime it seems best to simply not install it anymore so that
the fallback implementation from ZSH can be used (more inaccurate as the
git-log completion is reused but it is helpful to complete remotes,
branches, tags, etc. and doesn't emit an error to the console).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Without this change (errors and broken output when trying to use the completion):
```console
$ tig orWARNING: this script is deprecated, please see git-completion.zsh
__git_complete: command not found

$ tig __tig_main: command not found
                tig ori__tig_main: command not found
file            tig ori__tig_main: command not found
Sorry, no matchetig ori   
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @bjornfor @domenkozar @qknight @globin