### PR TITLE
nixos/ipfs: Allow QUIC connections to socket activate too

### DIFF
--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -25,6 +25,15 @@ let
       then "/${lib.concatStringsSep "/" (lib.tail addr)}"
     else null; # not valid for listen stream, skip
 
+  multiaddrToListenDatagram = addrRaw: let
+      addr = splitMulitaddr addrRaw;
+      s = builtins.elemAt addr;
+    in if s 0 == "ip4" && s 2 == "udp"
+      then "${s 1}:${s 3}"
+    else if s 0 == "ip6" && s 2 == "udp"
+      then "[${s 1}]:${s 3}"
+    else null; # not valid for listen datagram, skip
+
 in {
 
   ###### interface
@@ -268,9 +277,14 @@ in {
 
     systemd.sockets.ipfs-gateway = {
       wantedBy = [ "sockets.target" ];
-      socketConfig.ListenStream = let
-          fromCfg = multiaddrToListenStream cfg.gatewayAddress;
-        in [ "" ] ++ lib.optional (fromCfg != null) fromCfg;
+      socketConfig = {
+        ListenStream = let
+            fromCfg = multiaddrToListenStream cfg.gatewayAddress;
+          in [ "" ] ++ lib.optional (fromCfg != null) fromCfg;
+        ListenDatagram = let
+            fromCfg = multiaddrToListenDatagram cfg.gatewayAddress;
+          in [ "" ] ++ lib.optional (fromCfg != null) fromCfg;
+      };
     };
 
     systemd.sockets.ipfs-api = {

--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -379,6 +379,16 @@ in rec {
       '';
     };
 
+    listenDatagrams = mkOption {
+      default = [];
+      type = types.listOf types.str;
+      example = [ "0.0.0.0:993" "/run/my-socket" ];
+      description = ''
+        For each item in this list, a <literal>ListenDatagram</literal>
+        option in the <literal>[Socket]</literal> section will be created.
+      '';
+    };
+
     socketConfig = mkOption {
       default = {};
       example = { ListenStream = "/run/my-socket"; };

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -354,6 +354,7 @@ let
           [Socket]
           ${attrsToSection def.socketConfig}
           ${concatStringsSep "\n" (map (s: "ListenStream=${s}") def.listenStreams)}
+          ${concatStringsSep "\n" (map (s: "ListenDatagram=${s}") def.listenDatagrams)}
         '';
     };
 


### PR DESCRIPTION
###### Motivation for this change

I don't think the `listenDatagrams` change is needed, but it seems like a good idea in any case. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
