### PR TITLE
gfbgraph: 0.2.3 -> 0.2.4

### DIFF
--- a/pkgs/development/libraries/gfbgraph/default.nix
+++ b/pkgs/development/libraries/gfbgraph/default.nix
@@ -1,22 +1,36 @@
 { stdenv, fetchurl, pkgconfig, glib, librest, gnome-online-accounts
-, gnome3, libsoup, json-glib, gobject-introspection }:
+, gnome3, libsoup, json-glib, gobject-introspection
+, gtk-doc, pkgs, docbook-xsl-nons, autoconf, automake, libtool }:
 
 stdenv.mkDerivation rec {
   pname = "gfbgraph";
-  version = "0.2.3";
+  version = "0.2.4";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1dp0v8ia35fxs9yhnqpxj3ir5lh018jlbiwifjfn8ayy7h47j4fs";
+    sha256 = "0yck7dwvjk16a52nafjpi0a39rxwmg0w833brj45acz76lgkjrb0";
   };
 
-  nativeBuildInputs = [ pkgconfig gobject-introspection ];
+  nativeBuildInputs = [
+    pkgconfig gobject-introspection gtk-doc
+    docbook-xsl-nons autoconf automake libtool
+  ];
   buildInputs = [ glib gnome-online-accounts ];
   propagatedBuildInputs = [ libsoup json-glib librest ];
 
-  configureFlags = [ "--enable-introspection" ];
+  configureFlags = [ "--enable-introspection" "--enable-gtk-doc" ];
+
+  prePatch = ''
+    patchShebangs autogen.sh
+    substituteInPlace autogen.sh \
+      --replace "which" "${pkgs.which}/bin/which"
+  '';
+
+  preConfigure = ''
+    NOCONFIGURE=1 ./autogen.sh
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump.
```
=================
LibGFBGraph 0.2.4
=================

The changes include:

- Change Facebook Graph API version to v2.10 by Álvaro Peña.
- Fix memory leaks of GFBGraphNode class by Krzesimir Nowak.
- Support g_autoptr for GFBGraphAlbum, GFBGraphNode, GFBGraphPhoto,
  GFBGraphUser by Leesoo Ahn.
- Fix memory leaks of GFBGraphUser, GFBGraphSimpleAuthorizer,
  GFBGraphAlbum by Leesoo Ahn.

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
CC: @jtojnar @worldofpeace @hedning 