### PR TITLE
home-assistant: relax cryptography dependency

### DIFF
--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -15,6 +15,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     sed -i 's/"acme.*"/"acme"/' setup.py
+    sed -i 's/"cryptography.*"/"cryptography"/' setup.py
   '';
 
   patches = [

--- a/pkgs/servers/home-assistant/relax-dependencies.patch
+++ b/pkgs/servers/home-assistant/relax-dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/setup.py b/setup.py
-index c2042ab245..98f348510f 100755
+index 7cf06942f3..bace4479fb 100755
 --- a/setup.py
 +++ b/setup.py
 @@ -32,7 +32,7 @@ PROJECT_URLS = {
@@ -11,7 +11,13 @@ index c2042ab245..98f348510f 100755
      "astral==1.10.1",
      "async_timeout==3.0.1",
      "attrs==19.3.0",
-@@ -48,8 +48,8 @@ REQUIRES = [
+@@ -43,13 +43,13 @@ REQUIRES = [
+     "jinja2>=2.11.1",
+     "PyJWT==1.7.1",
+     # PyJWT has loose dependency. We want the latest one.
+-    "cryptography==2.9.2",
++    "cryptography>=2.9.2",
+     "pip>=8.0.3",
      "python-slugify==4.0.0",
      "pytz>=2020.1",
      "pyyaml==5.3.1",
@@ -21,4 +27,4 @@ index c2042ab245..98f348510f 100755
 +    "ruamel.yaml>=0.15.100",
      "voluptuous==0.11.7",
      "voluptuous-serialize==2.4.0",
- ]
+     "yarl==1.4.2",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Both the `home-assistant` and `python3Packages.hass-nabucasa` package broke when cryptography was updated to 3.0 in 434a0111f6a7618a7024b637c5496ea261b23016.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - `home-assistant`
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
