### PR TITLE
nix-prefetch: make fit for flakes

### DIFF
--- a/pkgs/tools/package-management/nix-prefetch/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, installShellFiles, makeWrapper, asciidoc
 , docbook_xml_dtd_45, git, docbook_xsl, libxml2, libxslt, coreutils, gawk
-, gnugrep, gnused, jq, nix }:
+, gnugrep, gnused, jq, nix, fetchpatch }:
 
 let
   binPath = stdenv.lib.makeBinPath [ coreutils gawk git gnugrep gnused jq nix ];
@@ -19,6 +19,14 @@ in stdenv.mkDerivation rec {
       echo $(stat -c %Y $out) > $out/.timestamp
     '';
   };
+
+  patches = [
+    # Fix compatibility with nixUnstable: https://github.com/msteen/nix-prefetch/pull/8
+    (fetchpatch {
+      url = "https://github.com/msteen/nix-prefetch/commit/817a7695d98663386fa27a6c04d1617e0a83e1ab.patch";
+      sha256 = "1zfgvafg30frwrh56k2wj4g76cljyjylm47ll60ms0yfx55spa7x";
+    })
+  ];
 
   postPatch = ''
     lib=$out/lib/${pname}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
