### PR TITLE
go-dqlite: init at 1.7.0

### DIFF
--- a/pkgs/tools/admin/go-dqlite/default.nix
+++ b/pkgs/tools/admin/go-dqlite/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, sqlite-replication
+, dqlite
+, raft-canonical
+, libco-canonical
+}:
+buildGoModule rec {
+  pname = "go-dqlite";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "go-dqlite";
+    rev = "v${version}";
+    sha256 = "17b0by6vxz7dyrbx7wrrrjn4nd2vlcsdzxwrjkgjzqihgbcx5f75";
+  };
+
+  buildInputs = [
+    dqlite.dev
+    libco-canonical.dev
+    raft-canonical.dev
+    sqlite-replication
+  ];
+
+  buildFlags = [ "-tags libsqlite3" ];
+
+  doCheck = false;
+
+  vendorSha256 = "1j3q52w39bi66al62hcd04rwi86n1p96116vqpwcaw14gvkd9ihb";
+
+  meta = with lib; {
+    description = "A pure-Go client for the dqlite wire protocol";
+    homepage = "https://github.com/canonical/go-dqlite";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mt-caret ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1947,6 +1947,8 @@ in
 
   go-dependency-manager = callPackage ../development/tools/gdm { };
 
+  go-dqlite = callPackage ../tools/admin/go-dqlite { };
+
   go-neb = callPackage ../applications/networking/instant-messengers/go-neb { };
 
   geckodriver = callPackage ../development/tools/geckodriver { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add go-dqlite, which includes a binary for interfacing with dqlite clusters.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
