### PR TITLE
gtg: refactor (description, platform, version, requirement, formatting)

### DIFF
--- a/pkgs/applications/office/gtg/default.nix
+++ b/pkgs/applications/office/gtg/default.nix
@@ -2,7 +2,6 @@
 , fetchFromGitHub
 , meson
 , python3Packages
-, pkgconfig
 , ninja
 , gtk3
 , wrapGAppsHook
@@ -16,20 +15,21 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gtg";
-  version = "0.4";
+  version = "unstable-2020-08-02";
 
   src = fetchFromGitHub {
-      owner = "getting-things-gnome";
-      repo = "gtg";
-      rev = "6623731f301c1b9c7b727e009f4a6462ad381c68";
-      sha256 = "14gxgg4nl0ki3dn913041jpyfhxsj90fkd55z6mmpyklhr8mwss1";
+    owner = "getting-things-gnome";
+    repo = "gtg";
+    rev = "6623731f301c1b9c7b727e009f4a6462ad381c68";
+    sha256 = "14gxgg4nl0ki3dn913041jpyfhxsj90fkd55z6mmpyklhr8mwss1";
   };
 
 
   nativeBuildInputs = [
     meson
     ninja
-    pkgconfig
+    itstool
+    gettext
     wrapGAppsHook
     gobject-introspection
   ];
@@ -37,8 +37,6 @@ python3Packages.buildPythonApplication rec {
   buildInputs = [
     glib
     gtk3
-    itstool
-    gettext
     pango
     gdk-pixbuf
   ];
@@ -50,24 +48,21 @@ python3Packages.buildPythonApplication rec {
     dbus-python
     gst-python
     liblarch
-    pyxdg # can probably be removed after next release
   ];
 
   format = "other";
-  strictDeps = false;
+  strictDeps = false; # gobject-introspection does not run with strictDeps (https://github.com/NixOS/nixpkgs/issues/56943)
 
   meta = with stdenv.lib; {
-    description = "
-      Getting Things GNOME! (GTG) is a personal tasks and TODO-list items organizer for the GNOME desktop environment and inspired by the ''Getting Things Done'' (GTD) methodology.
-    ";
-    longDescription = "
-      GTG is designed with flexibility, adaptability, and ease of use in mind so it can be used as more than just GTD software.
+    description = " A personal tasks and TODO-list items organizer.";
+    longDescription = ''
+      "Getting Things GNOME" (GTG) is a personal tasks and ToDo list organizer inspired by the "Getting Things Done" (GTD) methodology.
       GTG is intended to help you track everything you need to do and need to know, from small tasks to large projects.
-    ";
+    '';
     homepage = "https://wiki.gnome.org/Apps/GTG";
     downloadPage = "https://github.com/getting-things-gnome/gtg/releases";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ oyren ];
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Introduction of some changes based on the comments of @jtojnar see https://github.com/NixOS/nixpkgs/pull/94686/files/bca02ca6862d652fce4df143c302e2581489d329.

- pkgconfig was removed, since apparently unnecessary
- version has been changed to comply with package naming guidelines
- itstool and gettext was moved to nativeBuildInputs
- comment about #56943 added
- description has been shortened
- switched from platform `x86_64-linux` to `platforms.linux`


###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
