### PR TITLE
[WIP] xfce.xfce4-vala-panel-appmenu-plugin: 0.7.3.0 -> 0.7.3.2

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-vala-panel-appmenu-plugin/appmenu-gtk-module.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-vala-panel-appmenu-plugin/appmenu-gtk-module.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, vala, glib, gtk2, gtk3 }:
 stdenv.mkDerivation rec {
   pname = "vala-panel-appmenu-xfce";
-  version = "0.6.94";
+  version = "0.7.3.2";
 
   src = "${fetchFromGitHub {
     owner = "rilian-la-te";
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Port of the Unity GTK Module";
-    license = licenses.lgpl3;
+    license = licenses.lgpl3Only;
     maintainers = with maintainers; [ jD91mZM2 ];
   };
 }

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-vala-panel-appmenu-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-vala-panel-appmenu-plugin/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchFromGitHub, substituteAll, callPackage, pkgconfig, cmake, vala, libxml2,
   glib, pcre, gtk2, gtk3, xorg, libxkbcommon, epoxy, at-spi2-core, dbus-glib, bamf,
-  xfce, libwnck3, libdbusmenu, gobject-introspection }:
+  xfce, libwnck3, libdbusmenu, gobject-introspection, harfbuzz }:
 
 stdenv.mkDerivation rec {
   pname = "xfce4-vala-panel-appmenu-plugin";
-  version = "0.7.3";
+  version = "0.7.3.2";
 
   src = fetchFromGitHub {
     owner = "rilian-la-te";
@@ -12,14 +12,14 @@ stdenv.mkDerivation rec {
     rev = version;
     fetchSubmodules = true;
 
-    sha256 = "06rykdr2c9rnzxwinwdynd73v9wf0gjkx6qfva7sx2n94ajsdnaw";
+    sha256 = "0xxn3zs60a9nfix8wrdp056wviq281cm1031hznzf1l38lp3wr5p";
   };
 
   nativeBuildInputs = [ pkgconfig cmake vala libxml2.bin ];
   buildInputs = [ (callPackage ./appmenu-gtk-module.nix {})
                   glib pcre gtk2 gtk3 xorg.libpthreadstubs xorg.libXdmcp libxkbcommon epoxy
                   at-spi2-core dbus-glib bamf xfce.xfce4panel_gtk3 xfce.libxfce4util xfce.xfconf
-                  libwnck3 libdbusmenu gobject-introspection ];
+                  libwnck3 libdbusmenu gobject-introspection harfbuzz ];
 
   patches = [
     (substituteAll {
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
       bamf = bamf;
     })
   ];
+
+  configureFlags = [ "CPPFLAGS=-I${harfbuzz}/include/harfbuzz" ];
 
   cmakeFlags = [
       "-DENABLE_XFCE=ON"
@@ -49,8 +51,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Global Menu applet for XFCE4";
-    license = licenses.lgpl3;
+    license = licenses.lgpl3Only;
     maintainers = with maintainers; [ jD91mZM2 ];
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

xfce.xfce4-vala-panel-appmenu-plugin: 0.7.3.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
