### PR TITLE
inkscape: allow loading external extensions

### DIFF
--- a/pkgs/applications/graphics/inkscape/extensions.nix
+++ b/pkgs/applications/graphics/inkscape/extensions.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, fetchFromGitHub
+}:
+
+{
+  hexmap = stdenv.mkDerivation {
+    name = "hexmap";
+    version = "2020-06-06";
+
+    src = fetchFromGitHub {
+      owner = "lifelike";
+      repo = "hexmapextension";
+      rev = "11401e23889318bdefb72df6980393050299d8cc";
+      sha256 = "1a4jhva624mbljj2k43wzi6hrxacjz4626jfk9y2fg4r4sga22mm";
+    };
+
+    preferLocalBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/share/inkscape/extensions"
+      cp -p *.inx *.py "$out/share/inkscape/extensions/"
+      find "$out/share/inkscape/extensions/" -name "*.py" -exec chmod +x {} \;
+
+      runHook postInstall
+    '';
+
+    meta = with stdenv.lib; {
+      description = "This is an extension for creating hex grids in Inkscape. It can also be used to make brick patterns of staggered rectangles";
+      homepage = "https://github.com/lifelike/hexmapextension";
+      license = licenses.gpl2Plus;
+      maintainers = [ maintainers.raboof ];
+      platforms = platforms.all;
+    };
+  };
+}

--- a/pkgs/applications/graphics/inkscape/with-extensions.nix
+++ b/pkgs/applications/graphics/inkscape/with-extensions.nix
@@ -1,0 +1,21 @@
+{ lib
+, inkscape
+, symlinkJoin
+, makeWrapper
+, inkscapeExtensions ? []
+}:
+
+symlinkJoin {
+  name = "inkscape-with-extensions-${lib.getVersion inkscape}";
+
+  paths = [ inkscape ] ++ inkscapeExtensions;
+
+  buildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    rm -f $out/bin/inkscape
+    makeWrapper "${inkscape}/bin/inkscape" "$out/bin/inkscape" --set INKSCAPE_DATADIR "$out/share"
+  '';
+
+  inherit (inkscape) meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20929,6 +20929,8 @@ in
 
   inkscape-with-extensions = callPackage ../applications/graphics/inkscape/with-extensions.nix { };
 
+  inkscape-extensions = recurseIntoAttrs (callPackages ../applications/graphics/inkscape/extensions.nix {});
+
   inkscape_0 = callPackage ../applications/graphics/inkscape/0.x.nix {
     lcms = lcms2;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20927,6 +20927,8 @@ in
     lcms = lcms2;
   };
 
+  inkscape-with-extensions = callPackage ../applications/graphics/inkscape/with-extensions.nix { };
+
   inkscape_0 = callPackage ../applications/graphics/inkscape/0.x.nix {
     lcms = lcms2;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

My longer-term motivation is that I want to be able to load inkcut as an
extension, but let's start with getting the infrastructure ready and adding
a simple one.

I added the 'hexmap' extension to show the process. You could use this for
example like:

```
{ pkgs ? import <nixpkgs> {} }:

pkgs.mkShell {
  buildInputs = [
    (pkgs.inkscape-with-extensions.override {
      inkscapeExtensions = [
        pkgs.inkscape-extensions.hexmap
      ];
    })
  ];
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @jtojnar 