### PR TITLE
molotov: init at 4.2.2

### DIFF
--- a/pkgs/applications/video/molotov/default.nix
+++ b/pkgs/applications/video/molotov/default.nix
@@ -1,0 +1,35 @@
+{ lib, fetchurl, appimageTools }:
+
+let
+  pname = "molotov";
+  version = "4.2.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://desktop-auto-upgrade.molotov.tv/linux/${version}/molotov.AppImage";
+    sha256 = "00p8srf4yswbihlsi3s7kfkav02h902yvrq99wys11is63n01x8z";
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit name src; };
+in  appimageTools.wrapType2 {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+    install -m 444 -D \
+      ${appimageContents}/${pname}.desktop \
+      $out/share/applications/${pname}.desktop
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description = "A french TV wrapper and on-demand provider.";
+    homepage = "https://www.molotov.tv";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ apeyroux ];
+    platforms = [ "x86_64-linux" ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20182,6 +20182,8 @@ in
 
   moe =  callPackage ../applications/editors/moe { };
 
+  molotov = callPackage ../applications/video/molotov { };
+
   multibootusb = qt5.callPackage ../applications/misc/multibootusb {};
 
   praat = callPackage ../applications/audio/praat { };


### PR DESCRIPTION
###### Motivation for this change

Implementation of  #76849. Currently can't work with "master" because gst-plugins-base-0.10.36 has been marked broken with d034a00 . You can test with https://github.com/apeyroux/molotov.nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
