### PR TITLE
[20.03] mautrix-telegram: add postgresql database driver

### DIFF
--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -2,7 +2,14 @@
 
 with python3.pkgs;
 
-buildPythonPackage rec {
+let
+  # officially supported database drivers
+  dbDrivers = [
+    psycopg2
+    # sqlite driver is already shipped with python by default
+  ];
+
+in buildPythonPackage rec {
   pname = "mautrix-telegram";
   version = "0.7.2";
   disabled = pythonOlder "3.6";
@@ -32,7 +39,7 @@ buildPythonPackage rec {
     pillow
     lxml
     setuptools
-  ];
+  ] ++ dbDrivers;
 
   # `alembic` (a database migration tool) is only needed for the initial setup,
   # and not needed during the actual runtime. However `alembic` requires `mautrix-telegram`
@@ -41,7 +48,7 @@ buildPythonPackage rec {
   # Hence we need to patch away `alembic` from `mautrix-telegram` and create an `alembic`
   # which has `mautrix-telegram` in its environment.
   passthru.alembic = alembic.overrideAttrs (old: {
-    propagatedBuildInputs = old.propagatedBuildInputs ++ [
+    propagatedBuildInputs = old.propagatedBuildInputs ++ dbDrivers ++ [
       mautrix-telegram
     ];
   });


### PR DESCRIPTION
###### Motivation for this change

Backport of #94467.

PostgreSQL is listed as an officially supported database backend.

(cherry picked from commit 1bee4762c3336b2ae4c015a692e96ee89ef0d1e6)


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC: @Ma27 