### PR TITLE
neomutt: 20200626 -> 20200814

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchFromGitHub, gettext, makeWrapper, tcl, which, writeScript
 , ncurses, perl , cyrus_sasl, gss, gpgme, kerberos, libidn, libxml2, notmuch, openssl
 , lmdb, libxslt, docbook_xsl, docbook_xml_dtd_42, elinks, mailcap, runtimeShell, sqlite, zlib
-, glibcLocales, fetchpatch
+, glibcLocales
 }:
 
 stdenv.mkDerivation rec {
-  version = "20200807";
+  version = "20200814";
   pname = "neomutt";
 
   src = fetchFromGitHub {
     owner  = "neomutt";
     repo   = "neomutt";
     rev    = version;
-    sha256 = "0bj81bl54jx1c9fnyrplwvgvwq8l0ldqd58jjb4haw2rlzfj2a8s";
+    sha256 = "00i2xbadw7rq2b30yjla54m0df4jbh22g6phby41albw2wc2hn72";
   };
 
   buildInputs = [
@@ -26,14 +26,6 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
-
-  patches = [
-    # fixes segfault on startup
-    (fetchpatch {
-      url = "https://github.com/neomutt/neomutt/commit/887428a38f845f9eaca80c3e05e0c2aedb137669.patch";
-      sha256 = "1yqpj0xaryxmsvj6hbfksy50i9alqxidifqf3daqgg4vypi8s9b9";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace contrib/smime_keys \

--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchFromGitHub, gettext, makeWrapper, tcl, which, writeScript
 , ncurses, perl , cyrus_sasl, gss, gpgme, kerberos, libidn, libxml2, notmuch, openssl
 , lmdb, libxslt, docbook_xsl, docbook_xml_dtd_42, elinks, mailcap, runtimeShell, sqlite, zlib
-, glibcLocales
+, glibcLocales, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
-  version = "20200626";
+  version = "20200807";
   pname = "neomutt";
 
   src = fetchFromGitHub {
     owner  = "neomutt";
     repo   = "neomutt";
     rev    = version;
-    sha256 = "0r16fy02z61dbjdxc28yzj5i4f6r7aakh453gaqc8ilm1nsxhmnp";
+    sha256 = "0bj81bl54jx1c9fnyrplwvgvwq8l0ldqd58jjb4haw2rlzfj2a8s";
   };
 
   buildInputs = [
@@ -27,6 +27,14 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  patches = [
+    # fixes segfault on startup
+    (fetchpatch {
+      url = "https://github.com/neomutt/neomutt/commit/887428a38f845f9eaca80c3e05e0c2aedb137669.patch";
+      sha256 = "1yqpj0xaryxmsvj6hbfksy50i9alqxidifqf3daqgg4vypi8s9b9";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace contrib/smime_keys \
       --replace /usr/bin/openssl ${openssl}/bin/openssl
@@ -40,7 +48,7 @@ stdenv.mkDerivation rec {
 
     # allow neomutt to map attachments to their proper mime.types if specified wrongly
     # and use a far more comprehensive list than the one shipped with neomutt
-    substituteInPlace sendlib.c \
+    substituteInPlace send/sendlib.c \
       --replace /etc/mime.types ${mailcap}/etc/mime.types
   '';
 


### PR DESCRIPTION
###### Motivation for this change

<del>:warning: **Caution:** `20200807` is only a development release and not considered stable, so please *don't* merge! I already had to apply a patch to fix a segfault on startup.</del>

<del>This is *only* intended to be used by power-users who want to try out the latest version. I don't consider this mergable until the 20.09 branchoff happened, after that we can discuss how to proceed with this.</del>

ChangeLog: https://github.com/neomutt/neomutt/releases/tag/20200807, https://github.com/neomutt/neomutt/releases/tag/20200814

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
