### PR TITLE
nixos/xmonad: Fix behavior of config opt

### DIFF
--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -82,12 +82,11 @@ in
     services.xserver.windowManager = {
       session = [{
         name = "xmonad";
-        start = if (cfg.config != null) then ''
-          ${xmonadBin}
-          waitPID=$!
-        '' else ''
-          systemd-cat -t xmonad ${xmonad}/bin/xmonad &
-          waitPID=$!
+        start = let
+          xmonadCommand = if (cfg.config != null) then xmonadBin else "${xmonad}/bin/xmonad";
+        in ''
+           systemd-cat -t xmonad ${xmonadCommand} &
+           waitPID=$!
         '';
       }];
     };


### PR DESCRIPTION
Prior to this change, the `config` option (which allows you define the
haskell configuration for xmonad in your configuration.nix instead of
needing something in the home directory) prevents desktop manager
resources from starting. This can be demonstrated by configuring the
following:

```
  services.xserver = {
    displayManager.defaultSession = "xfce+xmonad";
    displayManager.lightdm.enable = true;

    desktopManager.xterm.enable = false;
    desktopManager.xfce.enable = true;
    desktopManager.xfce.enableXfwm = false;
    desktopManager.xfce.noDesktop = true;

    windowManager.xmonad = {
      enable = true;
      enableContribAndExtras = true;
      extraPackages = haskellPackages: [
        haskellPackages.xmonad-contrib
        haskellPackages.xmonad-extras
        haskellPackages.xmonad
      ];
      config = ''
        import XMonad
        import XMonad.Config.Xfce
        main = xmonad xfceConfig
               { terminal = "terminator"
               , modMask = mod4Mask }
      '';
    };
  };
```

and after user log in, search for xfce processes `ps aux | grep xfce`.
You will not find xfce processes running until after the xmonad process is killed.

The prevents utilities included with the desktopManager,
(e.g. powerManagement, session logout, etc.)
from working as expected.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
