### PR TITLE
jupyterhub, jupyter-telemetry: 1.0.0 -> 1.1.0, init at 0.1.0

### DIFF
--- a/pkgs/development/python-modules/jupyter-telemetry/default.nix
+++ b/pkgs/development/python-modules/jupyter-telemetry/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, python-json-logger
+, jsonschema
+, ruamel_yaml
+, traitlets
+}:
+
+buildPythonPackage rec {
+  pname = "jupyter_telemetry";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "052khyn6h97jxl3k5i2m81xvga5v6vwh5qixzrax4w6zwcx62p24";
+  };
+
+  propagatedBuildInputs = [
+    python-json-logger jsonschema ruamel_yaml traitlets
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Telemetry for Jupyter Applications and extensions";
+    homepage = "https://jupyter-telemetry.readthedocs.io/";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/jupyterhub/default.nix
+++ b/pkgs/development/python-modules/jupyterhub/default.nix
@@ -18,6 +18,7 @@
 , nodePackages
 , oauthlib
 , certipy
+, jupyter-telemetry
 }:
 
 let
@@ -53,12 +54,12 @@ in
 
 buildPythonPackage rec {
   pname = "jupyterhub";
-  version = "1.0.0";
+  version = "1.1.0";
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0zx6gw9yhgki05j21p6x1x2sf5a2mg2c2mx0ii8rl6q4b98ilm1k";
+    sha256 = "1mqknz0rxqzx4nc57vscvfh2d4znzlzpy83ancqxdaq3b8i70al5";
   };
 
   # Most of this only applies when building from source (e.g. js/css assets are
@@ -110,6 +111,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     alembic ipython jinja2 pamela python-oauth2 requests sqlalchemy tornado
     traitlets prometheus_client async_generator notebook certipy oauthlib
+    jupyter-telemetry
   ];
 
   # Disable tests because they take an excessive amount of time to complete.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3971,6 +3971,8 @@ in {
     pkgs-docker = pkgs.docker;
   };
 
+  jupyter-telemetry = callPackage ../development/python-modules/jupyter-telemetry { };
+
   jupyterhub = callPackage ../development/python-modules/jupyterhub { };
 
   jupyterhub-ldapauthenticator = callPackage ../development/python-modules/jupyterhub-ldapauthenticator { };


### PR DESCRIPTION
Resolve issue with jupyterhub 1.0.0 through upgrade, requires jupyter-telemetry as a dependency

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Experienced an issue with JupyterHub 1.0.0 which is resolved by upgrading to 1.1.0. During the upgrade, determined that jupyter-telemetry is a build dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Unsure how to proceed (errors seem unrelated to change)

- Command `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` fails with Python XML related error
- Command `nix path-info -S` errors out