### PR TITLE
[20.03] openjdk: 11.06 -> 11.08

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -10,16 +10,17 @@
 
 let
   major = "11";
-  update = ".0.7";
-  build = "ga";
+  minor = "0";
+  update = "8";
+  build = "10";
 
   openjdk = stdenv.mkDerivation rec {
     pname = "openjdk" + lib.optionalString headless "-headless";
-    version = "${major}${update}-${build}";
+    version = "${major}.${minor}.${update}+${build}";
 
     src = fetchurl {
       url = "http://hg.openjdk.java.net/jdk-updates/jdk${major}u/archive/jdk-${version}.tar.gz";
-      sha256 = "14daacng9ndxf4kmvsn7nracwfiwwmw5rha8rkk3723pfk9g8q7p";
+      sha256 = "1sdncn1bk4h8xxfnmrl1125maqy6mc0v0y1dyifwsa04wasj9hbz";
     };
 
     nativeBuildInputs = [ pkgconfig autoconf ];

--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -10,7 +10,7 @@
 
 let
   major = "11";
-  update = ".0.6";
+  update = ".0.7";
   build = "ga";
 
   openjdk = stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ let
 
     src = fetchurl {
       url = "http://hg.openjdk.java.net/jdk-updates/jdk${major}u/archive/jdk-${version}.tar.gz";
-      sha256 = "1w6n0cnz9izpjb3sc870q7a0jz85a6c7fiszymxin10cnsajkzir";
+      sha256 = "14daacng9ndxf4kmvsn7nracwfiwwmw5rha8rkk3723pfk9g8q7p";
     };
 
     nativeBuildInputs = [ pkgconfig autoconf ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Backporting latest java release.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
 asbachb@nixos  ~/dev/src/nix/nixpkgs   backport/openjdk11  nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
these paths will be fetched (38.95 MiB download, 169.16 MiB unpacked):
  /nix/store/91qp2v2h0fd9d6b6hchzf13zki091grv-nixpkgs-review-2.3.1
  /nix/store/b3zsk4ihlpiimv3vff86bb5bxghgdzb9-gcc-9.2.0
  /nix/store/d43v6bx7r6fcaq3fbbfd5mwh1f5s7rmg-bash-interactive-4.4-p23-dev
  /nix/store/hrkc2sf2883l16d5yq3zg0y339kfw4xv-binutils-2.31.1
  /nix/store/m6h7zh8w6s52clnyskffj5lbkakqgywn-gcc-wrapper-9.2.0
  /nix/store/n48b8n251dwwb04q7f3fwxdmirsakllz-binutils-wrapper-2.31.1
  /nix/store/sm7kk5n84vaisqvhk1yfsjqls50j8s0m-stdenv-linux
  /nix/store/y7bnk8yvamaqfh19vvfapp2412qniipl-expand-response-params
copying path '/nix/store/91qp2v2h0fd9d6b6hchzf13zki091grv-nixpkgs-review-2.3.1' from 'https://cache.nixos.org'...
copying path '/nix/store/y7bnk8yvamaqfh19vvfapp2412qniipl-expand-response-params' from 'https://cache.nixos.org'...
copying path '/nix/store/b3zsk4ihlpiimv3vff86bb5bxghgdzb9-gcc-9.2.0' from 'https://cache.nixos.org'...
copying path '/nix/store/d43v6bx7r6fcaq3fbbfd5mwh1f5s7rmg-bash-interactive-4.4-p23-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/hrkc2sf2883l16d5yq3zg0y339kfw4xv-binutils-2.31.1' from 'https://cache.nixos.org'...
copying path '/nix/store/n48b8n251dwwb04q7f3fwxdmirsakllz-binutils-wrapper-2.31.1' from 'https://cache.nixos.org'...
copying path '/nix/store/m6h7zh8w6s52clnyskffj5lbkakqgywn-gcc-wrapper-9.2.0' from 'https://cache.nixos.org'...
copying path '/nix/store/sm7kk5n84vaisqvhk1yfsjqls50j8s0m-stdenv-linux' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
   f9b0bc3f297..588940d405d  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-c4bb2630f5add9ca417910bb1f285e21d6a8949f-dirty/nixpkgs 588940d405de503d60751bfe965fe772cbb91bde
Preparing worktree (detached HEAD 588940d405d)
Updating files: 100% (22285/22285), done.
HEAD is now at 588940d405d Merge pull request #94570 from r-ryantm/auto-update/python2.7-autopep8
$ nix-env -f /home/asbachb/.cache/nixpkgs-review/rev-c4bb2630f5add9ca417910bb1f285e21d6a8949f-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
