### PR TITLE
gobetween, kustomize: remove deleteVendor, enable checks

### DIFF
--- a/pkgs/development/tools/kustomize/default.nix
+++ b/pkgs/development/tools/kustomize/default.nix
@@ -23,10 +23,7 @@ buildGoModule rec {
   # avoid finding test and development commands
   sourceRoot = "source/kustomize";
 
-  deleteVendor = true;
   vendorSha256 = "01ff3w4hwp4ynqhg8cplv0i2ixs811d2x2j6xbh1lslyyh3z3wc5";
-
-  doCheck = false;
 
   meta = with lib; {
     description = "Customization of kubernetes YAML configurations";

--- a/pkgs/servers/gobetween/default.nix
+++ b/pkgs/servers/gobetween/default.nix
@@ -11,8 +11,6 @@ buildGoModule rec {
     sha256 = "0bxf89l53sqan9qq23rwawjkcanv9p61sw56zjqhyx78f0bh0zbc";
   };
 
-  deleteVendor = true;
-
   patches = [
     ./gomod.patch
   ];
@@ -22,8 +20,6 @@ buildGoModule rec {
   '';
 
   vendorSha256 = "1nkni9ikpc0wngh5v0qmlpn5s9v85lb2ih22f3h3lih7nc29yv87";
-
-  doCheck = false;
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
Neither of these have a vendor directory to delete so `deleteVendor` is a no op.