### PR TITLE
nixos-install: add support for flakes

### DIFF
--- a/nixos/doc/manual/man-nixos-install.xml
+++ b/nixos/doc/manual/man-nixos-install.xml
@@ -46,6 +46,10 @@
    </arg>
 
    <arg>
+    <option>--flake</option> <replaceable>flake-uri</replaceable>
+   </arg>
+
+   <arg>
      <arg choice='plain'>
        <option>--channel</option>
      </arg>
@@ -196,6 +200,18 @@
       closure is typically obtained with a command such as <command>nix-build
       -I nixos-config=./configuration.nix '&lt;nixpkgs/nixos&gt;' -A system
       --no-out-link</command>
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>--flake</option> <replaceable>flake-uri</replaceable>#<replaceable>name</replaceable>
+    </term>
+    <listitem>
+     <para>
+      Build the NixOS system from the specified flake.
+      The flake must contain an output named
+      <literal>nixosConfigurations.<replaceable>name</replaceable></literal>.
      </para>
     </listitem>
    </varlistentry>

--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -521,7 +521,7 @@
 
    <varlistentry>
     <term>
-     <option>--flake</option> <replaceable>flake-uri</replaceable>[<replaceable>name</replaceable>]
+     <option>--flake</option> <replaceable>flake-uri</replaceable><optional>#<replaceable>name</replaceable></optional>
     </term>
     <listitem>
      <para>

--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -10,6 +10,7 @@ umask 0022
 
 # Parse the command line for the -I flag
 extraBuildFlags=()
+flakeFlags=()
 
 mountPoint=/mnt
 channelPath=
@@ -34,6 +35,23 @@ while [ "$#" -gt 0 ]; do
         --system|--closure)
             system="$1"; shift 1
             ;;
+        --flake)
+          flake="$1"
+          flakeFlags=(--experimental-features 'nix-command flakes')
+          shift 1
+          ;;
+        --recreate-lock-file|--no-update-lock-file|--no-write-lock-file|--no-registries|--commit-lock-file)
+          lockFlags+=("$i")
+          ;;
+        --update-input)
+          j="$1"; shift 1
+          lockFlags+=("$i" "$j")
+          ;;
+        --override-input)
+          j="$1"; shift 1
+          k="$1"; shift 1
+          lockFlags+=("$i" "$j" "$k")
+          ;;
         --channel)
             channelPath="$1"; shift 1
             ;;
@@ -92,14 +110,32 @@ if [[ ${NIXOS_CONFIG:0:1} != / ]]; then
     exit 1
 fi
 
