### PR TITLE
elmPackages.elm-json: init at 0.2.7

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -1,6 +1,8 @@
 { lib, stdenv, pkgs
 , haskell, nodejs
-, fetchurl, fetchpatch, makeWrapper, writeScriptBin }:
+, fetchurl, fetchpatch, makeWrapper, writeScriptBin
+  # Rust dependecies
+, rustPlatform, openssl, pkg-config }:
 let
   fetchElmDeps = import ./fetchElmDeps.nix { inherit stdenv lib fetchurl; };
 
@@ -126,5 +128,8 @@ let
     };
 
 in hsPkgs.elmPkgs // elmNodePackages // {
+  elm-json = import ./packages/elm-json.nix {
+    inherit rustPlatform fetchurl openssl stdenv pkg-config;
+  };
   lib = elmLib;
 }

--- a/pkgs/development/compilers/elm/packages/elm-json.nix
+++ b/pkgs/development/compilers/elm/packages/elm-json.nix
@@ -1,0 +1,30 @@
+{ rustPlatform, fetchurl, openssl, stdenv, pkg-config }:
+rustPlatform.buildRustPackage rec {
+  pname = "elm-json";
+  version = "0.2.7";
+
+  src = fetchurl {
+    url = "https://github.com/zwilias/elm-json/archive/v${version}.tar.gz";
+    sha256 = "sha256:1b9bhl7rb01ylqjbfd1ccm26lhk4hzwd383rbg89aj2jwjv0w4hs";
+  };
+
+  cargoPatches = [ ./elm-json.patch ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  cargoSha256 = "0ylniriq073kpiykamkn9mxdaa6kyiza4pvf7gnfq2h1dvbqa6z7";
+  verifyCargoDeps = true;
+
+  # Tests perform networking and therefore can't work in sandbox
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Install, upgrade and uninstall Elm dependencies";
+    homepage = "https://github.com/zwilias/elm-json";
+    license = licenses.mit;
+    maintainers = [ maintainers.turbomack ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/compilers/elm/packages/elm-json.patch
+++ b/pkgs/development/compilers/elm/packages/elm-json.patch
@@ -1,0 +1,48 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index f4d95f5..6830b3d 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -625,14 +625,6 @@ name = "openssl-probe"
+ version = "0.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+-[[package]]
+-name = "openssl-src"
+-version = "111.9.0+1.1.1g"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+ [[package]]
+ name = "openssl-sys"
+ version = "0.9.56"
+@@ -641,7 +633,6 @@ dependencies = [
+  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
+- "openssl-src 111.9.0+1.1.1g (registry+https://github.com/rust-lang/crates.io-index)",
+  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+  "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -1162,7 +1153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ "checksum object 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+ "checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+ "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+-"checksum openssl-src 111.9.0+1.1.1g (registry+https://github.com/rust-lang/crates.io-index)" = "a2dbe10ddd1eb335aba3780eb2eaa13e1b7b441d2562fd962398740927f39ec4"
+ "checksum openssl-sys 0.9.56 (registry+https://github.com/rust-lang/crates.io-index)" = "f02309a7f127000ed50594f0b50ecc69e7c654e16d41b4e8156d1b3df8e0b52e"
+ "checksum petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
+ "checksum pin-project 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
+diff --git a/Cargo.toml b/Cargo.toml
+index adfab25..37ae0c2 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -21,7 +21,7 @@ colored = "1.9"
+ dialoguer = "0.6"
+ dirs = "2.0"
+ fs2 = "0.4"
+-isahc = { version = "0.9", features = ["static-ssl"] }
++isahc = "0.9"
+ 
+ [dev-dependencies]
+ assert_cmd = "0.11"


### PR DESCRIPTION
[elm-json](https://github.com/zwilias/elm-json) is tool for managing `elm.json` file. In addition to Elm's built-in `elm install` command it allows user to uninstall, list or upgrade dependencies.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
