### PR TITLE
beets: apply patch to fix incompatibilites with python 3.8

### DIFF
--- a/pkgs/tools/audio/beets/compatibility-with-breaking-changes-to-the-ast-module.patch
+++ b/pkgs/tools/audio/beets/compatibility-with-breaking-changes-to-the-ast-module.patch
@@ -1,0 +1,55 @@
+From 771ce704ebeac4cd9bd74b3ddde9fb01f3dc7eb4 Mon Sep 17 00:00:00 2001
+From: wisp3rwind <17089248+wisp3rwind@users.noreply.github.com>
+Date: Tue, 9 Jun 2020 19:34:31 +0200
+Subject: [PATCH] compatibility with breaking changes to the ast module
+
+new in 3.10, also backported to 3.8 and 3.9: https://github.com/python/cpython/pull/20649
+In fact, our generation of some Literals has been invalid since Python
+3.4, fix that too.
+---
+ beets/util/functemplate.py | 29 ++++++++++++++++++++---------
+ 1 file changed, 20 insertions(+), 9 deletions(-)
+
+diff --git a/beets/util/functemplate.py b/beets/util/functemplate.py
+index af22b790..266534a9 100644
+--- a/beets/util/functemplate.py
++++ b/beets/util/functemplate.py
+@@ -73,15 +73,26 @@ def ex_literal(val):
+     """An int, float, long, bool, string, or None literal with the given
+     value.
+     """
+-    if val is None:
+-        return ast.Name('None', ast.Load())
+-    elif isinstance(val, six.integer_types):
+-        return ast.Num(val)
+-    elif isinstance(val, bool):
+-        return ast.Name(bytes(val), ast.Load())
+-    elif isinstance(val, six.string_types):
+-        return ast.Str(val)
+-    raise TypeError(u'no literal for {0}'.format(type(val)))
++    if sys.version_info[:2] < (3, 4):
++        if val is None:
++            return ast.Name('None', ast.Load())
++        elif isinstance(val, six.integer_types):
++            return ast.Num(val)
++        elif isinstance(val, bool):
++            return ast.Name(bytes(val), ast.Load())
++        elif isinstance(val, six.string_types):
++            return ast.Str(val)
++        raise TypeError(u'no literal for {0}'.format(type(val)))
++    elif sys.version_info[:2] < (3, 6):
++        if val in [None, True, False]:
++            return ast.NameConstant(val)
++        elif isinstance(val, six.integer_types):
++            return ast.Num(val)
++        elif isinstance(val, six.string_types):
++            return ast.Str(val)
++        raise TypeError(u'no literal for {0}'.format(type(val)))
++    else:
++        return ast.Constant(val)
+ 
+ 
+ def ex_varassign(name, expr):
+-- 
+2.27.0
+

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -190,6 +190,11 @@ in pythonPackages.buildPythonApplication rec {
       url = "https://github.com/beetbox/beets/commit/d43d54e21cde97f57f19486925ab56b419254cc8.patch";
       sha256 = "13n2gzmcgfi0m2ycl2r1hpczgksplnkc3y6b66vg57rx5y8nnv5c";
     })
+
+    # Fixes 548 tests due to breaking changes to the ast module
+    # https://github.com/beetbox/beets/pull/3621
+    # Can be dropped after 1.4.9
+    ./compatibility-with-breaking-changes-to-the-ast-module.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

548 tests in beets were failing due to a breaking change to the ast module that was backported to python 3.8.

https://github.com/beetbox/beets/pull/3621
https://github.com/python/cpython/pull/20649

The upstream patch did not apply cleanly onto 1.4.9, so here we are.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