-if [[ ! -e $NIXOS_CONFIG && -z $system ]]; then
+if [[ -n $flake ]]; then
+    if [[ $flake =~ ^(.*)\#([^\#\"]*)$ ]]; then
+       flake="${BASH_REMATCH[1]}"
+       flakeAttr="${BASH_REMATCH[2]}"
+    fi
+    if [[ -z "$flakeAttr" ]]; then
+        echo "Please specify the name of the NixOS configuration to be installed, as a URI fragment in the flake-uri."
+        echo "For example, to use the output nixosConfigurations.foo from the flake.nix, append \"#foo\" to the flake-uri."
+        exit 1
+    fi
+    flakeAttr="nixosConfigurations.\"$flakeAttr\""
+fi
+
+# Resolve the flake.
+if [[ -n $flake ]]; then
+    flake=$(nix "${flakeFlags[@]}" flake info --json "${extraBuildFlags[@]}" "${lockFlags[@]}" -- "$flake" | jq -r .url)
+fi
+
+if [[ ! -e $NIXOS_CONFIG && -z $system && -z $flake ]]; then
     echo "configuration file $NIXOS_CONFIG doesn't exist"
     exit 1
 fi
 
 # A place to drop temporary stuff.
-tmpdir="$(mktemp -d -p $mountPoint)"
-trap "rm -rf $tmpdir" EXIT
+tmpdir="$(mktemp -d -p "$mountPoint")"
+trap 'rm -rf $tmpdir' EXIT
 
 # store temporary files on target filesystem by default
 export TMPDIR=${TMPDIR:-$tmpdir}
@@ -108,12 +144,19 @@ sub="auto?trusted=1"
 
 # Build the system configuration in the target filesystem.
 if [[ -z $system ]]; then
-    echo "building the configuration in $NIXOS_CONFIG..."
     outLink="$tmpdir/system"
-    nix-build --out-link "$outLink" --store "$mountPoint" "${extraBuildFlags[@]}" \
-        --extra-substituters "$sub" \
-        '<nixpkgs/nixos>' -A system -I "nixos-config=$NIXOS_CONFIG" ${verbosity[@]}
-    system=$(readlink -f $outLink)
+    if [[ -z $flake ]]; then
+        echo "building the configuration in $NIXOS_CONFIG..."
+        nix-build --out-link "$outLink" --store "$mountPoint" "${extraBuildFlags[@]}" \
+            --extra-substituters "$sub" \
+            '<nixpkgs/nixos>' -A system -I "nixos-config=$NIXOS_CONFIG" "${verbosity[@]}"
+    else
+        echo "building the flake in $flake..."
+        nix "${flakeFlags[@]}" build "$flake#$flakeAttr.config.system.build.toplevel" \
+            --extra-substituters "$sub" "${verbosity[@]}" \
+            "${extraBuildFlags[@]}" "${lockFlags[@]}" --out-link "$outLink"
+    fi
+    system=$(readlink -f "$outLink")
 fi
 
 # Set the system profile to point to the configuration. TODO: combine
@@ -121,7 +164,7 @@ fi
 # a progress bar.
 nix-env --store "$mountPoint" "${extraBuildFlags[@]}" \
         --extra-substituters "$sub" \
-        -p $mountPoint/nix/var/nix/profiles/system --set "$system" ${verbosity[@]}
+        -p "$mountPoint"/nix/var/nix/profiles/system --set "$system" "${verbosity[@]}"
 
 # Copy the NixOS/Nixpkgs sources to the target as the initial contents
 # of the NixOS channel.
@@ -131,12 +174,12 @@ if [[ -z $noChannelCopy ]]; then
     fi
     if [[ -n $channelPath ]]; then
         echo "copying channel..."
-        mkdir -p $mountPoint/nix/var/nix/profiles/per-user/root
+        mkdir -p "$mountPoint"/nix/var/nix/profiles/per-user/root
         nix-env --store "$mountPoint" "${extraBuildFlags[@]}" --extra-substituters "$sub" \
-                -p $mountPoint/nix/var/nix/profiles/per-user/root/channels --set "$channelPath" --quiet \
-                ${verbosity[@]}
-        install -m 0700 -d $mountPoint/root/.nix-defexpr
-        ln -sfn /nix/var/nix/profiles/per-user/root/channels $mountPoint/root/.nix-defexpr/channels
+                -p "$mountPoint"/nix/var/nix/profiles/per-user/root/channels --set "$channelPath" --quiet \
+                "${verbosity[@]}"
+        install -m 0700 -d "$mountPoint"/root/.nix-defexpr
+        ln -sfn /nix/var/nix/profiles/per-user/root/channels "$mountPoint"/root/.nix-defexpr/channels
     fi
 fi
 
@@ -150,7 +193,7 @@ touch "$mountPoint/etc/NIXOS"
 if [[ -z $noBootLoader ]]; then
     echo "installing the boot loader..."
     # Grub needs an mtab.
-    ln -sfn /proc/mounts $mountPoint/etc/mtab
+    ln -sfn /proc/mounts "$mountPoint"/etc/mtab
     NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root "$mountPoint" -- /run/current-system/bin/switch-to-configuration boot
 fi
 

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -17,6 +17,7 @@ showSyntax() {
 origArgs=("$@")
 extraBuildFlags=()
 lockFlags=()
+flakeFlags=()
 action=
 buildNix=1
 fast=
@@ -99,6 +100,7 @@ while [ "$#" -gt 0 ]; do
         ;;
       --flake)
         flake="$1"
+        flakeFlags=(--experimental-features 'nix-command flakes')
         shift 1
         ;;
       --recreate-lock-file|--no-update-lock-file|--no-write-lock-file|--no-registries|--commit-lock-file)
@@ -281,7 +283,7 @@ fi
 
 # Resolve the flake.
 if [[ -n $flake ]]; then
-    flake=$(nix flake info --json "${extraBuildFlags[@]}" "${lockFlags[@]}" -- "$flake" | jq -r .url)
+    flake=$(nix "${flakeFlags[@]}" flake info --json "${extraBuildFlags[@]}" "${lockFlags[@]}" -- "$flake" | jq -r .url)
 fi
 
 # Find configuration.nix and open editor instead of building.
@@ -290,7 +292,7 @@ if [ "$action" = edit ]; then
         NIXOS_CONFIG=${NIXOS_CONFIG:-$(nix-instantiate --find-file nixos-config)}
         exec "${EDITOR:-nano}" "$NIXOS_CONFIG"
     else
-        exec nix edit "${lockFlags[@]}" -- "$flake#$flakeAttr"
+        exec nix "${flakeFlags[@]}" edit "${lockFlags[@]}" -- "$flake#$flakeAttr"
     fi
     exit 1
 fi
@@ -416,7 +418,7 @@ if [ -z "$rollback" ]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' --no-out-link -A system "${extraBuildFlags[@]}")"
         else
             outLink=$tmpDir/result
-            nix build "$flake#$flakeAttr.config.system.build.toplevel" \
+            nix "${flakeFlags[@]}" build "$flake#$flakeAttr.config.system.build.toplevel" \
               "${extraBuildFlags[@]}" "${lockFlags[@]}" --out-link $outLink
             pathToConfig="$(readlink -f $outLink)"
         fi
@@ -426,7 +428,7 @@ if [ -z "$rollback" ]; then
         if [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A system -k "${extraBuildFlags[@]}")"
         else
-            nix build "$flake#$flakeAttr.config.system.build.toplevel" "${extraBuildFlags[@]}" "${lockFlags[@]}"
+            nix "${flakeFlags[@]}" build "$flake#$flakeAttr.config.system.build.toplevel" "${extraBuildFlags[@]}" "${lockFlags[@]}"
             pathToConfig="$(readlink -f ./result)"
         fi
     elif [ "$action" = build-vm ]; then

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -20,7 +20,7 @@ let
     name = "nixos-install";
     src = ./nixos-install.sh;
     nix = config.nix.package.out;
-    path = makeBinPath [ nixos-enter ];
+    path = makeBinPath [ pkgs.nixUnstable nixos-enter ];
   };
 
   nixos-rebuild =


### PR DESCRIPTION
###### Motivation for this change
Use `nixos-install` with a `flake.nix`.

###### Things done
I've just copied code from `nixos-rebuild`, not sure whether all this is correct.

- [X] Add support for `--flake` and other options like in `nixos-rebuild`.
- [X] Quote variables to please ShellCheck (I hope I've not done any mistake in doing so).
- [X] Pass `pkgs.nixFlakes`'s `nix` prepended on `PATH`, to be used only when `--flake` is involved. This avoids adding all `nixUnstable`'s closure to `nixos-install`.
- [X] Pass `--experimental-features 'nix-command flakes'` to `nix` when using `--flake` in `nixos-install` and `nixos-rebuild`.
- [X] Document `--flake`.
- [X] Fix documentation by using the URI fragment syntax.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).