### PR TITLE
python35Packages.pandas: fix build

### DIFF
--- a/pkgs/development/python-modules/numpy/1.18.nix
+++ b/pkgs/development/python-modules/numpy/1.18.nix
@@ -1,0 +1,94 @@
+{ lib
+, fetchPypi
+, python
+, buildPythonPackage
+, gfortran
+, pytest
+, blas
+, lapack
+, writeTextFile
+, isPyPy
+, cython
+, setuptoolsBuildHook
+ }:
+
+assert (!blas.isILP64) && (!lapack.isILP64);
+
+let
+  cfg = writeTextFile {
+    name = "site.cfg";
+    text = (lib.generators.toINI {} {
+      ${blas.implementation} = {
+        include_dirs = "${lib.getDev blas}/include:${lib.getDev lapack}/include";
+        library_dirs = "${blas}/lib:${lapack}/lib";
+        libraries = "lapack,lapacke,blas,cblas";
+      };
+      lapack = {
+        include_dirs = "${lib.getDev lapack}/include";
+        library_dirs = "${lapack}/lib";
+      };
+      blas = {
+        include_dirs = "${lib.getDev blas}/include";
+        library_dirs = "${blas}/lib";
+      };
+    });
+  };
+in buildPythonPackage rec {
+  pname = "numpy";
+  version = "1.18.5";
+  format = "pyproject.toml";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "02qjccg30by6fhqdyzyffg5jrvnnmlx044h0v2dq7i35msfnxs9l";
+  };
+
+  nativeBuildInputs = [ gfortran pytest cython setuptoolsBuildHook ];
+  buildInputs = [ blas lapack ];
+
+  patches = lib.optionals python.hasDistutilsCxxPatch [
+    # We patch cpython/distutils to fix https://bugs.python.org/issue1222585
+    # Patching of numpy.distutils is needed to prevent it from undoing the
+    # patch to distutils.
+    ./numpy-distutils-C++.patch
+  ];
+
+  preConfigure = ''
+    sed -i 's/-faltivec//' numpy/distutils/system_info.py
+    export NPY_NUM_BUILD_JOBS=$NIX_BUILD_CORES
+  '';
+
+  preBuild = ''
+    ln -s ${cfg} site.cfg
+  '';
+
+  enableParallelBuilding = true;
+
+  doCheck = !isPyPy; # numpy 1.16+ hits a bug in pypy's ctypes, using either numpy or pypy HEAD fixes this (https://github.com/numpy/numpy/issues/13807)
+
+  checkPhase = ''
+    runHook preCheck
+    pushd dist
+    ${python.interpreter} -c 'import numpy; numpy.test("fast", verbose=10)'
+    popd
+    runHook postCheck
+  '';
+
+  passthru = {
+    # just for backwards compatibility
+    blas = blas.provider;
+    blasImplementation = blas.implementation;
+    inherit cfg;
+  };
+
+  # Disable test
+  # - test_large_file_support: takes a long time and can cause the machine to run out of disk space
+  NOSE_EXCLUDE="test_large_file_support";
+
+  meta = {
+    description = "Scientific tools for Python";
+    homepage = "https://numpy.org/";
+    maintainers = with lib.maintainers; [ fridh ];
+  };
+}

