### PR TITLE
pipr: init at 0.0.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2448,6 +2448,12 @@
     githubId = 97852;
     name = "Ellis Whitehead";
   };
+  elkowar = {
+    email = "thereal.elkowar@gmail.com";
+    github = "elkowar";
+    githubId = 5300871;
+    name = "Leon Kowarschick";
+  };
   elohmeier = {
     email = "elo-nixos@nerdworks.de";
     github = "elohmeier";

--- a/pkgs/applications/misc/pipr/default.nix
+++ b/pkgs/applications/misc/pipr/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+, bubblewrap
+, makeWrapper
+, lib
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pipr";
+  version = "0.0.12";
+
+  src = fetchFromGitHub {
+    owner = "ElKowar";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0l7yvpc59mbzh87lngj6pj8w586fwa07829l5x9mmxnkf6srapmc";
+  };
+
+  cargoSha256 = "1xzc1x5mjvj2jgdhwmjbdbqi8d7ln1ss7akn72d96kmy1wsj1qsa";
+
+  nativeBuildInputs = [ makeWrapper ];
+  postFixup = ''
+    wrapProgram "$out/bin/pipr" --prefix PATH : ${lib.makeBinPath [ bubblewrap ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A commandline-tool to interactively write shell pipelines";
+    homepage = "https://github.com/ElKowar/pipr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ elkowar ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6089,6 +6089,8 @@ in
 
   pirate-get = callPackage ../tools/networking/pirate-get { };
 
+  pipr = callPackage ../applications/misc/pipr { };
+
   pipreqs = callPackage ../tools/misc/pipreqs { };
 
   pius = callPackage ../tools/security/pius { };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/elkowar/pipr

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
