### PR TITLE
lib: add mkEnabledOption

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -69,6 +69,16 @@ rec {
     type = lib.types.bool;
   };
 
+  /* Like mkEnableOption but defaulting to true. */
+  mkEnabledOption =
+    # Name for the created option
+    name: mkOption {
+    default = true;
+    example = false;
+    description = "Whether to enable ${name}.";
+    type = lib.types.bool;
+  };
+
   /* This option accepts anything, but it does not produce any result.
 
      This is useful for sharing a module across different module sets


### PR DESCRIPTION
###### Motivation for this change
Some `enable*` options are better with a `true` default, but there is only a `mkEnableOption` in the lib.
Eg. `openFirewall` in https://github.com/NixOS/nixpkgs/pull/94917

###### Things done
- [X] Add a `mkEnabledOption` in `lib/options.nix`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
