### PR TITLE
Add goDeps handling to go-modules.

### DIFF
--- a/pkgs/development/tools/goproxy/default.nix
+++ b/pkgs/development/tools/goproxy/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoModule, fetchgit }:
+
+buildGoModule {
+  pname = "goproxy";
+  version = "unstable-2020-08-02";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~c00w/tooling";
+    rev = "b7d8a852aeed9789dcc6a8920dc23c159fa6e02f";
+    sha256 = "1jdcpyw889a90y51mnh7cl4izlidgypa926q3wh4x19hkm9vyy42";
+  } + "/goproxy";
+
+  vendorSha256 = null;
+
+  meta = with stdenv.lib; {
+    homepage = "https://git.sr.ht/~c00w/tooling";
+    description = "Serves a go folder as a goproxy";
+    maintainers = with maintainers; [ c00w ];
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1035,6 +1035,8 @@ in
 
   gopacked = callPackage ../applications/misc/gopacked { };
 
+  goproxy = callPackage ../development/tools/goproxy { };
+
   gucci = callPackage ../tools/text/gucci { };
 
   grc = callPackage ../tools/misc/grc { };


### PR DESCRIPTION
As far as I can tell this works, but it appears the no goPackage has a valid deps file that works with go modules. I'm mostly putting this up so people can see how it works. I think the next step is a tool which correctly generate a deps.nix based on module information. (likely I'll add it to govendor form nix-community)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
