### PR TITLE
Add KLU support to sundials

### DIFF
--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -5,7 +5,9 @@
 , blas
 , lapack
 , gfortran
-, lapackSupport ? true }:
+, suitesparse
+, lapackSupport ? true
+, kluSupport ? true }:
 
 assert (!blas.isILP64) && (!lapack.isILP64);
 
@@ -13,7 +15,20 @@ stdenv.mkDerivation rec {
   pname = "sundials";
   version = "5.3.0";
 
-  buildInputs = [ python ] ++ stdenv.lib.optionals (lapackSupport) [ gfortran blas lapack ];
+  buildInputs = [
+    python
+  ] ++ stdenv.lib.optionals (lapackSupport) [
+    gfortran
+    blas
+    lapack
+  ] 
+  # KLU support is based on Suitesparse.
+  # It is tested upstream according to the section 1.1.4 of
+  # [INSTALL_GUIDE.pdf](https://raw.githubusercontent.com/LLNL/sundials/master/INSTALL_GUIDE.pdf)
+  ++ stdenv.lib.optionals (kluSupport) [
+    suitesparse
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   src = fetchurl {
@@ -35,6 +50,10 @@ stdenv.mkDerivation rec {
     "-DSUNDIALS_INDEX_TYPE=int32_t"
     "-DLAPACK_ENABLE=ON"
     "-DLAPACK_LIBRARIES=${lapack}/lib/liblapack${stdenv.hostPlatform.extensions.sharedLibrary}"
+  ] ++ stdenv.lib.optionals (kluSupport) [
+    "-DKLU_ENABLE=ON"
+    "-DKLU_INCLUDE_DIR=${suitesparse.dev}/include"
+    "-DKLU_LIBRARY_DIR=${suitesparse}/lib"
   ];
 
   doCheck = true;

--- a/pkgs/development/python-modules/scikits-odes/default.nix
+++ b/pkgs/development/python-modules/scikits-odes/default.nix
@@ -6,6 +6,7 @@
 , cython
 , enum34
 , gfortran
+, isPy27
 , isPy3k
 , numpy
 , pytest
@@ -17,6 +18,8 @@
 buildPythonPackage rec {
   pname = "scikits.odes";
   version = "2.6.1";
+
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change

Add KLU support to sundials.
Needed for Haskell `hmatrix-sparse` for instance

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
