### PR TITLE
slack: 4.7.0 -> 4.8.0 (linux)

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -41,7 +41,7 @@ let
   pname = "slack";
   version = {
     x86_64-darwin = "4.8.0";
-    x86_64-linux = "4.7.0";
+    x86_64-linux = "4.8.0";
   }.${system} or throwSystem;
 
   src = let
@@ -53,7 +53,7 @@ let
     };
     x86_64-linux = fetchurl {
       url = "${base}/linux_releases/slack-desktop-${version}-amd64.deb";
-      sha256 = "1nwyl70caaz9k0hccfpkjli0jjc6m9zbjb3nf4bwmykpbxbzr9w3";
+      sha256 = "0q8qpz5nwhps7y5gq1bl8hjw7vsk789srrv39hzc7jrl8f1bxzk0";
     };
   }.${system} or throwSystem;
 


### PR DESCRIPTION
###### Motivation for this change

* Update to 4.8.0 on linux ([Slack for Linux - Release Notes](https://slack.com/intl/en-ru/release-notes/linux))

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
