### PR TITLE
pythonPackages.bsdiff4: init at 1.2.0

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -110,6 +110,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = ''BSD 4-clause "Original" or "Old" License'';
   };
 
+  bsdProtection = spdx {
+    spdxId = "BSD-Protection";
+    fullName = "BSD Protection License";
+  };
+
   bsl11 = {
     fullName = "Business Source License 1.1";
     url = "https://mariadb.com/bsl11";

--- a/pkgs/development/python-modules/bsdiff4/default.nix
+++ b/pkgs/development/python-modules/bsdiff4/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, aflplusplus
+}:
+
+buildPythonPackage rec {
+  pname = "bsdiff4";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17fc0dd4204x5gqapvbrc4kv83jdajs00jxm739586pl0iapybrw";
+  };
+
+  checkPhase = ''
+    mv bsdiff4 _bsdiff4
+    python -c 'import bsdiff4; bsdiff4.test()'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "binary diff and patch using the BSDIFF4-format";
+    homepage = "https://github.com/ilanschnell/bsdiff4";
+    license = licenses.bsdProtection;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2225,6 +2225,8 @@ in {
 
   bsddb3 = callPackage ../development/python-modules/bsddb3 { };
 
+  bsdiff4 = callPackage ../development/python-modules/bsdiff4 { };
+
   bkcharts = callPackage ../development/python-modules/bkcharts { };
 
   bokeh = callPackage ../development/python-modules/bokeh { };


### PR DESCRIPTION
###### Motivation for this change
New package. Requires new license "BSD-Protection" (see https://spdx.org/licenses/BSD-Protection.html)

Tests enabled. Includes cli tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
