### PR TITLE
gdm: 3.34.1 -> 3.36.3

### DIFF
--- a/pkgs/desktops/gnome-3/core/gdm/default.nix
+++ b/pkgs/desktops/gnome-3/core/gdm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, glib, itstool, libxml2, xorg
 , accountsservice, libX11, gnome3, systemd, autoreconfHook, dconf
 , gtk3, libcanberra-gtk3, pam, libtool, gobject-introspection, plymouth
-, librsvg, coreutils, xwayland, nixos-icons, fetchpatch }:
+, librsvg, coreutils, xwayland, nixos-icons, fetchpatch, keyutils }:
 
 let
 
@@ -19,11 +19,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gdm";
-  version = "3.34.1";
+  version = "3.36.3";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gdm/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1lyqvcwxhwxklbxn4xjswjzr6fhjix6h28mi9ypn34wdm9bzcpg8";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "10byz8jwqv1qpvjj8wd36vfb8pbh9g7pchsc1gbwplf0rchbdyrv";
   };
 
   # Only needed to make it build
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
     glib accountsservice systemd
     gobject-introspection libX11 gtk3
     libcanberra-gtk3 pam plymouth librsvg
+    keyutils
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/gnome-3/core/gdm/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/core/gdm/fix-paths.patch
@@ -11,38 +11,38 @@
  #endif
 --- a/daemon/gdm-manager.c
 +++ b/daemon/gdm-manager.c
-@@ -145,7 +145,7 @@
+@@ -148,7 +148,7 @@
          GError  *error;
- 
+
          error = NULL;
--        res = g_spawn_command_line_sync ("/bin/plymouth --ping",
+-        res = g_spawn_command_line_sync ("plymouth --ping",
 +        res = g_spawn_command_line_sync ("@plymouth@/bin/plymouth --ping",
                                           NULL, NULL, &status, &error);
          if (! res) {
                  g_debug ("Could not ping plymouth: %s", error->message);
-@@ -163,7 +163,7 @@
+@@ -166,7 +166,7 @@
          GError  *error;
- 
+
          error = NULL;
--        res = g_spawn_command_line_sync ("/bin/plymouth deactivate",
+-        res = g_spawn_command_line_sync ("plymouth deactivate",
 +        res = g_spawn_command_line_sync ("@plymouth@/bin/plymouth deactivate",
                                           NULL, NULL, NULL, &error);
          if (! res) {
                  g_warning ("Could not deactivate plymouth: %s", error->message);
-@@ -178,7 +178,7 @@
+@@ -181,7 +181,7 @@
          GError  *error;
- 
+
          error = NULL;
--        res = g_spawn_command_line_async ("/bin/plymouth quit --retain-splash", &error);
+-        res = g_spawn_command_line_async ("plymouth quit --retain-splash", &error);
 +        res = g_spawn_command_line_async ("@plymouth@/bin/plymouth quit --retain-splash", &error);
          if (! res) {
                  g_warning ("Could not quit plymouth: %s", error->message);
                  g_error_free (error);
-@@ -194,7 +194,7 @@
+@@ -197,7 +197,7 @@
          GError  *error;
- 
+
          error = NULL;
--        res = g_spawn_command_line_async ("/bin/plymouth quit", &error);
+-        res = g_spawn_command_line_async ("plymouth quit", &error);
 +        res = g_spawn_command_line_async ("@plymouth@/bin/plymouth quit", &error);
          if (! res) {
                  g_warning ("Could not quit plymouth: %s", error->message);
@@ -56,5 +56,5 @@
 -ExecReload=/bin/kill -SIGHUP $MAINPID
 +ExecReload=@coreutils@/bin/kill -SIGHUP $MAINPID
  KeyringMode=shared
- 
+
  [Install]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Version bump.
Changelog:
```
==============
Version 3.36.2
==============
- Fixes for when GDM isn't started on its configured initial VT
- Don't hardcode path to plymouth
- keyutils has a .pc file so use it
- Chrome remote desktop fix
- Always use separate session bus for greeter sessions
  This runs dbus-run-session, so the binary needs to be available
- Translation updates
==============
Version 3.36.3
==============
- User switching fix
- Translation updates


```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC: @worldofpeace @jtojnar 