### PR TITLE
arduino-cli: init at 0.11.0

### DIFF
--- a/pkgs/development/arduino/arduino-cli/default.nix
+++ b/pkgs/development/arduino/arduino-cli/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, buildGoModule, fetchFromGitHub, buildFHSUserEnv }:
+
+let
+
+  pkg = buildGoModule rec {
+    pname = "arduino-cli";
+    version = "0.11.0";
+
+    src = fetchFromGitHub {
+      owner = "arduino";
+      repo = pname;
+      rev = version;
+      sha256 = "0k9091ci7n7hl44nyzlxkmbwibgrrh9s6z7pgyj9v0mzxjmgz8h2";
+    };
+
+    subPackages = [ "." ];
+
+    vendorSha256 = "1qybym95a38az8lk8bqc53ngn08hijckajv8v2giifc4q7sb17d2";
+
+    buildFlagsArray = [
+      "-ldflags=-s -w -X github.com/arduino/arduino-cli/version.versionString=${version} -X github.com/arduino/arduino-cli/version.commit=unknown"
+    ] ++ stdenv.lib.optionals stdenv.isLinux [ "-extldflags '-static'" ];
+
+    meta = with stdenv.lib; {
+      inherit (src.meta) homepage;
+      description = "Arduino from the command line";
+      license = licenses.gpl3Only;
+      maintainers = with maintainers; [ ryantm ];
+    };
+
+  };
+
+# buildFHSUserEnv is needed because the arduino-cli downloads compiler
+# toolchains from the internet that have their interpreters pointed at
+# /lib64/ld-linux-x86-64.so.2
+in buildFHSUserEnv {
+  inherit (pkg) name meta;
+
+  runScript = "${pkg.outPath}/bin/arduino-cli";
+
+  extraInstallCommands = ''
+    mv $out/bin/$name $out/bin/arduino-cli
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -719,6 +719,8 @@ in
 
   arduino = arduino-core.override { withGui = true; };
 
+  arduino-cli = callPackage ../development/arduino/arduino-cli { };
+
   arduino-core = callPackage ../development/arduino/arduino-core { };
 
   arduino-mk = callPackage ../development/arduino/arduino-mk {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Arduino is a popular microcontroller development board ecosystem and arduino-cli is the flagship command line utility for interacting with Arduino projects.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
