### PR TITLE
[19.09] wire-desktop: linux 3.18.2925 -> 3.19.2928, mac 3.18.3728 -> 3.19.3799

### DIFF
--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -19,12 +19,12 @@ let
 
   version = {
     x86_64-darwin = "3.18.3728";
-    x86_64-linux = "3.18.2925";
+    x86_64-linux = "3.19.2928";
   }.${system} or throwSystem;
 
   sha256 = {
     x86_64-darwin = "0xi3k95yw59xsfavncc1giwxlwjz26z34qm3i604ksjjalvpzy5l";
-    x86_64-linux = "01g39hncj1w0zyfrzv4mgv8npwvx0g0lw99azyai99877b30bm8j";
+    x86_64-linux = "038h1j59qfj5ckaxk823qpfflxay47v0jrqc0hmrdmnd2y59dpx7";
   }.${system} or throwSystem;
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -18,12 +18,12 @@ let
   pname = "wire-desktop";
 
   version = {
-    x86_64-darwin = "3.18.3728";
+    x86_64-darwin = "3.19.3799";
     x86_64-linux = "3.19.2928";
   }.${system} or throwSystem;
 
   sha256 = {
-    x86_64-darwin = "0xi3k95yw59xsfavncc1giwxlwjz26z34qm3i604ksjjalvpzy5l";
+    x86_64-darwin = "1sv8n4g1pd4nwpwsg0m61zhrfjlh7sj29rnh46xjw1qg332g6cw9";
     x86_64-linux = "038h1j59qfj5ckaxk823qpfflxay47v0jrqc0hmrdmnd2y59dpx7";
   }.${system} or throwSystem;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Backport wire-desktop: linux 3.18.2925 -> 3.19.2928, mac 3.18.3728 -> 3.19.3799 #94758

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).