### PR TITLE
tre-command: 0.3.1 -> 0.3.2

### DIFF
--- a/pkgs/tools/system/tre-command/default.nix
+++ b/pkgs/tools/system/tre-command/default.nix
@@ -1,17 +1,23 @@
-{ rustPlatform, fetchFromGitHub, stdenv }:
+{ rustPlatform, fetchFromGitHub, stdenv, installShellFiles }:
 
 rustPlatform.buildRustPackage rec {
   pname = "tre-command";
-  version = "0.3.1";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
     owner = "dduan";
     repo = "tre";
     rev = "v${version}";
-    sha256 = "1fm3fszy7fd0dgf5dwm35nb0ym0waw92iyx128lr2vlbyzln6ija";
+    sha256 = "1kb8jwmjhlp9bk08rb6gq3j810cv9bidm28sa417vyykp9a8p2ky";
   };
 
-  cargoSha256 = "0sk4dn5rrqhkaxm76y1d7rsjsw6pdjdhb2xv7qqrlivfk6y5k31x";
+  cargoSha256 = "0cqkpvq8b2vnqpkd819cdgh4fqr9yns337fgzah4m40ygs25n9iv";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  preFixup = ''
+    installManPage manual/tre.1
+  '';
 
   meta = with stdenv.lib; {
     description = "Tree command, improved";


### PR DESCRIPTION
release notes: https://github.com/dduan/tre/releases/tag/v0.3.2

relavent: this release introduces a Unix manual.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
