### PR TITLE
jwto: init at 0.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/jwto/default.nix
+++ b/pkgs/development/ocaml-modules/jwto/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildDunePackage, fetchFromGitHub, alcotest, cryptokit, fmt, yojson
+, base64, re, ppx_deriving }:
+
+buildDunePackage rec {
+  pname = "jwto";
+  version = "0.3.0";
+
+  minimumOCamlVersion = "4.05";
+
+  src = fetchFromGitHub {
+    owner = "sporto";
+    repo = "jwto";
+    rev = version;
+    sha256 = "1p799zk8j9c0002xzi2x7ndj1bzqf14744ampcqndrjnsi7mq71s";
+  };
+
+  propagatedBuildInputs =
+    [ cryptokit fmt yojson base64 re ppx_deriving ];
+
+  checkInputs = [ alcotest ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://github.com/sporto/jwto";
+    description = "JSON Web Tokens (JWT) for OCaml";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Zimmi48 jtcoolen ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -346,6 +346,8 @@ let
       extlib = ocaml_extlib;
     };
 
+    jwto = callPackage ../development/ocaml-modules/jwto { };
+
     dypgen = callPackage ../development/ocaml-modules/dypgen { };
 
     gapi_ocaml = callPackage ../development/ocaml-modules/gapi-ocaml { };


### PR DESCRIPTION
#### Motivation for this change
[jwto](https://github.com/sporto/jwto): JSON Web Tokens (JWT) encoding, decoding and verification

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
