### PR TITLE
gtg: refactor (licenses)

### DIFF
--- a/pkgs/applications/office/gtg/default.nix
+++ b/pkgs/applications/office/gtg/default.nix
@@ -61,7 +61,7 @@ python3Packages.buildPythonApplication rec {
     '';
     homepage = "https://wiki.gnome.org/Apps/GTG";
     downloadPage = "https://github.com/getting-things-gnome/gtg/releases";
-    license = licenses.gpl3Only;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ oyren ];
     platforms = platforms.linux;
   };

--- a/pkgs/development/python-modules/liblarch/default.nix
+++ b/pkgs/development/python-modules/liblarch/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     description = "A python library built to easily handle data structure such are lists, trees and acyclic graphs";
     homepage = "https://github.com/getting-things-gnome/liblarch";
     downloadPage = "https://github.com/getting-things-gnome/liblarch/releases";
-    license = licenses.lgpl3Only;
+    license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ oyren ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
The given license is wrong as it turned out [here](https://github.com/getting-things-gnome/gtg/issues/445) and through @jtojnar comment (https://github.com/NixOS/nixpkgs/pull/94686#discussion_r465532946).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
