### PR TITLE
tmuxPlugins.tmux-fzf: init at unstable-2020-11-12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4789,6 +4789,12 @@
     githubId = 2422454;
     name = "Kai Wohlfahrt";
   };
+  kyleondy = {
+    email = "kyle@ondy.org";
+    github = "kyleondy";
+    githubId = 1640900;
+    name = "Kyle Ondy";
+  };
   kylesferrazza = {
     name = "Kyle Sferrazza";
     email = "kyle.sferrazza@gmail.com";

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -377,6 +377,41 @@ in rec {
     };
   };
 
+  tmux-fzf = mkDerivation {
+    pluginName = "tmux-fzf";
+    version = "unstable-2020-11-23";
+    src = fetchFromGitHub {
+      owner = "sainnhe";
+      repo = "tmux-fzf";
+      rev = "312685b2a7747b61f1f4a96bd807819f1450479d";
+      sha256 = "1z0zmsf8asxs9wbwvkiyd81h93wb2ikl8nxxc26sdpi6l333q5s9";
+    };
+    postInstall = ''
+      find $target -type f -print0 | xargs -0 sed -i -e 's|fzf |${pkgs.fzf}/bin/fzf |g'
+      find $target -type f -print0 | xargs -0 sed -i -e 's|sed |${pkgs.gnused}/bin/sed |g'
+      find $target -type f -print0 | xargs -0 sed -i -e 's|tput |${pkgs.ncurses}/bin/tput |g'
+    '';
+     meta = {
+      homepage = "https://github.com/sainnhe/tmux-fzf";
+      description = "Use fzf to manage your tmux work environment! ";
+      longDescription =
+        ''
+        Features:
+        * Manage sessions (attach, detach*, rename, kill*).
+        * Manage windows (switch, link, move, swap, rename, kill*).
+        * Manage panes (switch, break, join*, swap, layout, kill*, resize).
+        * Multiple selection (support for actions marked by *).
+        * Search commands and append to command prompt.
+        * Search key bindings and execute.
+        * User menu.
+        * Popup window support.
+      '';
+      license = stdenv.lib.licenses.mit;
+      platforms = stdenv.lib.platforms.unix;
+      maintainers = with stdenv.lib.maintainers; [ kyleondy ];
+    };
+  };
+
   urlview = mkDerivation {
     pluginName = "urlview";
     version = "unstable-2016-01-06";


### PR DESCRIPTION
 This plugin has no releases or tags yet, so pinned to the current head
 of master as of this commit.


###### Motivation for this change
 I want to use this tmux plugin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
