### PR TITLE
modules-closure: don't ignore all deps if the first is builtin

### DIFF
--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -23,11 +23,9 @@ closure=
 for module in $rootModules; do
     echo "root module: $module"
     deps=$(modprobe --config no-config -d $kernel --set-version "$version" --show-depends "$module" \
-        | sed 's/^insmod //') \
+        | sed 's/^insmod //; /^builtin/d') \
         || if test -z "$allowMissing"; then exit 1; fi
-    if [[ "$deps" != builtin* ]]; then
-        closure="$closure $deps"
-    fi
+    closure="$closure $deps"
 done
 
 echo "closure:"


### PR DESCRIPTION
###### Motivation for this change
The previous version resulted in modules being omitted entirely
because the first dependency listed for them by modprobe was
built-in. Now, only the actual built-in modules will be ignored when
building the closure.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


~TODO: test if this fixes the issue for me in practice~ it does!

@ofborg test boot