### PR TITLE
tdrop: 2018-11-13 -> 2020-05-14

### DIFF
--- a/pkgs/applications/misc/tdrop/default.nix
+++ b/pkgs/applications/misc/tdrop/default.nix
@@ -1,24 +1,34 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper
-, xwininfo, xdotool, xprop }:
+, xwininfo, xdotool, xprop, gawk, coreutils
+, gnugrep, procps }:
 
 stdenv.mkDerivation {
   pname = "tdrop";
-  version = "unstable-2018-11-13";
+  version = "unstable-2020-05-14";
 
   src = fetchFromGitHub {
     owner = "noctuid";
     repo = "tdrop";
-    rev = "198795c0d2573a31979330d6a2ae946eb81deebf";
-    sha256 = "1fhibqgmls64mylcb6q46ipmg1q6pvaqm26vz933gqav6cqsbdzs";
+    rev = "a9f2862515e5c190ac61d394e7fe7e1039871b89";
+    sha256 = "1zxhihgba33k8byjsracsyhby9qpdngbly6c8hpz3pbsyag5liwc";
   };
 
   dontBuild = true;
 
   installFlags = [ "PREFIX=$(out)" ];
 
-  postInstall = ''
-    wrapProgram $out/bin/tdrop \
-      --prefix PATH : ${lib.makeBinPath [ xwininfo xdotool xprop ]}
+  postInstall = let
+    binPath = lib.makeBinPath [
+      xwininfo
+      xdotool
+      xprop
+      gawk
+      coreutils
+      gnugrep
+      procps
+    ];
+  in ''
+    wrapProgram $out/bin/tdrop --prefix PATH : ${binPath}
   '';
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


The simplest way to to test that it works is  to run `tdrop -a auto_hide && <command> && tdrop -a auto_show`, where `<command>` is some GUI app. It'll hide a terminal window, open a GUI app and when you close the app, it'll show the same terminal window.

