### PR TITLE
kanji-stroke-order-font: 4.002 -> 4.003

### DIFF
--- a/pkgs/data/fonts/kanji-stroke-order-font/default.nix
+++ b/pkgs/data/fonts/kanji-stroke-order-font/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, fetchzip }:
+{ stdenv, fetchurl }:
 
 let
-  version = "4.002";
-in fetchzip {
+  version = "4.003";
+  debianVersion = "dfsg-1";
+in stdenv.mkDerivation {
   name = "kanji-stroke-order-font-${version}";
 
-  url = "https://sites.google.com/site/nihilistorguk/KanjiStrokeOrders_v${version}.zip?attredirects=0";
+  src = fetchurl {
+    url = "https://salsa.debian.org/fonts-team/fonts-kanjistrokeorders/-/archive/debian/${version}_${debianVersion}/fonts-kanjistrokeorders-debian-${version}_${debianVersion}.tar.bz2";
+    sha256 = "1a8hxzkrfjz0h5gl9h0panzzsn7cldlklxryyzmpam23g32q6bg1";
+  };
 
-  postFetch = ''
+  installPhase = ''
     mkdir -p $out/share/fonts/kanji-stroke-order $out/share/doc/kanji-stroke-order
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/kanji-stroke-order
-    unzip -j $downloadedFile \*.txt -d $out/share/doc/kanji-stroke-order
+    cp *.ttf $out/share/fonts/kanji-stroke-order
+    cp *.txt $out/share/doc/kanji-stroke-order
   '';
-
-  sha256 = "194ylkx5p7r1461wnnd3hisv5dz1xl07fyxmg8gv47zcwvdmwkc0";
 
   meta = with stdenv.lib; {
     description = "Font containing stroke order diagrams for over 6500 kanji, 180 kana and other characters";


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
