### PR TITLE
jsonnet-bundler: init at 20200804-ada055a

### DIFF
--- a/pkgs/development/tools/build-managers/jsonnet-bundler/default.nix
+++ b/pkgs/development/tools/build-managers/jsonnet-bundler/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoModule, fetchgit, lib }:
+
+buildGoModule rec {
+  pname = "jsonnet-bundler";
+  version = "20200804-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "ada055a225fa6fc37b05bdbd838ed91b04727a6e";
+
+  src = fetchGit {
+    url = "https://github.com/jsonnet-bundler/jsonnet-bundler";
+    inherit rev;
+  };
+
+  deleteVendor=true;
+  vendorSha256 = "1h1d32zi1pfb7spprsacxg8ygrigswqqngrc8gsdzn1xbldphl5g";
+
+  meta = with lib; {
+    description = "A package manager for Jsonnet";
+    homepage = "https://github.com/jsonnet-bundler/jsonnet-bundler";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mikefaille ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12759,6 +12759,8 @@ in
 
   jsonnet = callPackage ../development/compilers/jsonnet { };
 
+  jsonnet-bundler = callPackage ../development/tools/build-managers/jsonnet-bundler { };
+
   go-jsonnet = callPackage ../development/compilers/go-jsonnet { };
 
   jsonrpc-glib = callPackage ../development/libraries/jsonrpc-glib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

jsonnet-bundler will help Kubernetes admit to manage jsonnet package on remote repos.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
