### PR TITLE
ocamlPackages.lua-ml: 0.9 → 0.9.1

### DIFF
--- a/pkgs/development/ocaml-modules/lua-ml/default.nix
+++ b/pkgs/development/ocaml-modules/lua-ml/default.nix
@@ -7,13 +7,13 @@ else
 stdenv.mkDerivation rec {
   pname = "lua-ml";
   name = "ocaml${ocaml.version}-${pname}-${version}";
-  version = "0.9";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "lindig";
     repo = pname;
     rev = "${version}";
-    sha256 = "09lj6qykg15fdf65in7xdry0jcifcr8vqbvz85v12gwfckmmxjir";
+    sha256 = "04lv98nxmzanvyn4c0k6k0ax29f5xfdl8qzpf5hwadslq213a044";
   };
 
   buildInputs = [ ocaml findlib ocamlbuild ];


### PR DESCRIPTION
###### Motivation for this change

New release: https://github.com/lindig/lua-ml/releases/tag/0.9.1

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
