### PR TITLE
agdaPackages.generic: init at v0.1

### DIFF
--- a/pkgs/development/libraries/agda/generic/default.nix
+++ b/pkgs/development/libraries/agda/generic/default.nix
@@ -1,0 +1,31 @@
+{ lib, mkDerivation, fetchFromGitHub, standard-library }:
+
+mkDerivation rec {
+  pname = "generic";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    repo = "Generic";
+    owner = "effectfully";
+    rev = "v${version}";
+    sha256 = "121121rg3daaqp91845fbyws6g28hyj1ywmh12n54r3nicb35g5q";
+  };
+
+  buildInputs = [
+    standard-library
+  ];
+
+  preBuild = ''
+    echo "module Everything where" > Everything.agda
+	  find src -name '*.agda' | sed -e 's/src\///;s/\//./g;s/\.agda$//;s/^/import /' >> Everything.agda
+  '';
+
+  meta = with lib; {
+    description =
+      "A library for doing generic programming in Agda";
+    homepage = src.meta.homepage;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ alexarice turion ];
+  };
+}

--- a/pkgs/top-level/agda-packages.nix
+++ b/pkgs/top-level/agda-packages.nix
@@ -24,5 +24,7 @@ let
     agda-categories = callPackage ../development/libraries/agda/agda-categories { };
 
     cubical = callPackage ../development/libraries/agda/cubical { };
+
+    generic = callPackage ../development/libraries/agda/generic { };
   };
 in mkAgdaPackages Agda


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes #94932

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@turion 

There appears to be no `Everything.agda` file. There is a `Main.agda` but I don't think it hits all the files using `find` (commented in code atm) takes a while and I think there might be some errors
