### PR TITLE
Font joypixels emoji

### DIFF
--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, acceptLicense ? false }:
+{ stdenv, fetchurl, config
+, acceptLicense ? config.joypixels.acceptLicense or false
+}:
 
 let inherit (stdenv.hostPlatform) system;
 
@@ -40,8 +42,9 @@ assert !acceptLicense -> throw ''
     - ${joypixels-free-license.fullName} [1]
     - ${joypixels-license-appendix.fullName} [2]
 
-  You can express acceptance by overriding acceptLicense:
-    (joypixels.override { acceptLicense = true; })
+  You can express acceptance by setting acceptLicense to true in your
+  configuration (configuration.nix or config.nix):
+    joypixels.acceptLicense = true;
 
   [1]: ${joypixels-free-license.url}
   [2]: ${joypixels-license-appendix.url}

--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -2,17 +2,17 @@
 , acceptLicense ? config.joypixels.acceptLicense or false
 }:
 
-let inherit (stdenv.hostPlatform) system;
+let inherit (stdenv.hostPlatform.parsed) kernel;
 
     systemSpecific = {
-      x86_64-darwin = rec {
+      darwin = rec {
         systemTag =  "nix-darwin";
         capitalized = systemTag;
         ext = "ttc";
         fontFile = "Apple%20Color%20Emoji.ttc";
         name = "joypixels-apple-color-emoji.ttc";
       };
-    }.${system} or rec {
+    }.${kernel.name} or rec {
         systemTag = "nix-os";
         capitalized = "NixOS";
         ext = "ttf";
@@ -55,8 +55,8 @@ stdenv.mkDerivation rec {
     inherit name;
     url = "https://cdn.joypixels.com/distributions/${systemTag}/font/${version}/${fontFile}";
     sha256 = {
-      x86_64-darwin = "043980g0dlp8vd4qkbx6298fwz8ns0iwbxm0f8czd9s7n2xm4npq";
-    }.${system} or "1vxqsqs93g4jyp01r47lrpcm0fmib2n1vysx32ksmfxmprimb75s";
+      darwin = "043980g0dlp8vd4qkbx6298fwz8ns0iwbxm0f8czd9s7n2xm4npq";
+    }.${kernel.name} or "1vxqsqs93g4jyp01r47lrpcm0fmib2n1vysx32ksmfxmprimb75s";
   };
 
   dontUnpack = true;

--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -42,7 +42,15 @@ assert !acceptLicense -> throw ''
     - ${joypixels-license-appendix.fullName} [2]
 
   You can express acceptance by setting acceptLicense to true in your
-  configuration (configuration.nix or config.nix):
+  configuration. Note that this is not a free license so it requires allowing
+  unfree licenses.
+
+  configuration.nix:
+    nixpkgs.config.allowUnfree = true;
+    nixpkgs.config.joypixels.acceptLicense = true;
+  
+  config.nix:
+    allowUnfree = true;
     joypixels.acceptLicense = true;
 
   [1]: ${joypixels-free-license.url}

--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -1,24 +1,51 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
+  inherit (stdenv.hostPlatform) system;
+
+  throwSystem = throw "Unsupported system: ${system}";
+
   pname = "joypixels";
   version = "6.0.0";
 
+  url = {
+    x86_64-darwin = "https://cdn.joypixels.com/distributions/nix-darwin/font/6.0.0/Apple%20Color%20Emoji.ttc";
+    x86_64-linux = "https://cdn.joypixels.com/distributions/nix-os/font/${version}/joypixels-android.ttf";
+  }.${system} or throwSystem;
+
+  name = {
+    x86_64-darwin = "joypixels-apple-color-emoji.ttc";
+    x86_64-linux = "joypixels-android.ttf";
+  }.${system} or throwSystem;
+
+  sha256 = {
+    x86_64-darwin = "043980g0dlp8vd4qkbx6298fwz8ns0iwbxm0f8czd9s7n2xm4npq";
+    x86_64-linux = "1vxqsqs93g4jyp01r47lrpcm0fmib2n1vysx32ksmfxmprimb75s";
+  }.${system} or throwSystem;
+
   src = fetchurl {
-    url = "https://cdn.joypixels.com/distributions/nix-os/font/${version}/joypixels-android.ttf";
-    sha256 = "1vxqsqs93g4jyp01r47lrpcm0fmib2n1vysx32ksmfxmprimb75s";
+    inherit url name sha256;
   };
 
   dontUnpack = true;
 
-  installPhase = ''
-    install -Dm644 $src $out/share/fonts/truetype/joypixels.ttf
-  '';
+  installPhase = {
+    x86_64-darwin = ''
+      install -Dm644 $src $out/share/fonts/truetype/joypixels.ttc
+    '';
+    x86_64-linux = ''
+      install -Dm644 $src $out/share/fonts/truetype/joypixels.ttf
+    '';
+  }.${system} or throwSystem;
 
   meta = with stdenv.lib; {
     description = "Emoji as a Service (formerly EmojiOne)";
     homepage = "https://www.joypixels.com/";
     license = licenses.unfree;
     maintainers = with maintainers; [ toonn jtojnar ];
+    platforms = [
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   };
 }

--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -13,7 +13,7 @@ let inherit (stdenv.hostPlatform.parsed) kernel;
         name = "joypixels-apple-color-emoji.ttc";
       };
     }.${kernel.name} or rec {
-        systemTag = "nix-os";
+        systemTag = "nixos";
         capitalized = "NixOS";
         ext = "ttf";
         fontFile = "joypixels-android.ttf";

--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -24,12 +24,14 @@ let inherit (stdenv.hostPlatform.parsed) kernel;
       spdxId = "LicenseRef-JoyPixels-Free-6.0";
       fullName = "JoyPixels Free License Agreement 6.0";
       url = "https://cdn.joypixels.com/distributions/${systemTag}/license/free-license.pdf";
+      free = false;
     };
 
     joypixels-license-appendix = with systemSpecific; {
       spdxId = "LicenseRef-JoyPixels-NixOS-Appendix";
       fullName = "JoyPixels ${capitalized} License Appendix";
       url = "https://cdn.joypixels.com/distributions/${systemTag}/appendix/joypixels-license-appendix.pdf";
+      free = false;
     };
 
 in
