### PR TITLE
reno: 2.3.2 -> 3.1.0

### DIFF
--- a/pkgs/development/tools/reno/default.nix
+++ b/pkgs/development/tools/reno/default.nix
@@ -1,27 +1,58 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv
+, git
+, gnupg1
+, python3Packages
+}:
 
-with pythonPackages; buildPythonApplication rec {
+with python3Packages; buildPythonApplication rec {
   pname = "reno";
-  version = "2.3.2";
+  version = "3.1.0";
 
-  src = fetchurl {
-    url = "mirror://pypi/r/reno/${pname}-${version}.tar.gz";
-    sha256 = "018vl9fj706jjf07xdx8q6761s53mrihjn69yjq09gp0vmp1g7i4";
+  # Must be built from python sdist because of versioning quirks
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2510e3aae4874674187f88f22f854e6b0ea1881b77039808a68ac1a5e8ee69b6";
   };
 
-  # Don't know how to make tests pass
-  doCheck = false;
+  propagatedBuildInputs = [
+    dulwich
+    pbr
+    pyyaml
+    setuptools  # required for finding pkg_resources at runtime
+  ];
 
-  # Nothing to strip (python files)
-  dontStrip = true;
+  checkInputs = [
+    # Python packages
+    pytestCheckHook
+    docutils
+    fixtures
+    sphinx
+    testtools
+    testscenarios
 
-  propagatedBuildInputs = [ pbr six pyyaml dulwich ];
-  buildInputs = [ Babel ];
+    # Required programs to run all tests
+    git
+    gnupg1
+  ];
+
+  # remove b/c doesn't list all dependencies, and requires a few packages not in nixpkgs
+  postPatch = ''
+    rm test-requirements.txt
+  '';
+
+  disabledTests = [
+    "test_build_cache_db" # expects to be run from a git repository
+  ];
+
+  # verify executable
+  postCheck = ''
+    $out/bin/reno -h
+  '';
 
   meta = with stdenv.lib; {
     description = "Release Notes Manager";
-    homepage    = "http://docs.openstack.org/developer/reno/";
-    license     = licenses.asl20;
-    maintainers = with maintainers; [ guillaumekoenig ];
+    homepage = "https://docs.openstack.org/reno/latest";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger guillaumekoenig ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Reno release notes manager was 3 years out of date, and didn't work anyways.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
