### PR TITLE
exiv2: Patch cmake files to correctly locate libs

### DIFF
--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -106,6 +106,10 @@ stdenv.mkDerivation rec {
       rm *
       mv .exiv2 exiv2
     )
+
+    # Tell cmake to look in the default output to find exiv2's .so and .a files
+    substituteInPlace $out/lib/cmake/exiv2/exiv2Config-release.cmake \
+          --replace "\''${_IMPORT_PREFIX}/lib/libexiv2" "$out/lib/libexiv2"
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Exiv2's `.so` and `.a` files are placed in the default output, but the cmake file looks for them in the `dev` output. This causes build failures in at least once case (#77581).

This patch takes the same approach as #33953, which solved a similar issue in the clang derivation.

The two outputs in question (`.out` and `.dev`) looks like this:

    /nix/store/...-exiv2-0.27.2
    |-- bin
    |   `-- exiv2
    `-- lib
        |-- libexiv2-xmp.a
        |-- libexiv2.so -> libexiv2.so.27
        |-- libexiv2.so.0.27.2
        `-- libexiv2.so.27 -> libexiv2.so.0.27.2

    /nix/store/...exiv2-0.27.2-dev
    |-- include
    |   `-- exiv2
    |       |-- *.h
    |       `-- *.hpp
    |-- lib
    |   |-- cmake
    |   |   `-- exiv2
    |   |       |-- exiv2Config-release.cmake
    |   |       |-- exiv2Config.cmake
    |   |       `-- exiv2ConfigVersion.cmake
    |   `-- pkgconfig
    |       `-- exiv2.pc
    `-- nix-support
        `-- propagated-build-inputs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
