### PR TITLE
wapm-cli: init at 0.5.0

### DIFF
--- a/pkgs/tools/package-management/wapm/cli/default.nix
+++ b/pkgs/tools/package-management/wapm/cli/default.nix
@@ -16,8 +16,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0w0ck60xm47b93y803i2b2bpv7nsahzvzda3ll7pjg88f8qz5fx1";
   };
 
-  buildInputs = []
-    ++ stdenv.lib.optionals stdenv.isLinux [ openssl ]
+  buildInputs = stdenv.lib.optionals stdenv.isLinux [ openssl ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ Security ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/package-management/wapm/cli/default.nix
+++ b/pkgs/tools/package-management/wapm/cli/default.nix
@@ -8,7 +8,6 @@
 rustPlatform.buildRustPackage rec {
   pname = "wapm-cli";
   version = "0.5.0";
-  cargoSha256 = "1bx9rv6bkmkpysz0zfcwfv88r47d5nbzw0zwakqs3n7mdsyb4q2x";
 
   src = fetchFromGitHub {
     owner = "wasmerio";

--- a/pkgs/tools/package-management/wapm/cli/default.nix
+++ b/pkgs/tools/package-management/wapm/cli/default.nix
@@ -1,0 +1,31 @@
+{ fetchFromGitHub
+, openssl
+, rustPlatform
+, Security
+, stdenv
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wapm-cli";
+  version = "0.5.0";
+  cargoSha256 = "1bx9rv6bkmkpysz0zfcwfv88r47d5nbzw0zwakqs3n7mdsyb4q2x";
+
+  src = fetchFromGitHub {
+    owner = "wasmerio";
+    repo = "wapm-cli";
+    rev = "v${version}";
+    sha256 = "0w0ck60xm47b93y803i2b2bpv7nsahzvzda3ll7pjg88f8qz5fx1";
+  };
+
+  buildInputs = []
+    ++ stdenv.lib.optionals stdenv.isLinux [ openssl ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Security ];
+
+  meta = with stdenv.lib; {
+    description = "A package manager for WebAssembly modules";
+    homepage = "https://docs.wasmer.io/ecosystem/wapm";
+    license = with licenses; [ mit ];
+    maintainers = [ maintainers.lucperkins ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7796,6 +7796,10 @@ in
 
   wakelan = callPackage ../tools/networking/wakelan { };
 
+  wapm-cli = callPackage ../tools/package-management/wapm/cli {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   wavemon = callPackage ../tools/networking/wavemon { };
 
   wdfs = callPackage ../tools/filesystems/wdfs { };


### PR DESCRIPTION
###### Motivation for this change

Adds a package for [wapm](https://docs.wasmer.io/ecosystem/wapm), the WebAssembly package manager.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
