### PR TITLE
mangohud: init at 0.4.1

### DIFF
--- a/pkgs/tools/graphics/mangohud/combined.nix
+++ b/pkgs/tools/graphics/mangohud/combined.nix
@@ -1,0 +1,14 @@
+{ stdenv, pkgs, lib
+, libXNVCtrl
+}:
+let
+  mangohud_64 = pkgs.callPackage ./default.nix { inherit libXNVCtrl; };
+  mangohud_32 = pkgs.pkgsi686Linux.callPackage ./default.nix { inherit libXNVCtrl; };
+in
+pkgs.buildEnv rec {
+  name = "mangohud-${mangohud_64.version}";
+
+  paths = [ mangohud_32 ] ++ lib.optionals stdenv.is64bit [ mangohud_64 ];
+
+  meta = mangohud_64.meta;
+}

--- a/pkgs/tools/graphics/mangohud/default.nix
+++ b/pkgs/tools/graphics/mangohud/default.nix
@@ -1,0 +1,79 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, meson
+, ninja
+, pkg-config
+, python3Packages
+, dbus
+, glslang
+, libglvnd
+, libXNVCtrl
+, mesa
+, vulkan-headers
+, vulkan-loader
+, xorg
+}:
+
+
+stdenv.mkDerivation rec {
+  pname = "mangohud${lib.optionalString stdenv.is32bit "_32"}";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "flightlessmango";
+    repo = "MangoHud";
+    rev = "v${version}";
+    sha256 = "04v2ps8n15ph2smjgnssax5hq88bszw2kbcff37cnd5c8yysvfi6";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    (fetchpatch {
+      # FIXME obsolete in >=0.5.0
+      url = "https://patch-diff.githubusercontent.com/raw/flightlessmango/MangoHud/pull/208.patch";
+      sha256 = "1i6x6sr4az1zv0p6vpw99n947c7awgbbv087fghjlczhry676nmh";
+    })
+  ];
+
+  mesonFlags = [
+    "-Dappend_libdir_mangohud=false"
+    "-Duse_system_vulkan=enabled"
+    "--libdir=lib${lib.optionalString stdenv.is32bit "32"}"
+  ];
+
+  buildInputs = [
+    dbus
+    glslang
+    libglvnd
+    libXNVCtrl
+    mesa
+    python3Packages.Mako
+    vulkan-headers
+    vulkan-loader
+    xorg.libX11
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    python3Packages.Mako
+    python3Packages.python
+  ];
+
+  preConfigure = ''
+    mkdir -p "$out/share/vulkan/"
+    ln -sf "${vulkan-headers}/share/vulkan/registry/" $out/share/vulkan/
+    ln -sf "${vulkan-headers}/include" $out
+  '';
+
+  meta = with lib; {
+    description = "A Vulkan and OpenGL overlay for monitoring FPS, temperatures, CPU/GPU load and more";
+    homepage = "https://github.com/flightlessmango/MangoHud";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ zeratax ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6532,6 +6532,10 @@ in
 
   mandoc = callPackage ../tools/misc/mandoc { };
 
+  mangohud = callPackage ../tools/graphics/mangohud/combined.nix {
+    libXNVCtrl = linuxPackages.nvidia_x11.settings.libXNVCtrl;
+  };
+
   manix = callPackage ../tools/nix/manix {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

closes #84686 

###### Things done

I tested this with several OpenGL and Vulkan 32/64 bit games.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


###### Questions

This is currently a little hackish with the `combined.nix` file, since to use mangohud with 32bit application like a lot of games still are we also need to compile a 32bit version.
but if I just try to build the `default.nix` file with:
```nix
nix-env -f . -iA mangohud
nix-env -f . -iA mangohud --argstr system i686-linux
```

The second derivation fails with:
```
error: packages '/nix/store/98anspysbisprqmzr2rwsm9dvgkxzz2z-mangohud-0.4.1/share/vulkan/registry/cgenerator.py' and '/nix/store/hg7vqhxy0kb2kdxm6rrncajb036mjg15-vulkan-headers-1.2.131.1/share/vulkan/registry/cgenerator.py' have the same priority 5; use 'nix-env --set-flag priority NUMBER INSTALLED_PKGNAME' to change the priority of one of the conflicting packages (0 being the highest priority)
```

The `combined.nix` now installs both versions next to each other.

~~I am also not using the exact 0.4.1 version, but am a few commits ahead to fix https://github.com/flightlessmango/MangoHud/issues/231 and also https://github.com/flightlessmango/MangoHud/commit/acf2d88fbcb7a7a47f957a87d20739c67049bd0d~~

~~Or should I include all extra commits with the patches option?~~

Edit: resolved with https://github.com/ZerataX/nixpkgs/pull/1