### PR TITLE
bs-platform: 7.3.2 -> 8.2.0

### DIFF
--- a/pkgs/development/compilers/bs-platform/build-bs-platform.nix
+++ b/pkgs/development/compilers/bs-platform/build-bs-platform.nix
@@ -3,6 +3,7 @@
 
 { stdenv, fetchFromGitHub, ninja, runCommand, nodejs, python3,
   ocaml-version, version, src,
+  patches ? [],
   ocaml ? (import ./ocaml.nix {
     version = ocaml-version;
     inherit stdenv;
@@ -22,7 +23,7 @@ let
 in
 
 stdenv.mkDerivation rec {
-  inherit src version;
+  inherit src version patches;
   pname = "bs-platform";
 
   BS_RELEASE_BUILD = "true";
@@ -34,7 +35,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ nodejs python3 custom-ninja ];
 
-  patchPhase = ''
+  prePatch = ''
     sed -i 's:./configure.py --bootstrap:python3 ./configure.py --bootstrap:' ./scripts/install.js
     mkdir -p ./native/${ocaml-version}/bin
     ln -sf ${ocaml}/bin/*  ./native/${ocaml-version}/bin
@@ -46,7 +47,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     # This is an unfortunate name, but it's actually how to build a release
     # binary for BuckleScript
-    node scripts/install.js
+    npm run postinstall
   '';
 
   installPhase = ''

--- a/pkgs/development/compilers/bs-platform/default.nix
+++ b/pkgs/development/compilers/bs-platform/default.nix
@@ -4,14 +4,16 @@ let
 in
 (build-bs-platform rec {
   inherit stdenv runCommand fetchFromGitHub ninja nodejs python3;
-  version = "7.3.2";
+  version = "8.2.0";
   ocaml-version = "4.06.1";
+
+  patches = [ ./jscomp-release-ninja.patch ];
 
   src = fetchFromGitHub {
     owner = "BuckleScript";
     repo = "bucklescript";
     rev = version;
-    sha256 = "1nvp7wiiv149r4qf9bgc84bm4w7s44sjq9i7j103v24wllzz218s";
+    sha256 = "1hql7sxps1k17zmwyha6idq6nw20abpq770l55ry722birclmsmf";
     fetchSubmodules = true;
   };
 }).overrideAttrs (attrs: {

--- a/pkgs/development/compilers/bs-platform/jscomp-release-ninja.patch
+++ b/pkgs/development/compilers/bs-platform/jscomp-release-ninja.patch
@@ -1,0 +1,16 @@
+ jscomp/others/release.ninja | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/jscomp/others/release.ninja b/jscomp/others/release.ninja
+index 9ea6d11c5..a91ed9c80 100644
+--- a/jscomp/others/release.ninja
++++ b/jscomp/others/release.ninja
+@@ -30,7 +30,7 @@ build others/js_json.cmj : cc_cmi others/js_json.ml | others/js_array2.cmj other
+ build others/js_json.cmi : cc others/js_json.mli | others/js_dict.cmi others/js_null.cmi others/js_string.cmj others/js_types.cmi runtime
+ build others/js_list.cmj : cc_cmi others/js_list.ml | others/js_array2.cmj others/js_list.cmi others/js_vector.cmj runtime
+ build others/js_list.cmi : cc others/js_list.mli | others/js_vector.cmi runtime
+-build others/js_mapperRt.cmj : cc_cmi others/js_mapperRt.ml | others/js_mapperRt.cmi runtime
++build others/js_mapperRt.cmj : cc_cmi others/js_mapperRt.ml | others/js_array2.cmj others/js_mapperRt.cmi runtime
+ build others/js_mapperRt.cmi : cc others/js_mapperRt.mli | runtime
+ build others/js_math.cmi others/js_math.cmj : cc others/js_math.ml | others/js_int.cmj runtime
+ build others/js_null.cmj : cc_cmi others/js_null.ml | others/js_exn.cmj others/js_null.cmi runtime


### PR DESCRIPTION
update of bs-platform / buckescript compiler

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
