### PR TITLE
refactor: refactor jruby to allow multiple versions

### DIFF
--- a/pkgs/development/interpreters/jruby/default.nix
+++ b/pkgs/development/interpreters/jruby/default.nix
@@ -1,63 +1,26 @@
-{ stdenv, callPackage, fetchurl, makeWrapper, jre }:
+{ callPackage, lib }:
+rec {
 
-let
-# The version number here is whatever is reported by the RUBY_VERSION string
-rubyVersion = callPackage ../ruby/ruby-version.nix {} "2" "5" "7" "";
-jruby = stdenv.mkDerivation rec {
-  pname = "jruby";
+  rubyVersion = import ../ruby/ruby-version.nix { inherit lib; };
 
-  version = "9.2.13.0";
+  generic_jruby =  {version, sha256, rubyVersion}: callPackage ./generic.nix {
+    inherit version;
+    inherit sha256;
+    inherit rubyVersion;
+  };
 
-  src = fetchurl {
-    url = "https://s3.amazonaws.com/jruby.org/downloads/${version}/jruby-bin-${version}.tar.gz";
+  v9_2_12_0 = generic_jruby {
+    version = "9.2.12.0";
+    sha256 = "013c1q1n525y9ghp369z1jayivm9bw8c1x0g5lz7479hqhj62zrh";
+    rubyVersion = rubyVersion "2" "5" "7" "";
+  };
+
+  v9_2_13_0 = generic_jruby {
+    version = "9.2.13.0";
     sha256 = "0n5glz6xm3skrfihzn3g5awdxpjsqn2k8k46gv449rk2l50w5a3k";
+    rubyVersion = rubyVersion "2" "5" "7" "";
   };
 
-  buildInputs = [ makeWrapper ];
-
-  installPhase = ''
-     mkdir -pv $out/docs
-     mv * $out
-     rm $out/bin/*.{bat,dll,exe,sh}
-     mv $out/COPYING $out/LICENSE* $out/docs
-
-     for i in $out/bin/jruby{,.bash}; do
-       wrapProgram $i \
-         --set JAVA_HOME ${jre}
-     done
-
-     ln -s $out/bin/jruby $out/bin/ruby
-
-     # Bundler tries to create this directory
-     mkdir -pv $out/${passthru.gemPath}
-     mkdir -p $out/nix-support
-     cat > $out/nix-support/setup-hook <<EOF
-       addGemPath() {
-         addToSearchPath GEM_PATH \$1/${passthru.gemPath}
-       }
-
-       addEnvHooks "$hostOffset" addGemPath
-     EOF
-  '';
-
-  passthru = rec {
-    rubyEngine = "jruby";
-    gemPath = "lib/${rubyEngine}/gems/${rubyVersion.libDir}";
-    libPath = "lib/${rubyEngine}/${rubyVersion.libDir}";
-  };
-
-  meta = with stdenv.lib; {
-    description = "Ruby interpreter written in Java";
-    homepage = "http://jruby.org/";
-    license = with licenses; [ cpl10 gpl2 lgpl21 ];
-    platforms = platforms.unix;
-    maintainers = [ maintainers.fzakaria ];
-  };
-};
-in jruby.overrideAttrs (oldAttrs: {
-  passthru = oldAttrs.passthru // {
-    devEnv = callPackage ../ruby/dev.nix {
-      ruby = jruby;
-    };
-  };
-})
+  # jruby tracks the latest
+  latest = v9_2_13_0;
+}

--- a/pkgs/development/interpreters/jruby/generic.nix
+++ b/pkgs/development/interpreters/jruby/generic.nix
@@ -1,0 +1,64 @@
+{ stdenv,
+  callPackage,
+  fetchurl,
+  makeWrapper,
+  jre,
+  version,
+  sha256,
+  # The version number here is whatever is reported by the RUBY_VERSION string
+  rubyVersion}:
+let self = stdenv.mkDerivation rec {
+  inherit version;
+
+  pname = "jruby";
+
+  src = fetchurl {
+    url = "https://s3.amazonaws.com/jruby.org/downloads/${version}/jruby-bin-${version}.tar.gz";
+    sha256 = sha256;
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+     mkdir -pv $out/docs
+     mv * $out
+     rm $out/bin/*.{bat,dll,exe,sh}
+     mv $out/COPYING $out/LICENSE* $out/docs
+
+     for i in $out/bin/jruby{,.bash}; do
+       wrapProgram $i \
+         --set JAVA_HOME ${jre}
+     done
+
+     ln -s $out/bin/jruby $out/bin/ruby
+
+     # Bundler tries to create this directory
+     mkdir -pv $out/${passthru.gemPath}
+     mkdir -p $out/nix-support
+     cat > $out/nix-support/setup-hook <<EOF
+       addGemPath() {
+         addToSearchPath GEM_PATH \$1/${passthru.gemPath}
+       }
+
+       addEnvHooks "$hostOffset" addGemPath
+     EOF
+  '';
+
+  passthru = rec {
+    rubyEngine = "jruby";
+    gemPath = "lib/${rubyEngine}/gems/${rubyVersion.libDir}";
+    libPath = "lib/${rubyEngine}/${rubyVersion.libDir}";
+    devEnv = callPackage ../ruby/dev.nix {
+      ruby = self;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Ruby interpreter written in Java";
+    homepage = "http://jruby.org/";
+    license = with licenses; [ cpl10 gpl2 lgpl21 ];
+    platforms = platforms.unix;
+    maintainers = [ maintainers.fzakaria ];
+  };
+};
+in self

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10084,7 +10084,8 @@ in
 
   sourceFromHead = callPackage ../build-support/source-from-head-fun.nix {};
 
-  jruby = callPackage ../development/interpreters/jruby { };
+  jruby-group = callPackage ../development/interpreters/jruby {};
+  jruby = jruby-group.latest;
 
   jython = callPackage ../development/interpreters/jython {};
 


### PR DESCRIPTION
###### Motivation for this change
Many packages within Nix support multiple packages & a versionless
attribute that tracks "latest";

This refactors the JRuby derivation to be similar to that of Ruby
itself.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions (Debian)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```bash
> nix-build $(pwd) -A jruby-group.v9_2_13_0
/nix/store/52nrl3czv5jxvpw9kvnvgaa7npwc4kkx-jruby-9.2.13.0

> nix-build $(pwd) -A jruby
/nix/store/52nrl3czv5jxvpw9kvnvgaa7npwc4kkx-jruby-9.2.13.0
```