### PR TITLE
katago: 1.4.4 -> 1.5.0

### DIFF
--- a/pkgs/games/katago/default.nix
+++ b/pkgs/games/katago/default.nix
@@ -17,7 +17,7 @@
 , useTcmalloc ? true}:
 
 assert cudaSupport -> (
-  libGL_driver != null && 
+  libGL_driver != null &&
   cudatoolkit != null &&
   cudnn != null);
 
@@ -29,35 +29,20 @@ assert useTcmalloc -> (
   gperftools != null);
 
 let
-  env = if cudaSupport 
+  env = if cudaSupport
     then gcc8Stdenv
     else stdenv;
 
 in env.mkDerivation rec {
   pname = "katago";
-  version = "1.4.4";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "lightvector";
     repo = "katago";
-    rev = "v${version}";
-    sha256 = "14xs2bm8sky9cdsjdahjqs82q6blzcw05f5d9r1h171dm1hcx566";
+    rev = "${version}";
+    sha256 = "0ajdjdmlzwh7zwk5v0k9zzjawgkf7w30pzqp5bhcsdqz4svvyll2";
   };
-
-  # To workaround CMake 3.17.0's new buggy behavior wrt CUDA Compiler testing
-  # See the following tracking issues:
-  # KataGo:
-  #  - Issue #225: https://github.com/lightvector/KataGo/issues/225
-  #  - PR #227: https://github.com/lightvector/KataGo/pull/227
-  # CMake:
-  #  - Issue #20708: https://gitlab.kitware.com/cmake/cmake/-/issues/20708
-  patches = [
-    (fetchpatch {
-      name = "227.patch";
-      url = "https://patch-diff.githubusercontent.com/raw/lightvector/KataGo/pull/227.patch";
-      sha256 = "03f1vmdjhb79mpj95sijcwla8acy32clrjgrn4xqw5h90zdgj511";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
###### Motivation for this change

Updating to version 1.5.0 of KataGo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
