### PR TITLE
gperftools: fix dlopen() of gperftools on AArch64

### DIFF
--- a/pkgs/development/libraries/gperftools/default.nix
+++ b/pkgs/development/libraries/gperftools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libunwind }:
+{ stdenv, fetchurl, fetchpatch, autoreconfHook, libunwind }:
 
 stdenv.mkDerivation rec {
   name = "gperftools-2.8";
@@ -8,8 +8,24 @@ stdenv.mkDerivation rec {
     sha256 = "0gjiplvday50x695pwjrysnvm5wfvg2b0gmqf6b4bdi8sv6yl394";
   };
 
+  patches = [
+    # Add the --disable-general-dynamic-tls configure option:
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1483558
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/gperftools/raw/f62d87a34f56f64fb8eb86727e34fbc2d3f5294a/f/gperftools-2.7.90-disable-generic-dynamic-tls.patch";
+      sha256 = "02falhpaqkl27hl1dib4yvmhwsddmgbw0krb46w31fyf3awb2ydv";
+    })
+  ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+
   # tcmalloc uses libunwind in a way that works correctly only on non-ARM linux
   buildInputs = stdenv.lib.optional (stdenv.isLinux && !(stdenv.isAarch64 || stdenv.isAarch32)) libunwind;
+
+  # Disable general dynamic TLS on AArch to support dlopen()'ing the library:
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1483558
+  configureFlags = stdenv.lib.optional (stdenv.isAarch32 || stdenv.isAarch64)
+    "--disable-general-dynamic-tls";
 
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace Makefile.am --replace stdc++ c++


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The `sentencepiece` Python module cannot be build on AArch64 due to an error `cannot allocate memory in static TLS
block`:

https://hydra.nixos.org/build/124772579/nixlog/1

See also:

https://bugzilla.redhat.com/show_bug.cgi?id=1483558

This change uses a patch from Fedora to disable generic dynamic TLS on
AArch32/64.

(Since this requires `autoreconfHook`, maybe it's worthwhile switching to `fetchFromGitHub` as well?)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
