### PR TITLE
build elementary-files with vala 0.48

### DIFF
--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -49,7 +49,9 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   elementary-dock = callPackage ./apps/elementary-dock { };
 
-  elementary-files = callPackage ./apps/elementary-files { };
+  elementary-files = callPackage ./apps/elementary-files {
+    vala = vala_0_48;
+  };
 
   elementary-feedback = callPackage ./apps/elementary-feedback { };
 
@@ -199,6 +201,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   ### ALIASES
 
   inherit (pkgs) vala; # added 2019-10-10
+  inherit (pkgs) vala_0_48; #added for issue #94707
 
   cerbere = throw "Cerbere is now obsolete https://github.com/elementary/cerbere/releases/tag/2.5.1.";
 

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -36,6 +36,8 @@ let
 
         "0.46" = ./disable-graphviz-0.46.1.patch;
 
+        "0.48" = ./disable-graphviz-0.46.1.patch;
+
       }.${lib.versions.majorMinor version} or (throw "no graphviz patch for this version of vala");
 
     disableGraphviz = lib.versionAtLeast version "0.38" && !withGraphviz;
@@ -118,6 +120,11 @@ in rec {
   vala_0_46 = generic {
     version = "0.46.5";
     sha256 = "07fv895sp9wq74b20qig7hic0r4ynrr5pfaqba02r44xb794fy0s";
+  };
+
+  vala_0_48 = generic {
+    version = "0.48.1";
+    sha256 = "61c5TAqQj/Y2I9F54J+h6dazjTHH61l9MCFInyl+cdQ=";
   };
 
   vala = vala_0_46;

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -123,8 +123,8 @@ in rec {
   };
 
   vala_0_48 = generic {
-    version = "0.48.1";
-    sha256 = "61c5TAqQj/Y2I9F54J+h6dazjTHH61l9MCFInyl+cdQ=";
+    version = "0.48.7";
+    sha256 = "0lswkb7gj0chas9n3l3dbrm9l71hs77adhvm2v600id2ipi37pi8";
   };
 
   vala = vala_0_46;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8988,6 +8988,7 @@ in
     vala_0_40
     vala_0_44
     vala_0_46
+    vala_0_48
     vala;
 
   wcc = callPackage ../development/compilers/wcc { };


### PR DESCRIPTION
###### Motivation for this change
fixes #94707 

There is probably a more elegant way to do it but this was the one with the least impact I could find.

ping @vcunat 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
