### PR TITLE
perl: 5.30.3 -> 5.32.0

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -175,11 +175,11 @@ let
       priority = 6; # in `buildEnv' (including the one inside `perl.withPackages') the library files will have priority over files in `perl`
     };
   } // optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) rec {
-    crossVersion = "1.3.4"; # Jun 2, 2020
+    crossVersion = "15ca5359f99698ef0a199bc307b7956c08907abc"; # Aug 27, 2020
 
     perl-cross-src = fetchurl {
       url = "https://github.com/arsv/perl-cross/archive/${crossVersion}.tar.gz";
-      sha256 = "15wvlafhpsh9h66s3vazhx46hf8ik75473acrvf6722ijd1wpz45";
+      sha256 = "0pcwv2ac02i2l0fjc8drdw70q6gwbypj2c5a53x2449m919v37h9";
     };
 
     depsBuildBuild = [ buildPackages.stdenv.cc makeWrapper ];
@@ -196,14 +196,6 @@ let
   });
 in {
   # Maint version
-  perl528 = common {
-    perl = pkgs.perl528;
-    buildPerl = buildPackages.perl528;
-    version = "5.28.3";
-    sha256 = "052if351m81yhaab429i1kv77v9b15qm0g48kr6y2yjrc7bc3jdg";
-  };
-
-  # Maint version
   perl530 = common {
     perl = pkgs.perl530;
     buildPerl = buildPackages.perl530;
@@ -211,11 +203,19 @@ in {
     sha256 = "0vs0wwwlw47sswxaflkk4hw0y45cmc7arxx788kwpbminy5lrq1j";
   };
 
+  # Maint version
+  perl532 = common {
+    perl = pkgs.perl532;
+    buildPerl = buildPackages.perl532;
+    version = "5.32.0";
+    sha256 = "1d6001cjnpxfv79000bx00vmv2nvdz7wrnyas451j908y7hirszg";
+  };
+
   # the latest Devel version
   perldevel = common {
     perl = pkgs.perldevel;
     buildPerl = buildPackages.perldevel;
-    version = "5.32.0-RC0";
-    sha256 = "02i6n1xa4j0ksp014yy8q0j7scjcy5mr0yd4iash2ryrrfv5yw5k";
+    version = "5.33.1";
+    sha256 = "1rlnqqqzyhal79ys5dv7fwm3mg81s43dwks28b74x2gcmsngjnw9";
   };
 }

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -4,8 +4,8 @@
 , withPHP72 ? false, php72
 , withPHP73 ? false, php73
 , withPHP74 ? true, php74
-, withPerl528 ? false, perl528
-, withPerl530 ? true, perl530
+, withPerl530 ? false, perl530
+, withPerl532 ? true, perl532
 , withPerldevel ? false, perldevel
 , withRuby_2_5 ? false, ruby_2_5
 , withRuby_2_6 ? true, ruby_2_6
@@ -50,8 +50,8 @@ in stdenv.mkDerivation rec {
     ++ optional withPHP72 php72-unit
     ++ optional withPHP73 php73-unit
     ++ optional withPHP74 php74-unit
-    ++ optional withPerl528 perl528
     ++ optional withPerl530 perl530
+    ++ optional withPerl532 perl532
     ++ optional withPerldevel perldevel
     ++ optional withRuby_2_5 ruby_2_5
     ++ optional withRuby_2_6 ruby_2_6
@@ -78,8 +78,8 @@ in stdenv.mkDerivation rec {
     ${optionalString withPHP72      "./configure php    --module=php72    --config=${php72-unit.unwrapped.dev}/bin/php-config --lib-path=${php72-unit}/lib"}
     ${optionalString withPHP73      "./configure php    --module=php73    --config=${php73-unit.unwrapped.dev}/bin/php-config --lib-path=${php73-unit}/lib"}
     ${optionalString withPHP74      "./configure php    --module=php74    --config=${php74-unit.unwrapped.dev}/bin/php-config --lib-path=${php74-unit}/lib"}
-    ${optionalString withPerl528    "./configure perl   --module=perl528  --perl=${perl528}/bin/perl"}
     ${optionalString withPerl530    "./configure perl   --module=perl530  --perl=${perl530}/bin/perl"}
+    ${optionalString withPerl532    "./configure perl   --module=perl532  --perl=${perl532}/bin/perl"}
     ${optionalString withPerldevel  "./configure perl   --module=perldev  --perl=${perldevel}/bin/perl"}
     ${optionalString withRuby_2_5   "./configure ruby   --module=ruby25   --ruby=${ruby_2_5}/bin/ruby"}
     ${optionalString withRuby_2_6   "./configure ruby   --module=ruby26   --ruby=${ruby_2_6}/bin/ruby"}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15784,14 +15784,14 @@ in
   ### DEVELOPMENT / PERL MODULES
 
   perlInterpreters = callPackages ../development/interpreters/perl {};
-  inherit (perlInterpreters) perl528 perl530 perldevel;
+  inherit (perlInterpreters) perl530 perl532 perldevel;
 
-  perl528Packages = recurseIntoAttrs perl528.pkgs;
   perl530Packages = recurseIntoAttrs perl530.pkgs;
+  perl532Packages = recurseIntoAttrs perl532.pkgs;
   perldevelPackages = perldevel.pkgs;
 
-  perl = perl530;
-  perlPackages = perl530Packages;
+  perl = perl532;
+  perlPackages = perl532Packages;
 
   ack = perlPackages.ack;
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11,8 +11,8 @@
 , perl, overrides, buildPerl, shortenPerlShebang
 }:
 
-# cpan2nix assumes that perl-packages.nix will be used only with perl 5.28.3 or above
-assert stdenv.lib.versionAtLeast perl.version "5.28.3";
+# cpan2nix assumes that perl-packages.nix will be used only with perl 5.30.3 or above
+assert stdenv.lib.versionAtLeast perl.version "5.30.3";
 let
   inherit (stdenv.lib) maintainers;
   self = _self // (overrides pkgs);


### PR DESCRIPTION
This PR updates `perl` to 5.32.0

Replaces https://github.com/NixOS/nixpkgs/pull/93036

* `perl` and `perl532` set to 5.32.0
* `perldevelop` set to ~5.33~ ~5.32.0~ 5.33.1
* `perl-cross` updated to latest with support for 5.33.1
* `perl528` removed

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
