### PR TITLE
vale: 2.2.2 -> 2.3.0

### DIFF
--- a/pkgs/tools/text/vale/default.nix
+++ b/pkgs/tools/text/vale/default.nix
@@ -2,27 +2,22 @@
 
 buildGoModule rec {
   pname = "vale";
-  version = "2.2.2";
+  version = "2.3.0";
 
   subPackages = [ "." ];
-  outputs = ["out" "doc" "data"];
+  outputs = [ "out" "data" ];
 
   src = fetchFromGitHub {
     owner  = "errata-ai";
     repo   = "vale";
     rev    = "v${version}";
-    sha256 = "11pgszm9cb65liczpnq04l1rx0v68jgmkzrw7ax5kln5hgnrh4kb";
+    sha256 = "0jxlh8dlhhqw1mrhp42nywnp6wwpk7nw373s89lp3khhqwb1n08f";
   };
 
-  deleteVendor = true;
+  vendorSha256 = null;
 
-  vendorSha256 = "150pvy94vfjvn74d63az917szixw1nhl60y1adixg8xqpcjnv9hj";
-
-  goPackagePath = "github.com/errata-ai/vale";
   postInstall = ''
-    mkdir -p $doc/share/doc/vale
     mkdir -p $data/share/vale
-    cp -r docs/* $doc/share/doc/vale
     cp -r styles $data/share/vale
   '';
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/errata-ai/vale/releases/tag/v2.3.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
