### PR TITLE
pyspread: Correct dependencies and make wrapper

### DIFF
--- a/pkgs/applications/misc/pyspread-app/default.nix
+++ b/pkgs/applications/misc/pyspread-app/default.nix
@@ -1,0 +1,34 @@
+{ mkDerivation
+, lib
+, makeDesktopItem
+, python3
+, pyspread
+}:
+rec {
+  wrapPyspread = import ./wrap-pyspread.nix {
+    inherit mkDerivation lib makeDesktopItem;
+  };
+
+  pickRequiredDeps = if (lib.hasAttr "pickRequiredDeps" pyspread)
+    then  pyspread.pickRequiredDeps else
+    (ps: with ps; [
+      numpy
+      pyqt5
+    ]);
+
+  pickOptionalDeps = if (lib.hasAttr "pickOptionalDeps" pyspread)
+    then pyspread.pickOptionalDeps else
+    (ps: with ps; [
+      matplotlib
+      pyenchant
+    ]);
+
+  app = wrapPyspread {
+    inherit pyspread;
+    pythonWithPackages = (python3.withPackages (ps:
+      [ pyspread ] ++
+      (pickRequiredDeps ps) ++
+      (pickOptionalDeps ps)
+    ));
+  };
+}

--- a/pkgs/applications/misc/pyspread-app/wrap-pyspread.nix
+++ b/pkgs/applications/misc/pyspread-app/wrap-pyspread.nix
@@ -1,0 +1,81 @@
+{ mkDerivation, lib, makeDesktopItem }:
+args@{ pyspread
+     , version ? pyspread.version # Pyspread version, use pyspread.version if not specified
+     , pythonWithPackages ? null # Specified python interpreter
+     , customInterpreterName ? null # Name of specified python interpreter (useful if you want something like pypy)
+     , ...
+     }:
+let
+_customInterpreterName = (
+  if customInterpreterName != null
+  then customInterpreterName
+  else if (pythonWithPackages != null && lib.hasAttr "executable" pythonWithPackages)
+  then pythonWithPackages.executable
+  else null);
+
+in mkDerivation (rec {
+
+  pname = "pyspread-app";
+  inherit version;
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  propagatedBuildInputs = [ pyspread ]
+    ++ lib.lists.optional (pythonWithPackages != null) pythonWithPackages;
+
+  desktopItem = makeDesktopItem rec {
+    name = pname;
+    exec = name;
+    icon = name;
+    desktopName = "Pyspread";
+    genericName = "Spreadsheet";
+    comment = meta.description;
+    categories = "Development;Spreadsheet;";
+    mimeType =
+      "application/x-pyspread-spreadsheet;application/x-pyspread-bz-spreadsheet";
+    startupNotify = "false";
+  };
+
+  installPhase = ''
+    mkdir -p "$out/share"
+
+    # Symlinking instead of copying to save space
+    # Symlinking files and links
+    # in ${pyspread}/lib/python*/site-packages/pyspread/share
+    # from $out/share
+    shareDefault=${pyspread}/${pyspread.pythonModule.sitePackages}/pyspread/share
+    (
+      cd $shareDefault;
+      find . -mindepth 1 -type d -exec mkdir -p $out/share/{} \;
+      find . -mindepth 1 -type f,l -exec ln -s $PWD/{} $out/share/{} \;
+    )
+
+    mkdir -p "$out/share/applications"
+    cp $desktopItem/share/applications/* $out/share/applications
+
+    mkdir -p "$out/bin"
+    cp -r "${pyspread.outPath}/bin/." "$out/bin"
+  '';
+
+  dontWrapQtApps = true;
+  preFixup = (lib.strings.optionalString (_customInterpreterName != null) ''
+    sed -i -r 's/(python|pypy)[0-9]*m?\s+-m/'${_customInterpreterName}' -m/' $out/bin/pyspread
+  '') + (if (pythonWithPackages != null) then ''
+    wrapQtApp "$out/bin/pyspread" --prefix PATH : "${pythonWithPackages}/bin"
+  '' else ''
+    wrapQtApp "$out/bin/pyspread"
+  '');
+
+  meta = with lib; {
+      description = "A non-traditional spreadsheet application that is based on and written in the programming language Python";
+      longDescription = ''
+        This is a package wrapping around python3Packages.pyspread
+        to make it executable out of the box.
+        It doesn't come with the libreary of the python module.
+      '';
+      homepage = "https://manns.github.io";
+      license = licenses.gpl3;
+      maintainers = with maintainers; [ ShamrockLee ];
+    };
+} // args)

--- a/pkgs/development/python-modules/pyspread/default.nix
+++ b/pkgs/development/python-modules/pyspread/default.nix
@@ -1,56 +1,70 @@
 { buildPythonPackage
 , fetchPypi
 , isPy3k
-, stdenv
+, isPy35
+# NOTE: PyPy would not be compatible with
+# SIP (a PyQt5 dependency) and MatPlotLib
+, isPyPy
+, lib
 , numpy
-, wxPython
-, matplotlib
-, pycairo
-, python-gnupg
-, xlrd
-, xlwt
-, jedi
-, pyenchant
-, basemap
-, pygtk
-, makeDesktopItem
+, pyqt5
 }:
-
+let
+  pickRequiredDeps = (ps: with ps; [
+    numpy
+    pyqt5
+    ]);
+  pickOptionalDeps = (ps: with ps; [
+    matplotlib
+    pyenchant
+  ]);
+  requiredPythonDependencies = [
+    numpy
+    pyqt5
+  ];
+in
 buildPythonPackage rec {
   pname = "pyspread";
   version = "1.99.5";
+
+  passthru = {
+    inherit version;
+    inherit pickRequiredDeps pickOptionalDeps;
+  };
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "d396c2f94bf1ef6140877ab19205e6f2375bfe01d1bf50ff33bb63384744dd78";
   };
 
-  propagatedBuildInputs = [ numpy wxPython matplotlib pycairo python-gnupg xlrd xlwt jedi pyenchant basemap pygtk ];
-  # Could also (optionally) add pyrsvg and python bindings for libvlc
+  propagatedBuildInputs = requiredPythonDependencies;
 
   # Tests try to access X Display
   doCheck = false;
 
-  disabled = isPy3k;
-
-  desktopItem = makeDesktopItem rec {
-    name = pname;
-    exec = name;
-    icon = name;
-    desktopName = "Pyspread";
-    genericName = "Spreadsheet";
-    comment = meta.description;
-    categories = "Development;Spreadsheet;";
-  };
+  disabled = (!isPy3k) || isPy35;
 
   postInstall = ''
-    mkdir -p $out/share/applications
-    cp $desktopItem/share/applications/* $out/share/applications
-  '';
+    executerName=$(head -n 1 "$out/bin/pyspread" | sed -r '1 s/#!(\/usr)?\/bin\/(\S+)(.*)$/\2/')
+    if test executerName != "env"; then
+      sed -i -r '1 s/#!(\/usr)?\/bin\/(\S+)(.*)$/#!\/usr\/bin\/env \2/' "$out/bin/pyspread"
+    else
+      sed -i -r '1 s/#!(\/usr)?\/bin\/(\S+)(.*)$/#!\/usr\/bin\/env\3/' "$out/bin/pyspread"
+    fi
+  '' + (lib.strings.optionalString isPyPy ''
+    sed -i -r 's/python([0-9]*m?\s+)-m/pypy\1-m/' $out/bin/pyspread
+  '');
 
-  meta = with stdenv.lib; {
-    description = "Pyspread is a non-traditional spreadsheet application that is based on and written in the programming language Python";
-    homepage = "https://manns.github.io/pyspread/";
+  meta = with lib; {
+    description = "API of PySpread, a non-traditional spreadsheet application that is based on and written in the programming language Python";
+    longDescription = ''
+      This is the API of PySpread, and is meant to be
+      imported in a python script
+      instead of installing into user profiles,
+      as the execution script has not been properly wrapped
+      and won't run out of the box.
+    '';
+    homepage = "https://pyspread.gitlab.io/pyspread/";
     license = licenses.gpl3;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23589,6 +23589,11 @@ in
 
   pybitmessage = callPackage ../applications/networking/instant-messengers/pybitmessage { };
 
+  pyspread-app = libsForQt5.callPackage ../applications/misc/pyspread-app/default.nix {
+    inherit python3;
+    inherit (python3Packages) pyspread;
+  };
+
   qbittorrent = libsForQt5.callPackage ../applications/networking/p2p/qbittorrent { };
   qbittorrent-nox = qbittorrent.override {
     guiSupport = false;


### PR DESCRIPTION
Change dependent python version to 3.6-3.9
Change dependent widget toolkit to pyqt5
Add a wrapper so as to execute the application from `$out/bin`.
Maintainers needed.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
pyspread 1.99.x depends on Python 3.6-3.9 and pyqt5 instead of Python 2.7, wxPython or pygtk. Some dependent packages have also dropped Python2 support.
A wrapper is made using `overrideAttrs` and `pythonFull.withPackages` to make it executable out of the box.

It is the first time for me to package a Python application (rewrite the expressions of a package) in nixpkgs.
There might be some better or more efficient ways to do so.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`) (Tested python36Packages.pyspread)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after) (The closure size of `pyspread` is now 706115728)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
