### PR TITLE
ocamlPackages.torch: 0.9b → 0.10

### DIFF
--- a/pkgs/development/ocaml-modules/torch/default.nix
+++ b/pkgs/development/ocaml-modules/torch/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildDunePackage
 , fetchFromGitHub
 , cmdliner
@@ -42,7 +43,7 @@ buildDunePackage rec {
 
   preBuild = ''export LIBTORCH=${pytorch.dev}/'';
 
-  doCheck = true;
+  doCheck = !stdenv.isAarch64;
   checkPhase = "dune runtest";
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/torch/default.nix
+++ b/pkgs/development/ocaml-modules/torch/default.nix
@@ -15,7 +15,7 @@
 
 buildDunePackage rec {
   pname = "torch";
-  version = "0.9b";
+  version = "0.10";
 
   minimumOCamlVersion = "4.07";
 
@@ -23,7 +23,7 @@ buildDunePackage rec {
     owner = "LaurentMazare";
     repo   = "ocaml-${pname}";
     rev    = version;
-    sha256 = "1xn8zfs3viz80agckcpl9a4vjbq6j5g280i95jyy5s0zbcnajpnm";
+    sha256 = "1rqrv6hbical8chk0bl2nf60q6m4b5d1gab9fc5q03vkz2987f9b";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Fix build after #94156

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
