### PR TITLE
Add imagemagick-support to exwm's emacs

### DIFF
--- a/nixos/modules/services/x11/window-managers/exwm.nix
+++ b/nixos/modules/services/x11/window-managers/exwm.nix
@@ -12,7 +12,8 @@ let
     ''}
   '';
   packages = epkgs: cfg.extraPackages epkgs ++ [ epkgs.exwm ];
-  exwm-emacs = pkgs.emacsWithPackages packages;
+  emacs = pkgs.emacs.override { imagemagick = pkgs.imagemagickBig; };
+  exwm-emacs = (pkgs.emacsPackagesNgGen emacs).emacsWithPackages packages;
 in
 
 {


### PR DESCRIPTION
###### Motivation for this change

There is an open [discussion](https://github.com/NixOS/nixpkgs/issues/70631) about how to add ImageMagick-support to emacs. Unfortunately, there is no solution to add ImageMagick-support to emacs when using EXWM. This PR is an intent to fix this. 

I added pkgs.imagemagick to the cfg.extraPackages attribute in my config (though I'm not sure if it's really necessary).

This is just a proposal, and I see that, for now, the code is not very flexible. I'm happy for suggestions on how to make adding packages to exwm's emacs more flexible, in case it's necessary.

Closes #70631

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
