### PR TITLE
restinio: init at 0.6.8.1

### DIFF
--- a/pkgs/development/libraries/restinio/default.nix
+++ b/pkgs/development/libraries/restinio/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, fetchurl
+# native
+, cmake
+, pkg-config
+# not native
+, asio
+, openssl
+, pcre2
+, zlib
+, catch2
+, http-parser
+}:
+
+stdenv.mkDerivation rec {
+  pname = "restinio";
+  version = "0.6.8.1";
+
+  # Ideally we would have used the git clone, but it's impossible to use it
+  # without failing build. See https://github.com/Stiffstream/restinio/pull/6
+  src = fetchurl {
+    url = "https://github.com/Stiffstream/restinio/releases/download/v.${version}/${pname}-${version}-full.tar.bz2";
+    sha256 = "0vy91njksyyhp00vx5q5xw4wi4xkbg10dky2a0zn3d2knvv63ixx";
+  };
+  patches = [
+    ./remove-failing-tests.patch
+  ];
+  preConfigure = ''
+    cd dev
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  buildInputs = [
+    asio
+    openssl
+    pcre2
+    zlib
+    catch2
+    http-parser
+  ];
+
+  cmakeFlags = [
+    "-DRESTINIO_USE_EXTERNAL_HTTP_PARSER=ON"
+    # Build and run tests but don't build or install samples and benchmarks
+    "-DRESTINIO_TEST=ON"
+    "-DRESTINIO_SAMPLE=OFF"
+    "-DRESTINIO_INSTALL_SAMPLES=OFF"
+    "-DRESTINIO_BENCH=OFF"
+    "-DRESTINIO_INSTALL_BENCHES=OFF"
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Cross-platform, efficient, customizable, and robust asynchronous HTTP/WebSocket server C++14 library";
+    homepage = "https://github.com/Stiffstream/restinio";
+    license = licenses.free; # See https://github.com/Stiffstream/restinio/blob/master/LICENSE
+    # see:
+    # https://github.com/NixOS/nixpkgs/pull/94460/checks?check_run_id=937777778
+    # and: https://github.com/Stiffstream/restinio/pull/6
+    broken = stdenv.isDarwin;
+    maintainers = [ maintainers.doronbehar ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/restinio/remove-failing-tests.patch
+++ b/pkgs/development/libraries/restinio/remove-failing-tests.patch
@@ -1,0 +1,28 @@
+diff --git i/dev/test/CMakeLists.txt w/dev/test/CMakeLists.txt
+index bc5a152..0a75137 100644
+--- i/dev/test/CMakeLists.txt
++++ w/dev/test/CMakeLists.txt
+@@ -13,23 +13,13 @@ add_subdirectory(buffers)
+ add_subdirectory(response_coordinator)
+ add_subdirectory(write_group_output_ctx)
+ add_subdirectory(uri_helpers)
+-add_subdirectory(socket_options)
+ add_subdirectory(start_stop)
+-add_subdirectory(handle_requests)
+-add_subdirectory(run_on_thread_pool)
+-add_subdirectory(http_pipelining)
+-add_subdirectory(sendfile)
+ add_subdirectory(router)
+-add_subdirectory(transforms/zlib)
+-add_subdirectory(transforms/zlib_body_appender)
+-add_subdirectory(transforms/zlib_body_handler)
+ add_subdirectory(encoders)
+ add_subdirectory(from_string)
+-add_subdirectory(websocket)
+ add_subdirectory(file_upload)
+ add_subdirectory(basic_auth)
+ add_subdirectory(bearer_auth)
+ 
+ if ( OPENSSL_FOUND )
+-	add_subdirectory(socket_options_tls)
+ endif ()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16555,6 +16555,8 @@ in
 
   restic-rest-server = callPackage ../tools/backup/restic/rest-server.nix { };
 
+  restinio = callPackage ../development/libraries/restinio { };
+
   restya-board = callPackage ../servers/web-apps/restya-board { };
 
   rethinkdb = callPackage ../servers/nosql/rethinkdb {


### PR DESCRIPTION
##### Motivation for this change

In my quest to package [Jami](https://jami.net/), also requested at #83411 I learned that this is a dependency of several components of the project.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
