### PR TITLE
bazelisk: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/development/tools/bazelisk/default.nix
+++ b/pkgs/development/tools/bazelisk/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "bazelisk";
-  version = "1.5.0";
+  version = "1.6.0";
 
   patches = [ ./gomod.patch ];
 
@@ -10,10 +10,10 @@ buildGoModule rec {
     owner = "bazelbuild";
     repo = pname;
     rev = "v${version}";
-    sha256 = "06vimiklcprsxq7l6rmxshv8l0kjr7aanpm206qgx3wvw4shibmw";
+    sha256 = "0l1032c0nqbdyasq6f8yf0vph06w6v81w044fs70rgzsa91m038r";
   };
 
-  vendorSha256 = "11iwgrnid0f8sq9f23m1a3s55sc7lpl60phykmd9ss4xs39bapl5";
+  vendorSha256 = "1jgm6j04glvk7ib5yd0h04p9qxzl1ca100cv909kngx52jp61yxp";
 
   buildFlagsArray = [ "-ldflags=-s -w -X main.BazeliskVersion=${version}" ];
 

--- a/pkgs/development/tools/bazelisk/gomod.patch
+++ b/pkgs/development/tools/bazelisk/gomod.patch
@@ -6,7 +6,7 @@ index 8eef134..54382cb 100644
  go 1.14
  
  require (
-+	github.com/bazelbuild/rules_go v0.23.3
++	github.com/bazelbuild/rules_go v0.23.7
  	github.com/hashicorp/go-version v1.2.0
  	github.com/mitchellh/go-homedir v1.1.0
  )


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/bazelbuild/bazelisk/releases/tag/v1.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
