### PR TITLE
mfcj835dwlpr: init at 3.0.1-1, mfcj835dw-cupswrapper: init at 3.0.0-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9031,11 +9031,11 @@
     githubId = 1319905;
     name = "Uma Zalakain";
   };
-  zandroidius = {
-    email = "abodoh.github@gmail.com";
-    github = "zandroidius";
+  alexander-c-b = {
+    email = "alexander.c.bodoh@gmail.com";
+    github = "alexander-c-b";
     githubId = 64812209;
-    name = "Alexander Bodoh";
+    name = "Alexander C. Bodoh";
   };
   zaninime = {
     email = "francesco@zanini.me";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9034,6 +9034,7 @@
   zandroidius = {
     email = "abodoh.github@gmail.com";
     github = "zandroidius";
+    githubId = 64812209;
     name = "Alexander Bodoh";
   };
   zaninime = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9031,6 +9031,11 @@
     githubId = 1319905;
     name = "Uma Zalakain";
   };
+  zandroidius = {
+    email = "abodoh.github@gmail.com";
+    github = "zandroidius";
+    name = "Alexander Bodoh";
+  };
   zaninime = {
     email = "francesco@zanini.me";
     github = "zaninime";

--- a/pkgs/misc/cups/drivers/mfcj835dwcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj835dwcupswrapper/default.nix
@@ -60,6 +60,6 @@ stdenv.mkDerivation rec {
     license = with licenses; gpl2;
     platforms = with platforms; linux;
     downloadPage = https://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=mfcj835dw_us&os=128;
-    maintainers = with maintainers; [ zandroidius ];
+    maintainers = with maintainers; [ alexander-c-b ];
   };
 }

--- a/pkgs/misc/cups/drivers/mfcj835dwcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj835dwcupswrapper/default.nix
@@ -1,0 +1,65 @@
+{ stdenv, fetchurl, mfcj835dwlpr, makeWrapper}:
+
+stdenv.mkDerivation rec {
+  pname = "mfcj835dw-cupswrapper";
+  version = "3.0.0-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf006818/mfcj835dwcupswrapper-src-${version}.tar.gz";
+    sha256 = "0gwpp46cvlq11lcszxqv6qvyjrrbp2hxdq34nb25gs8dnb21zic2";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ mfcj835dwlpr ];
+
+  buildPhase = ''
+    cd brcupsconfig
+    make all
+    cd ..
+    '';
+
+  installPhase = ''
+    TARGETFOLDER=$out/opt/brother/Printers/mfcj835dw/cupswrapper
+    mkdir -p $TARGETFOLDER
+    cp ppd/brother_mfcj835dw_printer_en.ppd $TARGETFOLDER
+    cp brcupsconfig/brcupsconfpt1 $TARGETFOLDER
+    cp cupswrapper/cupswrappermfcj835dw $TARGETFOLDER
+    sed -i -e '26,304d' $TARGETFOLDER/cupswrappermfcj835dw
+    substituteInPlace $TARGETFOLDER/cupswrappermfcj835dw \
+      --replace "\$ppd_file_name" "$TARGETFOLDER/brother_mfcj835dw_printer_en.ppd"
+
+    CPUSFILTERFOLDER=$out/lib/cups/filter
+    mkdir -p $TARGETFOLDER $CPUSFILTERFOLDER
+    ln -s ${mfcj835dwlpr}/lib/cups/filter/brother_lpdwrapper_mfcj835dw $out/lib/cups/filter/brother_lpdwrapper_mfcj835dw
+    ##TODO: Use the cups filter instead of the LPR one.
+    #cp scripts/cupswrappermfcj835dw $CPUSFILTERFOLDER/brother_lpdwrapper_mfcj835dw
+    #sed -i -e '110,258!d' $CPUSFILTERFOLDER/brother_lpdwrapper_mfcj835dw
+    #sed -i -e '33,40d' $CPUSFILTERFOLDER/brother_lpdwrapper_mfcj835dw
+    #sed -i -e '34,35d' $CPUSFILTERFOLDER/brother_lpdwrapper_mfcj835dw
+    #substituteInPlace $CPUSFILTERFOLDER/brother_lpdwrapper_mfcj835dw \
+    #  --replace "/opt/brother/$``{device_model``}/$``{printer_model``}/lpd/filter$``{printer_model``}" \
+    #    "${mfcj835dwlpr}/opt/brother/Printers/mfcj835dw/lpd/filtermfcj835dw" \
+    #  --replace "/opt/brother/Printers/$``{printer_model``}/inf/br$``{printer_model``}rc" \
+    #    "${mfcj835dwlpr}/opt/brother/Printers/mfcj835dw/inf/brmfcj835dwrc" \
+    #  --replace "/opt/brother/$``{device_model``}/$``{printer_model``}/cupswrapper/brcupsconfpt1" \
+    #    "$out/opt/brother/Printers/mfcj835dw/cupswrapper/brcupsconfpt1" \
+    #  --replace "/usr/share/cups/model/Brother/brother_" "$out/opt/brother/Printers/mfcj835dw/cupswrapper/brother_"
+    #substituteInPlace $CPUSFILTERFOLDER/brother_lpdwrapper_mfcj835dw \
+    #  --replace "$``{printer_model``}" "mfcj835dw" \
+    #  --replace "$``{printer_name``}" "MFCJ835DW"
+    '';
+
+  cleanPhase = ''
+    cd brcupsconfpt1
+    make clean
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.brother.com/;
+    description = "Brother MFC-J835DW CUPS wrapper driver";
+    license = with licenses; gpl2;
+    platforms = with platforms; linux;
+    downloadPage = https://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=mfcj835dw_us&os=128;
+    maintainers = with maintainers; [ zandroidius ];
+  };
+}

