### PR TITLE
nixos/sshd: change authorizedKeysFiles

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -232,9 +232,12 @@ in
         '';
       };
 
+      # These values are merged with the ones defined externally, see:
+      # https://github.com/NixOS/nixpkgs/pull/10155
+      # https://github.com/NixOS/nixpkgs/pull/41745
       authorizedKeysFiles = mkOption {
         type = types.listOf types.str;
-        default = [];
+        default = [ ".ssh/authorized_keys" ".ssh/authorized_keys2" "/etc/ssh/authorized_keys.d/%u" ];
         description = "Files from which authorized keys are read.";
       };
 
@@ -463,12 +466,6 @@ in
         showMotd = true;
         unixAuth = cfg.passwordAuthentication;
       };
-
-    # These values are merged with the ones defined externally, see:
-    # https://github.com/NixOS/nixpkgs/pull/10155
-    # https://github.com/NixOS/nixpkgs/pull/41745
-    services.openssh.authorizedKeysFiles =
-      [ ".ssh/authorized_keys" ".ssh/authorized_keys2" "/etc/ssh/authorized_keys.d/%u" ];
 
     services.openssh.extraConfig = mkOrder 0
       ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This update need to correct work this configuration:

`default/services/sshd.nix`
```
{ lib, ... }:
{
  services.openssh = with lib; {
...
    authorizedKeysFiles = [
      "/etc/ssh/authorized_keys.d/%u"
    ];
...
```

`servers/vm-test/services/sshd.nix`
```
    services.openssh = {
      authorizedKeysFiles = [ /var/lib/gitea/.ssh/authorized_keys" ];
    };
```


Result before update:
```
AuthorizedKeysFile /etc/ssh/authorized_keys.d/%u .ssh/authorized_keys .ssh/authorized_keys2 /etc/ssh/authorized_keys.d/%u /var/data/gitea/.ssh/authorized_keys
```
Result after update:
```
AuthorizedKeysFile /etc/ssh/authorized_keys.d/%u /var/data/gitea/.ssh/authorized_keys
```

cc @Ma27 @aanderse @fpletz

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
