### PR TITLE
go_1_15: 1.15beta1 -> 1.15

### DIFF
--- a/pkgs/development/compilers/go/1.15.nix
+++ b/pkgs/development/compilers/go/1.15.nix
@@ -31,11 +31,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.15beta1";
+  version = "1.15";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "1h1sg6j9jac5bw2pjrd13bf4nr18prs89147izdhzbhp896sikbq";
+    sha256 = "0fmc53pamxxbvmp5bcvh1fhffirpv3gz6y7qz97iacpmsiz8yhv9";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/ssl-cert-file-1.15.patch
+++ b/pkgs/development/compilers/go/ssl-cert-file-1.15.patch
@@ -1,16 +1,16 @@
 diff --git a/src/crypto/x509/root_darwin_amd64.go b/src/crypto/x509/root_darwin_amd64.go
-index 8ad5a9607d..1d6091cf83 100644
+index ce88de025e..258ecc45d1 100644
 --- a/src/crypto/x509/root_darwin_amd64.go
 +++ b/src/crypto/x509/root_darwin_amd64.go
-@@ -8,6 +8,7 @@ import (
+@@ -10,6 +10,7 @@ import (
  	"bytes"
- 	"crypto/x509/internal/macOS"
+ 	macOS "crypto/x509/internal/macos"
  	"fmt"
 +	"io/ioutil"
  	"os"
  	"strings"
  )
-@@ -23,6 +24,14 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
+@@ -25,6 +26,14 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
  var loadSystemRootsWithCgo func() (*CertPool, error)
  
  func loadSystemRoots() (*CertPool, error) {
@@ -25,10 +25,10 @@ index 8ad5a9607d..1d6091cf83 100644
  	var trustedRoots []*Certificate
  	untrustedRoots := make(map[string]bool)
  
-diff --git a/src/crypto/x509/root_darwin_arm64.go b/src/crypto/x509/root_darwin_arm64.go
-index 2fb079ba66..6a072f3e78 100644
---- a/src/crypto/x509/root_darwin_arm64.go
-+++ b/src/crypto/x509/root_darwin_arm64.go
+diff --git a/src/crypto/x509/root_darwin_ios.go b/src/crypto/x509/root_darwin_ios.go
+index 5ecc4911b3..14b4205c00 100644
+--- a/src/crypto/x509/root_darwin_ios.go
++++ b/src/crypto/x509/root_darwin_ios.go
 @@ -6,6 +6,11 @@
  
  package x509


### PR DESCRIPTION
Actions taken:
ssl patch removed ARM section, file no longer exists
bump source version and hash

###### Motivation for this change
https://golang.org/doc/go1.15

###### Things done
Modified patch to remove failure. File no longer exists. Needs additional testing on other architectures.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS - x86 only (EDIT: + armv7l)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
