### PR TITLE
replacement: init at 0.4.4

### DIFF
--- a/pkgs/development/tools/misc/replacement/default.nix
+++ b/pkgs/development/tools/misc/replacement/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "replacement";
+  version = "0.4.4";
+
+  disabled = python3Packages.isPy27;
+
+  src = fetchFromGitHub {
+    owner = "siriobalmelli";
+    repo = "replacement";
+    rev = "v${version}";
+    sha256 = "0j4lvn3rx1kqvxcsd8nhc2lgk48jyyl7qffhlkvakhy60f9lymj3";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    ruamel_yaml
+  ];
+
+  checkInputs = with python3Packages; [
+    pytestCheckHook
+    sh
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/siriobalmelli/replacement";
+    description = "A tool to execute yaml templates and output text";
+    longDescription = ''
+        Replacement is a python utility
+        that parses a yaml template and outputs text.
+
+        A 'template' is a YAML file containing a 'replacement' object.
+
+        A 'replacement' object contains a list of blocks,
+        each of which is executed in sequence.
+
+        This tool is useful in generating configuration files,
+        static websites and the like.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ siriobalmelli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11256,6 +11256,8 @@ in
 
   remake = callPackage ../development/tools/build-managers/remake { };
 
+  replacement = callPackage ../development/tools/misc/replacement { };
+
   retdec = callPackage ../development/tools/analysis/retdec {
     stdenv = gcc8Stdenv;
   };


### PR DESCRIPTION
Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add new python package for use in a Nix CI/CD

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).