@@ -80,6 +82,7 @@ stdenv.mkDerivation rec {
         fullName = "${free-license.fullName} with ${appendix.fullName}";
         url = free-license.url;
         appendixUrl = appendix.url;
+        free = false;
       };
     maintainers = with maintainers; [ toonn jtojnar ];
   };

--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -1,42 +1,55 @@
 { stdenv, fetchurl }:
 
+let inherit (stdenv.hostPlatform) system;
+
+    throwSystem = throw "Unsupported system: ${system}";
+
+    systemTag = {
+      x86_64-darwin = "nix-darwin";
+      x86_64-linux = "nix-os";
+    }.${system} or throwSystem;
+
+    capitalized = {
+      x86_64-darwin = systemTag;
+      x86_64-linux = "NixOS";
+    }.${system} or throwSystem;
+
+    fontFile = {
+      x86_64-darwin = "Apple%20Color%20Emoji.ttc";
+      x86_64-linux = "joypixels-android.ttf";
+    }.${system} or throwSystem;
+
+    name = {
+      x86_64-darwin = "joypixels-apple-color-emoji.ttc";
+      x86_64-linux = fontFile;
+    }.${system} or throwSystem;
+
+    ext = {
+      x86_64-darwin = "ttc";
+      x86_64-linux = "ttf";
+    }.${system} or throwSystem;
+
+    sha256 = {
+      x86_64-darwin = "043980g0dlp8vd4qkbx6298fwz8ns0iwbxm0f8czd9s7n2xm4npq";
+      x86_64-linux = "1vxqsqs93g4jyp01r47lrpcm0fmib2n1vysx32ksmfxmprimb75s";
+    }.${system} or throwSystem;
+
+in
+
 stdenv.mkDerivation rec {
-  inherit (stdenv.hostPlatform) system;
-
-  throwSystem = throw "Unsupported system: ${system}";
-
   pname = "joypixels";
   version = "6.0.0";
 
-  url = {
-    x86_64-darwin = "https://cdn.joypixels.com/distributions/nix-darwin/font/6.0.0/Apple%20Color%20Emoji.ttc";
-    x86_64-linux = "https://cdn.joypixels.com/distributions/nix-os/font/${version}/joypixels-android.ttf";
-  }.${system} or throwSystem;
-
-  name = {
-    x86_64-darwin = "joypixels-apple-color-emoji.ttc";
-    x86_64-linux = "joypixels-android.ttf";
-  }.${system} or throwSystem;
-
-  sha256 = {
-    x86_64-darwin = "043980g0dlp8vd4qkbx6298fwz8ns0iwbxm0f8czd9s7n2xm4npq";
-    x86_64-linux = "1vxqsqs93g4jyp01r47lrpcm0fmib2n1vysx32ksmfxmprimb75s";
-  }.${system} or throwSystem;
-
   src = fetchurl {
-    inherit url name sha256;
+    inherit name sha256;
+    url = "https://cdn.joypixels.com/distributions/${systemTag}/font/${version}/${fontFile}";
   };
 
   dontUnpack = true;
 
-  installPhase = {
-    x86_64-darwin = ''
-      install -Dm644 $src $out/share/fonts/truetype/joypixels.ttc
-    '';
-    x86_64-linux = ''
-      install -Dm644 $src $out/share/fonts/truetype/joypixels.ttf
-    '';
-  }.${system} or throwSystem;
+  installPhase = ''
+    install -Dm644 $src $out/share/fonts/truetype/joypixels.${ext}
+  '';
 
   meta = with stdenv.lib; {
     description = "Emoji as a Service (formerly EmojiOne)";

--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -4,46 +4,34 @@ let inherit (stdenv.hostPlatform) system;
 
     throwSystem = throw "Unsupported system: ${system}";
 
-    systemTag = {
-      x86_64-darwin = "nix-darwin";
-      x86_64-linux = "nix-os";
+    systemSpecific = {
+      x86_64-darwin = rec {
+        systemTag =  "nix-darwin";
+        capitalized = systemTag;
+        ext = "ttc";
+        fontFile = "Apple%20Color%20Emoji.ttc";
+        name = "joypixels-apple-color-emoji.ttc";
+      };
+      x86_64-linux = rec {
+        systemTag = "nix-os";
+        capitalized = "NixOS";
+        ext = "ttf";
+        fontFile = "joypixels-android.ttf";
+        name = fontFile;
+      };
     }.${system} or throwSystem;
 
-    capitalized = {
-      x86_64-darwin = systemTag;
-      x86_64-linux = "NixOS";
-    }.${system} or throwSystem;
-
-    fontFile = {
-      x86_64-darwin = "Apple%20Color%20Emoji.ttc";
-      x86_64-linux = "joypixels-android.ttf";
-    }.${system} or throwSystem;
-
-    name = {
-      x86_64-darwin = "joypixels-apple-color-emoji.ttc";
-      x86_64-linux = fontFile;
-    }.${system} or throwSystem;
-
-    ext = {
-      x86_64-darwin = "ttc";
-      x86_64-linux = "ttf";
-    }.${system} or throwSystem;
-
-    joypixels-free-license = {
+    joypixels-free-license = with systemSpecific; {
       spdxId = "LicenseRef-JoyPixels-Free-6.0";
       fullName = "JoyPixels Free License Agreement 6.0";
       url = "https://cdn.joypixels.com/distributions/${systemTag}/license/free-license.pdf";
     };
-    joypixels-license-appendix = {
+
+    joypixels-license-appendix = with systemSpecific; {
       spdxId = "LicenseRef-JoyPixels-NixOS-Appendix";
       fullName = "JoyPixels ${capitalized} License Appendix";
       url = "https://cdn.joypixels.com/distributions/${systemTag}/appendix/joypixels-license-appendix.pdf";
     };
-
-    sha256 = {
-      x86_64-darwin = "043980g0dlp8vd4qkbx6298fwz8ns0iwbxm0f8czd9s7n2xm4npq";
-      x86_64-linux = "1vxqsqs93g4jyp01r47lrpcm0fmib2n1vysx32ksmfxmprimb75s";
-    }.${system} or throwSystem;
 
 in
 
@@ -63,14 +51,18 @@ stdenv.mkDerivation rec {
   pname = "joypixels";
   version = "6.0.0";
 
-  src = fetchurl {
-    inherit name sha256;
+  src = with systemSpecific; fetchurl {
+    inherit name;
     url = "https://cdn.joypixels.com/distributions/${systemTag}/font/${version}/${fontFile}";
+    sha256 = {
+      x86_64-darwin = "043980g0dlp8vd4qkbx6298fwz8ns0iwbxm0f8czd9s7n2xm4npq";
+      x86_64-linux = "1vxqsqs93g4jyp01r47lrpcm0fmib2n1vysx32ksmfxmprimb75s";
+    }.${system} or throwSystem;
   };
 
   dontUnpack = true;
 
-  installPhase = ''
+  installPhase = with systemSpecific; ''
     install -Dm644 $src $out/share/fonts/truetype/joypixels.${ext}
   '';
 

--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -4,8 +4,6 @@
 
 let inherit (stdenv.hostPlatform) system;
 
-    throwSystem = throw "Unsupported system: ${system}";
-
     systemSpecific = {
       x86_64-darwin = rec {
         systemTag =  "nix-darwin";
@@ -14,14 +12,13 @@ let inherit (stdenv.hostPlatform) system;
         fontFile = "Apple%20Color%20Emoji.ttc";
         name = "joypixels-apple-color-emoji.ttc";
       };
-      x86_64-linux = rec {
+    }.${system} or rec {
         systemTag = "nix-os";
         capitalized = "NixOS";
         ext = "ttf";
         fontFile = "joypixels-android.ttf";
         name = fontFile;
       };
-    }.${system} or throwSystem;
 
     joypixels-free-license = with systemSpecific; {
       spdxId = "LicenseRef-JoyPixels-Free-6.0";
@@ -59,8 +56,7 @@ stdenv.mkDerivation rec {
     url = "https://cdn.joypixels.com/distributions/${systemTag}/font/${version}/${fontFile}";
     sha256 = {
       x86_64-darwin = "043980g0dlp8vd4qkbx6298fwz8ns0iwbxm0f8czd9s7n2xm4npq";
-      x86_64-linux = "1vxqsqs93g4jyp01r47lrpcm0fmib2n1vysx32ksmfxmprimb75s";
-    }.${system} or throwSystem;
+    }.${system} or "1vxqsqs93g4jyp01r47lrpcm0fmib2n1vysx32ksmfxmprimb75s";
   };
 
   dontUnpack = true;

--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -8,16 +8,12 @@ let inherit (stdenv.hostPlatform.parsed) kernel;
       darwin = rec {
         systemTag =  "nix-darwin";
         capitalized = systemTag;
-        ext = "ttc";
-        fontFile = "Apple%20Color%20Emoji.ttc";
-        name = "joypixels-apple-color-emoji.ttc";
+        fontFile = "JoyPixels-SBIX.ttf";
       };
     }.${kernel.name} or rec {
         systemTag = "nixos";
         capitalized = "NixOS";
-        ext = "ttf";
         fontFile = "joypixels-android.ttf";
-        name = fontFile;
       };
 
     joypixels-free-license = with systemSpecific; {
@@ -46,7 +42,7 @@ let inherit (stdenv.hostPlatform.parsed) kernel;
       configuration.nix:
         nixpkgs.config.allowUnfree = true;
         nixpkgs.config.joypixels.acceptLicense = true;
-      
+
       config.nix:
         allowUnfree = true;
         joypixels.acceptLicense = true;
@@ -63,17 +59,17 @@ stdenv.mkDerivation rec {
 
   src = assert !acceptLicense -> throwLicense;
     with systemSpecific; fetchurl {
-      inherit name;
+      name = fontFile;
       url = "https://cdn.joypixels.com/distributions/${systemTag}/font/${version}/${fontFile}";
       sha256 = {
-        darwin = "043980g0dlp8vd4qkbx6298fwz8ns0iwbxm0f8czd9s7n2xm4npq";
+        darwin = "1s1dibgpv4lc9cwbgykgwjxxhg2rbn5g9fyd10r6apj9xhfn8cyn";
       }.${kernel.name} or "1vxqsqs93g4jyp01r47lrpcm0fmib2n1vysx32ksmfxmprimb75s";
     };
 
   dontUnpack = true;
 
   installPhase = with systemSpecific; ''
-    install -Dm644 $src $out/share/fonts/truetype/joypixels.${ext}
+    install -Dm644 $src $out/share/fonts/truetype/${fontFile}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "6.0.0";
 
   src = fetchurl {
-    url = "https://cdn.joypixels.com/arch-linux/font/${version}/joypixels-android.ttf";
+    url = "https://cdn.joypixels.com/distributions/nix-os/font/${version}/joypixels-android.ttf";
     sha256 = "1vxqsqs93g4jyp01r47lrpcm0fmib2n1vysx32ksmfxmprimb75s";
   };
 
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     description = "Emoji as a Service (formerly EmojiOne)";
     homepage = "https://www.joypixels.com/";
     license = licenses.unfree;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ toonn jtojnar ];
   };
 }

--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -52,13 +52,14 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Emoji as a Service (formerly EmojiOne)";
-    homepage = "https://www.joypixels.com/";
+    description = "The finest emoji you can use legally (formerly EmojiOne)";
+    longDescription = ''
+      New for 2020! JoyPixels 6.0 includes 3,342 originally crafted icon
+      designs and is 100% Unicode 13 compatible. We offer the largest selection
+      of files ranging from png, svg, iconjar, sprites, and fonts.
+    '';
+    homepage = "https://www.joypixels.com/fonts";
     license = licenses.unfree;
     maintainers = with maintainers; [ toonn jtojnar ];
-    platforms = [
-      "x86_64-darwin"
-      "x86_64-linux"
-    ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The JoyPixels emoji font (formerly EmojiOne) was packaged using a CDN endpoint created for Arch Linux.
Arch Linux received an altered license for distribution of the font. Furthermore,  the license requires explicit acceptance from users. And last but not least, as-is the font doesn't work on macOS.

I expect foss licenses to be complied to. In turn, this means we should respect the terms other projects put in their licenses. I contacted the JoyPixels licensing team and they were happy to provide CDN endpoints and similarly altered licenses for distribution of their font for NixOS and nix-darwin.

I altered the expression to work on macOS, which requires downloading and installing a "TrueType Collection" file rather than the TrueType font file. I also updated the licensing information and the package now requires an override to indicate acceptance of the license before you can install it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
