### PR TITLE
qcsxcad: init at 0.6.2

### DIFF
--- a/pkgs/applications/science/electronics/qcsxcad/default.nix
+++ b/pkgs/applications/science/electronics/qcsxcad/default.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, csxcad
+, tinyxml
+, vtkWithQt5
+, wrapQtAppsHook
+, qtbase
+}:
+
+mkDerivation {
+  pname = "qcsxcad";
+  version = "unstable-2020-01-04";
+
+  src = fetchFromGitHub {
+    owner = "thliebig";
+    repo = "QCSXCAD";
+    rev = "0dabbaf2bc1190adec300871cf309791af842c8e";
+    sha256 = "11kbh0mxbdfh7s5azqin3i2alic5ihmdfj0jwgnrhlpjk4cbf9rn";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+    "-DCSXCAD_ROOT_DIR=${csxcad}"
+    "-DENABLE_RPATH=OFF"
+  ];
+
+  buildInputs = [
+    csxcad
+    tinyxml
+    vtkWithQt5
+    qtbase
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Qt library for CSXCAD";
+    homepage = "https://github.com/thliebig/QCSXCAD";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ matthuszagh ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25770,6 +25770,10 @@ in
 
   pcb = callPackage ../applications/science/electronics/pcb { };
 
+  qcsxcad = libsForQt5.callPackage ../applications/science/electronics/qcsxcad {
+    inherit (qt5) wrapQtAppsHook qtbase;
+  };
+
   qucs = callPackage ../applications/science/electronics/qucs { };
 
   xcircuit = callPackage ../applications/science/electronics/xcircuit { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Part of [this pr](https://github.com/NixOS/nixpkgs/pull/69262). @jonringer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
