### PR TITLE
amd-libflame: init at 2.2

### DIFF
--- a/pkgs/development/libraries/science/math/amd-libflame/add-lapacke.diff
+++ b/pkgs/development/libraries/science/math/amd-libflame/add-lapacke.diff
@@ -1,0 +1,34 @@
+diff --git a/Makefile b/Makefile
+index 5549ce30..ac2ee51e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -583,14 +583,14 @@ endif
+ 
+ # --- Shared library linker rules ---
+ 
+-$(LIBFLAME_SO_PATH): $(MK_ALL_FLAMEC_OBJS)
++$(LIBFLAME_SO_PATH): $(MK_ALL_FLAMEC_OBJS) $(LAPACKE_A_PATH)
+ ifeq ($(ENABLE_VERBOSE),yes)
+ ifeq ($(FLA_ENABLE_MAX_ARG_LIST_HACK),yes)
+ 	$(CAT) $(AR_OBJ_LIST_FILE) | xargs -n$(AR_CHUNK_SIZE) $(AR) $(ARFLAGS) $(LIBFLAME_A)
+ ifeq ($(OS_NAME),Darwin)
+-	$(LINKER) $(SOFLAGS) -o $@ -Wl,-force_load,$(LIBFLAME_A) $(LDFLAGS)
++	$(LINKER) $(SOFLAGS) -o $@ -Wl,-force_load,$(LIBFLAME_A),$(LAPACKE_A_PATH) $(LDFLAGS)
+ else
+-	$(LINKER) $(SOFLAGS) -o $@ -Wl,--whole-archive,$(LIBFLAME_A),--no-whole-archive $(LDFLAGS)
++	$(LINKER) $(SOFLAGS) -o $@ -Wl,--whole-archive,$(LIBFLAME_A),$(LAPACKE_A_PATH)--no-whole-archive $(LDFLAGS)
+ endif
+ else
+ #	NOTE: Can't use $^ automatic variable as long as $(AR_OBJ_LIST_FILE) is in
+@@ -602,9 +602,9 @@ else
+ ifeq ($(FLA_ENABLE_MAX_ARG_LIST_HACK),yes)
+ 	@$(CAT) $(AR_OBJ_LIST_FILE) | xargs -n$(AR_CHUNK_SIZE) $(AR) $(ARFLAGS) $(LIBFLAME_A)
+ ifeq ($(OS_NAME),Darwin)
+-	@$(LINKER) $(SOFLAGS) -o $@ -Wl,-force_load,$(LIBFLAME_A) $(LDFLAGS)
++	@$(LINKER) $(SOFLAGS) -o $@ -Wl,-force_load,$(LIBFLAME_A),$(LAPACKE_A_PATH) $(LDFLAGS)
+ else
+-	@$(LINKER) $(SOFLAGS) -o $@ -Wl,--whole-archive,$(LIBFLAME_A),--no-whole-archive $(LDFLAGS)
++	@$(LINKER) $(SOFLAGS) -o $@ -Wl,--whole-archive,$(LIBFLAME_A),$(LAPACKE_A_PATH),--no-whole-archive $(LDFLAGS)
+ endif
+ else
+ #	NOTE: Can't use $^ automatic variable as long as $(AR_OBJ_LIST_FILE) is in

--- a/pkgs/development/libraries/science/math/amd-libflame/default.nix
+++ b/pkgs/development/libraries/science/math/amd-libflame/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gfortran
+, python3
+, amd-blis
+
+, withOpenMP ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "amd-libflame";
+  version = "2.2";
+
+  src = fetchFromGitHub {
+    owner = "amd";
+    repo = "libflame";
+    rev = version;
+    sha256 = "1s8zvq6p843jb52lrbxra7vv0wzmifs4j36z9bp7wf3xr20a0zi5";
+  };
+
+  patches = [
+    # The LAPACKE interface is compiled as a separate static library,
+    # we want the main dynamic library to provide LAPACKE symbols.
+    # This patch adds lapacke.a to the shared library as well.
+    ./add-lapacke.diff
+  ];
+
+  nativeBuildInputs = [ gfortran python3 ];
+
+  buildInputs = [ amd-blis ];
+
+  configureFlags = [
+    # Build a dynamic library with a LAPACK interface.
+    "--disable-static-build"
+    "--enable-dynamic-build"
+    "--enable-lapack2flame"
+
+    # Use C BLAS interface.
+    "--enable-cblas-interfaces"
+
+    # Avoid overloading maximum number of arguments.
+    "--enable-max-arg-list-hack"
+
+    # libflame by default leaves BLAS symbols unresolved and leaves it
+    # up to the application to explicitly link to a BLAS. This is
+    # problematic for us, since then the BLAS library becomes an
+    # implicit dependency. Moreover, since the point of the AMD forks
+    # is to optimized for recent AMD CPUs, link against AMD BLIS.
+    "LDFLAGS=-lcblas"
+  ]
+  ++ lib.optionals withOpenMP [ "--enable-multithreading=openmp" ];
+
+  enableParallelBuilding = true;
+
+  postPatch = ''
+    patchShebangs build
+  '';
+
+  postInstall = ''
+    ln -s $out/lib/libflame.so.${version} $out/lib/liblapack.so.3
+    ln -s $out/lib/libflame.so.${version} $out/lib/liblapacke.so.3
+  '';
+
+  meta = with stdenv.lib; {
+    description = "LAPACK-compatible linear algebra library optimized for AMD CPUs";
+    homepage = "https://developer.amd.com/amd-aocl/blas-library/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ danieldk ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25307,6 +25307,8 @@ in
 
   amd-blis = callPackage ../development/libraries/science/math/amd-blis { };
 
+  amd-libflame = callPackage ../development/libraries/science/math/amd-libflame { };
+
   arpack = callPackage ../development/libraries/science/math/arpack { };
 
   blas = callPackage ../build-support/alternatives/blas { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

libflame is a protable library for dense matrix computations, providing a complete LAPACK implementation. The AMD fork of libflame is optimized for AMD CPUs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
