### PR TITLE
wg-bond: init at 0.2.0

### DIFF
--- a/pkgs/applications/networking/wg-bond/default.nix
+++ b/pkgs/applications/networking/wg-bond/default.nix
@@ -1,0 +1,30 @@
+{ pkgs, lib, rustPlatform, fetchFromGitLab, wireguard-tools, makeWrapper }:
+rustPlatform.buildRustPackage rec {
+  pname = "wg-bond";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    owner = "cab404";
+    repo = "wg-bond";
+    rev = "v${version}";
+    hash = "sha256:04k0maxy39k7qzcsqsv1byddsmjszmnyjffrf22nzbvml83p3l0y";
+  };
+
+  cargoSha256 = "1v2az0v6l8mqryvq3898hm7bpvqdd2c4kpv6ck7932jfjyna512k";
+
+  buildInputs = [ makeWrapper ];
+  postInstall = ''
+    wrapProgram $out/bin/wg-bond --set PATH ${
+      lib.makeBinPath [ wireguard-tools ]
+    }
+  '';
+
+  meta = with lib; {
+    description = "Wireguard configuration manager";
+    homepage = "https://gitlab.com/cab404/wg-bond";
+    changelog = "https://gitlab.com/cab404/wg-bond/-/releases#v${version}";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ cab404 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7811,6 +7811,8 @@ in
     libpsl = null;
   };
 
+  wg-bond = callPackage ../applications/networking/wg-bond { };
+
   which = callPackage ../tools/system/which { };
 
   whsniff = callPackage ../applications/networking/sniffers/whsniff { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Packaged wg-bond — easy configuration manager for Wireguard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
