### PR TITLE
zfs: backport linux 5.8 compatibility patch to 0.8.4 release

### DIFF
--- a/pkgs/os-specific/linux/zfs/BACKPORT-Linux-5.8-compat-__vmalloc.patch
+++ b/pkgs/os-specific/linux/zfs/BACKPORT-Linux-5.8-compat-__vmalloc.patch
@@ -1,0 +1,154 @@
+From 6cc95288ccea12ad7b67b2b5b3997dfad8e5b5c9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michael=20Niew=C3=B6hner?=
+ <c0d3z3r0@users.noreply.github.com>
+Date: Tue, 9 Jun 2020 01:32:02 +0200
+Subject: [PATCH] BACKPORT: Linux 5.8 compat: __vmalloc()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The `pgprot` argument has been removed from `__vmalloc` in Linux 5.8,
+being `PAGE_KERNEL` always now [1].
+
+Detect this during configure and define a wrapper for older kernels.
+
+[1] https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/mm/vmalloc.c?h=next-20200605&id=88dca4ca5a93d2c09e5bbc6a62fbfc3af83c4fca
+
+Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
+Co-authored-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>
+Co-authored-by: Michael Niewöhner <foss@mniewoehner.de>
+Signed-off-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>
+Signed-off-by: Michael Niewöhner <foss@mniewoehner.de>
+Closes #10422
+---
+ config/kernel-kmem.m4       | 26 ++++++++++++++++++++++++++
+ config/kernel.m4            |  2 ++
+ include/spl/sys/kmem.h      |  9 +++++++++
+ module/spl/spl-kmem-cache.c |  4 ++--
+ module/spl/spl-kmem.c       |  9 ++++-----
+ 5 files changed, 43 insertions(+), 7 deletions(-)
+
+diff --git a/config/kernel-kmem.m4 b/config/kernel-kmem.m4
+index cc055e530..f1c0d2412 100644
+--- a/config/kernel-kmem.m4
++++ b/config/kernel-kmem.m4
+@@ -56,3 +56,29 @@ AC_DEFUN([SPL_AC_DEBUG_KMEM_TRACKING], [
+ 	AC_MSG_CHECKING([whether detailed kmem tracking is enabled])
+ 	AC_MSG_RESULT([$enable_debug_kmem_tracking])
+ ])
++
++dnl #
++dnl # 5.8 API,
++dnl # __vmalloc PAGE_KERNEL removal
++dnl #
++AC_DEFUN([ZFS_AC_KERNEL_SRC_VMALLOC_PAGE_KERNEL], [
++	ZFS_LINUX_TEST_SRC([__vmalloc], [
++		#include <linux/mm.h>
++		#include <linux/vmalloc.h>
++	],[
++		void *p __attribute__ ((unused));
++
++		p = __vmalloc(0, GFP_KERNEL, PAGE_KERNEL);
++	])
++])
++
++AC_DEFUN([ZFS_AC_KERNEL_VMALLOC_PAGE_KERNEL], [
++	AC_MSG_CHECKING([whether __vmalloc(ptr, flags, pageflags) is available])
++	ZFS_LINUX_TEST_RESULT([__vmalloc], [
++		AC_MSG_RESULT(yes)
++		AC_DEFINE(HAVE_VMALLOC_PAGE_KERNEL, 1, [__vmalloc page flags exists])
++	],[
++		AC_MSG_RESULT(no)
++	])
++])
++-
+diff --git a/config/kernel.m4 b/config/kernel.m4
+index b67fcef8c..23edfdcd8 100644
+--- a/config/kernel.m4
++++ b/config/kernel.m4
+@@ -45,6 +45,7 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_SRC], [
+ 	ZFS_AC_KERNEL_SRC_SCHED
+ 	ZFS_AC_KERNEL_SRC_USLEEP_RANGE
+ 	ZFS_AC_KERNEL_SRC_KMEM_CACHE
++	ZFS_AC_KERNEL_SRC_VMALLOC_PAGE_KERNEL
+ 	ZFS_AC_KERNEL_SRC_WAIT
+ 	ZFS_AC_KERNEL_SRC_INODE_TIMES
+ 	ZFS_AC_KERNEL_SRC_INODE_LOCK
+@@ -163,6 +164,7 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_RESULT], [
+ 	ZFS_AC_KERNEL_SCHED
+ 	ZFS_AC_KERNEL_USLEEP_RANGE
+ 	ZFS_AC_KERNEL_KMEM_CACHE
++	ZFS_AC_KERNEL_VMALLOC_PAGE_KERNEL
+ 	ZFS_AC_KERNEL_WAIT
+ 	ZFS_AC_KERNEL_INODE_TIMES
+ 	ZFS_AC_KERNEL_INODE_LOCK
+diff --git a/include/spl/sys/kmem.h b/include/spl/sys/kmem.h
+index 72d3a7765..ca15bfe7f 100644
+--- a/include/spl/sys/kmem.h
++++ b/include/spl/sys/kmem.h
+@@ -169,6 +169,15 @@ extern void *spl_kmem_alloc(size_t sz, int fl, const char *func, int line);
+ extern void *spl_kmem_zalloc(size_t sz, int fl, const char *func, int line);
+ extern void spl_kmem_free(const void *ptr, size_t sz);
+ 
++/*
++ * 5.8 API change, pgprot_t argument removed.
++ */
++#ifdef HAVE_VMALLOC_PAGE_KERNEL
++#define	spl_vmalloc(size, flags)	__vmalloc(size, flags, PAGE_KERNEL)
++#else
++#define	spl_vmalloc(size, flags)	__vmalloc(size, flags)
++#endif
++
+ /*
+  * The following functions are only available for internal use.
+  */
+diff --git a/module/spl/spl-kmem-cache.c b/module/spl/spl-kmem-cache.c
+index d71b4b348..4866b2993 100644
+--- a/module/spl/spl-kmem-cache.c
++++ b/module/spl/spl-kmem-cache.c
+@@ -203,7 +203,7 @@ kv_alloc(spl_kmem_cache_t *skc, int size, int flags)
+ 		ASSERT(ISP2(size));
+ 		ptr = (void *)__get_free_pages(lflags, get_order(size));
+ 	} else {
+-		ptr = __vmalloc(size, lflags | __GFP_HIGHMEM, PAGE_KERNEL);
++		ptr = spl_vmalloc(size, lflags | __GFP_HIGHMEM);
+ 	}
+ 
+ 	/* Resulting allocated memory will be page aligned */
+@@ -1242,7 +1242,7 @@ spl_cache_grow(spl_kmem_cache_t *skc, int flags, void **obj)
+ 	 * allocation.
+ 	 *
+ 	 * However, this can't be applied to KVM_VMEM due to a bug that
+-	 * __vmalloc() doesn't honor gfp flags in page table allocation.
++	 * spl_vmalloc() doesn't honor gfp flags in page table allocation.
+ 	 */
+ 	if (!(skc->skc_flags & KMC_VMEM)) {
+ 		rc = __spl_cache_grow(skc, flags | KM_NOSLEEP);
+diff --git a/module/spl/spl-kmem.c b/module/spl/spl-kmem.c
+index cee69ad43..ca1fc145f 100644
+--- a/module/spl/spl-kmem.c
++++ b/module/spl/spl-kmem.c
+@@ -172,16 +172,15 @@ spl_kmem_alloc_impl(size_t size, int flags, int node)
+ 		 * kmem_zalloc() callers.
+ 		 *
+ 		 * For vmem_alloc() and vmem_zalloc() callers it is permissible
+-		 * to use __vmalloc().  However, in general use of __vmalloc()
+-		 * is strongly discouraged because a global lock must be
+-		 * acquired.  Contention on this lock can significantly
++		 * to use spl_vmalloc().  However, in general use of
++		 * spl_vmalloc() is strongly discouraged because a global lock
++		 * must be acquired.  Contention on this lock can significantly
+ 		 * impact performance so frequently manipulating the virtual
+ 		 * address space is strongly discouraged.
+ 		 */
+ 		if ((size > spl_kmem_alloc_max) || use_vmem) {
+ 			if (flags & KM_VMEM) {
+-				ptr = __vmalloc(size, lflags | __GFP_HIGHMEM,
+-				    PAGE_KERNEL);
++				ptr = spl_vmalloc(size, lflags | __GFP_HIGHMEM);
+ 			} else {
+ 				return (NULL);
+ 			}
+-- 
+2.25.1
+

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -42,7 +42,7 @@ let
         inherit rev sha256;
       };
 
-      patches = [ ] ++ extraPatches;
+      patches = [ ./BACKPORT-Linux-5.8-compat-__vmalloc.patch ] ++ extraPatches;
 
       postPatch = optionalString buildKernel ''
         patchShebangs scripts


### PR DESCRIPTION
Adding this patch makes zfs compile against 5.8-rc7 kernels.

Upstream PR (merged): https://github.com/openzfs/zfs/pull/10422
Modifications:
- spl_kvmalloc does not exists in zfs 0.8.4 - related code was dropped.

###### Motivation for this change

I am trying to build a 5.8 kernel and zfs did not build.
There is an upstream PR that added a thin define around `__vmalloc` to support both the old and new interface.

This will probably turn into an issue once 5.8 is released and promoted from `linuxPackages_testing`.

###### Things done

I have build a small nixos iso image with this nixpkgs version and successfully created a zfs backed mount with the updated kernel package (kernel 5.4.54).

I have then switched the kernel to the `linuxPackages_testing` and created a new zfs volume (kernel 5.8-rc7).

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
