### PR TITLE
python3Packages.pyHS100: init at 0.3.5.1

### DIFF
--- a/pkgs/development/python-modules/click-datetime/default.nix
+++ b/pkgs/development/python-modules/click-datetime/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, click }:
+
+buildPythonPackage rec {
+  pname = "click-datetime";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "click-contrib";
+    repo = pname;
+    rev = version;
+    sha256 = "1yxagk4wd2h77nxml19bn2y26fv2xw2n9g981ls8mjy0g51ms3gh";
+  };
+
+  propagatedBuildInputs = [ click ];
+
+  # no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "click_datetime" ];
+
+  meta = with lib; {
+    description = "Datetime type support for click.";
+    homepage = "https://github.com/click-contrib/click-datetime";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/pyhs100/default.nix
+++ b/pkgs/development/python-modules/pyhs100/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+, click, click-datetime, deprecation
+, pytest, voluptuous }:
+
+buildPythonPackage rec {
+  pname = "pyHS100";
+  version = "0.3.5.1";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "GadgetReactor";
+    repo = pname;
+    rev = version;
+    sha256 = "1vddr9sjn6337i1vx0mm7pb3qibvl2gx6nx18vm4fajgv9vcjxny";
+  };
+
+  propagatedBuildInputs = [
+    click
+    click-datetime
+    deprecation
+  ];
+
+  checkInputs = [
+    pytest
+    voluptuous
+  ];
+
+  checkPhase = ''
+    py.test pyHS100
+  '';
+
+  meta = with lib; {
+    description = "Python Library to control TPLink Switch (HS100 / HS110)";
+    homepage = "https://github.com/GadgetReactor/pyHS100";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -824,7 +824,7 @@
     "torque" = ps: with ps; [ aiohttp-cors];
     "totalconnect" = ps: with ps; [ ]; # missing inputs: total_connect_client
     "touchline" = ps: with ps; [ ]; # missing inputs: pytouchline
-    "tplink" = ps: with ps; [ ]; # missing inputs: pyHS100
+    "tplink" = ps: with ps; [ pyhs100];
     "tplink_lte" = ps: with ps; [ ]; # missing inputs: tp-connected
     "traccar" = ps: with ps; [ aiohttp-cors stringcase]; # missing inputs: pytraccar
     "trackr" = ps: with ps; [ ]; # missing inputs: pytrackr

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2572,6 +2572,8 @@ in {
 
   pyhcl = callPackage ../development/python-modules/pyhcl { };
 
+  pyhs100 = callPackage ../development/python-modules/pyhs100 { };
+
   pytest = if isPy3k then self.pytest_5 else self.pytest_4;
 
   pytest_5 = callPackage ../development/python-modules/pytest {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2350,6 +2350,8 @@ in {
 
   click-completion = callPackage ../development/python-modules/click-completion {};
 
+  click-datetime = callPackage ../development/python-modules/click-datetime { };
+
   click-default-group = callPackage ../development/python-modules/click-default-group { };
 
   click-didyoumean = callPackage ../development/python-modules/click-didyoumean {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Ability to control TP-Link smart devices from within home-assistant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
