### PR TITLE
jellyfin-mpv-shim: 1.5.11 -> 1.7.1

### DIFF
--- a/pkgs/applications/video/jellyfin-mpv-shim/disable-desktop-client.patch
+++ b/pkgs/applications/video/jellyfin-mpv-shim/disable-desktop-client.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index a831959..2206e6e 100644
+--- a/setup.py
++++ b/setup.py
+@@ -25,7 +25,6 @@ setup(
+     entry_points={
+         'console_scripts': [
+             'jellyfin-mpv-shim=jellyfin_mpv_shim.mpv_shim:main',
+-            'jellyfin-mpv-desktop=jellyfin_mpv_shim.mpv_shim:main_desktop',
+         ]
+     },
+     classifiers=[

--- a/pkgs/applications/video/jellyfin-mpv-shim/disable-update-check.patch
+++ b/pkgs/applications/video/jellyfin-mpv-shim/disable-update-check.patch
@@ -1,0 +1,15 @@
+diff --git a/jellyfin_mpv_shim/conf.py b/jellyfin_mpv_shim/conf.py
+index 0ab9326..ccedc17 100644
+--- a/jellyfin_mpv_shim/conf.py
++++ b/jellyfin_mpv_shim/conf.py
+@@ -88,8 +88,8 @@ class Settings(object):
+         "sync_revert_seek":     True,
+         "sync_osd_message":     True,
+         "screenshot_menu":      True,
+-        "check_updates":        True,
+-        "notify_updates":       True,
++        "check_updates":        False,
++        "notify_updates":       False,
+         "lang":                 None,
+         "desktop_scale":        1.0,
+     }

--- a/pkgs/applications/video/jellyfin-mpv-shim/shader-pack.nix
+++ b/pkgs/applications/video/jellyfin-mpv-shim/shader-pack.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "jellyfin-mpv-shim-shader-pack";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "iwalton3";
+    repo = "default-shader-pack";
+    rev = "v${version}";
+    sha256 = "04y8gvjy4v3773b1kyan4dxqcf86b56x7v33m2k246jbn0rl2pgr";
+  };
+
+  installPhase = ''
+    mkdir -p $out
+    cp -a . $out
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/iwalton3/default-shader-pack";
+    description = "Preconfigured set of MPV shaders and configurations for MPV Shim media clients";
+    license = with licenses; [ mit lgpl3Plus unlicense ];
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/development/python-modules/jellyfin-apiclient-python/default.nix
+++ b/pkgs/development/python-modules/jellyfin-apiclient-python/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "jellyfin-apiclient-python";
-  version = "1.5.1";
+  version = "1.6.1";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "iwalton3";
     repo = "jellyfin-apiclient-python";
     rev = "v${version}";
-    sha256 = "1mzs4i9c4cf7pmymsyzs8x17hvjs8g9wr046l4f85rkzmz23v1rp";
+    sha256 = "0f7czq83ic22fz1vnf0cavb7l3grcxxd5yyw9wcjz3g1j2d76735";
   };
 
   propagatedBuildInputs = [ requests websocket_client ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New Upstream release https://github.com/iwalton3/jellyfin-mpv-shim/releases/tag/v1.7.1. Also updated jellyfin-apiclient-python to the latest required release.

----

This release supports enabling some prepackaged MPV shaders via the configuration menu (https://github.com/iwalton3/default-shader-pack).
The shader pack combines 5 shaders with different licenses (LGPL3+, MIT, Unlicense). Packaging these shaders increases the closure size by ~2.6MB.

**Question:** Is there a better way to embed the shader repository?

----

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/7hj9aj8gghpx5nbrd1krgfbk7wj2xd5j-python3.8-jellyfin-apiclient-python-1.5.1	  119736832
/nix/store/rvpppa3qkyl1f0cs2xkfrkilyqhp9g7p-python3.8-jellyfin-apiclient-python-1.6.1	  119757208

/nix/store/lgmaqqmx0dk0djmil1j6mzvff2drl2yz-jellyfin-mpv-shim-1.5.11	  366087568
/nix/store/nby703qvd8yxjxxbhli92qxbagzks4fa-jellyfin-mpv-shim-1.7.1	  368883280
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
