### PR TITLE
hyp2mat: init at 0.0.17

### DIFF
--- a/pkgs/applications/science/electronics/hyp2mat/default.nix
+++ b/pkgs/applications/science/electronics/hyp2mat/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, fetchFromGitHub
+, bison
+, flex
+, gengetopt
+, help2man
+, groff
+, libharu
+, autoreconfHook
+, pkgconfig
+, libpng
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hyp2mat";
+  version = "0.0.17";
+
+  src = fetchFromGitHub {
+    owner = "koendv";
+    repo = "hyp2mat";
+    rev = "v${version}";
+    sha256 = "04bd2vrn8y1izir7pwl34a60cg2v05baqcrmpfdx5fvf33bbflaj";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+  ];
+
+  buildInputs = [
+    libharu
+    libpng
+    zlib
+    bison
+    flex
+    gengetopt
+    help2man
+    groff
+  ];
+
+  configureFlags = [ "--enable-library" ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Import Hyperlynx Boardsim files to openEMS, an open source 3D full-wave electromagnetic field solver";
+    homepage = https://github.com/koendv/hyp2mat;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ matthuszagh ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25689,6 +25689,8 @@ in
 
   gtkwave = callPackage ../applications/science/electronics/gtkwave { };
 
+  hyp2mat = callPackage ../applications/science/electronics/hyp2mat { };
+
   fped = callPackage ../applications/science/electronics/fped { };
 
   # this is a wrapper for kicad.base and kicad.libraries


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Next part of a series of changes for [this pr](https://github.com/NixOS/nixpkgs/pull/69262). @jonringer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
