### PR TITLE
packet-cli: 0.0.7 -> 0.0.8

### DIFF
--- a/pkgs/development/tools/packet-cli/default.nix
+++ b/pkgs/development/tools/packet-cli/default.nix
@@ -13,6 +13,10 @@ buildGoModule rec {
 
   vendorSha256 = "1h9p3hrr61hwkhkh4qbw0ld3hd5xi75qm8rwfrpz5z06jba1ll25";
 
+  postInstall = ''
+    ln -s $out/bin/packet-cli $out/bin/packet
+  '';
+
   meta = with stdenv.lib; {
     description = "Official Packet CLI";
     homepage = "https://github.com/packethost/packet-cli";

--- a/pkgs/development/tools/packet-cli/default.nix
+++ b/pkgs/development/tools/packet-cli/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "packet-cli";
-  version = "0.0.7";
+  version = "0.0.8";
 
   src = fetchFromGitHub {
     owner = "packethost";
     repo = pname;
     rev = version;
-    sha256 = "1ixdqq0xwy2l2m1w93rzqw5gfrzw7w03r42qab3n733m4jkf4ni1";
+    sha256 = "0ys6zyhyi65g0sj15pb6rslgbjgkh73y32gc0yvhfd6xmgzaxpxf";
   };
 
-  vendorSha256 = "10praxaiscxq4v3zknrabldxl7rpklkr5wdlwa5lxsx0if8mrvp7";
+  vendorSha256 = "1h9p3hrr61hwkhkh4qbw0ld3hd5xi75qm8rwfrpz5z06jba1ll25";
 
   meta = with stdenv.lib; {
     description = "Official Packet CLI";


### PR DESCRIPTION
##### Motivation for this change

packet-cli: update to latest

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
