### PR TITLE
firefox-beta-bin: 79.0b7 -> 80.0b5

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "79.0b7";
+  version = "80.0b5";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ach/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ach/firefox-80.0b5.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "423172ecaa10ac58180d725febebb54131c7443b77fb5205102512a467cb9698";
+      sha256 = "0916202a2a6ad49b19a859004db87faab12cb730527847d3c54ca0fcaf93a556";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/af/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/af/firefox-80.0b5.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "408a019bd91f9f167606fc068fcf8c815fbf63253040323a496ecb039e048239";
+      sha256 = "1fdefb57e3fa9a584a117b0ab4716b760aeb63b089c4ae7249e70520765ac90d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/an/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/an/firefox-80.0b5.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "9e1ba3ade4031b2a1349cac7ae2df975705dec9a0928721c4fae634f16ad2336";
+      sha256 = "ce2b6aed20ae3792088530afeae2d9abbe0f1998aa135a90d02c40e580dc5c89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ar/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ar/firefox-80.0b5.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "b007dcecaf3c3fbf4e2d1b55311269984932e9193f045ae5659656d288a6d290";
+      sha256 = "ba3c77297c7ccfe9ed983121f6d7af67614dc7d379e8384ea5647fed37b08c11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ast/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ast/firefox-80.0b5.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "dd4e126494416fd0188d8dfcf7b202a61199cd9ceeae2d59d4c278cb82dee95e";
+      sha256 = "1efd03284b8249acefa9c792825129b1c14e8f011a750a00ae03d6c51c5469c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/az/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/az/firefox-80.0b5.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "a375291cf4e6b86b8bb4097115014e16dec3e75237bb5124cc2c71c630103aae";
+      sha256 = "f86fa446035e0603a14273416c2ba26eea885009c5c8b745134573db219956cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/be/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/be/firefox-80.0b5.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "678768f65e54aaab7c1088f0b65e1eb9d8590b257c8f72ceeaaf690235cb3ed1";
+      sha256 = "d3781492c54dc8f71dbe46e1d50c49c34baa631bdfad628ad6d79fb73042086e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/bg/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/bg/firefox-80.0b5.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "4d3a8bda9f809af7fae056bc17b6ca49acff26f175b750af2e341048ae18e502";
+      sha256 = "1f412cba9a10d35a61eda922a502eccdbe5ad911c1b3ea4cbfbdb960e67dd789";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/bn/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/bn/firefox-80.0b5.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "3e389228649921f1accf39541d9c76797be1e94e9b65a7cfe69c40f2a1081c58";
+      sha256 = "b5903420dd4315f57fff7aabd4ccad02a54a72c7b58689cac333b442916e34e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/br/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/br/firefox-80.0b5.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "f5813909a8ea779ac7a13db38af5630ef4581f9df482169342108825573a4fd6";
+      sha256 = "72cd10c7061103d8e575d6aa05aec1547d338c122e9bc9067159a155156a8afc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/bs/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/bs/firefox-80.0b5.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "7cd07a4e9bb83df432450fd6babd4058ea445d14d1769e31592954f14838252d";
+      sha256 = "852fad7206a20771583ebfef0aaf4169141a22bf896f2454c7e325bd0a960c50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ca-valencia/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ca-valencia/firefox-80.0b5.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "a2ca4b866d764880a0dca1397f655e074bad53cfc9b811cf113c13e8525b0d0f";
+      sha256 = "67038d4e4ec3fe3809be5d7262b47cd6d4ea20e7e938f6f0de2a708101a3e2ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ca/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ca/firefox-80.0b5.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "cbfbe3266fcad8b4887a3dfe6c90b6808297803a112245a40984e6648242dee3";
+      sha256 = "ed601308a8844a37af425678c79dd9b751df65a199cad0d64888b61f88592438";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/cak/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/cak/firefox-80.0b5.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "aa9e74a8ed9fff2e04cb2b4b0eaaa81b8a40e9409d48e70af9dcb68397f7b331";
+      sha256 = "0f4c4dfd89cad9ae9cc341dacdc9d9e31e9d8bdd9ab81f455084526f42b6d578";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/cs/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/cs/firefox-80.0b5.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "894dec5e0affc7b3f3bd5bf44e1109593a8aa6435fe71e481e3f8983af98a3fc";
+      sha256 = "ce51602d7cb30d95766dd857af8789035628d91f9901df78c0a47dc5738f21a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/cy/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/cy/firefox-80.0b5.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "8f3784f77b09c674a23a255492f1634d280e0fc56f0a3694275ef6c024dba530";
+      sha256 = "26db6a471985b9b33b4d0e7b55cbd4a761643412818537c5c0675163bba2ba29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/da/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/da/firefox-80.0b5.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "57bc320453a7a7d19ea98c61915cafb964044be95d3d25ebfbb67668d2e8ec33";
+      sha256 = "5bd12bbabafbfe1737a50a44e4ec412f6403db5fa382430db561dc308034d3ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/de/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/de/firefox-80.0b5.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "7e782965454cef0005df730141f593b37e01f15c120185de02ae315a6471b0bf";
+      sha256 = "a74477aeb40f39e527fffbbc6979515266ddaf9e1f920fc85b68782d3fd41532";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/dsb/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/dsb/firefox-80.0b5.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "ffab16697e970e33256b518a2f607f660a4b6ea6bcb66c89ddef9d77bc2f0073";
+      sha256 = "7e086c213807cabf176403a2616f6b492f1d2a5c8077f84be6992253bff5d718";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/el/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/el/firefox-80.0b5.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "72e2f63d29736b517c1cb1a715b3f53adc2a1b7a5275bb9254ed5246fc809d50";
+      sha256 = "54ae8b094676bb84a3b2f434ed02857cfd6291ea0db830493baa564eacc2651e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/en-CA/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/en-CA/firefox-80.0b5.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "afc0656f0c1cf3b45a17475531294dd88976d2ab5adced074d041f8ab0b82e5c";
+      sha256 = "8401dfb33c8fd24c2337d96107d950f1fb3db57f89ea75119b91e695a989bff3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/en-GB/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/en-GB/firefox-80.0b5.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "cc9a1b76381a57025a814f50240a3f54ad4c65afc6dbcb964bc64cfa0428a8b9";
+      sha256 = "be8d438a4c361a5d3f6b03da2aacdaeccfcf6150104de89b099aec63182f8ce0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/en-US/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/en-US/firefox-80.0b5.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "baa573e6205a1892e30d5dd4cb1f569e7d188a196ff44fae9fe3b9d1f3698e53";
+      sha256 = "1c420fc89299f9ff4252ae5d35b020c13f49b47cfc24d36e6de668ccc62c52db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/eo/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/eo/firefox-80.0b5.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "affb91fbc15242b9d7d1dd95f5a5f4d2baaba7f4c299667bb83cd2852d0e0070";
+      sha256 = "cd4715fb9c29bd06463adfbbef732a2dfefe6893c75108583f837c0963e96287";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/es-AR/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/es-AR/firefox-80.0b5.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "b2990fce69dd8a605367297fbb031e683a91b7992dab83bac67024dc2f4c8967";
+      sha256 = "fb8d6590bc10784b8401897de4a01ff05879369fa38cc298365112b50525d9e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/es-CL/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/es-CL/firefox-80.0b5.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "4a3ed88b87309f482c43ef8acc30e67e1e791364a774dae5ef2de9d3948dbf52";
+      sha256 = "43bc8a2b6e2d8ea9ed458ce4721d0b33092d42a9571f188ec9e86aabbc29364a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/es-ES/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/es-ES/firefox-80.0b5.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "3c33e05e6d28db7a164984c746c3919e641dc2a6db8d192cfe9cac000fa16743";
+      sha256 = "30cc251ea5ef9adcfc9167e7fe28deffcf1196cc10cd11c3a7d3ba96083f4450";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/es-MX/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/es-MX/firefox-80.0b5.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "4b8c25940ec033be273e83694784c5175fd54f146e5d20eed04c5c675c3aa902";
+      sha256 = "acaeddceabb804cd7eac5c64113d532454d9544f908836dba8cc64092f728a64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/et/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/et/firefox-80.0b5.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "512bec2a4e96fc4cc55bdcd2651928e3070556fb3ac266776674d2f157f839a4";
+      sha256 = "681eec8b12cfc2c310d70affd06e0321085e55573982e838e9c9dfa08d847edf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/eu/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/eu/firefox-80.0b5.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "a27a0907895889a42d803da53de25c8d89387ab5dadbbf0907a9b49124de5e6a";
+      sha256 = "f0881ad646ca9ad05e0565cc79951f779841969446a42d81ea74d3b087ae872e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/fa/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/fa/firefox-80.0b5.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "3d3fe4787c0f5cc9980cabff9830f107664af7bf30b1f7a5f9195d36a6bbeb11";
+      sha256 = "2bd512eb9e24ea0cb7a3232bad53eae71b7f3a4a70807c6d9f2c026aeb54d3e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ff/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ff/firefox-80.0b5.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "4b768ef1f4c02bbd4e6ce524fb1d23c9d94778da4ef706fab4f8b6c5bbc2e22b";
+      sha256 = "3f4bf20d149a7a2ad2a982cde66c66bca2f4edbaabea7861c2c2d015f7e51635";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/fi/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/fi/firefox-80.0b5.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "bf65329b5cdd186b68d14471bde971beb85d8d8d8bf1ef539b9b6ddcda352c6c";
+      sha256 = "1df516483de0ed6772f8b5b6e6b30ba135e01c7ae14b97c2eaf291d4c396a849";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/fr/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/fr/firefox-80.0b5.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "a3f7e5ca5cf021135ee4e3723cc6752815877698f12f9f0192f6ef5df1d6ab66";
+      sha256 = "dc041c46fdbe80c7fb270a0082cdc4b5b89e7d39ceeb2ee90c4a4530a7d8ea79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/fy-NL/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/fy-NL/firefox-80.0b5.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "f8ded8da8420d57eeb97f896c1ca300ea37a05a9c4ec0882f6458fe90f9d57f4";
+      sha256 = "ce6f7f35578d3c58e3dc2119c9a864d3c8acfca6f9638d6b939c08041fc5b1c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ga-IE/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ga-IE/firefox-80.0b5.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "e243ae2eb3bbaa2062149b81ae7a0b3707a22cdd22cf12d52b4ad16a092b1f50";
+      sha256 = "019641493f03931fb0b025c41b10ccbf01d7499a11c30f99b9a7864244c99a94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/gd/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/gd/firefox-80.0b5.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "21c754935d320abf785d9da13458cd7cad87b94a9bd58f04b7d2caccc74d4a23";
+      sha256 = "6934320e2987b3d9315fa328d8a923089e0f6dc4ab42df3ce8afb6d51559c7ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/gl/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/gl/firefox-80.0b5.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "3ed764d4ffb47f8b044122677333c56a43097f9a9f6ac41f14cd3e2c2c1b1f0f";
+      sha256 = "c648c67f08131840c8b732056e3056b04eb236b089df8d8ca3f6a67663580844";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/gn/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/gn/firefox-80.0b5.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "4f74dce5938a97ef1b813f5e7423f8f7915a22c5248da3462ac3692534dcda09";
+      sha256 = "a6694736d424928fda4126e5b63b62c9ba09444f73b122d8b099c306fd5114a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/gu-IN/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/gu-IN/firefox-80.0b5.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "1d75b6b71937b131b09ea15d5f2e1abaa53077f7e2c7d4d9716f64dc73c0c27c";
+      sha256 = "ac5d16fc36d3577df90e2ad6011924f92ab9792baeb226c33e7bb61f749f0880";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/he/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/he/firefox-80.0b5.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "1e383432af4efb2e8ecf50f1ba2491312066f3b6212a82d7ce586ea6075183f6";
+      sha256 = "13ebf7f9b85e48a5b0be8b129b021d868a3775cadd54fe0d57f53ea1f7c934f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/hi-IN/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/hi-IN/firefox-80.0b5.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "2eebb66deb729e9b3ba6b2672467c3e7e1e30f978eb7a9a25c6cc87b2a524795";
+      sha256 = "965b53871ebd9b9890906cfd449ff26901874dd3b61800ce3ae8ca7100f93856";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/hr/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/hr/firefox-80.0b5.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "f4e71ac432b6e3991ca68190ba837ef0b6da2ca2ed0e5d4e21e0257f6bc95821";
+      sha256 = "b88976dfa1f30bd9cd063568cecd0918f3c9559533578164ffe4be394bcbe746";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/hsb/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/hsb/firefox-80.0b5.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "12b5694518fc5bb41a7d371a2dd0e38b0c8a63f82fc10cb9838c2f6d85f442ba";
+      sha256 = "ae9b444070caa2d561e7e94f55e6607997a08b224814ee30f8c0f43c21b60637";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/hu/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/hu/firefox-80.0b5.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "bb12e0d9ffa8adb6f34702e553b87b36f5b346a40819674f54edd6e127e3cfb7";
+      sha256 = "238e5ac5ba47daf8a36fff4aabe6a9170646c93d8994e31ed37700a6db3fc067";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/hy-AM/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/hy-AM/firefox-80.0b5.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "96224e693763a6aef998b6166a8026c6c9ac96cab1bbd064e91e823bf299c5bc";
+      sha256 = "b9243816bb9874c1d54c5286f5cc2ee13028f1b9adb27e4301042dded9c90ef5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ia/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ia/firefox-80.0b5.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "e2b65a3363dcc13ebbdbe85fca49038bd1bc9ec98cbc49f148de407f0c905e75";
+      sha256 = "a5807ec3208e97b7a479bc261335f81b5b7370fed396c5b3711a947fd7a26f89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/id/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/id/firefox-80.0b5.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "d8aa4ba3b4f86c1110cf2da3a5b999901dae2510ee4083189cfa62c5db0ce0fd";
+      sha256 = "0ba244346b7b4401aa996b9f9066f1985b94833da463a63fe59bb234f2df7617";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/is/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/is/firefox-80.0b5.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "3a814210821ef5b0d9f6c6c20bff5b8a658febab7d1c2480d4de23c4a57ab52d";
+      sha256 = "fe8f8c13ffa8981ff2bc346d682e58cc3f01d3d02918bfed89e6bb1c317aad79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/it/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/it/firefox-80.0b5.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "2acce241d65617fcb1aa4ea992fbd84a1089848f3f8a2daee58d381368189bb6";
+      sha256 = "29299eac2add81b5ec8806327e98a6d08f0988c8d934c1f8c1ba455c42834215";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ja/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ja/firefox-80.0b5.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "d25196134b98791547e92d0d1af29d27ef1ca180eec31a9b71700ccafbbff093";
+      sha256 = "13d4328e769c11942c7e603d496d5c2a0b61beddeb21d86c0cbc82434ea42749";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ka/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ka/firefox-80.0b5.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "733c8da99cb3746fe056b4cf76eb827333857d296a9c4d1d4617ee546001f87d";
+      sha256 = "498f189071482ac86df940e231b1f422ceb1e10515a0c513a575d3beafbc4ec3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/kab/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/kab/firefox-80.0b5.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "80c0bfabb148359eda25c475563038682237df10662681577c5d652b46661180";
+      sha256 = "254260ce4ff1480e3fdd4c5198fb3c9c6d8be1377ebc9fab276670b6695bb07f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/kk/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/kk/firefox-80.0b5.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "b87bc307b178c6c6fb3652fcceda3f442616f97be21e72fcdafdbd93dac18f63";
+      sha256 = "d653d7ce5eda93102ed50472978a676c8e3db04d3b55fb20b9a1b6b85f7df3ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/km/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/km/firefox-80.0b5.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "4284fc0cc354aa780785a090672ca4391c697a40a4c4ad41f5802aa43057ee6d";
+      sha256 = "63bb531290b3822a951199d8187a549ba7815301ff3e4d6dc9a656d1a6301b61";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/kn/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/kn/firefox-80.0b5.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "106342053396211986095a4cca1ebef5c3b91f4cd06b93db8dadcbaf4822c0dc";
+      sha256 = "4139740d10bf9a95930c9faa9f4411ee91f7f21fb0f08d0d7fb6f0455f57c0f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ko/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ko/firefox-80.0b5.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "5b57440c026c2815bea57df975697b15ae347f5b82cae855d4b01b21e82e36db";
+      sha256 = "a3ecdce55826613514085111b38d2916435e37e3e7741f12952958006cb8fbd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/lij/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/lij/firefox-80.0b5.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "b3a7b7e78c228f73d3fcb5524d786e51fa9e4826acbb0b2ac9fad70ec6e02f50";
+      sha256 = "0fb9514579413d7407087f2926114a53f3298bd6b0b7a5b3e9ba441c509a6161";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/lt/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/lt/firefox-80.0b5.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "f2309fc6a904f33bd96902ba349dbc47b655b888169f451ba8f8eda952ebe94a";
+      sha256 = "b77b998f35bbd3c589db97682a4cea2b76e009cf7dd33d04885e68bc090b9c72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/lv/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/lv/firefox-80.0b5.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "70e583717b3b17fa68d9fab1a1c2470eaae52474e7b774f653183ba371041fce";
+      sha256 = "0100227afb336b5c269e4afd5fbf24cebf8e8f46f35ce7907373aaca94e38a0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/mk/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/mk/firefox-80.0b5.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "ba20c3d5c88ecde3aa8fe382b8af4dd372f070fc6fae75644030315e33840859";
+      sha256 = "b25f8f292420442dd2d453519af8a4e82405a2973cee04902532055258d9147a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/mr/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/mr/firefox-80.0b5.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "f20ff1fc503b01746c040cadd0298dfbaa96892aba20a3020f0f69ec7bc6873e";
+      sha256 = "2f2e2efed4d42d8fc96701afc8a6956d5b8eaaa3c8fa823d01e006a810854d45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ms/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ms/firefox-80.0b5.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "6b1f0aac0028fcb24e45aade305e9e1315fff61c7e602d76e5a142326643c8a9";
+      sha256 = "d2743e86ff4d820cef8548ead1c14191870c1dd60c155ddb434dae6c20b0551c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/my/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/my/firefox-80.0b5.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "c5994f515d238efc6fc1eb0c9aaeb0b445970594ee26802ec80331614029657b";
+      sha256 = "8cb99f9032df7a878f5abe76cdf3839973e67b7786725fdc1d5943c056ed5cd0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/nb-NO/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/nb-NO/firefox-80.0b5.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "bdd3cbd3188b64fb29dfcc073bd66bb19ba92978c03720a348b04d2d8ceb4ff3";
+      sha256 = "2860c6cc9e0ac4a565cd3cbc76bc14f25c2f896173862d342cd8694a66047e10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ne-NP/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ne-NP/firefox-80.0b5.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "2c91bf86d1c6b5c9b7fbda1daf57ec554a69845d27cd1900c7089ea51b99aa52";
+      sha256 = "59a89bc2948f8d83cb87606481c5db97a62bcbae8dc2bab45c9720d4798424a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/nl/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/nl/firefox-80.0b5.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "26999404dbfa9cd673d22d32a8c310aa5e486bfa9c18890189358f35a676e42a";
+      sha256 = "5e93a24375dc608dd654819a1a94246fe6d76f0f52ae22363ba398b20fadf31c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/nn-NO/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/nn-NO/firefox-80.0b5.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "7f6897fbdd4cefe9619f7c73b2c82ca951ef54939e353ea3e36fdf72b114ddc2";
+      sha256 = "17b4616b1c8b01a8504c179146a6f2e321d060c3ed59e7dd66bf88e5defb391e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/oc/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/oc/firefox-80.0b5.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "b06bbf9b56c67330dea919244ba5ddfc424eb48c2776df2c3059a5786d702a1b";
+      sha256 = "4fc04859775ad7981a0590af5c740e4c85be4862ebc301acf30b3dc3309efef7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/pa-IN/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/pa-IN/firefox-80.0b5.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "c644a7e89020c0640085ff7925dbc8a3428b1d17b021822643e02949427e0581";
+      sha256 = "a7724f6d36c88d32f1bea552c1c256854a5db4412863f1019876c651c1bf2755";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/pl/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/pl/firefox-80.0b5.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "baaf3ad6bbff585b82de9fcfbad371146cdc64fcca60daac2db018335472528c";
+      sha256 = "bb50e2677f371af8a3b65fcf34aaac51bee18a4d17c54d9d51acb58e6b7fb7c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/pt-BR/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/pt-BR/firefox-80.0b5.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "c0daeaba4f24cd35f2ba107817553c226368ab9133782245f47c92f26cf4b49e";
+      sha256 = "a72b37e2d0bc3d2d6ecfda4d78d82a93e1e1f8e2e846a98621c7c23091586ebd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/pt-PT/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/pt-PT/firefox-80.0b5.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "1515e964eb405bd368bd46a66354aac8cd0cc44f0922b50714f55d2adc98ec88";
+      sha256 = "d0bff1596a4833488895454222c1115d380dd77855ede88cd3e078ba88668115";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/rm/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/rm/firefox-80.0b5.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "a0772fc62a05dbe85e435bf218fa643dbf9a81292dda482df1d4d283bc88eae7";
+      sha256 = "c335156273ce4c17b40fe5e0b8693e69cdc37403e8636f5b94208e52483b44fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ro/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ro/firefox-80.0b5.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "2e2d674cce4e2fefbc70689a5057cb6f19294cc61f37775879340dae5ac3ac54";
+      sha256 = "531666eab3163dc9abd108929070c93d0c8d51aafaa6c029af3fdcff29c545e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ru/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ru/firefox-80.0b5.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "0d6b8905d5ebdb0642ad5722fc547ff09b7b8a0453cd30b16872ec28bb68f760";
+      sha256 = "54f74bf7032c4f61d2b6f6af11f2faea4d9bbe57bdd6ccb8b39ba1b7eb2f05f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/si/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/si/firefox-80.0b5.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "f7c83715895a77c87c7e711ea37eda5e58360f5616d35247e1919ead9535ab70";
+      sha256 = "378a7cf707ace2a58ab170ffb18c87b9a8796607d1934aec890b2d7a1f1124db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/sk/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/sk/firefox-80.0b5.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "a436fc43f923baac4269a40e0f4ca06b782171f3aa7abb2d35c69cc44656fb57";
+      sha256 = "2ddaa4b427fdb243609a926aaa3850ecafa8fd080a824e547d620f70dca8ea42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/sl/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/sl/firefox-80.0b5.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "4580231b7220cc85e9cfbce8ab8d1c8a4071818344df3738a3cd0c2b4b83e791";
+      sha256 = "4acd2815ef0debbdb7e3b284199fae0c7acc3ffb48181677ce6074bdaeae543d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/son/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/son/firefox-80.0b5.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "310f20fb411aa27fa45d826008b39b4add9155af76347b7dfcee3363f4a40130";
+      sha256 = "11152335ac3c225584cb1ad61e0ae2a348cb10fef663e962cab78ae3677e0ced";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/sq/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/sq/firefox-80.0b5.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "44ce349d3db8b1afb7f020da53a04613b31c906795bba259dae156dcb6ef1d92";
+      sha256 = "bb9fabea549e21f1c82da2982bea84751a17e0c6e5fe272c0758ab6ebae1555b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/sr/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/sr/firefox-80.0b5.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "045e01214cc8d9c74d273960165982fa5b739bb8e18e91d59e576c815c5a4afe";
+      sha256 = "76e2a8cb1bd3dd2b2ebe4147e81eae053cb181c5ea9195a8ee598df6d7823ee2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/sv-SE/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/sv-SE/firefox-80.0b5.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "66a2bc65df656d98b4245c2d1611beb085c0403f87178fe9b7920018a2b0abd9";
+      sha256 = "b9ab41a2a45ad8022a2467ba36cd0cf9389e91fae3a5f1d021da5548054599f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ta/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ta/firefox-80.0b5.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "2e53ff624eacf0df39db5d208aa397dc21751c97ddbfaa21b4850614c40f68df";
+      sha256 = "733aba696ae2f370ad5186acdd1792b98c432bb5d8b4f5ab8c1ea92f3fe592db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/te/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/te/firefox-80.0b5.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "3b98487fbb9339321c321c306d0c240da5b2f56c936f7581128493c91e7bba0e";
+      sha256 = "89bdabf9cd4100bef75d0bc6b85c3fdc515d76e66f7be186e085f211bf6bbe68";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/th/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/th/firefox-80.0b5.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "188230c8eee66fc85c1e20d76d953d3cf3d2fa85d9803f1adf396fba8a4bf62e";
+      sha256 = "6e3f5d595d8b8cc7cd597cb8cc1197f275d0310a9000946ed1439b445f3a34a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/tl/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/tl/firefox-80.0b5.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "47612e155887b0de76a0a9b74c84d2894dd43f7999c252ee74346fdb74f60f4a";
+      sha256 = "94de068c79a1f563707ac7d7c1c53986a08db49670b658dcbae3ee1a234a38c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/tr/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/tr/firefox-80.0b5.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "050f115edc3ae514c0fa08174e9f15dbf3acf43cb1aa6bca9d3c4fcb5b9255e4";
+      sha256 = "cdee04c4719073da215e626e1a1d3b727aa69bb2dccd14b0545dea6ffe120465";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/trs/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/trs/firefox-80.0b5.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "8c02bc28f5951350c62be9aa9a6f8a76f33eb1f4d018b12f3860e26866169578";
+      sha256 = "8b99ed1bad47962e3364a4b82a3a27741d4819d2246d52653fb54862421505da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/uk/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/uk/firefox-80.0b5.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "bb131c9754fcbee6c62de6ba95a2d786775c2835d12ca69b2b3dc556fef7d2e1";
+      sha256 = "431532e371fe3da4fbe0a1f67a957ad8b08d3cc0448cc4719aa69cc99b323e89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/ur/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/ur/firefox-80.0b5.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "54fe4551d9095b8256d9d65dfae0f2433afc5d51055f47ec9fb9a5b538079164";
+      sha256 = "bd7d9f1fc41f549c956b396b84f304781962270241a4a7e6ba485be104e44bc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/uz/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/uz/firefox-80.0b5.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "d1e874a0aa5225a6e8d95a6d40771689663148a6eb3b6d25581339370f345187";
+      sha256 = "275f88e2779d18ac66e8f0289576ee3fec9dbe764842f79836ffd4855a1f93f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/vi/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/vi/firefox-80.0b5.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "1335be8474044bff9a47a5c2952974f55edb80d7b70de25fcaf5aee5c0487d33";
+      sha256 = "f851dd8525d7117852bae5833ff920312cfaa41b590362094f5a747513cfe8aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/xh/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/xh/firefox-80.0b5.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "dad0ac74d192b5d89d7e89dac553f3f18a781a51330f7e154ce4cb6ee4c45782";
+      sha256 = "306473f12600d1f953ab792e1755364b93eaa041f1d76ba70c764371381cabc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/zh-CN/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/zh-CN/firefox-80.0b5.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "a19ace9857172338831b1cf0b581ce1b09ff75e96417bc5ada5805c3074c0a98";
+      sha256 = "78c05977e7e94f81a5c7268c7b2f0cfedec60574020d3a30d20af826738a31d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-x86_64/zh-TW/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-x86_64/zh-TW/firefox-80.0b5.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "73914747c3472b6ff5cac485822fbba4be19c630dd4ddf925a6f2afba2849cf9";
+      sha256 = "816a6dd8bc27922d6ab24cafa3f22ab095655b029c4d399c95995168ad311f07";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ach/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ach/firefox-80.0b5.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "c95aa05f0a86fc30f20a4438ac66541b5ad03ecb904db4c19f50e659403d20f7";
+      sha256 = "2e28f99b2916720adcae5be56b795ee0ff36629f3475bfa56af6b546e3654a7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/af/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/af/firefox-80.0b5.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "c20dc401907d2b42aa4f2e920833c2cd7fe1fed35788422e84837d401f48bede";
+      sha256 = "765169fa05695b9f593ab8350c69dfcd6200f48fdadc21e9ba3d51ee5d08e599";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/an/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/an/firefox-80.0b5.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "5b965e8d6c0baf11be096efe2ad3ba638bf7b10afbc39db7c29b9bbf6fe0c797";
+      sha256 = "1833926492e17ef9dfa53957b42691ba819602422a7215a521c0d02539e25157";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ar/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ar/firefox-80.0b5.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "fba07c7262166659140132b7380f8f293194abe46045a3994e5f6c194709b120";
+      sha256 = "fe7031b6cecb593d3d0f7a40c935b9469c17bf8c4a23417f6587d169ac122739";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ast/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ast/firefox-80.0b5.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "8d4daa8bc48e6975eea8229718b0a04698c0ab0aecc5ab767d14444e854187f8";
+      sha256 = "2e3cf914d00aca18e0842eee6e6438fa1c8fe9e81847b6df29c2e0616892ed89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/az/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/az/firefox-80.0b5.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "41c13d04350b9fdf5be5c385bb74ac5e8ab9296c186627b89e43e5a0ab1deff0";
+      sha256 = "ee48e4665bae17cbf969104399561197d9e9f0c5178db756bfb0e99fb54d17c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/be/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/be/firefox-80.0b5.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "d46d199e66e4c4049496b29acf973731e1cfac1e3e40c45f8387444075dbfa51";
+      sha256 = "93d0f91c5e069c0eecfbc315741c3b70fc2cf9116e42b0d306b4fd28608bf376";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/bg/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/bg/firefox-80.0b5.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "157571ec4956ec72ace64ccc156d565f96f42bfce4d79c25fe5e60ab62197388";
+      sha256 = "a3e7d0488aa0b6ba4aa85589f0f94b50a4477821c37e372d95971b260ee3ad6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/bn/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/bn/firefox-80.0b5.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "82a7018fb11e81f26d1870021266182c608433e64b38b4ef59422332261327ef";
+      sha256 = "d5b9b1e85b5cd69d55dafa424a9e412eaea85cac577f19313ff940fc2555c8d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/br/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/br/firefox-80.0b5.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "ba31697f52277171e4de631e161c319c9aa9b35ca128d9f1e94b4a43badcf5d7";
+      sha256 = "c0e947b023d98261b294cf656c1f16d8f600b23f4ef3d1ba4229e43b7e3d9768";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/bs/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/bs/firefox-80.0b5.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "a99c9753fd41832d4ab310d5bc31978dae09b217f046fe7bc3c5c52f9e82193d";
+      sha256 = "533bbc0d47a4bbfc23593516811ac386e9bc1e3258d7d95d33e67be5e908298f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ca-valencia/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ca-valencia/firefox-80.0b5.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "630893c4edc30df6c41e2124be493be1a7927f94fc0638796b335a9ae3b990ca";
+      sha256 = "6ca26ed653b6055cc1fe0dadc80a0a4bbc93a87edf3cb16bc88786324b37a00f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ca/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ca/firefox-80.0b5.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "9a38f2b2697d453b946486f293d4c8da0b63c22f0866c90ca42ab1200d27a5bc";
+      sha256 = "2690847ae98de932c654dc12d58b9d403cf34d63d2e4bb486749341d3cc5f99e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/cak/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/cak/firefox-80.0b5.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "a78bc582617086d993bd35cf763e5da105c37ec1d2ce962c28c9d8761cc47535";
+      sha256 = "3c425f40c8c3a0db1550c3a6c432ee2272ed1c637b7b72a9a8ee5d879d06a287";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/cs/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/cs/firefox-80.0b5.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "466826a061e54f7e5d5aac5db9ce288588ba3d839db4d94e32d377e845aa869e";
+      sha256 = "16ab6b8a60eaec6f1c24d5abacdf69583a535c33c3d3748738542b5a8aa983fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/cy/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/cy/firefox-80.0b5.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "f95226e082dd690f037b0ba60e8d47ce7d880005c0b7c8ff97db3f6d24f536f7";
+      sha256 = "a6b6a935fec17157aee06ff20f6e356b13d2fb97618f9effbe32cf837d54cfac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/da/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/da/firefox-80.0b5.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "ee5cdbe8be79834b0d81bfbe7f10c2c98f42d07bb511681eea566a2009d3a363";
+      sha256 = "71775c067178e28517abbe5d663f75fb37d1ba438f4c3992c9aeee2afbc9f6fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/de/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/de/firefox-80.0b5.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "7a633122b530bce8d6869f5fd03d7ecae40f3b718cd862151b179d4e4c9234a1";
+      sha256 = "b4d7148762e691f6c6853528f5a9f5a5544d9b5c7575f421f6dbf1f3d0eeab0f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/dsb/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/dsb/firefox-80.0b5.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "d6c6ba8f3c3ac64fd847bf2c48cc57b025908fcfba43722db2056971d413bf21";
+      sha256 = "ad4f80e48d08dfdc5410aabbac45c5621964eeb7a69b484dc6a61158f88860c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/el/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/el/firefox-80.0b5.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "767d72120d99c6868859218abd2a19df545e00537d82f720d630aa2714eb1500";
+      sha256 = "ed620a877a2b3dc0eeebea3275a10dcf06ecf25e4626f4d644fdee2da95f0e08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/en-CA/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/en-CA/firefox-80.0b5.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "9e52734eb1ad30092a1e51d9a1d2c0d9fef1657c471ff8af5a709654c28d9991";
+      sha256 = "469ad0b743b717532acfa8bdf4671c628e5179253198140bcf34426c2b74aa16";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/en-GB/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/en-GB/firefox-80.0b5.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "0b78313c516b2da9c3442c50a1678a7c5898acd53f8f55a0506f1e60ae1c622a";
+      sha256 = "1157356b3ed89b702f4209e6bfa60e9b6822a3f2f624ff78dfe2830fa9bfb22a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/en-US/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/en-US/firefox-80.0b5.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "a254b48fc1faabe03db018a22166898a2363bcad6a507dfa2df3889dd4977e80";
+      sha256 = "c868faeff9b96646dba62b1c845d978d37646888724919962f49df6febae5b7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/eo/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/eo/firefox-80.0b5.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "decc99f94501b1a4ff11194ca4f02731aca46293faae7663c10b77d845b07c97";
+      sha256 = "d78b353ed7b64fa4d8956fc9cdbb3a56cfd6a2436ec8606e5fbd5865e65451a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/es-AR/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/es-AR/firefox-80.0b5.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "561b1c3687b676b1bbbdb9730801a487bb97efe98efe5bf44731cd0245e231e8";
+      sha256 = "9ba797d989c45519d8593912283aa3128e3824ea395f858806525544d1b9203a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/es-CL/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/es-CL/firefox-80.0b5.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "5de4b0c90da0f5b9a081dfd12143fa406d3712d4693ee28fb1667947fe3f0289";
+      sha256 = "0f2ce24d4406a0c6062a76745ba67c5c177c9f81fbd5ed93dfa67b89ac34c0cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/es-ES/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/es-ES/firefox-80.0b5.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "99aaf2c57fd51e61781053b3ee60ce1a89319b1101f95201f31f4128cec02905";
+      sha256 = "711a027c651a6ed11dc90746fdd765cfc566b6a993866fd533efea30386c683e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/es-MX/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/es-MX/firefox-80.0b5.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "d1e7e80b55ed6567cc3d651ec28efd64512276178ae1a0c8af9cb4db37103c11";
+      sha256 = "1511add39b72fa9465e160c84986e25e3cf8f578a538a623bf63abbf5cfff7e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/et/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/et/firefox-80.0b5.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "9ff5dfd1b737f3eb881decea26a36af108c7b4d7729d19849d9834eec7b853b4";
+      sha256 = "5ebcb28ae22be2f0ba8c9bdb46634020e94e91f9b2c29b075c8152ba47cb7ddb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/eu/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/eu/firefox-80.0b5.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "3da605f9a1bc592f9bdf7ce041bfc43f2235c2764828af4bee017993f38b34f9";
+      sha256 = "19c6169f3c0aa2797c1428c36c6965290bb7afc86cb8bb9c576fe924473633a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/fa/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/fa/firefox-80.0b5.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "1ea532fad20ae95df4bef6e68e6ca39a40c546edf14f164d052b9bcef3ba59d2";
+      sha256 = "27686b6569e76a7b41b2b5486f12ea66e2441edd33ca93ec310e087378aa4eb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ff/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ff/firefox-80.0b5.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "0fc5478ea083211c952d0c6f43a6061e7ad6a1b4c44f419204f143f1ada6c46e";
+      sha256 = "f8d589939bae46c456ac4e27cd38ca555917a25abaf836fb383dcf1bf3c6b1e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/fi/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/fi/firefox-80.0b5.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "3374b7bd157211e8ddb5b3c5b2b719a341387eefd59016ae0856a2bab71ae8f2";
+      sha256 = "90e3e9e22fbaffafbeb12c5525e80c2788bb39cb09833d8b7e0daa07a9411e23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/fr/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/fr/firefox-80.0b5.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "024ce5cd0bafee4ef9060e75a64cc7e04023fd9e9a62bc7bfcbb0e7895316d54";
+      sha256 = "a7262240a450fa8e0f943daae060b67cd3218ef4655e18af8ae6adea854aca8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/fy-NL/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/fy-NL/firefox-80.0b5.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "76b362664bb225421a845171afdc859575b0f706549e1b60657cea47f3678265";
+      sha256 = "9c12d7a86570de1f7934e4b60173593ef0fcf0bb36cf4aa146be20695fa1cdf5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ga-IE/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ga-IE/firefox-80.0b5.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "6093099531b07d1e6a37703aeee8333cf5e486faf7712f444a8b9e439c599a6c";
+      sha256 = "ed45137bb2679d237693ff112b43b07ae37c9e221e23633020cbf978d87fb66c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/gd/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/gd/firefox-80.0b5.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "0c463034000e2835bd13f4ba7f411ff155462590e161b07d89ab4c3bbc3726d6";
+      sha256 = "e22a6fe49290c71b3b0e004deb966fe8447c0ecaa55780cbecaed8409a8bc002";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/gl/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/gl/firefox-80.0b5.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "e743aa14124231717ad972f50b7ac1bf295cc67b9477b9db08cb688fcd7ec3d8";
+      sha256 = "69d7beead5e16a9bbeef75ab6fa5b33c83b4a647fb49cb146ac58c1ad07d1862";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/gn/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/gn/firefox-80.0b5.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "8c6811b5d5dd33d18e6610af344f97d62790d8d5750418ec0f21d9f9e0fd37f2";
+      sha256 = "005ebacc97342bf1dc001721df93354cfb58143ce48fd2464b3a94401f7cc27d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/gu-IN/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/gu-IN/firefox-80.0b5.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "b983b6d1f852c78f9930d4f0a8ecd8c2dfd552bd096e0cf29f228c3e1bc35fa6";
+      sha256 = "2f8b286d325472fc199b784a381cab92b932e231fe0898e0ee06b8cc9047b364";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/he/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/he/firefox-80.0b5.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "ddfb93bbd03aa7d7bd52fa0f7b934bd46898975b728f6418e7318bd63c3efcf7";
+      sha256 = "8c2f929d6aa2bc3a7ebf6970fbb1a800764ad102244e9969aff48c6e6f8250c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/hi-IN/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/hi-IN/firefox-80.0b5.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "b2cafc34206987deb4357d3f7628cc85ba2df43df8c4b2e4ca1e0b997737372d";
+      sha256 = "705c4cf48fa7398602b83b0d96da7f52a18e13523ebb6026ff63cf8de0e23fa0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/hr/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/hr/firefox-80.0b5.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "03e543d215397e93ff41604909f81a74a45ed5fcc09ff6d17fc26e9ada47b3d0";
+      sha256 = "852ce91d0aaf1eb3242b4ba67821499e6e9a9d6f78fe3710106c603be003c5b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/hsb/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/hsb/firefox-80.0b5.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "c7fe91aeab07e566c817e6bf34c08bf2c7c2c126fcaa62bed9d666f89d9cecd3";
+      sha256 = "0203b98b81a4416592ce24c8010287def2775b3ab9ee59293a43be1445b35084";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/hu/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/hu/firefox-80.0b5.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "8075abfc9e82ad812cb413440cb20c55b1f8807c05a164b5fb1658504639e13e";
+      sha256 = "fe8f5c6a486c71e3f1e577a90cbb7f755a7200aeff296c10e1d86f96870e4c2f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/hy-AM/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/hy-AM/firefox-80.0b5.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "e14e6d19c65fac2de302fa203760efae8804db439ad67bc4e8e604a98394ad34";
+      sha256 = "6750893fe1d7d156f46d072b9b9199585bfba88086f4cb86e04182b7959403fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ia/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ia/firefox-80.0b5.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "b8e500e10a6ebc05a7c666075851e4e37fcb2199b0bd0a0729d8a6a3a2a1ff90";
+      sha256 = "6c590d7268f7d86512da1e4a4b34ab86e8bede4a77e3ec7b92c909854ad48953";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/id/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/id/firefox-80.0b5.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "ef0684735d48f667df792036ff5917f8d1ce58bd2dcd719c8990ff077f5d47a3";
+      sha256 = "f5d185574caaefa6c1bd12f9adc3de508025c4d576d3446844060e67e0f2963b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/is/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/is/firefox-80.0b5.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "bf734b89739a181cfb8ed7eb5daf7412553e279aab1467d677cf3e1476460f7e";
+      sha256 = "4d6afff4cda9df9e280c812bd8eee09c98db09080dedeea4faa0a716b9122f95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/it/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/it/firefox-80.0b5.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "76eeb8b7466ac0eb3e0f12d393cd35d6ced9805dc78463327e0ad434af442dc3";
+      sha256 = "d5162f4c103c0e71f12423692ebbb2ae5a4a29ed2ab0576657498ea810a31890";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ja/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ja/firefox-80.0b5.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "80899dafca1e9b9b9526cd611cc41e4e3c78fa6e4a700908e6c3749d1a6d4753";
+      sha256 = "5d40dac80797ae0cc629a3515db23a6f465f4f436f3c528cb9923017238f1a1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ka/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ka/firefox-80.0b5.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "dcc7c6540cfda312a3ab4f410969aabac19307b29217dc935f5f9f0d3f027211";
+      sha256 = "c12c8183a8699e3d95e9469068eb6d78862a4cd4110dc8f12a85e0bc8cba9993";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/kab/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/kab/firefox-80.0b5.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "7bcb2bc74f9e46e69a218bebc63fef7ec86848feae475dc381f654ab958fc07c";
+      sha256 = "21f312fcc5539d02e3c4c275690cbaf0d982e0bc285cf7ff31340776eaf06f82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/kk/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/kk/firefox-80.0b5.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "605adecfebfa0664fd97b621e22f6bb1835733c46f2c96aaffa7d73e9f658dd3";
+      sha256 = "47b52fc3b75965fbb3b0a93f7b473c938adbbdc95f28861cfaf5ec947b6f75b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/km/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/km/firefox-80.0b5.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "9911c0e3e88888a4066151c9e7a0c6f70e3add4b8f99e496e5a0fe53d8af937c";
+      sha256 = "5ac99419d2da14b1eb92330d1cc8f9a23b89a893dbbfe9cd365864e433e16f1b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/kn/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/kn/firefox-80.0b5.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "411a655cff2f061dca76bee33b723a286e3672950441be143a29b57269179f42";
+      sha256 = "fca6d44dfe228ea0c95d4387bb97afea135461a11e35745e4e6c91e05cc45dcd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ko/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ko/firefox-80.0b5.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "82aba23c212ff220854ccff2b84932473037ff7732bc8aeace6f771732fc3add";
+      sha256 = "9acb14fd75076e46cb14082c33f02601593f7e45e4cce8f8d1acb79d5999dd70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/lij/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/lij/firefox-80.0b5.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "903ac88108c6b8973dadc412f85b8b241dd388f83508bf7d2aefd64234ffb62c";
+      sha256 = "ca1760b843d35c0f125ff06ca2edd3c14bceba30d2af668e343c0e21273fc7fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/lt/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/lt/firefox-80.0b5.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "3b97cca86af3b94777b4ef389d7ba9027f482c3a48dd5f16dea3130d508ee20f";
+      sha256 = "95daa6c7f4d001d96810c8bbf581f6cca6afb7f486a43ef5389ac18e3d3a29bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/lv/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/lv/firefox-80.0b5.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "f5100e1ebfe3e8df3873e487221b4829c9b05e995d02f93dcac7e4ddd37a473d";
+      sha256 = "3801a27b6eb954919922881246bec712b74661484a3f0431138c6028eee0efdc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/mk/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/mk/firefox-80.0b5.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "78237d16087898319dd6f8993494a84bd8554ff68826ce1bcaecb0733375a46b";
+      sha256 = "c2f2b3423214fa69d59cc12c4b91ceec9f11f946c30f9133b49c165fac7a08cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/mr/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/mr/firefox-80.0b5.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "4ab019edd1a72b22faa8f294698f09d1b760855ace96396a53745d53013da407";
+      sha256 = "7552a0361cfd5db9d87227b3bee9c428db6e82281e63a9c50917ae4693439850";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ms/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ms/firefox-80.0b5.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "ced211480048fb2105bfb956430459706d4185d01a740f30d544b2da4de16282";
+      sha256 = "4b85c65384655e6a9a8b20f17af2c27e2845621d368ad81b4b07608b9a3db72d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/my/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/my/firefox-80.0b5.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "44a29644307d24b1e6f2c178c262858212fb0294bf46ddae8d6ebc5606541f0c";
+      sha256 = "f614678968f9f15dae8bfcade4673d70dc38ff4a9d8571c65f69d28f4d884aae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/nb-NO/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/nb-NO/firefox-80.0b5.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "00c84bfd35833898706297f35b78eb0bfd3767bdcb9688e4deac0731b99720de";
+      sha256 = "c8caed7b3755102b09df285d671c2df1344eec0b7ab9da9e19bb95ec7495485c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ne-NP/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ne-NP/firefox-80.0b5.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "e7eb9deabda42cdaa0f5b94b9e216d7681bb95f271fb4a73fad216a7fe7b9ee3";
+      sha256 = "ff9c7f069eab2efba222f15788e5603c227b0d63ac97bb5b75145a95ca1e48f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/nl/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/nl/firefox-80.0b5.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "c73694c9c25f5bb45e657fbb47b5143c6812e15b62487036306074f5818ac107";
+      sha256 = "df5357df7e4834158cd69f52584364060ea0c1588e42b29153c40685d8fca56d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/nn-NO/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/nn-NO/firefox-80.0b5.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "defeb54e992715ff6f3e450d0ca2fe1dedf70a0f2776010d44e0ad864dfa2231";
+      sha256 = "69f0f7c772bebe28fd89a788a44f8c9bdff72208d896b47c249dacc26075a877";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/oc/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/oc/firefox-80.0b5.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "e60ab6dea689030851a07178b56a979d30f4f1247329692ff93ca81dd59d5435";
+      sha256 = "b6982629c7c353c1052d41495f155a681ddcd39250e0e3513648893e348d03b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/pa-IN/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/pa-IN/firefox-80.0b5.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "79dcb55f76031c0d05ff97810f0b9f6c11fbca3cf8a41b2b04ac06526dea5020";
+      sha256 = "ef86d94e901d3ea227f9f0eefac70d551c4a8a3320d7254a7a2a055f31ed3fb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/pl/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/pl/firefox-80.0b5.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "5944423bd0bbdd744c66237fcfa6aa00eba60e68b5cfa400b47a39b9fa77baa9";
+      sha256 = "fe74d0e222cfdce3240a839776752f90f159101f79829efc4ff5dbc741e1ae95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/pt-BR/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/pt-BR/firefox-80.0b5.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "6efa3010b67b697211b8f83a1fae8e7b62f4207bef1d71fa3a02fb6d9d620195";
+      sha256 = "d52997efa9e700767ce525dd6444cf1728b3e25501f7cecc2b352c4c59aa2d88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/pt-PT/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/pt-PT/firefox-80.0b5.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "b817ad0bfbd0cd0f8f3fa304ca82b0b2f30bb8dd5542e7d3422237d53b31cad5";
+      sha256 = "8bc9c0ee8a4d3202385e4918cf9cb87075ebd65a78454c4362afbded8f2f843f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/rm/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/rm/firefox-80.0b5.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "a46d4e796bc3771b076845281a07a83016880295b35db3ff8fcfb2f0485602ac";
+      sha256 = "de5ff0db1ec758f93f0d1b0f256571a7d62ad8207115132a37b0e9057b9ee39d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ro/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ro/firefox-80.0b5.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "5ea2f33d5274e4e1c105229ebe0a1cb1e8118c4157d059d62dafb893e7281d4f";
+      sha256 = "2003ba70aeb9e3f53126fc72dfd6941c9c246a51e5a155b09f72aff35dd7a61b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ru/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ru/firefox-80.0b5.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "e5513faf273a108b271cdb4eb3f20600030ea8ccf095fb7e4992fd72537c6433";
+      sha256 = "5d4c810e8cf90c35cdb78a292b57351dbe351e79fbc8189846b0074bdc9601ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/si/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/si/firefox-80.0b5.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "71b01eb76cc515af4ac1d4a28fbd27acea07cf57c26c84896ac70838cbc4d88d";
+      sha256 = "cbb56bcdc79f03b0b9d5a7d5a9399a69f2bc59e88869f852728c0e72110104b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/sk/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/sk/firefox-80.0b5.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "78e954e351141f5c92b0e975f6c3bdfa9dea259cfdbb195848f8a926009d8cbc";
+      sha256 = "61d5a87544ceea72298878b1cf96dfd1617c9d7ac3cf0b6d64ad5760a5eff3d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/sl/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/sl/firefox-80.0b5.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "50f8d47d6de655322ae96b637045c44c27461dd9781d05c7a5c68fdec9433a22";
+      sha256 = "06a8d7a402624d246bab72b742d5841681d61bd8f37fb4706be9be7fd7ba9479";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/son/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/son/firefox-80.0b5.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "0225bbf879728bbc64bbaf8b8db1881cff37706865a85ba786d159607865e4e9";
+      sha256 = "709941202dea2bc7b3a5c9752b1a0147938b38fe7b99a120948ca49ef9aa4528";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/sq/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/sq/firefox-80.0b5.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "3653b02ba5b32a2d5b2d886cbf5aa8279d4217a5066ba7757668c3bc4a7928b1";
+      sha256 = "d14bb984d2b3cd3c2de68a8ce1b66a91b145cddf7ac78b9114daea2e283cf717";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/sr/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/sr/firefox-80.0b5.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "5a5965f6855eecf7aa11a11cf752f354663a30daa7623cee72364eebc1e7540f";
+      sha256 = "58c3d01f10fb4c274c5b1eee93cfe07e5cfee08d09d30d3e0cf67953253fd13c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/sv-SE/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/sv-SE/firefox-80.0b5.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "723689ff6da680082e1e3e3ac3c81b2e6378780150ec958df91c49e1b655304a";
+      sha256 = "7525d2d133a08b897cba5ac5b781fe415e275bd0a92c99deb117ce018b2f048b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ta/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ta/firefox-80.0b5.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "2a3a062e0c00667d011d07c94863f93dec6197c2d627c32a3b7d53aa8cf4fd16";
+      sha256 = "cf726155f9a3277939650149889192ced79c87ba99aec512d7eb536af8473965";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/te/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/te/firefox-80.0b5.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "56c8bafd594a4661618424fb0cf56dbcdbf8c7192b875dd9175ad0716f5aead3";
+      sha256 = "a02e0c42fe93067851604d0bc39a5eaec559a48588cb34f39f423639f1053164";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/th/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/th/firefox-80.0b5.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "e8fe3a7ae603b2e10edabf6b7d21831f1e90ef33cd32ddbd42c2d51dbd2bf347";
+      sha256 = "097b0b4c01cb9ff182ccc465fac7c8bf81131c92de5a436fbf6529337d2858e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/tl/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/tl/firefox-80.0b5.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "1843201fdd0c198f1b0a7faabbcf3eb1bf94bb90aaf17f637b3a21aec3fd46bd";
+      sha256 = "93a1988b30b419c0798b19044e1cc673a2d8daa1d87144456e7523c39644c03d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/tr/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/tr/firefox-80.0b5.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "f50155ef38be88543bfa039c293a5e405b6f0cc45988356213707c6a23e91c3a";
+      sha256 = "a638707bbc1a5d5b64fcb7437ee6958625a11617c48311944ea8a37fe6e4403e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/trs/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/trs/firefox-80.0b5.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "4e25bb3f9a3e30b110dd08297c34db0a6df068117bd60a7ce1adc7541637fa3a";
+      sha256 = "61b9cb95089e81036700f0ad904d2f48f1613e80fe88d3ed8bbd05d1f955dfb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/uk/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/uk/firefox-80.0b5.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "037e10ecb056be944a039ed69cf00d5e26e423d9f224fb632256bdcb0df9fe56";
+      sha256 = "4c4664bed97585dac6e63aeea2c0aade015270418b8b4f52ac35428345592c45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/ur/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/ur/firefox-80.0b5.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "79ec0515ed9c39dec7fc053bf1c0649494571d1d240737b9e99b7cf081d0ac24";
+      sha256 = "b07cdd9781aa5cb29b5e2ba29d0b6df023274218fd72cea9a9f81a88b04cbabc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/uz/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/uz/firefox-80.0b5.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "20007b42603acf29a32f20a900597928fead8bf550f5e085d20f75fd7043000d";
+      sha256 = "08afabff9bf76df8b2af189bab8b320888e462b1242285a88fc11348d642f358";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/vi/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/vi/firefox-80.0b5.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "66826957d8668cb8e5970a812469f5cc8703b9e7251314c89ad79389c08834e1";
+      sha256 = "1520a23efe038aa52ef9b48c8e064562ae5e6ec269175f8e191d70f06509c301";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/xh/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/xh/firefox-80.0b5.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "1d304796883187c2d610ab171c72db38e915cdbd958f2b27adceb932d41bbfed";
+      sha256 = "de28503a1de2e18ede213c05621cd4625d3da1ea278c9bb1252d6bd43e8b068b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/zh-CN/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/zh-CN/firefox-80.0b5.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "dbf10c078118dbb59d18504465f30cca18c76603679ef71e209afe1017711a1b";
+      sha256 = "1b0f7815bf6b1fd9dc79a86c0b3ff3dbaa73fda87779d6c0a60e78d8ef702c03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/79.0b7/linux-i686/zh-TW/firefox-79.0b7.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0b5/linux-i686/zh-TW/firefox-80.0b5.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "97a3f9fe2527a6b1f74c46e63d75794eb616ecab1b98962dc591d2e5a634fad3";
+      sha256 = "e06233b66e85768aad44593395f5c63cb1a81ffe341a86413754dfa130c31cdf";
     }
     ];
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
FF80 brings VAAPI decoding to X11 which I can confirm to be working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
