### PR TITLE
dconf2nix: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3218,6 +3218,12 @@
     githubId = 6768842;
     name = "Joris Guyonvarch";
   };
+  gvolpe = {
+    email = "volpegabriel@gmail.com";
+    github = "gvolpe";
+    githubId = 443978;
+    name = "Gabriel Volpe";
+  };
   hakuch = {
     email = "hakuch@gmail.com";
     github = "hakuch";

--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -10,6 +10,8 @@ self: super: {
   multi-ghc-travis = throw ("haskellPackages.multi-ghc-travis has been renamed"
     + " to haskell-ci, which is now on hackage");
 
+  dconf2nix = self.callPackage ../tools/haskell/dconf2nix/dconf2nix.nix { };
+
   # https://github.com/channable/vaultenv/issues/1
   vaultenv = self.callPackage ../tools/haskell/vaultenv { };
 

--- a/pkgs/development/tools/haskell/dconf2nix/dconf2nix.nix
+++ b/pkgs/development/tools/haskell/dconf2nix/dconf2nix.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, base, containers, fetchgit, optparse-applicative
+, parsec, stdenv, text
+}:
+mkDerivation {
+  pname = "dconf2nix";
+  version = "0.0.5";
+  src = fetchgit {
+    url = "https://github.com/gvolpe/dconf2nix.git";
+    sha256 = "0immbx4bgfq3xmbbrpw441nx0sdpm4cp64s7qbvcbvllp4gbivpg";
+    rev = "848ff9966db21c66e61a19c04ab6dfc9270eb78e";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base containers optparse-applicative parsec text
+  ];
+  executableHaskellDepends = [ base ];
+  description = "Convert dconf files to Nix, as expected by Home Manager";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/pkgs/development/tools/haskell/dconf2nix/default.nix
+++ b/pkgs/development/tools/haskell/dconf2nix/default.nix
@@ -1,0 +1,32 @@
+{ haskell, haskellPackages, lib, runCommand }:
+
+let
+  dconf2nix =
+    haskell.lib.justStaticExecutables
+      (haskell.lib.overrideCabal haskellPackages.dconf2nix (oldAttrs: {
+        maintainers = (oldAttrs.maintainers or []) ++ [
+          lib.maintainers.gvolpe
+        ];
+      }));
+in
+
+dconf2nix.overrideAttrs (oldAttrs: {
+  passthru = (oldAttrs.passthru or {}) // {
+    updateScript = ./update.sh;
+
+    # These tests can be run with the following command.
+    #
+    # $ nix-build -A dconf2nix.passthru.tests
+    tests =
+      runCommand
+        "dconf2nix-tests"
+        {
+          nativeBuildInputs = [
+            dconf2nix
+          ];
+        }
+        ''
+          dconf2nix > $out
+        '';
+  };
+})

--- a/pkgs/development/tools/haskell/dconf2nix/update.sh
+++ b/pkgs/development/tools/haskell/dconf2nix/update.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p cabal2nix curl jq
+#
+# This script will update the dconf2nix derivation to the latest version using
+# cabal2nix.
+
+set -eo pipefail
+
+# This is the directory of this update.sh script.
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# dconf2nix derivation created with cabal2nix.
+dconf2nix_derivation_file="${script_dir}/dconf2nix.nix"
+
+# This is the current revision of dconf2nix in Nixpkgs.
+old_version="$(sed -En 's/.*\bversion = "(.*?)".*/\1/p' "$dconf2nix_derivation_file")"
+
+# This is the latest release version of dconf2nix on GitHub.
+new_version=$(curl --silent "https://api.github.com/repos/gvolpe/dconf2nix/releases" | jq '.[0].tag_name' --raw-output)
+
+echo "Updating dconf2nix from old version $old_version to new version $new_version."
+echo "Running cabal2nix and outputting to ${dconf2nix_derivation_file}..."
+
+cabal2nix --revision "$new_version" "https://github.com/gvolpe/dconf2nix.git" > "$dconf2nix_derivation_file"
+
+echo "Finished."

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2921,6 +2921,8 @@ in
 
   dclxvi = callPackage ../development/libraries/dclxvi { };
 
+  dconf2nix = callPackage ../development/tools/haskell/dconf2nix { };
+
   dcraw = callPackage ../tools/graphics/dcraw { };
 
   dcfldd = callPackage ../tools/system/dcfldd { };


### PR DESCRIPTION
###### Motivation for this change

To make the [dconf2nix](https://github.com/gvolpe/dconf2nix) package available on Nixpkgs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
