### PR TITLE
luaPackages.pulseaudio: remove

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -79,5 +79,4 @@ say,,,,,
 std__debug,std._debug,,,,
 std_normalize,std.normalize,,,,
 stdlib,,,,,vyp
-pulseaudio,,,,,doronbehar
 vstruct,,,,,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1499,24 +1499,6 @@ stdlib = buildLuarocksPackage {
     license.fullName = "MIT/X11";
   };
 };
-pulseaudio = buildLuarocksPackage {
-  pname = "pulseaudio";
-  version = "0.2-1";
-
-  src = fetchurl {
-    url    = "mirror://luarocks/pulseaudio-0.2-1.src.rock";
-    sha256 = "06w8fmwddrpm02yam818yi30gghw4ckb18zljjncy3x0zfijyhz7";
-  };
-  disabled = (luaOlder "5.1");
-  propagatedBuildInputs = [ lua ];
-
-  meta = with stdenv.lib; {
-    homepage = "https://github.com/doronbehar/lua-pulseaudio";
-    description = "Bindings to libpulse";
-    maintainers = with maintainers; [ doronbehar ];
-    license.fullName = "Apache v2.0";
-  };
-};
 vstruct = buildLuarocksPackage {
   pname = "vstruct";
   version = "2.0.2-1";

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -344,13 +344,4 @@ with super;
       sourceRoot=./readline-2.6
     '';
   });
-
-  pulseaudio = super.pulseaudio.override({
-    buildInputs = [
-      pkgs.libpulseaudio
-    ];
-    nativeBuildInputs = [
-      pkgs.pulseaudio pkgs.pkgconfig
-    ];
-  });
 }


### PR DESCRIPTION
###### Motivation for this change

It's not maintained any more by upstream (by me) and it doesn't build correctly with `buildLuarocksPackage` (see #89767). I hardly imagine it has users (not even me), as it's not functional for a long time now and nobody complained. cc @teto .

###### Things done

Close https://github.com/NixOS/nixpkgs/pull/89767

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
