### PR TITLE
jruby: 9.2.12.0 → 9.2.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9267,4 +9267,10 @@
     github = "deifactor";
     githubId = 30192992;
   };
+  fzakaria = {
+    name = "Farid Zakaria";
+    email = "farid.m.zakaria@gmail.com";
+    github = "fzakaria";
+    githubId = 605070;
+  };
 }

--- a/pkgs/development/interpreters/jruby/default.nix
+++ b/pkgs/development/interpreters/jruby/default.nix
@@ -2,15 +2,15 @@
 
 let
 # The version number here is whatever is reported by the RUBY_VERSION string
-rubyVersion = callPackage ../ruby/ruby-version.nix {} "2" "3" "3" "";
+rubyVersion = callPackage ../ruby/ruby-version.nix {} "2" "5" "7" "";
 jruby = stdenv.mkDerivation rec {
   pname = "jruby";
 
-  version = "9.2.12.0";
+  version = "9.2.13.0";
 
   src = fetchurl {
     url = "https://s3.amazonaws.com/jruby.org/downloads/${version}/jruby-bin-${version}.tar.gz";
-    sha256 = "013c1q1n525y9ghp369z1jayivm9bw8c1x0g5lz7479hqhj62zrh";
+    sha256 = "0n5glz6xm3skrfihzn3g5awdxpjsqn2k8k46gv449rk2l50w5a3k";
   };
 
   buildInputs = [ makeWrapper ];

--- a/pkgs/development/interpreters/jruby/default.nix
+++ b/pkgs/development/interpreters/jruby/default.nix
@@ -46,11 +46,12 @@ jruby = stdenv.mkDerivation rec {
     libPath = "lib/${rubyEngine}/${rubyVersion.libDir}";
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Ruby interpreter written in Java";
     homepage = "http://jruby.org/";
-    license = with stdenv.lib.licenses; [ cpl10 gpl2 lgpl21 ];
-    platforms = stdenv.lib.platforms.unix;
+    license = with licenses; [ cpl10 gpl2 lgpl21 ];
+    platforms = platforms.unix;
+    maintainers = [ maintainers.fzakaria ];
   };
 };
 in jruby.overrideAttrs (oldAttrs: {


### PR DESCRIPTION
###### Motivation for this change

Bump JRuby to latest release
https://www.jruby.org/2020/08/03/jruby-9-2-13-0

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I built the latest JRuby package and ran the following

```bash
> nix-build -E 'with import <nixpkgs> {}; callPackage ./pkgs/development/interpreters/jruby {}' --pure
> cd ./result/bin

> PATH=$(pwd):$PATH ruby -e 'puts RUBY_VERSION'
2.5.7

> PATH=$(pwd):$PATH gem env
RubyGems Environment:
  - RUBYGEMS VERSION: 3.0.6
  - RUBY VERSION: 2.5.7 (2020-08-03 patchlevel 0) [java]
  - INSTALLATION DIRECTORY: /nix/store/g4pfrjl276hc1rxccdxccrpk2nw1qk8j-jruby-9.2.13.0/lib/ruby/gems/shared
  - USER INSTALLATION DIRECTORY: /home/fmzakari/.gem/jruby/2.5.0
  - RUBY EXECUTABLE: /nix/store/g4pfrjl276hc1rxccdxccrpk2nw1qk8j-jruby-9.2.13.0/bin/jruby
  - GIT EXECUTABLE: /home/fmzakari/.nix-profile/bin/git
  - EXECUTABLE DIRECTORY: /nix/store/g4pfrjl276hc1rxccdxccrpk2nw1qk8j-jruby-9.2.13.0/bin
  - SPEC CACHE DIRECTORY: /home/fmzakari/.gem/specs
  - SYSTEM CONFIGURATION DIRECTORY: /nix/store/g4pfrjl276hc1rxccdxccrpk2nw1qk8j-jruby-9.2.13.0/etc
  - RUBYGEMS PLATFORMS:
    - ruby
    - universal-java-1.8
  - GEM PATHS:
     - /nix/store/g4pfrjl276hc1rxccdxccrpk2nw1qk8j-jruby-9.2.13.0/lib/ruby/gems/shared
     - /home/fmzakari/.gem/jruby/2.5.0
```