### PR TITLE
homeassistant: 0.113.0 -> 0.113.3

### DIFF
--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.113.0";
+  version = "0.113.3";
   components = {
     "abode" = ps: with ps; [ ]; # missing inputs: abodepy
     "acer_projector" = ps: with ps; [ pyserial];
@@ -664,7 +664,7 @@
     "rocketchat" = ps: with ps; [ ]; # missing inputs: rocketchat-API
     "roku" = ps: with ps; [ ]; # missing inputs: rokuecp
     "roomba" = ps: with ps; [ ]; # missing inputs: roombapy
-    "route53" = ps: with ps; [ boto3]; # missing inputs: ipify
+    "route53" = ps: with ps; [ boto3];
     "rova" = ps: with ps; [ ]; # missing inputs: rova
     "rpi_camera" = ps: with ps; [ ];
     "rpi_gpio" = ps: with ps; [ ]; # missing inputs: RPi.GPIO

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -72,7 +72,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.113.0";
+  hassVersion = "0.113.3";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -91,7 +91,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "1yb943wkiawh5p4mj5089qcsjfnwb91ga666qriz32bzpfgrzrna";
+    sha256 = "1lrllhafjawrghdp81lz1ffdqcj2q0x9ndp11nhi8s9fd8bb4c8j";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -82,6 +82,7 @@ in with py.pkgs; buildPythonApplication rec {
 
   patches = [
     ./relax-dependencies.patch
+    ./fix-flapping-chained-task-logging-test.patch
   ];
 
   inherit availableComponents;

--- a/pkgs/servers/home-assistant/fix-flapping-chained-task-logging-test.patch
+++ b/pkgs/servers/home-assistant/fix-flapping-chained-task-logging-test.patch
@@ -1,0 +1,33 @@
+From 1d54dafad9968465d995d195f683d8032a5194d1 Mon Sep 17 00:00:00 2001
+From: "J. Nick Koston" <nick@koston.org>
+Date: Sun, 2 Aug 2020 23:05:53 +0000
+Subject: [PATCH] Fix flapping chained task logging test
+
+Creating 20 tasks was taking less than 0.0001 seconds which caused
+the tests to fail.  Increase the number of test tasks by two orders
+of magnitude.
+---
+ tests/test_core.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/test_core.py b/tests/test_core.py
+index 12ed00fde2c9..167eda3f6cb4 100644
+--- a/tests/test_core.py
++++ b/tests/test_core.py
+@@ -1436,14 +1436,14 @@ async def test_chained_logging_hits_log_timeout(hass, caplog):
+     async def _task_chain_1():
+         nonlocal created
+         created += 1
+-        if created > 10:
++        if created > 1000:
+             return
+         hass.async_create_task(_task_chain_2())
+ 
+     async def _task_chain_2():
+         nonlocal created
+         created += 1
+-        if created > 10:
++        if created > 1000:
+             return
+         hass.async_create_task(_task_chain_1())
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/home-assistant/core/releases/tag/0.113.1
https://github.com/home-assistant/core/releases/tag/0.113.2
https://github.com/home-assistant/core/releases/tag/0.113.3


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@GrahamcOfBorg test home-assistant