### PR TITLE
hping: 20051105 -> 2014-12-26

### DIFF
--- a/pkgs/tools/networking/hping/default.nix
+++ b/pkgs/tools/networking/hping/default.nix
@@ -1,50 +1,41 @@
-{ stdenv, fetchurl, libpcap, tcl }:
+{ stdenv, fetchFromGitHub, libpcap, withTcl ? true, tcl }:
 
 stdenv.mkDerivation rec {
   pname = "hping";
-  version = "20051105";
+  version = "2014-12-26";
 
-  src = fetchurl {
-    url = "http://www.hping.org/hping3-${version}.tar.gz";
-    sha256 = "1s5f9xd1msx05ibhwaw37jmc7l9fahcxxslqz8a83p0i5ak739pm";
+  src = fetchFromGitHub {
+    owner = "antirez";
+    repo = pname;
+    rev = "3547c7691742c6eaa31f8402e0ccbb81387c1b99"; # there are no tags/releases
+    sha256 = "0y0n1ybij3yg9lfgzcwfmjz1sjg913zcqrv391xx83dm0j80sdpb";
   };
 
-  buildInputs = [ libpcap tcl ];
+  buildInputs = [ libpcap ] ++ stdenv.lib.optional withTcl tcl;
 
-  configurePhase = ''
-    MANPATH="$out/share/man" ./configure
-    sed -i -r -e 's|/usr(/s?bin)|'"$out"'\1|g' Makefile
-  '';
-
-  TCLSH = "${tcl}/bin/tclsh";
-
-  prePatch = ''
-    sed -i -e '/#if.*defined(__i386__)/a \
-      || defined(__x86_64__) \\
-    ' bytesex.h
-
-    sed -i -e 's|#include.*net/bpf.h|#include <pcap/bpf.h>|' \
+  postPatch = ''
+    substituteInPlace Makefile.in --replace "gcc" "$CC"
+    substituteInPlace version.c --replace "RELEASE_DATE" "\"$version\""
+  '' + stdenv.lib.optionalString stdenv.isLinux ''
+    sed -i -e 's|#include <net/bpf.h>|#include <pcap/bpf.h>|' \
       libpcap_stuff.c script.c
-
-    sed -i -r -e 's|"(/usr/(local/)?)?bin/"|"${tcl}/bin"|g' \
-              -e 's!/usr/(local/)?(lib|include)!${tcl}/\2!g' \
-              configure
   '';
 
-  preInstall = ''
-    mkdir -vp "$out/sbin" "$out/share/man/man8"
-  '';
+  configureFlags = [ (if withTcl then "TCLSH=${tcl}/bin/tclsh" else "--no-tcl") ];
 
-  postInstall = ''
-    ln -vs hping3.8.gz "$out/share/man/man8/hping.8.gz"
-    ln -vs hping3.8.gz "$out/share/man/man8/hping2.8.gz"
+  installPhase = ''
+    install -Dm755 hping3 -t $out/sbin
+    ln -s $out/sbin/hping3 $out/sbin/hping
+    ln -s $out/sbin/hping3 $out/sbin/hping2
+    install -Dm644 docs/hping3.8 -t $out/share/man/man8
+    ln -s hping3.8.gz $out/share/man/man8/hping.8.gz
+    ln -s hping3.8.gz $out/share/man/man8/hping2.8.gz
   '';
 
   meta = with stdenv.lib; {
     description = "A command-line oriented TCP/IP packet assembler/analyzer";
     homepage = "http://www.hping.org/";
-    license = licenses.gpl2;
-    platforms = platforms.all;
-    broken = stdenv.isDarwin;
+    license = licenses.gpl2Only;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
* Update to latest ([switch to GH](http://www.hping.org/download.php))
* Fix on darwin
* Optional Tcl scripting (`withTcl ? true`)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
