### PR TITLE
nixos/openldap: switch to slapd.d configuration with structured settings

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -185,6 +185,14 @@
      which is the new stable release.  OpenAFS 1.6 was removed.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      The <literal>openldap</literal> module now has support for OLC-style
+      configuration, users of the <literal>configDir</literal> option may wish
+      to migrate. If you continue to use <literal>configDir</literal>, ensure that
+      <literal>olcPidFile</literal> is set to <literal>/run/slapd/slapd.pid</literal>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -192,6 +192,24 @@
       to migrate. If you continue to use <literal>configDir</literal>, ensure that
       <literal>olcPidFile</literal> is set to <literal>/run/slapd/slapd.pid</literal>.
     </para>
+    <para>
+      As a result, <literal>extraConfig</literal> and <literal>extraDatabaseConfig</literal>
+      are removed. To help with migration, you can convert your <literal>slapd.conf</literal>
+      file to OLC configuration with the following script (find the location of this
+      configuration file by running <literal>systemctl status openldap</literal>, it is the
+      <literal>-f</literal> option.
+    </para>
+    <programlisting>
+      TMPDIR=$(mktemp -d)
+      slaptest -f /path/to/slapd.conf $TMPDIR
+      slapcat -F $TMPDIR -n0 -H 'ldap:///???(!(objectClass=olcSchemaConfig))'
+    </programlisting>
+    <para>
+      This will dump your current configuration in LDIF format, which should be
+      straightforward to convert into Nix settings. This does not show your schema
+      configuration, as this is unnecessarily verbose for users of the default schemas
+      and <literal>slaptest</literal> is buggy with schemas directly in the config file.
+    </para>
    </listitem>
   </itemizedlist>
  </section>

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -135,7 +135,7 @@ in
       #keys = 96; # unused
       #haproxy = 97; # dynamically allocated as of 2020-03-11
       mongodb = 98;
-      openldap = 99;
+      #openldap = 99; # dynamically allocated as of PR#94610
       #users = 100; # unused
       cgminer = 101;
       munin = 102;
@@ -451,7 +451,7 @@ in
       keys = 96;
       #haproxy = 97; # dynamically allocated as of 2020-03-11
       #mongodb = 98; # unused
-      openldap = 99;
+      #openldap = 99; # dynamically allocated as of PR#94610
       munin = 102;
       #logcheck = 103; # unused
       #nix-ssh = 104; # unused

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -51,26 +51,26 @@ let
           default = {};
           description = "Child entries of the current entry, with recursively the same structure.";
           example = lib.literalExample ''
-          {
-            "cn=schema" = {
-              # The attribute used in the DN must be defined
-              attrs = { cn = "schema"; };
-              children = {
-                # This entry's DN is expanded to "cn=foo,cn=schema"
-                "cn=foo" = { ... };
-              };
-              # These includes are inserted after "cn=schema", but before "cn=foo,cn=schema"
-              includes = [ ... ];
-            };
-          }
-        '';
+            {
+                "cn=schema" = {
+                # The attribute used in the DN must be defined
+                attrs = { cn = "schema"; };
+                children = {
+                    # This entry's DN is expanded to "cn=foo,cn=schema"
+                    "cn=foo" = { ... };
+                };
+                # These includes are inserted after "cn=schema", but before "cn=foo,cn=schema"
+                includes = [ ... ];
+                };
+            }
+          '';
         };
         includes = mkOption {
           type = types.listOf types.path;
           default = [];
           description = ''
-          LDIF files to include after the parent's attributes but before its children.
-        '';
+            LDIF files to include after the parent's attributes but before its children.
+          '';
         };
       };
     in types.submodule { inherit options; };

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -421,13 +421,7 @@ in {
           let oldValue = (getAttr old cfg);
           in if (isList oldValue) then "[ ${concatStringsSep " " oldValue} ]" else oldValue
         )}
