### PR TITLE
Adding two jupyterhub spawners: dockerspawner, batchspawner

### DIFF
--- a/pkgs/development/python-modules/batchspawner/default.nix
+++ b/pkgs/development/python-modules/batchspawner/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, jupyterhub
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "batchspawner";
+  version = "1.0.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "jupyterhub";
+    repo = "batchspawner";
+    rev = "v${version}";
+    sha256 = "0yn312sjfjpjjfciagbczfmqprk2fj4lbb3vsbzj17p948acq5w2";
+  };
+
+  propagatedBuildInputs = [
+    jupyterhub
+  ];
+
+  # tests require a job scheduler e.g. slurm, pbs, etc.
+  doCheck = false;
+
+  pythonImportCheck = [ "batchspawner" ];
+
+  meta = with lib; {
+    description = "A spawner for Jupyterhub to spawn notebooks using batch resource managers";
+    homepage = "https://jupyter.org";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/dockerspawner/default.nix
+++ b/pkgs/development/python-modules/dockerspawner/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, jupyterhub
+, escapism
+, docker
+}:
+
+buildPythonPackage rec {
+  pname = "dockerspawner";
+  version = "0.11.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "83fd8ee012bb32432cb57bd408ff65534749aed8696648e6ac029a87fc474928";
+  };
+
+  propagatedBuildInputs = [
+    jupyterhub
+    escapism
+    docker
+  ];
+
+  # tests require docker
+  doCheck = false;
+
+  pythonImportCheck = [ "dockerspawner" ];
+
+  meta = with lib; {
+    description = "Dockerspawner: A custom spawner for Jupyterhub";
+    homepage = "https://jupyter.org";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5437,6 +5437,8 @@ in {
 
   babelgladeextractor = callPackage ../development/python-modules/babelgladeextractor { };
 
+  batchspawner = callPackage ../development/python-modules/batchspawner { };
+
   pybfd = callPackage ../development/python-modules/pybfd { };
 
   pybigwig = callPackage ../development/python-modules/pybigwig { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2870,6 +2870,8 @@ in {
 
   dockerpty = callPackage ../development/python-modules/dockerpty {};
 
+  dockerspawner = callPackage ../development/python-modules/dockerspawner {};
+
   docker_pycreds = callPackage ../development/python-modules/docker-pycreds {};
 
   docloud = callPackage ../development/python-modules/docloud { };


### PR DESCRIPTION
###### Motivation for this change

In my work to create a jupyterhub nixos service I also wanted to provide modules that will allow for more spawning formats. Especially since my first use of the nixos jupyterhub service is to run a reproducible slurm cluster (which requires batchspawner).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
