### PR TITLE
nixos/dokuwiki: drop SSL forcing and document incompatibility

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -588,6 +588,31 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
       When updating Graylog from a version before 3.3.3 make sure to check the Graylog <link xlink:href="https://www.graylog.org/post/announcing-graylog-v3-3-3">release info</link> for information on how to avoid the issue.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The <literal>dokuwiki</literal> module has changed to multi-instance, using submodules.
+     Therefore, it is now mandatory to name each instance. Moreover, forcing SSL by default has been dropped, so
+     <literal>nginx.forceSSL</literal> and <literal>nginx.enableACME</literal> are no longer set to <literal>true</literal>.
+     To continue using your service with the original SSL settings, you have to adjust the original config, e.g.:
+<programlisting>
+services.dokuwiki = {
+  enable = true;
+  ...
+};
+</programlisting>
+     To something similar:
+<programlisting>
+services.dokuwiki."mywiki" = {
+  enable = true;
+  nginx = {
+    forceSSL = true;
+    enableACME = true;
+  };
+  ...
+};
+</programlisting>
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -548,7 +548,7 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
     <para>
      The <literal>bitcoind</literal> module has changed to multi-instance, using submodules.
      Therefore, it is now mandatory to name each instance.
-     To use this new multi-instance config with an existing bitcoind data directory and user, 
+     To use this new multi-instance config with an existing bitcoind data directory and user,
      you have to adjust the original config, e.g.:
 <programlisting>
   services.bitcoind = {

--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -249,22 +249,19 @@ let
       nginx = mkOption {
         type = types.submodule (
           recursiveUpdate
-            (import ../web-servers/nginx/vhost-options.nix { inherit config lib; })
-            {
-              # Enable encryption by default,
-              options.forceSSL.default = true;
-              options.enableACME.default = true;
-            }
+            (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {}
         );
-        default = {forceSSL = true; enableACME = true;};
+        default = {};
         example = {
           serverAliases = [
             "wiki.\${config.networking.domain}"
           ];
-          enableACME = false;
+          # To enable encryption and let let's encrypt take care of certificate
+          forceSSL = true;
+          enableACME = true;
         };
         description = ''
-          With this option, you can customize the nginx virtualHost which already has sensible defaults for DokuWiki.
+          With this option, you can customize the nginx virtualHost settings.
         '';
       };
     };
@@ -276,7 +273,7 @@ in
     services.dokuwiki = mkOption {
       type = types.attrsOf (types.submodule siteOpts);
       default = {};
-      description = "Sepcification of one or more dokuwiki sites to service.";
+      description = "Sepcification of one or more dokuwiki sites to serve.";
     };
   };
 

--- a/nixos/tests/dokuwiki.nix
+++ b/nixos/tests/dokuwiki.nix
@@ -39,18 +39,10 @@ in {
     services.dokuwiki."site1.local" = {
       aclUse = false;
       superUser = "admin";
-      nginx = {
-        forceSSL = false;
-        enableACME = false;
-      };
     };
     services.dokuwiki."site2.local" = {
       aclUse = true;
       superUser = "admin";
-      nginx = {
-        forceSSL = false;
-        enableACME = false;
-      };
       templates = [ template-bootstrap3 ];
       plugins = [ plugin-icalevents ];
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Dropping configuration which was forcing user to use Let's encrypt and SSL as default. It was non-intuitive and causing problems in some configurations.

Moreover, I've documented breaking changes introduced in https://github.com/NixOS/nixpkgs/pull/83769.

Following up on https://github.com/NixOS/nixpkgs/pull/94551.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
