### PR TITLE
buildRustCrate: editorconfig fixes

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -38,7 +38,7 @@
     build_bin = if buildTests then "build_bin_test" else "build_bin";
   in ''
     runHook preBuild
- 
+
     # configure & source common build functions
     LIB_RUSTC_OPTS="${libRustcOpts}"
     BIN_RUSTC_OPTS="${binRustcOpts}"

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -43,7 +43,7 @@ in ''
   noisily cd "${workspace_member}"
 ''}
   ${lib.optionalString (workspace_member == null) ''
-  echo_colored "Searching for matching Cargo.toml (${crateName})" 
+  echo_colored "Searching for matching Cargo.toml (${crateName})"
   local cargo_toml_dir=$(matching_cargo_toml_dir "${crateName}")
   if [ -z "$cargo_toml_dir" ]; then
     echo_error "ERROR configuring ${crateName}: No matching Cargo.toml in $(pwd) found." >&2
@@ -53,7 +53,7 @@ in ''
 ''}
 
   runHook preConfigure
- 
+
   symlink_dependency() {
     # $1 is the nix-store path of a dependency
     # $2 is the target path

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -153,8 +153,8 @@ matching_cargo_toml_path() {
   # is referenced there.
   cargo metadata --no-deps --format-version 1 \
     --manifest-path "$manifest_path" \
-    | jq -r '.packages[] 
-            | select( .name == "'$expected_crate_name'") 
+    | jq -r '.packages[]
+            | select( .name == "'$expected_crate_name'")
             | .manifest_path'
 }
 

--- a/pkgs/build-support/rust/build-rust-crate/log.nix
+++ b/pkgs/build-support/rust/build-rust-crate/log.nix
@@ -1,23 +1,23 @@
 { lib }:
 
 let echo_colored_body = start_escape:
-      # Body of a function that behaves like "echo" but 
+      # Body of a function that behaves like "echo" but
       # has the output colored by the given start_escape
       # sequence. E.g.
       #
       # * echo_x "Building ..."
       # * echo_x -n "Running "
       #
-      # This is more complicated than apparent at first sight 
+      # This is more complicated than apparent at first sight
       # because:
       #   * The color markers and the text must be print
       #     in the same echo statement. Otherise, other
-      #     intermingled text from concurrent builds will 
+      #     intermingled text from concurrent builds will
       #     be colored as well.
       #   * We need to preserve the trailing newline of the
       #     echo if and only if it is present. Bash likes
       #     to strip those if we capture the output of echo
-      #     in a variable.  
+      #     in a variable.
       #   * Leading "-" will be interpreted by test as an
       #     option for itself. Therefore, we prefix it with
       #     an x in `[[ "x$1" =~ ^x- ]]`.
@@ -27,13 +27,13 @@ let echo_colored_body = start_escape:
         echo_args+=" $1"
         shift
       done
-      
+
       local start_escape="$(printf '${start_escape}')"
       local reset="$(printf '\033[0m')"
       echo $echo_args $start_escape"$@"$reset
       '';
   echo_conditional_colored_body = colors: start_escape:
-      if colors == "always" 
+      if colors == "always"
       then (echo_colored_body start_escape)
       else ''echo "$@"'';
 in {
@@ -50,7 +50,7 @@ in {
   noisily = colors: verbose: ''
     noisily() {
   	  ${lib.optionalString verbose ''
-        echo_colored -n "Running " 
+        echo_colored -n "Running "
         echo $@
   	  ''}
   	  $@


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
