### PR TITLE
python.pkgs.construct: 2.9.45 -> 2.10.56

### DIFF
--- a/pkgs/development/python-modules/construct/default.nix
+++ b/pkgs/development/python-modules/construct/default.nix
@@ -1,27 +1,24 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub
-, six, pytest, arrow
+{ stdenv, buildPythonPackage, fetchFromGitHub, pythonOlder
+, six, pytestCheckHook, pytest-benchmark, numpy, arrow, ruamel_yaml
 }:
 
 buildPythonPackage rec {
   pname   = "construct";
-  version = "2.9.45";
+  version = "2.10.56";
 
+  disabled = pythonOlder "3.6";
+
+  # no tests in PyPI tarball
   src = fetchFromGitHub {
     owner  = pname;
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "0ig66xrzswpkhhmw123p2nvr15a9lxz54a1fmycfdh09327c1d3y";
+    sha256 = "1j4mqwyxkbdcsnnk5bbdcljv855w4fglaqc94q1xdzm8kgjxk4mr";
   };
 
-  propagatedBuildInputs = [ six ];
+  checkInputs = [ pytestCheckHook pytest-benchmark numpy arrow ruamel_yaml ];
 
-  checkInputs = [ pytest arrow ];
-
-  # TODO: figure out missing dependencies
-  doCheck = false;
-  checkPhase = ''
-    py.test -k 'not test_numpy and not test_gallery' tests
-  '';
+  pytestFlagsArray = [ "--benchmark-disable" ];
 
   meta = with stdenv.lib; {
     description = "Powerful declarative parser (and builder) for binary data";

--- a/pkgs/development/python-modules/pykeepass/default.nix
+++ b/pkgs/development/python-modules/pykeepass/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchPypi, buildPythonPackage
-, lxml, pycryptodome, construct
+, lxml, pycryptodomex, construct
 , argon2_cffi, dateutil, future
 }:
 
@@ -12,8 +12,12 @@ buildPythonPackage rec {
     sha256 = "b3e07eb2dd3aeb1dfa1a2d2d17be77066ee560c1e770f1c72d7ea5608117d284";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py --replace "==" ">="
+  '';
+
   propagatedBuildInputs = [
-    lxml pycryptodome construct
+    lxml pycryptodomex construct
     argon2_cffi dateutil future
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
make qutebrowser build again

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
