### PR TITLE
nixos/postgresql: fix setup script

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -333,7 +333,7 @@ in
             # Wait for PostgreSQL to be ready to accept connections.
             ExecStartPost =
               let
-                setupScript = pkgs.writeScript "postgresql-setup" ''
+                setupScript = pkgs.writeScript "postgresql-setup" (''
                   #!${pkgs.runtimeShell} -e
 
                   PSQL="${pkgs.utillinux}/bin/runuser -u ${cfg.superUser} -- psql --port=${toString cfg.port}"
@@ -360,7 +360,7 @@ in
                       $PSQL -tAc 'GRANT ${permission} ON ${database} TO "${user.name}"'
                     '') user.ensurePermissions)}
                   '') cfg.ensureUsers}
-                '';
+                '');
               in
                 "+${setupScript}";
           }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

After https://github.com/NixOS/nixpkgs/pull/94454 postgresql didn't start up on my machine anymore.

After some analysis I think the missing () caused parts of the setup script to be added to the
ExecStartPost line instead of inside the script.

This caused postgresql start to fail under certain conditions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
