### PR TITLE
sd-mux-ctrl: init at 2020-02-17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7180,6 +7180,12 @@
     githubId = 1153271;
     name = "Sander van der Burg";
   };
+  sarcasticadmin = {
+    email = "rob@sarcasticadmin.com";
+    github = "sarcasticadmin";
+    githubId = 30531572;
+    name = "Robert James Hernandez";
+  };
   sargon = {
     email = "danielehlers@mindeye.net";
     github = "sargon";

--- a/pkgs/tools/misc/sd-mux-ctrl/default.nix
+++ b/pkgs/tools/misc/sd-mux-ctrl/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchgit, cmake, pkgconfig, libftdi1, popt}:
+
+stdenv.mkDerivation rec {
+  pname = "sd-mux-ctrl-unstable";
+  version = "2020-02-17";
+
+  src = fetchgit {
+    url = "https://git.tizen.org/cgit/tools/testlab/sd-mux";
+    rev = "9dd189d973da64e033a0c5c2adb3d94b23153d94";
+    sha256 = "0fxl8m1zkkyxkc2zi8930m0njfgnd04a22acny6vljnzag2shjvg";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ libftdi1 popt ];
+
+  postInstall = ''
+    install -D -m 644 ../doc/man/sd-mux-ctrl.1 $out/share/man/man1/sd-mux-ctrl.1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tool for controlling multiple sd-mux devices";
+    homepage = "https://wiki.tizen.org/SD_MUX";
+    license = licenses.asl20;
+    maintainers =  with maintainers; [ sarcasticadmin ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6646,6 +6646,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  sd-mux-ctrl = callPackage ../tools/misc/sd-mux-ctrl { };
+
   sd-switch = callPackage ../os-specific/linux/sd-switch { };
 
   sdate = callPackage ../tools/misc/sdate { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This adds [sd-mux-ctrl](https://wiki.tizen.org/SD_MUX#Software) which is a tool for controlling multiple [sd-mux devices](https://wiki.tizen.org/SD_MUX) for automated testing of single board computers: https://wiki.tizen.org/Laboratory

I figured this might be useful to others who are working on single-board computers (for example nixos: https://nixos.wiki/wiki/NixOS_on_ARM/Raspberry_Pi) and require automated testing around these systems. 

I have been using `sd-mux-ctrl` with [SDWire](https://wiki.tizen.org/SDWire) hardware. This board is based on [sd-mux devices](https://wiki.tizen.org/SD_MUX) minus any power switch or USB switching. Essentially it enables you to flash the sdcard without having to take the card out of the board. The workflow ends up being something along the lines of:

```
sudo sd-mux-ctrl --device-serial=odroid_u3_1 --ts
... - do the flashing things (dd)
sudo sd-mux-ctrl --device-serial=odroid_u3_1 --dut
```
> ts = test server (i.e. laptop, workstation)
> dut = device under test (i.e. rpi, Odroid, etc.)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
