### PR TITLE
emacs: Make gccemacs build on darwin

### DIFF
--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -68,11 +68,15 @@ in stdenv.mkDerivation {
     # Make native compilation work both inside and outside of nix build
     (lib.optionalString nativeComp (let
       libPath = (lib.concatStringsSep " "
-        (builtins.map (x: ''\"-L${x}\"'') [
+        (builtins.map (x: ''\"-B${x}\"'') [
           "${lib.getLib libgccjit}/lib"
           "${lib.getLib libgccjit}/lib/gcc/${targetPlatform.config}/${libgccjit.version}"
           "${lib.getLib stdenv.cc.cc}/lib"
           "${lib.getLib stdenv.cc.libc}/lib"
+          "${lib.getBin stdenv.cc.cc}"
+          "${lib.getBin stdenv.cc.cc}"
+          "${lib.getBin stdenv.cc.bintools}"
+          "${lib.getBin stdenv.cc.bintools.bintools}"
         ]));
     in ''
       substituteInPlace lisp/emacs-lisp/comp.el --replace \
@@ -156,11 +160,6 @@ in stdenv.mkDerivation {
         "$out/bin/emacs"
       patchelf --add-needed "libXcursor.so.1" "$out/bin/emacs"
     '')
-
-    (lib.optionalString nativeComp ''
-      wrapProgram $out/bin/emacs-* --prefix PATH : "${lib.makeBinPath [ stdenv.cc.bintools stdenv.cc.bintools.bintools ]}"
-    '')
-
   ];
 
   passthru = {

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -70,7 +70,7 @@ in stdenv.mkDerivation {
       libPath = lib.concatStringsSep ":" [
         "${lib.getLib libgccjit}/lib/gcc/${targetPlatform.config}/${libgccjit.version}"
         "${lib.getLib stdenv.cc.cc}/lib"
-        "${lib.getLib stdenv.glibc}/lib"
+        "${lib.getLib stdenv.libc}/lib"
       ];
     in ''
       substituteInPlace lisp/emacs-lisp/comp.el --replace \

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -11,7 +11,7 @@
 , libtiff, librsvg, gconf, libxml2, imagemagick, gnutls, libselinux
 , alsaLib, cairo, acl, gpm, AppKit, GSS, ImageIO, m17n_lib, libotf
 , jansson, harfbuzz
-, libgccjit, targetPlatform, binutils, binutils-unwrapped, makeWrapper # native-comp params
+, libgccjit, targetPlatform, binutils, clang ? null, binutils-unwrapped, makeWrapper # native-comp params
 , systemd ? null
 , withX ? !stdenv.isDarwin
 , withNS ? stdenv.isDarwin
@@ -158,7 +158,7 @@ in stdenv.mkDerivation {
     '')
 
     (lib.optionalString nativeComp ''
-      wrapProgram $out/bin/emacs-* --prefix PATH : "${lib.makeBinPath [ binutils binutils-unwrapped ]}"
+      wrapProgram $out/bin/emacs-* --prefix PATH : "${lib.makeBinPath [ clang.bintools binutils binutils-unwrapped ]}"
     '')
 
   ];

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -72,7 +72,7 @@ in stdenv.mkDerivation {
           "${lib.getLib libgccjit}/lib"
           "${lib.getLib libgccjit}/lib/gcc/${targetPlatform.config}/${libgccjit.version}"
           "${lib.getLib stdenv.cc.cc}/lib"
-          "${lib.getLib stdenv.libc}/lib"
+          "${lib.getLib stdenv.cc.libc}/lib"
         ]));
     in ''
       substituteInPlace lisp/emacs-lisp/comp.el --replace \

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -11,7 +11,7 @@
 , libtiff, librsvg, gconf, libxml2, imagemagick, gnutls, libselinux
 , alsaLib, cairo, acl, gpm, AppKit, GSS, ImageIO, m17n_lib, libotf
 , jansson, harfbuzz
-, libgccjit, targetPlatform, binutils, clang ? null, binutils-unwrapped, makeWrapper # native-comp params
+, libgccjit, targetPlatform, makeWrapper # native-comp params
 , systemd ? null
 , withX ? !stdenv.isDarwin
 , withNS ? stdenv.isDarwin
@@ -158,7 +158,7 @@ in stdenv.mkDerivation {
     '')
 
     (lib.optionalString nativeComp ''
-      wrapProgram $out/bin/emacs-* --prefix PATH : "${lib.makeBinPath [ clang.bintools binutils binutils-unwrapped ]}"
+      wrapProgram $out/bin/emacs-* --prefix PATH : "${lib.makeBinPath [ stdenv.cc.bintools stdenv.cc.bintools.bintools ]}"
     '')
 
   ];

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -67,18 +67,18 @@ in stdenv.mkDerivation {
 
     # Make native compilation work both inside and outside of nix build
     (lib.optionalString nativeComp (let
-      libPath = lib.concatStringsSep ":" [
-        "${lib.getLib libgccjit}/lib/gcc/${targetPlatform.config}/${libgccjit.version}"
-        "${lib.getLib stdenv.cc.cc}/lib"
-        "${lib.getLib stdenv.libc}/lib"
-      ];
+      libPath = (lib.concatStringsSep " "
+        (builtins.map (x: ''\"-L${x}\"'') [
+          "${lib.getLib libgccjit}/lib"
+          "${lib.getLib libgccjit}/lib/gcc/${targetPlatform.config}/${libgccjit.version}"
+          "${lib.getLib stdenv.cc.cc}/lib"
+          "${lib.getLib stdenv.libc}/lib"
+        ]));
     in ''
       substituteInPlace lisp/emacs-lisp/comp.el --replace \
-        "(defcustom comp-async-env-modifier-form nil" \
-        "(defcustom comp-async-env-modifier-form '((setenv \"LIBRARY_PATH\" (string-join (seq-filter (lambda (v) (null (eq v nil))) (list (getenv \"LIBRARY_PATH\") \"${libPath}\")) \":\")))"
-
+        "(defcustom comp-native-driver-options nil" \
+        "(defcustom comp-native-driver-options '(${libPath})"
     ''))
-
     ""
   ];
 

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -67,13 +67,14 @@ in stdenv.mkDerivation {
 
     # Make native compilation work both inside and outside of nix build
     (lib.optionalString nativeComp (let
-      libPath = (lib.concatStringsSep " "
+      backendPath = (lib.concatStringsSep " "
         (builtins.map (x: ''\"-B${x}\"'') [
+          # Paths necessary so the JIT compiler finds its libraries:
           "${lib.getLib libgccjit}/lib"
-          "${lib.getLib libgccjit}/lib/gcc/${targetPlatform.config}/${libgccjit.version}"
-          "${lib.getLib stdenv.cc.cc}/lib"
+          "${lib.getLib libgccjit}/lib/gcc"
           "${lib.getLib stdenv.cc.libc}/lib"
-          "${lib.getBin stdenv.cc.cc}"
+
+          # Executable paths necessary for compilation (ld, as):
           "${lib.getBin stdenv.cc.cc}"
           "${lib.getBin stdenv.cc.bintools}"
           "${lib.getBin stdenv.cc.bintools.bintools}"
@@ -81,7 +82,7 @@ in stdenv.mkDerivation {
     in ''
       substituteInPlace lisp/emacs-lisp/comp.el --replace \
         "(defcustom comp-native-driver-options nil" \
-        "(defcustom comp-native-driver-options '(${libPath})"
+        "(defcustom comp-native-driver-options '(${backendPath})"
     ''))
     ""
   ];

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -181,7 +181,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit (stdenv) lib;
-    inherit version hostPlatform gnatboot langAda langGo;
+    inherit version hostPlatform gnatboot langAda langGo langJit;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -251,7 +251,7 @@ postInstall() {
     fi
 
     if type "install_name_tool"; then
-        for i in "${!outputLib}"/lib/*.*.dylib; do
+        for i in "${!outputLib}"/lib/*.*.dylib "${!outputLib}"/lib/*.so.[0-9]; do
             install_name_tool -id "$i" "$i" || true
             for old_path in $(otool -L "$i" | grep "$out" | awk '{print $1}'); do
               new_path=`echo "$old_path" | sed "s,$out,${!outputLib},"`

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -2,6 +2,7 @@
 , gnatboot ? null
 , langAda ? false
 , langJava ? false
+, langJit ? false
 , langGo }:
 
 assert langJava -> lib.versionOlder version "7";
@@ -50,10 +51,10 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
   export ac_cv_func_aligned_alloc=no
 ''
 
-# In order to properly install on macOS Catalina, strip(1) upon
-# installation must not remove external symbols, otherwise the install
-# step errors with "symbols referenced by indirect symbol table
-# entries that can't be stripped".
-+ lib.optionalString (hostPlatform.isDarwin) ''
+# In order to properly install libgccjit on macOS Catalina, strip(1)
+# upon installation must not remove external symbols, otherwise the
+# install step errors with "symbols referenced by indirect symbol
+# table entries that can't be stripped".
++ lib.optionalString (hostPlatform.isDarwin && langJit) ''
   export STRIP='strip -x'
 ''

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -49,3 +49,11 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 + lib.optionalString (hostPlatform.isDarwin) ''
   export ac_cv_func_aligned_alloc=no
 ''
+
+# In order to properly install on macOS Catalina, strip(1) upon
+# installation must not remove external symbols, otherwise the install
+# step errors with "symbols referenced by indirect symbol table
+# entries that can't be stripped".
++ lib.optionalString (hostPlatform.isDarwin) ''
+  export STRIP='strip -x'
+''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
To allow macOS/darwin users to build Emacs with the native-comp feature. These changes are all for problems that on Darwin, result in broken binary installs and failures to resolve the emacs derivation.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
