### PR TITLE
python2Packages.cryptography*: pin at 2.9.2

### DIFF
--- a/pkgs/development/python-modules/cryptography/2.9.nix
+++ b/pkgs/development/python-modules/cryptography/2.9.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, fetchpatch
+, isPy27
+, ipaddress
+, openssl
+, cryptography_vectors
+, darwin
+, packaging
+, six
+, pythonOlder
+, isPyPy
+, cffi
+, pytest
+, pretend
+, iso8601
+, pytz
+, hypothesis
+, enum34
+}:
+
+buildPythonPackage rec {
+  pname = "cryptography";
+  version = "2.9.2"; # Also update the hash in vectors.nix
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0af25w5mkd6vwns3r6ai1w5ip9xp0ms9s261zzssbpadzdr05hx0";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  buildInputs = [ openssl ]
+             ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
+  propagatedBuildInputs = [
+    packaging
+    six
+  ] ++ stdenv.lib.optional (!isPyPy) cffi
+  ++ stdenv.lib.optionals isPy27 [ ipaddress enum34 ];
+
+  checkInputs = [
+    cryptography_vectors
+    hypothesis
+    iso8601
+    pretend
+    pytest
+    pytz
+  ];
+
+  checkPhase = ''
+    py.test --disable-pytest-warnings tests
+  '';
+
+  # IOKit's dependencies are inconsistent between OSX versions, so this is the best we
+  # can do until nix 1.11's release
+  __impureHostDeps = [ "/usr/lib" ];
+
+  meta = with stdenv.lib; {
+    description = "A package which provides cryptographic recipes and primitives";
+    longDescription = ''
+      Cryptography includes both high level recipes and low level interfaces to
+      common cryptographic algorithms such as symmetric ciphers, message
+      digests, and key derivation functions.
+      Our goal is for it to be your "cryptographic standard library". It
+      supports Python 2.7, Python 3.5+, and PyPy 5.4+.
+    '';
+    homepage = "https://github.com/pyca/cryptography";
+    changelog = "https://cryptography.io/en/latest/changelog/#v"
+      + replaceStrings [ "." ] [ "-" ] version;
+    license = with licenses; [ asl20 bsd3 psfl ];
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/development/python-modules/cryptography/vectors-2.9.nix
+++ b/pkgs/development/python-modules/cryptography/vectors-2.9.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage, fetchPypi, lib, cryptography }:
+
+buildPythonPackage rec {
+  pname = "cryptography_vectors";
+  # The test vectors must have the same version as the cryptography package:
+  version = cryptography.version;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1d4iykcv7cn9j399hczlxm5pzxmqy6d80h3j16dkjwlmv3293b4r";
+  };
+
+  # No tests included
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Test vectors for the cryptography package";
+    homepage = "https://cryptography.io/en/latest/development/test-vectors/";
+    # Source: https://github.com/pyca/cryptography/tree/master/vectors;
+    license = with licenses; [ asl20 bsd3 ];
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2463,7 +2463,10 @@ in {
     else
       callPackage ../development/python-modules/cryptography { };
 
-  cryptography_vectors = callPackage ../development/python-modules/cryptography/vectors.nix { };
+  cryptography_vectors = if isPy27 then
+      callPackage ../development/python-modules/cryptography/vectors-2.9.nix { }
+    else
+      callPackage ../development/python-modules/cryptography/vectors.nix { };
 
   curtsies = callPackage ../development/python-modules/curtsies { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2458,7 +2458,10 @@ in {
 
   cryptacular = callPackage ../development/python-modules/cryptacular { };
 
-  cryptography = callPackage ../development/python-modules/cryptography { };
+  cryptography = if isPy27 then
+      callPackage ../development/python-modules/cryptography/2.9.nix { }
+    else
+      callPackage ../development/python-modules/cryptography { };
 
   cryptography_vectors = callPackage ../development/python-modules/cryptography/vectors.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
cryptography dropped support for python in version 3.0

I consider this a crucial package, and will make an exception to "not worry about python2 breakages" for it.

Noticed it was broken in: #94851
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