--- a/pkgs/misc/cups/drivers/mfcj835dwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj835dwlpr/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     downloadPage = https://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=mfcj835dw_us&os=128;
     homepage     = http://www.brother.com/;
     license      = with licenses; unfree;
-    maintainers  = with maintainers; [ zandroidius ];
+    maintainers  = with maintainers; [ alexander-c-b ];
     platforms    = with platforms; linux;
   };
 }

--- a/pkgs/misc/cups/drivers/mfcj835dwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj835dwlpr/default.nix
@@ -1,0 +1,89 @@
+{ stdenv, fetchurl, pkgsi686Linux, dpkg, makeWrapper, coreutils, gnused, gawk, file, cups, utillinux, xxd, runtimeShell
+, ghostscript, a2ps }:
+
+# Why:
+# The executable "brprintconf_mfcj835dw" binary is looking for "/opt/brother/Printers/%s/inf/br%sfunc" and "/opt/brother/Printers/%s/inf/br%src".
+# Whereby, %s is printf(3) string substitution for stdin's arg0 (the command's own filename) from the 10th char forwards, as a runtime dependency.
+# e.g. Say the filename is "0123456789ABCDE", the runtime will be looking for /opt/brother/Printers/ABCDE/inf/brABCDEfunc.
+# Presumably, the binary was designed to be deployed under the filename "printconf_mfcj835dw", whereby it will search for "/opt/brother/Printers/mfcj835dw/inf/brmfcj835dwfunc".
+# For NixOS, we want to change the string to the store path of brmfcj835dwfunc and brmfcj835dwrc but we're faced with two complications:
+# 1. Too little room to specify the nix store path. We can't even take advantage of %s by renaming the file to the store path hash since the variable is too short and can't contain the whole hash.
+# 2. The binary needs the directory it's running from to be r/w.
+# What:
+# As such, we strip the path and substitution altogether, leaving only "brmfcj835dwfunc" and "brmfcj835dwrc", while filling the leftovers with nulls.
+# Fully null terminating the cstrings is necessary to keep the array the same size and preventing overflows.
+# We then use a shell script to link and execute the binary, func and rc files in a temporary directory.
+# How:
+# In the package, we dump the raw binary as a string of search-able hex values using hexdump. We execute the substitution with sed. We then convert the hex values back to binary form using xxd.
+# We also write a shell script that invoked "mktemp -d" to produce a r/w temporary directory and link what we need in the temporary directory.
+# Result:
+# The user can run brprintconf_mfcj835dw in the shell.
+
+stdenv.mkDerivation rec {
+  pname = "mfcj835dwlpr";
+  version = "3.0.1-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf006630/mfcj835dwlpr-${version}.i386.deb";
+    sha256 = "1p48blsjihb90wpcl4wag8mggc9r5098cb7g28lkmhaqa0ixgln6";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ cups ghostscript dpkg a2ps ];
+
+  dontUnpack = true;
+
+  brprintconf_mfcj835dw_script = ''
+    #!${runtimeShell}
+    cd $(mktemp -d)
+    ln -s @out@/usr/bin/brprintconf_mfcj835dw_patched brprintconf_mfcj835dw_patched
+    ln -s @out@/opt/brother/Printers/mfcj835dw/inf/brmfcj835dwfunc brmfcj835dwfunc
+    ln -s @out@/opt/brother/Printers/mfcj835dw/inf/brmfcj835dwrc brmfcj835dwrc
+    ./brprintconf_mfcj835dw_patched "$@"
+  '';
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+    substituteInPlace $out/opt/brother/Printers/mfcj835dw/lpd/filtermfcj835dw \
+      --replace /opt "$out/opt"
+    substituteInPlace $out/opt/brother/Printers/mfcj835dw/lpd/psconvertij2 \
+      --replace "GHOST_SCRIPT=`which gs`" "GHOST_SCRIPT=${ghostscript}/bin/gs"
+    substituteInPlace $out/opt/brother/Printers/mfcj835dw/inf/setupPrintcapij \
+      --replace "/opt/brother/Printers" "$out/opt/brother/Printers" \
+      --replace "printcap.local" "printcap"
+
+    patchelf --set-interpreter ${pkgsi686Linux.stdenv.cc.libc.out}/lib/ld-linux.so.2 \
+      --set-rpath $out/opt/brother/Printers/mfcj835dw/inf:$out/opt/brother/Printers/mfcj835dw/lpd \
+      $out/opt/brother/Printers/mfcj835dw/lpd/brmfcj835dwfilter
+    patchelf --set-interpreter ${pkgsi686Linux.stdenv.cc.libc.out}/lib/ld-linux.so.2 $out/usr/bin/brprintconf_mfcj835dw
+
+    #stripping the hardcoded path.
+    ${utillinux}/bin/hexdump -ve '1/1 "%.2X"' $out/usr/bin/brprintconf_mfcj835dw | \
+    sed 's.2F6F70742F62726F746865722F5072696E746572732F25732F696E662F6272257366756E63.62726d66636a36353130647766756e63000000000000000000000000000000000000000000.' | \
+    sed 's.2F6F70742F62726F746865722F5072696E746572732F25732F696E662F627225737263.62726D66636A3635313064777263000000000000000000000000000000000000000000.' | \
+    ${xxd}/bin/xxd -r -p > $out/usr/bin/brprintconf_mfcj835dw_patched
+    chmod +x $out/usr/bin/brprintconf_mfcj835dw_patched
+    #executing from current dir. segfaults if it's not r\w.
+    mkdir -p $out/bin
+    echo -n "$brprintconf_mfcj835dw_script" > $out/bin/brprintconf_mfcj835dw
+    chmod +x $out/bin/brprintconf_mfcj835dw
+    substituteInPlace $out/bin/brprintconf_mfcj835dw --replace @out@ $out
+
+    mkdir -p $out/lib/cups/filter/
+    ln -s $out/opt/brother/Printers/mfcj835dw/lpd/filtermfcj835dw $out/lib/cups/filter/brother_lpdwrapper_mfcj835dw
+
+    wrapProgram $out/opt/brother/Printers/mfcj835dw/lpd/psconvertij2 \
+      --prefix PATH ":" ${ stdenv.lib.makeBinPath [ coreutils gnused gawk ] }
+    wrapProgram $out/opt/brother/Printers/mfcj835dw/lpd/filtermfcj835dw \
+      --prefix PATH ":" ${ stdenv.lib.makeBinPath [ coreutils gnused file ghostscript a2ps ] }
+    '';
+
+  meta = with stdenv.lib; {
+    description  = "Brother MFC-J835DW LPR driver";
+    downloadPage = https://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=mfcj835dw_us&os=128;
+    homepage     = http://www.brother.com/;
+    license      = with licenses; unfree;
+    maintainers  = with maintainers; [ zandroidius ];
+    platforms    = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26620,6 +26620,7 @@ in
   mfcj6510dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj6510dwcupswrapper { };
   mfcj6510dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj6510dwlpr { };
 
+  mfcj835dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj835dwcupswrapper { };
   mfcj835dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj835dwlpr { };
 
   mfcl2700dncupswrapper = callPackage ../misc/cups/drivers/mfcl2700dncupswrapper { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26620,6 +26620,8 @@ in
   mfcj6510dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj6510dwcupswrapper { };
   mfcj6510dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj6510dwlpr { };
 
+  mfcj835dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj835dwlpr { };
+
   mfcl2700dncupswrapper = callPackage ../misc/cups/drivers/mfcl2700dncupswrapper { };
   mfcl2700dnlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcl2700dnlpr { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add the drivers and cups wrappers for the Brother MFCJ835DW printer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
