### PR TITLE
python3Packages.nix-kernel: init at 0.1

### DIFF
--- a/pkgs/development/python-modules/nix-kernel/default.nix
+++ b/pkgs/development/python-modules/nix-kernel/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pexpect
+, notebook
+, nix
+}:
+
+buildPythonPackage rec {
+  pname = "nix-kernel";
+  version = "unstable-2020-04-26";
+
+  src = fetchFromGitHub {
+    owner = "GTrunSec";
+    repo = "nix-kernel";
+    rev = "dfa42d0812d508ded99f690ee1a83281d900a3ec";
+    sha256 = "1lf4rbbxjmq9h6g3wrdzx3v3dn1bndfmiybxiy0sjavgb6lzc8kq";
+  };
+
+  postPatch = ''
+    substituteInPlace nix-kernel/kernel.py \
+      --replace "'nix'" "'${nix}/bin/nix'" \
+      --replace "'nix repl'" "'${nix}/bin/nix repl'"
+
+    substituteInPlace setup.py \
+      --replace "cmdclass={'install': install_with_kernelspec}," ""
+  '';
+
+  propagatedBuildInputs = [
+    pexpect
+    notebook
+  ];
+
+  # no tests in repo
+  doCheck = false;
+
+  pythonImportsCheck = [ "nix-kernel" ];
+
+  meta = with lib; {
+    description = "Simple jupyter kernel for nix-repl";
+    homepage = "https://github.com/GTrunSec/nix-kernel";
+    license = licenses.mit;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4957,6 +4957,10 @@ in {
 
   nitime = callPackage ../development/python-modules/nitime { };
 
+  nix-kernel = callPackage ../development/python-modules/nix-kernel {
+    inherit (pkgs) nix;
+  };
+
   nixpkgs = callPackage ../development/python-modules/nixpkgs { };
 
   nixpkgs-pytools = callPackage ../development/python-modules/nixpkgs-pytools { };


### PR DESCRIPTION
###### Motivation for this change

Adding nix-repl kernel to nixpkgs for jupyter

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
