### PR TITLE
nixos/mysql: run postStart as an unprivileged user

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -109,6 +109,17 @@ systemd.services.mysql.serviceConfig.ProtectHome = lib.mkForce "read-only";
 systemd.services.mysql.serviceConfig.ReadWritePaths = [ "/var/data" ];
 </programlisting>
     </para>
+    <para>
+      The MySQL service no longer runs its <literal>systemd</literal> service startup script as <literal>root</literal> anymore. A dedicated non <literal>root</literal>
+      super user account is required for operation. This means users with an existing MySQL or MariaDB database server are required to run the following SQL statements
+      as a super admin user before upgrading:
+<programlisting>
+CREATE USER IF NOT EXISTS 'mysql'@'localhost' identified with unix_socket;
+GRANT ALL PRIVILEGES ON *.* TO 'mysql'@'localhost' WITH GRANT OPTION;
+</programlisting>
+      If you use MySQL instead of MariaDB please replace <literal>unix_socket</literal> with <literal>auth_socket</literal>. If you have changed the value of <xref linkend="opt-services.mysql.user"/>
+      from the default of <literal>mysql</literal> to a different user please change <literal>'mysql'@'localhost'</literal> to the corresponding user instead.
+    </para>
    </listitem>
    <listitem>
     <para>

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -20,7 +20,7 @@ in
 
 {
   imports = [
-    (mkRemovedOptionModule [ "services" "mysql" "pidDir" ] "Don't wait for pidfiles, describe dependencies through systemd")
+    (mkRemovedOptionModule [ "services" "mysql" "pidDir" ] "Don't wait for pidfiles, describe dependencies through systemd.")
     (mkRemovedOptionModule [ "services" "mysql" "rootPassword" ] "Use socket authentication or set the password outside of the nix store.")
   ];
 
@@ -44,19 +44,19 @@ in
         type = types.nullOr types.str;
         default = null;
         example = literalExample "0.0.0.0";
-        description = "Address to bind to. The default is to bind to all addresses";
+        description = "Address to bind to. The default is to bind to all addresses.";
       };
 
       port = mkOption {
         type = types.int;
         default = 3306;
-        description = "Port of MySQL";
+        description = "Port of MySQL.";
       };
 
       user = mkOption {
         type = types.str;
         default = "mysql";
-        description = "User account under which MySQL runs";
+        description = "User account under which MySQL runs.";
       };
 
       group = mkOption {
@@ -68,7 +68,7 @@ in
       dataDir = mkOption {
         type = types.path;
         example = "/var/lib/mysql";
-        description = "Location where MySQL stores its table files";
+        description = "Location where MySQL stores its table files.";
       };
 
       configFile = mkOption {
@@ -175,7 +175,7 @@ in
       initialScript = mkOption {
         type = types.nullOr types.path;
         default = null;
-        description = "A file containing SQL statements to be executed on the first startup. Can be used for granting certain permissions on the database";
+        description = "A file containing SQL statements to be executed on the first startup. Can be used for granting certain permissions on the database.";
       };
 
       ensureDatabases = mkOption {
@@ -263,33 +263,33 @@ in
         serverId = mkOption {
           type = types.int;
           default = 1;
-          description = "Id of the MySQL server instance. This number must be unique for each instance";
+          description = "Id of the MySQL server instance. This number must be unique for each instance.";
         };
 
         masterHost = mkOption {
           type = types.str;
-          description = "Hostname of the MySQL master server";
+          description = "Hostname of the MySQL master server.";
         };
 
         slaveHost = mkOption {
           type = types.str;
-          description = "Hostname of the MySQL slave server";
+          description = "Hostname of the MySQL slave server.";
         };
 
         masterUser = mkOption {
           type = types.str;
-          description = "Username of the MySQL replication user";
+          description = "Username of the MySQL replication user.";
         };
 
         masterPassword = mkOption {
           type = types.str;
-          description = "Password of the MySQL replication user";
+          description = "Password of the MySQL replication user.";
         };
 
         masterPort = mkOption {
           type = types.int;
           default = 3306;
-          description = "Port number on which the MySQL master server runs";
+          description = "Port number on which the MySQL master server runs.";
         };
       };
     };

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -347,7 +347,7 @@ in
     ];
 
     systemd.services.mysql = let
