### PR TITLE
kicad: reenable scriptingSupport

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   i18n = libraries.i18n;
 
   pname = "kicad-base";
-  version = "${versions.${baseName}.kicadVersion.version}";
+  version = "${builtins.substring 0 10 versions.${baseName}.kicadVersion.src.rev}";
 
   src = fetchFromGitLab (
     {

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -9,7 +9,7 @@
 , oceSupport ? false, opencascade
 , withOCCT ? true, opencascade-occt
 , ngspiceSupport ? true, libngspice
-, scriptingSupport ? false, swig, python3
+, scriptingSupport ? true, swig, python3
 , debug ? false, valgrind
 , with3d ? true
 , withI18n ? true

--- a/pkgs/applications/science/electronics/kicad/libraries.nix
+++ b/pkgs/applications/science/electronics/kicad/libraries.nix
@@ -15,7 +15,9 @@ let
   mkLib = name:
     stdenv.mkDerivation {
       pname = "kicad-${name}";
-      version = "${version}";
+      # Use the revision instead of `version` (which is an ISO 8601 date)
+      # to prevent duplicating the library when just the date changed
+      version = "${builtins.substring 0 10 libSources.${name}.rev}";
       src = fetchFromGitHub (
         {
           owner = "KiCad";
@@ -50,7 +52,7 @@ in
   i18n = let name = "i18n"; in
     stdenv.mkDerivation {
       pname = "kicad-${name}";
-      version = "${version}";
+      version = "${builtins.substring 0 10 libSources.${name}.rev}";
       src = fetchFromGitLab (
         {
           group = "kicad";

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -27,25 +27,25 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2020-07-21";
+      version =			"2020-08-22";
       src = {
-        rev =			"9a801d8b72f24e297a7d9d6e8cee2eef6cab2988";
-        sha256 =		"0yilmmng7y3rz1bxw2b0s0aqs8hdqr7ach2r45bx8v1f4bih4ka9";
+        rev =			"a2341f0f335b0abb9fc8cb86d19cbe6f9b38fade";
+        sha256 =		"0167yb39f800xarq3khn7sbdkgcx9j2ayhy8c7lhhks6kh7459g0";
       };
     };
     libVersion = {
-      version =			"2020-07-21";
+      version =			"2020-08-22";
       libSources = {
-        i18n.rev =		"a311975d139caf8be9848dd613a9800570adc245";
-        i18n.sha256 =		"1bkn2hhwcg8xdpn9yfm9nnqsg02c1nizhpxd4yhpxgifhh4psz1g";
-        symbols.rev =		"18572c4c118fe8ef779edf3131eebf2c33c6fa46";
-        symbols.sha256 =	"0hqx0aznzrnlbdkpsnl8mbs9bdgiv029d6zjh10nyjzcw27q3hxz";
+        i18n.rev =		"cbbb1efd940094bf0c3168280698b2b059a8c509";
+        i18n.sha256 =		"1q4jakn6m8smnr2mg7jgb520nrb6fag9mdvlcpx3smp3qbxka818";
+        symbols.rev =		"9ca6a5348cdeb88e699582d4ed051ff7303b44d3";
+        symbols.sha256 =	"13w6pb34rhz96rnar25z7kiscy6q1fm8l39hq1bpb8g9yn86ssz4";
         templates.rev =		"ae16953b81055855bcede4a33305413599d86a15";
         templates.sha256 =	"1pkv90p3liy3bj4nklxsvpzh9m56p0k5ldr22armvgqfaqaadx9v";
-        footprints.rev =	"4835f80b4a52256aa7a3eb650e6e0fef33a77d0d";
-        footprints.sha256 =	"00rc6phxmkry35i0xzry14axvh2akvvkly45s3xxi06vaydaw7i5";
-        packages3d.rev =	"9b560cf94a35b692ca516d37bdaf392ce10e549d";
-        packages3d.sha256 =	"0b9jglf77fy0n0r8xs4yqkv6zvipyfvp0z5dnqlzp32csy5aqpi1";
+        footprints.rev =	"f94c2d5d619d16033f69a555b449f59604d97865";
+        footprints.sha256 =	"1g71sk77jvqaf9xvgq6dkyvd9pij2lb4n0bn0dqnwddhwam935db";
+        packages3d.rev =	"f699b0e3c13fe75618086913e39279c85da14cc7";
+        packages3d.sha256 =	"0m5rb5axa946v729z35ga84in76y4zpk32qzi0hwqx957zy72hs9";
       };
     };
   };


### PR DESCRIPTION
###### Motivation for this change
#94108 fixed the wxPython dependency, this is probably required for #88923

###### Things done
- reenable ScriptingSupport
- change the components to use the hash of their source for the name, instead of the version/date
  - so that i don't get duplicates if i update after midnight
  - the final package still has the version/date in the name
- update kicad-unstable (quite a few new fixes and features)

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  `kicad-small`: from `711685672` to `1114861552`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
