### PR TITLE
nixos/wpa_supplicant: add configFile option

### DIFF
--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -243,22 +243,22 @@ in {
       path = [ pkgs.wpa_supplicant ];
 
       script = ''
-        iface_args="-s -u -D${cfg.driver} -c ${cfg.configFile}"
+        iface_args=(-s -u -D${escapeShellArg cfg.driver} -c ${escapeShellArg cfg.configFile})
         ${if ifaces == [] then ''
           for i in $(cd /sys/class/net && echo *); do
             DEVTYPE=
-            UEVENT_PATH=/sys/class/net/$i/uevent
+            UEVENT_PATH="/sys/class/net/$i/uevent"
             if [ -e "$UEVENT_PATH" ]; then
               source "$UEVENT_PATH"
-              if [ "$DEVTYPE" = "wlan" -o -e /sys/class/net/$i/wireless ]; then
-                args+="''${args:+ -N} -i$i $iface_args"
+              if [ "$DEVTYPE" = wlan -o -e "/sys/class/net/$i/wireless" ]; then
+                args+=(''${args:+-N} -i"$i" "''${iface_args[@]}")
               fi
             fi
           done
         '' else ''
-          args="${concatMapStringsSep " -N " (i: "-i${i} $iface_args") ifaces}"
+          args=(${concatMapStringsSep " -N " (i: ''-i${escapeShellArg i} "''${iface_args[@]}"'') ifaces})
         ''}
-        exec wpa_supplicant $args
+        exec wpa_supplicant "''${args[@]}"
       '';
     };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds the `networking.wireless.configFile` option, which allows users to specify the location for a custom `wpa_supplicant.conf` file. Currently, if the module is not configured to generate a config file, the service looks for the config at `/etc/wpa_supplicant.conf`. The `configFile` option allows changing this fallback location.

I also added a commit that hardens the service script against spaces in various variables.

I have tested this PR with and without `network.wireless.interfaces` set.

cc @globin
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
