### PR TITLE
cached-nix-shell: 0.1.3 -> 0.1.4

### DIFF
--- a/pkgs/tools/nix/cached-nix-shell/default.nix
+++ b/pkgs/tools/nix/cached-nix-shell/default.nix
@@ -28,9 +28,13 @@ in rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ ronn ];
 
-  postBuild = "make -f nix/Makefile post-build";
+  postBuild = ''
+    make -f nix/Makefile post-build
+  '';
 
-  postInstall = "make -f nix/Makefile post-install";
+  postInstall = ''
+    make -f nix/Makefile post-install
+  '';
 
   meta = with stdenv.lib; {
     description = "Instant startup time for nix-shell";

--- a/pkgs/tools/nix/cached-nix-shell/default.nix
+++ b/pkgs/tools/nix/cached-nix-shell/default.nix
@@ -10,16 +10,16 @@ let
 
 in rustPlatform.buildRustPackage rec {
   pname = "cached-nix-shell";
-  version = "0.1.3";
+  version = "0.1.4";
 
   src = fetchFromGitHub {
     owner = "xzfc";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1ni671wr2lrvyz6myaz3v4llrjvq4jc1ygw1m7rvnadzyf3va3lw";
+    sha256 = "0w6khry1ncyqy5h6996xw1f6viw4wdrfji5m8lz9gm487xlq5v0b";
   };
 
-  cargoSha256 = "19i39b1yqdf81ql4psr3nfah6ci2mw3ljkv740clqmz088j2av8g";
+  cargoSha256 = "0d4fz0rhqy1n30wfl2pmf76zpp21agr3h0hswp3r5bfnxqp6i54h";
 
   # The BLAKE3 C library is intended to be built by the project depending on it
   # rather than as a standalone library.
@@ -28,16 +28,9 @@ in rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ ronn ];
 
-  postBuild = ''
-    ronn -r cached-nix-shell.1.md
-  '';
+  postBuild = "make -f nix/Makefile post-build";
 
-  postInstall = ''
-    mkdir -p $out/lib $out/share/cached-nix-shell $out/share/man/man1 $out/var/empty
-    cp $releaseDir/build/cached-nix-shell-*/out/trace-nix.so $out/lib
-    cp rcfile.sh $out/share/cached-nix-shell/rcfile.sh
-    cp cached-nix-shell.1 $out/share/man/man1
-  '';
+  postInstall = "make -f nix/Makefile post-install";
 
   meta = with stdenv.lib; {
     description = "Instant startup time for nix-shell";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
