### PR TITLE
aliza: 1.48.10 -> 1.98.32

### DIFF
--- a/pkgs/applications/science/medicine/aliza/default.nix
+++ b/pkgs/applications/science/medicine/aliza/default.nix
@@ -3,11 +3,11 @@
 with stdenv.lib;
 stdenv.mkDerivation {
   pname = "aliza";
-  version = "1.48.10";
+  version = "1.98.32";
   src = fetchurl {
     # See https://www.aliza-dicom-viewer.com/download
-    url = "https://drive.google.com/uc?export=download&id=16WEScARaSrzJpJkyGuOUxDF95eUwGyET";
-    sha256 = "1ls16cwd0fmb5axxmy9lgf8cqrf7g7swm26f0gr2vqp4z9bw6qn3";
+    url = "https://drive.google.com/uc?export=download&id=1nggavPhY_633T-AW9PdkcAgbWtzv3QKG";
+    sha256 = "00vbgv8ca9ckgkicyyngrb01yhhcqc8hygg2bls7b44c47hcc8zz";
     name = "aliza.rpm";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Package didn't build anymore, RPM link turned 404.

Just fetched the latest and update the hash.

Not a physician but works as expected AFAICT (opened a MRI scan of mine with it and browsed the scans).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