-    '') deprecations)) ++ (optional (cfg.configDir != null && (versionOlder config.system.stateVersion "20.09")) ''
-      The attribute `services.openldap.settings` now exists, and may be more
-      useful than `services.openldap.configDir`. If you continue to use
-      `configDir`, ensure that `olcPidFile` is set to "/run/slapd/slapd.pid".
-
-      Set `system.stateVersion` to "20.09" or greater to silence this message.
-    '');
+    '') deprecations));
 
     assertions = [{
       assertion = !(cfg.rootpwFile != null && cfg.rootpw != null);

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -411,8 +411,10 @@ in {
 
       After deploying this configuration, you can run:
         slapcat -F ${configDir} -n0 -H 'ldap:///???(!(objectClass=olcSchemaConfig))'
-      on the same host to print your current configuration in LDIF format,
-      which should be straightforward to convert into Nix settings.
+      on the same host to print your current configuration in LDIF format, which
+      should be straightforward to convert into Nix settings. This does not show
+      your schema configuration (as this is unnecessarily verbose users of the
+      default schemas), so be sure to migrate that as well.
     '') ++ (flatten (map (args@{old, new, ...}: lib.optional ((lib.hasAttr old cfg) && (lib.getAttr old cfg) != null) ''
       The attribute `services.openldap.${old}` is deprecated. Please set it to
       `null` and use the following option instead:

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -474,14 +474,14 @@ in {
             ${openldap}/bin/slaptest -f ${configFile} -F ${configDir} || true
           '' else ''
             rm -Rf '${configDir}'/*
-            ${openldap}/bin/slapadd -F ${configDir} -n0 -l ${settingsFile}
+            ${openldap}/bin/slapadd -F ${configDir} -bcn=config -l ${settingsFile}
           ''
         )}
         chown -R "${cfg.user}:${cfg.group}" '${configDir}'
 
         ${optionalString (cfg.declarativeContents != null) ''
           rm -Rf '${lib.head dataDirs}'/*
-          ${openldap}/bin/slapadd -F ${configDir} -n1 -l ${dataFile}
+          ${openldap}/bin/slapadd -F ${configDir} -b${cfg.suffix} -l ${dataFile}
           chown -R "${cfg.user}:${cfg.group}" ${lib.escapeShellArgs dataDirs}
         ''}
 

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -4,27 +4,6 @@ with lib;
 let
   cfg = config.services.openldap;
   openldap = cfg.package;
-
-  configFile = pkgs.writeText "slapd.conf" ((optionalString (cfg.defaultSchemas != null && cfg.defaultSchemas) ''
-    include ${openldap}/etc/schema/core.schema
-    include ${openldap}/etc/schema/cosine.schema
-    include ${openldap}/etc/schema/inetorgperson.schema
-    include ${openldap}/etc/schema/nis.schema
-  '') + ''
-    pidfile /run/slapd/slapd.pid
-    ${if cfg.extraConfig != null then cfg.extraConfig else ""}
-    database ${cfg.database}
-    suffix ${cfg.suffix}
-    rootdn ${cfg.rootdn}
-    ${if (cfg.rootpw != null) then ''
-      rootpw ${cfg.rootpw}
-    '' else ''
-      include ${cfg.rootpwFile}
-    ''}
-    directory ${cfg.dataDir}
-    ${if cfg.extraDatabaseConfig != null then cfg.extraDatabaseConfig else ""}
-  '');
-
   configDir = if cfg.configDir != null then cfg.configDir else "/etc/openldap/slapd.d";
 
   ldapValueType = let
@@ -113,6 +92,12 @@ let
     lib.flatten (lib.mapAttrsToList (name: value: attrsToLdif "${name},${dn}" value) children)
   );
 in {
+  imports = let
+    deprecationNote = "This option is removed due to the deprecation of `slapd.conf` upstream. Please migrate to `services.openldap.settings`, see the release notes for advice with this process.";
+  in [
+    (lib.mkRemovedOptionModule [ "services" "openldap" "extraConfig" ] deprecationNote)
+    (lib.mkRemovedOptionModule [ "services" "openldap" "extraDatabaseConfig" ] deprecationNote)
+  ];
   options = {
     services.openldap = {
       enable = mkOption {
@@ -280,34 +265,11 @@ in {
         type = types.nullOr types.path;
         default = null;
         description = ''
-          Use this optional config directory instead of generating one from the
-          <literal>settings</literal> option.
+          Use this config directory instead of generating one from the
+          <literal>settings</literal> option. Overrides all NixOS settings. If
+          you use this option,ensure `olcPidFile` is set to `/run/slapd/slapd.conf`.
         '';
         example = "/var/db/slapd.d";
-      };
-
-      # These options are deprecated
-      extraConfig = mkOption {
-        type = types.lines;
-        default = "";
-        description = "
-          slapd.conf configuration
-        ";
-        example = literalExample ''
-            '''
-            include ${openldap}/etc/schema/core.schema
-            include ${openldap}/etc/schema/cosine.schema
-            include ${openldap}/etc/schema/inetorgperson.schema
-            include ${openldap}/etc/schema/nis.schema
-
-            database bdb
-            suffix dc=example,dc=org
-            rootdn cn=admin,dc=example,dc=org
-            # NOTE: change after first start
-            rootpw secret
-            directory /var/db/openldap
-            '''
-          '';
       };
 
       declarativeContents = mkOption {
@@ -337,41 +299,7 @@ in {
           # ...
         '';
       };
-
-      extraDatabaseConfig = mkOption {
-        type = types.lines;
-        default = "";
-        description = ''
-          slapd.conf configuration after the database option.
-          This setting will be ignored if configDir is set.
-        '';
-        example = ''
-          # Indices to maintain for this directory
-          # unique id so equality match only
-          index uid eq
-          # allows general searching on commonname, givenname and email
-          index cn,gn,mail eq,sub
-          # allows multiple variants on surname searching
-          index sn eq,sub
-          # sub above includes subintial,subany,subfinal
-          # optimise department searches
-          index ou eq
-          # if searches will include objectClass uncomment following
-          # index objectClass eq
-          # shows use of default index parameter
-          index default eq,sub
-          # indices missing - uses default eq,sub
-          index telephonenumber
-
-          # other database parameters
-          # read more in slapd.conf reference section
-          cachesize 10000
-          checkpoint 128 15
-        '';
-      };
-
     };
-
   };
 
   meta = {
@@ -404,18 +332,7 @@ in {
           newValue = "{ path = \"${cfg.rootpwFile}\"; }";
           note = "The file should contain only the password (without \"rootpw \" as before)"; }
       ];
-    in (optional (cfg.extraConfig != "" || cfg.extraDatabaseConfig != "") ''
-      The options `extraConfig` and `extraDatabaseConfig` of `services.openldap`
-      are deprecated. This is due to the deprecation of `slapd.conf`
-      upstream. Please migrate to `services.openldap.settings`.
-
-      After deploying this configuration, you can run:
-        slapcat -F ${configDir} -n0 -H 'ldap:///???(!(objectClass=olcSchemaConfig))'
-      on the same host to print your current configuration in LDIF format, which
-      should be straightforward to convert into Nix settings. This does not show
-      your schema configuration (as this is unnecessarily verbose users of the
-      default schemas), so be sure to migrate that as well.
-    '') ++ (flatten (map (args@{old, new, ...}: lib.optional ((lib.hasAttr old cfg) && (lib.getAttr old cfg) != null) ''
+    in (flatten (map (args@{old, new, ...}: lib.optional ((lib.hasAttr old cfg) && (lib.getAttr old cfg) != null) ''
       The attribute `services.openldap.${old}` is deprecated. Please set it to
       `null` and use the following option instead:
 
@@ -487,35 +404,32 @@ in {
         mkdir -p ${lib.escapeShellArg configDir} ${lib.escapeShellArgs (lib.attrValues dataDirs)}
         chown "${cfg.user}:${cfg.group}" ${lib.escapeShellArg configDir} ${lib.escapeShellArgs (lib.attrValues dataDirs)}
 
-        ${lib.optionalString (cfg.configDir == null) (
-          if (cfg.extraConfig != "" || cfg.extraDatabaseConfig != "") then ''
-            rm -Rf ${configDir}/*
-            # -u disables config generation, so just ignore the return code
-            ${openldap}/bin/slaptest -f ${configFile} -F ${configDir} || true
-          '' else ''
-            rm -Rf ${configDir}/*
-            ${openldap}/bin/slapadd -F ${configDir} -bcn=config -l ${settingsFile}
-          ''
-        )}
+        ${lib.optionalString (cfg.configDir == null) (''
+          rm -Rf ${configDir}/*
+          ${openldap}/bin/slapadd -F ${configDir} -bcn=config -l ${settingsFile}
+        '')}
         chown -R "${cfg.user}:${cfg.group}" ${lib.escapeShellArg configDir}
 
-        ${if types.lines.check cfg.declarativeContents then (let
-          dataFile = pkgs.writeText "ldap-contents.ldif" cfg.declarativeContents;
-        in ''
-          rm -rf ${lib.escapeShellArg cfg.dataDir}/*
-          ${openldap}/bin/slapadd -F ${lib.escapeShellArg configDir} -l ${dataFile}
-          chown -R "${cfg.user}:${cfg.group}" ${lib.escapeShellArg cfg.dataDir}
-        '') else (let
-          dataFiles = lib.mapAttrs (dn: contents: pkgs.writeText "${dn}.ldif" contents) cfg.declarativeContents;
-        in ''
-          ${lib.concatStrings (lib.mapAttrsToList (dn: file: let
-            dataDir = lib.escapeShellArg (getAttr dn dataDirs);
+        ${if types.lines.check cfg.declarativeContents
+          then (let
+            dataFile = pkgs.writeText "ldap-contents.ldif" cfg.declarativeContents;
           in ''
-            rm -rf ${dataDir}/*
-            ${openldap}/bin/slapadd -F ${lib.escapeShellArg configDir} -b ${dn} -l ${file}
-            chown -R "${cfg.user}:${cfg.group}" ${dataDir}
-          '') dataFiles)}
-        '')}
+            rm -rf ${lib.escapeShellArg cfg.dataDir}/*
+            ${openldap}/bin/slapadd -F ${lib.escapeShellArg configDir} -l ${dataFile}
+            chown -R "${cfg.user}:${cfg.group}" ${lib.escapeShellArg cfg.dataDir}
+          '')
+          else (let
+            dataFiles = lib.mapAttrs (dn: contents: pkgs.writeText "${dn}.ldif" contents) cfg.declarativeContents;
+          in ''
+            ${lib.concatStrings (lib.mapAttrsToList (dn: file: let
+              dataDir = lib.escapeShellArg (getAttr dn dataDirs);
+            in ''
+              rm -rf ${dataDir}/*
+              ${openldap}/bin/slapadd -F ${lib.escapeShellArg configDir} -b ${dn} -l ${file}
+              chown -R "${cfg.user}:${cfg.group}" ${dataDir}
+            '') dataFiles)}
+          '')
+         }
 
         ${openldap}/bin/slaptest -u -F ${lib.escapeShellArg configDir}
       '';

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -1,33 +1,146 @@
-import ./make-test-python.nix {
-  name = "openldap";
+{ pkgs, system ? builtins.currentSystem, ... }: let
+  declarativeContents = ''
+    dn: dc=example
+    objectClass: domain
+    dc: example
 
-  machine = { pkgs, ... }: {
-    services.openldap = {
-      enable = true;
-      suffix = "dc=example";
-      rootdn = "cn=root,dc=example";
-      rootpw = "notapassword";
-      database = "bdb";
-      extraDatabaseConfig = ''
-        directory /var/db/openldap
-      '';
-      declarativeContents = ''
-        dn: dc=example
-        objectClass: domain
-        dc: example
-
-        dn: ou=users,dc=example
-        objectClass: organizationalUnit
-        ou: users
-      '';
-    };
-  };
-
+    dn: ou=users,dc=example
+    objectClass: organizationalUnit
+    ou: users
+  '';
   testScript = ''
     machine.wait_for_unit("openldap.service")
     machine.succeed(
-        "systemctl status openldap.service",
         'ldapsearch -LLL -D "cn=root,dc=example" -w notapassword -b "dc=example"',
     )
   '';
+in {
+  # New-style configuration
+  current = import ./make-test-python.nix {
+    inherit testScript;
+    name = "openldap";
+
+    machine = { pkgs, ... }: {
+      services.openldap = {
+        inherit declarativeContents;
+        enable = true;
+        defaultSchemas = null;
+        dataDir = null;
+        database = null;
+        settings = {
+          children = {
+            "cn=schema" = {
+              includes = [
+                "${pkgs.openldap}/etc/schema/core.ldif"
+                "${pkgs.openldap}/etc/schema/cosine.ldif"
+                "${pkgs.openldap}/etc/schema/inetorgperson.ldif"
+                "${pkgs.openldap}/etc/schema/nis.ldif"
+              ];
+            };
+            "olcDatabase={1}mdb" = {
+              attrs = {
+                objectClass = [ "olcDatabaseConfig" "olcMdbConfig" ];
+                olcDatabase = "{1}mdb";
+                olcDbDirectory = "/var/db/openldap";
+                olcSuffix = "dc=example";
+                olcRootDN = "cn=root,dc=example";
+                olcRootPW = "notapassword";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+
+  # Old-style configuration
+  shortOptions = import ./make-test-python.nix {
+    inherit testScript;
+    name = "openldap";
+
+    machine = { pkgs, ... }: {
+      services.openldap = {
+        inherit declarativeContents;
+        enable = true;
+        suffix = "dc=example";
+        rootdn = "cn=root,dc=example";
+        rootpw = "notapassword";
+      };
+    };
+  };
+
+  # Manually managed configDir, for example if dynamic config is essential
+  manualConfigDir = import ./make-test-python.nix {
+    name = "openldap";
+
+    machine = { pkgs, ... }: {
+      services.openldap = {
+        enable = true;
+        configDir = "/var/db/slapd.d";
+        # Silence warnings
+        defaultSchemas = null;
+        dataDir = null;
+        database = null;
+      };
+    };
+
+    testScript = let
+      contents = pkgs.writeText "data.ldif" declarativeContents;
+      config = pkgs.writeText "config.ldif" ''
+        dn: cn=config
+        cn: config
+        objectClass: olcGlobal
+        olcLogLevel: stats
+        olcPidFile: /run/slapd/slapd.pid
+
+        dn: cn=schema,cn=config
+        cn: schema
+        objectClass: olcSchemaConfig
+
+        include: file://${pkgs.openldap}/etc/schema/core.ldif
+        include: file://${pkgs.openldap}/etc/schema/cosine.ldif
+        include: file://${pkgs.openldap}/etc/schema/inetorgperson.ldif
+
+        dn: olcDatabase={1}mdb,cn=config
+        objectClass: olcDatabaseConfig
+        objectClass: olcMdbConfig
+        olcDatabase: {1}mdb
+        olcDbDirectory: /var/db/openldap
+        olcDbIndex: objectClass eq
+        olcSuffix: dc=example
+        olcRootDN: cn=root,dc=example
+        olcRootPW: notapassword
+      '';
+    in ''
+      machine.succeed(
+          "mkdir -p /var/db/slapd.d /var/db/openldap",
+          "slapadd -F /var/db/slapd.d -n0 -l ${config}",
+          "slapadd -F /var/db/slapd.d -n1 -l ${contents}",
+          "chown -R openldap:openldap /var/db/slapd.d /var/db/openldap",
+          "systemctl restart openldap",
+      )
+    '' + testScript;
+  };
+
+  # extraConfig forces use of slapd.conf, test this until that option is removed
+  legacyConfig = import ./make-test-python.nix {
+    inherit testScript;
+    name = "openldap";
+
+    machine = { pkgs, ... }: {
+      services.openldap = {
+        inherit declarativeContents;
+        enable = true;
+        suffix = "dc=example";
+        rootdn = "cn=root,dc=example";
+        rootpw = "notapassword";
+        extraConfig = ''
+          # No-op
+        '';
+        extraDatabaseConfig = ''
+          # No-op
+        '';
+      };
+    };
+  };
 }

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -24,9 +24,6 @@ in {
       environment.etc."openldap/root_password".text = "notapassword";
       services.openldap = {
         enable = true;
-        defaultSchemas = null;
-        dataDir = null;
-        database = null;
         settings = {
           children = {
             "cn=schema" = {
@@ -61,17 +58,21 @@ in {
   };
 
   # Old-style configuration
-  shortOptions = import ./make-test-python.nix {
+  oldOptions = import ./make-test-python.nix {
     inherit testScript;
     name = "openldap";
 
     machine = { pkgs, ... }: {
       services.openldap = {
         enable = true;
+        logLevel = "stats acl";
+        defaultSchemas = true;
+        database = "mdb";
         suffix = "dc=example";
         rootdn = "cn=root,dc=example";
         rootpw = "notapassword";
-        declarativeContents = dbContents;
+        dataDir = "/var/db/openldap";
+        declarativeContents."dc=example" = dbContents;
       };
     };
   };
@@ -84,10 +85,6 @@ in {
       services.openldap = {
         enable = true;
         configDir = "/var/db/slapd.d";
-        # Silence warnings
-        defaultSchemas = null;
-        dataDir = null;
-        database = null;
       };
     };
 

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -71,7 +71,6 @@ in {
         suffix = "dc=example";
         rootdn = "cn=root,dc=example";
         rootpw = "notapassword";
-        dataDir = "/var/db/openldap";
         declarativeContents."dc=example" = dbContents;
       };
     };

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -121,26 +121,4 @@ in {
       )
     '' + testScript;
   };
-
-  # extraConfig forces use of slapd.conf, test this until that option is removed
-  legacyConfig = import ./make-test-python.nix {
-    inherit testScript;
-    name = "openldap";
-
-    machine = { pkgs, ... }: {
-      services.openldap = {
-        enable = true;
-        suffix = "dc=example";
-        rootdn = "cn=root,dc=example";
-        rootpw = "notapassword";
-        extraConfig = ''
-          # No-op
-        '';
-        extraDatabaseConfig = ''
-          # No-op
-        '';
-        declarativeContents = dbContents;
-      };
-    };
-  };
 }

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -21,6 +21,7 @@ in {
     name = "openldap";
 
     machine = { pkgs, ... }: {
+      environment.etc."openldap/root_password".text = "notapassword";
       services.openldap = {
         enable = true;
         defaultSchemas = null;
@@ -37,13 +38,19 @@ in {
               ];
             };
             "olcDatabase={1}mdb" = {
+              # This tests string, base64 and path values, as well as lists of string values
               attrs = {
                 objectClass = [ "olcDatabaseConfig" "olcMdbConfig" ];
                 olcDatabase = "{1}mdb";
                 olcDbDirectory = "/var/db/openldap";
                 olcSuffix = "dc=example";
-                olcRootDN = "cn=root,dc=example";
-                olcRootPW = "notapassword";
+                olcRootDN = {
+                  # cn=root,dc=example
+                  base64 = "Y249cm9vdCxkYz1leGFtcGxl";
+                };
+                olcRootPW = {
+                  path = "/etc/openldap/root_password";
+                };
               };
             };
           };

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -26,14 +26,12 @@ in {
         enable = true;
         settings = {
           children = {
-            "cn=schema" = {
-              includes = [
-                "${pkgs.openldap}/etc/schema/core.ldif"
-                "${pkgs.openldap}/etc/schema/cosine.ldif"
-                "${pkgs.openldap}/etc/schema/inetorgperson.ldif"
-                "${pkgs.openldap}/etc/schema/nis.ldif"
-              ];
-            };
+            "cn=schema".includes = [
+              "${pkgs.openldap}/etc/schema/core.ldif"
+              "${pkgs.openldap}/etc/schema/cosine.ldif"
+              "${pkgs.openldap}/etc/schema/inetorgperson.ldif"
+              "${pkgs.openldap}/etc/schema/nis.ldif"
+            ];
             "olcDatabase={1}mdb" = {
               # This tests string, base64 and path values, as well as lists of string values
               attrs = {

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -1,5 +1,5 @@
 { pkgs, system ? builtins.currentSystem, ... }: let
-  declarativeContents = ''
+  dbContents = ''
     dn: dc=example
     objectClass: domain
     dc: example
@@ -22,7 +22,6 @@ in {
 
     machine = { pkgs, ... }: {
       services.openldap = {
-        inherit declarativeContents;
         enable = true;
         defaultSchemas = null;
         dataDir = null;
@@ -49,6 +48,7 @@ in {
             };
           };
         };
+        declarativeContents."dc=example" = dbContents;
       };
     };
   };
@@ -60,11 +60,11 @@ in {
 
     machine = { pkgs, ... }: {
       services.openldap = {
-        inherit declarativeContents;
         enable = true;
         suffix = "dc=example";
         rootdn = "cn=root,dc=example";
         rootpw = "notapassword";
+        declarativeContents = dbContents;
       };
     };
   };
@@ -85,7 +85,7 @@ in {
     };
 
     testScript = let
-      contents = pkgs.writeText "data.ldif" declarativeContents;
+      contents = pkgs.writeText "data.ldif" dbContents;
       config = pkgs.writeText "config.ldif" ''
         dn: cn=config
         cn: config
@@ -129,7 +129,6 @@ in {
 
     machine = { pkgs, ... }: {
       services.openldap = {
-        inherit declarativeContents;
         enable = true;
         suffix = "dc=example";
         rootdn = "cn=root,dc=example";
@@ -140,6 +139,7 @@ in {
         extraDatabaseConfig = ''
           # No-op
         '';
+        declarativeContents = dbContents;
       };
     };
   };

--- a/nixos/tests/sssd-ldap.nix
+++ b/nixos/tests/sssd-ldap.nix
@@ -17,10 +17,26 @@
     machine = { pkgs, ... }: {
       services.openldap = {
         enable = true;
-        database = "mdb";
-        rootdn = "cn=${ldapRootUser},${dbSuffix}";
-        rootpw = ldapRootPassword;
-        suffix = dbSuffix;
+        settings = {
+          children = {
+            "cn=schema".includes = [
+              "${pkgs.openldap}/etc/schema/core.ldif"
+              "${pkgs.openldap}/etc/schema/cosine.ldif"
+              "${pkgs.openldap}/etc/schema/inetorgperson.ldif"
+              "${pkgs.openldap}/etc/schema/nis.ldif"
+            ];
+            "olcDatabase={1}mdb" = {
+              attrs = {
+                objectClass = [ "olcDatabaseConfig" "olcMdbConfig" ];
+                olcDatabase = "{1}mdb";
+                olcDbDirectory = "/var/db/openldap";
+                olcSuffix = dbSuffix;
+                olcRootDN = "cn=${ldapRootUser},${dbSuffix}";
+                olcRootPW = ldapRootPassword;
+              };
+            };
+          };
+        };
         declarativeContents = {
           ${dbSuffix} = ''
             dn: ${dbSuffix}

--- a/nixos/tests/sssd-ldap.nix
+++ b/nixos/tests/sssd-ldap.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ pkgs, ... }:
+({ pkgs, ... }:
   let
     dbDomain = "example.org";
     dbSuffix = "dc=example,dc=org";
@@ -7,8 +7,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     ldapRootPassword = "foobar";
 
     testUser = "alice";
-  in
-  {
+  in import ./make-test-python.nix {
     name = "sssd-ldap";
 
     meta = with pkgs.stdenv.lib.maintainers; {
@@ -18,34 +17,37 @@ import ./make-test-python.nix ({ pkgs, ... }:
     machine = { pkgs, ... }: {
       services.openldap = {
         enable = true;
+        database = "mdb";
         rootdn = "cn=${ldapRootUser},${dbSuffix}";
         rootpw = ldapRootPassword;
         suffix = dbSuffix;
-        declarativeContents = ''
-          dn: ${dbSuffix}
-          objectClass: top
-          objectClass: dcObject
-          objectClass: organization
-          o: ${dbDomain}
+        declarativeContents = {
+          ${dbSuffix} = ''
+            dn: ${dbSuffix}
+            objectClass: top
+            objectClass: dcObject
+            objectClass: organization
+            o: ${dbDomain}
 
-          dn: ou=posix,${dbSuffix}
-          objectClass: top
-          objectClass: organizationalUnit
+            dn: ou=posix,${dbSuffix}
+            objectClass: top
+            objectClass: organizationalUnit
 
-          dn: ou=accounts,ou=posix,${dbSuffix}
-          objectClass: top
-          objectClass: organizationalUnit
+            dn: ou=accounts,ou=posix,${dbSuffix}
+            objectClass: top
+            objectClass: organizationalUnit
 
-          dn: uid=${testUser},ou=accounts,ou=posix,${dbSuffix}
-          objectClass: person
-          objectClass: posixAccount
-          # userPassword: somePasswordHash
-          homeDirectory: /home/${testUser}
-          uidNumber: 1234
-          gidNumber: 1234
-          cn: ""
-          sn: ""
-        '';
+            dn: uid=${testUser},ou=accounts,ou=posix,${dbSuffix}
+            objectClass: person
+            objectClass: posixAccount
+            # userPassword: somePasswordHash
+            homeDirectory: /home/${testUser}
+            uidNumber: 1234
+            gidNumber: 1234
+            cn: ""
+            sn: ""
+          '';
+        };
       };
 
       services.sssd = {


### PR DESCRIPTION
###### Motivation for this change

The current configuration options are rather limited (without escaping from NixOS via `configDir` or `extraConfig`).

Second, the use of `slapd.conf`, which is what NixOS currently generates, is deprecated upstream. As a result, `extraConfig` is not a good long-term solution for complex configurations (and `configDir` completely removes the configuration from NixOS's control, so this is not a good solution either).

###### Things done

- Add a structured `services.openldap.settings`, that mirrors the structure of OpenLDAP's configuration. This is used to generate an LDIF file to load and test the configuration at run-time.
- Deprecate `extraConfig` and `extraDatabaseConfig`. This is deprecated upstream. Provide instructions to hopefully ease migration.
- Deprecate the old top-level options, with instructions on how to translate them to the new `settings`. They could still be supported, but the current API is poor in some respects (e.g. support for only one database), so for now I've deprecated them pending discussion.
- Use `Type = forking`, this way the service is not reported as up until it is ready to service requests.
- Add myself as a maintainer. It's only fair I look after the damage I've done here :stuck_out_tongue: 

This conflicts with #92544 (sorry!). I'm happy to add support for initial (as opposed to declarative) contents on top of this PR but haven't included that work here to keep the scope down a little.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
