### PR TITLE
openjdk: 11.0.7 -> 11.0.8

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -10,16 +10,17 @@
 
 let
   major = "11";
-  update = ".0.7";
-  build = "ga";
+  minor = "0";
+  update = "8";
+  build = "10";
 
   openjdk = stdenv.mkDerivation rec {
     pname = "openjdk" + lib.optionalString headless "-headless";
-    version = "${major}${update}-${build}";
+    version = "${major}.${minor}.${update}+${build}";
 
     src = fetchurl {
       url = "http://hg.openjdk.java.net/jdk-updates/jdk${major}u/archive/jdk-${version}.tar.gz";
-      sha256 = "14daacng9ndxf4kmvsn7nracwfiwwmw5rha8rkk3723pfk9g8q7p";
+      sha256 = "1sdncn1bk4h8xxfnmrl1125maqy6mc0v0y1dyifwsa04wasj9hbz";
     };
 
     nativeBuildInputs = [ pkgconfig autoconf ];


### PR DESCRIPTION
Also added `minor` variable to reflect namin schme introduced in java 9: https://bugs.openjdk.java.net/browse/JDK-8061493

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Switched to most recent update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
 asbachb@nixos  ~/dev/src/nix/nixpkgs   update-java11  nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
these paths will be fetched (0.03 MiB download, 0.13 MiB unpacked):
  /nix/store/91qp2v2h0fd9d6b6hchzf13zki091grv-nixpkgs-review-2.3.1
copying path '/nix/store/91qp2v2h0fd9d6b6hchzf13zki091grv-nixpkgs-review-2.3.1' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 11, done.
remote: Counting objects: 100% (11/11), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 11 (delta 5), reused 7 (delta 5), pack-reused 0
Unpacking objects: 100% (11/11), 2.90 KiB | 742.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   e0f07f9b8d7..ad7c4e495a4  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-07ba3e512768147b5f4e679fac60f66e6e761db3-dirty/nixpkgs ad7c4e495a4aa2838e5068d05bbd4f2b56b3731f
Preparing worktree (detached HEAD ad7c4e495a4)
Updating files: 100% (22269/22269), done.
HEAD is now at ad7c4e495a4 Merge pull request #94514 from r-ryantm/auto-update/kmon
$ nix-env -f /home/asbachb/.cache/nixpkgs-review/rev-07ba3e512768147b5f4e679fac60f66e6e761db3-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
