### PR TITLE
WIP: altair-transform: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/altair-transform/default.nix
+++ b/pkgs/development/python-modules/altair-transform/default.nix
@@ -1,0 +1,45 @@
+{ buildPythonPackage
+, fetchPypi
+, ply
+, altair
+, numpy
+, pandas
+, dataclasses
+, pytest
+, jinja2
+, lib
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "altair_transform";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0rid432fqslaaqjnpd4fm5hxq88160w5yqr6qsm4n9bi795cjj5k";
+  };
+
+  propagatedBuildInputs = [
+    ply
+    altair
+    numpy
+    pandas
+  ] ++ lib.optionals (pythonOlder "3.7") [ dataclasses ];
+
+  checkInputs = [
+    jinja2
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = {
+    homepage = "https://github.com/altair-viz/altair-transform";
+    description = "Python evaluation of Altair/Vega-Lite transforms";
+    license = lib.licenses.mit;
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1771,6 +1771,8 @@ in {
 
   altair = callPackage ../development/python-modules/altair { };
 
+  altair-transform = callPackage ../development/python-modules/altair-transform { };
+
   vega = callPackage ../development/python-modules/vega { };
 
   accupy = callPackage ../development/python-modules/accupy { };


### PR DESCRIPTION
###### Motivation for this change

Adding altair-transform to do server-side transformations of the Vega lite transform later.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
