### PR TITLE
zfs-prune-snapshots: init at 1.1.0

### DIFF
--- a/pkgs/tools/backup/zfs-prune-snapshots/default.nix
+++ b/pkgs/tools/backup/zfs-prune-snapshots/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, go-md2man }:
+
+stdenv.mkDerivation rec {
+  version = "1.1.0";
+  pname = "zfs-prune-snapshots";
+
+  src = fetchFromGitHub {
+    owner = "bahamas10";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "09dz9v6m47dxfvfncz0k926dqfhagm87kd33dcw66cbw15ac3spx";
+  };
+
+  nativeBuildInputs = [ go-md2man ];
+
+  makeTargets = [ "man" ];
+
+  installPhase = ''
+    install -m 755 -D zfs-prune-snapshots $out/bin/zfs-prune-snapshots
+    install -m 644 -D man/zfs-prune-snapshots.1 $out/share/man/man1/zfs-prune-snapshots.1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Remove snapshots from one or more zpools that match given criteria";
+    homepage = "https://github.com/bahamas10/zfs-prune-snapshots";
+    license = licenses.mit;
+    maintainers = [ maintainers.ymarkus ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27302,6 +27302,8 @@ in
 
   kube3d =  callPackage ../applications/networking/cluster/kube3d {};
 
+  zfs-prune-snapshots = callPackage ../tools/backup/zfs-prune-snapshots {};
+
   zfs-replicate = python3Packages.callPackage ../tools/backup/zfs-replicate { };
 
   runwayml = callPackage ../applications/graphics/runwayml {};


### PR DESCRIPTION
Also changed ymarkus' email

###### Motivation for this change
Add zfs-prune-snapshots tool


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
