### PR TITLE
firejail: add patches to fix CVE-2020-17367 and CVE-2020-17368

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, which}:
+{stdenv, fetchurl, fetchpatch, which}:
 let
   s = # Generated upstream information
   rec {
@@ -19,6 +19,19 @@ stdenv.mkDerivation {
     inherit (s) url sha256;
     name = "${s.name}.tar.bz2";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2020-17367.patch";
+      url = "https://github.com/netblue30/firejail/commit/2c734d6350ad321fccbefc5ef0382199ac331b37.patch";
+      sha256 = "1gxz4jxp80gxnn46195qxcpmikwqab9d0ylj9zkm62lycp84ij6n";
+    })
+    (fetchpatch {
+      name = "CVE-2020-17368.patch";
+      url = "https://github.com/netblue30/firejail/commit/34193604fed04cad2b7b6b0f1a3a0428afd9ed5b.patch";
+      sha256 = "0n4ch3qykxx870201l8lz81f7h84vk93pzz77f5cjbd30cxnbddl";
+    })
+  ];
 
   prePatch = ''
     # Allow whitelisting ~/.nix-profile


### PR DESCRIPTION
Patches applied:

* https://github.com/netblue30/firejail/commit/2c734d6350ad321fccbefc5ef0382199ac331b37 CVE-2020-17367
* https://github.com/netblue30/firejail/commit/34193604fed04cad2b7b6b0f1a3a0428afd9ed5b CVE-2020-17368

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
