### PR TITLE
.github/workflows/editorconfig.yml: remove branch restriction

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -2,8 +2,6 @@ name: "Checking EditorConfig"
 
 on:
   pull_request:
-    branches:
-      - master
 
 jobs:
   tests:


### PR DESCRIPTION
May as well remove this as it seems to be working okay and we don't want errors slipping back in via staging PRs.

I guess deleting the actions from `release-20.09` after branch off is the simplest way of limiting these to master/unstable?