### PR TITLE
qt-video-wlr: init at 2020-08-03

### DIFF
--- a/pkgs/applications/misc/qt-video-wlr/default.nix
+++ b/pkgs/applications/misc/qt-video-wlr/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, lib, fetchFromGitHub, pkg-config, meson, ninja, wayland, pixman, cairo, librsvg, wayland-protocols, wlroots, libxkbcommon, gst_all_1, wrapQtAppsHook, qtbase, qtmultimedia }:
+let
+ gstreamerPath = with gst_all_1; stdenv.lib.makeSearchPath "lib/gstreamer-1.0" [
+     gstreamer
+     gst-plugins-base
+     gst-plugins-good
+     gst-plugins-bad
+     gst-plugins-ugly
+ ];
+in stdenv.mkDerivation rec {
+  pname = "qt-video-wlr";
+  version = "2020-08-03";
+
+  src = fetchFromGitHub {
+    owner = "xdavidwu";
+    repo = "qt-video-wlr";
+    rev = "f88a7aa43f28b879b18752069f4a1ec33d73f2fe";
+    sha256 = "135kfyg1b61xvfpk8vpk4qyw6s9q1mn3a6lfkrqrhl0dz9kka9lx";
+  };
+
+  nativeBuildInputs = [ pkg-config meson ninja wrapQtAppsHook ];
+  buildInputs = [
+      wayland
+      pixman
+      cairo
+      librsvg
+      wayland-protocols
+      wlroots
+      libxkbcommon
+      qtbase
+      qtmultimedia
+  ];
+
+  qtWrapperArgs = [
+      "--prefix PATH : $out/bin/qt-video-wlr"
+      "--prefix GST_PLUGIN_PATH : ${gstreamerPath}"
+  ];
+
+  meta = with lib; {
+    description = "Qt pip-mode-like video player for wlroots-based wayland compositors";
+    homepage = "https://github.com/xdavidwu/qt-video-wlr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fionera ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1906,6 +1906,8 @@ in
 
   fuzzel = callPackage ../applications/misc/fuzzel { };
 
+  qt-video-wlr = libsForQt5.callPackage ../applications/misc/qt-video-wlr { };
+
   fwup = callPackage ../tools/misc/fwup { };
 
   fx_cast_bridge = callPackage ../tools/misc/fx_cast { };


### PR DESCRIPTION
###### Motivation for this change
Adding the Package so I can enjoy a Video Wallpaper

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
