### PR TITLE
zeek: 3.1.5 -> 3.2.0

### DIFF
--- a/pkgs/applications/networking/ids/zeek/default.nix
+++ b/pkgs/applications/networking/ids/zeek/default.nix
@@ -20,11 +20,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "zeek";
-  version = "3.1.5";
+  version = "3.2.0";
 
   src = fetchurl {
     url = "https://download.zeek.org/zeek-${version}.tar.gz";
-    sha256 = "1rwrwdx0jf76pb11vpmv5z513ss9rrkgpjv1pa1vydf4gbafhi5r";
+    sha256 = "0ky4485z0gpaj1z75y7jr5bn9wr8x8w3v637aqq4v9a0a5iyagmg";
   };
 
   nativeBuildInputs = [ cmake flex bison file ];
@@ -40,8 +40,8 @@ stdenv.mkDerivation rec {
     # Fix pybind c++17 build with Clang. See: https://github.com/pybind/pybind11/issues/1604
     (fetchpatch {
       url = "https://github.com/pybind/pybind11/commit/759221f5c56939f59d8f342a41f8e2d2cacbc8cf.patch";
-      sha256 = "0l8z7d7chq1awd8dnfarj4c40wx36hkhcan0702p5l89x73wqk54";
-      extraPrefix = "aux/broker/bindings/python/3rdparty/pybind11/";
+      sha256 = "17qznp8yavnv84fjsbghv3d59z6k6rx74j49w0izakmgw5a95w84";
+      extraPrefix = "auxil/broker/bindings/python/3rdparty/pybind11/";
       stripLen = 1;
     })
   ];


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/zeek/zeek/releases/tag/v3.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
