### PR TITLE
glibc: Fix _CS_PATH to include default profile

### DIFF
--- a/pkgs/development/libraries/glibc/fix_path_attribute_in_getconf.patch
+++ b/pkgs/development/libraries/glibc/fix_path_attribute_in_getconf.patch
@@ -3,4 +3,4 @@ diff -ubr glibc-2.17-orig/sysdeps/unix/confstr.h glibc-2.17/sysdeps/unix/confstr
 +++ glibc-2.17/sysdeps/unix/confstr.h	2013-06-03 22:04:39.469376740 +0200
 @@ -1 +1 @@
 -#define	CS_PATH	"/bin:/usr/bin"
-+#define	CS_PATH	"/run/current-system/sw/bin:/bin:/usr/bin"
++#define	CS_PATH	"/run/current-system/sw/bin:/bin:/usr/bin:/nix/var/nix/profiles/default/bin"


### PR DESCRIPTION
###### Motivation for this change

The string returned by [`confstr(_CS_PATH)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/confstr.html), which is also the output of the command [`getconf PATH`](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/getconf.html), contains a default path that is guaranteed to find (at least) all POSIX standard utilities. The current value is:

    /run/current-system/sw/bin:/bin:/usr/bin

There are two problems with this.

1. `/bin` and `/usr/bin` should be removed, as NixOS package management never puts anything there. Anything dropped in `/bin` or `/usr/bin` under the name of a standard utility would likely be bogus.

2. The default profile binaries directory is not in it. This is a problem because the default NixOS installation lacks several mandatory standard POSIX utilities. The command recommended by the system's error message for a missing command to install a missing package *foo* is `nix-env -iA nixos.foo`. When this is done as root, the corresponding binaries are installed for all users in `/nix/var/nix/profiles/default/bin`.

###### Things done

`pkgs/development/libraries/glibc/fix_path_attribute_in_getconf.patch`:
- `CS_PATH`: Replace `/bin:/usr/bin` fallback by default profile path `/nix/var/nix/profiles/default/bin`.

Fixes: https://github.com/NixOS/nixpkgs/issues/65512
