### PR TITLE
manual: add AMD BLIS/LIBFLAME to the BLAS/LAPACK list

### DIFF
--- a/doc/using/overlays.xml
+++ b/doc/using/overlays.xml
@@ -178,7 +178,7 @@ self: super:
          <para>
            <link
            xlink:href="https://software.intel.com/en-us/mkl">Intel
-           MKL</link> (only works on x86 architecture, unfree)
+           MKL</link> (only works on the x86_64 architecture, unfree)
          </para>
          <para>
            The Nixpkgs attribute is <literal>mkl</literal>.
@@ -201,16 +201,17 @@ self: super:
      <para>
        Introduced in <link
        xlink:href="https://github.com/NixOS/nixpkgs/pull/83888">PR
-       #83888</link>, we are able to override the ‘blas’ and ‘lapack’
-       packages to use different implementations, through the
-       ‘blasProvider’ and ‘lapackProvider’ argument. This can be used
+       #83888</link>, we are able to override the <literal>blas</literal>
+       and <literal>lapack</literal> packages to use different implementations,
+       through the <literal>blasProvider</literal> and
+       <literal>lapackProvider</literal> argument. This can be used
        to select a different provider. BLAS providers will have
        symlinks in <literal>$out/lib/libblas.so.3</literal> and
        <literal>$out/lib/libcblas.so.3</literal> to their respective
        BLAS libraries. Likewise, LAPACK providers will have symlinks
        in <literal>$out/lib/liblapack.so.3</literal> and
        <literal>$out/lib/liblapacke.so.3</literal> to their respective
-       LAPCK libraries. For example, Intel MKL is both a BLAS and
+       LAPACK libraries. For example, Intel MKL is both a BLAS and
        LAPACK provider. An overlay can be created to use Intel MKL
        that looks like:
      </para>
@@ -229,8 +230,9 @@ self: super:
      <para>
        This overlay uses Intel’s MKL library for both BLAS and LAPACK
        interfaces. Note that the same can be accomplished at runtime
-       using <literal>LD_LIBRARY_PATH</literal> of libblas.so.3 and
-       liblapack.so.3. For instance:
+       using <literal>LD_LIBRARY_PATH</literal> of
+       <literal>libblas.so.3</literal> and
+       <literal>liblapack.so.3</literal>. For instance:
      </para>
      <programlisting>
 $ LD_LIBRARY_PATH=$(nix-build -A mkl)/lib:$LD_LIBRARY_PATH nix-shell -p octave --run octave

--- a/doc/using/overlays.xml
+++ b/doc/using/overlays.xml
@@ -184,6 +184,19 @@ self: super:
            The Nixpkgs attribute is <literal>mkl</literal>.
          </para>
        </listitem>
+       <listitem>
+         <para>
+           <link
+           xlink:href="https://developer.amd.com/amd-aocl/blas-library/">AMD
+           BLIS/LIBFLAME</link> (optimized for modern AMD x86_64 CPUs)
+         </para>
+         <para>
+          The AMD BLIS library, with attribute <literal>amd-blis</literal>,
+          provides a BLAS implementation. The complementary AMD LIBFLAME
+          library, with attribute <literal>amd-libflame</literal>, provides
+          a LAPACK implementation.
+         </para>
+       </listitem>
      </itemizedlist>
      <para>
        Introduced in <link


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Also tacked on a commit with some small markup/spelling fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