--- a/pkgs/development/python-modules/pandas/0.25.nix
+++ b/pkgs/development/python-modules/pandas/0.25.nix
@@ -1,0 +1,137 @@
+{ buildPythonPackage
+, fetchPypi
+, python
+, stdenv
+, pytest
+, glibcLocales
+, cython
+, dateutil
+, scipy
+, moto
+, numexpr
+, pytz
+, xlrd
+, bottleneck
+, sqlalchemy
+, lxml
+, html5lib
+, beautifulsoup4
+, hypothesis
+, openpyxl
+, tables
+, xlwt
+, runtimeShell
+, isPy38
+, libcxx ? null
+}:
+
+let
+  inherit (stdenv.lib) optional optionals optionalString;
+  inherit (stdenv) isDarwin;
+
+in buildPythonPackage rec {
+  pname = "pandas";
+  version = "0.25.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "191048m6kdc6yfvqs9w412lq60cfvigrsb57y0x116lwibgp9njj";
+  };
+
+  checkInputs = [ pytest glibcLocales moto hypothesis ];
+
+  nativeBuildInputs = [ cython ];
+  buildInputs = optional isDarwin libcxx;
+  propagatedBuildInputs = [
+    dateutil
+    scipy
+    numexpr
+    pytz
+    xlrd
+    bottleneck
+    sqlalchemy
+    lxml
+    html5lib
+    beautifulsoup4
+    openpyxl
+    tables
+    xlwt
+  ];
+
+  # For OSX, we need to add a dependency on libcxx, which provides
+  # `complex.h` and other libraries that pandas depends on to build.
+  postPatch = optionalString isDarwin ''
+    cpp_sdk="${libcxx}/include/c++/v1";
+    echo "Adding $cpp_sdk to the setup.py common_include variable"
+    substituteInPlace setup.py \
+      --replace "['pandas/src/klib', 'pandas/src']" \
+                "['pandas/src/klib', 'pandas/src', '$cpp_sdk']"
+  '';
+
+  # Parallel Cythonization is broken in Python 3.8 on Darwin. Fixed in the next
+  # release. https://github.com/pandas-dev/pandas/pull/30862
+  setupPyBuildFlags = optionals (!(isPy38 && isDarwin)) [
+    # As suggested by
+    # https://pandas.pydata.org/pandas-docs/stable/development/contributing.html#creating-a-python-environment
+    "--parallel=$NIX_BUILD_CORES"
+  ];
+
+
+  disabledTests = stdenv.lib.concatMapStringsSep " and " (s: "not " + s) ([
+    # since dateutil 0.6.0 the following fails: test_fallback_plural, test_ambiguous_flags, test_ambiguous_compat
+    # was supposed to be solved by https://github.com/dateutil/dateutil/issues/321, but is not the case
+    "test_fallback_plural"
+    "test_ambiguous_flags"
+    "test_ambiguous_compat"
+    # Locale-related
+    "test_names"
+    "test_dt_accessor_datetime_name_accessors"
+    "test_datetime_name_accessors"
+    # Can't import from test folder
+    "test_oo_optimizable"
+    # Disable IO related tests because IO data is no longer distributed
+    "io"
+    # KeyError Timestamp
+    "test_to_excel"
+    # ordering logic has changed
+    "numpy_ufuncs_other"
+    "order_without_freq"
+    # tries to import from pandas.tests post install
+    "util_in_top_level"
+    # Fails with 1.0.5
+    "test_constructor_list_frames"
+    "test_constructor_with_embedded_frames"
+  ] ++ optionals isDarwin [
+    "test_locale"
+    "test_clipboard"
+  ]);
+
+  doCheck = !stdenv.isAarch64; # upstream doesn't test this architecture
+
+  checkPhase = ''
+    runHook preCheck
+  ''
+  # TODO: Get locale and clipboard support working on darwin.
+  #       Until then we disable the tests.
+  + optionalString isDarwin ''
+    # Fake the impure dependencies pbpaste and pbcopy
+    echo "#!${runtimeShell}" > pbcopy
+    echo "#!${runtimeShell}" > pbpaste
+    chmod a+x pbcopy pbpaste
+    export PATH=$(pwd):$PATH
+  '' + ''
+    LC_ALL="en_US.UTF-8" py.test $out/${python.sitePackages}/pandas --skip-slow --skip-network -k "$disabledTests"
+    runHook postCheck
+  '';
+
+  meta = {
+    # https://github.com/pandas-dev/pandas/issues/14866
+    # pandas devs are no longer testing i686 so safer to assume it's broken
+    broken = stdenv.isi686;
+    homepage = "https://pandas.pydata.org/";
+    description = "Python Data Analysis Library";
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ raskin fridh knedlsepp ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5059,6 +5059,8 @@ in {
   numpy =
     if pythonOlder "3.5" then
       callPackage ../development/python-modules/numpy/1.16.nix { }
+    else if isPy35 then
+      callPackage ../development/python-modules/numpy/1.18.nix { }
     else
       callPackage ../development/python-modules/numpy { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5198,7 +5198,9 @@ in {
 
   pagerduty = callPackage ../development/python-modules/pagerduty { };
 
-  pandas = if isPy3k then
+  pandas = if isPy35 then
+    callPackage ../development/python-modules/pandas/0.25.nix { }
+  else if isPy3k then
     callPackage ../development/python-modules/pandas { }
   else
     callPackage ../development/python-modules/pandas/2.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6034,14 +6034,24 @@ in {
 
   scipy = let
     scipy_ = callPackage ../development/python-modules/scipy { };
-    scipy_1_2 = scipy_.overridePythonAttrs(oldAttrs: rec {
-      version = "1.2.2";
-      src = oldAttrs.src.override {
-        inherit version;
-        sha256 = "a4331e0b8dab1ff75d2c67b5158a8bb9a83c799d7140094dda936d876c7cfbb1";
-      };
-    });
-  in if pythonOlder "3.5" then scipy_1_2 else scipy_;
+  in if isPy27 then
+      scipy_.overridePythonAttrs(oldAttrs: rec {
+        version = "1.2.2";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "a4331e0b8dab1ff75d2c67b5158a8bb9a83c799d7140094dda936d876c7cfbb1";
+        };
+      })
+    else if isPy35 then
+      scipy_.overridePythonAttrs(oldAttrs: rec {
+        version = "1.4.1";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "0ndw7zyxd2dj37775mc75zm4fcyiipnqxclc45mkpxy8lvrvpqfy";
+        };
+      })
+    else
+      scipy_;
 
   scipy_1_3 = self.scipy.overridePythonAttrs(oldAttrs: rec {
     version = "1.3.3";


### PR DESCRIPTION
###### Motivation for this change
It's great being able to switch between interpreter versions effortless in nix, but still need some packages in older interpreter versions.

pin version was determined to be the last stable release which supported python3.5
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
