### PR TITLE
theme-jade1: 1.7 -> 1.8

### DIFF
--- a/pkgs/data/themes/jade1/default.nix
+++ b/pkgs/data/themes/jade1/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "theme-jade1";
-  version = "1.7";
+  version = "1.8";
 
   src = fetchFromGitHub {
     owner = "madmaxms";
     repo = "theme-jade-1";
     rev = "v${version}";
-    sha256 = "19vg95bf0ylmfhg0frs2k0k7c0wfn933h06wrklb9p5qy84hfig3";
+    sha256 = "1nvn2ghkdhilrsjpvl7r92aldvbs0nx0xc82jwrfaahi87dgfs8x";
   };
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [1.8](https://github.com/madmaxms/theme-jade-1/releases/tag/v1.8).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
