### PR TITLE
python3Packages.kinparse: init at unstable-2019-12-18

### DIFF
--- a/pkgs/development/python-modules/kinparse/default.nix
+++ b/pkgs/development/python-modules/kinparse/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, future
+, pyparsing
+}:
+
+buildPythonPackage {
+  pname = "kinparse";
+  version = "unstable-2019-12-18";
+
+  src = fetchFromGitHub {
+    owner = "xesscorp";
+    repo = "kinparse";
+    rev = "eeb3f346d57a67a471bdf111f39bef8932644481";
+    sha256 = "1nrjnybwzy93c79yylcwmb4lvkx7hixavnjwffslz0zwn32l0kx3";
+  };
+
+  doCheck = true;
+  pythonImportsCheck = [ "kinparse" ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    future
+    pyparsing
+  ];
+
+  meta = with lib; {
+    description = "A Parser for KiCad EESCHEMA netlists";
+    homepage = "https://github.com/xesscorp/kinparse";
+    license = licenses.mit;
+    maintainers = with maintainers; [ matthuszagh ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -926,6 +926,8 @@ in {
 
   kconfiglib = callPackage ../development/python-modules/kconfiglib { };
 
+  kinparse = callPackage ../development/python-modules/kinparse { };
+
   labelbox = callPackage ../development/python-modules/labelbox { };
 
   lammps-cython = callPackage ../development/python-modules/lammps-cython {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adds [kinparse](https://github.com/xesscorp/kinparse).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
