### PR TITLE
environment.noXlibs: disable X11 support in cairo

### DIFF
--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -27,6 +27,7 @@ with lib;
     fonts.fontconfig.enable = false;
 
     nixpkgs.overlays = singleton (const (super: {
+      cairo = super.cairo.override { x11Support = false; };
       dbus = super.dbus.override { x11Support = false; };
       networkmanager-fortisslvpn = super.networkmanager-fortisslvpn.override { withGnome = false; };
       networkmanager-l2tp = super.networkmanager-l2tp.override { withGnome = false; };

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -4,13 +4,13 @@
 , gobjectSupport ? true, glib
 , xcbSupport ? x11Support, libxcb, xcbutil # no longer experimental since 1.12
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
-, glSupport ? config.cairo.gl or (libGLSupported && stdenv.isLinux)
+, glSupport ? x11Support && config.cairo.gl or (libGLSupported && stdenv.isLinux)
 , libGL ? null # libGLU libGL is no longer a big dependency
 , pdfSupport ? true
 , darwin
 }:
 
-assert glSupport -> libGL != null;
+assert glSupport -> x11Support && libGL != null;
 
 let
   version = "1.16.0";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds cairo to `environment.noXlibs`. If OpenGL support in cairo is enabled without X11, the build fails with:
```
In file included from /nix/store/5fxfy06brjd1rzga8fdz0ay1ljyv0m4q-libglvnd-1.3.1-dev/include/EGL/egl.h:39,
                 from cairo-gl.h:130,
                 from cairo-gl-private.h:51,
                 from cairo-gl-composite.c:48:
/nix/store/5fxfy06brjd1rzga8fdz0ay1ljyv0m4q-libglvnd-1.3.1-dev/include/EGL/eglplatform.h:128:10: fatal error: X11/Xlib.h: No such file or directory
  128 | #include <X11/Xlib.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```

Therefore I made `glSupport` depend on `x11Support`.

No one maintains cairo, so I'm just pinging people who worked on it recently:
cc @symphorien @matthewbauer @dtzWill 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
