### PR TITLE
marble: switch from qtwebkit to qtwebengine

### DIFF
--- a/pkgs/applications/kde/marble.nix
+++ b/pkgs/applications/kde/marble.nix
@@ -1,6 +1,6 @@
 { mkDerivation, lib
 , extra-cmake-modules, kdoctools
-, qtscript, qtsvg, qtquickcontrols, qtwebkit
+, qtscript, qtsvg, qtquickcontrols, qtwebengine
 , krunner, shared-mime-info, kparts, knewstuff
 , gpsd, perl
 }:
@@ -11,7 +11,7 @@ mkDerivation {
   outputs = [ "out" "dev" ];
   nativeBuildInputs = [ extra-cmake-modules kdoctools perl ];
   propagatedBuildInputs = [
-    qtscript qtsvg qtquickcontrols qtwebkit shared-mime-info krunner kparts
+    qtscript qtsvg qtquickcontrols qtwebengine shared-mime-info krunner kparts
     knewstuff gpsd
   ];
   preConfigure = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Switch marble from qtwebkit to the more modern qtwebengine.

https://github.com/NixOS/nixpkgs/issues/53079

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
