### PR TITLE
pythonPackages.flask_assets: fix tests

### DIFF
--- a/pkgs/development/python-modules/flask-assets/default.nix
+++ b/pkgs/development/python-modules/flask-assets/default.nix
@@ -11,6 +11,8 @@ buildPythonPackage rec {
 
   patchPhase = ''
     substituteInPlace tests/test_integration.py --replace 'static_path=' 'static_url_path='
+    substituteInPlace tests/test_integration.py --replace "static_folder = '/'" "static_folder = '/x'"
+    substituteInPlace tests/test_integration.py --replace "'/foo'" "'/x/foo'"
   '';
 
   propagatedBuildInputs = [ flask webassets flask_script nose ];


### PR DESCRIPTION
The changes in https://github.com/pallets/flask/pull/3456/commits/e6178fe489b7828acc2bb8fd4b56a70b11ab6c6a introduced in Flask 1.1.2 broke the tests of flask-assets.

This is a bug of flask-assets itself and not of the version in nixpkgs. But I'm doing the same as in #47203 which I think was the best option, since flask-assets seems to be quite unmaintainted.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Be able to use `flask_assets`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