-      hasNotify = (cfg.package == pkgs.mariadb);
+      hasNotify = isMariaDB;
     in {
         description = "MySQL Server";
 

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -6,12 +6,10 @@ let
 
   cfg = config.services.mysql;
 
-  mysql = cfg.package;
-
-  isMariaDB = lib.getName mysql == lib.getName pkgs.mariadb;
+  isMariaDB = lib.getName cfg.package == lib.getName pkgs.mariadb;
 
   mysqldOptions =
-    "--user=${cfg.user} --datadir=${cfg.dataDir} --basedir=${mysql}";
+    "--user=${cfg.user} --datadir=${cfg.dataDir} --basedir=${cfg.package}";
 
   settingsFile = pkgs.writeText "my.cnf" (
     generators.toINI { listsAsDuplicateKeys = true; } cfg.settings +
@@ -329,7 +327,7 @@ in
 
     users.groups.mysql.gid = config.ids.gids.mysql;
 
-    environment.systemPackages = [mysql];
+    environment.systemPackages = [ cfg.package ];
 
     environment.etc."my.cnf".source = cfg.configFile;
 
@@ -357,12 +355,12 @@ in
 
         preStart = if isMariaDB then ''
           if ! test -e ${cfg.dataDir}/mysql; then
-            ${mysql}/bin/mysql_install_db --defaults-file=/etc/my.cnf ${mysqldOptions}
+            ${cfg.package}/bin/mysql_install_db --defaults-file=/etc/my.cnf ${mysqldOptions}
             touch ${cfg.dataDir}/mysql_init
           fi
         '' else ''
           if ! test -e ${cfg.dataDir}/mysql; then
-            ${mysql}/bin/mysqld --defaults-file=/etc/my.cnf ${mysqldOptions} --initialize-insecure
+            ${cfg.package}/bin/mysqld --defaults-file=/etc/my.cnf ${mysqldOptions} --initialize-insecure
             touch ${cfg.dataDir}/mysql_init
           fi
         '';
@@ -372,7 +370,7 @@ in
           Restart = "on-abort";
           RestartSec = "5s";
           # The last two environment variables are used for starting Galera clusters
-          ExecStart = "${mysql}/bin/mysqld --defaults-file=/etc/my.cnf ${mysqldOptions} $_WSREP_NEW_CLUSTER $_WSREP_START_POSITION";
+          ExecStart = "${cfg.package}/bin/mysqld --defaults-file=/etc/my.cnf ${mysqldOptions} $_WSREP_NEW_CLUSTER $_WSREP_START_POSITION";
           ExecStartPost =
             let
               setupScript = pkgs.writeScript "mysql-setup" ''
@@ -416,7 +414,7 @@ in
                                 cat ${database.schema}/mysql-databases/*.sql
                             fi
                             ''}
-                          ) | ${mysql}/bin/mysql -u root -N
+                          ) | ${cfg.package}/bin/mysql -u root -N
                       fi
                     '') cfg.initialDatabases}
 
@@ -428,7 +426,7 @@ in
                           echo "CREATE USER '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}' IDENTIFIED WITH mysql_native_password;"
                           echo "SET PASSWORD FOR '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}' = PASSWORD('${cfg.replication.masterPassword}');"
                           echo "GRANT REPLICATION SLAVE ON *.* TO '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}';"
-                        ) | ${mysql}/bin/mysql -u root -N
+                        ) | ${cfg.package}/bin/mysql -u root -N
                       ''}
 
                     ${optionalString (cfg.replication.role == "slave")
@@ -438,7 +436,7 @@ in
                         ( echo "stop slave;"
                           echo "change master to master_host='${cfg.replication.masterHost}', master_user='${cfg.replication.masterUser}', master_password='${cfg.replication.masterPassword}';"
                           echo "start slave;"
-                        ) | ${mysql}/bin/mysql -u root -N
+                        ) | ${cfg.package}/bin/mysql -u root -N
                       ''}
 
                     ${optionalString (cfg.initialScript != null)
@@ -446,7 +444,7 @@ in
                         # Execute initial script
                         # using toString to avoid copying the file to nix store if given as path instead of string,
                         # as it might contain credentials
-                        cat ${toString cfg.initialScript} | ${mysql}/bin/mysql -u root -N
+                        cat ${toString cfg.initialScript} | ${cfg.package}/bin/mysql -u root -N
                       ''}
 
                     rm ${cfg.dataDir}/mysql_init
@@ -457,7 +455,7 @@ in
                   ${concatMapStrings (database: ''
                     echo "CREATE DATABASE IF NOT EXISTS \`${database}\`;"
                   '') cfg.ensureDatabases}
-                  ) | ${mysql}/bin/mysql -u root -N
+                  ) | ${cfg.package}/bin/mysql -u root -N
                 ''}
 
                 ${concatMapStrings (user:
@@ -466,7 +464,7 @@ in
                       ${concatStringsSep "\n" (mapAttrsToList (database: permission: ''
                         echo "GRANT ${permission} ON ${database} TO '${user.name}'@'localhost';"
                       '') user.ensurePermissions)}
-                    ) | ${mysql}/bin/mysql -u root -N
+                    ) | ${cfg.package}/bin/mysql -u root -N
                   '') cfg.ensureUsers}
               '';
             in


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
- general module cleanup
- remove the need to run any part of this module as `root`
- keep consistent with `upstream`
- keep consistent with NixOS best practices

My intention is to squash e3c210dfd19f60587a98c055266570d0f950edec (`nixos/mysql: run ExecStartPost as an unprivileged user`) and a0539fbe8635205ce3e5d0bf4daba316a92651ba (`nixos/mysql: move ExecStartPost into postStart`) before merge.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ping @thorstenweber83 