### PR TITLE
ephemeral: Patch to disable paid and native infobars

### DIFF
--- a/pkgs/applications/networking/browsers/ephemeral/default.nix
+++ b/pkgs/applications/networking/browsers/ephemeral/default.nix
@@ -15,6 +15,7 @@
 , webkitgtk
 , wrapGAppsHook
 , glib-networking
+, disableInfobars ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -27,6 +28,11 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1lzcwaczh601kwbx7fzg32nrzlg67asby7p86qy10qz86xf4g608";
   };
+
+  patches = stdenv.lib.optionalString disableInfobars [
+    ## Disable infobars regarding app not running on ElementaryOS and donation recommendation
+    ./disable_paid_and_native_infobars.patch
+  ];
 
   nativeBuildInputs = [
     desktop-file-utils
@@ -65,6 +71,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/cassidyjames/ephemeral";
     maintainers = with maintainers; [ xiorcale ] ++ pantheon.maintainers;
     platforms = platforms.linux;
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
   };
 }

--- a/pkgs/applications/networking/browsers/ephemeral/disable_paid_and_native_infobars.patch
+++ b/pkgs/applications/networking/browsers/ephemeral/disable_paid_and_native_infobars.patch
@@ -1,0 +1,17 @@
+ {a => b}/src/Application.vala | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+diff --git a/src/Application.vala b/src/Application.vala
+index 74f5cd2..7d7dbde 100644
+--- a/src/Application.vala
++++ b/src/Application.vala
+@@ -40,8 +40,8 @@ public class Ephemeral.Application : Gtk.Application {
+     public Gtk.IconSize icon_size = Gtk.IconSize.SMALL_TOOLBAR;
+ 
+     public bool ask_default_for_session = true;
+-    public bool warn_native_for_session = true;
+-    public bool warn_paid_for_session = true;
++    public bool warn_native_for_session = false;
++    public bool warn_paid_for_session = false;
+     public int64 last_external_open = int64.MIN;
+ 
+     private bool opening_link = false;


### PR DESCRIPTION


###### Motivation for this change

Ephemeral show an infobar if the program is running on another dist than ElementaryOS and also one if the program seems to be downloaded from github for free.

An optional patch is included to hide these warnings.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
