### PR TITLE
k8s-gen: init 20200804-27edf66731c4c32a2b13ed7376f75e5291665a52

### DIFF
--- a/pkgs/applications/networking/cluster/k8s-gen/default.nix
+++ b/pkgs/applications/networking/cluster/k8s-gen/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildGoModule, fetchgit, lib }:
+
+buildGoModule rec {
+  pname = "k8s-gen";
+  version = "20200804-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "27edf66731c4c32a2b13ed7376f75e5291665a52";
+
+  src = fetchGit {
+    url = "https://github.com/jsonnet-libs/k8s";
+    inherit rev;
+
+  };
+
+  vendorSha256 = "1dl21vip5mwz2xrxhvwv4vq6v37bm89mi8qyhy7hqfl7ccgz7zak";
+
+  postInstall = ''
+    mv $out/bin/{k8s,k8s-gen}
+  '';
+
+  meta = with lib; {
+    description = "A code generator for the Jsonnet Kubernetes library";
+    homepage = "https://github.com/jsonnet-libs/k8s";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mikefaille ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20848,6 +20848,8 @@ in
 
   k3s = callPackage ../applications/networking/cluster/k3s {};
 
+  k8s-gen = callPackage ../applications/networking/cluster/k8s-gen { };
+
   k9copy = libsForQt5.callPackage ../applications/video/k9copy {};
 
   kail = callPackage ../tools/networking/kail {  };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I needed k8s-gen to generate my own Kubernetes object on jsonnet format. I think all the nix community members who manage a kubernetes cluster could appreciate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
