### PR TITLE
gxemul: 0.6.0.1 -> 0.6.2

### DIFF
--- a/pkgs/misc/emulators/gxemul/default.nix
+++ b/pkgs/misc/emulators/gxemul/default.nix
@@ -2,26 +2,24 @@
 
 stdenv.mkDerivation rec {
   pname = "gxemul";
-  version = "0.6.0.1";
+  version = "0.6.2";
 
   src = fetchurl {
-    url = "http://gxemul.sourceforge.net/src/${pname}-${version}.tar.gz";
-    sha256 = "1afd9l0igyv7qgc0pn3rkdgrl5d0ywlyib0qhg4li23zilyq5407";
+    url = "http://gavare.se/gxemul/src/gxemul-${version}.tar.gz";
+    sha256 = "0iqmazfn7ss5n27m1a9n9nps3vzhag1phzb7qw0wgczycmwsq0x7";
   };
 
   configurePhase = "./configure";
 
   installPhase = ''
-    mkdir -p $out/bin;
-    mkdir -p $out/share/${pname}-${version};
-    cp gxemul $out/bin;
-    cp -r doc $out/share/${pname}-${version};
-    cp -r demos $out/share/${pname}-${version};
-    cp -r ./man $out/;
+    mkdir -p {$out/bin,$out/share/${pname}-${version}}
+    cp -r {doc,demos} $out/share/${pname}-${version}
+    cp gxemul $out/bin
+    cp -r ./man $out
   '';
 
-  meta = {
-    license = stdenv.lib.licenses.bsd3;
+  meta = with stdenv.lib; {
+    homepage = "http://gavare.se/gxemul/";
     description = "Gavare's experimental emulator";
     longDescription = ''
       GXemul is a framework for full-system computer architecture
@@ -32,6 +30,6 @@ stdenv.mkDerivation rec {
       and serial controllers. The emulation is working well enough to
       allow several unmodified "guest" operating systems to run.
     '';
-    homepage = "http://gxemul.sourceforge.net/";
+    license = licenses.bsd3;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Main site seems to be http://gavare.se/gxemul/ instead of the sourceforge one, it has a more recent version and more documentation.

There don't seem to be any maintainers, and I'm personally not interested enough to add myself as one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
