### PR TITLE
ocamlPackages.merlin-extend: 0.4 → 0.6

### DIFF
--- a/pkgs/development/ocaml-modules/merlin-extend/default.nix
+++ b/pkgs/development/ocaml-modules/merlin-extend/default.nix
@@ -1,20 +1,18 @@
-{ lib, buildDunePackage, fetchFromGitHub, cppo }:
+{ lib, buildDunePackage, fetchurl, cppo }:
 
 buildDunePackage rec {
   pname = "merlin-extend";
-  version = "0.4";
+  version = "0.6";
 
-  src = fetchFromGitHub {
-    owner = "let-def";
-    repo = pname;
-    sha256 = "1dxiqmm7ry24gvw6p9n4mrz37mnq4s6m8blrccsv3rb8yq82acx9";
-    rev = "v${version}";
+  src = fetchurl {
+    url = "https://github.com/let-def/merlin-extend/releases/download/v${version}/merlin-extend-v${version}.tbz";
+    sha256 = "0hvc4mz92x3rl2dxwrhvhzwl4gilnyvvwcqgr45vmdpyjyp3dwn2";
   };
 
   buildInputs = [ cppo ];
 
   meta = with lib; {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/let-def/merlin-extend";
     description = "SDK to extend Merlin";
     license = licenses.mit;
     maintainers = [ maintainers.volth ];


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
