### PR TITLE
qtcreator: 4.11.0 -> 4.12.4

### DIFF
--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -1,6 +1,6 @@
 { mkDerivation, lib, fetchurl, fetchgit, fetchpatch
-, qtbase, qtquickcontrols, qtscript, qtdeclarative, qmake, llvmPackages_8
-, withDocumentation ? false, withClangPlugins ? true 
+, qtbase, qtquickcontrols, qtscript, qtdeclarative, qmake, llvmPackages_10
+, withDocumentation ? false, withClangPlugins ? true
 }:
 
 with lib;
@@ -8,37 +8,38 @@ with lib;
 let
   # Fetch clang from qt vendor, this contains submodules like this:
   # clang<-clang-tools-extra<-clazy.
-  clang_qt_vendor = llvmPackages_8.clang-unwrapped.overrideAttrs (oldAttrs: {
+  clang_qt_vendor = llvmPackages_10.clang-unwrapped.overrideAttrs (oldAttrs: {
     src = fetchgit {
-      url = "https://code.qt.io/clang/clang.git";
-      rev = "c12b012bb7465299490cf93c2ae90499a5c417d5";
-      sha256 = "0mgmnazgr19hnd03xcrv7d932j6dpz88nhhx008b0lv4bah9mqm0";
+      url = "https://code.qt.io/clang/llvm-project.git";
+      rev = "f7b8eaf78eda7b8ff6f1a3b3ef8d75d74a365b50";
+      sha256 = "1881xb0saaa0p1v0rf0bifs3zhlzv60bsn259s3hx6q2b6b53inn";
     };
     unpackPhase = "";
+    postUnpack = "sourceRoot+=/clang";
   });
 in
 
 mkDerivation rec {
   pname = "qtcreator";
-  version = "4.11.0";
+  version = "4.12.4";
   baseVersion = builtins.concatStringsSep "." (lib.take 2 (builtins.splitVersion version));
 
   src = fetchurl {
     url = "http://download.qt-project.org/official_releases/${pname}/${baseVersion}/${version}/qt-creator-opensource-src-${version}.tar.xz";
-    sha256 = "0ibn7bapw7m26nmxl26dns1hnpawfdqk1i1mgg0gjssja8famszg";
+    sha256 = "0ymrf4s7cxi2llksivnjipfyi34xb8gkb8ji1hpifss78hrxhirz";
   };
 
-  buildInputs = [ qtbase qtscript qtquickcontrols qtdeclarative ] ++ 
-    optionals withClangPlugins [ llvmPackages_8.libclang 
-                                 clang_qt_vendor 
-                                 llvmPackages_8.llvm ];
+  buildInputs = [ qtbase qtscript qtquickcontrols qtdeclarative ] ++
+    optionals withClangPlugins [ llvmPackages_10.libclang
+                                 clang_qt_vendor
+                                 llvmPackages_10.llvm ];
 
   nativeBuildInputs = [ qmake ];
 
   # 0001-Fix-clang-libcpp-regexp.patch is for fixing regexp that is used to
   # find clang libc++ library include paths. By default it's not covering paths
   # like libc++-version, which is default name for libc++ folder in nixos.
-  # ./0002-Dont-remove-clang-header-paths.patch is for forcing qtcreator to not 
+  # ./0002-Dont-remove-clang-header-paths.patch is for forcing qtcreator to not
   # remove system clang include paths.
   patches = [ ./0001-Fix-clang-libcpp-regexp.patch
               ./0002-Dont-remove-clang-header-paths.patch ];
@@ -52,12 +53,15 @@ mkDerivation rec {
   installFlags = [ "INSTALL_ROOT=$(out)" ] ++ optional withDocumentation "install_docs";
 
   preConfigure = ''
+    substituteInPlace src/libs/libs.pro \
+      --replace '$$[QT_INSTALL_QML]/QtQuick/Controls' '${qtquickcontrols}/${qtbase.qtQmlPrefix}/QtQuick/Controls'
+
     substituteInPlace src/plugins/plugins.pro \
-      --replace '$$[QT_INSTALL_QML]/QtQuick/Controls' '${qtquickcontrols}/${qtbase.qtQmlPrefix}/QtQuick/Controls' 
+      --replace '$$[QT_INSTALL_QML]/QtQuick/Controls' '${qtquickcontrols}/${qtbase.qtQmlPrefix}/QtQuick/Controls'
     '' + optionalString withClangPlugins ''
     # Fix paths for llvm/clang includes directories.
     substituteInPlace src/shared/clang/clang_defines.pri \
-      --replace '$$clean_path($${LLVM_LIBDIR}/clang/$${LLVM_VERSION}/include)' '${clang_qt_vendor}/lib/clang/8.0.0/include' \
+      --replace '$$clean_path($${LLVM_LIBDIR}/clang/$${LLVM_VERSION}/include)' '${clang_qt_vendor}/lib/clang/10.0.0/include' \
       --replace '$$clean_path($${LLVM_BINDIR})' '${clang_qt_vendor}/bin'
 
     # Fix include path to find clang and clang-c include directories.
@@ -66,7 +70,7 @@ mkDerivation rec {
 
     # Fix paths to libclang library.
     substituteInPlace src/shared/clang/clang_installation.pri \
-      --replace 'LIBCLANG_LIBS = -L$${LLVM_LIBDIR}' 'LIBCLANG_LIBS = -L${llvmPackages_8.libclang}/lib' \
+      --replace 'LIBCLANG_LIBS = -L$${LLVM_LIBDIR}' 'LIBCLANG_LIBS = -L${llvmPackages_10.libclang}/lib' \
       --replace 'LIBCLANG_LIBS += $${CLANG_LIB}' 'LIBCLANG_LIBS += -lclang' \
       --replace 'LIBTOOLING_LIBS = -L$${LLVM_LIBDIR}' 'LIBTOOLING_LIBS = -L${clang_qt_vendor}/lib' \
       --replace 'LLVM_CXXFLAGS ~= s,-gsplit-dwarf,' '${lib.concatStringsSep "\n" ["LLVM_CXXFLAGS ~= s,-gsplit-dwarf," "    LLVM_CXXFLAGS += -fno-rtti"]}'


### PR DESCRIPTION
###### Motivation for this change

QtCreator 4.11 had a bug that rendered it unusable for me and the internet said 4.12 would work better. It was true.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] only `qtcreator` itself
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
