### PR TITLE
cgal: add patch so include files can be found by dependent packages

### DIFF
--- a/pkgs/development/libraries/CGAL/cgal_path.patch
+++ b/pkgs/development/libraries/CGAL/cgal_path.patch
@@ -1,0 +1,15 @@
+--- Installation/cmake/modules/CGALConfig_install.cmake.in.original	2019-07-10 10:39:12.377022659 -0700
++++ Installation/cmake/modules/CGALConfig_install.cmake.in	2019-07-10 10:47:24.310154928 -0700
+@@ -45,9 +45,9 @@
+ set(CGAL_SHARED_LINKER_FLAGS_DEBUG_INIT   "@CMAKE_SHARED_LINKER_FLAGS_DEBUG@" )
+ set(CGAL_BUILD_TYPE_INIT                  "@CMAKE_BUILD_TYPE@" )
+
+-set(CGAL_INCLUDE_DIRS  "${CGAL_INSTALL_PREFIX}/@CGAL_INSTALL_INC_DIR@" )
+-set(CGAL_MODULES_DIR   "${CGAL_INSTALL_PREFIX}/@CGAL_INSTALL_CMAKE_DIR@" )
+-set(CGAL_LIBRARIES_DIR "${CGAL_INSTALL_PREFIX}/@CGAL_INSTALL_LIB_DIR@" )
++set(CGAL_INCLUDE_DIRS  "@CGAL_INSTALL_INC_DIR@" )
++set(CGAL_MODULES_DIR   "@CGAL_INSTALL_CMAKE_DIR@" )
++set(CGAL_LIBRARIES_DIR "@CGAL_INSTALL_LIB_DIR@" )
+
+ # If CGAL_ImageIO is built, tell if it was linked with Zlib.
+ set(CGAL_ImageIO_USE_ZLIB                 "@CGAL_ImageIO_USE_ZLIB@" )

--- a/pkgs/development/libraries/CGAL/default.nix
+++ b/pkgs/development/libraries/CGAL/default.nix
@@ -1,8 +1,14 @@
-{ stdenv, fetchFromGitHub, cmake, boost, gmp, mpfr }:
+{ stdenv
+, fetchFromGitHub
+, cmake
+, boost
+, gmp
+, mpfr
+}:
 
 stdenv.mkDerivation rec {
+  pname = "cgal";
   version = "5.0.2";
-  name = "cgal-" + version;
 
   src = fetchFromGitHub {
     owner = "CGAL";
@@ -15,6 +21,8 @@ stdenv.mkDerivation rec {
   #   there are also libCGAL_Qt{3,4} omitted ATM
   buildInputs = [ boost gmp mpfr ];
   nativeBuildInputs = [ cmake ];
+
+  patches = [ ./cgal_path.patch ];
 
   doCheck = false;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
See [this issue](https://github.com/NixOS/nixpkgs/issues/61276).

###### Things done
Add patch so include files can be found by dependent packages.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
