### PR TITLE
ssh-audit: 1.7.0 -> 2.2.0

### DIFF
--- a/pkgs/tools/security/ssh-audit/default.nix
+++ b/pkgs/tools/security/ssh-audit/default.nix
@@ -1,53 +1,44 @@
-{ fetchFromGitHub, python3Packages, stdenv }:
+{ lib, fetchFromGitHub, python3Packages }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   pname = "ssh-audit";
-  version = "1.7.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
-    owner = "arthepsy";
+    owner = "jtesta";
     repo = pname;
-    rev = "refs/tags/v${version}";
-    sha256 = "0akrychkdym9f6830ysq787c9nc0bkyqvy4h72498lyghwvwc2ms";
+    rev = "v${version}";
+    sha256 = "1z1h9nsgfaxdnkr9dvc0yzc23b3wz436rg2fycg2glwjhhal8az7";
   };
 
-  checkInputs = [
-    python3Packages.pytest
-    python3Packages.pytestcov
+  postPatch = ''
+    cp ./README.md pypi/sshaudit/
+    cp ./ssh-audit.py pypi/sshaudit/sshaudit.py
+    mv pypi/* .
+    ls -lah
+  '';
+
+  checkInputs = with python3Packages; [
+    pytestCheckHook
   ];
 
-  checkPhase = ''
-    py.test --cov-report= --cov=ssh-audit -v test
-  '';
+  disabledTests = [
+    "test_resolve_error"
+    "test_resolve_hostname_without_records"
+    "test_resolve_ipv4"
+    "test_resolve_ipv6"
+    "test_resolve_ipv46_both"
+    "test_resolve_ipv46_order"
+    "test_invalid_host"
+    "test_invalid_port"
+    "test_not_connected_socket"
+    "test_ssh2_server_simple"
+  ];
 
-  postPatch = ''
-    printf %s "$setupPy" > setup.py
-    mkdir scripts
-    cp ssh-audit.py scripts/ssh-audit
-    mkdir ssh_audit
-    cp ssh-audit.py ssh_audit/__init__.py
-  '';
-
-  setupPy = /* py */ ''
-    from distutils.core import setup
-    setup(
-      author='arthepsy',
-      description='${meta.description}',
-      license='${meta.license.spdxId}',
-      name='${pname}',
-      packages=['ssh_audit'],
-      scripts=['scripts/ssh-audit'],
-      url='${meta.homepage}',
-      version='${version}',
-    )
-  '';
-
-  meta = {
+  meta = with lib; {
     description = "Tool for ssh server auditing";
-    homepage = "https://github.com/arthepsy/ssh-audit";
-    license = stdenv.lib.licenses.mit;
-    maintainers = [
-      stdenv.lib.maintainers.tv
-    ];
+    homepage = "https://github.com/jtesta/ssh-audit";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tv ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes: #94618 

- Migrates to the fork, the original project is dead.
- The project structure is a bit messy, hence the cp/mv hack in postPatch.

I disabled a few tests since 10 of 99 are failing, but IMO that's not our fauflt.

```
=================================== FAILURES ===================================
________________________ TestResolve.test_resolve_error ________________________

self = <test_resolve.TestResolve object at 0x7ffff69f9460>, output_spy = []
virtual_socket = <conftest._VirtualSocket object at 0x7ffff655b430>

    def test_resolve_error(self, output_spy, virtual_socket):
        vsocket = virtual_socket
        vsocket.gsock.addrinfodata['localhost#22'] = socket.gaierror(8, 'hostname nor servname provided, or not known')
>       s = self.ssh.Socket('localhost', 22)
E    TypeError: __init__() missing 3 required positional arguments: 'ipvo', 'timeout', and 'timeout_set'

test/test_resolve.py:24: TypeError
----------------------------- Captured stderr call -----------------------------
Exception ignored in: <function SSH.Socket.__del__ at 0x7ffff69af4c0>
Traceback (most recent call last):
  File "/build/source/ssh-audit.py", line 2321, in __del__
    self.__cleanup()
  File "/build/source/ssh-audit.py", line 2325, in __cleanup
    self._close_socket(self.__sock)
AttributeError: 'Socket' object has no attribute '_Socket__sock'
______________ TestResolve.test_resolve_hostname_without_records _______________

self = <test_resolve.TestResolve object at 0x7ffff67fb100>, output_spy = []
virtual_socket = <conftest._VirtualSocket object at 0x7ffff68a2be0>

    def test_resolve_hostname_without_records(self, output_spy, virtual_socket):
        vsocket = virtual_socket
        vsocket.gsock.addrinfodata['localhost#22'] = []
>       s = self.ssh.Socket('localhost', 22)
E    TypeError: __init__() missing 3 required positional arguments: 'ipvo', 'timeout', and 'timeout_set'

test/test_resolve.py:36: TypeError
----------------------------- Captured stderr call -----------------------------
Exception ignored in: <function SSH.Socket.__del__ at 0x7ffff69af4c0>
Traceback (most recent call last):
  File "/build/source/ssh-audit.py", line 2321, in __del__
    self.__cleanup()
  File "/build/source/ssh-audit.py", line 2325, in __cleanup
    self._close_socket(self.__sock)
AttributeError: 'Socket' object has no attribute '_Socket__sock'
________________________ TestResolve.test_resolve_ipv4 _________________________

self = <test_resolve.TestResolve object at 0x7ffff654f760>
virtual_socket = <conftest._VirtualSocket object at 0x7ffff69eba30>

    def test_resolve_ipv4(self, virtual_socket):
        vsocket = virtual_socket
        conf = self._conf()
        conf.ipv4 = True
>       s = self.ssh.Socket('localhost', 22)
E    TypeError: __init__() missing 3 required positional arguments: 'ipvo', 'timeout', and 'timeout_set'

test/test_resolve.py:46: TypeError
----------------------------- Captured stderr call -----------------------------
Exception ignored in: <function SSH.Socket.__del__ at 0x7ffff69af4c0>
Traceback (most recent call last):
  File "/build/source/ssh-audit.py", line 2321, in __del__
    self.__cleanup()
  File "/build/source/ssh-audit.py", line 2325, in __cleanup
    self._close_socket(self.__sock)
AttributeError: 'Socket' object has no attribute '_Socket__sock'
________________________ TestResolve.test_resolve_ipv6 _________________________

self = <test_resolve.TestResolve object at 0x7ffff68be850>
virtual_socket = <conftest._VirtualSocket object at 0x7ffff68bec10>

    def test_resolve_ipv6(self, virtual_socket):
        vsocket = virtual_socket
>       s = self.ssh.Socket('localhost', 22)
E    TypeError: __init__() missing 3 required positional arguments: 'ipvo', 'timeout', and 'timeout_set'

test/test_resolve.py:53: TypeError
----------------------------- Captured stderr call -----------------------------
Exception ignored in: <function SSH.Socket.__del__ at 0x7ffff69af4c0>
Traceback (most recent call last):
  File "/build/source/ssh-audit.py", line 2321, in __del__
    self.__cleanup()
  File "/build/source/ssh-audit.py", line 2325, in __cleanup
    self._close_socket(self.__sock)
AttributeError: 'Socket' object has no attribute '_Socket__sock'
_____________________ TestResolve.test_resolve_ipv46_both ______________________

self = <test_resolve.TestResolve object at 0x7ffff63ed910>
virtual_socket = <conftest._VirtualSocket object at 0x7ffff63ed580>

    def test_resolve_ipv46_both(self, virtual_socket):
        vsocket = virtual_socket
>       s = self.ssh.Socket('localhost', 22)
E    TypeError: __init__() missing 3 required positional arguments: 'ipvo', 'timeout', and 'timeout_set'

test/test_resolve.py:62: TypeError
----------------------------- Captured stderr call -----------------------------
Exception ignored in: <function SSH.Socket.__del__ at 0x7ffff69af4c0>
Traceback (most recent call last):
  File "/build/source/ssh-audit.py", line 2321, in __del__
    self.__cleanup()
  File "/build/source/ssh-audit.py", line 2325, in __cleanup
    self._close_socket(self.__sock)
AttributeError: 'Socket' object has no attribute '_Socket__sock'
_____________________ TestResolve.test_resolve_ipv46_order _____________________

self = <test_resolve.TestResolve object at 0x7ffff68acca0>
virtual_socket = <conftest._VirtualSocket object at 0x7ffff68acd30>

    def test_resolve_ipv46_order(self, virtual_socket):
        vsocket = virtual_socket
>       s = self.ssh.Socket('localhost', 22)
E    TypeError: __init__() missing 3 required positional arguments: 'ipvo', 'timeout', and 'timeout_set'

test/test_resolve.py:71: TypeError
----------------------------- Captured stderr call -----------------------------
Exception ignored in: <function SSH.Socket.__del__ at 0x7ffff69af4c0>
Traceback (most recent call last):
  File "/build/source/ssh-audit.py", line 2321, in __del__
    self.__cleanup()
  File "/build/source/ssh-audit.py", line 2325, in __cleanup
    self._close_socket(self.__sock)
AttributeError: 'Socket' object has no attribute '_Socket__sock'
_________________________ TestSocket.test_invalid_host _________________________

self = <test_socket.TestSocket object at 0x7ffff69f94c0>
virtual_socket = <conftest._VirtualSocket object at 0x7ffff68acbb0>

    def test_invalid_host(self, virtual_socket):
        with pytest.raises(ValueError):
>               s = self.ssh.Socket(None, 22)
E     TypeError: __init__() missing 3 required positional arguments: 'ipvo', 'timeout', and 'timeout_set'

test/test_socket.py:15: TypeError
----------------------------- Captured stderr call -----------------------------
Exception ignored in: <function SSH.Socket.__del__ at 0x7ffff69af4c0>
Traceback (most recent call last):
  File "/build/source/ssh-audit.py", line 2321, in __del__
    self.__cleanup()
  File "/build/source/ssh-audit.py", line 2325, in __cleanup
    self._close_socket(self.__sock)
AttributeError: 'Socket' object has no attribute '_Socket__sock'
_________________________ TestSocket.test_invalid_port _________________________

self = <test_socket.TestSocket object at 0x7ffff64487f0>
virtual_socket = <conftest._VirtualSocket object at 0x7ffff64480a0>

    def test_invalid_port(self, virtual_socket):
        with pytest.raises(ValueError):
>               s = self.ssh.Socket('localhost', 'abc')
E     TypeError: __init__() missing 3 required positional arguments: 'ipvo', 'timeout', and 'timeout_set'

test/test_socket.py:19: TypeError
----------------------------- Captured stderr call -----------------------------
Exception ignored in: <function SSH.Socket.__del__ at 0x7ffff69af4c0>
Traceback (most recent call last):
  File "/build/source/ssh-audit.py", line 2321, in __del__
    self.__cleanup()
  File "/build/source/ssh-audit.py", line 2325, in __cleanup
    self._close_socket(self.__sock)
AttributeError: 'Socket' object has no attribute '_Socket__sock'
_____________________ TestSocket.test_not_connected_socket _____________________

self = <test_socket.TestSocket object at 0x7ffff69f4370>
virtual_socket = <conftest._VirtualSocket object at 0x7ffff69f4eb0>

    def test_not_connected_socket(self, virtual_socket):
>       sock = self.ssh.Socket('localhost', 22)
E    TypeError: __init__() missing 3 required positional arguments: 'ipvo', 'timeout', and 'timeout_set'

test/test_socket.py:28: TypeError
----------------------------- Captured stderr call -----------------------------
Exception ignored in: <function SSH.Socket.__del__ at 0x7ffff69af4c0>
Traceback (most recent call last):
  File "/build/source/ssh-audit.py", line 2321, in __del__
    self.__cleanup()
  File "/build/source/ssh-audit.py", line 2325, in __cleanup
    self._close_socket(self.__sock)
AttributeError: 'Socket' object has no attribute '_Socket__sock'
_______________________ TestSSH2.test_ssh2_server_simple _______________________

self = <test_ssh2.TestSSH2 object at 0x7ffff6448ee0>, output_spy = []
virtual_socket = <conftest._VirtualSocket object at 0x7ffff63ed880>

    def test_ssh2_server_simple(self, output_spy, virtual_socket):
        vsocket = virtual_socket
        w = self.wbuf()
        w.write_byte(self.ssh.Protocol.MSG_KEXINIT)
        w.write(self._kex_payload())
        vsocket.rdata.append(b'SSH-2.0-OpenSSH_7.3 ssh-audit-test\r\n')
        vsocket.rdata.append(self._create_ssh2_packet(w.write_flush()))
        output_spy.begin()
>       self.audit(self._conf())

test/test_ssh2.py:140:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
ssh-audit.py:3334: in audit
    SSH2.HostKeyTest.run(s, kex)
ssh-audit.py:710: in run
    SSH2.HostKeyTest.__test(s, server_kex, kex_str, kex_group, SSH2.HostKeyTest.HOST_KEY_TYPES)
ssh-audit.py:740: in __test
    SSH2.Kex.parse(payload)
ssh-audit.py:647: in parse
    kex_algs = buf.read_list()
ssh-audit.py:1142: in read_list
    list_size = self.read_int()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ssh-audit.ReadBuf object at 0x7ffff689a5e0>

    def read_int(self):
        # type: () -> int
>       v = struct.unpack('>I', self.read(4))[0]  # type: int
E    struct.error: unpack requires a buffer of 4 bytes

ssh-audit.py:1137: error
=========================== short test summary info ============================
FAILED test/test_resolve.py::TestResolve::test_resolve_error - TypeError: __i...
FAILED test/test_resolve.py::TestResolve::test_resolve_hostname_without_records
FAILED test/test_resolve.py::TestResolve::test_resolve_ipv4 - TypeError: __in...
FAILED test/test_resolve.py::TestResolve::test_resolve_ipv6 - TypeError: __in...
FAILED test/test_resolve.py::TestResolve::test_resolve_ipv46_both - TypeError...
FAILED test/test_resolve.py::TestResolve::test_resolve_ipv46_order - TypeErro...
FAILED test/test_socket.py::TestSocket::test_invalid_host - TypeError: __init...
FAILED test/test_socket.py::TestSocket::test_invalid_port - TypeError: __init...
FAILED test/test_socket.py::TestSocket::test_not_connected_socket - TypeError...
FAILED test/test_ssh2.py::TestSSH2::test_ssh2_server_simple - struct.error: u...
======================== 10 failed, 99 passed in 1.48s =========================
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
