### PR TITLE
bitcoin: 0.20.0 -> 0.20.1

### DIFF
--- a/pkgs/applications/blockchains/bitcoin.nix
+++ b/pkgs/applications/blockchains/bitcoin.nix
@@ -20,15 +20,11 @@
 
 with stdenv.lib;
 let
-  version = "0.20.0";
+  version = "0.20.1";
   majorMinorVersion = versions.majorMinor version;
   desktop = fetchurl {
     url = "https://raw.githubusercontent.com/bitcoin-core/packaging/${majorMinorVersion}/debian/bitcoin-qt.desktop";
     sha256 = "0cpna0nxcd1dw3nnzli36nf9zj28d2g9jf5y0zl9j18lvanvniha";
-  };
-  pixmap = fetchurl {
-    url = "https://raw.githubusercontent.com/bitcoin/bitcoin/v${version}/share/pixmaps/bitcoin128.png";
-    sha256 = "08p7j7dg50jlj783kkgdw037klmx0spqjikaprmbkzgcb620r25d";
   };
 in
 stdenv.mkDerivation rec {
@@ -40,7 +36,7 @@ stdenv.mkDerivation rec {
       "https://bitcoincore.org/bin/bitcoin-core-${version}/bitcoin-${version}.tar.gz"
       "https://bitcoin.org/bin/bitcoin-core-${version}/bitcoin-${version}.tar.gz"
     ];
-    sha256 = "ec5a2358ee868d845115dc4fc3ed631ff063c57d5e0a713562d083c5c45efb28";
+    sha256 = "4bbd62fd6acfa5e9864ebf37a24a04bc2dcfe3e3222f056056288d854c53b978";
   };
 
   nativeBuildInputs =
@@ -53,7 +49,7 @@ stdenv.mkDerivation rec {
 
   postInstall = optional withGui ''
     install -Dm644 ${desktop} $out/share/applications/bitcoin-qt.desktop
-    install -Dm644 ${pixmap} $out/share/pixmaps/bitcoin128.png
+    install -Dm644 share/pixmaps/bitcoin128.png $out/share/pixmaps/bitcoin128.png
   '';
 
   configureFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

* Version update - Changelog: https://lists.linuxfoundation.org/pipermail/bitcoin-core-dev/2020-August/000093.html - hash can be checked from https://bitcoin.org/bin/bitcoin-core-0.20.1/SHA256SUMS.asc
* Use icon from the release tarball

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
