### PR TITLE
symbolator: init at 1.0.2

### DIFF
--- a/pkgs/tools/misc/symbolator/default.nix
+++ b/pkgs/tools/misc/symbolator/default.nix
@@ -1,0 +1,30 @@
+{ lib, python27Packages }:
+
+python27Packages.buildPythonApplication rec {
+  pname = "symbolator";
+  version = "1.0.2";
+
+  src = python27Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "cb25c11443536bdd9a998ed2245e143c406591b96ed236d2f2c43941f566752a";
+  };
+
+  #This module does not contain any tests.
+  doCheck = false;
+
+  buildInputs = with python27Packages; [ setuptools ];
+
+  propagatedBuildInputs = with python27Packages; [
+    pygtk
+    sphinx
+    pycairo
+    hdlparse
+  ];
+
+  meta = with lib; {
+    homepage = "https://kevinpt.github.io/symbolator/";
+    description = "A component diagramming tool for VHDL and Verilog";
+    license = licenses.mit;
+    maintainers = with maintainers; [ elliottvillars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25432,6 +25432,8 @@ in
 
   symmetrica = callPackage ../applications/science/math/symmetrica {};
 
+  symbolator = callPackage ../tools/misc/symbolator { };
+
   sympow = callPackage ../development/libraries/science/math/sympow { };
 
   ipopt = callPackage ../development/libraries/science/math/ipopt { };


### PR DESCRIPTION
Signed-off-by: Elliott Villars <elliottvillars@gmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Symbolator is not in the nixpkgs repository.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
