### PR TITLE
evolution-data-server: 3.36.4 -> 3.36.5

### DIFF
--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
-  version = "3.36.4";
+  version = "3.36.5";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "03sc7r6hpi62kcxpnzm5gv1ky3hmslh4fnf2vy2qghb5xqg3zy1r";
+    sha256 = "1nbzzqxlck3jz42wnxl281yfzpylcvbsbb0fvkh7nibdaj654mf5";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Version bump for evolution-data-server.
Changelog:
```
Evolution-Data-Server 3.36.5 2020-08-07
---------------------------------------

Bug Fixes:
	I#236 - Uses LC_ADDRESS unconditionally in libphonenumber code (Milan Crha)
	I#240 - IMAPx: Disable move to real junk/trash in server-side virtual folders (Milan Crha)

Miscellaneous:
	Fix a memory leak in ebmb_gather_photos_local_filenames() (Milan Crha)
	ESoupSession: Provided SoupAuth might not be always used by libsoup (Milan Crha)

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC: @jtojnar @worldofpeace 
