### PR TITLE
swm: init at 0.4.0-alpha1

### DIFF
--- a/pkgs/development/tools/swm/default.nix
+++ b/pkgs/development/tools/swm/default.nix
@@ -1,0 +1,12 @@
+{ callPackage }:
+
+let
+  version = "0.4.0-alpha1";
+  sha256 = "17s6ccwg4240b6ykam27pz4kisyfm977rh1zzzx6ykarqi0x2fkf";
+
+  swm-src = builtins.fetchTarball {
+    url = "https://github.com/kalbasit/swm/archive/v${version}.tar.gz";
+    inherit sha256;
+  };
+in
+  callPackage swm-src { inherit version; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -165,6 +165,8 @@ in
 
   clj-kondo = callPackage ../development/tools/clj-kondo { };
 
+  swm = callPackage ../development/tools/swm { };
+
   cmark = callPackage ../development/libraries/cmark { };
 
   cm256cc = callPackage ../development/libraries/cm256cc {  };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions

###### Motivation for this change

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

-->

I'm curious, how do we feel about adding packages to nixpkgs where the derivation is defined in the source package? My swm package defines its own derivation, and it feels like a waste to copy/paste the derivation over here: https://github.com/kalbasit/swm/blob/master/default.nix

cc @Mic92 @c00w @zowoq