### PR TITLE
luajit_2_0, luajit_2_1: 2.1.0-2020-03-20 -> 2.1.0-2020-08-05

### DIFF
--- a/pkgs/development/interpreters/luajit/2.0.nix
+++ b/pkgs/development/interpreters/luajit/2.0.nix
@@ -1,10 +1,10 @@
 { self, callPackage, lib }:
 callPackage ./default.nix {
   inherit self;
-  version = "2.0.5-2020-03-20";
-  rev = "e613105";
+  version = "2.0.5-2020-08-05";
+  rev = "2211f6f";
   isStable = true;
-  sha256 = "0k843z90s4hi0qhri6ixy8sv21nig8jwbznpqgqg845ji530kqj7";
+  sha256 = "01adxmknq2xyb3w9sn8ilnar8181h7ksd9i80yrsbwzix5lwkn6m";
   extraMeta = { # this isn't precise but it at least stops the useless Hydra build
     platforms = with lib; filter (p: p != "aarch64-linux")
       (platforms.linux ++ platforms.darwin);

--- a/pkgs/development/interpreters/luajit/2.1.nix
+++ b/pkgs/development/interpreters/luajit/2.1.nix
@@ -1,8 +1,8 @@
 { self, callPackage }:
 callPackage ./default.nix {
   inherit self;
-  version = "2.1.0-2020-03-20";
-  rev = "9143e86";
+  version = "2.1.0-2020-08-05";
+  rev = "10ddae7";
   isStable = false;
-  sha256 = "1zw1yr0375d6jr5x20zvkvk76hkaqamjynbswpl604w6r6id070b";
+  sha256 = "1lmjs0gz9vgbhh5f45jvvibpj7f3sz81r8cz4maln9yhc67f2zmk";
 }

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -104,6 +104,6 @@ stdenv.mkDerivation rec {
     homepage    = "http://luajit.org";
     license     = licenses.mit;
     platforms   = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ thoughtpolice smironov vcunat andir ];
+    maintainers = with maintainers; [ thoughtpolice smironov vcunat andir lblasc ];
   } // extraMeta;
 }

--- a/pkgs/development/lua-modules/luaexpat.patch
+++ b/pkgs/development/lua-modules/luaexpat.patch
@@ -1,0 +1,36 @@
+diff --git a/src/lxplib.c b/src/lxplib.c
+index 1c972db..5712611 100644
+--- a/src/lxplib.c
++++ b/src/lxplib.c
+@@ -590,7 +590,7 @@ static void set_info (lua_State *L) {
+ /*
+ ** Adapted from Lua 5.2.0
+ */
+-static void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
++static void compat_luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
+   luaL_checkstack(L, nup, "too many upvalues");
+   for (; l->name != NULL; l++) {  /* fill the table with given functions */
+     int i;
+@@ -602,6 +602,8 @@ static void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
+   }
+   lua_pop(L, nup);  /* remove upvalues */
+ }
++#else
++#define compat_luaL_setfuncs(L, reg, nup) luaL_setfuncs(L, reg, nup)
+ #endif
+ 
+ 
+@@ -612,11 +614,11 @@ int luaopen_lxp (lua_State *L) {
+ 	lua_pushvalue(L, -2);
+ 	lua_rawset(L, -3);
+ 
+-	luaL_setfuncs (L, lxp_meths, 0);
++	compat_luaL_setfuncs (L, lxp_meths, 0);
+ 	lua_pop (L, 1); /* remove metatable */
+ 
+ 	lua_newtable (L);
+-	luaL_setfuncs (L, lxp_funcs, 0);
++	compat_luaL_setfuncs (L, lxp_funcs, 0);
+ 	set_info (L);
+ 	return 1;
+ }

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -204,6 +204,9 @@ with super;
     externalDeps = [
       { name = "EXPAT"; dep = pkgs.expat; }
     ];
+    patches = [
+      ./luaexpat.patch
+    ];
   });
 
   # TODO Somehow automatically amend buildInputs for things that need luaffi


### PR DESCRIPTION
###### Motivation for this change

2.0 changes: https://github.com/LuaJIT/LuaJIT/compare/e613105..2211f6f
Mostly bugfixes.

2.1 changes: https://github.com/LuaJIT/LuaJIT/compare/9143e86..10ddae7
Lot of bugfixes, optimizations and modernization. For me the most interesting commits:
*  https://github.com/LuaJIT/LuaJIT/commit/1a4ff1311740aa6c85f7a9101b6aa9bfaafa3f8e (Optimize table length computation with hinting.)
* https://github.com/LuaJIT/LuaJIT/commit/a44f53acf53603e7d9b88352de035b1804be4e88 (Use a securely seeded global PRNG for the VM.)
* https://github.com/LuaJIT/LuaJIT/commit/ff34b48ddd6f2b3bdd26d6088662a214ba6b0288 (Redesign and harden string interning.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
