### PR TITLE
kodi: 18.6 -> 18.8

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -44,15 +44,15 @@ assert vdpauSupport -> libvdpau != null;
 assert useWayland -> wayland != null && wayland-protocols != null && waylandpp != null && libxkbcommon != null;
 
 let
-  kodiReleaseDate = "20200301";
-  kodiVersion = "18.6";
+  kodiReleaseDate = "20200728";
+  kodiVersion = "18.8";
   rel = "Leia";
 
   kodi_src = fetchFromGitHub {
     owner  = "xbmc";
     repo   = "xbmc";
     rev    = "${kodiVersion}-${rel}";
-    sha256 = "0rwymipn5hljy5xrslzmrljmj6f9wb191wi7gjw20wl6sv44d0bk";
+    sha256 = "0qpkpz43s207msvv3qkiy6vzqwcgmydxv3py7vc29mv6h30chrva";
   };
 
   cmakeProto = fetchurl {
@@ -192,8 +192,8 @@ in stdenv.mkDerivation {
     ++ lib.optional  usbSupport      libusb-compat-0_1
     ++ lib.optional  vdpauSupport    libvdpau
     ++ lib.optionals useWayland [
-      wayland 
-      waylandpp.dev 
+      wayland
+      waylandpp.dev
       wayland-protocols
       # Not sure why ".dev" is needed here, but CMake doesn't find libxkbcommon otherwise
       libxkbcommon.dev


### PR DESCRIPTION
###### Motivation for this change

Version upgrade, but also I was getting a build error with the current version and from some searching it looked like a fix had been implemented in 18.8. 18.8 builds for me without issue.

```
[ 37%] Linking CXX static library music_tags.a
[ 37%] Built target music_tags
/build/source/xbmc/network/WebServer.cpp: In member function 'void CWebServer::SetupPostDataProcessing(const HTTPRequest&, CWebServer::ConnectionHandler*, std::shared_ptr<IHTTPRequestHandler>, void**) const':
/build/source/xbmc/network/WebServer.cpp:503:106: error: invalid conversion from 'int (*)(void*, MHD_ValueKind, const char*, const char*, const char*, const char*, const char*, uint64_t, size_t)' {aka 'int (*)(void*, MHD_ValueKind, const char*, const char*, const char*, const char*, const char*, long unsigned int, long unsigned int)'} to 'MHD_PostDataIterator' {aka 'MHD_Result (*)(void*, MHD_ValueKind, const char*, const char*, const char*, const char*, const char*, long unsigned int, long unsigned int)'} [-fpermissive]
  503 |   connectionHandler->postprocessor = MHD_create_post_processor(request.connection, MAX_POST_BUFFER_SIZE, &CWebServer::HandlePostField, static_cast<void*>(connectionHandler));
      |                                                                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                          |
      |                                                                                                          int (*)(void*, MHD_ValueKind, const char*, const char*, const char*, const char*, const char*, uint64_t, size_t) {aka int (*)(void*, MHD_ValueKind, const char*, const char*, const char*, const char*, const char*, long unsigned int, long unsigned int)}
In file included from /build/source/xbmc/network/httprequesthandler/IHTTPRequestHandler.h:21,
                 from /build/source/xbmc/network/WebServer.h:14,
                 from /build/source/xbmc/network/WebServer.cpp:9:
/nix/store/c5mbgq649szrf1wl409n13c7wdrba3q9-libmicrohttpd-0.9.71-dev/include/microhttpd.h:3465:49: note:   initializing argument 3 of 'MHD_PostProcessor* MHD_create_post_processor(MHD_Connection*, size_t, MHD_PostDataIterator, void*)'
 3465 |                            MHD_PostDataIterator iter, void *iter_cls);
      |                            ~~~~~~~~~~~~~~~~~~~~~^~~~
/build/source/xbmc/network/WebServer.cpp: In member function 'MHD_Daemon* CWebServer::StartMHD(unsigned int, int)':
/build/source/xbmc/network/WebServer.cpp:1127:27: error: invalid conversion from 'int (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, size_t*, void**)' {aka 'int (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, long unsigned int*, void**)'} to 'MHD_AccessHandlerCallback' {aka 'MHD_Result (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, long unsigned int*, void**)'} [-fpermissive]
 1127 |                           &CWebServer::AnswerToConnection,
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                           |
      |                           int (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, size_t*, void**) {aka int (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, long unsigned int*, void**)}
In file included from /build/source/xbmc/network/httprequesthandler/IHTTPRequestHandler.h:21,
                 from /build/source/xbmc/network/WebServer.h:14,
                 from /build/source/xbmc/network/WebServer.cpp:9:
/nix/store/c5mbgq649szrf1wl409n13c7wdrba3q9-libmicrohttpd-0.9.71-dev/include/microhttpd.h:2428:45: note:   initializing argument 5 of 'MHD_Daemon* MHD_start_daemon(unsigned int, uint16_t, MHD_AcceptPolicyCallback, void*, MHD_AccessHandlerCallback, void*, ...)'
 2428 |                   MHD_AccessHandlerCallback dh, void *dh_cls,
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/build/source/xbmc/network/WebServer.cpp:1154:27: error: invalid conversion from 'int (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, size_t*, void**)' {aka 'int (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, long unsigned int*, void**)'} to 'MHD_AccessHandlerCallback' {aka 'MHD_Result (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, long unsigned int*, void**)'} [-fpermissive]
 1154 |                           &CWebServer::AnswerToConnection,
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                           |
      |                           int (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, size_t*, void**) {aka int (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, long unsigned int*, void**)}
In file included from /build/source/xbmc/network/httprequesthandler/IHTTPRequestHandler.h:21,
                 from /build/source/xbmc/network/WebServer.h:14,
                 from /build/source/xbmc/network/WebServer.cpp:9:
/nix/store/c5mbgq649szrf1wl409n13c7wdrba3q9-libmicrohttpd-0.9.71-dev/include/microhttpd.h:2428:45: note:   initializing argument 5 of 'MHD_Daemon* MHD_start_daemon(unsigned int, uint16_t, MHD_AcceptPolicyCallback, void*, MHD_AccessHandlerCallback, void*, ...)'
 2428 |                   MHD_AccessHandlerCallback dh, void *dh_cls,
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
make[2]: *** [build/network/CMakeFiles/network.dir/build.make:290: build/network/CMakeFiles/network.dir/WebServer.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:6602: build/network/CMakeFiles/network.dir/all] Error 2
make: *** [Makefile:160: all] Error 2
builder for '/nix/store/r537vv7im02k1r0722cxqm26i5lypknj-kodi-wayland-18.6.drv' failed with exit code 2
cannot build derivation '/nix/store/v5wv7wlbnwncib8qh6qxpkx5nmlzilzv-kodi-wayland-with-plugins-18.6.drv': 1 dependencies couldn't be built
building '/nix/store/xx41b9s8qj80q8zg4fxlvdwpv573q1xg-rambox-0.7.5.drv'...
building '/nix/store/fiiiqj9phkm75b90wqmmxw2kjhjfzxvm-reload-container.drv'...
cannot build derivation '/nix/store/v06wda9z2a7s3r9wc38brr16i6kf5z2r-system-path.drv': 1 dependencies couldn't be built
building '/nix/store/69ys8183njsvkwj1308vj80x59sbslmq-teamviewer_15.2.2756_amd64.deb.drv'...
cannot build derivation '/nix/store/khfspvkx0br9pc313lg2mx0hh7lcy92f-nixos-system-austin-laptop-20.09pre237279.8e2b14aceb1.drv': 1 dependencies couldn't be built
error: build of '/nix/store/khfspvkx0br9pc313lg2mx0hh7lcy92f-nixos-system-austin-laptop-20.09pre237279.8e2b14aceb1.drv' failed
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).