### PR TITLE
mblaze: fix mcom to use file utility.

### DIFF
--- a/pkgs/applications/networking/mailreaders/mblaze/default.nix
+++ b/pkgs/applications/networking/mailreaders/mblaze/default.nix
@@ -1,5 +1,5 @@
 { coreutils, fetchFromGitHub, fetchpatch, file, gawk, gnugrep, gnused
-, installShellFiles, less, lib, libiconv, makeWrapper, nano, stdenv, ruby ? null
+, installShellFiles, less, lib, libiconv, makeWrapper, nano, stdenv, ruby
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/applications/networking/mailreaders/mblaze/default.nix
+++ b/pkgs/applications/networking/mailreaders/mblaze/default.nix
@@ -31,8 +31,7 @@ stdenv.mkDerivation rec {
     # wrapper breaks this behaviour. The following wrappers preserve it.
 
     mkdir -p $out/wrapped
-    for x in mcom mbnc mfwd mrep
-    do
+    for x in mcom mbnc mfwd mrep; do
       mv $out/bin/$x $out/wrapped
       makeWrapper $out/wrapped/$x $out/bin/$x \
         --argv0 $out/bin/$x \

--- a/pkgs/applications/networking/mailreaders/mblaze/default.nix
+++ b/pkgs/applications/networking/mailreaders/mblaze/default.nix
@@ -1,10 +1,12 @@
-{ stdenv, lib, fetchFromGitHub, installShellFiles, libiconv, ruby ? null }:
+{ coreutils, fetchFromGitHub, fetchpatch, file, gawk, gnugrep, gnused
+, installShellFiles, less, lib, libiconv, makeWrapper, nano, stdenv, ruby ? null
+}:
 
 stdenv.mkDerivation rec {
   pname = "mblaze";
   version = "1.0";
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
   buildInputs = [ ruby ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   src = fetchFromGitHub {
@@ -20,6 +22,25 @@ stdenv.mkDerivation rec {
     installShellCompletion contrib/_mblaze
   '' + lib.optionalString (ruby != null) ''
     install -Dt $out/bin contrib/msuck contrib/mblow
+
+    # The following wrappings are used to preserve the executable
+    # names (the value of $0 in a script). The script mcom is
+    # designed to be run directly or via symlinks such as mrep. Using
+    # symlinks changes the value of $0 in the script, and makes it
+    # behave differently. When using the wrapProgram tool, the resulting
+    # wrapper breaks this behaviour. The following wrappers preserve it.
+
+    mkdir -p $out/wrapped
+    for x in mcom mbnc mfwd mrep
+    do
+      mv $out/bin/$x $out/wrapped
+      makeWrapper $out/wrapped/$x $out/bin/$x \
+        --argv0 $out/bin/$x \
+        --prefix PATH : $out/bin \
+        --prefix PATH : ${lib.makeBinPath [
+          coreutils file gawk gnugrep gnused
+        ]}
+    done
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
mcom needs the file utility when attaching document with `mcom -attach bla.txt`.

###### Things done
I wrapped mcom to add `file` to `PATH`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
