### PR TITLE
sfrotz: init at 2.52

### DIFF
--- a/pkgs/games/sfrotz/default.nix
+++ b/pkgs/games/sfrotz/default.nix
@@ -1,0 +1,69 @@
+{ fetchFromGitLab
+, freetype
+, libao
+, libjpeg
+, libmodplug
+, libpng
+, libsamplerate
+, libsndfile
+, libvorbis
+, pkg-config
+, SDL2
+, SDL2_mixer
+, stdenv
+, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "sfrotz";
+  version = "2.52";
+
+  src = fetchFromGitLab  {
+    domain = "gitlab.com";
+    owner = "DavidGriffith";
+    repo = "frotz";
+    rev = version;
+    sha256 = "11ca1dz31b7s5vxjqncwjwmbbcr2m5v2rxjn49g4gnvwd6mqw48y";
+  };
+
+  buildInputs = [
+    freetype
+    libao
+    libjpeg
+    libmodplug
+    libpng
+    libsamplerate
+    libsndfile
+    libvorbis
+    SDL2
+    SDL2_mixer
+    zlib
+  ];
+  nativeBuildInputs = [ pkg-config ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  buildPhase = "make sdl";
+  installTargets = [ "install_sfrotz" ];
+
+  meta = with stdenv.lib; {
+    description =
+      "Interpreter for Infocom and other Z-Machine games (SDL interface)";
+    longDescription = ''
+      Frotz is a Z-Machine interpreter. The Z-machine is a virtual machine
+      designed by Infocom to run all of their text adventures. It went through
+      multiple revisions during the lifetime of the company, and two further
+      revisions (V7 and V8) were created by Graham Nelson after the company's
+      demise. The specification is now quite well documented; this version of
+      Frotz supports version 1.0.
+
+      This version of Frotz fully supports all these versions of the Z-Machine
+      including the graphical version 6. Graphics and sound are created through
+      the use of the SDL libraries. AIFF sound effects and music in MOD and OGG
+      formats are supported when packaged in Blorb container files or optionally
+      from individual files.
+    '';
+    homepage = "https://davidgriffith.gitlab.io/frotz/";
+    changelog = "https://gitlab.com/DavidGriffith/frotz/-/raw/${version}/NEWS";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ddelabru ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24597,6 +24597,8 @@ in
 
   service-wrapper = callPackage ../os-specific/linux/service-wrapper { };
 
+  sfrotz = callPackage ../games/sfrotz { };
+
   sgtpuzzles = callPackage (callPackage ../games/sgt-puzzles) { };
 
   shattered-pixel-dungeon = callPackage ../games/shattered-pixel-dungeon { };


### PR DESCRIPTION
sfrotz is an SDL interface version of frotz, the Z-machine interpreter which plays both Infocom games and newer games targeting the Z-machine. Unlike the curses interface version of Frotz, SDL Frotz can handle the graphics in Z-machine version 6 games.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
