### PR TITLE
libreoffice: Templates for LibreOffice Impress

### DIFF
--- a/pkgs/applications/office/libreoffice/plugins.nix
+++ b/pkgs/applications/office/libreoffice/plugins.nix
@@ -20,14 +20,18 @@ stdenv.mkDerivation rec {
   installPhase = ''
 #    EXCLUDE_DEFAULTS=/beehive/|/blue-curve/|/classy-red/|/clean-inspiration/|/dna/|/focus/|/impress/|/lights/|/nature-illustration/|/metropolis/|/pencil/|/piano/|/portfolio/|/progress/
 #    TEMPLATES=(''$(ls -d1 */*/ | grep -Ev ''$EXCLUDE_DEFAULTS))
-#    for i in ''$(find -mindepth 2 -maxdepth 2 ! -name material-simple -type d;find user-contrib -mindepth 2 -maxdepth 2 -type d); do
-#      zip -r ''$(basename $i).otp $i
-#    done
+    for i in ''$(find -mindepth 2 -maxdepth 2 ! -name material-simple -type d;find user-contrib -mindepth 2 -maxdepth 2 -type d); do
+      zip -r ''$(basename $i).otp $i
+    done
 #    find -mindepth 2 -maxdepth 2 ! -name material-simple -type d -exec echo zip -r ''$(echo {}|basename).otp {} \;
 #    find user-contrib -mindepth 2 -maxdepth 2 -type d -exec echo zip -r ''$(echo {}.otp {} \;
-    find -mindepth 2 -maxdepth 2 ! -name material-simple -type d -exec VAR={} echo $VAR \;
-    mkdir -p $out/share/template/common/presnt/
-    install -vDm755 *.otp $out/share/template/common/presnt/    
+#    find -mindepth 2 -maxdepth 2 ! -name material-simple -type d -exec VAR={} echo $VAR \;
+#    mkdir -p $out/share/libreoffice-impress-templates/template/common/presnt/
+#    install -vDm755 *.otp $out/share/libreoffice-impress-templates/template/common/presnt/    
+#    mkdir -p $out/share/libreoffice/template/common/presnt/
+#    install -vDm755 *.otp $out/share/libreoffice/template/common/presnt/
+    mkdir -p $out/lib/libreoffice/share/template/common/presnt/
+    install -vDm755 *.otp $out/lib/libreoffice/share/template/common/presnt/
  '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/office/libreoffice/plugins.nix
+++ b/pkgs/applications/office/libreoffice/plugins.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, ruby.devEnv, zip }:
+
+stdenv.mkDerivation rec {
+  pname = "libreoffice-impress-templates";
+  version = "2.2";
+
+  src = fetchFromGitHub {
+    owner = "dohliam";
+    repo = "libreoffice-impress-templates";
+    rev = "v${version}";
+    sha256 = "1kgxzm70rn071w6w7jjbasyvpf6jxsldl6c1gszdp1fzhv15qj0p";
+  };
+
+  nativeBuildInputs = [ ruby, zip ];
+
+  patchPhase = ''
+    patchShebangs scripts/repack_otp.rb
+  ''
+
+  installPhase = ''
+    EXCLUDE_DEFAULTS=/beehive/|/blue-curve/|/classy-red/|/clean-inspiration/|/dna/|/focus/|/impress/|/lights/|/nature-illustration/|/metropolis/|/pencil/|/piano/|/portfolio/|/progress/
+    TEMPLATES=($(ls -d1 */*/ | grep -Ev "$EXCLUDE_DEFAULTS"))
+    ./scripts/repack_otp.rb ${TEMPLATES[@]}
+    mkdir -p $out/share/template/common/presnt
+    install -vDm755 */*.otp $out/share/template/common/presnt/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/dohliam/libreoffice-impress-templates";
+    description = "Templates for LibreOffice Impress";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ louisdk1 ];
+  };
+
+};
+

