### PR TITLE
kopia: init at 0.5.2

### DIFF
--- a/pkgs/tools/backup/kopia/default.nix
+++ b/pkgs/tools/backup/kopia/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildGoModule, fetchFromGitHub, coreutils }:
+
+buildGoModule rec {
+  pname = "kopia";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1s74wa2r6nzrbp1f1bcbypwggishwwvpnwnqzs8gncz7dsa44zj4";
+  };
+
+  vendorSha256 = "11az7zgwzbcx4dknwqiwmdbrbkdzhpwzqnyk8vw9mkbda0xaif3k";
+  subPackages = [ "." ];
+
+  postConfigure = ''
+    # make 'vendor' writable
+    cp -L -r vendor tmp-vendor
+    rm -rf vendor
+    mv tmp-vendor vendor
+
+    # speakeasy hardcodes /bin/stty https://github.com/bgentry/speakeasy/issues/22
+    substituteInPlace vendor/github.com/bgentry/speakeasy/speakeasy_unix.go \
+      --replace "/bin/stty" "${coreutils}/bin/stty"
+  '';
+
+  meta = with lib; {
+    homepage = "https://kopia.io";
+    description = "Cross-platform backup tool with fast, incremental backups, client-side end-to-end encryption, compression and data deduplication";
+    platforms = platforms.all;
+    license = licenses.asl20;
+    maintainers = [ maintainers.bbigras ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18462,6 +18462,8 @@ in
 
   kochi-substitute-naga10 = callPackage ../data/fonts/kochi-substitute-naga10 {};
 
+  kopia = callPackage ../tools/backup/kopia { };
+
   lato = callPackage ../data/fonts/lato {};
 
   league-of-moveable-type = callPackage ../data/fonts/league-of-moveable-type {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

I only tested a "filesystem" backup for now.

Thanks to @Infinisil for the help with the "vendor" thing.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
