### PR TITLE
python3Packages.cherrypy: 18.3.0 -> 18.6.0

### DIFF
--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -1,36 +1,27 @@
 { stdenv, buildPythonPackage, fetchPypi, isPy3k
 , setuptools_scm
 , cheroot, portend, more-itertools, zc_lockfile, routes
+, jaraco_collections
 , objgraph, pytest, pytestcov, pathpy, requests_toolbelt, pytest-services
 , fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "cherrypy";
-  version = "18.3.0";
+  version = "18.6.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     pname = "CherryPy";
     inherit version;
-    sha256 = "0q6cs4vrv0rwim4byxfizrlp4h6hmwg3n4baz0ga66vvgiz6hgk8";
+    sha256 = "16f410izp2c4qhn4n3l5l3qirmkf43h2amjqms8hkl0shgfqwq2n";
   };
-
-  # Remove patches once 88d2163 and 713f672
-  # become part of a release - they're currently only present in master.
-  # ref: https://github.com/cherrypy/cherrypy/pull/1820
-  patches = [
-    (fetchpatch {
-      name = "test_HTTP11_Timeout.patch";
-      url = "https://github.com/cherrypy/cherrypy/commit/88d21630f68090c56d07000cabb6df4f1b612a71.patch";
-      sha256 = "1i6a3qs3ijyd9rgsxb8axigkzdlmr5sl3ljif9rvn0d90211bzwh";
-    })
-  ];
 
   propagatedBuildInputs = [
     # required
     cheroot portend more-itertools zc_lockfile
+    jaraco_collections
     # optional
     routes
   ];


### PR DESCRIPTION
###### Motivation for this change
trying to fix

cc @costrouc 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
