### PR TITLE
gtg: init at 0.4.0 (Getting Things GNOME)

### DIFF
--- a/pkgs/applications/office/gtg/default.nix
+++ b/pkgs/applications/office/gtg/default.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, python3Packages
+, pkgconfig
+, ninja
+, gtk3
+, wrapGAppsHook
+, glib
+, itstool
+, gettext
+, pango
+, gdk-pixbuf
+, gobject-introspection
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "gtg";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+      owner = "getting-things-gnome";
+      repo = "gtg";
+      rev = "6623731f301c1b9c7b727e009f4a6462ad381c68";
+      sha256 = "14gxgg4nl0ki3dn913041jpyfhxsj90fkd55z6mmpyklhr8mwss1";
+  };
+
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    wrapGAppsHook
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    itstool
+    gettext
+    pango
+    gdk-pixbuf
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pycairo
+    pygobject3
+    lxml
+    dbus-python
+    gst-python
+    liblarch
+    pyxdg # can probably be removed after next release
+  ];
+
+  format = "other";
+  strictDeps = false;
+
+  meta = with stdenv.lib; {
+    description = "
+      Getting Things GNOME! (GTG) is a personal tasks and TODO-list items organizer for the GNOME desktop environment and inspired by the ''Getting Things Done'' (GTD) methodology.
+    ";
+    longDescription = "
+      GTG is designed with flexibility, adaptability, and ease of use in mind so it can be used as more than just GTD software.
+      GTG is intended to help you track everything you need to do and need to know, from small tasks to large projects.
+    ";
+    homepage = "https://wiki.gnome.org/Apps/GTG";
+    downloadPage = "https://github.com/getting-things-gnome/gtg/releases";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ oyren ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/python-modules/liblarch/default.nix
+++ b/pkgs/development/python-modules/liblarch/default.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, fetchFromGitHub
+, buildPythonPackage
+, python
+, pygobject3
+, xvfb_run
+, gobject-introspection
+, gtk3
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  version = "3.0.1";
+  pname = "liblarch";
+  disabled = pythonOlder "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = "getting-things-gnome";
+    repo = "liblarch";
+    rev = "v${version}";
+    sha256 = "0xv2mfvyzipbny3iz8vll77wsqxfwh28xj6bj1ff0l452waph45m";
+  };
+
+  checkInputs = [
+    gobject-introspection # for setup hook
+    gtk3
+  ];
+
+  propagatedBuildInputs = [
+    pygobject3
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${xvfb_run}/bin/xvfb-run -s '-screen 0 800x600x24' \
+      ${python.interpreter} nix_run_setup test
+    runHook postCheck
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A python library built to easily handle data structure such are lists, trees and acyclic graphs";
+    homepage = "https://github.com/getting-things-gnome/liblarch";
+    downloadPage = "https://github.com/getting-things-gnome/liblarch/releases";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ oyren ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1996,6 +1996,8 @@ in
 
   gthree = callPackage ../development/libraries/gthree { };
 
+  gtg = callPackage ../applications/office/gtg { };
+
   gti = callPackage ../tools/misc/gti { };
 
   hdate = callPackage ../applications/misc/hdate { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3603,6 +3603,8 @@ in {
 
   rotate-backups = callPackage ../tools/backup/rotate-backups { };
 
+  liblarch = callPackage ../development/python-modules/liblarch { };
+
   librosa = callPackage ../development/python-modules/librosa { };
 
   samplerate = callPackage ../development/python-modules/samplerate { };


### PR DESCRIPTION
###### Motivation for this change
Adding Getting Things GNOME as requested here #93370.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
