### PR TITLE
osu-lazer: 2020.801.0 -> 2020.806.0

### DIFF
--- a/pkgs/games/osu-lazer/bypass-tamper-detection.patch
+++ b/pkgs/games/osu-lazer/bypass-tamper-detection.patch
@@ -1,0 +1,23 @@
+diff --git a/osu.Game/OsuGameBase.cs b/osu.Game/OsuGameBase.cs
+index 98f60d52d..a27ce47ca 100644
+--- a/osu.Game/OsuGameBase.cs
++++ b/osu.Game/OsuGameBase.cs
+@@ -135,17 +135,7 @@ public OsuGameBase()
+         [BackgroundDependencyLoader]
+         private void load()
+         {
+-            try
+-            {
+-                using (var str = File.OpenRead(typeof(OsuGameBase).Assembly.Location))
+-                    VersionHash = str.ComputeMD5Hash();
+-            }
+-            catch
+-            {
+-                // special case for android builds, which can't read DLLs from a packed apk.
+-                // should eventually be handled in a better way.
+-                VersionHash = $"{Version}-{RuntimeInfo.OS}".ComputeMD5Hash();
+-            }
++            VersionHash = "253aa3a3a356a71295bf5b018cd4fda1";
+ 
+             Resources.AddStore(new DllResourceStore(OsuResources.ResourceAssembly));
+ 

--- a/pkgs/games/osu-lazer/default.nix
+++ b/pkgs/games/osu-lazer/default.nix
@@ -13,14 +13,17 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "osu-lazer";
-  version = "2020.801.0";
+  version = "2020.806.0";
 
   src = fetchFromGitHub {
     owner = "ppy";
     repo = "osu";
     rev = version;
-    sha256 = "02klqc56fskc8r8p3z9d38r1i0rwgglfilb97pdqm1ph8jpr1c20";
+    sha256 = "BelmqcDnrGH84fTs6M0krwWz6SHn2hOm7y+PNEOOOZM=";
   };
+
+  patches = [ ./bypass-tamper-detection.patch ];
+  patchFlags = [ "--binary" "-p1" ];
 
   nativeBuildInputs = [ dotnet-sdk dotnetPackages.Nuget makeWrapper ];
 

--- a/pkgs/games/osu-lazer/deps.nix
+++ b/pkgs/games/osu-lazer/deps.nix
@@ -586,8 +586,8 @@
   })
   (fetchNuGet {
     name = "ppy.osu.Framework";
-    version = "2020.730.1";
-    sha256 = "0hsrb01rhcpan00bwk9zxzgj1ghsgsmx36g7sd8rlygr3v5sfvmr";
+    version = "2020.806.0";
+    sha256 = "1d4aprz81xbhk5addl1n7jwj8xxny51s6nvpn37alld0x6n7k8nv";
   })
   (fetchNuGet {
     name = "ppy.osu.Framework.NativeLibs";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Bump version.

While testing, I also discovered that this build of osu-lazer was unable to play multiplayer, due to some unusual and presumably misinformed hash/tamper check of a game component (`osu.Game.dll`), so I've made a patch to hardcode it to a hash from their appimage (the version itself appears to be irrelevant), though I can integrate the process of acquiring this hash into the Nix derivation if necessary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
