### PR TITLE
debugpy: 1.0.0b12 -> 1.0.0rc2

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "debugpy";
-  version = "1.0.0b12";
+  version = "1.0.0rc2";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0sz33aq5qldl7kh4qjf5w3d08l9s77ipcj4i9wfklj8f6vf9w1wh";
+    sha256 = "17bmgji0dh3yrg0cw5zqnkkdw7mpxhqkiwx2zx78j362ki14n3xg";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change
Upgrade to latest version: https://github.com/microsoft/debugpy/releases/tag/v1.0.0rc1

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  No bin files, only a python library. Tested through dap-mode in Emacs.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).