### PR TITLE
nixos/jupyterhub: init service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -331,6 +331,7 @@
   ./services/development/bloop.nix
   ./services/development/hoogle.nix
   ./services/development/jupyter/default.nix
+  ./services/development/jupyterhub/default.nix
   ./services/development/lorri.nix
   ./services/editors/emacs.nix
   ./services/editors/infinoted.nix

--- a/nixos/modules/services/development/jupyterhub/default.nix
+++ b/nixos/modules/services/development/jupyterhub/default.nix
@@ -1,0 +1,190 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.jupyterhub;
+
+  kernels = (pkgs.jupyter-kernel.create  {
+    definitions = if cfg.kernels != null
+      then cfg.kernels
+      else  pkgs.jupyter-kernel.default;
+  });
+
+  jupyterhubConfig = pkgs.writeText "jupyterhub_config.py" ''
+    c.JupyterHub.bind_url = "http://${cfg.host}:${toString cfg.port}"
+
+    c.JupyterHub.authentication_class = "${cfg.authentication}"
+    c.JupyterHub.spawner_class = "${cfg.spawner}"
+
+    c.SystemdSpawner.default_url = '/lab'
+    c.SystemdSpawner.cmd = "${cfg.jupyterlabEnv}/bin/jupyterhub-singleuser"
+    c.SystemdSpawner.environment = {
+      'JUPYTER_PATH': '${kernels}'
+    }
+
+    ${cfg.extraConfig}
+  '';
+in {
+  meta.maintainers = with maintainers; [ costrouc ];
+
+  options.services.jupyterhub = {
+    enable = mkEnableOption "Jupyterhub development server";
+
+    authentication = mkOption {
+      type = types.str;
+      default = "jupyterhub.auth.PAMAuthenticator";
+      description = ''
+        Jupyterhub authentication to use
+
+        There are many authenticators available including: oauth, pam,
+        ldap, kerberos, etc.
+      '';
+    };
+
+    spawner = mkOption {
+      type = types.str;
+      default = "systemdspawner.SystemdSpawner";
+      description = ''
+        Jupyterhub spawner to use
+
+        There are many spawners available including: local process,
+        systemd, docker, kubernetes, yarn, batch, etc.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra contents appended to the jupyterhub configuration
+
+        Jupyterhub configuration is a normal python file using
+        Traitlets. https://jupyterhub.readthedocs.io/en/stable/getting-started/config-basics.html. The
+        base configuration of this module was designed to have sane
+        defaults for configuration but you can override anything since
+        this is a python file.
+      '';
+      example = literalExample ''
+         c.SystemdSpawner.memory = "8G"
+         c.SystemdSpawner.cpus = "2"
+      '';
+    };
+
+    jupyterhubEnv = mkOption {
+      type = types.package;
+      default = (pkgs.python3.withPackages (p: with p; [
+        jupyterhub
+        jupyterhub-systemdspawner
+      ]));
+      description = ''
+        Python environment to run jupyterhub
+
+        Customizing will affect the packages available in the hub and
+        proxy. This will allow packages to be available for the
+        extraConfig that you may need. This will not normally need to
+        be changed.
+      '';
+    };
+
+    jupyterlabEnv = mkOption {
+      type = types.package;
+      default = (pkgs.python3.withPackages (p: with p; [
+        jupyterhub
+        jupyterlab
+      ]));
+      description = ''
+        Python environment to run jupyterlab
+
+        Customizing will affect the packages available in the
+        jupyterlab server and the default kernel provided. This is the
+        way to customize the jupyterlab extensions and jupyter
+        notebook extensions. This will not normally need to
+        be changed.
+      '';
+    };
+
+    kernels = mkOption {
+      type = types.nullOr (types.attrsOf(types.submodule (import ../jupyter/kernel-options.nix {
+        inherit lib;
+      })));
+
+      default = null;
+      example = literalExample ''
+        {
+          python3 = let
+            env = (pkgs.python3.withPackages (pythonPackages: with pythonPackages; [
+                    ipykernel
+                    pandas
+                    scikitlearn
+                  ]));
+          in {
+            displayName = "Python 3 for machine learning";
+            argv = [
+              "''${env.interpreter}"
+              "-m"
+              "ipykernel_launcher"
+              "-f"
+              "{connection_file}"
+            ];
+            language = "python";
+            logo32 = "''${env}/''${env.sitePackages}/ipykernel/resources/logo-32x32.png";
+            logo64 = "''${env}/''${env.sitePackages}/ipykernel/resources/logo-64x64.png";
+          };
+        }
+      '';
+      description = ''
+        Declarative kernel config
+
+        Kernels can be declared in any language that supports and has
+        the required dependencies to communicate with a jupyter server.
+        In python's case, it means that ipykernel package must always be
+        included in the list of packages of the targeted environment.
+      '';
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8000;
+      description = ''
+        Port number Jupyterhub will be listening on
+      '';
+    };
+
+    host = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = ''
+        Bind IP JupyterHub will be listening on
+      '';
+    };
+
+    stateDirectory = mkOption {
+      type = types.str;
+      default = "jupyterhub";
+      description = ''
+        Directory for jupyterhub state (token + database)
+      '';
+    };
+  };
+
+  config = mkMerge [
+    (mkIf cfg.enable  {
+      systemd.services.jupyterhub = {
+        description = "Jupyterhub development server";
+
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          Restart = "always";
+          ExecStart = "${cfg.jupyterhubEnv}/bin/jupyterhub --config ${jupyterhubConfig}";
+          User = "root";
+          StateDirectory = cfg.stateDirectory;
+          WorkingDirectory = "/var/lib/${cfg.stateDirectory}";
+        };
+      };
+    })
+  ];
+}

