### PR TITLE
tinygo: include files from gen-device

### DIFF
--- a/pkgs/development/compilers/tinygo/default.nix
+++ b/pkgs/development/compilers/tinygo/default.nix
@@ -12,7 +12,8 @@ buildGoModule rec {
     owner = "tinygo-org";
     repo = "tinygo";
     rev = "v${version}";
-    sha256 = "0das5z5y2x1970yi9c4yssxvwrrjhdmsj495q0r5mb02amvc954v";
+    sha256 = "1shvqqyxhaffbwakh48ma3hwj39phw06ylqap53pwqcpv970czsm";
+    fetchSubmodules = true;
   };
 
   overrideModAttrs = (_: {
@@ -34,6 +35,7 @@ buildGoModule rec {
 
   postInstall = ''
     mkdir -p $out/share/tinygo
+    make gen-device
     cp -a lib src targets $out/share/tinygo
     wrapProgram $out/bin/tinygo --prefix "TINYGOROOT" : "$out/share/tinygo"
     ln -sf $out/bin $out/share/tinygo


### PR DESCRIPTION
#### Motivation for this change

fix #94793

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
