### PR TITLE
nixos/iso-image: make squashfs compression easily configurable

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -417,6 +417,14 @@ in
       '';
     };
 
+    isoImage.squashfsCompression = mkOption {
+      default = "xz -Xdict-size 100%";
+      description = ''
+        Compression settings to use for the squashfs nix store.
+      '';
+      example = "zstd -Xcompression-level 6";
+    };
+
     isoImage.edition = mkOption {
       default = "";
       description = ''
@@ -614,6 +622,7 @@ in
     # Create the squashfs image that contains the Nix store.
     system.build.squashfsStore = pkgs.callPackage ../../../lib/make-squashfs.nix {
       storeContents = config.isoImage.storeContents;
+      comp = config.isoImage.squashfsCompression;
     };
 
     # Individual files to be included on the CD, outside of the Nix


### PR DESCRIPTION
###### Motivation for this change

(Re)building the ISO image currently takes ~7min on a modern system, mostly due to `squashfs` compression of the store.
Using `zstd` at level 6 instead of `xz` drops this to ~1 minute (at the cost of a somewhat increased size obviously). This is quite relevant, e.g. if you find yourself repeatedly building `iso` images with small changes. 

While in theory the compression is already configurable in `nixos/lib/make-squashfs.nix`, `iso-image.nix` does not pass this option through in a friendly manner. Change this, so people who prefer fast build times over size can just set:
`isoImage.squashfsCompression = "zstd -Xcompression-level 6"`

This is not my personal motivation, but some people may also choose e.g. `zstd` for faster decompression.

###### Things done

Checked that the iso image still builds with these changes as well as with `zstd`compression set as hinted above.
