### PR TITLE
python37Packages.pendulum: fix build and add tests

### DIFF
--- a/pkgs/development/python-modules/pendulum/default.nix
+++ b/pkgs/development/python-modules/pendulum/default.nix
@@ -1,24 +1,30 @@
 { lib, fetchPypi, buildPythonPackage, pythonOlder
-, dateutil, pytzdata, typing
+, dateutil
+, importlib-metadata
+, poetry
 , poetry-core
+, pytzdata
+, typing
 }:
 
 buildPythonPackage rec {
   pname = "pendulum";
   version = "2.1.2";
-
   format = "pyproject";
-
-  nativeBuildInputs = [
-    poetry-core
-  ];
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "b06a0ca1bfe41c990bbf0c029f0b6501a7f2ec4e38bfec730712015e8860f207";
   };
 
-  propagatedBuildInputs = [ dateutil pytzdata ] ++ lib.optional (pythonOlder "3.5") typing;
+  preBuild = ''
+    export HOME=$TMPDIR
+  '';
+
+  nativeBuildInputs = [ poetry-core ];
+  propagatedBuildInputs = [ dateutil pytzdata ]
+  ++ lib.optional (pythonOlder "3.5") typing
+  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   # No tests
   doCheck = false;

--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -1,22 +1,63 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, isPy27
+, importlib-metadata
+, intreehooks
+, isort
+, pathlib2
+, pep517
+, pytest-mock
+, pytestCheckHook
+, tomlkit
+, typing
+, virtualenv
 }:
 
 buildPythonPackage rec {
   pname = "poetry-core";
   version = "1.0.0a9";
+  format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "f08e9829fd06609ca5615faa91739b589eb71e025a6aaf7ddffb698676eb7c8c";
+  src = fetchFromGitHub {
+    owner = "python-poetry";
+    repo = pname;
+    rev = version;
+    sha256 = "1ln47x1bc1yvhdfwfnkqx4d2j7988a59v8vmcriw14whfgzfki75";
   };
 
-  doCheck = false; # No tests in sdist.
+  # avoid mass-rebuild of python packages
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "^1.7.0" "^1.6.0"
+  '';
 
-  meta = {
+  nativeBuildInputs = [
+    intreehooks
+  ];
+
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ] ++ lib.optionals isPy27 [
+    pathlib2
+    typing
+  ];
+
+  checkInputs = [
+    isort
+    pep517
+    pytest-mock
+    pytestCheckHook
+    tomlkit
+    virtualenv
+  ];
+
+  # requires git history to work correctly
+  disabledTests = [ "default_with_excluded_data" ];
+
+  pythonImportsCheck = [ "poetry.core" ];
+
+  meta = with lib; {
     description = "Core utilities for Poetry";
-    homepage = "https://github.com/python-poetry/core";
-    license = lib.licenses.mit;
+    homepage = "https://github.com/python-poetry/poetry-core/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
follow up to #95208

add tests and fixed dependencies for other python versions than just python3.8
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

failures broken on master:
```
https://github.com/NixOS/nixpkgs/pull/95211
7 packages failed to build:
apache-airflow ape buku python37Packages.qasm2image python37Packages.qiskit python38Packages.qasm2image python38Packages.qiskit

44 packages built:
azure-cli google-music-scripts http-prompt httpie lexicon nvchecker papis python37Packages.audio-metadata python37Packages.duecredit python37Packages.flask-common python37Packages.google-music python37Packages.google-music-proto python37Packages.google-music-utils python37Packages.habanero python37Packages.httpbin python37Packages.knack python37Packages.maya python37Packages.nvchecker python37Packages.papis python37Packages.pendulum python37Packages.poetry-core python37Packages.pytest-httpbin python37Packages.qiskit-ibmq-provider python37Packages.secure python37Packages.tbm-utils python37Packages.toggl-cli python37Packages.vcrpy python38Packages.audio-metadata python38Packages.duecredit python38Packages.flask-common python38Packages.google-music python38Packages.google-music-proto python38Packages.google-music-utils python38Packages.habanero python38Packages.httpbin python38Packages.knack python38Packages.maya python38Packages.pendulum python38Packages.poetry-core python38Packages.pytest-httpbin python38Packages.qiskit-ibmq-provider python38Packages.secure python38Packages.tbm-utils python38Packages.vcrpy
```
this fixes ~15 builds, when trying to build on master:
```
error: build of '/nix/store/1hpjzhzh4asgilx8yg4jihkmlv7cq8my-python3.7-poetry-core-1.0.0a9.drv' on 'ssh://build' failed: builder for '/nix/store/1hpjzhzh4asgilx8yg4jihkmlv7cq8my-python3.7-poetry-core-1.0.0a9.drv' failed with exit code 1
builder for '/nix/store/1hpjzhzh4asgilx8yg4jihkmlv7cq8my-python3.7-poetry-core-1.0.0a9.drv' failed with exit code 1; last 10 log lines:
  adding 'poetry_core-1.0.0a9.dist-info/RECORD'
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsBuildPhase
  installing
  Executing pipInstallPhase
  /build/poetry-core-1.0.0a9/dist /build/poetry-core-1.0.0a9
  Processing ./poetry_core-1.0.0a9-py3-none-any.whl
  ERROR: Could not find a version that satisfies the requirement importlib-metadata<2.0.0,>=1.7.0; python_version >= "2.7" and python_version < "2.8" or python_version >= "3.5" and python_version < "3.8" (from poetry-core==1.0.0a9) (from versions: none)
  ERROR: No matching distribution found for importlib-metadata<2.0.0,>=1.7.0; python_version >= "2.7" and python_version < "2.8" or python_version >= "3.5" and python_version < "3.8" (from poetry-core==1.0.0a9)
  builder for '/nix/store/1hpjzhzh4asgilx8yg4jihkmlv7cq8my-python3.7-poetry-core-1.0.0a9.drv' failed with exit code 1
cannot build derivation '/nix/store/x84zbrf2xianx8m76xhr81wvcmxaghsi-python3.7-pendulum-2.1.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/bi07plj6j7rgfah3xi24g9zk5kplk66a-python3.7-maya-0.3.3.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/dvpj4h1mfk9k45yn8hd1yw78krcgf20p-python3.7-tbm-utils-2.6.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/py5bdpj1hx3aip6aj7zz410hs8jd4i8n-python3.7-Flask-Common-0.3.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/qwa2xczj7mzbsv4a348c6x67nk7csr05-python3.7-Flask-Common-0.3.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/4dfxwy1vvxpv8bbjlz318dnxjryqlbc3-python3.7-secure-0.2.1.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/fmjmqvn5dalx5c3zpkvdr9rxlc2k1k9y-python3.7-httpbin-0.6.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/vbxh185zblx69pkpcy4pqm7ww94sm9bp-python3.7-httpbin-0.6.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/hidgaar0279cqls5g6r1105zrshjx74g-python3.7-pytest-httpbin-1.0.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/i2fqhsfnzgdicy2258g9dq7ysrp7qj51-python3.7-pytest-httpbin-1.0.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/wvbqz1wrs4c224s01797x3hsdc5wsx33-python3.7-nvchecker-1.7.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/5v19rq8vaj7v12cvm99647z635g95zm9-python3.7-vcrpy-4.0.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/qnf33xpsc1hynv64d71240hz0r86wq2g-python3.7-vcrpy-4.0.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/16zk4bcivsawxq2yxif97w3ymzz57djk-python3.7-duecredit-0.8.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/cabkxic1dq94zj9zbq64yl3n2qji4lli-python3.7-habanero-0.6.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/4bcky3i1j5bzai8sj0dnc0p80j9vs71v-python3.7-knack-0.7.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/6gx6xsjh1bcc5h72w0asd3z89h6xmwdj-python3.7-knack-0.7.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/jncj5gjn13wzsxf8y7j4i0dpr9qwy4g0-python3.7-qiskit-ibmq-provider-0.7.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/zn8cqgdm202b3k7p3xckm02biiyqgi90-python3.7-azure-cli-core-2.10.1.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/r7zihfdxb9k41ljflnhjnv4wmgc52k7r-python3.7-papis-0.10.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/5fk5zbs7davw3zmk443h0l3i0dkr4ryf-python3.7-azure-cli-2.10.1.drv': 2 dependencies couldn't be built
cannot build derivation '/nix/store/yks67pmc8minv35bsdlxfp82rvx9away-python3.7-toggl-cli-2.1.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/084p1yszz2a1xj8rvn8iy7vv2q8c2jwl-python3.7-audio-metadata-0.11.1.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/cci8hndqsl8p1i7ankfnpkjf4ckknckd-python3.7-google-music-proto-2.10.0.drv': 2 dependencies couldn't be built
cannot build derivation '/nix/store/s00clzm1sw5hrqfikrwc0lrxcg67nwhm-python3.7-google-music-utils-2.1.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/mgslzsd0yr2689z2i4bwnxphklsy9wsr-python3.7-google-music-3.7.0.drv': 2 dependencies couldn't be built
```