### PR TITLE
orca: 3.36.3 -> 3.36.4

### DIFF
--- a/pkgs/applications/misc/orca/default.nix
+++ b/pkgs/applications/misc/orca/default.nix
@@ -35,13 +35,13 @@
 
 buildPythonApplication rec {
   pname = "orca";
-  version = "3.36.3";
+  version = "3.36.4";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1x0xrcyxlvcjlqp6wcsx5d951i500079wqs04scssjzwqggy330n";
+    sha256 = "1s6qrmbn3pywidwwfa24ly21c1cz6fnnsipi9vlp3sxswbdcwiwz";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump.
Release news:
```
3.36.4 - 10 August 2020

Web:

 * Fix false positive causing us to not present self-referential labels

 * Fix crash caused by author using aria-labelledby pointing to itself

 * Always speak the current line when caret moves due to mouse click
   so that presentation is consistent regardless of the element

 * Fix bug causing events from Google Docs to be ignored when a dialog
   appears but lacks focus

Thunderbird:

 * Fix bug causing us to incorrectly update our location within settings

General:

 * Fix bug causing learn mode to not work in (at least) gnome-shell
   controls

New and updated translations (THANKS EVERYONE!!!):

   fr            French                Charles Monzat
   kk            Kazakh                Baurzhan Muftakhidinov
   uk            Ukrainian             Yuri Chornoivan

=========
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
