### PR TITLE
cpupower-gui: init at 0.8.0

### DIFF
--- a/pkgs/applications/system/cpupower-gui/default.nix
+++ b/pkgs/applications/system/cpupower-gui/default.nix
@@ -1,0 +1,64 @@
+{ lib, stdenv, fetchFromGitHub
+, desktop-file-utils
+, gettext
+, glib
+, gobject-introspection
+, gtk3
+, hicolor-icon-theme
+, meson
+, ninja
+, pkg-config
+, python3
+, systemd
+, wrapGAppsHook
+}:
+
+let
+  # use pythonEnv, so that patchShebang fixup will choose this interpreter
+  pythonEnv = python3.withPackages(ps: with ps; [
+    pygobject3
+    dbus-python
+  ]);
+in
+
+stdenv.mkDerivation rec {
+  pname = "cpupower-gui";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "vagnum08";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0iklhnsw76mclzj177kg8zd6jvg0rpmsslr5mwddv6n0ayx2sj7m";
+  };
+
+  nativeBuildInputs = [
+    hicolor-icon-theme # needed for postinstall script
+    desktop-file-utils # needed for update-desktop-database
+    meson
+    ninja
+    glib # needed for glib-compile-scemas
+    pkg-config
+    wrapGAppsHook
+    gettext
+    pythonEnv
+    gtk3
+    gobject-introspection # need for gtk namespace to be available
+  ];
+
+  mesonFlags = [
+    "--datadir=${placeholder "out"}/share"
+    "-Dsystemddir=${placeholder "out"}"
+  ];
+
+  preConfigure = ''
+    patchShebangs ./build-aux/meson/postinstall.py
+  '';
+
+  meta = with lib; {
+    description = "Change the frequency limits of your cpu and its governor";
+    homepage = "https://github.com/vagnum08/cpupower-gui/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -179,6 +179,8 @@ in
 
   cpu-x = callPackage ../applications/misc/cpu-x { };
 
+  cpupower-gui = callPackage ../applications/system/cpupower-gui { };
+
   dhallToNix = callPackage ../build-support/dhall-to-nix.nix {
     inherit dhall-nix;
   };


### PR DESCRIPTION
###### Motivation for this change
related thread: https://discourse.nixos.org/t/how-to-switch-cpu-governor-on-battery-power/8446

Unfortunately, this program needs a dedicated systemd service to work properly (The service file is present in the build output, just needs to be configured with nixos). I didn't want to go through the pain of also creating a nixos module for a program that I'm unlikely to use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
