### PR TITLE
borgbackup: Allow backup of data streams

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -256,7 +256,8 @@ in {
           };
 
           backupCommand = mkOption {
-            type = types.str;
+            type = with types; nullOr str;
+            default = null;
             description = ''
               Backup the stdout of this program instead of filesystem paths.
               You must set <option>paths</option> to <literal>-</literal>

--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -182,6 +182,13 @@ let
       + " without at least one public key";
   };
 
+  mkCommandAssertions = name: cfg: {
+    assertion = (cfg.backupCommand != null) -> (cfg.paths == [ "-" ]);
+    message = ''
+      borgbackup.jobs.${name}.paths must be set to [ "-" ] while specifying a backupCommand!
+    '';
+  };
+
   mkRemovableDeviceAssertions = name: cfg: {
     assertion = !(isLocalPath cfg.repo) -> !cfg.removableDevice;
     message = ''
@@ -671,6 +678,7 @@ in {
       assertions =
         mapAttrsToList mkPassAssertion jobs
         ++ mapAttrsToList mkKeysAssertion repos
+        ++ mapAttrsToList mkCommandAssertions jobs
         ++ mapAttrsToList mkRemovableDeviceAssertions jobs;
 
       system.activationScripts = mapAttrs' mkActivationScript jobs;

--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -41,26 +41,16 @@ let
         $extraInitArgs
       ${cfg.postInit}
     fi
-  '' + (
-    if (cfg.paths == [ "-" ]) then
-      ''
-        ${cfg.backupCommand} | borg create $extraArgs \
-          --compression ${cfg.compression} \
-          --exclude-from ${mkExcludeFile cfg} \
-          $extraCreateArgs \
-          "::$archiveName$archiveSuffix" \
-          -
-      ''
-    else
-      ''
-        borg create $extraArgs \
-          --compression ${cfg.compression} \
-          --exclude-from ${mkExcludeFile cfg} \
-          $extraCreateArgs \
-          "::$archiveName$archiveSuffix" \
-          ${escapeShellArgs cfg.paths}
-      ''
-    ) + optionalString cfg.appendFailedSuffix ''
+  '' + optionalString (cfg.backupCommand != null) ''
+    ${cfg.backupCommand} | \
+  '' + ''
+    borg create $extraArgs \
+      --compression ${cfg.compression} \
+      --exclude-from ${mkExcludeFile cfg} \
+      $extraCreateArgs \
+      "::$archiveName$archiveSuffix" \
+      ${escapeShellArgs cfg.paths}
+  '' + optionalString cfg.appendFailedSuffix ''
     borg rename $extraArgs \
       "::$archiveName$archiveSuffix" "$archiveName"
   '' + ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Borgbackup is able to backup data from stdin. I had to backup an unmounted ZFS dataset, which is only possible by having borgbackup read the data from a pipe.
Kind of quickly hacked together, but at least my first backup is running right now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
