### PR TITLE
firefox: add firefox-policies w/ patch

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/enterprise-policies.patch
+++ b/pkgs/applications/networking/browsers/firefox/enterprise-policies.patch
@@ -1,0 +1,46 @@
+This patch allows for Firefox to load a policies.json file on a pr. profile basis.
+This means that for each profile in ~/.mozilla/firefox/<profile>, there can be one
+`policies.json` file, which will get parsed/executed when running Firefox with the
+given profile. The reason for this is, to allow to customze your profile with 
+extensions, settings, bookmarks, etc. as can be found here: 
+https://github.com/mozilla/policy-templates/blob/master/README.md
+
+This is meant to be used in conjuction with home-manager, to provide a greater level
+of costomization.
+
+KEEP IN MIND! This opens up for the possibilty to sideload extensions into Firefox, 
+which was dropped at it sometimes cause issues for users + used to sideload maleware.
+https://blog.mozilla.org/addons/2019/10/31/firefox-to-discontinue-sideloaded-extensions/
+This however should not be as big of a issue with Nix users, as the general Firefox is 
+targeted towards both advanced users + novice, whereas Nix will have a tedency towards
+advanced users.
+
+diff --git a/toolkit/components/enterprisepolicies/EnterprisePolicies.js b/toolkit/components/enterprisepolicies/EnterprisePolicies.js
+index b4742ee123..87556bd43a 100644
+--- a/toolkit/components/enterprisepolicies/EnterprisePolicies.js
++++ b/toolkit/components/enterprisepolicies/EnterprisePolicies.js
+@@ -26,6 +26,11 @@ const POLICIES_FILENAME = "policies.json";
+ // When true browser policy is loaded per-user from
+ // /run/user/$UID/appname
+ const PREF_PER_USER_DIR = "toolkit.policies.perUserDir";
++// used to specify where to load the policies from.
++// value of `1` means to use the dir `/run/user/$UID/appname`, whereas
++// a value of `2` will use the profile dir, to load the `policies.json`.
++// `/etc/firefox/policies/policies.json` overrides everything else.
++const PREF_POLICIES_LOADFROM_DIR = "toolkit.policies.loadFrom";
+ // For easy testing, modify the helpers/sample.json file,
+ // and set PREF_ALTERNATE_PATH in firefox.js as:
+ // /your/repo/browser/components/enterprisepolicies/helpers/sample.json
+@@ -490,8 +495,11 @@ class JSONPoliciesProvider {
+ 
+     try {
+       let perUserPath = Services.prefs.getBoolPref(PREF_PER_USER_DIR, false);
+-      if (perUserPath) {
++      let loadFromDir = Services.prefs.getIntPref(PREF_POLICIES_LOADFROM_DIR, 0);
++      if (perUserPath || loadFromDir == 1) {
+         configFile = Services.dirsvc.get("XREUserRunTimeDir", Ci.nsIFile);
++      } else if (loadFromDir == 2) {
++        configFile = Services.dirsvc.get("ProfD", Ci.nsIFile);
+       } else {
+         configFile = Services.dirsvc.get("XREAppDist", Ci.nsIFile);
+       }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -61,4 +61,11 @@ rec {
       versionKey = "ffversion";
     };
   };
+
+  # apply enterprise-policies.patch so that we can have enterprise policies
+  # on a pr. profile basis, instead of pr. user or global for the installation.
+  # see patch for more information of pros/cons of this patch
+  firefox-policies = firefox.overrideAttrs(old: {
+    patches = old.patches ++ [ ./enterprise-policies.patch ];
+  });
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20806,6 +20806,7 @@ in
   firefox-unwrapped = firefoxPackages.firefox;
   firefox-esr-78-unwrapped = firefoxPackages.firefox-esr-78;
   firefox = wrapFirefox firefox-unwrapped { };
+
   firefox-wayland = wrapFirefox firefox-unwrapped { forceWayland = true; };
   firefox-esr-78 = wrapFirefox firefox-esr-78-unwrapped { };
   firefox-esr = firefox-esr-78;
@@ -20843,6 +20844,8 @@ in
     pname = "firefox-devedition-bin";
     desktopName = "Firefox DevEdition";
   };
+
+  firefox-policies = wrapFirefox firefoxPackages.firefox-policies { };
 
   flac = callPackage ../applications/audio/flac { };
 


### PR DESCRIPTION
###### Motivation for this change
Allows for enterprise policies `policies.json` to be specified on a pr.
profile basis, instead of pr. user/global. This could pose a security
rist IF NOT because it is already possible to do as it can be placed in
`/run/user/:uid`.

This is heavily for use in home-manager, where configuring on a pr.
profile basis is nice/needed. This is placed in nixpkgs, as we would
like to cache the `firefox-policies`, as it is quite heavy to compile
yourself each time.

There has been some questions regarding if this is a sane commit, regards to branding which was described here - https://github.com/NixOS/nixpkgs/issues/31843#issuecomment-346372756

I have asked Sylvestre in chat.mozilla.org and has said it is a `portability modification`.
![2020_08_07-15:04:11](https://user-images.githubusercontent.com/25955146/89692695-ae942200-d90c-11ea-9a94-d390696179a2.png)

Besides this, the legal department has said OK for it, if Sylvestre said OK.

```
Hi <removed>,

At a high-level that sounds okay though I would usually check-in with Sylvestre to make sure he is comfortable with that the changes really are very minor and don't impact the experience of the product (since I am a lawyer and not an engineer). Sounds like you were able to connect but let me know if you need anything further.

Best,
Daniel
```
The patch is fairly trivial in general, but I am unsure if it should be placed elsewhere?
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
