### PR TITLE
skaffold: 1.12.1 → 1.13.1

### DIFF
--- a/pkgs/development/tools/skaffold/default.nix
+++ b/pkgs/development/tools/skaffold/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "skaffold";
-  version = "1.12.1";
+  version = "1.13.1";
 
   goPackagePath = "github.com/GoogleContainerTools/skaffold";
   subPackages = ["cmd/skaffold"];
@@ -19,7 +19,7 @@ buildGoPackage rec {
     owner = "GoogleContainerTools";
     repo = "skaffold";
     rev = "v${version}";
-    sha256 = "1mk4mn9h44v2xs65jjslmi03j3bixg0fkn396hmxp718w68850lz";
+    sha256 = "1v6napcpx8k45s8w55lbxahfc1p0qlvl597zgb4dzyg9w67fwnqk";
   };
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
See `nix-review` output below

Follow up on: https://github.com/NixOS/nixpkgs/pull/93680

Before this PR, k3d support is currently broken.

- [x] manually tested executable