### PR TITLE
postgresqlPackages.smlar: init at 2020-04-08

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/smlar.nix
+++ b/pkgs/servers/sql/postgresql/ext/smlar.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchgit, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "smlar-unstable";
+  version = "2020-04-08";
+
+  src = fetchgit {
+    url = "git://sigaev.ru/smlar.git";
+    rev = "0c345af71969d9863bb76efa833391d00705669e";
+    sha256 = "1pr3pbnjc9n209l52sgsn4xqzp92qk6wci55hcqjjrwf2gdxy0yr";
+  };
+
+  buildInputs = [ postgresql ];
+
+  makeFlags = [ "USE_PGXS=1" ];
+
+  installPhase = ''
+    install -D -t $out/lib *.so
+    install -D -t $out/share/postgresql/extension *.sql
+    install -D -t $out/share/postgresql/extension *.control
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Compute similary of any one-dimensional arrays";
+    homepage = "http://sigaev.ru/git/gitweb.cgi?p=smlar.git";
+    platforms = postgresql.meta.platforms;
+    license = licenses.bsd2;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -41,6 +41,8 @@ self: super: {
 
     pipelinedb = super.callPackage ./ext/pipelinedb.nix { };
 
+    smlar = super.callPackage ./ext/smlar.nix { };
+
     temporal_tables = super.callPackage ./ext/temporal_tables.nix { };
 
     timescaledb = super.callPackage ./ext/timescaledb.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
