### PR TITLE
blackmagic: unstable-2020-02-20 -> unstable-2020-08-05

### DIFF
--- a/pkgs/development/tools/misc/blackmagic/default.nix
+++ b/pkgs/development/tools/misc/blackmagic/default.nix
@@ -7,15 +7,15 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "blackmagic";
-  version = "unstable-2020-02-20";
+  version = "unstable-2020-08-05";
   # `git describe --always`
-  firmwareVersion = "v1.6.1-409-g7a595ea";
+  firmwareVersion = "v1.6.1-539-gdd74ec8";
 
   src = fetchFromGitHub {
     owner = "blacksphere";
     repo = "blackmagic";
-    rev = "7a595ead255f2a052fe4561c24a0577112c9de84";
-    sha256 = "01kdm1rkj7ll0px882crf9w27d2ka8f3hcdmvhb9jwd60bf5dlap";
+    rev = "dd74ec8e6f734302daa1ee361af88dfb5043f166";
+    sha256 = "18w8y64fs7wfdypa4vm3migk5w095z8nbd8qp795f322mf2bz281";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/tools/misc/blackmagic/helper.sh
+++ b/pkgs/development/tools/misc/blackmagic/helper.sh
@@ -23,16 +23,8 @@ make_platform() {
   make clean
   make PROBE_HOST="$1"
 
-  if [ "$1" = "libftdi" ]; then
+  if [ "$1" = "hosted" ]; then
     install -m 0555 blackmagic "$out/bin"
-  fi
-
-  if [ "$1" = "pc-hosted" ]; then
-    install -m 0555 blackmagic_hosted "$out/bin"
-  fi
-
-  if [ "$1" = "pc-stlinkv2" ]; then
-    install -m 0555 blackmagic_stlinkv2 "$out/bin"
   fi
 
   for f in $PRODUCTS; do


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Noticed that the build fails.

- Fixes build.
- `libftdi`, `pc-hosted`, and `pc-stlinkv2` platforms are replaced by
  `hosted`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
