### PR TITLE
python3Packages.openwebifpy: init at 3.1.1

### DIFF
--- a/pkgs/development/python-modules/openwebifpy/default.nix
+++ b/pkgs/development/python-modules/openwebifpy/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder
+, requests, zeroconf, wakeonlan
+, python }:
+
+buildPythonPackage rec {
+  pname = "openwebifpy";
+  version = "3.1.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zqa74i54ww9qjciiv8s58mxbs6vxq06cq5k4pxfarc0l75l4gh2";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    zeroconf
+    wakeonlan
+  ];
+
+  checkPhase = ''
+    ${python.interpreter} setup.py test
+  '';
+
+  meta = with lib; {
+    description = "Provides a python interface to interact with a device running OpenWebIf";
+    homepage = "https://openwebifpy.readthedocs.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}
+

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -212,7 +212,7 @@
     "emoncms_history" = ps: with ps; [ ];
     "emulated_hue" = ps: with ps; [ aiohttp-cors];
     "emulated_roku" = ps: with ps; [ ]; # missing inputs: emulated_roku
-    "enigma2" = ps: with ps; [ ]; # missing inputs: openwebifpy
+    "enigma2" = ps: with ps; [ openwebifpy];
     "enocean" = ps: with ps; [ ]; # missing inputs: enocean
     "enphase_envoy" = ps: with ps; [ ]; # missing inputs: envoy_reader
     "entur_public_transport" = ps: with ps; [ ]; # missing inputs: enturclient

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2502,6 +2502,8 @@ in {
 
   openidc-client = callPackage ../development/python-modules/openidc-client {};
 
+  openwebifpy = callPackage ../development/python-modules/openwebifpy {};
+
   optuna = callPackage ../development/python-modules/optuna { };
 
   idna = callPackage ../development/python-modules/idna { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Enables the enigma2 component in home-assistant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
