### PR TITLE
osu: init at 2020.806.0

### DIFF
--- a/pkgs/games/osu/default.nix
+++ b/pkgs/games/osu/default.nix
@@ -1,0 +1,33 @@
+{ appimageTools, stdenv, lib, fetchurl }:
+let
+  name = "osu";
+  version = "2020.806.0";
+
+  src = fetchurl {
+    url = "https://github.com/ppy/osu/releases/download/${version}/osu.AppImage";
+    sha256 = "04a1sskp0h9bakvx79n0nay77kp6liadahhycr0pgjfhyy7wwk47";
+  };
+
+  unpacked = appimageTools.extractType2 {
+    inherit name src;
+  };
+
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  extraInstallCommands = ''
+    install -m 444 -D ${unpacked}/osu!.desktop $out/share/applications/osu!.desktop
+    install -m 444 -D ${unpacked}/osu!.png $out/share/applications/osu!.png
+  '';
+
+  extraPkgs = pkgs: [ pkgs.icu ];
+
+  meta = with lib; {
+    description = "rhythm is just a click away";
+    homepage = "https://osu.ppy.sh";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cab404 ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9856,6 +9856,8 @@ in
 
   ocropus = callPackage ../applications/misc/ocropus { };
 
+  osu = callPackage ../games/osu { };
+
   pachyderm = callPackage ../applications/networking/cluster/pachyderm { };
 
   php = php74;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Packaged the bestest free-to-win rhythm game, lazer edition

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
