### PR TITLE
gnomeExtensions.timepp: unstable-2019-03-30 -> unstable-2020-03-15

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/timepp/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/timepp/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-timepp";
-  version = "unstable-2019-03-30";
+  version = "unstable-2020-03-15";
 
   src = fetchFromGitHub {
     owner = "zagortenay333";
     repo = "timepp__gnome";
-    rev = "f90fb5573b37ac89fb57bf62e07d6d3bdb6a2c63";
-    sha256 = "0p6rsbm6lf61vzly775qkwc2rcjjl38bkqdxnv4sccqmw2wwclnp";
+    rev = "34ae477a51267cc1e85992a80cf85a1a7b7005c1";
+    sha256 = "1v0xbrp0x5dwizscxh7h984pax4n92bj8iyw3qvjk27ynpxq8ag1";
   };
 
   uuid = "timepp@zagortenay333";
@@ -24,6 +24,5 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/zagortenay333/timepp__gnome";
     license = licenses.gpl3;
     maintainers = with maintainers; [ svsdep ];
-    broken = versionAtLeast gnome3.gnome-shell.version "3.32"; # Dosen't support 3.34 https://github.com/zagortenay333/timepp__gnome/issues/113
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This update is supposed to unbreak the package.

###### Things done

~~I didn't test the extension yet. I'll do it soon.~~

3.32 failed to load with the latest Gnome.

2020-03-15 loads but there seem to be a [bunch of bugs](https://github.com/zagortenay333/timepp__gnome/issues?q=is%3Aopen+is%3Aissue).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/nix/store/kx1qhzmpffzpib6ivvbqjvrs1db1v767-gnome-shell-extension-timepp-3.32  35.8M