### PR TITLE
nixos/systemd-networkd-vrf: implement working TCP test on a 5.x kernel

### DIFF
--- a/nixos/tests/systemd-networkd-vrf.nix
+++ b/nixos/tests/systemd-networkd-vrf.nix
@@ -194,18 +194,16 @@ in {
         client.succeed("ping -c5 192.168.1.2")
         client.succeed("ping -c5 192.168.2.3")
 
-    # Test whether SSH through a VRF IP is possible.
-    # (Note: this seems to be an issue on Linux 5.x, so I decided to add this to
-    # ensure that we catch this when updating the default kernel).
-    # with subtest("tcp traffic through vrf works"):
-    #     node1.wait_for_open_port(22)
-    #     client.succeed(
-    #         "cat ${snakeOilPrivateKey} > privkey.snakeoil"
-    #     )
-    #     client.succeed("chmod 600 privkey.snakeoil")
-    #     client.succeed(
-    #         "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil root@192.168.1.2 true"
-    #     )
+    # Test whether TCP through a VRF IP is possible.
+    with subtest("tcp traffic through vrf works"):
+        node1.wait_for_open_port(22)
+        client.succeed(
+            "cat ${snakeOilPrivateKey} > privkey.snakeoil"
+        )
+        client.succeed("chmod 600 privkey.snakeoil")
+        client.succeed(
+            "ulimit -l 2048; ip vrf exec vrf1 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil root@192.168.1.2 true"
+        )
 
     # Only configured routes through the VRF from the main routing table should
     # work. Additional IPs are only reachable when binding to the vrf interface.


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

By design, VRFs allow route-leaking for forwarded packages, but not for
local processes using a socket. While it was possible to leak such TCP
traffic through a VRF on a 4.x kernel, this behavior was considered
wrong and got fixed in Linux 5.x[1].

From now on, local unix sockets must run in the VRF itself using
`ip vrf exec`[2] which basically injects a BPF program into the VRF and
drops elevated networking capabilities by default for the specified
command.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=3c82a21f4320c8d54cf6456b27c8d49e5ffb722e
[2] https://man7.org/linux/man-pages/man8/ip-vrf.8.html


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
