### PR TITLE
tanka: add bash completion

### DIFF
--- a/pkgs/applications/networking/cluster/tanka/default.nix
+++ b/pkgs/applications/networking/cluster/tanka/default.nix
@@ -1,4 +1,4 @@
-{ buildGoModule, fetchFromGitHub, lib }:
+{ buildGoModule, fetchFromGitHub, lib, installShellFiles }:
 
 buildGoModule rec {
   pname = "tanka";
@@ -14,6 +14,13 @@ buildGoModule rec {
   vendorSha256 = "15x8fqz2d2793ivgxpd9jyr34njzi1xpyxdlfyj1b01n2vr3xg4m";
 
   buildFlagsArray = [ "-ldflags=-s -w -X main.Version=${version}" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    echo "complete -C $out/bin/tk tk" > tk.bash
+    installShellCompletion tk.bash
+  '';
 
   meta = with lib; {
     description = "Flexible, reusable and concise configuration for Kubernetes";


### PR DESCRIPTION

###### Motivation for this change

As suggested [here](https://github.com/NixOS/nixpkgs/pull/94659), adding bash completion should be great for Tanka

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
