### PR TITLE
newsflash: 1.0.2 -> 1.0.4

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsflash/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsflash/default.nix
@@ -19,16 +19,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "newsflash";
-  version = "1.0.2";
+  version = "1.0.4";
 
   src = fetchFromGitLab {
     owner = "news-flash";
     repo = "news_flash_gtk";
     rev = version;
-    sha256 = "17a8fd5rhs56qrqlfj9ckv45hwfcjhdb8j4cxlnvy7s770s225gd";
+    sha256 = "0x0ws3mhkvf1a8986c8mh2navvvmkkiwymn0smrybffsgqdd2jh1";
   };
 
-  cargoSha256 = "1p0m7la59fn9r2rr26q9mfd1nvyvxb630qiwj96x91p77xv1i30i";
+  cargoSha256 = "0rv2zrbarkkg56yg1w75lpdazgbik36yb70bzc6zqz1rmxinhqb0";
 
   patches = [
     ./no-post-install.patch
@@ -65,7 +65,7 @@ rustPlatform.buildRustPackage rec {
     # SVG support for gdk-pixbuf
     librsvg
   ] ++ (with gst_all_1; [
-    # Audio & video & support for webkitgtk WebView
+    # Audio & video support for webkitgtk WebView
     gstreamer
     gst-plugins-base
     gst-plugins-good


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest release: https://gitlab.com/news-flash/news_flash_gtk/-/tags/1.0.4

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).