### PR TITLE
salt: 3001 -> 3001.1

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -5,34 +5,16 @@
   # passing them in this array enables Salt to find them.
 , extraInputs ? []
 }:
-let
-
-  py = python3.override {
-    packageOverrides = self: super: {
-      # Can be unpinned once https://github.com/saltstack/salt/issues/56007 is resolved
-      msgpack = super.msgpack.overridePythonAttrs (
-        oldAttrs: rec {
-          version = "0.6.2";
-          src = oldAttrs.src.override {
-            inherit version;
-            sha256 = "0c0q3vx0x137567msgs5dnizghnr059qi5kfqigxbz26jf2jyg7a";
-          };
-        }
-      );
-    };
-  };
-
-in
-py.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "salt";
-  version = "3001";
+  version = "3001.1";
 
-  src = py.pkgs.fetchPypi {
+  src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "0m7immip3r8yffiv7qlcqibszvhlg48qpgcm16skvrn85hdhv9jw";
+    sha256 = "1g2sdcibir0zhldmngv1iyzlhh2adq9dqjc73grap3df5zcv9sz9";
   };
 
-  propagatedBuildInputs = with py.pkgs; [
+  propagatedBuildInputs = with python3.pkgs; [
     distro
     jinja2
     markupsafe


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Salt 3001.1 was released, finally compatible with a newer msgpack version: https://docs.saltstack.com/en/latest/topics/releases/3001.1.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Checked that `salt hostname test.ping` works.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
