### PR TITLE
networking: Set networking.search to [domain] by default

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -118,7 +118,7 @@ let
                   ${optionalString (cfg.nameservers != [] && cfg.domain != null) ''
                     domain ${cfg.domain}
                   ''}
-                  ${optionalString (cfg.search != []) ("search " + concatStringsSep " " cfg.search)}
+                  search ${concatStringsSep " " cfg.search}
                   ${flip concatMapStrings cfg.nameservers (ns: ''
                     nameserver ${ns}
                   '')}

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -468,7 +468,7 @@ in
     };
 
     networking.search = mkOption {
-      default = [];
+      default = lib.optional (cfg.domain != null) cfg.domain;
       example = [ "example.com" "local.domain" ];
       type = types.listOf types.str;
       description = ''


### PR DESCRIPTION
###### Motivation for this change

The net effect of this PR is that it allows setting `networking.search = []`. Please, see the commit message for details.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
