### PR TITLE
pythonPackages.uvcclient: init at 0.11.0

### DIFF
--- a/pkgs/development/python-modules/uvcclient/default.nix
+++ b/pkgs/development/python-modules/uvcclient/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchFromGitHub, nose, mock }:
+
+buildPythonPackage rec {
+  pname = "uvcclient";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "kk7ds";
+    repo = pname;
+    rev = "58e7a53815482b7778481f81cde95f53a60bb6f6";
+    sha256 = "0k8aswrk1n08w6pi6dg0zdzsmk23cafihkrss9ywg3i85w7q43x2";
+  };
+
+  checkInputs = [
+    nose
+    mock
+  ];
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with lib; {
+    description = "Client for Ubiquiti's Unifi Camera NVR";
+    homepage = "https://github.com/kk7ds/uvcclient";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -861,7 +861,7 @@
     "uscis" = ps: with ps; [ ]; # missing inputs: uscisstatus
     "usgs_earthquakes_feed" = ps: with ps; [ ]; # missing inputs: geojson_client
     "utility_meter" = ps: with ps; [ ];
-    "uvc" = ps: with ps; [ ]; # missing inputs: uvcclient
+    "uvc" = ps: with ps; [ uvcclient];
     "vacuum" = ps: with ps; [ ];
     "vallox" = ps: with ps; [ ]; # missing inputs: vallox-websocket-api
     "vasttrafik" = ps: with ps; [ ]; # missing inputs: vtjp

--- a/pkgs/servers/home-assistant/test-timeout.patch
+++ b/pkgs/servers/home-assistant/test-timeout.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/test_core.py b/tests/test_core.py
+index a63f42af61..04b333868b 100644
+--- a/tests/test_core.py
++++ b/tests/test_core.py
+@@ -1432,7 +1432,7 @@ async def test_chained_logging_hits_log_timeout(hass, caplog):
+     async def _task_chain_2():
+         nonlocal created
+         created += 1
+-        if created > 10:
++        if created > 1000:
+             return
+         hass.async_create_task(_task_chain_1())
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1705,6 +1705,8 @@ in {
 
   unifi = callPackage ../development/python-modules/unifi { };
 
+  uvcclient = callPackage ../development/python-modules/uvcclient { };
+
   uvloop = callPackage ../development/python-modules/uvloop {
     inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices CoreServices;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Enable the Unifi Video integration in home-assistant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
