### PR TITLE
notmuch: 0.30 -> 0.30.1c80020

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv
+{ fetchurl, fetchgit, stdenv
 , pkgconfig, gnupg
 , xapian, gmime, talloc, zlib
 , doxygen, perl, texinfo
@@ -12,17 +12,18 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "0.30";
+  version = "0.30.1c80020";
   pname = "notmuch";
 
   passthru = {
-    pythonSourceRoot = "${pname}-${version}/bindings/python";
+    pythonSourceRoot = "${src.name}/bindings/python";
     inherit version;
   };
 
-  src = fetchurl {
-    url = "https://notmuchmail.org/releases/${pname}-${version}.tar.xz";
-    sha256 = "1ylnj12f7xr18v3ckb1nwc2aw2rj3ghqnj5f4rzccr8xw5pslfsy";
+  src = fetchgit {
+    url = "https://git.notmuchmail.org/git/notmuch";
+    sha256 = "0xj944c4ayps1bg21pksjih3y9v6lb34dd582df14i14q0yzji51";
+    rev = "1c80020e701c7323de137c0616fc8864443d7bd3";
   };
 
   nativeBuildInputs = [
@@ -75,6 +76,7 @@ stdenv.mkDerivation rec {
       sha256 = "1lk91s00y4qy4pjh8638b5lfkgwyl282g1m27srsf7qfn58y16a2";
     };
   in ''
+    mkdir -p test/test-databases
     ln -s ${test-database} test/test-databases/database-v1.tar.xz
   '';
   doCheck = !stdenv.hostPlatform.isDarwin && (versionAtLeast gmime.version "3.0.3");


### PR DESCRIPTION
###### Motivation for this change

This update is required because [recent update of Emacs (to 27.1)](https://github.com/NixOS/nixpkgs/pull/95169) broke
notmuch build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @adisbladis 