### PR TITLE
mesa.drivers: build with patchelf's master

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14028,7 +14028,17 @@ in
   }
     # Temporary fix for .drivers that avoids causing lots of rebuilds; see #91145
      // { drivers = (mesa.overrideAttrs (a: {
-            nativeBuildInputs = [ patchelf_0_9 ] ++ a.nativeBuildInputs or [];
+            nativeBuildInputs = [
+              (patchelf.overrideAttrs (pa: {
+                src = fetchFromGitHub {
+                  owner = "NixOS";
+                  repo = "patchelf";
+                  rev = "61bc10176"; # current master; what matters is merge of #225
+                  sha256 = "0cy77mn77w3mn64ggp20f4ygnbxfjmddhjjhfwkva53lsirg6w93";
+                };
+                nativeBuildInputs = pa.nativeBuildInputs or [] ++ [ autoreconfHook ];
+              }))
+            ] ++ a.nativeBuildInputs or [];
           })).drivers;
         }
     ;


### PR DESCRIPTION
Apparently using 0.9 (in b59fbf76d2) didn't fully fix the problem.

See https://github.com/NixOS/nixpkgs/issues/91145#issuecomment-667637361

I only verified it builds.  I don't think I have any iris-capable HW at hand.