### PR TITLE
python3Packages.pyipp: init at 0.10.1

### DIFF
--- a/pkgs/development/python-modules/deepmerge/default.nix
+++ b/pkgs/development/python-modules/deepmerge/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, vcver }:
+
+buildPythonPackage rec {
+  pname = "deepmerge";
+  version = "0.1.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0d1ab9lxwymqxxd58j50id1wib48xym3ss5xw172i2jfwwwzfdrx";
+  };
+
+  propagatedBuildInputs = [
+    vcver
+  ];
+
+  # depends on https://pypi.org/project/uranium/
+  doCheck = false;
+
+  pythonImportsCheck = [ "deepmerge" ];
+
+  meta = with lib; {
+    description = "A toolset to deeply merge python dictionaries.";
+    homepage = "http://deepmerge.readthedocs.io/en/latest/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/pyipp/default.nix
+++ b/pkgs/development/python-modules/pyipp/default.nix
@@ -1,0 +1,40 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27
+, aiohttp, deepmerge, yarl
+, aresponses, pytest, pytest-asyncio, pytestcov }:
+
+buildPythonPackage rec {
+  pname = "pyipp";
+  version = "0.10.1";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+   owner = "ctalkington";
+   repo = "python-ipp";
+   rev = version;
+   sha256 = "0y9mkrx66f4m77jzfgdgmvlqismvimb6hm61j2va7zapm8dyabvr";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    deepmerge
+    yarl
+  ];
+
+  checkInputs = [
+    aresponses
+    pytest
+    pytest-asyncio
+    pytestcov
+  ];
+
+  checkPhase = ''
+    pytest -q .
+  '';
+
+  meta = with lib; {
+    description = "Asynchronous Python client for Internet Printing Protocol (IPP)";
+    homepage = "https://github.com/ctalkington/python-ipp";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/vcver/default.nix
+++ b/pkgs/development/python-modules/vcver/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, packaging
+, fetchurl, python }:
+
+buildPythonPackage rec {
+  pname = "vcver";
+  version = "0.2.10";
+
+  src = fetchFromGitHub {
+    owner = "toumorokoshi";
+    repo = "vcver-python";
+    rev = "c5d8a6f1f0e49bb25f5dbb07312e42cb4da096d6";
+    sha256 = "1cvgs70jf7ki78338zaglaw2dkvyndmx15ybd6k4zqwwsfgk490b";
+  };
+
+  propagatedBuildInputs = [
+    packaging
+  ];
+
+  # circular dependency on test tool uranium https://pypi.org/project/uranium/
+  doCheck = false;
+
+  pythonImportTests = [ "vcver" ];
+
+  meta = with lib; {
+    description = "Reference Implementation of vcver";
+    homepage = "https://github.com/toumorokoshi/vcver-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -386,7 +386,7 @@
     "iota" = ps: with ps; [ ]; # missing inputs: pyota
     "iperf3" = ps: with ps; [ ]; # missing inputs: iperf3
     "ipma" = ps: with ps; [ ]; # missing inputs: pyipma
-    "ipp" = ps: with ps; [ ]; # missing inputs: pyipp
+    "ipp" = ps: with ps; [ pyipp];
     "iqvia" = ps: with ps; [ numpy]; # missing inputs: pyiqvia
     "irish_rail_transport" = ps: with ps; [ ]; # missing inputs: pyirishrail
     "islamic_prayer_times" = ps: with ps; [ ]; # missing inputs: prayer_times_calculator

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4004,6 +4004,8 @@ in {
 
   jsonschema = callPackage ../development/python-modules/jsonschema { };
 
+  vcver = callPackage ../development/python-modules/vcver { };
+
   vcversioner = callPackage ../development/python-modules/vcversioner { };
 
   falcon = callPackage ../development/python-modules/falcon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -549,6 +549,8 @@ in {
 
   deepdiff = callPackage ../development/python-modules/deepdiff { };
 
+  deepmerge = callPackage ../development/python-modules/deepmerge { };
+
   django-sesame = callPackage ../development/python-modules/django-sesame { };
 
   bravado-core = callPackage ../development/python-modules/bravado-core { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5543,6 +5543,8 @@ in {
 
   pyinotify = callPackage ../development/python-modules/pyinotify { };
 
+  pyipp = callPackage ../development/python-modules/pyipp { };
+
   pyjwt = callPackage ../development/python-modules/pyjwt { };
 
   pykickstart = callPackage ../development/python-modules/pykickstart { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Enable ipp support in home-assistant.

The vcver and deepmerge dependencies require [uranium](https://pypi.org/project/uranium/) to run tests, but the uranium name has been squatted by https://github.com/Ultimaker/Uranium.  @abbradar @gebner 

IMO the ultimaker package should be renamed to ultimaker-uranium, since the pypi name should take precedence.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
