### PR TITLE
qtdeclarative: Patch for scrollbar regression

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
@@ -1,4 +1,4 @@
-{ qtModule, lib, python3, qtbase, qtsvg }:
+{ qtModule, lib, fetchpatch, python3, qtbase, qtsvg }:
 
 with lib;
 
@@ -23,4 +23,12 @@ qtModule {
     "bin/qmlscene"
     "bin/qmltestrunner"
   ];
+  patches =
+    # https://mail.kde.org/pipermail/kde-distro-packagers/2020-June/000419.html
+    lib.optional (lib.versionAtLeast qtbase.version "5.14.2")
+      (fetchpatch {
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtdeclarative.git;a=patch;h=3e47ac319b0f53c43cc02a8356c2dec4f0daeef4";
+        sha256 = "0wvncg7047q73nm0svc6kb14sigwk7sc53r4778kn033aj0qqszj";
+        name = "qtdeclarative-QQuickItemView-fix-max-extent.patch";
+      });
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

KDE upstream is asking us to carry this patch: https://mail.kde.org/pipermail/kde-distro-packagers/2020-June/000419.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
