### PR TITLE
mopidy-tunein: init at 1.0.0

### DIFF
--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -40,6 +40,8 @@ let
 
     mopidy-iris = callPackage ./iris.nix { };
 
+    mopidy-tunein = callPackage ./tunein.nix { };
+
   };
 
 in self

--- a/pkgs/applications/audio/mopidy/tunein.nix
+++ b/pkgs/applications/audio/mopidy/tunein.nix
@@ -1,0 +1,28 @@
+{ stdenv, python3Packages, mopidy }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "mopidy-tunein";
+  version = "1.0.0";
+
+  src = python3Packages.fetchPypi {
+    inherit version;
+    pname = "Mopidy-TuneIn";
+    sha256 = "0insasf4w8ajsqjh5zmax7pkzmrk1p245vh4y8ddicldj45p6qfj";
+  };
+
+  propagatedBuildInputs = [
+    mopidy
+  ];
+
+  # tests fail with "ValueError: Namespace Gst not available" in mopidy itself
+  doCheck = false;
+
+  pythonImportsCheck = [ "mopidy_tunein.tunein" ];
+
+  meta = with stdenv.lib; {
+    description = "Mopidy extension for playing music from tunein.";
+    homepage = "https://github.com/kingosticks/mopidy-tunein";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21365,6 +21365,7 @@ in
     mopidy-soundcloud
     mopidy-spotify
     mopidy-spotify-tunigo
+    mopidy-tunein
     mopidy-youtube;
 
   motif = callPackage ../development/libraries/motif { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

TuneIn integration for mopidy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
