### PR TITLE
musl: 1.1.24 -> 1.2.0

### DIFF
--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -17,15 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libpthreadstubs libpciaccess ]
     ++ lib.optional withValgrind valgrind-light;
 
-  patches = [ ./cross-build-nm-path.patch ] ++
-    lib.optionals stdenv.hostPlatform.isMusl [
-      # Fix tests not building on musl because they use the glibc-specific
-      # (non-POSIX) `ioctl()` type signature. See #66441.
-      (fetchpatch {
-        url = "https://raw.githubusercontent.com/openembedded/openembedded-core/30a2af80f5f8c8ddf0f619e4f50451b02baa22dd/meta/recipes-graphics/drm/libdrm/musl-ioctl.patch";
-        sha256 = "0rdmh4k5kb80hhk1sdhlil30yf0s8d8w0fnq0hzyvw3ir1mki3by";
-      })
-    ];
+  patches = [ ./cross-build-nm-path.patch ];
 
   postPatch = ''
     for a in */*-symbol-check ; do

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -35,11 +35,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "musl";
-  version = "1.1.24";
+  version = "1.2.0";
 
   src = fetchurl {
     url    = "https://www.musl-libc.org/releases/${pname}-${version}.tar.gz";
-    sha256 = "18r2a00k82hz0mqdvgm7crzc7305l36109c0j9yjmkxj2alcjw0k";
+    sha256 = "1s6lix02k1ijm4nmhzpmwzk5w6xfkhn70nvvk8zjs51r24cpppn6";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

New release; beyond others, fixes compile errors about lacking `SYS_pidfd_open` in `util-linux-2.35.2` (which is in nixpkgs).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


I've tested it a bit as part of https://github.com/nh2/static-haskell-nix/pull/98.