### PR TITLE
appcsxcad: init at unstable-2020-01-04

### DIFF
--- a/pkgs/applications/science/electronics/appcsxcad/default.nix
+++ b/pkgs/applications/science/electronics/appcsxcad/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, csxcad
+, qcsxcad
+, hdf5
+, vtkWithQt5
+, qtbase
+, wrapQtAppsHook
+, fparser
+, tinyxml
+, cgal
+, boost
+}:
+
+mkDerivation {
+  pname = "appcsxcad";
+  version = "unstable-2020-01-04";
+
+  src = fetchFromGitHub {
+    owner = "thliebig";
+    repo = "AppCSXCAD";
+    rev = "de8c271ec8b57e80233cb2a432e3d7fd54d30876";
+    sha256 = "0shnfa0if3w588a68gr82qi6k7ldg1j2921fnzji90mmay21birp";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    csxcad
+    qcsxcad
+    hdf5
+    vtkWithQt5
+    qtbase
+    fparser
+    tinyxml
+    cgal
+    boost
+  ];
+
+  postFixup = ''
+    rm $out/bin/AppCSXCAD.sh
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Minimal Application using the QCSXCAD library";
+    homepage = "https://github.com/thliebig/AppCSXCAD";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ matthuszagh ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25738,6 +25738,8 @@ in
 
   adms = callPackage ../applications/science/electronics/adms { };
 
+  appcsxcad = libsForQt5.callPackage ../applications/science/electronics/appcsxcad { };
+
   # Since version 8 Eagle requires an Autodesk account and a subscription
   # in contrast to single payment for the charged editions.
   # This is the last version with the old model.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Next in [this PR](https://github.com/NixOS/nixpkgs/pull/69262). @jonringer thanks!

[appcsxcad](https://github.com/thliebig/AppCSXCAD)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