--- a/pkgs/applications/office/libreoffice/plugins.nix
+++ b/pkgs/applications/office/libreoffice/plugins.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ruby.devEnv, zip }:
+{ stdenv, fetchFromGitHub, ruby, zip }:
 
 stdenv.mkDerivation rec {
   pname = "libreoffice-impress-templates";
@@ -8,22 +8,27 @@ stdenv.mkDerivation rec {
     owner = "dohliam";
     repo = "libreoffice-impress-templates";
     rev = "v${version}";
-    sha256 = "1kgxzm70rn071w6w7jjbasyvpf6jxsldl6c1gszdp1fzhv15qj0p";
+    sha256 = "0vird1fapcvimw7fa7dj08bqsmjzp5r2zczhnk4n5g9xc724azvk";
   };
 
-  nativeBuildInputs = [ ruby, zip ];
+  nativeBuildInputs = [ ruby zip ];
 
   patchPhase = ''
     patchShebangs scripts/repack_otp.rb
-  ''
+  '';
 
   installPhase = ''
-    EXCLUDE_DEFAULTS=/beehive/|/blue-curve/|/classy-red/|/clean-inspiration/|/dna/|/focus/|/impress/|/lights/|/nature-illustration/|/metropolis/|/pencil/|/piano/|/portfolio/|/progress/
-    TEMPLATES=($(ls -d1 */*/ | grep -Ev "$EXCLUDE_DEFAULTS"))
-    ./scripts/repack_otp.rb ${TEMPLATES[@]}
-    mkdir -p $out/share/template/common/presnt
-    install -vDm755 */*.otp $out/share/template/common/presnt/
-  '';
+#    EXCLUDE_DEFAULTS=/beehive/|/blue-curve/|/classy-red/|/clean-inspiration/|/dna/|/focus/|/impress/|/lights/|/nature-illustration/|/metropolis/|/pencil/|/piano/|/portfolio/|/progress/
+#    TEMPLATES=(''$(ls -d1 */*/ | grep -Ev ''$EXCLUDE_DEFAULTS))
+#    for i in ''$(find -mindepth 2 -maxdepth 2 ! -name material-simple -type d;find user-contrib -mindepth 2 -maxdepth 2 -type d); do
+#      zip -r ''$(basename $i).otp $i
+#    done
+#    find -mindepth 2 -maxdepth 2 ! -name material-simple -type d -exec echo zip -r ''$(echo {}|basename).otp {} \;
+#    find user-contrib -mindepth 2 -maxdepth 2 -type d -exec echo zip -r ''$(echo {}.otp {} \;
+    find -mindepth 2 -maxdepth 2 ! -name material-simple -type d -exec VAR={} echo $VAR \;
+    mkdir -p $out/share/template/common/presnt/
+    install -vDm755 *.otp $out/share/template/common/presnt/    
+ '';
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/dohliam/libreoffice-impress-templates";
@@ -33,5 +38,5 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ louisdk1 ];
   };
 
-};
+}
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24835,6 +24835,8 @@ in
   });
   libreoffice-still-unwrapped = libreoffice-still.libreoffice;
 
+  libreofficePlugins = callPackage ../applications/office/libreoffice/plugins.nix { };
+
   libvmi = callPackage ../development/libraries/libvmi { };
 
   lifelines = callPackage ../applications/misc/lifelines { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24791,7 +24791,10 @@ in
   librecad = libsForQt514.callPackage ../applications/misc/librecad { };
 
   libreoffice = hiPrio libreoffice-still;
-  libreoffice-unwrapped = libreoffice.libreoffice;
+  
+  libreoffice-impress-templates = callPackage ../applications/office/libreoffice/plugins.nix { };
+  
+libreoffice-unwrapped = libreoffice.libreoffice;
 
   libreoffice-args = {
     inherit (perlPackages) ArchiveZip IOCompress;


### PR DESCRIPTION
###### Motivation for this change

LibreOffice Impress has few templates by default so I want to get some more.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
