### PR TITLE
wayland-utils: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8769,6 +8769,12 @@
     githubId = 43315;
     name = "William Roe";
   };
+  wkral = {
+    email = "william.kral@gmail.com";
+    github = "wkral";
+    githubId = 105114;
+    name = "William Kral";
+  };
   wmertens = {
     email = "Wout.Mertens@gmail.com";
     github = "wmertens";

--- a/pkgs/tools/wayland/wayland-utils/default.nix
+++ b/pkgs/tools/wayland/wayland-utils/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchurl, pkg-config, meson, ninja, wayland, wayland-protocols }:
+
+stdenv.mkDerivation rec {
+  pname = "wayland-utils";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "https://wayland.freedesktop.org/releases/${pname}-${version}.tar.xz";
+    sha256 = "1h38l850ww6hxjb1l8iwa33nkbz8q88bw6lh0aryjyp8b16crzk4";
+  };
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
+  buildInputs = [ wayland wayland-protocols ];
+
+  meta = {
+    description = "Display supported protocols by a Wayland compositor";
+    homepage = "https://gitlab.freedesktop.org/wayland/wayland-utils";
+    license = lib.licenses.mit; # Expat version
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ wkral ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15379,6 +15379,8 @@ in
 
   wayland-protocols = callPackage ../development/libraries/wayland/protocols.nix { };
 
+  wayland-utils = callPackage ../tools/wayland/wayland-utils { };
+
   waylandpp = callPackage ../development/libraries/waylandpp { };
 
   wcslib = callPackage ../development/libraries/wcslib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add utility for inspecting current wayland session https://lists.freedesktop.org/archives/wayland-devel/2020-July/041565.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
