### PR TITLE
blueberry: init at 1.3.9

### DIFF
--- a/pkgs/tools/bluetooth/blueberry/default.nix
+++ b/pkgs/tools/bluetooth/blueberry/default.nix
@@ -1,0 +1,96 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, bluez-tools
+, cinnamon
+, gnome3
+, gobject-introspection
+, intltool
+, pavucontrol
+, python3Packages
+, rfkill
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "blueberry";
+  version = "1.3.9";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    sha256 = "0llvz1h2dmvhvwkkvl0q4ggi1nmdbllw34ppnravs5lybqkicyw9";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    python3Packages.wrapPython
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    bluez-tools
+    cinnamon.xapps
+    gnome3.gnome-bluetooth
+    python3Packages.python
+    rfkill
+  ];
+
+  pythonPath = with python3Packages; [
+    dbus-python
+    pygobject3
+    setproctitle
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -a etc usr/* $out
+
+    # Fix paths
+    substituteInPlace $out/bin/blueberry \
+      --replace /usr/lib/blueberry $out/lib/blueberry
+    substituteInPlace $out/bin/blueberry-tray \
+      --replace /usr/lib/blueberry $out/lib/blueberry
+    substituteInPlace $out/etc/xdg/autostart/blueberry-obex-agent.desktop \
+      --replace /usr/lib/blueberry $out/lib/blueberry
+    substituteInPlace $out/etc/xdg/autostart/blueberry-tray.desktop \
+      --replace Exec=blueberry-tray Exec=$out/bin/blueberry-tray
+    substituteInPlace $out/lib/blueberry/blueberry-obex-agent.py \
+      --replace /usr/share $out/share
+    substituteInPlace $out/lib/blueberry/blueberry-tray.py \
+      --replace /usr/share $out/share
+    substituteInPlace $out/lib/blueberry/blueberry.py \
+      --replace '"bt-adapter"' '"${bluez-tools}/bin/bt-adapter"' \
+      --replace /usr/bin/pavucontrol ${pavucontrol}/bin/pavucontrol \
+      --replace /usr/lib/blueberry $out/lib/blueberry \
+      --replace /usr/share $out/share
+    substituteInPlace $out/lib/blueberry/rfkillMagic.py \
+      --replace /usr/bin/rfkill ${rfkill}/bin/rfkill \
+      --replace /usr/sbin/rfkill ${rfkill}/bin/rfkill \
+      --replace /usr/lib/blueberry $out/lib/blueberry
+    substituteInPlace $out/share/applications/blueberry.desktop \
+      --replace Exec=blueberry Exec=$out/bin/blueberry
+
+    glib-compile-schemas --strict $out/share/glib-2.0/schemas
+
+    runHook postInstall
+  '';
+
+  dontWrapGApps = true;
+
+  postFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    wrapPythonProgramsIn $out/lib "$out $pythonPath"
+  '';
+
+  meta = with lib; {
+    description = "Bluetooth configuration tool";
+    homepage = "https://github.com/linuxmint/blueberry";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2458,6 +2458,8 @@ in
     inherit (python27Packages) pillow;
   };
 
+  blueberry = callPackage ../tools/bluetooth/blueberry { };
+
   blueman = callPackage ../tools/bluetooth/blueman { };
 
   bmrsa = callPackage ../tools/security/bmrsa/11.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [blueberry](https://github.com/linuxmint/blueberry), a Bluetooth configuration tool.

It is Linux Mint's spin-off of GNOME Bluetooth, which works in all desktop environments.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
