### PR TITLE
busybox: Pull in upstream patch for CVE-2018-1000500

### DIFF
--- a/pkgs/os-specific/linux/busybox/0001-wget-implement-TLS-verification-with-ENABLE_FEATURE_.patch
+++ b/pkgs/os-specific/linux/busybox/0001-wget-implement-TLS-verification-with-ENABLE_FEATURE_.patch
@@ -1,0 +1,94 @@
+From 45fa3f18adf57ef9d743038743d9c90573aeeb91 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <xnox@ubuntu.com>
+Date: Tue, 19 May 2020 18:20:39 +0100
+Subject: [PATCH] wget: implement TLS verification with
+ ENABLE_FEATURE_WGET_OPENSSL
+
+When ENABLE_FEATURE_WGET_OPENSSL is enabled, correctly implement TLS
+verification by default. And only ignore verification errors, if
+--no-check-certificate was passed.
+
+Also note, that previously OPENSSL implementation did not implement
+TLS verification, nor printed any warning messages that verification
+was not performed.
+
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1879533
+
+CVE-2018-1000500
+
+Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+---
+ networking/wget.c | 20 +++++++++++++++++---
+ 1 file changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/networking/wget.c b/networking/wget.c
+index f2fc9e215..6a8c08324 100644
+--- a/networking/wget.c
++++ b/networking/wget.c
+@@ -91,6 +91,9 @@
+ //config:	patches, but do want to waste bandwidth expaining how wrong
+ //config:	it is, you will be ignored.
+ //config:
++//config:	FEATURE_WGET_OPENSSL does implement TLS verification
++//config:	using the certificates available to OpenSSL.
++//config:
+ //config:config FEATURE_WGET_OPENSSL
+ //config:	bool "Try to connect to HTTPS using openssl"
+ //config:	default y
+@@ -115,6 +118,9 @@
+ //config:	If openssl can't be executed, internal TLS code will be used
+ //config:	(if you enabled it); if openssl can be executed but fails later,
+ //config:	wget can't detect this, and download will fail.
++//config:
++//config:	By default TLS verification is performed, unless
++//config:	--no-check-certificate option is passed.
+ 
+ //applet:IF_WGET(APPLET(wget, BB_DIR_USR_BIN, BB_SUID_DROP))
+ 
+@@ -124,8 +130,11 @@
+ //usage:	IF_FEATURE_WGET_LONG_OPTIONS(
+ //usage:       "[-c|--continue] [--spider] [-q|--quiet] [-O|--output-document FILE]\n"
+ //usage:       "	[-o|--output-file FILE] [--header 'header: value'] [-Y|--proxy on/off]\n"
++//usage:	IF_FEATURE_WGET_OPENSSL(
++//usage:       "	[--no-check-certificate]\n"
++//usage:	)
+ /* Since we ignore these opts, we don't show them in --help */
+-/* //usage:    "	[--no-check-certificate] [--no-cache] [--passive-ftp] [-t TRIES]" */
++/* //usage:    "	[--no-cache] [--passive-ftp] [-t TRIES]" */
+ /* //usage:    "	[-nv] [-nc] [-nH] [-np]" */
+ //usage:       "	[-P DIR] [-S|--server-response] [-U|--user-agent AGENT]" IF_FEATURE_WGET_TIMEOUT(" [-T SEC]") " URL..."
+ //usage:	)
+@@ -137,7 +146,9 @@
+ //usage:       "Retrieve files via HTTP or FTP\n"
+ //usage:	IF_FEATURE_WGET_LONG_OPTIONS(
+ //usage:     "\n	--spider	Only check URL existence: $? is 0 if exists"
+-///////:     "\n	--no-check-certificate	Don't validate the server's certificate"
++//usage:	IF_FEATURE_WGET_OPENSSL(
++//usage:     "\n	--no-check-certificate	Don't validate the server's certificate"
++//usage:	)
+ //usage:	)
+ //usage:     "\n	-c		Continue retrieval of aborted transfer"
+ //usage:     "\n	-q		Quiet"
+@@ -662,7 +673,7 @@ static int spawn_https_helper_openssl(const char *host, unsigned port)
+ 	pid = xvfork();
+ 	if (pid == 0) {
+ 		/* Child */
+-		char *argv[8];
++		char *argv[9];
+ 
+ 		close(sp[0]);
+ 		xmove_fd(sp[1], 0);
+@@ -689,6 +700,9 @@ static int spawn_https_helper_openssl(const char *host, unsigned port)
+ 			argv[5] = (char*)"-servername";
+ 			argv[6] = (char*)servername;
+ 		}
++		if (!(option_mask32 & WGET_OPT_NO_CHECK_CERT)) {
++			argv[7] = (char*)"-verify_return_error";
++		}
+ 
+ 		BB_EXECVP(argv[0], argv);
+ 		xmove_fd(3, 2);
+-- 
+2.28.0
+

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -42,6 +42,9 @@ let
 in
 
 stdenv.mkDerivation rec {
+  # TODO: When bumping this version, please validate whether the wget patch is present upstream
+  # and remove the patch if it is. The patch should be present upstream for all versions 1.32.0+.
+  # See NixOs/nixpkgs#94722 for context.
   name = "busybox-1.31.1";
 
   # Note to whoever is updating busybox: please verify that:
@@ -58,6 +61,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./busybox-in-store.patch
     ./0001-Fix-build-with-glibc-2.31.patch
+    ./0001-wget-implement-TLS-verification-with-ENABLE_FEATURE_.patch
   ] ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ./clang-cross.patch;
 
   postPatch = "patchShebangs .";


### PR DESCRIPTION
###### Motivation for this change

This is a fix for the security vulnerability identified in #94722. See the [ubuntu bug](https://bugs.launchpad.net/ubuntu/+source/busybox/+bug/1879533) for some additional context.

This PR cherry-picks the patch from the upstream git repository.

This was validated as follows:

```
~> nix-shell -I nixpkgs=$HOME/git/nixpkgs -p busybox openssl

[nix-shell:~]$ busybox wget https://untrusted-root.badssl.com/
Connecting to untrusted-root.badssl.com (104.154.89.105:443)
wget: error getting response: Connection reset by peer
```

When this is run on the current master, it will instead download the file without any warnings.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
