### PR TITLE
pjsip: split outputs to reduce closure

### DIFF
--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -36,6 +36,11 @@ stdenv.mkDerivation rec {
   # We need the libgcc_s.so.1 loadable (for pthread_cancel to work)
   dontPatchELF = true;
 
+  # Most outputs retain reference to gcc - due to the samples at /share and due
+  # to $out/bin/pjsip. Splitting the outputs reduces closure for most usages of
+  # this derivation - as a library.
+  outputs = [ "out" "lib" "dev" ];
+
   meta = with stdenv.lib; {
     description = "A multimedia communication library written in C, implementing standard based protocols such as SIP, SDP, RTP, STUN, TURN, and ICE";
     homepage = "https://pjsip.org/";


### PR DESCRIPTION

###### Motivation for this change

I noticed there are a lot of references in current pjsip to gcc-unwrapped. This is understandable as `dontPatchElf` is set and there are samples at `/share/pjsip/samples` that don't get `strip`ped because they are not in `stripDebugList` (see https://nixos.org/nixpkgs/manual/#ssec-fixup-phase). Hence I think it'd be best to just split the outputs. I've confirmed that compiling a certain different package with `pjsip` as a library works, and that the binary `pjsip` seems to function fine as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
