### PR TITLE
pandoc-plantuml-filter: init at 0.1.2

### DIFF
--- a/pkgs/tools/misc/pandoc-plantuml-filter/default.nix
+++ b/pkgs/tools/misc/pandoc-plantuml-filter/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonApplication
+, fetchPypi
+, pandocfilters
+, lib
+}:
+
+buildPythonApplication rec {
+  pname = "pandoc-plantuml-filter";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08673mfwxsw6s52mgglbdz7ybb68svqyr3s9w97d7rifbwvvc9ia";
+  };
+
+  propagatedBuildInputs = [
+    pandocfilters
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/timofurrer/pandoc-plantuml-filter";
+    description = "Pandoc filter which converts PlantUML code blocks to PlantUML images.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cmcdragonkai ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5628,6 +5628,8 @@ in
 
   pandoc-imagine = python3Packages.callPackage ../tools/misc/pandoc-imagine { };
 
+  pandoc-plantuml-filter = python3Packages.callPackage ../tools/misc/pandoc-plantuml-filter { };
+
   pasystray = callPackage ../tools/audio/pasystray { };
 
   phash = callPackage ../development/libraries/phash { };


### PR DESCRIPTION
###### Motivation for this change

Adds the Pandoc filter which converts PlantUML code blocks to PlantUML images. Pretty useful!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
