### PR TITLE
pythonPackages.dask-gateway: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/dask-gateway-server/default.nix
+++ b/pkgs/development/python-modules/dask-gateway-server/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+, colorlog
+, cryptography
+, traitlets
+, go
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "dask-gateway-server";
+  # update dask-gateway-server lock step with dask-gateway
+  version = "0.8.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "272134933b7e2068cd89a17a5012c76a29fbd9e40a78164345a2b15353d4b40a";
+  };
+
+  nativeBuildInputs = [
+    go
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    colorlog
+    cryptography
+    traitlets
+  ];
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # tests requires cluster for testing
+  doCheck = false;
+
+  pythonImportsCheck = [ "dask_gateway_server" ];
+
+  meta = with lib; {
+    description = "A multi-tenant server for securely deploying and managing multiple Dask clusters";
+    homepage = "https://gateway.dask.org/";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/dask-gateway/default.nix
+++ b/pkgs/development/python-modules/dask-gateway/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+, dask
+, distributed
+}:
+
+buildPythonPackage rec {
+  pname = "dask-gateway";
+  # update dask-gateway lock step with dask-gateway-server
+  version = "0.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "519818f3598ddd726882c5a6bf7053941613d8517b80e8a2c28467e30d57da9b";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    dask
+    distributed
+  ];
+
+  # tests requires cluster for testing
+  doCheck = false;
+
+  pythonImportsCheck = [ "dask_gateway" ];
+
+  meta = with lib; {
+    description = "A client library for interacting with a dask-gateway server";
+    homepage = "https://gateway.dask.org/";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2735,6 +2735,10 @@ in {
 
   dask-gateway = callPackage ../development/python-modules/dask-gateway { };
 
+  dask-gateway-server = callPackage ../development/python-modules/dask-gateway-server {
+    inherit (pkgs) go;
+  };
+
   dask-glm = callPackage ../development/python-modules/dask-glm { };
 
   dask-image = callPackage ../development/python-modules/dask-image { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2733,6 +2733,8 @@ in {
 
   dask = callPackage ../development/python-modules/dask { };
 
+  dask-gateway = callPackage ../development/python-modules/dask-gateway { };
+
   dask-glm = callPackage ../development/python-modules/dask-glm { };
 
   dask-image = callPackage ../development/python-modules/dask-image { };


### PR DESCRIPTION

###### Motivation for this change

Looking at creating dask-gateway nixos service for hpc computations. Need package to exist first.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
