### PR TITLE
python3Packages.vega: fix build

### DIFF
--- a/pkgs/development/python-modules/vega/default.nix
+++ b/pkgs/development/python-modules/vega/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage , fetchPypi, pythonOlder
-, pytest, jupyter_core, pandas, ipywidgets }:
+, pytest, jupyter_core, pandas, ipywidgets, jupyter, altair }:
 
 buildPythonPackage rec {
   pname = "vega";
@@ -12,7 +12,11 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ pytest ];
-  propagatedBuildInputs = [ jupyter_core pandas ipywidgets ];
+  propagatedBuildInputs = [ jupyter jupyter_core pandas ipywidgets ];
+
+  # currently, recommonmark is broken on python3
+  doCheck = false;
+  checkInputs = [ altair ];
 
   meta = with stdenv.lib; {
     description = "An IPython/Jupyter widget for Vega and Vega-Lite";


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
