### PR TITLE
roundcube: 1.4.7 -> 1.4.8

### DIFF
--- a/pkgs/servers/roundcube/default.nix
+++ b/pkgs/servers/roundcube/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "roundcube";
-  version = "1.4.7";
+  version = "1.4.8";
 
   src = fetchurl {
     url = "https://github.com/roundcube/roundcubemail/releases/download/${version}/roundcubemail-${version}-complete.tar.gz";
-    sha256 = "1jdcda6102n948l6qzhjsiylnmx5fkgjg2hn17g93x3yzwkmvn16";
+    sha256 = "0jkas28k7px95sm3zix86ggraxc9vyy66271sgpr2wrmbg2r056r";
   };
 
   patches = [ ./0001-Don-t-resolve-symlinks-when-trying-to-find-INSTALL_P.patch ];


### PR DESCRIPTION
###### Motivation for this change
Security fixes. 

see https://roundcube.net/news/2020/08/10/security-updates-1.4.8-1.3.15-and-1.2.12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
 asbachb@nixos  ~/dev/src/nix/nixpkgs   update/roundcube  nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
these paths will be fetched (0.03 MiB download, 0.13 MiB unpacked):
  /nix/store/91qp2v2h0fd9d6b6hchzf13zki091grv-nixpkgs-review-2.3.1
copying path '/nix/store/91qp2v2h0fd9d6b6hchzf13zki091grv-nixpkgs-review-2.3.1' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
   066c604eec6..44d841f758d  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-e513a4e1f9c68337fec67e4931f207a32117092b-dirty/nixpkgs 44d841f758d943636b185f76f6a3f54e5e05a910
Preparing worktree (detached HEAD 44d841f758d)
Updating files: 100% (22399/22399), done.
HEAD is now at 44d841f758d inkcut: init at 2.1.1
$ nix-env -f /home/asbachb/.cache/nixpkgs-review/rev-e513a4e1f9c68337fec67e4931f207a32117092b-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
