### PR TITLE
 thunderbird, thunderbird-bin: 68.10.0 -> 68.11.0, 78.1.0 -> 78.1.1 [High security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/68.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/68.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/${version}/${source.arch}/${source.locale}/thunderbird-${version}.tar.bz2";
-    inherit (source) sha512;
+    inherit (source) sha256;
   };
 
   phases = "unpackPhase installPhase";

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/68_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/68_sources.nix
@@ -1,615 +1,615 @@
 {
-  version = "68.10.0";
+  version = "68.11.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ar/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ar/thunderbird-68.11.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "2f49abd71f7542042ef2823cd420e225bb1015684dc258fd7e8eb1104ac9865957b0e6c975043e3611d4d884c085ad670ce21af8c8cab1da80f08aa302078059";
+      sha256 = "878336931005573f76fb15c25fcf2593bfabde16356ec6b1f9b8913663b5fcaa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ast/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ast/thunderbird-68.11.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "91043afae8c2f31f6d2aa5b7f6c7f874150c7f8ef0ef7401132b12822bbdde8c7d7f24022f3f5d0cec262100a2b8791f440a55f0ed00c30acb9429290aa290f5";
+      sha256 = "5e3f29fb47ccb059d983946d6efec14b8ab00695fdd84a5cc7baa0cc40657cc5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/be/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/be/thunderbird-68.11.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "6167bd7fe2d980af40a0d5594e67dfc262bb7ab5fb76ea07c919136d967505e84b4d27448d883a31323db7aafd33b4222cff63d27d10ec914354ba4264736459";
+      sha256 = "5cd4c3a3d6ac865b727b58cbb51def60779c0d731a9f6b8f01d4b8cdc90d42b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/bg/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/bg/thunderbird-68.11.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "885c5ee186933eac265ed530f9b8b3cabc934e1ff4efc50b10381f8e53ddc39fe385e21e22041d93ef987e031ec41c2b98e898bcceacec004542bcaa35d0ccca";
+      sha256 = "f359cf1bd12f14bd6636fdb0bd885ed829235559c20c86bd361668f057039f34";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/br/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/br/thunderbird-68.11.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "e5c31ab8b32f9f0bd72a03207d4c9a2ca75d0c5f28e497456850bf92f75020784258725942079e52f6b38c0740e7d2ec80ef24bd88aca9fe35e9386f65cf7c1a";
+      sha256 = "6cfc9608b392b1e604eaefda5a5dcdc346bd88a1bc411532e8864a04631cf6f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ca/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ca/thunderbird-68.11.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "2d727f09dd202291cbb908c2e7805ecc7ec29302bb2481b63a5df1f43c29c39d1ae26bcf3b5dea550619391a96982d3d2bb831548a9a2331e986345c64b4b6b4";
+      sha256 = "9068b49e2d8a6f5e82b70ddda1b0a048d094328c96cf21848eefa431d358e6ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/cak/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/cak/thunderbird-68.11.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "1e74db72b4bc0ca3db90b9ae678dea551293dd54eb5cc5e5c124c51e61ef0d4cb074769bf807ba2d680db10f6086bb3bbcf5d082e815bff10fb8c6ae14c5a72a";
+      sha256 = "b3aef7c88302e2b9d0fcff8daa0d8ad4e2893d41e54ec29b746e79d5b03128b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/cs/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/cs/thunderbird-68.11.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "9c89e7328879f82cec0e2c5f7efb2711242cb3f36a4ccf6a014c6ed589f0e02748c997ea98909d546ca33478022bc9143987710945eed1e191517d1348f8a064";
+      sha256 = "a2338c8ac38a4cef41d8fab1e7857c290afa30af0b131a31e675368944d69ba9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/cy/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/cy/thunderbird-68.11.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "46e234560ac4a9e7c5b54816bde0f22f2677b6ea117ce5c528260222e940b5e47b12d8b08b24d2ee9bcfc4dd72168faa036207c88f5bc573051fd7eea2281fd0";
+      sha256 = "b02118f945ee76653df0364da6b2b8c597fff2bf52f4e20b64f2b8ac69aaf60a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/da/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/da/thunderbird-68.11.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "8ef4fb0210a21df0be22e1866859ac316890cc90e6b157e0cad2725d59360b06db068aa000627ffa750c05cdc8314cb564c32476dcea3975bb63f66b20873059";
+      sha256 = "a565beeaf67c01edf83a2478732fa9e245645d6e6b4fb566affe552762b8bc86";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/de/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/de/thunderbird-68.11.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "b3c7673728c8af318c0c8e0c3af8e1b7ba457bfd2c5a67bf3df4df6c3c990970d45e1a0884c03aa0a3d973efb12983afea40de55c8831d2b254acfb742c71478";
+      sha256 = "00a8f51254b2152ba37d964bfaca77cc06b9d778ef750eb6500e01510e298fb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/dsb/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/dsb/thunderbird-68.11.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "adeba633f288fff864e7247e36b4d7f49046a3901de0e4f93f12ada6fef275578b494441d01e820400045d5f7d64048684554934be678d1b7259910a162a4ed8";
+      sha256 = "7cfcafbf7f46a4be23003a59390b0404d04ee344c883c29a18f42accb5fddc4c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/el/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/el/thunderbird-68.11.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "6ed60a3cb194de3e2bcffbdf1d0c89460b2c2416878f348c913aaaff911f43e9a624a8de87d46df366c8bd608c47f6a6de8b90fec9c0c82e38afe860ca760f65";
+      sha256 = "b0d0865f8b64de26af8eeff6eb84f159f585e3f9f7590dab413e04167215dcf3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/en-GB/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/en-GB/thunderbird-68.11.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "a09f578de9b8f23c9b24123092abecedc70e5b48c9c15089505ca049258621f14d8a4f02c8154f7d2c729ed002814af17e08bf211708fc59e5345c92cb259fa2";
+      sha256 = "eb6731a9baaa1cd99584aec7c6dcce8f819d41106ac6ed4f42f02f747cb2afe4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/en-US/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/en-US/thunderbird-68.11.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "3f7d4c844185b0be0ee3354130112ecc034f06cc2335681998e210b79537df7365f251b005387f319b0a2d2dd6a6337fd6287a007fd54ac03c39315c42893dfe";
+      sha256 = "6ddd72732957282280a7209f2d5137229ca8af4ad7f02e112187fe333cc79a7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/es-AR/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/es-AR/thunderbird-68.11.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "a028429230c625b0dcb9e200b2e21c6d4db8e96a93313881701b5965dc25db31a0992d4d6da6072a6ed73eb5891d15ac71f19f343172796db82d6e98355baa75";
+      sha256 = "0d620d929ed41ffd16cfd8297ec70e8cb9105e726af99d2cd207de50920a1f93";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/es-ES/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/es-ES/thunderbird-68.11.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "58afe4eb60993bae1271fa03a45ce13611a1d83e4defc1f237ed47b243785881c8309f5fa8a5257fa5b343e2dec7595c8ba6143faa63f49749453ad229ee8102";
+      sha256 = "28bac94492c7444caab029f3cc3995275000496aab854f20368f941514cd7b11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/et/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/et/thunderbird-68.11.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "402c33c3fd7194a3f5c0d6afb81f639fd4a0cfebdaa61043858938fb5b2690844ec2fabfe9f73d41f45c26d56adcb121234fb1baa76b2455c87863dd79cf065d";
+      sha256 = "49fe0adb4fc5c5135083ba53369030faa95d3a530e8eb49180f81e359229bf81";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/eu/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/eu/thunderbird-68.11.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "ace87496370c17b663971365da8c1f88000b76247aba2a6fd5d29a31b5d4b02bf9b56e101c477d48553ca56416e73209aff7f729ea2b8c044e33b9307009321f";
+      sha256 = "a422935f96d5a3033c6c2a7bd39f19e3f84211d99b57d3996b31e404414703e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/fi/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/fi/thunderbird-68.11.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "775c937de9d9ed49ec70850a1d8ccbe22c964e12a932c52d3dc360425643f2be5487857caa811556e341d94bc62ed9b8dba5e94039c2cff6de50bdf16e364c89";
+      sha256 = "649c3908ecccc8466e555aa76aac47bf7153da8b6f45ddf83f36f6ac676cb4c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/fr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/fr/thunderbird-68.11.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "1ac4d3e23f71bedf77a8d2dd4fe8d02fbd1083977a8892d2c6db394a9d345bcff73a916f34a078ddd0850e8ac1bb0486aec06d6e36875eafcac0dab08bdedde1";
+      sha256 = "8270cf0e0acfb7280b8616462cd87a1d8d929c7c5fd4839f9607cb588a97c025";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/fy-NL/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/fy-NL/thunderbird-68.11.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "b62676e5302cc265a6ee65de7a31585bade7bfd51395bd56257f733fc9a6f4c391e5318aad3b48441464e5d8bcbe3606cca1edcd6fca6517b205814b9e39b635";
+      sha256 = "177a9f337719b2902ae964525803cd437b2cbcc8c7b85c7881e14f7e0d207875";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ga-IE/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ga-IE/thunderbird-68.11.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "81ba90087282fdfcd15a534e9065fdd94a859dedd6a85dc9da94de4af698eef6b31a19d3a007eaa27e08944682c9f6108a0d0991f1e394451da881018e5cc70c";
+      sha256 = "80d3625a04d027382ec3fdfdabd45d501fa4b451c82ec5cfdf5c3352a395a6ba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/gd/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/gd/thunderbird-68.11.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "1db39cc3ea8990ec8d9ff214d554bf95a6f2699e3f1bf625180b7f84ebc3284e1eec8e2cfdcf87b3a31b466ef2f84dd0a56d771078f4cb06962a28531ee085d8";
+      sha256 = "0b2fc2582ef518529f204b5096601047b5b3406201b1fc9f7ea88736d1ce1e0a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/gl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/gl/thunderbird-68.11.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "dbaa3cd2341d8ad4834b9db4982b731fbcb1125398cc4a7ce6a9cbc44db7218a165392781e144b68618781ed8d26216f11e1bf172ce4ba9b18515cce0feb9bf4";
+      sha256 = "d1cfc4e646fa6ce03765a56ea4cc2ad3936ec8224f1a7f5e74a34c189be11721";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/he/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/he/thunderbird-68.11.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "547795f844b60b347a10abc8e609f7d311b63ae4cf76b2b0cb0b0605f597ec0e1c7ec3347042161a4b15201f816f99c391851004de9a957754aca6f50a055d7d";
+      sha256 = "588f22ff9dd4dea7c808c4786f2c897842dedbf2a04c0b4d28b3aa162f88773c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/hr/thunderbird-68.11.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "6c72a46406396578c329b1ba1c47a46c124f22fb5c47eb1f16af7672e4269bb84f62ac4c1d9b61a5e8e46eaa4c91e5169b59e9908ad61606b243ed21ce31d859";
+      sha256 = "126ae387a1c97d253c4ca60441a192d6a00f63f0483b2888371624337e4fd2a9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hsb/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/hsb/thunderbird-68.11.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "e06eeaceffa7b39810faf42640f22b8edef8ad501530f1602a7b13265f5a9b34a1d9304a19a514e3beff2b3c7e8ba92c72aaae6b34cede15e6fa59125344c026";
+      sha256 = "456c323f61f77c07ae73a260a3ad2641190f165d14c75da1dba33ed1f8d2a3d5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hu/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/hu/thunderbird-68.11.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "9ab3e1b47a3120b74adb1f0f0ec657443578203f4c7f7e00804ef61bfeb2c7cd36721256943e8c86e0a62f90c1576e16a9051b33dc9a0006cb7fcf55bc90fc0c";
+      sha256 = "4790f014d95fe3ae00433e27fa291f7e4657b8062538ca52c46dd46ea41a05cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/hy-AM/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/hy-AM/thunderbird-68.11.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "614da904a59666d5e67852296eb22ea0ee0d137764ba9fc4f60edee2f547b91659147d14849ca83927671e94b32847f748f97df4bcd93569d46f3cfb0f8f372d";
+      sha256 = "7d81493a67e27eb485c1cb702cb8305788733e133bcb22659026737cc2afe1e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/id/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/id/thunderbird-68.11.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "13e01f8fe23f10d24b4399da8540c2afdeb762b1068f10984945c0920882b67bdef48f0f26180786a8d944ca1ea601e3c51bbf6f0cb64697fca0c0b0acb08b84";
+      sha256 = "9f558c85ba88c6350da0445ca2d2b63205c8c1e6700388e1d4f7de0978321667";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/is/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/is/thunderbird-68.11.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "176492bbf4ac3b2bb4367848f1283c7dbb805b5bfe6c71cab6c8893578f1d0ca1b9edcbc1e736748d04f2d0ca78f4d6edb21671b78379e26d41d9c43e8727075";
+      sha256 = "1f1f65bb573fb4fb563e890c043ff8c3283687575892853dd3e076473072b63f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/it/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/it/thunderbird-68.11.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "41d10acbb84fde6556530253ecb5926ba4b5d81a38349a00281a7273669cf37245640f789dae7363c4e1a0224127885fae3dac701926dab6e4512df723d39548";
+      sha256 = "de6c3adf83745370241c8935edccc412a60642ec758bd891d03c098b40b8792f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ja/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ja/thunderbird-68.11.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "8124ccd221818d37d6d22f204baaf34bd87e7907c50ab380a3a1bf252432b41caa71dc3ba2b575903bfd255f16b702cc89d91903f494437547a7b8fa16469cbf";
+      sha256 = "8b2ce4598af7323f59a31269c24bd05e369d9898266dc6e8cfa360dae7609273";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ka/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ka/thunderbird-68.11.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "464a9e0aebda0fa6412665e4cf2d6f590d44636bc395f8a03f96ffa7e8f5423e51499bd801f9ffb65c0c931960b761d00df3ac8f391b2157ab411ad49c7054b2";
+      sha256 = "be74a3edf9a1d931124c4351b51147be2e7a74f453d07482bce4f7721de701ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/kab/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/kab/thunderbird-68.11.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "d99305c424e0475ed2c1890e2c5cc96d1e4925d329948c33ac0183e3affadd960266e76e380c4fbc017e24538428439888d96f49d73468f9f6162dcb51a358f1";
+      sha256 = "1be81ab7bb429b44e0c63c81ebf249b66a79d43a3dba39ba0af6242db165d6d3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/kk/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/kk/thunderbird-68.11.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "9398172a5d2f902256b2b36df5f936a39e5f2d253ee4ee566109f67a49f2e2bd4239b92802475b459d79acb5af7e4839f6f5f0a5db1c7da10fa35873c470003d";
+      sha256 = "ee308381b1e0643b7e0683c365c763beb4afcaf21c9b0a1e8c8c2ec3c218c965";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ko/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ko/thunderbird-68.11.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "80e7f9929a197ea4b431376f168fcfaf42718b1744bbf0bddf8672346ff08e65c35af5816a21effaac6794d9e55009885037007e87a05571e1d7eaaf7c86f30c";
+      sha256 = "af2d7ee49a6295e41dbfcc7b8e19b8f146890f12baa36ffddbc7dfbfa39a8eb3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/lt/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/lt/thunderbird-68.11.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "74ca7346f87b078cb9f598e79278ee39498b09370be5517a3893dc4bc2d5efe81f9b9076b27891be0c8d170802a02ac67dabeffa022fe222e95b73455b40ff34";
+      sha256 = "8d384844274d048772fbc35da75f91ab6398ca64e26f089c4da116065584acf1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ms/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ms/thunderbird-68.11.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "90c71d0b3f598c21026441dd5b34efca7276f34153ffacd327f09d2c78296c9dbc2ae9eb8e1f7635b8e3cafed15f07cc3c19254405de2e6c9e1fd4300b844876";
+      sha256 = "6e447b3ed1903a20001963021598d957270c88980ff04d3da6c819ab106a2210";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/nb-NO/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/nb-NO/thunderbird-68.11.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "08da0c8a887c820d246559bb7c1394282a68f2971ba2f2943084ebf3cafdd2580477ef5a9ca06c1e5aac353287276aa88aab8346beb95addfa95d5014cd4974a";
+      sha256 = "710a982216120cbec822d7a9f74d8ae789b4a234fb3a192797604c9a47a23a62";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/nl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/nl/thunderbird-68.11.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "f846e221c2bf3cebd93961e6af10c24215b698cb8318c6446224f5de5b533e887e76818b6b902adc839a3f7c5ec24e9b13aae63b5d601d6716643f64aa29b7da";
+      sha256 = "2b02b7e3b5e310e5b7935cb72e59d6a385567100d22e87d196c4b4700851d439";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/nn-NO/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/nn-NO/thunderbird-68.11.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "c33a600e2d64c94cdda74f2a94fc54f05133cc543c795dee70909b00b92eb5a48b183600f328f45fc8c9bdabb59f455a4875e68e6e62ce4f6309cfc0aed24fc0";
+      sha256 = "128807f651cc0b09618bad42703970c391c17f5ff883c3ab11d115d0878fe1aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/pl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/pl/thunderbird-68.11.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "555b0fb0c4117521f020f7d9846b19dd18ccbec585cd89282384e0a311dd5bbedab84101bd55064c7ae20ecd811c70f31948da26befcb12abe0937ed2736b9b1";
+      sha256 = "181721ac04e9911f57ec7b4f36a5db82e261da71a310dc502efab75a101bec03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/pt-BR/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/pt-BR/thunderbird-68.11.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "a51b74e5d9394ee2ebc26149e1e01766b9c4cde5815fcd915bbc5307095a851e6242fb007c8e93027ea0a77b3074679041c65a1996528435f30f7f17b06959a6";
+      sha256 = "e82f40343e28ecd0abafb71f421c6d7df40b7cfca4898503b32fb0500686d7c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/pt-PT/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/pt-PT/thunderbird-68.11.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "4912989c47a3c021a28ed56629e308d2326a07ec99dc00b624889a10013f36445fbfe11a8cdde7ff4f69c965b0d2221c61c246933cc313df9f63ae3ec65db891";
+      sha256 = "96bea893919ff89441dd47e027a7d83aa691cc99abf4eaa342c941777ecf319a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/rm/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/rm/thunderbird-68.11.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "70298a29589b928748d32adcf83b12c006d23cd3a171af1eb790eaa34eae4b1a8e97056fc71f9a795a9b9e07f5d8e2a9f4ffc475eaa4b06b9390976fd6359668";
+      sha256 = "544f666af94043737503a30551ad5832f22ae529bc32495bef9d7443c8869072";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ro/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ro/thunderbird-68.11.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "7c36cefeec21820b90a8acc09856aaedf4cf94215cae71daa8142a1d166de79dd0114495b92d954f978d1be88c06ad5fa269fb33ae0b307ca05f3d7ae90844d5";
+      sha256 = "4c6e7793c206999e0a9510b390e4b47d82e19dc2da1cae8b4341b8afee440191";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/ru/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ru/thunderbird-68.11.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "b7dbd077b0271818ba33d8651fc60e371f9a89771020113ce2a0785c2d228b90d219fcf944e6ee2645fd683fbc1d597529382c4b808ee4cf81f7123e1de9d583";
+      sha256 = "66e951339323a3a44326cada8c572d7040d33057a3a487d8078eb27efa791eb8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/si/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/si/thunderbird-68.11.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "b9217a815c7f042bb33e0ea2ef9129e8ef1c825af315d0cddb6c0760bc87f1b8932b6f7cca747d50a29a55ac66a21d8113febc360e5f963566399a38e3b5a2a2";
+      sha256 = "3ef89e462359d09d95216a132c462f0529948073a4f0aef6358362d0457e747e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sk/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/sk/thunderbird-68.11.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "494ffad5906f35f9b3141fb06f6900e0d82553c16c8f3d99b50d6718643cac21fbd6a205af146df54125c009f190285281b09bb42996505a2fc120dd85bde882";
+      sha256 = "476641e4d45cd114dca94f59ddee15fda5fbd432c50e4f29af09eb3298782854";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/sl/thunderbird-68.11.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "d34836dbf915e4d5157a1f8760dae8d8659ceda2ceb594d737da7384139f245915f01a0b025585c117762f2d3261dffdf1c7efa5c2e1f920fe5a350d85406015";
+      sha256 = "5e85ff37554f47f585a155db65ae9e782c8604fa44db8d0dc9c3e2741704909d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sq/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/sq/thunderbird-68.11.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "909aa9e820cb984459deae17b80488db09718eb428e32a35ecb1723fa3c8d7ed974f6cb17a07db8e642cdb51b885291a3fca518542372fe2c2b3360553b3527b";
+      sha256 = "fc4f839973d6986979089c1dcc1e9b219007c34ecd2d587538db706e4b01eccd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/sr/thunderbird-68.11.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "aa39d12ff81a371722609a4ec401021512f651c4f592159f8ef9bcfcb641b55a8f6ccea970b4d8375cb326e0cfd5fa18097ee3131e7546c53b1e29d14058622f";
+      sha256 = "85a32f352d2b535366dd10a49116e65de4c8ec87886b37e34ac55082c4c310fd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/sv-SE/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/sv-SE/thunderbird-68.11.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "3f373131df39c343579ddd851e8c5eef3147650a5c75a5fc3ce84c2e1a694494cd6e3ab12b3cf86018880384f02ca38a54fcca8cc04f3074699fb89c4ded78e0";
+      sha256 = "19af3a847c9e28baed2db8f6b025dcfb0e688932b0483bae461c86861bfa67ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/tr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/tr/thunderbird-68.11.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "2c91ad17ddad9db19ff2eb47ff7a10253febd30faee710301dcb96ed0472f81153de5d7d906b3dc706d39ff058eefcdb9210ac274469fcc02a39cdbb99a126f0";
+      sha256 = "deea2513814df3e7a9004316dc50f6fa2bac46e0d9456cf124e33e6e03a9b4c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/uk/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/uk/thunderbird-68.11.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "d98a132e14a5921b6a75a8fe7cf3c1aaf22e83c4c8252dcbd5aa0434b98a7d9d88711b68cc470e6007027e6e588cf9ea00dd78a2d97b48b975adef1cd059e79d";
+      sha256 = "22b34b43ccc74eb2dc565a0c63bde89ff0d22f710bd26868341be91f51489f94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/uz/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/uz/thunderbird-68.11.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "dac94504203e7862608333f1f84134d7afe0e1f534eec9b91ec48a850e0143b625f4be311c2e6e716a16c941d3c2f5dd2101abfae205c802749ca95428b7e754";
+      sha256 = "26bb8336c617dc6fe485339b3c8da814f7aa0b46eb0a821db36309305ea87e58";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/vi/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/vi/thunderbird-68.11.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "684626eb432e89e85b9d3270198ee20470e675ea7294222755b5b588db7e318c20fd8d2fc9a0c95374e8ed53e792ab0e24e826709aa619fbab059a77e6341213";
+      sha256 = "88705691ae084991c198865f1e93d1ed127496245313cb8f28dafac0a64793a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/zh-CN/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/zh-CN/thunderbird-68.11.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "8a25fd27a555b18bc41ae31f024e80adc1b06de064bf2391c1db5510869af8c145780a01a26f6cb465d2c6b53f4ceeb924657eefeb95f7ae2ac584ddfc4a56d2";
+      sha256 = "5ebf1ad54acb6d6d17985d80bff9a0b39726d1f62eea30ad9ca0f04577f640a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-x86_64/zh-TW/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/zh-TW/thunderbird-68.11.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "8f202b1a79ae831bf5a28356a06213586bb2c0f4410516a8121c73a8902d0ce7e54f8e6fd7d2c74b300c9692eb3ad4a9b9290cc93ce3205f73842d93a46cb77c";
+      sha256 = "b795b0127cf922f65a2ad2d8f17ebe64089c6d06fe7a701c289b7af5afe7c371";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ar/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ar/thunderbird-68.11.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "868f092cc144611611133f50be9317161cb34ba2d0012d238789f2d1124b547c52d2aa02d4daa090322e327a4652808cc882835195f02bbea8e67818d22ca8da";
+      sha256 = "d19d082b55d76862977b9357e9cf245697c24d207a6d6b3aacd81abf1443747b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ast/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ast/thunderbird-68.11.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "bb077167ec58446aaaaaa7439e04332946d62cc6a35ff00bdda20a03eccf80b09bce70524c3b3351fe0b821dda0762cd666c66b00314751301a67d635c2d37e5";
+      sha256 = "6cd6c484888fe96fb08eab2b6b2a4dc8495823efee6a373536c26e9679fc664e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/be/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/be/thunderbird-68.11.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "a8ec19464c57509ccea6f83305d441aa9c61ddf0bfe2af172df24f67d7abaf2e568eeabfdfea9e0a843d42ff9c6d2610b1e1e5c060ccb50bce4045b47586f204";
+      sha256 = "bdd2ac4571d6444ff9a3ffd72c1b55cf5f564c740b5ceafce7a2e2268f482dda";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/bg/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/bg/thunderbird-68.11.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "9c8ef811f0bf04066f3c55e4b02107450d88a1774417ee503027423917bdf16ab9b102eb0f7f4c777ee60039998f8391164f1719bb8abc4d79774664041fa6c1";
+      sha256 = "3354c7e4b505e99a53a10cdbeac5b6425b13182def27a82c839eaee6ba6e2f86";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/br/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/br/thunderbird-68.11.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "e94fa2e49fca5bd6e6f1139adb86604482deeb1160cc8fe348a1cfab2bb19c8ba694ca5743ed6e5da81c9789521e8b6018db4ecc68ec91c8a277916c6a553521";
+      sha256 = "27339c12c5cdabea7a9a057cad70fa02cf4f69860e71b604f81a60f891345268";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ca/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ca/thunderbird-68.11.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "4dc73850268e885b9791b29573f35704d730e9a9ac833265f47413eadb2e3d359b8b56405ebfa58816b8b2ba390077c14f17a769fec94870652147d2a2915243";
+      sha256 = "b65b6d20d7251795e0a9f0ce88f8133d7742c6361375e4897a0bb2e043dd8c97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/cak/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/cak/thunderbird-68.11.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "569d8b373efc412180cf01ad9333a1b2f05687f3b8cfc4286c81c9309681d390d9ccc2767248e36db7931e2b941dce6ca209a00e7ba5dbebea6d40c710dc2cdd";
+      sha256 = "173a85565dfb7b9d44b5757245f8b5f8a62fd15a8a15bfee0680a96ef8f84625";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/cs/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/cs/thunderbird-68.11.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "e87eebe5c3486b02f46784209019b5f5dbfbeb36be8914604416c194bfebda2827861172019ca33bf754bc86ad91327ce5e29ecabcc77390d84be80c2f682e29";
+      sha256 = "9cb5def4eca0bb103516a66f90baf91f7b4e962d5ed59b4f09ae9f19e7f95b47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/cy/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/cy/thunderbird-68.11.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "e97bde29c976e200f418b2ec150969459e4e17872184dfef548b08e16286f948259d2fc84d0d07965a5dedae8d5e3268c3a6ac0794cb0c3a739ffc86b2a6f748";
+      sha256 = "8b51e01daf38091d3b1b32a249f3c6fb220ad8075bbfd16914cb72b24435d8bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/da/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/da/thunderbird-68.11.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "7bfbeb6e8bb427e7e3aee31e897d025e338a4c4da59eb2700b52dd08cd53efaf6dfe1d33e456572c0203fe6927bc069ff297288cc47dec2ef9835e047a5d2938";
+      sha256 = "1269600ab71c691563482c6d5787a7670fdceeda3a07c61d7cf2477aa16fe075";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/de/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/de/thunderbird-68.11.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "15da351e919e0b931dfe48f77b9eeeaec40e94c973de507560c62a86e2b106f7d4afa7602186829fad2984f9964ad23792ca88bd5b94976972bc103f0560ee4d";
+      sha256 = "46c5fcae1b11b7e31fff2e70397a560c502bb3360ed646dd09945fcee81efad7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/dsb/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/dsb/thunderbird-68.11.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "1b8c1b12b8d7979a0ce45db282bc2a3b933bda3711c07097533a8a04b38edae3f0bd00298cbd485954ab09fa57b10aca5238e8a7bf4e23ea80ebed2dba1d73e2";
+      sha256 = "4dc661243d99edb84d0bafd45300bf18d86d5289ede3db066ff89cc4094afed1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/el/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/el/thunderbird-68.11.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "67c5dad2a95ff1b8b3ab2ebcb0c1c4af87c5325e22d43c24f4f1c0df9ac328b43b0b25247408c8c95cb5f98b9396a1714b0cb39cd2e43ecd04b28f8bd1dc43ab";
+      sha256 = "efd5f7f46d53bf34146a6f39149abb2aed9c47b735339cf767e32e6387ba50bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/en-GB/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/en-GB/thunderbird-68.11.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "c9feebac54a357470523029377699fc9c0bca08e4705374dd1b8756cc8461237426cded2d9ee994b7ee529c60d50a555e4e1c2d9ec71ceccb7fccc651e35058c";
+      sha256 = "ce97a84ba103a7e5bedba43ee47a5c603c1b5d9bf3bc1a8cab4c26ec9ace21c7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/en-US/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/en-US/thunderbird-68.11.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "9280a58b42f93b38f4c9ab26b8b6c2956ccb135ae959c61799cd3ce3b3419c9642f86418ac53e9c4f69e0430508c0619db4cf856a28d233a8d319e262755f4a4";
+      sha256 = "632f078407322995eef93db134f1da753a1b35696a668a5b8be29f908a34c223";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/es-AR/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/es-AR/thunderbird-68.11.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "9c17d648a2ed9c2b6dc7d403436dc9aad91e10e63579e26e4dafe3d5b3a15633167c87b67924026882a03f1aab05673566a0c5f0d84efb656b6b3d7d4b812e5e";
+      sha256 = "88b67f07b6069adcb82c04f818493e25bd145b5d874a7503453e88ea14200499";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/es-ES/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/es-ES/thunderbird-68.11.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "d22ba4fbd7e8d22f70950b61354b99ffa6bb1c298504f8f05297cbc20f0c89a9d657c74ab367480906cbc4b699df6c603d6f6b936ccdb4213e178f3eb153a314";
+      sha256 = "a52a6917d77364e5f7ed06f4484abf7e607c53445ff338e65af6b9bad4626e0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/et/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/et/thunderbird-68.11.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "107fa0cd997edeba0a88d365c52fe48ea0d355ca8bf8723f5bf2ad4a930711e8fcdad27b457d309a5d4dfc0f29f6988f2b04f153b83384484ed397261c07db7d";
+      sha256 = "a0c15f0000a00984760419e6f737840b4637bf5aa014ee88093aa2a7a3258807";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/eu/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/eu/thunderbird-68.11.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "ba50b4fed2d682f1c46699f72d86b219a1bb398b1b2180cdfd246bf4eaffd61e34e24222bcd82ebcc68b9cfa9f98f56fe859cc6d5bd744a7223e7264d6d4f261";
+      sha256 = "d69e9af1a381743acc9ee1f800999b015129cba4fc112f312a04884c121535b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/fi/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/fi/thunderbird-68.11.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "6f4fde19af18845d50f591940786402233bb77f518f1f8f9cda727bd458e21669f692681cc691617a0ce05f8516383ce38b7b51445e3937ff8c1868e84a92ae0";
+      sha256 = "876673de48a047d75e0ac766dca338629069af1872308a7bc6a7e068da026d3a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/fr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/fr/thunderbird-68.11.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "7e9dc42478dae325a51f44781048a55fea3e2bedcbf663c534510404e59dfa10216dfc0df4efd40e0bf1f4fea3abdc9867b6c6b33f199e406ab07d68b68acfe5";
+      sha256 = "d83d87dca716d4cd3850df1c5923e88f15e35354abc874202c8c12bf8d1a006f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/fy-NL/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/fy-NL/thunderbird-68.11.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "1b665dce92e8c1de000063f1a12192a2fa5aff2c65db9aa6769ca16604e7e97a602baad9761110124c65dc479fdbce7640020701fb280b3c62e5c78368fb496f";
+      sha256 = "0cce3392aaace190f9ea0247d89699f73d534762278f4776146a1f75bbc09996";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ga-IE/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ga-IE/thunderbird-68.11.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "42faafcbe85ab995b549bf072942dcc2e87780099b3bcb2974ca3eff6acade40be7bd8ded5cb0db6a02bfdc255c60e252061a767543b2215719a1fc2600fdd81";
+      sha256 = "83b7e660e8098718bd4b205ad2de53522bd94e7a602afb960b6381fe4c11a395";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/gd/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/gd/thunderbird-68.11.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "e1455ef926d71ecfdad24ebcf4b3de59d04611bf641ba381534bd1b94c2f7b730687cf2e8412e6910d37e402b58f32588482089f4d12308a7b9cf6af82b66e97";
+      sha256 = "447a887ef76e57b9c12a0991d7eaf903ce29d7621d4f9143edd18b56bdab81d3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/gl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/gl/thunderbird-68.11.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "344d619a5437d0efe2e522680849dd809b07c3aa9cf2831610aaf7ce28e81f16782a4a8174c01cc339914e02a23cb3ce603d04dd0dca8eb4f547e0d0e780d8f6";
+      sha256 = "288b865596e2b8b1087cbca98bd9c55f9aff1f1cb8d432953d20854b0b1e9ab8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/he/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/he/thunderbird-68.11.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "c081d81f3c1a61d2922bdad144a97c8568326e97fe29909d4319ca9019d9bd466dccabc6f2069eadafaa6bf6bb5bd50e8cf0c070dd992cc095411dd909b43f06";
+      sha256 = "9d801a18324849e4a6faf3266c09eb5898c8122e89b020e35ea25a6b3899a4d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/hr/thunderbird-68.11.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "2c142b9bed17fc1fef3e4339f0477d3f469923083a37ec3b2dc3d4690a44ee34d5a23faa37876cec2f3bcd02c1048ec343f16bd02a1771296e77cf3f63ca787e";
+      sha256 = "f20210372b36b43cdae8f7f1294927dfb364d1ca4db21ee8af1c059a06f3e45e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hsb/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/hsb/thunderbird-68.11.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "fcbcc78b1d5620c27b7cfb7ee88463dc81664f5eba679a81920ac6923b0e3f05bc70b99ba7268017b59219872921e76860a113fbba757cebf942641ba0591517";
+      sha256 = "54daf67c97f2e7496fabe6bef2d1d9a60baccfee35d7331444d48fc6fe675c26";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hu/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/hu/thunderbird-68.11.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "d59024db516156a89cbcc0148a5bf85059ac2393f41709e224f109abca6fea693b822d7c4a3ce5e360435c8700010aaeb4b26ef9e163827bcc8b6cf1761d3781";
+      sha256 = "0791aa7bec49ff1bfe862f9114ed4b0013361f2f1fa0e4745ad49c8c0e0a9f84";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/hy-AM/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/hy-AM/thunderbird-68.11.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "17876cefb335375b7884080315690fef116983b7559421f86ad0ef787bdfdf5aed283d84114cc1c1d3cb3119d735f50e975f94ead6fcab6046c207d4c1a8fc8b";
+      sha256 = "e64bacff30d0b2b2a5038aa11d719c9ef3124d64b9923d52a9c5856f6584f9c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/id/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/id/thunderbird-68.11.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "0c74ca260ffee635cd556c0710a13ed091a1f2eb63a1b1ac2a745ea0e86d42b52b08b00f648c406356e1e170c77242d43d9a4d2b2f0bb1fb26d4dc83b4179a8c";
+      sha256 = "ba6108ba9b4f31f49e7c925a6051738276c67545f7f8d2b3cb378e8834dbd0ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/is/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/is/thunderbird-68.11.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "97fdf5fa7dd6fade8ec7efc179f6a65bda90cfb285341e3e98b9b2ab70ba91ebc8c47bf8948189d4c181566c9ed950fbd0fb6b4d4cd96b2e3329c0085e32771c";
+      sha256 = "a3eac36b640a61f2fc6bd62350bd8aaf020636035547c2b9d687df2bd2d7174b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/it/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/it/thunderbird-68.11.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "3d42b5a8c55519accb3246c5a7f50def9d854ccaffa0e34b20e6e2f51cc07a787a9ab0c0b205e28b40d9ec4f55f1176f391ff9156076327f8a4416a9ff6ea8ae";
+      sha256 = "bf3cc19a7d1c1415cad867b72c5765dfced27511616a8cbd230516adf8d3f20a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ja/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ja/thunderbird-68.11.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "bf90c9c27abac84ef91a2fe3ceea142ac7041c10d41a0e5a2ee31742f9f64b2b24a331af769e8ae93c7b09bf8645dc4d274524281fbfe69a908fd22aaac7c2d8";
+      sha256 = "d4788294f5e91c033c3c3251cfb614e50843631252a2b1fcc6389d099b1fee1e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ka/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ka/thunderbird-68.11.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "8e2fb192c6776ad702ea7aaa9bc9dd31b20c1c66e2ce4dd91aa10eda5528172680740e28f8a7bab52a7c6eae92578822669d6ad068bbc85a04d97c91a4b7e08b";
+      sha256 = "8735be035cf0ab5d4b2102aab8b207c1cc686da8843b45f15c1be91931850968";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/kab/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/kab/thunderbird-68.11.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "10b9418db83b328353afb73b7630add081309cc0b55fac8aec38f6e09036968082d3d12386efb6b4347b33977998bbd906501adc45a8c8d27dfd0f8d98288bde";
+      sha256 = "a570fd29e5eacdc08ed484bce7336f90ae74744e80d8f2ac0f05395cb3363e51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/kk/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/kk/thunderbird-68.11.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "7dcfb10ce402c90452815523d5672a1cd60201b33b997c5b769341e904f4840ff57685eab61dc3073f789bf042453f3d144e54bec32afae2dd65367a0f1768a1";
+      sha256 = "186b7457a96a64da0564c1b411bb04598de1067362a6238f7327abe780cc6aa3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ko/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ko/thunderbird-68.11.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "fddcd08f00cc4f3de59993c8c917e20e77918d87e2c23e989e8e8aaf78c6130f42e546acc17eb6f8c9a24550c596ad201d63f325e7ba078a6c791fc94589e0a5";
+      sha256 = "3c9513362c6b7a64bf6e74bbfad6ef586b0085baeb9a8ad8eb2fbc73461e9f67";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/lt/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/lt/thunderbird-68.11.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "ab221093a0df2876f558ff2e0df090b95872281e1cae8ac23c9753dadd6305608c6e7ec5104d491ca3a3f1c1ebd830b8094080ce99bba49b19b46e617238cc87";
+      sha256 = "e90df1606ec0e875fa02f7bf5a52b14d84f758bdc18ab0f395703c0129a18e57";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ms/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ms/thunderbird-68.11.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "ce6b0e1ba8a1a1bbfd4d2e265a45430c2d931530d13eff67fea4179c4a8e2a204ff35103c921073bc33c3e2a8f8f3f55fb91b3218cab9718df76da696ed09750";
+      sha256 = "ea686adcfb5cf4b1642e7dcb21053090ffb57d344b27269d807cebcf8469934c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/nb-NO/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/nb-NO/thunderbird-68.11.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "07e73fd67e0c1974c5e5b90d74e555b75820b66ae9bca0470b6d291e848e5f28fea680cf09c2167dd56b0765ae0e3682b5f2ab7f33cc5b059e60252236dc24cd";
+      sha256 = "6f827fee307917b590b99b5c85b16337865f027059f52bc9ab12da33f80448b9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/nl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/nl/thunderbird-68.11.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "a24ed7d30e53058653c0de6b96867fa9621118fa43e109940502eea798a5c7b8688c65bf08d765f3c6dc6e8ab0dabfef98ae005e00c465f847454b384953276f";
+      sha256 = "b88843831b982d1317e8bf64df99a8c7a1fa9f67461aa966b2737f12715c9cf3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/nn-NO/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/nn-NO/thunderbird-68.11.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "4bddbdd0a2353f8c43e65cbce5974911809cf28c3d7ce521d662d782f8858b469575857688a5c674f6d028acd55869c062edf9f55dfa3d387fab8fb60f6f2fad";
+      sha256 = "ab8383a432f55944d417108b59d891953f2d322ec81d09e971ec63d1883d4b46";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/pl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/pl/thunderbird-68.11.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "953d9e547eb343a0d7f96f501bb87ece71e2f860f8517fb13b76301c7b3e77d7f572a8106fdd43c2b390654457e43703b22566bd3159ace962af2eb1f8bc6ca8";
+      sha256 = "0f8c0feb68b090598a3db9295d4b4e09d9ffdedb69a73914228d7ef76b768414";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/pt-BR/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/pt-BR/thunderbird-68.11.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "b3807897100857c33768478c9dec57024f968a83188b51bd2708b7caf7c53edb39b15cc8dfb5f73ca937c298fa83551edf82d7f43c065bc2fc25467a02343d20";
+      sha256 = "ca78fad9dce15534754571b14d82ede798b123210599ade352016420faf0db5a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/pt-PT/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/pt-PT/thunderbird-68.11.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "e50bf636697714fc4dfd04e1a8d6d7d87239553f01064bb566e218395a2e5d9b16ef22c01509f18f9f562b75eb19a2616d8c7f8a4d212a9a445b1eece17527f7";
+      sha256 = "cf79430e02259d9117feeaebb5fe02139c3e3d95013e48fe290550814200cf6e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/rm/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/rm/thunderbird-68.11.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "1480eb4c77d88fc461000f423179e5bc693b2f25abe5c6384f4c98494f698c620fdd53e65d75ebd17ce9546c5fb00ef8f40bfffd9b31114417cd10262569a54d";
+      sha256 = "cc7d9614130f24969356b3496f4d322a9f73cafa5c7b60302ca8f2e2efe1f6ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ro/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ro/thunderbird-68.11.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "d9cfc8f03d75f3a58fe103c34eb0fdcb3530f0ebc68c0acae7fe1b783bf11c0585e266556d16fa3db174aaafcc319cef9cfa363361cad7b1053a504101b13880";
+      sha256 = "a8fcc2c6e0755fe701a56c2fa3bbf2d288d6351179ee74b8aa3da3180f14cdd1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/ru/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ru/thunderbird-68.11.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "d67f550615eb195b80f7338708b7ecf7455203f86aff1682f2e8e654d019fb49c6468eb1c099f7fc78797b97d41c9f42aff5498f27b6cb458f049fd8b6aa3d4e";
+      sha256 = "b9f68985e70f8aa47c36cd4a4fc0fb41918d43f089cc760ace8ec879e2561770";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/si/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/si/thunderbird-68.11.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "6dd9d78a9f2ef4ed28a95e83e76e9779d02c950ba906ca14d8fac0bf7300ad2d7d5ad9cfa3973cc8c861011dc8f1c58a6ea5909206443cd2f24bf5bcfe8c5673";
+      sha256 = "a2563b3c9d0ecb567c366aa41cb6a10bde8d09b8c1065cd3934c8c221afee056";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sk/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/sk/thunderbird-68.11.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "ba40286898a7722533f8a65e1e9bb494bc28212d2fe21c820f64b1a8bcaad6d0ca1d7a870d5289792a79a6c4851931236b13c1ba07b812b591b3d4c6004ff78d";
+      sha256 = "566906f011283fd27abf55e1e9a1bf7504e4028f7c4a631716ba590c07fe9d91";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sl/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/sl/thunderbird-68.11.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "bc8e926583e92f4cfe3081a1bb618d7c5fbe9e1f93af378040a72820b820a38915ff1c74deb6069bbaf2957adc536b78faf1df853e8ff6390a9396d909ee040e";
+      sha256 = "8b74b751b3ee706be9aeb06726ffd3a989a57a1dc9794112262fa2aac45498ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sq/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/sq/thunderbird-68.11.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "084bce04b0d83ab24682d04f4c788d61a2a6bfe0777f44f4c9a07d8fd7fef4251464e9a0e523f4e111bd5323ceb398fa09ae3391295047beac3157ce9d2e8905";
+      sha256 = "9f7bcc51d4bb3f7c8d6ae49c61b88c17a7a59f6de8d2f62e0ee3fb3a68d30791";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/sr/thunderbird-68.11.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "544ed1f0cb8beeac3ac1b2ed02078c3acc5961d6fe4c3f0722b1a36208740226053236453a215e564371453cc5acb541a6f307d594524081a5f4c96aa077c21f";
+      sha256 = "809c22c379c0c9943acb23de8b7023843ad6ecfedb9cf89006d6889ac1214203";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/sv-SE/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/sv-SE/thunderbird-68.11.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "806ea4d93a8cb3e5dba8cbc59dd25adbb19e048306124ffebbf1b2a56d49f236d9a79d0e14b5fc0c15537c266a85408ce1a5568e8e6e4417dd94f1b98d9bf36e";
+      sha256 = "9381345ab9229f4b8465c183c936c17ab73680fa6aca27535daff9a2f9a133a3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/tr/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/tr/thunderbird-68.11.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "cf30e9ebaf5770437415377c9a13d66b44a7de7c85bec9b980d9e2e059db7f3756f2c3a888ebf9185c59451e2473440fe2c1ff28a979e066225719effecb1c38";
+      sha256 = "0f08bc1e65a8bccf8765cf26af5c09ebf6b77ff463af2f8f133dd2499c1d935c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/uk/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/uk/thunderbird-68.11.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "a7f5f6b0f1bc849a3a48a30edc8e408eec0c5e544bb4444a8ade969b1fe7ef1fb9d26a0fea3d4d31bf88eb67570e895fb5d916b9ac88c2a8455abcec60d56ca0";
+      sha256 = "37a1fee3bcf2fca901c542295d01a32545e814217985414419a270ad9576c14c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/uz/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/uz/thunderbird-68.11.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "716e1c0a7b9b0ea33d1464930b68f3f817ce3310bee9000199f9e6bdc4d0d68dc6098665423ada94d7ede600cb0c965adcbb413068adf1415cbc048a7f847ebf";
+      sha256 = "50668670b10f3171b9033306d43c51ce24f1a48286c4156eff369530ae6d93d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/vi/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/vi/thunderbird-68.11.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "1667ab35ed705e739c5192246444eda912ec86a153dd1fc3ed83a5ed61d47d5849270492015198cca82827720bc019fa561e710df5fa77a758864e6cfb09d4aa";
+      sha256 = "3588d2ed7c67459f5c091a1881821eaba72c9f3307624f7890549fcd1da120f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/zh-CN/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/zh-CN/thunderbird-68.11.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "4ef6c9933ce8671442aa86f804085b4ce9a73aa4f8cd598b7d41a844be37d54cbd8a2dc39d6ab97f160856435475093f3240f960a206e53d327a4b2e47fac45d";
+      sha256 = "d8f2976535ef60e62c94338fd049365234a7b2a8658b32df231d1faa22529c0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.10.0/linux-i686/zh-TW/thunderbird-68.10.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/zh-TW/thunderbird-68.11.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "ab19d7c1114835a380e035dafc2e30849e8084cdac9175eb5eb3a9fde81d49cb710d9dce21652780a35011d139e070c0f61840275aa8d0e99252bfa5a8aa1735";
+      sha256 = "aca4a8410429bde9926f6ce6a183439750f490fd68dda229531b2e16bb7068ef";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.1.0";
+  version = "78.1.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/af/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/af/thunderbird-78.1.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "6e98afba5a93cd7ce496838974022d7c61c0188f32ab0504d9cecd6ee3e20360";
+      sha256 = "540aa91a70379c4d6975820649abbe3063515bae031229f01ed7e794cf87395d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ar/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ar/thunderbird-78.1.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "129ce719947a59c647ab28ceddad28a2ce1e06c63839bcd5b43b084b80c2bdca";
+      sha256 = "18d1b4f33895b5c4b17199ca8412f8060f40660c7e45e024d0dda486ad290044";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ast/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ast/thunderbird-78.1.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "0baf79a7d38c5a3728cba78510efbd4735e1c4e4d23ab574533d590a7d523ad8";
+      sha256 = "dd87c494ef5f142517aeec3d8890bc553664b323f2cadb46bca597101b275c91";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/be/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/be/thunderbird-78.1.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "870ca1c07897b8df1e2985165cb0802a5cf1fe87886e0aca5f46d0d8b1e6acf1";
+      sha256 = "90e0d5354f41244e2ebaeeeb65959d64fcef52f914a15af7b9808125e6e25639";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/bg/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/bg/thunderbird-78.1.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "bd2bb102a09132afa0a4110522fa7dd98ae3b0ddf9b28a97d21070880212f391";
+      sha256 = "4e8f53fc2e1c3b8dddec3d62bfa104a458943c1b0794fcca3a1658b812359b97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/br/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/br/thunderbird-78.1.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "cee91b71a6735e9c71a705e0c7a8a97d5acb733efac1d8bf8ddcd31a62fa439f";
+      sha256 = "068c48e37b4d921cb33e2df27b32a8e9abfc29698c30779b1771f2ab61697f27";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ca/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ca/thunderbird-78.1.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "257d027850fc31fa5e5f4b0fc4dd2205db2b9fe04dd5b8c0f34453df11eacd4d";
+      sha256 = "1f09e12e53d7bc76551c47995b0fa5ff649db94013a66e4ee445e6901352ead6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/cak/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/cak/thunderbird-78.1.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "405d409fad9a42a8c58196ac390dcccae100da950d9225f03b5755842642af47";
+      sha256 = "e917249cbc16e1ccaf630a5335577e76d971f422fb7c7d9b7c7f05805de18d78";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/cs/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/cs/thunderbird-78.1.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "fb554ed67ea40a31a296b37f95428f4fa9f81532c8048ec3b4563b91fbb989af";
+      sha256 = "89926439c396b64a701d688b2520eb1364e5f2a348a645651396e7f91a4b774a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/cy/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/cy/thunderbird-78.1.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "f74999b180cf8f32e634afd68340cdb8fb40c064fb1b78d4c4b2666a9bfe7121";
+      sha256 = "65a124a1840efdc33b0426a0a8ab8426423425326f7905844c74f7503c6e60f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/da/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/da/thunderbird-78.1.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "feea7e8ba58473d9f0159152aad4748827c88d3b575ebd5bfab18f3c08e1add3";
+      sha256 = "a572014192e6ba98994f8693b062400b7909bdcede065dd363a3ab182cf40293";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/de/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/de/thunderbird-78.1.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "4b067335dee19144898485c711eec865b4d0fd0be0ff95d6532f6a7c62b2651d";
+      sha256 = "a0eeef52d89bee326402354eb1de3f531c9c255d31840ed91e93110c9f170aaa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/dsb/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/dsb/thunderbird-78.1.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "349db67666bbda6c269c7b55e376cb3740e3b3eb7a4e6f0fcf44037dc7fe822b";
+      sha256 = "35d0295ebd60415457a7defa40c5bdee2dbf40b08dad387aef0557dc511ce489";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/el/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/el/thunderbird-78.1.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "40bd9509793e81a2601ea0746f6e27a65a364d95d7772eeb71c5eab24f31fbae";
+      sha256 = "135fe2424a1731e24c9602c40e0ae4f8fc551ed058fcd17516ce8f39a7d88bbe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/en-CA/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/en-CA/thunderbird-78.1.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "55acc02d61ed7a2b0ef2262346ff27afbcf836b03cb14dc67fb8cbc26bb5d6ec";
+      sha256 = "b5741a82e8d59300c1f2046b4a4deaa2804d90ad8e8cda7cda9a39b7d6293b87";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/en-GB/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/en-GB/thunderbird-78.1.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "f18cba25a9ab2b10f1f464163c904f7b1ec1afa5b79728c9b1fc1497971edca8";
+      sha256 = "61b0e85a24f56b1b7ad03e9d8206313d50cfc6480627cd377a4a4b1bfdd9f13a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/en-US/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/en-US/thunderbird-78.1.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "0768e00b6a7737bd4ce5dac4d3afc331e8d1dd5307bccd130d9581347c6ea35c";
+      sha256 = "9f0cc0edd2b23bc67824d3e8ed19b8c0a331e69a307b6d48c20e0e29e756e7e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/es-AR/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/es-AR/thunderbird-78.1.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "106b8a385e8f4bbd4fcbae08620fc621f69a3920b04300305ebc000b7007b512";
+      sha256 = "b0390addfb6133074aab52d1b6b73eccb9fae9031967fc94d57f95be30cce54d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/es-ES/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/es-ES/thunderbird-78.1.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "02a67358ed38587bdb67c5faa67d989cafda448441dfa60bcb56587d10a052b8";
+      sha256 = "4d9f115bba5f9f32247465398e8ccd2f279776fadc3961f79b9fcc923c9cc363";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/et/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/et/thunderbird-78.1.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "649bbbc89da5fb44f118be6c8f8a142e00aac26e50d7aa5217937d8356a8745b";
+      sha256 = "6db8f8c69d8452e402724bf3fc6fb42242d2839307f6ad387f813a97286f4773";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/eu/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/eu/thunderbird-78.1.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "4884b806aa36ef0d1f11cd876594d94614cd9a95a1dc8b072dea57f9b1664106";
+      sha256 = "7c8165bc0a0feffd71431f3dd30ce99092a0816581363c2d317c6f40149234e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/fa/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/fa/thunderbird-78.1.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "a8e8de1f187a103a9bea2d0bc4ad8359f80d2eb0f5148d0c93f3351e1e8efff6";
+      sha256 = "9537892fa5e9ba5b3f79b96fafef1e8e37c4813f0515f965ce05b410bc7c9448";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/fi/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/fi/thunderbird-78.1.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "4c7fd4083382830646486390efec548a6875f41fa373d1c35b83f1e7b1890352";
+      sha256 = "31ca37c4d0f13d1a30b2d7541fa9fbe80add66c6d787bbec069cb904d1157e18";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/fr/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/fr/thunderbird-78.1.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "3574bafabec4266fee05552a1be248af63531d6ca1993d8c8d61e0dc472a0786";
+      sha256 = "c7507fd9096e9c47632be197054be68631c9d1812b7242b4de06774dbc9c3b1b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/fy-NL/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/fy-NL/thunderbird-78.1.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "688346105eac2d51505f147c2baa74ac5a16915f2440e0e08d666eb77c702c3e";
+      sha256 = "0a3d9d62861eb11bf409ac20905e787fdb273dd1d74b754f10790ff7deb7160d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ga-IE/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ga-IE/thunderbird-78.1.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "aa75c3c00bded7ea7a8fb9043b24e264aed02598152e60a3a2d6644433e3f6b6";
+      sha256 = "4bd0b50313e9a85a83d5b5a032710478feb2df52936bcdfd2621cf30a4d02efb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/gd/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/gd/thunderbird-78.1.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "7eae8fc579878437ee25f988189c49a7d7121f66230d1f60e496d575f518497c";
+      sha256 = "a72ed3ea99e863f4a6150cfeeaa0052adf84f8f5ad52388b8bc30bf15d58a310";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/gl/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/gl/thunderbird-78.1.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "c2ccf567d2c4ac7598204a2a129678730ef2dc1d84ed3c547b569de3455723b2";
+      sha256 = "5d9bae1205ac9490821b1b6d5b700a540bccbb21a3d41943d7f3ccb8576e2087";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/he/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/he/thunderbird-78.1.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "aec6e559b34d539161a3367e434773f6016978f3e837431d27737a935d156fe2";
+      sha256 = "7cd6417391db27934b6945edcdd9d14b46a69052af7bccd5a62fed588c77894a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/hr/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/hr/thunderbird-78.1.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "37b478337cc9918cb386471000c5cc90d2f5de3023a67431b418781cac1d4cac";
+      sha256 = "b641cb7393e1e655adff946c82c43edf580e9fe3852b5c0cffe8f6d12759d190";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/hsb/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/hsb/thunderbird-78.1.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "6d08be19b9aaa9a0f11bf23aab8cf42c1e04288882d860ad45a625a9ad2d8ea5";
+      sha256 = "39a27b797117eaed4e939e1c38ade2da13486f9050b5c4d87219cdd46abb67c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/hu/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/hu/thunderbird-78.1.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "ff2b7d098e466cd6a9508f3d85e599de544eb8e3cf0cda15d5278fc61efab22d";
+      sha256 = "5c9795de2316add4e482f9e074c861ef2e05411ea3792d6256d3c43359dc692f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/hy-AM/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/hy-AM/thunderbird-78.1.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "2d53c3979a54981dc38c0db892b00b042cc6316972c42cffa6ff9409ad7753d6";
+      sha256 = "be1ba0a8fecf9a577cd63de519f92f48ddaf7c4b68fd629f94bb2ebff3cf16fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/id/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/id/thunderbird-78.1.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "d599ca640aadf1d6441e16f47c39553cc58d3676a5638f613ffadc0b26983831";
+      sha256 = "15eb3d6acda87645da2874cc92366fb50e821d7ec7885f87951366ddc66db2a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/is/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/is/thunderbird-78.1.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "004c1b4b00f3ab32e8e39fdbe8c8900cc4d36d716e81eb92cb49c7e0c105954b";
+      sha256 = "06549f464526e931f23c0925b402eb3da6fbd9bd16595387604fe7edc62c4672";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/it/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/it/thunderbird-78.1.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "8818951a98306959571060a673093397e6f337c5edb08d91c7202b2dd46a96ab";
+      sha256 = "d81344b5dc0e131d1796f63de559a18b59dc70403a957eab737354ab05fd31c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ja/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ja/thunderbird-78.1.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "f30ab0ece47a1bb9220f414f12158ae264261456728c2debb2acfd9860dcceaf";
+      sha256 = "48bd5534bfebd6c6f976ea4230ac7d364544c1467b2912f0db46fd23944d0908";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ka/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ka/thunderbird-78.1.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "ef3bfc1a4afb1f7cab9188848d789778e36ad2c376daaf5245611fade7c758f8";
+      sha256 = "8f581c4d9f6c2e8f79bf7be92bf06a69d0dfed017346e1c380a31f541c5155fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/kab/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/kab/thunderbird-78.1.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "a1240d9ff2ef510cc039f3e29c571eaac738caea1a737d872931923fe1f9adc8";
+      sha256 = "2cbcf1e64dcb914af8dfa0f8dab462d59d37992b3f4e22159e2edd340cb6e73a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/kk/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/kk/thunderbird-78.1.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "ed991b239aeac8c0b8e92ae59acb1cb949357514326e7377c2b028a0c9bf8be9";
+      sha256 = "1fd067e9751c60dc6c6dcf1e5cfee3650758ae6593cb20fa5e6103cd01e6e6b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ko/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ko/thunderbird-78.1.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "dbbd6291a1253c125cd6b1757c1f8a0a7bdbd8e611032db0d5d2efb5f6efd232";
+      sha256 = "efdd154ad42d1b8f257d0cf619afc4bdea44d7014882c82847cb5f21d7037469";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/lt/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/lt/thunderbird-78.1.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "86b3a09435b20c398572a9d261d2b64c7f25346ac1977fcdddd78340a36a7774";
+      sha256 = "4256ec374ea5a22553469393e7fde51b46cd2ade5a620e9b0fc442e9d524494f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ms/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ms/thunderbird-78.1.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "4cead9cf204b460230eb35174898741fabefcec7d6a08bda13f67484400a61dd";
+      sha256 = "40f6fc9fb01a83288a6952b7a6e625bd00659594f7fa21ee883c16501407b8be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/nb-NO/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/nb-NO/thunderbird-78.1.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "2f955e1436e78a2abf8395aeab59917001ea3affe763f12412247e48809867a4";
+      sha256 = "b3f363ccbc5946c6e0e87ca4b75e12e4e4372688ae7a034c9cf37fd401794840";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/nl/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/nl/thunderbird-78.1.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "246b0dc99ae05a9fc559c3d587f4ebf501a6bc264494960cb6295f7b8ee5d12c";
+      sha256 = "6963f3f09cf8a3370b06c894aa744c4ddbaa7c11df4e41f540a21427ec391135";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/nn-NO/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/nn-NO/thunderbird-78.1.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "9d6b8c48bf483860cbba470fdf221fae906fdf1b1b3762055ee2dad841d266b3";
+      sha256 = "da647b3c85db5ebbfbc530dd8d8fb1005928430775cd5c8a2999709614f4e35c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/pa-IN/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/pa-IN/thunderbird-78.1.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "3a62c8d1909353efdf67c758e49a5e938508fa8d433d887fd47faa768fbc4015";
+      sha256 = "9df18348eedd3b43a13ac991b875fe12678929faa58712b09ee7364a8dedbd2e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/pl/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/pl/thunderbird-78.1.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "d20f0e0c1b60efc5b549a347ea6055b5ab659e47ef0b28ceda91b03066c89606";
+      sha256 = "7f60d5a0a819f6b69cd3f8444c12758f7cee17a681859c03cbea29ec27e1221e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/pt-BR/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/pt-BR/thunderbird-78.1.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "ad633496d5183a99251128321810842623de0c4aa4f8895e23df756cbca6a4bb";
+      sha256 = "229073650b742b4566350ce82ea65f93f639a2b502bf706de4038c3c13ead354";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/pt-PT/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/pt-PT/thunderbird-78.1.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "e1ed2749803c255e16f7c5bc8e264adbe53381b33c15d7ec7995cf048a86260c";
+      sha256 = "f8596511964a688747ce51cf0ca6bb6da65ea78b9b3ef70ced4f69fae8edbeb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/rm/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/rm/thunderbird-78.1.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "e07c2f7600965d46a6db1bbc5082897f0a9d3b1d66555c388c9dca9b02bcc057";
+      sha256 = "fb101dae4058f2cf804aacaf60c1354415cb0287432bb367a83e2ef8109375ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ro/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ro/thunderbird-78.1.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "2b34d996f2130b3738bc2b2cc8f784ad9e62b207722c7038e1469929c174aaeb";
+      sha256 = "1cb1fc985122dea685fc1998764c60979a7c357d5e1e0646b8c4f45e856b4f00";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/ru/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ru/thunderbird-78.1.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "3cdb2afc48e70a6f27022fb672eed016ab5aede684d2791b4771e764f64befaa";
+      sha256 = "d89b9a418c78422e2a715e7e1c5d2bf57e90c2293ad63dc5e9f2645fdc910103";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/si/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/si/thunderbird-78.1.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "6207418917124e654283592fcbf8c05bdb47369486ac3f4cfa63376ce5c4f780";
+      sha256 = "584cd0dca877163073824e9dfbee4d6146e0ef8bd0b23cd2325462a1a72a41a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/sk/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/sk/thunderbird-78.1.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "e5551cda807e0c490fc3c6fb8c0ca3c2b75f2093984537f862d1cd3b9cf1f080";
+      sha256 = "cbb2b5678d11eef244a175d88207e00fc59584afd0b788a82319987368ff19c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/sl/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/sl/thunderbird-78.1.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "d43ff3688f641d07dc6bc4b9b6a5045ee64f76b94c8a90fabab76ccb3682990a";
+      sha256 = "e8727e9942c4555d6413a3ebe1d4b2ab2ea39da4f5b3b2ad7baaeb8abf49fd47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/sq/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/sq/thunderbird-78.1.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "08ea55f8bb49ad16d0ef16b1a95c9cb5657690e811608f147c93f79171dc6b9b";
+      sha256 = "31141f45121dab9c5ce3f3d6195264df91e61e434ee993c409c3cac164215737";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/sr/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/sr/thunderbird-78.1.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "a9a1a33b195ef2c18da5a18ecbe09cd5dfc9c48aaf445937642a9df1cc2694c1";
+      sha256 = "dc9a868b1345da0633d090877ae6cddaa3a1b2bb1fc3113bc9de2aac1c30366c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/sv-SE/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/sv-SE/thunderbird-78.1.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "9f7994ec48a0b70ce6ce33092b4d5252c2cf180f2589a46fc85009503671fb56";
+      sha256 = "fab7e11f8de1fcd2e8719d20e818d8bd2c39f7539328fb79f2cce56d4f312a78";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/th/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/th/thunderbird-78.1.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "d1ffeae4472df5483c8f55beab128456f3176b07e11444ca48f651a582b8d80f";
+      sha256 = "fa3173940d4e7109385d65b479297110545cc7e2e76e8a657f376553e370563a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/tr/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/tr/thunderbird-78.1.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "79fa59071ceb5f643759cd4e9161325f3717a099607407844ed58e854c680eb2";
+      sha256 = "a8cf6b95a6b890892d034c0b014a62f710bbafa34f3282a80e17828ad9365513";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/uk/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/uk/thunderbird-78.1.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "f41e9756c31a5d2047d7beb8f8f4d3a3f09d6b72d8ef8b375c8f0ce16ff25409";
+      sha256 = "a5086a87a87ccb605154aad5bc2986d6fe995391189b3e452640210e2016b08f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/uz/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/uz/thunderbird-78.1.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "9748985b628e76b75f15814b6d48641319716bdff8c3947c346b01be27e16854";
+      sha256 = "b5bea650b678808b7fbcca432c1de0121dc19886b2f32e764e4fe1a797d1e8ab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/vi/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/vi/thunderbird-78.1.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "cba83119c8e36f76d4697acd689e1f94effdb980e7738853cf27f6633a48c187";
+      sha256 = "8b8b57417b1d6faeb283b1b6037eac92841029bd73769d5cb8bc6c227e87efbf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/zh-CN/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/zh-CN/thunderbird-78.1.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "f06c5cbefd99d2da20b1bb64518c29907f746740d30f79d4b7d59ee286690194";
+      sha256 = "4a0c8629e2a5e5f95799169dba4ee9c10b728bf503e090ed829cdd11fbeb57d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-x86_64/zh-TW/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/zh-TW/thunderbird-78.1.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "82cfbf08584867e6d36d357e67ea6abe2ab3e2747de014bd747ed169065b0f07";
+      sha256 = "11a892d8ec3ec6e2dccbad4b97ce2fe7cb0a0b1dc309bef9819432f0be9d510c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/af/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/af/thunderbird-78.1.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "ecd85c75ce2935f776dabfd42402342526cc9f7050c6f444219618cdfd12930b";
+      sha256 = "a254eecebf45c16f55b7d72cc38da2c4d22f49704cdb5db72d2adfc199a7a78c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ar/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ar/thunderbird-78.1.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "1ad1466a524f505abe1a80fd6dc4ddeb4441a26ce6f63c07b9bd8c0cd27f75d2";
+      sha256 = "3e735d996bb3bf2674f1c04f035489893169ab632208af1427756bc3c15b1600";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ast/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ast/thunderbird-78.1.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "5683300f0c423c5ea2c62cea619d0f894d7ef5d4e46f952f67ba56863350c829";
+      sha256 = "a8fe0f85c250b0f71b0bac30cd51e10e5d1ded4265775afe93f986ccde4fbc49";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/be/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/be/thunderbird-78.1.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "882463c8e120438c418a540da6d7ad324eb071f400d1abfea43c04d7a8e978d5";
+      sha256 = "279a98d38f6c33945ddd1e86c9263e72f9a52555e7f26c56a2f3062696436bbb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/bg/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/bg/thunderbird-78.1.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "1ead6033fc9a7bfd504890a453ccbcad34a5421f6a33e2a382cdbd0ccd15c60c";
+      sha256 = "cb23b56841818af2e3e8dc922cace29c8538d22977ee951dee744bbc490c24a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/br/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/br/thunderbird-78.1.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "4aaa832ef4a2cba04d03c2ce8f956bd38bbd88c0c5732db02b73ac6d1097c55a";
+      sha256 = "f729274b064205cb9baf57be3732268a2c56893ac6b17ae6ddc0aed3269fda15";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ca/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ca/thunderbird-78.1.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "a237f035c3b7c6281096accb036f35d6c2b421ca9bc4144240ccbe44f30092af";
+      sha256 = "eb434c12d8d841eb8426b95663591f742a9e62b630cadb7afebfa79ab1142a38";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/cak/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/cak/thunderbird-78.1.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "c92a7700e7ff6184ecfb1f36615d1a6f68a5b534eacc3417233602d290ec3c2d";
+      sha256 = "daa19634d796f849ab9b3a575bc53e451453902f82ce7384a7ae5ae4f99a2165";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/cs/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/cs/thunderbird-78.1.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "7417c763b5a4c680d136c2f0f2e62276b4c616a1442282ee9e979bbd56748886";
+      sha256 = "181cc3c70985d41a806395b353ccd98475c37ae8151fd5f59adbe25bf2059457";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/cy/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/cy/thunderbird-78.1.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "0099ae95225562e2376a9ae7b5416b82b43d62e5e3c1672ac9a404c4fd4afc3b";
+      sha256 = "4cb93a1b38582e6fd4e4fc514c36e469b88bedf0bd36bee4d7a66d9c33c3c8ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/da/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/da/thunderbird-78.1.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "f58de0e53576831b345e38c30fbd0809f8fbf06aaeb8072ff24c6bc3254844ae";
+      sha256 = "6eb46018b763d22e62739ec9dd98d5f3804f85b5b65ca3092c42d5d9a1a258ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/de/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/de/thunderbird-78.1.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "4ec7d297c251a6af2bc94f69b1416819173e5a067e751dbb44b2b4d78a8866a6";
+      sha256 = "dff12cffa89c1ad5666b92b66361e17c604f0ca34305fb0e3b06be5fa8fb0f96";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/dsb/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/dsb/thunderbird-78.1.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "642a8a455fd5baee6443c5db7e971d41c9576e5c930913f1ab04d5c611a85e2e";
+      sha256 = "efa2f9449703fc0941620650f1ca1332682b2866339413aa03f2438580d18f78";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/el/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/el/thunderbird-78.1.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "e0040116779db8e0a48ceadbadc78f29ba6f7a30b287f631606e8e710605af62";
+      sha256 = "675cfc628dd02fe874a701e0e16986c797adac263605b304c1c69bb01552037f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/en-CA/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/en-CA/thunderbird-78.1.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "d020ee801bee8a6384e3da9dfcff135d62dc523f2d0e183417508214fbcf8384";
+      sha256 = "a710c91df20b4b25d9e363b585344e1595ab96b9cc1df35e973e485834942957";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/en-GB/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/en-GB/thunderbird-78.1.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "31124523570c294f1615af0f3fcedb91f2509d7446c93760c063383b70faac11";
+      sha256 = "3acd3020cb6116588a0f061aa9ba5d620477e3265eefac3dc22f4705757fe025";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/en-US/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/en-US/thunderbird-78.1.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "242bf4bacb3d99fc79845f3c5a27e317f1ce9878b124c41b2d9fcbec54460fd4";
+      sha256 = "bf9ebc54aff457654b5ea1fc81437281f70d78de96d5a4d3586ae83fb8135d39";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/es-AR/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/es-AR/thunderbird-78.1.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "178819d715fe526a086d6abf392e2b2ea5d7b8a803199b02cb0005561219f886";
+      sha256 = "cf1c278a36c9303956ac8dc29a51226a42ea17cf64559c34bef318c79ba6ed74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/es-ES/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/es-ES/thunderbird-78.1.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "88fd17b25de55a567c0e6eecce7edd5657d8f4bf6fa1c8e5c6221b53b6dd21ba";
+      sha256 = "4a9356476a18f292f763f1647611189ebe89ee368a3f01a7c75ef8dce48d91af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/et/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/et/thunderbird-78.1.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "eaec9c4c0b80d69ba8215e44f64d3bcfc392b5fce47f1a154a8d973ac60991f0";
+      sha256 = "03d3a43153b714f334a8f5d7d23e9080624488ec54400451b508c6aa50bcd594";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/eu/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/eu/thunderbird-78.1.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "cea1fe6066c348d27b1de6645f7250e03c9beb22a545a4dac3e50dc1af983013";
+      sha256 = "a7cca16186f0e2627dc6e06164b3cb2bb691cf798f7c41378ae90349521d9199";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/fa/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/fa/thunderbird-78.1.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "01976fc28112097ff160c6adeaffed75b6f998eeba8cbb14328127738972144d";
+      sha256 = "6a19a79d409acdc25c69b5c8d75a18f2de665a7d18244d578e4ef0f65597daea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/fi/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/fi/thunderbird-78.1.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "9f7406c2cd4f11c93d3515691c228940c7b1514df56ec2c8630a7a2e94e2ecaa";
+      sha256 = "4b82f0fadfb5f388948e33fd3408e9f6ece6737c8e5e4b53c164a124f017e553";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/fr/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/fr/thunderbird-78.1.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "46fa514a8a041d9ad6a84333bd6f815cea1ee2c69ef37b17e68f944d93400e67";
+      sha256 = "bc4fb423664576d4d94eb24383e3f4f23c199e52f1c985fd3bfccc947212f82a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/fy-NL/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/fy-NL/thunderbird-78.1.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "33a5b2f524666b3e5add090ac552d72c3c20f81b97982bcaf2e7939fb3ad5c98";
+      sha256 = "6eb76c3a4d3b31160dc0d0b807596095354c7c0740f5593f86042af1e1b03d48";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ga-IE/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ga-IE/thunderbird-78.1.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "331d44093ef699538b72aa2abc12ac0aa5eed8a2c0ddcb48b2550820b418fffb";
+      sha256 = "5321fff3eb4d341307233976de74624f6002abb8662f40ecbf77e3bdb5757add";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/gd/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/gd/thunderbird-78.1.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "0d31fb4fc586e4e0f307335144f4e52b6bd8e1f2cef1707143715d4ba5d7143a";
+      sha256 = "515207242fffd0513a550017f8bfb53061f0a0e3d795a111adf0154b55363d38";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/gl/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/gl/thunderbird-78.1.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "66c9159758d4639e2334e0ed37145a9b3fb51a53ae15919c956f6ab59ac431a1";
+      sha256 = "84c32bd92a783c680343aa5b01dbf58e37eda9ee466b16f817a79a135e37fbe5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/he/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/he/thunderbird-78.1.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "927b657eea49b18a5bae6e23c0614178a33a90db1e6a4bb8e62978be2e5b165e";
+      sha256 = "96d07263578fb16068e0f48309552ea9237d3dd5a46fc63e3293326778cb7af1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/hr/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/hr/thunderbird-78.1.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "7c76abbc7fe94d910002a0786d18973a1fce553a36bbc26123fffdf8bb63b1c8";
+      sha256 = "9c612aad3a12530052dd609c2f20a3739c458b3c7f3d761e7c00754f9b43db95";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/hsb/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/hsb/thunderbird-78.1.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "a34c51c6059effdc861bf1892b9ae2f7f88f7b06344dc73d1c0d02da919c2883";
+      sha256 = "376e4d8eadb9bb8f301053d30260ab0cbeb3dc9f590564583f07547585105fe0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/hu/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/hu/thunderbird-78.1.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "acdc7d7423570b707bba3941bef2c1654d51c9e1e23d263561e1d9393b2e3e74";
+      sha256 = "4e7e51dbbe359ec542e553f5b0691f1d191343261094828b2572dd5a03ec2c8a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/hy-AM/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/hy-AM/thunderbird-78.1.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "c3bb6b743016d39c6ee5e7e3776e7617bb1d6d3a32c0ce04fc7e0a962cf4fc30";
+      sha256 = "735624e30d1986d6c822fcbee4694389cf8a0061eba40926265bd4ac998e2186";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/id/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/id/thunderbird-78.1.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "125562d267d38c3f4a5cfb9d747dc3c16634ab82cdeecfe18352c5cc85bd37ee";
+      sha256 = "ce6d668f38d1e74e7c8bbfc7408edc749eed9449908044bdd57b2dcd868cb89f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/is/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/is/thunderbird-78.1.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "f2028467188c85d34108a5a72ab01921cb51cd65bd821780cf264351e72f78ed";
+      sha256 = "589369ce68b6c78ad7753ddd14412eb68f438dbd7cae449f828288d25ee3f795";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/it/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/it/thunderbird-78.1.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "06663b6d3800c4175ff8c16309174a323cc1a000b140e944d73e74ebeac2c08b";
+      sha256 = "fd909d5aaa68a208050a0812f15024ef115b99fbde0edb0afe995c3b766c0d76";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ja/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ja/thunderbird-78.1.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "90e9dd8d19552e286f0b88252f64de5de9b9798b1122c48470de4795ae833b9f";
+      sha256 = "160c2a1c36ef34339270abd59fed13b37414f8c37edd60463e0945e6751a0c74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ka/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ka/thunderbird-78.1.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "0998d6b871bdde86830d061bef1e6aa93ad7840ea5c705db05b6d6475246c324";
+      sha256 = "e822a28e62aae6d6e84e6788d5311af45396248f48cc60152b4273d75359dd8f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/kab/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/kab/thunderbird-78.1.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "88bd997d123541041594f16496baced969c06335079fb7d08473a09cb001a8fb";
+      sha256 = "2ea58cc79b80966b5bbc310fa32bd27621f95d4ffbd3646bf9e04f922c36ca6e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/kk/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/kk/thunderbird-78.1.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "56bc7376e0a7dcc1e6ca45b41de2769f887ed647320531895f6b3aee99b05592";
+      sha256 = "a874bc02f065be73a54b70567b7a04be5fc6a9f766f3b054b12555763361ea2a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ko/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ko/thunderbird-78.1.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "6bbc9f93dcc3c78d17806933020b45a6145e6df3ea0a155492500bcb500f0a31";
+      sha256 = "d9678f72569dfde84544fcb9afa7cb8d5a4a35baa52d4e560aa2b082a418ab00";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/lt/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/lt/thunderbird-78.1.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "49e2cbd0d86578f74623ab0c72f551a48d3835a583a5b7269303ab920f14b9c7";
+      sha256 = "1d7ec489dc52fae0f7597e40f8505bdd6a57a717389c75b66481749e85e2fab6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ms/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ms/thunderbird-78.1.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "53306a0a9a149fbc7d1e24c24c8ca3ea154ad766be23dc70aeb3bf90ef1bc5b3";
+      sha256 = "5d0c7cc00139c39a69dfc9ba1dc5c83b56973f26679860d048952bcf09baa737";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/nb-NO/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/nb-NO/thunderbird-78.1.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "fa2b3f9de332a40df46b32f4ab5451fb16fa400454b2269543c08f8ee156b52e";
+      sha256 = "e72a25e7d53e6e0d470632c487d31e08afdb6c27543d50c93ff72ecac3f70bc6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/nl/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/nl/thunderbird-78.1.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "4439bfa046cea7d823e12f837625fda5ce1953ded9f0af9dec252d9d58dae04e";
+      sha256 = "19efd7323e671fe25b64ee44c85f698f608e6c2b18fdbfc9f0cc95b9cd8cd149";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/nn-NO/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/nn-NO/thunderbird-78.1.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "3a9fc65618790837bb6d998c5ef6ec01019db8240b01c904a61c463bf17b848d";
+      sha256 = "b4be21281c6a13de05e5d0b96e43454bab662140a00d3837f609e23f14360c90";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/pa-IN/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/pa-IN/thunderbird-78.1.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "b433e58bb809a2f47cfc82848db5145cd92280725ce3b5d1bfafdc0e5f616076";
+      sha256 = "f2795a504616404616f7d22022e105e9e4ea54025d60e262c405b867cb9c7936";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/pl/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/pl/thunderbird-78.1.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "9ec00ac58795a5e7947a9effa2646081d4fdeed801f7e91ed651d2b457317774";
+      sha256 = "52f80b074dc168ec00d0fd78f6376c1dfd357c2b7e7ed78bb1b9cf17536508a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/pt-BR/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/pt-BR/thunderbird-78.1.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "fe187123f5c9b472de5154e126a1d736e1eae0d88fe11f5ca1c771006f37202f";
+      sha256 = "d02867899a54eebffb2b6e600f7e6260b960d686a8bcd61ce705e9d0bbebe377";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/pt-PT/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/pt-PT/thunderbird-78.1.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "6a09eab3e662f093ec5428c3d5b0dabd5ef8ca8a734f92bb52088a545dd5707c";
+      sha256 = "659a7ff3a0dcbb4f3fec32eda6b5a2087191c8d49ea310662ad540433d869180";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/rm/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/rm/thunderbird-78.1.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "87f96161f0d415ed24abd2bf7d88ffcadf327910b23c285a4fa7126612011cb1";
+      sha256 = "d9ee3c5e3cf2d7eedced9d12bf4d499ae931c262be166af6a14bbd4a2538788a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ro/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ro/thunderbird-78.1.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "6b6f0125a4354320abf34333353cf52a30ebaa764d1ae17b1fa48e7d1ad53b52";
+      sha256 = "c3db9965a25d52d25cde0b52bffcc274ae32862fb29be368f27b102774d0971b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/ru/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ru/thunderbird-78.1.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "3d3c72390d333abd6710b0653f8c95e0283b50580cc6aad3e7c38a90c369cb9b";
+      sha256 = "f0356ef5eadccfcdfc694d0bed9b1e4027e4883095f9c117403a68f1cb2810c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/si/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/si/thunderbird-78.1.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "f436f26b6baa8cbcbd407133c099669c45bea518202a34d7538260bd76fc7b19";
+      sha256 = "5b5d17a2b098fbe1c2d8686ab0e1adb7c72efedc38365ca9b39b1e122302c85c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/sk/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/sk/thunderbird-78.1.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "ab89336f29fdda1525e827f4f4419b2eb0137279717511ca3de32f221d5335fb";
+      sha256 = "b39bd41a38947ea467e1a89c5a173fd07cbce09562c10e6a60adb2150b04c9cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/sl/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/sl/thunderbird-78.1.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "fb43a4f2b360774a1c7e337a38bf9388cc1e453b987b7d8ac38e2dde255ae3f5";
+      sha256 = "602e0feffc5b786930005c376ca3e8819b834a0cfc9a649bc46d86c27999144d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/sq/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/sq/thunderbird-78.1.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "1029c843c2ff06842dca2af05054d60b87927674b36f6c6890118143f5aeadec";
+      sha256 = "fb265490d00c3a844f73e8f531b7c73f3787cb4e4ddc7cdcde72017fd7f3d612";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/sr/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/sr/thunderbird-78.1.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "e20f00961f70dec27c306c9442315a4e5061840604650ec62123d1cc74a3006b";
+      sha256 = "1574eaee6effc4df2c88fc94597e295f352455a9f68501080385c08cb4ab7e35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/sv-SE/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/sv-SE/thunderbird-78.1.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "1e2d290254f610e1dd8c4d8037e9aaad3abee6d7b7373471e53ff698b736af83";
+      sha256 = "8d55df4937fe28f7b9d0fcaebcde3fb9650de9f0b74f677111f339ae2365b822";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/th/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/th/thunderbird-78.1.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "1a80c2986f7f69228c1ae6f2829d3502154ccc9e92ea8bdb2530b82b3a933349";
+      sha256 = "6a872a6c332c7b3bfc24721bf1114c85475a73ae5c7b16d8637b0eb0045e112d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/tr/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/tr/thunderbird-78.1.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "136a7cd134f8782537a8063da75fca86340597da5832dc87468b9a353aba0b89";
+      sha256 = "26d2b8493a1508591b45f9ecc43598e244856c0d9bc3c185721a7239679c4e63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/uk/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/uk/thunderbird-78.1.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "ad0ebfd63617b7807fcb658744650a95c5a8a03328d152f64c48f8ed46a5825a";
+      sha256 = "ddb4b5fab55ded8f7bc2ae914f41af42b3b69c738727b055efd5e05b253ac872";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/uz/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/uz/thunderbird-78.1.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "4af26e15a2e1afb84ce9ff0024286b31b6f77b6810897906d7139ffa884ca623";
+      sha256 = "dce93fab320f90ece938ae2b2343c1d27a1143b0183318a9d9e0cbbcfb607982";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/vi/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/vi/thunderbird-78.1.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "4695f995cbf7e62eab32aa17a8c9b5cd01c7ccc16e50911436e940b0ff1a28bd";
+      sha256 = "cf1b4f96ef1a510d21b232e748ace6e567d27e382393a7d7f51ab392f026d55c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/zh-CN/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/zh-CN/thunderbird-78.1.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "d70c7e9667240f2fc9f705a66be84c2decb691af581e73bf2637f97b08f3f14d";
+      sha256 = "574acd0743a1202b6629883618278eb3ce113c518bc9c39f3d90e2dc12d4f644";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.0/linux-i686/zh-TW/thunderbird-78.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/zh-TW/thunderbird-78.1.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "1359fc351ef156bbc00a134de4f7dc878fa1bfa77a461ac289f90dc7f870ecd4";
+      sha256 = "51ccc5a4696841b3391a5dd9fb9ff1f55a9f6ccd6fbd86587ffb86c5f664f10f";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/68.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/68.nix
@@ -74,13 +74,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "68.10.0";
+  version = "68.11.0";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "24jq4wxhk58403ax8jf6p82fyzf0vszz8am5d8jb6j559da3lp6wv4m5xqavvcf9i57rdivzrmqw9agr8mypfxs8zb908aln5iy7d4d";
+      "1rdxizg1mpagh17fhnrbkilyv1i2zfcr6z62jf3ng31ns94za9kdg9f580srkp63png67jaj3b1kc33v5vb8wavl09n5d38g113x2m9";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -72,13 +72,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.1.0";
+  version = "78.1.1";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "2m1gqq11k5cql5f49mwrfjk06rm2r24lf9l0hrvj569gqxckyh8wdch3dn339x3yn5fhxqlw0l770p2ssr2kkllv3yy20qqzjqgfpgh";
+      "1lf15zl3p8y1vxv4s04y088flkspf0r0c6j8gfrlfzla5ckfcsbad3zbygh6y73m35j882g7fbacby5a4hiw891zq2kji5dn3nbahyi";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

78.1.1:

- Bug fixes and changes.

https://www.thunderbird.net/en-US/thunderbird/78.1.1/releasenotes/

68.11.0:

- High security fixes
- Other fix

https://www.thunderbird.net/en-US/thunderbird/68.11.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2020-35/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested `thunderbird-78`, `thunderbird-bin-78`, and `thunderbird-bin`. I'm building `thunderbird`.