### PR TITLE
parity: 3.0.0 -> 3.0.1 and rename it to openethereum

### DIFF
--- a/pkgs/applications/blockchains/openethereum/default.nix
+++ b/pkgs/applications/blockchains/openethereum/default.nix
@@ -9,17 +9,21 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "parity";
-  version = "3.0.0";
+  pname = "openethereum";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
-    owner = "paritytech";
-    repo = "parity-ethereum";
+    owner = "openethereum";
+    repo = "openethereum";
     rev = "v${version}";
-    sha256 = "124km8c2d7877yzd885wzlcl3gky15isx0z2l1qg1q3cqdsb5mjf";
+    sha256 = "08dkcrga1x18csh6pw6f54x5xwijppyjhg46cf4p452xc1l3a6ir";
   };
 
-  cargoSha256 = "0m4pms7agfyqk6gz6fwxdl8jmcyhphhzh3x4vykbi6186y7a8ihq";
+  cargoSha256 = "1xliragihwjfc5qmfm0ng519bw8a28m1w1yqcl9mpk8zywiybaah";
+
+  verifyCargoDeps = true;
+
+  cargoPatches = [ ./lock.patch ];
 
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
   nativeBuildInputs = [
@@ -38,7 +42,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Fast, light, robust Ethereum implementation";
-    homepage = "http://parity.io";
+    homepage = "http://parity.io/ethereum";
     license = licenses.gpl3;
     maintainers = with maintainers; [ akru xrelkd ];
     platforms = platforms.linux;

--- a/pkgs/applications/blockchains/openethereum/lock.patch
+++ b/pkgs/applications/blockchains/openethereum/lock.patch
@@ -1,0 +1,20 @@
+--- /nix/store/hv764a65zmfzw5scjhz5839agv10da6x-source/Cargo.lock	1969-12-31 16:00:01.000000000 -0800
++++ ./Cargo.lock	2020-07-31 21:30:31.146750066 -0700
+@@ -3113,7 +3113,7 @@
+ 
+ [[package]]
+ name = "openethereum"
+-version = "3.0.0"
++version = "3.0.1"
+ dependencies = [
+  "ansi_term",
+  "atty",
+@@ -3562,7 +3562,7 @@
+ 
+ [[package]]
+ name = "parity-version"
+-version = "3.0.0"
++version = "3.0.1"
+ dependencies = [
+  "parity-bytes",
+  "rlp",

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -335,6 +335,7 @@ mapAliases ({
   otter-browser = throw "otter-browser has been removed from nixpkgs, as it was unmaintained"; # added 2020-02-02
   owncloudclient = owncloud-client;  # added 2016-08
   p11_kit = p11-kit; # added 2018-02-25
+  parity = openethereum; # added 2020-08-01
   parquet-cpp = arrow-cpp; # added 2018-09-08
   pass-otp = pass.withExtensions (ext: [ext.pass-otp]); # added 2018-05-04
   perlXMLParser = perlPackages.XMLParser; # added 2018-10-12

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23886,7 +23886,7 @@ in
 
   zcash = callPackage ../applications/blockchains/zcash { };
 
-  parity = callPackage ../applications/blockchains/parity { };
+  openethereum = callPackage ../applications/blockchains/openethereum { };
 
   parity-ui = callPackage ../applications/blockchains/parity-ui { };
 


### PR DESCRIPTION
###### Motivation for this change
They've renamed the project to OpenEthereum, and released a new minor version.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
