### PR TITLE
gnome-subtitles: init at 1.7.2

### DIFF
--- a/pkgs/applications/video/gnome-subtitles/default.nix
+++ b/pkgs/applications/video/gnome-subtitles/default.nix
@@ -1,0 +1,89 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, autoconf
+, autoreconfHook
+, automake
+, gettext
+, pkg-config
+, intltool
+, itstool
+, libtool
+, mono5
+, yelp-tools
+, wrapGAppsHook
+, enchant2
+, gnome
+, glib
+, gtk3
+, gtk-doc
+, gtk-sharp-3_0
+, gtkspell3
+, gst_all_1
+, libxml2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-subtitles";
+  version = "1.7.2";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = pname;
+    rev = "${pname}-${version}";
+    hash = "sha256-/Rx0Rck3NdaOALoIyFHMwV1Obf+TjfyO/BBIwlm1KxY=";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    gtk-doc
+    autoreconfHook
+    autoconf
+    automake
+    gettext
+    mono5
+    libtool
+    intltool
+    itstool
+    pkg-config
+    yelp-tools
+  ];
+
+  buildInputs = [
+    enchant2
+    gtk3
+    glib
+    libxml2
+    gtk-sharp-3_0
+    gtkspell3
+    gnome.gnome-common
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    (gst-plugins-good.override {
+      gtkSupport = true;
+    })
+    gst-plugins-bad
+    gst-plugins-ugly
+  ]);
+
+  preConfigure = ''
+    intltoolize
+  '';
+
+  preFixup = ''
+      gappsWrapperArgs+=(
+        --prefix MONO_PATH : "${gtk-sharp-3_0}/lib/mono/gtk-sharp-3.0"
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ enchant2 glib gtk3 ]}
+      )
+  '';
+
+  meta = with lib; {
+    description = "Subtitle editor for the GNOME desktop";
+    homepage = "http://gnomesubtitles.org/";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ dasj19 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5892,6 +5892,8 @@ with pkgs;
 
   gnome-photos = callPackage ../applications/graphics/gnome-photos { };
 
+  gnome-subtitles = callPackage ../applications/video/gnome-subtitles { };
+
   gnokii = callPackage ../tools/misc/gnokii { };
 
   gnuapl = callPackage ../development/interpreters/gnu-apl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
WIP. Adding the gnome-subtitle package to the repo as requested here: https://github.com/NixOS/nixpkgs/issues/92176

###### Things done
Now the package builds and runs fine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
