### PR TITLE
initrd-network: fix flushBeforeStage2

### DIFF
--- a/nixos/modules/system/boot/initrd-network.nix
+++ b/nixos/modules/system/boot/initrd-network.nix
@@ -139,7 +139,7 @@ in
     boot.initrd.postMountCommands = mkIf cfg.flushBeforeStage2 ''
       for iface in $ifaces; do
         ip address flush "$iface"
-        ip link down "$iface"
+        ip link set "$iface" down
       done
     '';
 


### PR DESCRIPTION
###### Motivation for this change
Network interfaces are not properly shutdown before stage2 despite `boot.initrd.network.flushBeforeStage2` being set.
This is the error message printed on the screen:
```
ip: invalid argument 'down' to 'ip'
```

###### Things done
- [X] Use a correct syntax for the `ip` command.
- [ ] Use the optional "dev" prefix. Not done because it would required to change more lines accross the stage1 init, but this would be cleaner.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
