### PR TITLE
btcdeb: 0.2.19 -> unstable-20200806

### DIFF
--- a/pkgs/applications/blockchains/btcdeb/default.nix
+++ b/pkgs/applications/blockchains/btcdeb/default.nix
@@ -7,14 +7,14 @@
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  pname = "btcdeb";
-  version = "0.2.19";
+  pname = "btcdeb-unstable";
+  version = "200806";
 
   src = fetchFromGitHub {
-    owner = "kallewoof";
-    repo = pname;
-    rev = "fb2dace4cd115dc9529a81515cee855b8ce94784";
-    sha256 = "0l0niamcjxmgyvc6w0wiygfgwsjam3ypv8mvjglgsj50gyv1vnb3";
+    owner = "bitcoin-core";
+    repo = "btcdeb";
+    rev = "f6708c397c64894c9f9e31bea2d22285d9462de7";
+    sha256 = "0qkmf89z2n7s95vhw3n9vh9dbi14zy4vqw3ffdh1w911jwm5ry3z";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];


### PR DESCRIPTION
- now lives under [bitcoin-core](https://github.com/bitcoin-core/btcdeb) github org ([old repo](https://github.com/kallewoof/btcdeb) redirects to the new one)
- there seem to be no tags/releases

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to recent version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
