### PR TITLE
python3Packages.bids-validator: fix tests

### DIFF
--- a/pkgs/development/python-modules/bids-validator/default.nix
+++ b/pkgs/development/python-modules/bids-validator/default.nix
@@ -12,7 +12,10 @@ buildPythonPackage rec {
     sha256 = "b8292f4efb3617532f93c60acfec242150406bfd9e298d7f01187d67c311aa91";
   };
 
-  propagatedBuildInputs = [ ];
+  # needs packages which are not available in nixpkgs
+  doCheck = false;
+
+  pythonImportsCheck = [ "bids_validator" ];
 
   meta = with lib; {
     description = "Validator for the Brain Imaging Data Structure";

--- a/pkgs/development/python-modules/pybids/default.nix
+++ b/pkgs/development/python-modules/pybids/default.nix
@@ -15,12 +15,12 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.10.2";
+  version = "0.12.0";
   pname = "pybids";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6571ef82e03a958e56aa61cf5b15392f0b2d5dbca92f872061d81524e8da8525";
+    sha256 = "0flvrb61hfyjjgdz07dlm8m9pqwb8qrx027zfrwa9d5nw1az7g28";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken by the last staging merge

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

all of these were previously failing:
```
https://github.com/NixOS/nixpkgs/pull/95215
8 packages built:
python27Packages.bids-validator python37Packages.bids-validator python37Packages.heudiconv python37Packages.nipype python37Packages.pybids python38Packages.bids-validator python38Packages.nipype python38Packages.pybids
```