### PR TITLE
python3Packages.pendulum: fix build

### DIFF
--- a/pkgs/development/python-modules/pendulum/default.nix
+++ b/pkgs/development/python-modules/pendulum/default.nix
@@ -1,16 +1,29 @@
 { lib, fetchPypi, buildPythonPackage, pythonOlder
-, dateutil, pytzdata, typing }:
+, dateutil
+, importlib-metadata
+, poetry
+, poetry-core
+, pytzdata
+, typing
+}:
 
 buildPythonPackage rec {
   pname = "pendulum";
   version = "2.1.2";
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "b06a0ca1bfe41c990bbf0c029f0b6501a7f2ec4e38bfec730712015e8860f207";
   };
 
-  propagatedBuildInputs = [ dateutil pytzdata ] ++ lib.optional (pythonOlder "3.5") typing;
+  preBuild = ''
+    export HOME=$TMPDIR
+  '';
+  nativeBuildInputs = [ poetry-core ];
+  propagatedBuildInputs = [ dateutil pytzdata ]
+  ++ lib.optional (pythonOlder "3.5") typing
+  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   # No tests
   doCheck = false;

--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -1,0 +1,63 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, isPy27
+, importlib-metadata
+, intreehooks
+, isort
+, pathlib2
+, pep517
+, pytest-mock
+, pytestCheckHook
+, tomlkit
+, typing
+, virtualenv
+}:
+
+buildPythonPackage rec {
+  pname = "poetry-core";
+  version = "1.0.0a9";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "python-poetry";
+    repo = pname;
+    rev = version;
+    sha256 = "1ln47x1bc1yvhdfwfnkqx4d2j7988a59v8vmcriw14whfgzfki75";
+  };
+
+  # avoid mass-rebuild of python packages
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "^1.7.0" "^1.6.0"
+  '';
+
+  nativeBuildInputs = [
+    intreehooks
+  ];
+
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ] ++ lib.optionals isPy27 [
+    pathlib2
+    typing
+  ];
+
+  checkInputs = [
+    isort
+    pep517
+    pytest-mock
+    pytestCheckHook
+    tomlkit
+    virtualenv
+  ];
+
+  # requires git history to work correctly
+  disabledTests = [ "default_with_excluded_data" ];
+
+  pythonImportsCheck = [ "poetry.core" ];
+
+  meta = with lib; {
+    description = "Core utilities for Poetry";
+    homepage = "https://github.com/python-poetry/poetry-core/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/pytzdata/default.nix
+++ b/pkgs/development/python-modules/pytzdata/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "pytzdata";
-  version = "2019.3";
+  version = "2020.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "fac06f7cdfa903188dc4848c655e4adaee67ee0f2fe08e7daf815cf2a761ee5e";
+    sha256 = "0h0md0ldhb8ghlwjslkzh3wcj4fxg3n43bj5sghqs2m06nri7yiy";
   };
 
   # No tests

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1142,6 +1142,8 @@ in {
 
   poetry = callPackage ../development/python-modules/poetry { };
 
+  poetry-core = callPackage ../development/python-modules/poetry-core { };
+
   polyline = callPackage ../development/python-modules/polyline { };
 
   postorius = disabledIf (!isPy3k) (callPackage ../servers/mail/mailman/postorius.nix { });


### PR DESCRIPTION
###### Motivation for this change
pendulum switched over to a poetry build

also needed `poetry-core` to work correctly

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
