### PR TITLE
treewide: remove obsolete attribute goPackagePath in buildGoModule derivations

### DIFF
--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -5,7 +5,6 @@ buildGoModule rec {
   version = "3.0.0";
   k3sVersion = "1.18.6-k3s1";
 
-  goPackagePath = "github.com/rancher/k3d";
   excludedPackages = ''tools'';
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/instant-messengers/gomuks/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gomuks/default.nix
@@ -4,8 +4,6 @@ buildGoModule rec {
   pname = "gomuks";
   version = "0.1.2";
 
-  goPackagePath = "maunium.net/go/gomuks";
-
   src = fetchFromGitHub {
     owner = "tulir";
     repo = pname;

--- a/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
@@ -4,7 +4,6 @@ buildGoModule rec {
   pname = "git-bug";
   version = "0.7.1"; # the `rev` below pins the version of the source to get
   rev = "2d64b85db71a17ff3277bbbf7ac9d8e81f8e416c";
-  goPackagePath = "github.com/MichaelMure/git-bug";
 
   src = fetchFromGitHub {
     inherit rev;
@@ -19,9 +18,9 @@ buildGoModule rec {
 
   buildFlagsArray = ''
     -ldflags=
-      -X ${goPackagePath}/commands.GitCommit=${rev}
-      -X ${goPackagePath}/commands.GitLastTag=${version}
-      -X ${goPackagePath}/commands.GitExactTag=${version}
+      -X github.com/MichaelMure/git-bug/commands.GitCommit=${rev}
+      -X github.com/MichaelMure/git-bug/commands.GitLastTag=${version}
+      -X github.com/MichaelMure/git-bug/commands.GitExactTag=${version}
   '';
 
   postInstall = ''

--- a/pkgs/applications/version-management/sourcehut/builds.nix
+++ b/pkgs/applications/version-management/sourcehut/builds.nix
@@ -9,11 +9,10 @@ let
   buildWorker = src: buildGoModule {
     inherit src version;
     pname = "builds-sr-ht-worker";
-    goPackagePath = "git.sr.ht/~sircmpwn/builds.sr.ht/worker";
 
-  vendorSha256 = "0prdlihcy5yz760llwyby747yy2981dn3gy401a48df7ndlfj6lp";
+    vendorSha256 = "0prdlihcy5yz760llwyby747yy2981dn3gy401a48df7ndlfj6lp";
 
-  doCheck = false;
+    doCheck = false;
   };
 in buildPythonPackage rec {
   inherit version;

--- a/pkgs/applications/version-management/sourcehut/git.nix
+++ b/pkgs/applications/version-management/sourcehut/git.nix
@@ -9,41 +9,37 @@ let
   buildShell = src: buildGoModule {
     inherit src version;
     pname = "gitsrht-shell";
-    goPackagePath = "git.sr.ht/~sircmpwn/git.sr.ht/gitsrht-shell";
 
-  vendorSha256 = "1zvbqn4r940mibn4h1cqz94gbr476scm281ps361n0rfqlimw8g5";
+    vendorSha256 = "1zvbqn4r940mibn4h1cqz94gbr476scm281ps361n0rfqlimw8g5";
 
-  doCheck = false;
+    doCheck = false;
   };
 
   buildDispatcher = src: buildGoModule {
     inherit src version;
     pname = "gitsrht-dispatcher";
-    goPackagePath = "git.sr.ht/~sircmpwn/git.sr.ht/gitsrht-dispatch";
 
-  vendorSha256 = "1lzkf13m54pq0gnn3bcxc80nfg76hgck4l8q8jpaicrsiwgcyrd9";
+    vendorSha256 = "1lzkf13m54pq0gnn3bcxc80nfg76hgck4l8q8jpaicrsiwgcyrd9";
 
-  doCheck = false;
+    doCheck = false;
   };
 
   buildKeys = src: buildGoModule {
     inherit src version;
     pname = "gitsrht-keys";
-    goPackagePath = "git.sr.ht/~sircmpwn/git.sr.ht/gitsrht-keys";
 
-  vendorSha256 = "16j7kpar318s4766pln8xn6d51xqblwig5n1jywhj0sl80qjl5cv";
+    vendorSha256 = "16j7kpar318s4766pln8xn6d51xqblwig5n1jywhj0sl80qjl5cv";
 
-  doCheck = false;
+    doCheck = false;
   };
 
   buildUpdateHook = src: buildGoModule {
     inherit src version;
     pname = "gitsrht-update-hook";
-    goPackagePath = "git.sr.ht/~sircmpwn/git.sr.ht/gitsrht-update-hook";
 
-  vendorSha256 = "1rmv3p60g6w4h4v9wx99jkyx0q02snslyjrjy9n1flardjs01b63";
+    vendorSha256 = "1rmv3p60g6w4h4v9wx99jkyx0q02snslyjrjy9n1flardjs01b63";
 
-  doCheck = false;
+    doCheck = false;
   };
 in buildPythonPackage rec {
   inherit version;

--- a/pkgs/development/tools/continuous-integration/drone-cli/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-cli/default.nix
@@ -5,7 +5,6 @@ in buildGoModule rec {
   inherit version;
   pname = "drone-cli";
   revision = "v${version}";
-  goPackagePath = "github.com/drone/drone-cli";
 
   vendorSha256 = "1ryh94cj37j8x6qwxr5ydyw6cnjppakg1w84sipm11d0vvv98bhi";
 

--- a/pkgs/development/tools/continuous-integration/drone/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone/default.nix
@@ -3,7 +3,6 @@
 buildGoModule rec {
   name = "drone.io-${version}";
   version = "1.9.0";
-  goPackagePath = "github.com/drone/drone";
 
   vendorSha256 = "0idf11sr417lxcjryplgb87affr6lgzxazzlyvk0y40hp8zbhwsx";
 

--- a/pkgs/development/tools/godef/default.nix
+++ b/pkgs/development/tools/godef/default.nix
@@ -5,7 +5,6 @@ buildGoModule rec {
   version = "1.1.2";
   rev = "v${version}";
 
-  goPackagePath = "github.com/rogpeppe/godef";
   subPackages = [ "." ];
 
   vendorSha256 = null;

--- a/pkgs/development/tools/gomodifytags/default.nix
+++ b/pkgs/development/tools/gomodifytags/default.nix
@@ -8,8 +8,6 @@ buildGoModule rec {
 
   doCheck = false;
 
-  goPackagePath = "github.com/fatih/gomodifytags";
-
   src = fetchFromGitHub {
     owner = "fatih";
     repo = "gomodifytags";

--- a/pkgs/development/tools/gopkgs/default.nix
+++ b/pkgs/development/tools/gopkgs/default.nix
@@ -4,8 +4,6 @@ buildGoModule rec {
   pname = "gopkgs";
   version = "2.1.2";
 
-  goPackagePath = "github.com/uudashr/gopkgs";
-
   subPackages = [ "cmd/gopkgs" ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/gosec/default.nix
+++ b/pkgs/development/tools/gosec/default.nix
@@ -4,8 +4,6 @@ buildGoModule rec {
   pname = "gosec";
   version = "2.4.0";
 
-  goPackagePath = "github.com/securego/gosec";
-
   subPackages = [ "cmd/gosec" ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/hcloud/default.nix
+++ b/pkgs/development/tools/hcloud/default.nix
@@ -4,8 +4,6 @@ buildGoModule rec {
   pname = "hcloud";
   version = "1.17.0";
 
-  goPackagePath = "github.com/hetznercloud/cli";
-
   src = fetchFromGitHub {
     owner = "hetznercloud";
     repo = "cli";

--- a/pkgs/development/tools/kind/default.nix
+++ b/pkgs/development/tools/kind/default.nix
@@ -17,7 +17,6 @@ buildGoModule rec {
 
   doCheck = false;
 
-  goPackagePath = "sigs.k8s.io/kind";
   subPackages = [ "." ];
 
   nativeBuildInputs = [ installShellFiles ];

--- a/pkgs/development/tools/kubeprompt/default.nix
+++ b/pkgs/development/tools/kubeprompt/default.nix
@@ -15,10 +15,9 @@ buildGoModule rec {
     export buildFlagsArray+=(
       "-ldflags=
         -w -s
-        -X ${goPackagePath}/pkg/version.Version=${version}")
+        -X github.com/jlesquembre/kubeprompt/pkg/version.Version=${version}")
   '';
 
-  goPackagePath = "github.com/jlesquembre/kubeprompt";
   vendorSha256 = "089lfkvyf00f05kkmr935jbrddf2c0v7m2356whqnz7ad6a2whsi";
 
   doCheck = false;

--- a/pkgs/development/tools/misc/mkcert/default.nix
+++ b/pkgs/development/tools/misc/mkcert/default.nix
@@ -15,10 +15,8 @@ buildGoModule rec {
 
   doCheck = false;
 
-  goPackagePath = "github.com/FiloSottile/mkcert";
   buildFlagsArray = ''
-    -ldflags=
-      -X ${goPackagePath}/main.Version=${version}
+    -ldflags=-X main.Version=v${version}
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/nix-build-uncached/default.nix
+++ b/pkgs/development/tools/misc/nix-build-uncached/default.nix
@@ -11,7 +11,6 @@ buildGoModule rec {
     sha256 = "106k4234gpi8mr0n0rfsgwk4z7v0b2gim0r5bhjvg2v566j67g02";
   };
 
-  goPackagePath = "github.com/Mic92/nix-build-uncached";
   vendorSha256 = null;
 
   doCheck = false;

--- a/pkgs/development/tools/reftools/default.nix
+++ b/pkgs/development/tools/reftools/default.nix
@@ -12,7 +12,6 @@ buildGoModule rec {
 
   doCheck = false;
 
-  goPackagePath = "github.com/davidrjenni/reftools";
   excludedPackages = "\\(cmd/fillswitch/test-fixtures\\)";
 
   src = fetchFromGitHub {

--- a/pkgs/servers/caddy/default.nix
+++ b/pkgs/servers/caddy/default.nix
@@ -4,8 +4,6 @@ buildGoModule rec {
   pname = "caddy";
   version = "1.0.5";
 
-  goPackagePath = "github.com/caddyserver/caddy";
-
   subPackages = [ "caddy" ];
 
   src = fetchFromGitHub {

--- a/pkgs/servers/dns/coredns/default.nix
+++ b/pkgs/servers/dns/coredns/default.nix
@@ -4,8 +4,6 @@ buildGoModule rec {
   pname = "coredns";
   version = "1.7.0";
 
-  goPackagePath = "github.com/coredns/coredns";
-
   src = fetchFromGitHub {
     owner = "coredns";
     repo = "coredns";

--- a/pkgs/servers/hasura/cli.nix
+++ b/pkgs/servers/hasura/cli.nix
@@ -7,7 +7,6 @@ buildGoModule rec {
   src = hasura-graphql-engine.src;
   modRoot = "./cli";
 
-  goPackagePath = "github.com/hasura/graphql-engine/cli";
   subPackages = [ "cmd/hasura" ];
 
   vendorSha256 = "0a3mlkl00r680v8x3hy24ykggq5qm7k3101krlyfrb5y4karp75a";

--- a/pkgs/servers/kapow/default.nix
+++ b/pkgs/servers/kapow/default.nix
@@ -4,8 +4,6 @@ buildGoModule rec {
   pname = "kapow";
   version = "0.5.4";
 
-  goPackagePath = "github.com/BBVA/kapow";
-
   subPackages = [ "." ];
 
   src = fetchFromGitHub {

--- a/pkgs/servers/matterbridge/default.nix
+++ b/pkgs/servers/matterbridge/default.nix
@@ -4,7 +4,6 @@ buildGoModule rec {
   pname = "matterbridge";
   version = "1.17.5";
 
-  goPackagePath = "github.com/42wim/matterbridge";
   vendorSha256 = null;
 
   doCheck = false;

--- a/pkgs/servers/monitoring/sensu-go/default.nix
+++ b/pkgs/servers/monitoring/sensu-go/default.nix
@@ -7,8 +7,6 @@ let
       version = "5.21.0";
       shortRev = "3a1ac58"; # for internal version info
 
-      goPackagePath = "github.com/sensu/sensu-go";
-
       src = fetchFromGitHub {
         owner = "sensu";
         repo = "sensu-go";

--- a/pkgs/servers/monitoring/telegraf/default.nix
+++ b/pkgs/servers/monitoring/telegraf/default.nix
@@ -4,8 +4,6 @@ buildGoModule rec {
   pname = "telegraf";
   version = "1.15.2";
 
-  goPackagePath = "github.com/influxdata/telegraf";
-
   excludedPackages = "test";
 
   subPackages = [ "cmd/telegraf" ];

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -15,7 +15,6 @@ buildGoModule rec {
 
   CGO_ENABLED = 0;
 
-  goPackagePath = "tailscale.com";
   vendorSha256 = "0l9lzwwvshg9a2kmmq1cvvlaxncbas78a9hjhvjjar89rjr2k2sv";
 
   doCheck = false;

--- a/pkgs/shells/zsh/zsh-history/default.nix
+++ b/pkgs/shells/zsh/zsh-history/default.nix
@@ -17,8 +17,6 @@ buildGoModule rec {
 
   doCheck = false;
 
-  goPackagePath = "github.com/b4b4r07/history";
-
   postInstall = ''
     install -d $out/share
     cp -r "$NIX_BUILD_TOP/source/misc/"* "$out/share"

--- a/pkgs/tools/admin/iamy/default.nix
+++ b/pkgs/tools/admin/iamy/default.nix
@@ -4,8 +4,6 @@ buildGoModule rec {
   pname = "iamy";
   version = "2.3.2";
 
-  goPackagePath = "github.com/99designs/iamy";
-
   src = fetchFromGitHub {
     owner = "99designs";
     repo = "iamy";

--- a/pkgs/tools/networking/clash/default.nix
+++ b/pkgs/tools/networking/clash/default.nix
@@ -11,14 +11,13 @@ buildGoModule rec {
     sha256 = "0qyfv6h6m86m5bwayj0s1pjldnbagy63zc2ygzpnicihmd58khny";
   };
 
-  goPackagePath = "github.com/Dreamacro/clash";
   vendorSha256 = "0ap6wsx23s4q730s6d5cgc4ginh8zj5sd32k0za49fh50v8k8zbh";
 
   doCheck = false;
 
   buildFlagsArray = [
     "-ldflags="
-    "-X ${goPackagePath}/constant.Version=${version}"
+    "-X github.com/Dreamacro/clash/constant.Version=${version}"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/networking/oneshot/default.nix
+++ b/pkgs/tools/networking/oneshot/default.nix
@@ -11,7 +11,6 @@ buildGoModule rec {
     sha256 = "14s5cl1g0rgqj7fj699xgz2kmkzym1zpckhv3h33ypsn4dq7gjh2";
   };
 
-  goPackagePath = "github.com/raphaelreyna/oneshot";
   vendorSha256 = "0v53dsj0w959pmvk6v1i7rwlfd2y0vrghxlwkgidw0sf775qpgvy";
 
   doCheck = false;

--- a/pkgs/tools/networking/shadowfox/default.nix
+++ b/pkgs/tools/networking/shadowfox/default.nix
@@ -11,8 +11,6 @@ buildGoModule rec {
     sha256 = "125mw70jidbp436arhv77201jdp6mpgqa2dzmrpmk55f9bf29sg6";
   };
 
-  goPackagePath = "github.com/SrKomodo/shadowfox-updater";
-
   vendorSha256 = "06ar9ivry9b01609izjbl6hqgg0cy7aqd8n2cqpyq0g7my0l0lbj";
 
   doCheck = false;

--- a/pkgs/tools/security/age/default.nix
+++ b/pkgs/tools/security/age/default.nix
@@ -3,7 +3,6 @@
 buildGoModule rec {
   pname = "age";
   version = "1.0.0-beta4";
-  goPackagePath = "github.com/FiloSottile/age";
   vendorSha256 = "0km7a2826j3fk2nrkmgc990chrkcfz006wfw14yilsa4p2hmfl7m";
 
   doCheck = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The `buildGoModule` infrastructure does not make use of `goPackagePath`, it is a residue from `buildGoPackage`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
