### PR TITLE
openems: init at unstable-2020-02-15

### DIFF
--- a/pkgs/applications/science/electronics/openems/default.nix
+++ b/pkgs/applications/science/electronics/openems/default.nix
@@ -1,0 +1,76 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, csxcad
+, fparser
+, tinyxml
+, hdf5
+, vtk
+, boost
+, zlib
+, cmake
+, octave
+, gl2ps
+, withQcsxcad ? true
+, withMPI ? false
+, withHyp2mat ? true
+, qcsxcad ? null
+, openmpi ? null
+, hyp2mat ? null
+}:
+
+assert withQcsxcad -> qcsxcad != null;
+assert withMPI -> openmpi != null;
+assert withHyp2mat -> hyp2mat != null;
+
+stdenv.mkDerivation {
+  pname = "openems";
+  version = "unstable-2020-02-15";
+
+  src = fetchFromGitHub {
+    owner = "thliebig";
+    repo = "openEMS";
+    rev = "ba793ac84e2f78f254d6d690bb5a4c626326bbfd";
+    sha256 = "1dca6b6ccy771irxzsj075zvpa3dlzv4mjb8xyg9d889dqlgyl45";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = lib.optionals withMPI [ "-DWITH_MPI=ON" ];
+
+  buildInputs = [
+    fparser
+    tinyxml
+    hdf5
+    vtk
+    boost
+    zlib
+    csxcad
+    (octave.override { inherit hdf5; }) ]
+    ++ lib.optionals withQcsxcad [ qcsxcad ]
+    ++ lib.optionals withMPI [ openmpi ]
+    ++ lib.optionals withHyp2mat [ hyp2mat ];
+
+  postFixup = ''
+    substituteInPlace $out/share/openEMS/matlab/setup.m \
+      --replace /usr/lib ${hdf5}/lib \
+      --replace /usr/include ${hdf5}/include
+
+    ${octave}/bin/mkoctfile -L${hdf5}/lib -I${hdf5}/include \
+      -lhdf5 $out/share/openEMS/matlab/h5readatt_octave.cc \
+      -o $out/share/openEMS/matlab/h5readatt_octave.oct
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Open Source Electromagnetic Field Solver";
+    homepage = "http://openems.de/index.php/Main_Page.html";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ matthuszagh ];
+    platforms = platforms.linux;
+    badPlatforms = platforms.aarch64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25785,6 +25785,8 @@ in
 
   ngspice = callPackage ../applications/science/electronics/ngspice { };
 
+  openems = callPackage ../applications/science/electronics/openems { };
+
   pcb = callPackage ../applications/science/electronics/pcb { };
 
   qcsxcad = libsForQt5.callPackage ../applications/science/electronics/qcsxcad { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Next in [this pr](https://github.com/NixOS/nixpkgs/pull/69262). @jonringer thanks!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
