### PR TITLE
pythonPackages.iterfzf: init at 0.5.0.20.0

### DIFF
--- a/pkgs/development/python-modules/iterfzf/default.nix
+++ b/pkgs/development/python-modules/iterfzf/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fzf, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "iterfzf";
+  version = "0.5.0.20.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0by5pk7w1j2xzhj4l0nw09sz9025pdskbf1b7k87kfkwgbc08vrb";
+  };
+
+  prePatch = ''
+    substituteInPlace iterfzf/__init__.py \
+                      --replace "EXECUTABLE_NAME = 'fzf.exe' if sys.platform == 'win32' else 'fzf'" \
+                      "EXECUTABLE_NAME = 'fzf.exe' if sys.platform == 'win32' else '${fzf}/bin/fzf'"
+  '';
+
+  pythonImportsCheck = [ "iterfzf" ];
+
+  meta = with lib; {
+    description = "Pythonic interface to fzf";
+    homepage = "https://github.com/dahlia/iterfzf";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ swflint ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3213,6 +3213,8 @@ in {
 
   itemloaders = callPackage ../development/python-modules/itemloaders { };
 
+  iterfzf = callPackage ../development/python-modules/iterfzf { };
+
   iterm2 = callPackage ../development/python-modules/iterm2 { };
 
   itsdangerous = callPackage ../development/python-modules/itsdangerous { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I'm slowly working on packaging the Remt tool for Remarkable Tablets.  This package is required, and not packaged in NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
