### PR TITLE
frotz: 2.44 -> 2.52

### DIFF
--- a/pkgs/games/frotz/default.nix
+++ b/pkgs/games/frotz/default.nix
@@ -1,25 +1,40 @@
-{ stdenv, fetchFromGitHub, ncurses }:
+{ fetchFromGitLab
+, libao
+, libmodplug
+, libsamplerate
+, libsndfile
+, libvorbis
+, ncurses
+, stdenv }:
 
 stdenv.mkDerivation rec {
-  version = "2.44";
+  version = "2.52";
   pname = "frotz";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitLab {
+    domain = "gitlab.com";
     owner = "DavidGriffith";
     repo = "frotz";
     rev = version;
-    sha256 = "0gjkk4gxzqmxfdirrz2lr0bms6l9fc31vkmlywigkbdlh8wxgypp";
+    sha256 = "11ca1dz31b7s5vxjqncwjwmbbcr2m5v2rxjn49g4gnvwd6mqw48y";
   };
 
-  makeFlags = [ "CC=cc" "PREFIX=$(out)" "CURSES=-lncurses" ];
-
-  buildInputs = [ ncurses ];
+  buildInputs = [ libao libmodplug libsamplerate libsndfile libvorbis ncurses ];
+  preBuild = ''
+    makeFlagsArray+=(
+      CC="cc"
+      CFLAGS="-D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600"
+      LDFLAGS="-lncursesw -ltinfo"
+    )
+  '';
+  installFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
-    homepage = "http://frotz.sourceforge.net/";
+    homepage = "https://davidgriffith.gitlab.io/frotz/";
+    changelog = "https://gitlab.com/DavidGriffith/frotz/-/raw/${version}/NEWS";
     description = "A z-machine interpreter for Infocom games and other interactive fiction.";
     platforms = platforms.unix;
-    maintainers = [ maintainers.nicknovitski ];
+    maintainers = with maintainers; [ nicknovitski  ddelabru ];
     license = licenses.gpl2;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

As a bonus, this new derivation also adds unicode support, which the current nixpkgs build lacks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
