### PR TITLE
openjump: 1.3.1 -> 1.15

### DIFF
--- a/pkgs/applications/misc/openjump/default.nix
+++ b/pkgs/applications/misc/openjump/default.nix
@@ -1,33 +1,33 @@
-{ stdenv, fetchurl, unzip, runtimeShell }:
+{ stdenv, fetchurl, unzip, makeWrapper
+, coreutils, gawk, which, gnugrep, findutils
+, jdk
+}:
 
 stdenv.mkDerivation {
-  name = "openjump-1.3.1";
+  pname = "openjump";
+  version = "1.15";
 
   src = fetchurl {
-    url = "mirror://sourceforge/jump-pilot/OpenJUMP/1.3.1/openjump-1.3.1.zip";
-    sha256 = "0y4z53yx0x7rp3c8rnj028ni3gr47r35apgcpqp3jl7r2di6zgqm";
+    url = "mirror://sourceforge/jump-pilot/OpenJUMP/1.15/OpenJUMP-Portable-1.15-r6241-CORE.zip";
+    sha256 = "12snzkv83w6khcdqzp6xahqapwp82af6c7j2q8n0lj62hk79rfgl";
   };
 
-  # ln jump.log hack: a different user will probably get a permission denied
-  # error. Still this is better than getting it always.
-  # TODO: build from source and patch this
+  # TODO: build from source
   unpackPhase = ''
     mkdir -p $out/bin;
     cd $out; unzip $src
-    s=$out/bin/OpenJump
-    dir=$(echo $out/openjump-*)
-    cat >> $s << EOF
-    #!${runtimeShell}
-    cd $dir/bin
-    exec ${stdenv.shell} openjump.sh
-    EOF
-    chmod +x $s
-    ln -s /tmp/openjump.log $dir/bin/jump.log
   '';
 
-  installPhase = ":";
+  buildInputs = [unzip makeWrapper];
 
-  buildInputs = [unzip];
+  installPhase = ''
+    dir=$(echo $out/OpenJUMP-*)
+
+    chmod +x $dir/bin/oj_linux.sh
+    makeWrapper $dir/bin/oj_linux.sh $out/bin/OpenJump \
+      --set JAVA_HOME ${jdk.home} \
+      --set PATH "${coreutils}/bin:${gawk}/bin:${which}/bin:${gnugrep}/bin:${findutils}/bin"
+  '';
 
   meta = {
     description = "Open source Geographic Information System (GIS) written in the Java programming language";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I was trying to fix #38452 but ended up updating the version at the same time because it was very old at this point.
@das-g, I don't use this software myself so I can't very well test if everything works. I just know the basics work like drawing the UI. Would you be so friendly as to test whether this solves your problems and doesn't create new ones?

Also for any reviewer: I am very uncertain about how to package shell scripts so some feedback and suggestions when I'm doing it wrong would be much appreciated! It does work though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
