### PR TITLE
ledger: 3.1.3 -> 3.2.1

### DIFF
--- a/pkgs/applications/office/ledger/default.nix
+++ b/pkgs/applications/office/ledger/default.nix
@@ -1,37 +1,44 @@
-{ stdenv, fetchFromGitHub, cmake, boost, gmp, mpfr, libedit, python
+{ stdenv, lib, fetchFromGitHub, cmake, boost, gmp, mpfr, libedit, python
 , texinfo, gnused, usePython ? true }:
 
 stdenv.mkDerivation rec {
   pname = "ledger";
-  version = "3.1.3";
+  version = "3.2.1";
 
   src = fetchFromGitHub {
     owner  = "ledger";
     repo   = "ledger";
     rev    = "v${version}";
-    sha256 = "0bfnrqrd6wqgsngfpqi30xh6yy86pwl25iwzrqy44q31r0zl4mm3";
+    sha256 = "0x6jxwss3wwzbzlwmnwb8yzjk8f9wfawif4f1b74z2qg6hc4r7f6";
   };
+
+  outputs = [ "out" "dev" ];
 
   buildInputs = [
     (boost.override { enablePython = usePython; })
-    gmp mpfr libedit python texinfo gnused
+    gmp mpfr libedit python gnused
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake texinfo ];
 
   enableParallelBuilding = true;
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DBUILD_DOCS:BOOL=ON"
-    (stdenv.lib.optionalString usePython "-DUSE_PYTHON=true")
-   ];
+    (lib.optionalString usePython "-DUSE_PYTHON=true")
+  ];
 
-  postBuild = ''
-    make doc
+  # by default, it will query the python interpreter for it's sitepackages location
+  # however, that would write to a different nixstore path, pass our own sitePackages location
+  prePatch = lib.optionalString usePython ''
+    substituteInPlace src/CMakeLists.txt \
+      --replace 'DESTINATION ''${Python_SITEARCH}' 'DESTINATION "${python.sitePackages}"'
   '';
 
-  meta = with stdenv.lib; {
+  installTargets = [ "doc" "install" ];
+
+  meta = with lib; {
     homepage = "https://ledger-cli.org/";
     description = "A double-entry accounting system with a command-line reporting interface";
     license = licenses.bsd3;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21073,12 +21073,7 @@ in
 
   linuxband = callPackage ../applications/audio/linuxband { };
 
-  ledger = callPackage ../applications/office/ledger {
-    # Boost >= 1.67 changed the name of boost python; ledger's cmake build needs
-    # an update to find it:
-    # https://www.boost.org/doc/libs/1_68_0/libs/python/doc/html/rn.html
-    boost = boost15x;
-  };
+  ledger = callPackage ../applications/office/ledger { };
 
   ledger-autosync = callPackage  ../applications/office/ledger-autosync { };
 


### PR DESCRIPTION
###### Motivation for this change
PR inspired by https://discourse.nixos.org/t/how-can-i-install-a-newer-version-of-ledger/8104/7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @daraul 