### PR TITLE
python3Packages.brother: init at 0.1.14

### DIFF
--- a/pkgs/development/python-modules/brother/default.nix
+++ b/pkgs/development/python-modules/brother/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+, pysnmp
+, asynctest, pytestcov, pytestrunner, pytest-asyncio, pytest-trio, pytest-tornasync }:
+
+buildPythonPackage rec {
+  pname = "brother";
+  version = "0.1.14";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "bieniu";
+    repo = pname;
+    rev = version;
+    sha256 = "11pkr30bxrzgbz6bi42dyhav6qhr7rz9fb6a13297g7wa77jn4r4";
+  };
+
+  propagatedBuildInputs = [
+    pysnmp
+  ];
+
+  checkInputs = [
+    asynctest
+    pytestcov
+    pytestrunner
+    pytest-asyncio
+    pytest-trio
+    pytest-tornasync
+  ];
+
+  meta = with lib; {
+    description = "Python wrapper for getting data from Brother laser and inkjet printers via SNMP.";
+    homepage = "https://github.com/bieniu/brother";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-tornasync/default.nix
+++ b/pkgs/development/python-modules/pytest-tornasync/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27
+, pytest, tornado }:
+
+buildPythonPackage rec {
+  pname = "pytest-tornasync";
+  version = "0.6.0.post2";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "eukaryote";
+    repo = pname;
+    # upstream does not keep git tags in sync with pypy releases
+    # https://github.com/eukaryote/pytest-tornasync/issues/9
+    rev = "c5f013f1f727f1ca1fcf8cc748bba7f4a2d79e56";
+    sha256 = "04cg1cfrr55dbi8nljkpcsc103i5c6p0nr46vjr0bnxgkxx03x36";
+  };
+
+  propagatedBuildInputs = [
+    pytest
+    tornado
+  ];
+
+  checkInputs = [
+    pytest
+    tornado
+  ];
+
+  checkPhase = ''
+    pytest test
+  '';
+
+  meta = with lib; {
+    description = "py.test plugin for testing Python 3.5+ Tornado code";
+    homepage = "https://github.com/eukaryote/pytest-tornasync";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-trio/default.nix
+++ b/pkgs/development/python-modules/pytest-trio/default.nix
@@ -1,0 +1,39 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+, trio, async_generator, hypothesis, outcome, pytest, pytestcov }:
+
+buildPythonPackage rec {
+  pname = "pytest-trio";
+  version = "0.6.0";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "python-trio";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "09v2031yxm8ryhq12205ldcck76n3wwqhjjsgfmn6dxfiqb0vbw9";
+  };
+
+  propagatedBuildInputs = [
+    trio
+    async_generator
+    outcome
+    pytest
+  ];
+
+  checkInputs = [
+    pytest
+    pytestcov
+    hypothesis
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Pytest plugin for trio";
+    homepage = "https://github.com/python-trio/pytest-trio";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -93,7 +93,7 @@
     "bond" = ps: with ps; [ ]; # missing inputs: bond-home
     "braviatv" = ps: with ps; [ bravia-tv];
     "broadlink" = ps: with ps; [ broadlink];
-    "brother" = ps: with ps; [ ]; # missing inputs: brother
+    "brother" = ps: with ps; [ brother];
     "brottsplatskartan" = ps: with ps; [ ]; # missing inputs: brottsplatskartan
     "browser" = ps: with ps; [ ];
     "brunt" = ps: with ps; [ ]; # missing inputs: brunt

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1420,6 +1420,8 @@ in {
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 
+  pytest-trio = callPackage ../development/python-modules/pytest-trio { };
+
   pytest-twisted = callPackage ../development/python-modules/pytest-twisted { };
 
   pytest-xprocess = callPackage ../development/python-modules/pytest-xprocess { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1420,6 +1420,8 @@ in {
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 
+  pytest-tornasync = callPackage ../development/python-modules/pytest-tornasync { };
+
   pytest-trio = callPackage ../development/python-modules/pytest-trio { };
 
   pytest-twisted = callPackage ../development/python-modules/pytest-twisted { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -543,6 +543,8 @@ in {
 
   breezy = callPackage ../development/python-modules/breezy { };
 
+  brother = callPackage ../development/python-modules/brother { };
+
   build = callPackage ../development/python-modules/build { };
 
   ciso8601 = callPackage ../development/python-modules/ciso8601 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Enable the [brother integration](https://www.home-assistant.io/integrations/brother/) in home-assistant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
