### PR TITLE
js_of_ocaml: 3.6.0 → 3.7.0

### DIFF
--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -1,18 +1,19 @@
 { lib, fetchurl, buildDunePackage
 , ocaml, findlib, cmdliner, dune_2, cppo, yojson, ocaml-migrate-parsetree
+, menhir
 }:
 
 buildDunePackage rec {
 	pname = "js_of_ocaml-compiler";
-	version = "3.6.0";
+	version = "3.7.0";
 	useDune2 = true;
 
 	src = fetchurl {
 		url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
-		sha256 = "51eaa89c83ef3168ef270bf7997cbc35a747936d3f51aa6fac58fb0323b4cbb0";
+		sha256 = "0rw6cfkl3zlyav8q2w7grxxqjmg35mz5rgvmkiqb58nl4gmgzx6w";
 	};
 
-	nativeBuildInputs = [ ocaml findlib dune_2 cppo ];
+	nativeBuildInputs = [ ocaml findlib dune_2 cppo menhir ];
   buildInputs = [ cmdliner ];
 
   configurePlatforms = [];

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -10,8 +10,6 @@ stdenv.mkDerivation {
   buildInputs = [ findlib ocaml-migrate-parsetree ppx_tools_versioned ];
   nativeBuildInputs = [ ocaml findlib dune_2 ];
 
-  postPatch = "patchShebangs lib/generate_stubs.sh";
-
 	propagatedBuildInputs = [ js_of_ocaml-compiler uchar ];
 
 	buildPhase = "dune build -p js_of_ocaml";


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
