### PR TITLE
musescore: 3.4.2 -> 3.5.0

### DIFF
--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -7,11 +7,11 @@
 
 mkDerivation rec {
   pname = "musescore";
-  version = "3.4.2";
+  version = "3.5.0";
 
   src = fetchzip {
-    url = "https://github.com/musescore/MuseScore/releases/download/v${version}/MuseScore-${version}.zip";
-    sha256 = "1laskvp40dncs12brkgvk7wl0qrvzy52rn7nf3b67ps1vmd130gp";
+    url = "https://github.com/musescore/MuseScore/releases/download/v3.5/MuseScore-${version}.zip";
+    sha256 = "0m598xh0s4f5m4l2ymy7g44bbvc14bcfi4gifhjnrg091rsk57c9";
     stripRoot = false;
   };
 
@@ -20,7 +20,14 @@ mkDerivation rec {
   ];
 
   cmakeFlags = [
-  ] ++ lib.optional (lib.versionAtLeast freetype.version "2.5.2") "-DUSE_SYSTEM_FREETYPE=ON";
+    "-DUSE_SYSTEM_FREETYPE=ON"
+  ];
+
+  qtWrapperArgs = [
+    # Work around crash on update from 3.4.2 to 3.5.0
+    # https://bugreports.qt.io/browse/QTBUG-85967
+    "--set QML_DISABLE_DISK_CACHE 1"
+  ];
 
   nativeBuildInputs = [ cmake pkgconfig ];
 


### PR DESCRIPTION
###### Motivation for this change

Release notes: https://musescore.org/en/handbook/developers-handbook/release-notes/release-notes-musescore-3x/release-notes-musescore-35x-3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
