### PR TITLE
add ibus-bamboo engine for ibus input method

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-bamboo/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-bamboo/default.nix
@@ -1,0 +1,33 @@
+{ fetchFromGitHub, stdenv, go, xorg, gnused }:
+stdenv.mkDerivation
+{
+  pname = "ibus-bamboo";
+  version = "v0.6.5";
+
+  src = fetchFromGitHub {
+    owner = "BambooEngine";
+    repo = "ibus-bamboo";
+    rev = "3f4c148228c239c80d787cca207604f6acd95660";
+    sha256= "00fs9mlcvyrybm356q7yl5g2s03j6drsgc82qkx5hx73i56pyd0j";
+  };
+
+  nativeBuildInputs = [ gnused ];
+  buildInputs = [ go xorg.libX11 xorg.libXtst xorg.libXi ];
+
+  patchPhase = "sed -i 's|PREFIX=/usr|PREFIX=|' Makefile";
+  buildPhase = "GOCACHE=$NIX_BUILD_TOP/gocache make build";
+  installPhase = "DESTDIR=$out GOCACHE=$NIX_BUILD_TOP/gocache make install";
+  fixupPhase = ''
+    sed -i "s|/usr/lib/ibus-engine-bamboo|$out/lib/ibus-engine-bamboo|" $out/share/ibus/component/bamboo.xml
+    sed -i "s|/usr/share/ibus-bamboo|$out/share/ibus-bamboo|" $out/share/ibus/component/bamboo.xml
+    sed -i "s|>Bamboo<|>bamboo<|" $out/share/ibus/component/bamboo.xml
+  '';
+
+  meta = with stdenv.lib; {
+    isIbusEngine = true;
+    description = "IBus interface to the vietnamese input method";
+    homepage = "https://github.com/BambooEngine";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add Vietnamese input method to NixOS


###### Things done
Add package `ibus-bamboo`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
