### PR TITLE
libplacebo: allow for latest glslang

### DIFF
--- a/pkgs/development/libraries/libplacebo/default.nix
+++ b/pkgs/development/libraries/libplacebo/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitLab
+, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -23,6 +24,18 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1yhf9xyxdawbihsx89dpjlac800wrmpwx63rphad2nj225y9q40f";
   };
+
+  patches = [
+    # to work with latest glslang, remove on release >2.72.0
+    (fetchpatch {
+      url = "https://code.videolan.org/videolan/libplacebo/-/commit/523056828ab86c2f17ea65f432424d48b6fdd389.patch";
+      sha256 = "051vhd0l3yad1fzn5zayi08kqs9an9j8p7m63kgqyfv1ksnydpcs";
+    })
+    (fetchpatch {
+      url = "https://code.videolan.org/videolan/libplacebo/-/commit/82e3be1839379791b58e98eb049415b42888d5b0.patch";
+      sha256 = "0nklj9gfiwkbbj6wfm1ck33hphaxrvzb84c4h2nfj88bapnlm90l";
+    })
+  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
###### Motivation for this change
to enable #93604 #94049

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

failures broken on master
```
[18 built (1 failed), 19 copied (51.3 MiB), 0.0 MiB DL]
error: build of '/nix/store/wwrcpdiljx05xdl7id6k7rwri240shkh-env.drv' failed
2 packages failed to build:
deepin.dde-file-manager deepin.startdde

18 packages built:
celluloid curseradio deepin.deepin-movie-reborn jellyfin-mpv-shim jftui libplacebo minitube mpc-qt mpv mpv-unwrapped mpvScripts.mpris plex-media-player plex-mpv-shim python37Packages.mpv python38Packages.mpv qimgv sublime-music tuijam
```