### PR TITLE
WIP: flask-restx: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/flask-restx/default.nix
+++ b/pkgs/development/python-modules/flask-restx/default.nix
@@ -1,0 +1,38 @@
+{ buildPythonPackage
+, fetchPypi
+, jsonschema
+, flask
+, six
+, aniso8601
+, pytz
+, isPy27
+, enum34
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "flask-restx";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "19gjlb27x1wn77gmkma0p6j7jf6dwr20nx55a1dfrx1khf0a31ya";
+  };
+
+  propagatedBuildInputs = [
+    aniso8601
+    jsonschema
+    flask
+    six
+    pytz
+  ] ++ lib.optional isPy27 enum34;
+
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/python-restx/flask-restx";
+    description = "Flask-RESTX is an extension for Flask that adds support for quickly building REST APIs";
+    license = lib.licenses.bsd3;
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3943,6 +3943,8 @@ in {
 
   flask-restplus = callPackage ../development/python-modules/flask-restplus { };
 
+  flask-restx = callPackage ../development/python-modules/flask-restx { };
+
   flask-reverse-proxy-fix = callPackage ../development/python-modules/flask-reverse-proxy-fix { };
 
   flask_script = callPackage ../development/python-modules/flask-script { };


### PR DESCRIPTION
##### Motivation for this change

Added flask-restx that takes over from flask-restplus.

###### Things done

I still need to check how to run the tests. At the moment flask-restplus has tests  disabled for some reason. But this has extra dependencies that isn't covered by the current set of packages.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).