### PR TITLE
libhdhomerun: add comment about udp firewall rule suggestion

### DIFF
--- a/pkgs/development/libraries/libhdhomerun/default.nix
+++ b/pkgs/development/libraries/libhdhomerun/default.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchurl }:
 
+# libhdhomerun requires UDP port 65001 to be open in order to detect and communicate with tuners.
+# If your firewall is enabled, make sure to have something like:
+#   networking.firewall.allowedUDPPorts = [ 65001 ];
+
 stdenv.mkDerivation rec {
   pname = "libhdhomerun";
   version = "20200521";


### PR DESCRIPTION
###### Motivation for this change

libhdhomerun requires UDP port 65001 to be open in order to detect and communicate with tuners. I've therefore included a comment about a firewall suggestion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
