### PR TITLE
python3Packages.cheroot: fix tests

### DIFF
--- a/pkgs/development/python-modules/cheroot/default.nix
+++ b/pkgs/development/python-modules/cheroot/default.nix
@@ -8,6 +8,7 @@
 , pytest-mock
 , pytest-testmon
 , requests
+, requests-toolbelt
 , requests-unixsocket
 , setuptools_scm
 , setuptools-scm-git-archive
@@ -39,9 +40,14 @@ buildPythonPackage rec {
     pytest-mock
     pytest-testmon
     requests
+    requests-toolbelt
     requests-unixsocket
     trustme
   ];
+
+  # avoid attempting to use 3 packages not available on nixpkgs
+  # (jaraco.apt, jaraco.context, yg.lockfile)
+  pytestFlagsArray = [ "--ignore=cheroot/test/test_wsgi.py" ];
 
   # Disable doctest plugin because times out
   # Disable xdist (-n arg) because it's incompatible with testmon


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken in last staging update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

all were previously broken:
```
https://github.com/NixOS/nixpkgs/pull/95216
5 packages failed to build:
bareos ceph ceph-client libceph samba4Full

14 packages built:
fava flexget mnemosyne python37Packages.cheroot python37Packages.cherrypy python37Packages.pyalgotrade python37Packages.ws4py python37Packages.zerobin python38Packages.cheroot python38Packages.cherrypy python38Packages.pyalgotrade python38Packages.ws4py python38Packages.zerobin tribler
```