### PR TITLE
gitlab: 13.0.9 -> 13.0.12

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,11 +1,11 @@
 {
-  "version": "13.0.9",
-  "repo_hash": "0rzby1q4vy59cs9ghnx29f6gflmz9114yh5yia0kdikiyky95rsx",
+  "version": "13.0.12",
+  "repo_hash": "0m9pn1alxdib9ppf878wf186bvn0llik7vcpqijzcdzc18q9cldq",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v13.0.9-ee",
+  "rev": "v13.0.12-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "13.0.9",
+    "GITALY_SERVER_VERSION": "13.0.12",
     "GITLAB_PAGES_VERSION": "1.18.0",
     "GITLAB_SHELL_VERSION": "13.2.0",
     "GITLAB_WORKHORSE_VERSION": "8.31.2"

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -19,14 +19,14 @@ let
       };
   };
 in buildGoPackage rec {
-  version = "13.0.9";
+  version = "13.0.12";
   pname = "gitaly";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "0bw3g1c3ji78grh6fs4qq64hq1s4z2da5f18zbkac41hkkqbf1in";
+    sha256 = "00jzrib8f51b3wkl0zy9a9cr5j9kp6cmm49vxm27zgxpyz8k1axw";
   };
 
   # Fix a check which assumes that hook files are writeable by their


### PR DESCRIPTION
https://about.gitlab.com/releases/2020/08/05/gitlab-13-2-3-released

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
