### PR TITLE
 opengrm-ngram: init at 1.3.11, phonetisaurus: init at 2020-07-31

### DIFF
--- a/pkgs/development/libraries/opengrm-ngram/default.nix
+++ b/pkgs/development/libraries/opengrm-ngram/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, autoreconfHook, fetchurl, openfst }:
+
+stdenv.mkDerivation rec {
+  pname = "opengrm-ngram";
+  version = "1.3.11";
+
+  src = fetchurl {
+    url = "http://www.openfst.org/twiki/pub/GRM/NGramDownload/ngram-${version}.tar.gz";
+    sha256 = "0wwpcj8qncdr9f2pmi0vhlw277dyxr85ygdi8g57xp2ifysigm05";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ openfst ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Library to make and modify n-gram language models encoded as weighted finite-state transducers";
+    homepage = "http://www.openfst.org/twiki/bin/view/GRM/NGramLibrary";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mic92 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/phonetisaurus/default.nix
+++ b/pkgs/development/libraries/phonetisaurus/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchFromGitHub
+, openfst
+, pkg-config
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "phonetisaurus";
+  version = "2020-07-31";
+
+  src = fetchFromGitHub {
+    owner = "AdolfVonKleist";
+    repo = pname;
+    rev = "2831870697de5b4fbcb56a6e1b975e0e1ea10deb";
+    sha256 = "1b18s5zz0l0fhqh9n9jnmgjz2hzprwzf6hx5a12zibmmam3qyriv";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ python3 openfst ];
+
+  meta = with stdenv.lib; {
+    description = "Framework for Grapheme-to-phoneme models for speech recognition using the OpenFst framework";
+    inherit (src.meta) homepage;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ mic92 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27140,6 +27140,8 @@ in
 
   opengrm-ngram = callPackage ../development/libraries/opengrm-ngram {};
 
+  phonetisaurus = callPackage ../development/libraries/phonetisaurus {};
+
   duti = callPackage ../os-specific/darwin/duti {};
 
   dnstracer = callPackage ../tools/networking/dnstracer {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27138,6 +27138,8 @@ in
 
   openfst = callPackage ../development/libraries/openfst {};
 
+  opengrm-ngram = callPackage ../development/libraries/opengrm-ngram {};
+
   duti = callPackage ../os-specific/darwin/duti {};
 
   dnstracer = callPackage ../tools/networking/dnstracer {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This is a preparation for [rhasspy](https://github.com/rhasspy/rhasspy).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