--- a/nixos/modules/services/development/jupyterhub/default.nix
+++ b/nixos/modules/services/development/jupyterhub/default.nix
@@ -67,8 +67,8 @@ in {
         this is a python file.
       '';
       example = literalExample ''
-         c.SystemdSpawner.memory = "8G"
-         c.SystemdSpawner.cpus = "2"
+         c.SystemdSpawner.mem_limit = '8G'
+         c.SystemdSpawner.cpu_limit = 2.0
       '';
     };
 

--- a/pkgs/development/python-modules/bash_kernel/default.nix
+++ b/pkgs/development/python-modules/bash_kernel/default.nix
@@ -6,6 +6,7 @@
 , isPy27
 , python
 , pexpect
+, bash
 }:
 
 buildPythonPackage rec {
@@ -25,6 +26,12 @@ buildPythonPackage rec {
       sha256 = "1qd7qjjmcph4dk6j0bl31h2fdmfiyyazvrc9xqqj8y21ki2sl33j";
     })
   ];
+
+  postPatch = ''
+    substituteInPlace bash_kernel/kernel.py \
+      --replace "'bash'" "'${bash}/bin/bash'" \
+      --replace "\"bash\"" "'${bash}/bin/bash'"
+  '';
 
   propagatedBuildInputs = [ ipykernel pexpect ];
 

--- a/pkgs/development/python-modules/jupyter-c-kernel/default.nix
+++ b/pkgs/development/python-modules/jupyter-c-kernel/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ipykernel
+, gcc
+}:
+
+buildPythonPackage rec {
+  pname = "jupyter-c-kernel";
+  version = "1.2.2";
+
+  src = fetchPypi {
+    pname = "jupyter_c_kernel";
+    inherit version;
+    sha256 = "e4b34235b42761cfc3ff08386675b2362e5a97fb926c135eee782661db08a140";
+  };
+
+  postPatch = ''
+    substituteInPlace jupyter_c_kernel/kernel.py \
+      --replace "'gcc'" "'${gcc}/bin/gcc'"
+  '';
+
+  propagatedBuildInputs = [ ipykernel ];
+
+  # no tests in repository
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Minimalistic C kernel for Jupyter";
+    homepage = "https://github.com/brendanrius/jupyter-c-kernel/";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/jupyterhub-systemdspawner/default.nix
+++ b/pkgs/development/python-modules/jupyterhub-systemdspawner/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, jupyterhub
+, tornado
+, bash
+}:
+
+buildPythonPackage rec {
+  pname = "jupyterhub-systemdspawner";
+  version = "0.14";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "080dd9cd9292266dad35d1efc7aa1af0ed6993d15eadc79bd959d1ee273d1923";
+  };
+
+  propagatedBuildInputs = [
+    jupyterhub
+    tornado
+  ];
+
+  postPatch = ''
+    substituteInPlace systemdspawner/systemd.py \
+      --replace "/bin/bash" "${bash}/bin/bash"
+
+    substituteInPlace systemdspawner/systemdspawner.py \
+      --replace "/bin/bash" "${bash}/bin/bash"
+  '';
+
+  meta = with lib; {
+    description = "JupyterHub Spawner using systemd for resource isolation";
+    homepage = "https://github.com/jupyterhub/systemdspawner";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4481,6 +4481,10 @@ in {
 
   jupyterhub-ldapauthenticator = callPackage ../development/python-modules/jupyterhub-ldapauthenticator { };
 
+  jupyterhub-systemdspawner = callPackage ../development/python-modules/jupyterhub-systemdspawner {
+    inherit (pkgs) bash;
+  };
+
   kaggle = callPackage ../development/python-modules/kaggle { };
 
   keyring = if isPy3k then

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -509,7 +509,9 @@ in {
 
   baselines = callPackage ../development/python-modules/baselines { };
 
-  bash_kernel = callPackage ../development/python-modules/bash_kernel { };
+  bash_kernel = callPackage ../development/python-modules/bash_kernel {
+    inherit (pkgs) bash;
+  };
 
   bashlex = callPackage ../development/python-modules/bashlex { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3299,6 +3299,8 @@ in {
 
   jupyter = callPackage ../development/python-modules/jupyter { };
 
+  jupyter-c-kernel = callPackage ../development/python-modules/jupyter-c-kernel { };
+
   jupyter_console = if pythonOlder "3.5" then
        callPackage ../development/python-modules/jupyter_console/5.nix { }
      else


### PR DESCRIPTION
##### Motivation for this change

I work at Quansight and we do a lot of python data science deployments with jupyterhub and related tooling that allows for scalable data science environments. This will be my first contributed nixos module so I am happy for feedback. The goal is to have an opinionated standard jupyterhub deployment (with `extraConfig` option so that you can do what you want). This opinionated service will use pam for authentication and systemd for launching processes for users. Though I will design this in mind so it is easily extensible to add oauth authentication for users and changing the spawner to use Docker, Kubernetes, etc.

Once we have this component in place I see some interesting comparisons with this nixos module and https://tljh.jupyter.org/en/latest/ and https://zero-to-jupyterhub.readthedocs.io/en/latest/. I want to make reproducible data science environments. From using tooling such as terraform and ansible a lot for these types of deployments I am excited to see if we could replace those tools with this using nixops for example. Anyways that should be enough motiviation as to why I think this PR is important.

Things needing to be done for this PR to be complete:
  - [X] get jupyterhub service running
  - [x] provide entry hooks for customizing jupyterlab being run and the possibilty for multiple kernels (thanks to the nixos/jupyter module I will likely be using that).
  - [ ] add a nixos test for jupyterhub: authentication with server, demonstrate launching jupyterlab instance, and running python commands 

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
