### PR TITLE
_1password-gui: init at 0.8.0

### DIFF
--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, fetchurl
+, appimageTools
+, makeWrapper
+, electron
+, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "1password";
+  version = "0.8.0";
+
+  src = fetchurl {
+    url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
+    sha256 = "1r26vyx724h3k6p340bg3lmcxwyvgxj2kqvwczq784583hpq3lq9";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  appimageContents = appimageTools.extractType2 {
+    name = "${pname}-${version}";
+    inherit src;
+  };
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = let
+    runtimeLibs = [
+      openssl.out
+      stdenv.cc.cc
+    ];
+  in ''
+    mkdir -p $out/bin $out/share/1password
+
+    # Applications files.
+    cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
+
+    # Desktop file.
+    install -Dt $out/share/applications ${appimageContents}/${pname}.desktop
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+
+    # Icons.
+    cp -a ${appimageContents}/usr/share/icons $out/share
+
+    # Wrap the application with Electron.
+    makeWrapper "${electron}/bin/electron" "$out/bin/${pname}" \
+      --add-flags "$out/share/${pname}/resources/app.asar" \
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath runtimeLibs}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Multi-platform password manager";
+    longDescription = ''
+      1Password is a multi-platform package manager.
+
+      The Linux version is currently a development preview and can
+      only be used to search, view, and copy items. However items
+      cannot be created or edited.
+    '';
+    homepage = "https://1password.com/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ danieldk ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -536,6 +536,10 @@ in
 
   _1password = callPackage ../applications/misc/1password { };
 
+  _1password-gui = callPackage ../tools/security/1password-gui {
+    electron = electron_9;
+  };
+
   _6tunnel = callPackage ../tools/networking/6tunnel { };
 
   _9pfs = callPackage ../tools/filesystems/9pfs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add the new (electron-based) GUI for 1Password.

Ideally, this would just be named `1password`. However,

- variable names cannot start with a number;
- `_1password` already exists. This should probably have been named `op` (since that is what upstream calls it), but the attribute is taken now. So, I decided to call the attribute `_1password-gui`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
