### PR TITLE
mwic: Fix Python wrapping

### DIFF
--- a/pkgs/applications/misc/mwic/default.nix
+++ b/pkgs/applications/misc/mwic/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = with pythonPackages; [ pyenchant regex ];
 
   postFixup = ''
-    buildPythonPath "$out"
+    wrapPythonPrograms
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fixes this error when mwic is installed with nix-env:

```console
$ mwic
Traceback (most recent call last):
  File "/home/anders/.nix-profile/bin/mwic", line 30, in <module>
    import lib.cli  # pylint: disable=wrong-import-position
  File "/nix/store/zn9jli2v7znh6w6rpkjp6w0iz3na79yz-mwic-0.7.8/share/mwic/lib/cli.py", line 32, in <module>
    import enchant.tokenize
ModuleNotFoundError: No module named 'enchant'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
