### PR TITLE
otfcc: fix aarch64 compatibility

### DIFF
--- a/pkgs/tools/misc/otfcc/default.nix
+++ b/pkgs/tools/misc/otfcc/default.nix
@@ -13,16 +13,16 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ premake5 ];
 
-  # Don’t guess where our makefiles will end up. Just use current
-  # directory.
-  patchPhase = ''
-    substituteInPlace premake5.lua \
-      --replace 'location "build/gmake"' 'location "."'
-  '';
+  patches = [
+    ./fix-aarch64.patch
+    ./move-makefiles.patch
+  ];
+
+  buildFlags = stdenv.lib.optional stdenv.isAarch64 [ "config=release_arm" ];
 
   installPhase = ''
     mkdir -p $out/bin
-    cp bin/release-x*/otfcc* $out/bin/
+    cp bin/release-*/otfcc* $out/bin/
   '';
 
   enableParallelBuilding = true;
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "Optimized OpenType builder and inspector";
     homepage = "https://github.com/caryll/otfcc";
     license = licenses.asl20;
-    platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
+    platforms = [ "aarch64-linux" "i686-linux" "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ jfrankenau ttuegel ];
   };
 

--- a/pkgs/tools/misc/otfcc/fix-aarch64.patch
+++ b/pkgs/tools/misc/otfcc/fix-aarch64.patch
@@ -1,0 +1,22 @@
+diff --git a/premake5.lua b/premake5.lua
+index 997fd79..54a20a0 100644
+--- a/premake5.lua
++++ b/premake5.lua
+@@ -49,7 +49,7 @@ end
+ workspace "otfcc"
+ 	configurations { "release", "debug" }
+ 	
+-	platforms { "x64", "x86" }
++	platforms { "x64", "x86", "arm" }
+ 	filter "action:xcode4"
+ 		platforms { "x64" }
+ 	filter {}
+@@ -67,6 +67,8 @@ workspace "otfcc"
+ 		architecture "x86"
+ 	filter "platforms:x64"
+ 		architecture "x64"
++	filter "platforms:arm"
++		architecture "arm"
+ 	filter {}
+ 	
+ 	filter "action:vs2017"

--- a/pkgs/tools/misc/otfcc/move-makefiles.patch
+++ b/pkgs/tools/misc/otfcc/move-makefiles.patch
@@ -1,0 +1,13 @@
+diff --git a/premake5.lua b/premake5.lua
+index 997fd79..54a20a0 100644
+--- a/premake5.lua
++++ b/premake5.lua
+@@ -88,7 +90,7 @@ workspace "otfcc"
+ 		flags { "StaticRuntime" }
+ 		includedirs { "dep/polyfill-msvc" }
+ 	filter "action:gmake"
+-		location "build/gmake"
++		location "."
+ 	filter "action:xcode4"
+ 		location "build/xcode"
+ 	filter {}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Could not build otfcc on aarch64.

###### Things done
Patched the Premake-Script to enable the build.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS - x86_64 & aarch64
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
