### PR TITLE
libvirt: add hyperv driver

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -8,6 +8,7 @@
 , enableXen ? false, xen ? null
 , enableIscsi ? false, openiscsi
 , enableCeph ? false, ceph
+, enableHyperv ? false, openwsman
 }:
 
 with stdenv.lib;
@@ -46,6 +47,8 @@ in stdenv.mkDerivation rec {
     openiscsi
   ] ++ optionals enableCeph [
     ceph
+  ] ++ optionals enableHyperv [
+    openwsman
   ] ++ optionals stdenv.isDarwin [
     libiconv gmp
   ];
@@ -93,6 +96,8 @@ in stdenv.mkDerivation rec {
     "--with-storage-iscsi"
   ] ++ optionals enableCeph [
     "--with-storage-rbd"
+  ] ++ optionals enableHyperv [
+    "--with-hyperv"
   ] ++ optionals stdenv.isDarwin [
     "--with-init-script=none"
   ];


### PR DESCRIPTION
###### Motivation for this change
To add Hyper-V support to libvirt

###### Things done

It builds, and `virsh --connect hyperv://host/` no longer complains, but I haven't tested connecting to an actual Hyper-V server yet.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - Increase in closure size: 1.7M
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
