### PR TITLE
cups-brother-hl1210w: init at 3.0.1-1

### DIFF
--- a/pkgs/misc/cups/drivers/hl1210w/default.nix
+++ b/pkgs/misc/cups/drivers/hl1210w/default.nix
@@ -1,0 +1,62 @@
+{stdenv, pkgsi686Linux, fetchurl, cups, dpkg, gnused, makeWrapper, ghostscript, file, a2ps, coreutils, gawk}:
+
+let
+  version = "3.0.1-1";
+  cupsdeb = fetchurl {
+    url = "https://download.brother.com/welcome/dlf101546/hl1210wcupswrapper-${version}.i386.deb";
+    sha256 = "0395mnw6c7qpjgjch9in5q9p2fjdqvz9bwfwp6q1hzhs08ryk7w0";
+  };
+  lprdeb = fetchurl {
+    url = "https://download.brother.com/welcome/dlf101547/hl1210wlpr-${version}.i386.deb";
+    sha256 = "1sl3g2cd4a2gygryrr27ax3qaa65cbirz3kzskd8afkwqpmjyv7j";
+  };
+in
+stdenv.mkDerivation {
+  name = "cups-brother-hl1210W";
+
+  srcs = [ lprdeb cupsdeb ];
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ cups ghostscript dpkg a2ps ];
+  dontUnpack = true;
+
+  installPhase = ''
+    # install lpr
+    dpkg-deb -x ${lprdeb} $out
+
+    substituteInPlace $out/opt/brother/Printers/HL1210W/lpd/filter_HL1210W \
+      --replace /opt "$out/opt"
+
+    sed -i '/GHOST_SCRIPT=/c\GHOST_SCRIPT=gs' $out/opt/brother/Printers/HL1210W/lpd/psconvert2
+
+    patchelf --set-interpreter ${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2 $out/opt/brother/Printers/HL1210W/lpd/brprintconflsr3
+    patchelf --set-interpreter ${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2 $out/opt/brother/Printers/HL1210W/lpd/rawtobr3
+    patchelf --set-interpreter ${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2 $out/opt/brother/Printers/HL1210W/inf/braddprinter
+
+    wrapProgram $out/opt/brother/Printers/HL1210W/lpd/psconvert2 \
+      --prefix PATH ":" ${ stdenv.lib.makeBinPath [ gnused coreutils gawk ] }
+    wrapProgram $out/opt/brother/Printers/HL1210W/lpd/filter_HL1210W \
+      --prefix PATH ":" ${ stdenv.lib.makeBinPath [ ghostscript a2ps file gnused coreutils ] }
+
+    # install cups
+    dpkg-deb -x ${cupsdeb} $out
+
+    substituteInPlace $out/opt/brother/Printers/HL1210W/cupswrapper/brother_lpdwrapper_HL1210W --replace /opt "$out/opt"
+
+    mkdir -p $out/lib/cups/filter
+    ln -s $out/opt/brother/Printers/HL1210W/cupswrapper/brother_lpdwrapper_HL1210W $out/lib/cups/filter/brother_lpdwrapper_HL1210W
+    ln -s $out/opt/brother/Printers/HL1210W/cupswrapper/brother-HL1210W-cups-en.ppd $out/lib/cups/filter/brother-HL1210W-cups-en.ppd
+    # cp brcupsconfig4 $out/opt/brother/Printers/HL1110/cupswrapper/
+    ln -s $out/opt/brother/Printers/HL1210W/cupswrapper/brcupsconfig4 $out/lib/cups/filter/brcupsconfig4
+
+    wrapProgram $out/opt/brother/Printers/HL1210W/cupswrapper/brother_lpdwrapper_HL1210W \
+      --prefix PATH ":" ${ stdenv.lib.makeBinPath [ gnused coreutils gawk ] }
+    '';
+
+  meta = {
+    homepage = "http://www.brother.com/";
+    description = "Brother HL1210W printer driver";
+    license = stdenv.lib.licenses.unfree;
+    platforms = stdenv.lib.platforms.linux;
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=nz&lang=en&prod=hl1210w_eu_as&os=128";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25996,6 +25996,8 @@ in
 
   cups-brother-hl1110 = pkgsi686Linux.callPackage ../misc/cups/drivers/hl1110 { };
 
+  cups-brother-hl1210w = pkgsi686Linux.callPackage ../misc/cups/drivers/hl1210w { };
+
   cups-brother-hl3140cw = pkgsi686Linux.callPackage ../misc/cups/drivers/hl3140cw { };
 
   cups-brother-hll2340dw = pkgsi686Linux.callPackage  ../misc/cups/drivers/hll2340dw { };


### PR DESCRIPTION
Based on cups-brother-hl1110.
Installed PPD can be found at /var/lib/cups/path/lib/cups/filter/brother-HL1210W-cups-en.ppd

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Package Brother HL1210W Cups printer driver.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
