### PR TITLE
python3Packages.async-upnp-client: init at 0.14.14

### DIFF
--- a/pkgs/development/python-modules/async-upnp-client/default.nix
+++ b/pkgs/development/python-modules/async-upnp-client/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+, voluptuous, aiohttp, async-timeout, python-didl-lite, defusedxml
+, pytest, pytest-asyncio }:
+
+buildPythonPackage rec {
+  pname = "async-upnp-client";
+  version = "0.14.14";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "StevenLooman";
+    repo = "async_upnp_client";
+    rev = version;
+    sha256 = "1ysj72l4z78h427ar95x7af0jw0xq1cbca0k8b34vqyyhgs8wc6y";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+    defusedxml
+    python-didl-lite
+    voluptuous
+  ];
+
+  checkInputs = [
+    pytest
+    pytest-asyncio
+  ];
+
+  meta = with lib; {
+    description = "Asyncio UPnP Client library for Python/asyncio.";
+    homepage = "https://github.com/StevenLooman/async_upnp_client";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/python-didl-lite/default.nix
+++ b/pkgs/development/python-modules/python-didl-lite/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+, defusedxml
+, pytest }:
+
+buildPythonPackage rec {
+  pname = "python-didl-lite";
+  version = "1.2.4";
+  disabled = pythonOlder "3.5.3";
+
+  src = fetchFromGitHub {
+    owner = "StevenLooman";
+    repo = pname;
+    rev = version;
+    sha256 = "0jf1d5m4r8qd3pn0hh1xqbkblkx9wzrrcmk7qa7q8lzfysp4z217";
+  };
+
+  propagatedBuildInputs = [
+    defusedxml
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with lib; {
+    description = "DIDL-Lite (Digital Item Declaration Language) tools for Python";
+    homepage = "https://github.com/StevenLooman/python-didl-lite";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -173,7 +173,7 @@
     "dlib_face_detect" = ps: with ps; [ face_recognition];
     "dlib_face_identify" = ps: with ps; [ face_recognition];
     "dlink" = ps: with ps; [ ]; # missing inputs: pyW215
-    "dlna_dmr" = ps: with ps; [ ]; # missing inputs: async-upnp-client
+    "dlna_dmr" = ps: with ps; [ async-upnp-client];
     "dnsip" = ps: with ps; [ aiodns];
     "dominos" = ps: with ps; [ aiohttp-cors]; # missing inputs: pizzapi
     "doods" = ps: with ps; [ pillow]; # missing inputs: pydoods
@@ -855,7 +855,7 @@
     "upc_connect" = ps: with ps; [ ]; # missing inputs: connect-box
     "upcloud" = ps: with ps; [ ]; # missing inputs: upcloud-api
     "updater" = ps: with ps; [ distro];
-    "upnp" = ps: with ps; [ ]; # missing inputs: async-upnp-client
+    "upnp" = ps: with ps; [ async-upnp-client];
     "uptime" = ps: with ps; [ ];
     "uptimerobot" = ps: with ps; [ ]; # missing inputs: pyuptimerobot
     "uscis" = ps: with ps; [ ]; # missing inputs: uscisstatus

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1916,6 +1916,8 @@ in {
 
   async_generator = callPackage ../development/python-modules/async_generator { };
 
+  async-upnp-client = callPackage ../development/python-modules/async-upnp-client { };
+
   asn1ate = callPackage ../development/python-modules/asn1ate { };
 
   atlassian-python-api = callPackage ../development/python-modules/atlassian-python-api { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2562,6 +2562,8 @@ in {
 
   pysingleton = callPackage ../development/python-modules/pysingleton { };
 
+  python-didl-lite = callPackage ../development/python-modules/python-didl-lite { };
+
   python-jose = callPackage ../development/python-modules/python-jose {};
 
   python-json-logger = callPackage ../development/python-modules/python-json-logger { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Enables the UPNP and DLNA components in home-assistant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
