### PR TITLE
buildGoModule: update deleteVendor docs

### DIFF
--- a/doc/languages-frameworks/go.xml
+++ b/doc/languages-frameworks/go.xml
@@ -40,7 +40,9 @@ pet = buildGoModule rec {
 
   subPackages = [ "." ]; <co xml:id='ex-buildGoModule-2' />
 
-  runVend = true; <co xml:id='ex-buildGoModule-3' />
+  deleteVendor = true; <co xml:id='ex-buildGoModule-3' />
+
+  runVend = true; <co xml:id='ex-buildGoModule-4' />
 
   meta = with lib; {
     description = "Simple command-line snippet manager, written in Go";
@@ -67,6 +69,11 @@ pet = buildGoModule rec {
      </para>
     </callout>
     <callout arearefs='ex-buildGoModule-3'>
+     <para>
+      <varname>deleteVendor</varname> removes the pre-existing vendor directory and fetches the dependencies. This should only be used if the dependencies included in the vendor folder are broken or incomplete.
+     </para>
+    </callout>
+    <callout arearefs='ex-buildGoModule-4'>
      <para>
       <varname>runVend</varname> runs the vend command to generate the vendor directory. This is useful if your code depends on c code and go mod tidy does not include the needed sources to build.
      </para>

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -89,7 +89,7 @@ let
       fi
 
       if [ -e vendor ]; then
-        echo "vendor folder exists, please set 'vendorSha256=null;' or 'deleteVendor=true;' in your expression"
+        echo "vendor folder exists, please set 'vendorSha256 = null;' in your expression"
         exit 10
       fi
 

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -85,10 +85,15 @@ let
       runHook preBuild
 
       if [ ${deleteFlag} == "true" ]; then
-        rm -rf vendor
+        if [ ! -d vendor ]; then
+          echo "vendor folder does not exist, 'deleteVendor' is not needed"
+          exit 10
+        else
+          rm -rf vendor
+        fi
       fi
 
-      if [ -e vendor ]; then
+      if [ -d vendor ]; then
         echo "vendor folder exists, please set 'vendorSha256 = null;' in your expression"
         exit 10
       fi


### PR DESCRIPTION
I've seen some confusion about when `deleteVendor` should be used, we don't explain that is is for when the vendor folder is broken or incomplete and that `vendorSha256 = null` is preferred.

Simplifying the message and listing the less common options in the docs should be fine.