### PR TITLE
python: Apply patch for CVE-2019-20907

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/CVE-2019-20907.patch
+++ b/pkgs/development/interpreters/python/cpython/2.7/CVE-2019-20907.patch
@@ -1,0 +1,24 @@
+From 5a8d121a1f3ef5ad7c105ee378cc79a3eac0c7d4 Mon Sep 17 00:00:00 2001
+From: Rishi <rishi_devan@mail.com>
+Date: Wed, 15 Jul 2020 13:51:00 +0200
+Subject: [PATCH] bpo-39017: Avoid infinite loop in the tarfile module
+ (GH-21454)
+
+Avoid infinite loop when reading specially crafted TAR files using the tarfile module
+(CVE-2019-20907).
+---
+ Lib/tarfile.py                                    |   2 ++
+
+diff --git a/Lib/tarfile.py b/Lib/tarfile.py
+index e2b60532f6..6769066cab 100755
+--- a/Lib/tarfile.py
++++ b/Lib/tarfile.py
+@@ -1249,6 +1249,8 @@ class TarInfo(object):
+ 
+             length, keyword = match.groups()
+             length = int(length)
++            if length == 0:
++                raise InvalidHeaderError("invalid header")
+             value = buf[match.end(2) + 1:match.start(1) + length - 1]
+ 
+             # Normally, we could just use "utf-8" as the encoding and "strict"

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -90,6 +90,9 @@ let
 
       # Backport from CPython 3.8 of a good list of tests to run for PGO.
       ./profile-task.patch
+
+      # Patch is likely to go away in the next release (if there is any)
+      ./CVE-2019-20907.patch
     ] ++ optionals (x11Support && stdenv.isDarwin) [
       ./use-correct-tcl-tk-on-darwin.patch
     ] ++ optionals stdenv.isLinux [


### PR DESCRIPTION
###### Motivation for this change

Patch issue directly instead of waiting for a new point release since I doubt that there will be another release for Python 2.7. Including the patch file in tree because the upstream patch target is Python 3 not Python 2.

Needs backport to 20.03.

Re #94004

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions -> Ubuntu
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
