### PR TITLE
openrgb: 0.2 -> 0.3

### DIFF
--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -1,17 +1,17 @@
-{ mkDerivation, lib, fetchFromGitHub, qmake, libusb1, hidapi }:
+{ mkDerivation, lib, fetchFromGitHub, qmake, libusb1, hidapi, pkg-config }:
 
 mkDerivation rec {
   pname = "openrgb";
-  version = "0.2";
+  version = "0.3";
 
   src = fetchFromGitHub {
     owner = "CalcProgrammer1";
     repo = "OpenRGB";
     rev = "release_${version}";
-    sha256 = "0b1mkp4ca4gdzk020kp6dkd3i9a13h4ikrn3417zscsvv5y9kv0s";
+    sha256 = "1931aisdahjr99d4qqk824ib4x19mvhqgqmkm3j6fc5zd2hnw87m";
   };
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [ qmake pkg-config ];
   buildInputs = [ libusb1 hidapi ];
 
   installPhase = ''


### PR DESCRIPTION
##### Motivation for this change
noticed it was out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
