### PR TITLE
tanka: init at v0.11.1

### DIFF
--- a/pkgs/applications/networking/cluster/tanka/default.nix
+++ b/pkgs/applications/networking/cluster/tanka/default.nix
@@ -1,0 +1,25 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "tanka";
+  version = "0.11.1";
+
+  src = fetchFromGitHub {
+    owner = "grafana";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0hp10qgalglsdhh6z6v4azh2hsr89mdrv1g5lssfl5jyink409yd";
+  };
+
+  vendorSha256 = "15x8fqz2d2793ivgxpd9jyr34njzi1xpyxdlfyj1b01n2vr3xg4m";
+
+  buildFlagsArray = [ "-ldflags=-s -w -X main.Version=${version}" ];
+
+  meta = with lib; {
+    description = "Flexible, reusable and concise configuration for Kubernetes";
+    homepage = "https://github.com/grafana/tanka/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mikefaille ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22770,6 +22770,8 @@ in
 
   tambura = callPackage ../applications/audio/tambura { };
 
+  tanka = callPackage ../applications/networking/cluster/tanka { };
+
   teams = callPackage ../applications/networking/instant-messengers/teams { };
 
   teamspeak_client = libsForQt512.callPackage ../applications/networking/instant-messengers/teamspeak/client.nix { };


### PR DESCRIPTION

###### Motivation for this change
Tanka is a tool built by Grafana and Redhat to facilitate Kubernetes assets on jsonnet format.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
