### PR TITLE
azure-new: Amend `upload-image.sh` and `boot-vm.sh`

### DIFF
--- a/nixos/maintainers/scripts/azure-new/README.md
+++ b/nixos/maintainers/scripts/azure-new/README.md
@@ -1,40 +1,167 @@
-# azure
+# Deploy custom images and NixOS VMs to Azure
 
-## Demo
+## 1. Demo
 
 Here's a demo of this being used: https://asciinema.org/a/euXb9dIeUybE3VkstLWLbvhmp
-
-## Usage
 
 This is meant to be an example image that you can copy into your own
 project and modify to your own needs. Notice that the example image
 includes a built-in test user account, which by default uses your
 `~/.ssh/id_ed25519.pub` as an `authorized_key`.
 
-Build and upload the image
-```shell
-$ ./upload-image.sh ./examples/basic/image.nix
+## 2. Before using
 
-...
-+ attr=azbasic
-+ nix-build ./examples/basic/image.nix --out-link azure
-/nix/store/qdpzknpskzw30vba92mb24xzll1dqsmd-azure-image
-...
-95.5 %, 0 Done, 0 Failed, 1 Pending, 0 Skipped, 1 Total, 2-sec Throughput (Mb/s): 932.9565
-...
-/subscriptions/aff271ee-e9be-4441-b9bb-42f5af4cbaeb/resourceGroups/nixos-images/providers/Microsoft.Compute/images/azure-image-todo-makethisbetter
+The provided [`shell.nix`](./shell.nix) and [`image.nix`](./examples/basic/image.nix) will import the cloned Nixpkgs repo's [`default.nix`](../../../../default.nix).
+
+As a consequence, depending on the current state of Nixpkgs, `nix-shell` and the Azure image may not build at all.  The former can be resolved by the suggestions below, but the latter may still fail (when [`upload-image.sh`](./upload-image.sh) calls [`image.nix`](./examples/basic/image.nix)).
+
+### 2.1 `nix-shell` won't build
+
+1. Try using the channel of your system
+
+```text
+$ nix-shell --arg pkgs 'import <nixpkgs> {}'
 ```
 
-Take the output, boot an Azure VM:
+2. or find a stable Nixpkgs version via commit hash (such 0c0fe6d for example)
 
-```
-img="/subscriptions/.../..." # use output from last command
-./boot-vm.sh "${img}"
-...
-=> booted
+```text
+$ nix-shell --arg pkgs 'import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/0c0fe6d85b92c4e992e314bd6f9943413af9a309.tar.gz") {}'
 ```
 
-## Future Work
+### 2.2 Image build fails
+
+[`system.nix`](./examples/basic/system.nix) (called by [`image.nix`](./examples/basic/image.nix)) relies on the `virtualisation.azureImage` (defined in [`azure-image.nix`](https://github.com/NixOS/nixpkgs/blob/066c604eec6089e25aa5c4cc933decebdf8aa626/nixos/modules/virtualisation/azure-image.nix)?) attribute, that is not yet present in the 20.03 channel, ruling out option 1 in section 2.1 above.
+
+See also [issue #86005](https://github.com/NixOS/nixpkgs/issues/86005) when getting `The option `virtualisation.azureImage` defined in ... does not exist`.
+
+## 3. Usage
+
+In short:
+
+1. `nix-shell`
+
+2. [`upload-image.sh`](./upload-image.sh)
+
+3. (optional) [`boot-vm.sh`](./boot-vm.sh)
+
+### 3.1 Enter `nix-shell`
+
+```text
+$ nix-shell
+```
+
+See section 2.1 on how to provide a specific Nixpkgs version to `nix-shell`.
+
+### 3.2 Create and upload image ([`upload-image.sh`](./upload-image.sh))
+
+```text
+[..]$ ./upload-image.sh --resource-group "my-rg" --image-name "my-image"
+```
+
+or, to also boot up the new image, use:
+
+```text
+$ ./upload-image.sh -g "my-rg" -n "my-image" -b "
+```
+
+Other options and default values (`./upload-image.sh --help`):
+
+
+```text
+USAGE: (Every switch requires an argument)
+
+-g --resource-group REQUIRED Created if does  not exist. Will
+                             house a new disk and the created
+                             image.
+
+-n --image-name     REQUIRED The  name of  the image  created
+                             (and also of the new disk).
+
+-i --image-nix      Nix  expression   to  build  the
+                    image. Default value:
+                    "./examples/basic/image.nix".
+
+-l --location       Values from `az account list-locations`.
+                    Default value: "westus2".
+
+-b --boot-sh-opts   Once  the image  is created  and uploaded,
+                    run `./boot-vm.sh`  with arguments  in the
+                    format of "opt1=val1;...;optn=valn".
+
+                    + "vm-name=..." (or "n=...") is mandatory
+
+                    + "--image" will  be  pre-populated  with
+                      the created image's ID
+
+                    + if  resource group  is omitted,  the one
+                      for `./upload-image.sh` is used
+```
+
+### 3.3 Start virtual machine ([`boot-vm.sh`](./boot-vm.sh))
+
+To create an existing virtual machine on Azure:
+
+```text
+$ ./boot-vm.sh -g "my-rg" -i "my-image" -n "my-new-vm"
+```
+
+Other options and default values (`./boot-vm.sh --help`):
+
+```text
+-g --resource-group REQUIRED Created if does  not exist. Will
+                             house a new disk and the created
+                             image.
+
+-i --image          REQUIRED ID or name of an existing image.
+                             (See `az image list --output table`)
+                              or  `az image list --query "[].{ID:id, Name:name}"`.)
+
+-n --vm-name        REQUIRED The name of the new virtual machine
+                             to be created.
+
+-n --vm-size        See https://azure.microsoft.com/pricing/details/virtual-machines/ for s
+ize info.
+                    Default value: "Standard_DS1_v2"
+
+-d --os-size        OS disk size in GB to create.
+                    Default value: "42"
+
+-l --location       Values from `az account list-locations`.
+                    Default value: "westus2".
+
+NOTE: Brand new SSH  keypair is going to  be generated. To
+      provide  your own,  edit  the very  last command  in
+      `./boot-vm.sh`.
+```
+
+## 4. Limitations, quirks, etc.
+
+### 4.1 Ancillary artifacts
+
+#### 4.1.1 Disks
+
+A new disk (with the same name as the image) is generated every time [`upload-image.sh`](./upload-image.sh) is used to avoid using storage accounts and to be able to upload images directly.
+
+The disk is not deleted automatically, and re-use is not included in the script at the moment; to allow uplad, disks have to be in a specific state, and it is error-prone to get it right. Please see notes in [`upload-image.sh`](./upload-image.sh).
+
+#### 4.1.2 Resource groups
+
+Both [`upload-image.sh`](./upload-image.sh) and [`boot-vm.sh`](./boot-vm.sh) have a `--resource-group` (or `-g`) switch to provide additional granularity of organizing resources.
+
+Some [Best practices for naming your Microsoft Azure resources](https://techcommunity.microsoft.com/t5/itops-talk-blog/best-practices-for-naming-your-microsoft-azure-resources/ba-p/294480).
+
+#### 4.1.3 Identities
+
+Aside from creating and booting up a VM, [`boot-vm.sh`](./boot-vm.sh) also creates a [managed service identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview), with the same name as the provided resource group. (See also [`az identity` Azure CLI command](https://docs.microsoft.com/en-us/cli/azure/identity?view=azure-cli-latest#az-identity-create).)
+
+> TODO/QUESTION: Why? What are the benefits? This step is entirely optional, and [ `az vm create` ](https://docs.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-create) doesn't require it. If not need it, just rip out the relevant parts in [`boot-vm.sh`](./boot-vm.sh).
+
+#### 4.1.4 New SSH keypair by default for each VM
+
+Seemed like a sensible default. If you want to provide your own keys, please take a look at the very end of [`boot-vm.sh`](./boot-vm.sh) (and maybe [`system.nix`](./examples/basic/system.nix) as well).
+
+## 5. Future Work
 
 1. If the user specifies a hard-coded user, then the agent could be removed.
    Probably has security benefits; definitely has closure-size benefits.

--- a/nixos/maintainers/scripts/azure-new/boot-vm.sh
+++ b/nixos/maintainers/scripts/azure-new/boot-vm.sh
@@ -1,36 +1,192 @@
 #!/usr/bin/env bash
-set -euo pipefail
-set -x
 
-image="${1}"
-location="westus2"
-group="nixos-test-vm"
-vm_size="Standard_D2s_v3";  os_size=42;
+####################################################
+# AZ LOGIN CHECK                                   #
+####################################################
 
-# ensure group
-az group create --location "westus2" --name "${group}"
-group_id="$(az group show --name "${group}" -o tsv --query "[id]")"
-
-# (optional) identity
-if ! az identity show -n "${group}-identity" -g "${group}" &>/dev/stderr; then
-  az identity create --name "${group}-identity" --resource-group "${group}"
+# Making  sure  that  one   is  logged  in  (to  avoid
+# surprises down the line).
+if [ $(az account list 2> /dev/null) == [] ]
+then
+  echo
+  echo '********************************************************'
+  echo '* Please log  in to  Azure by  typing "az  login", and *'
+  echo '* repeat the "./upload-image.sh" command.              *'
+  echo '********************************************************'
+  exit 1
 fi
 
-# (optional) role assignment, to the resource group, bad but not really great alternatives
-identity_id="$(az identity show --name "${group}-identity" --resource-group "${group}" -o tsv --query "[id]")"
-principal_id="$(az identity show --name "${group}-identity" --resource-group "${group}" -o tsv --query "[principalId]")"
-until az role assignment create --assignee "${principal_id}" --role "Owner" --scope "${group_id}"; do sleep 1; done
+####################################################
+# HELPERS                                          #
+####################################################
+
+assign_role() {
+  az role assignment create      \
+    --assignee "${principal_id}" \
+    --role "Owner"               \
+    --scope "${group_id}"
+}
+
+usage() {
+  echo ''
+  echo 'USAGE: (Every switch requires an argument)'
+  echo ''
+  echo '-g --resource-group REQUIRED Created if does  not exist. Will'
+  echo '                             house a new disk and the created'
+  echo '                             image.'
+  echo ''
+  echo '-i --image          REQUIRED ID or name of an existing image.'
+  echo '                             (See `az image list --output table`)'
+  echo '                              or  `az image list --query "[].{ID:id, Name:name}"`.)'
+  echo ''
+  echo '-n --vm-name        REQUIRED The name of the new virtual machine'
+  echo '                             to be created.'
+  echo ''
+  echo '-n --vm-size        See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info.'
+  echo '                    Default value: "Standard_DS1_v2"'
+  echo ''
+  echo '-d --os-size        OS disk size in GB to create.'
+  echo '                    Default value: "42"'
+  echo ''
+  echo '-l --location       Values from `az account list-locations`.'
+  echo '                    Default value: "westus2".'
+  echo ''
+  echo 'NOTE: Brand new SSH  keypair is going to  be generated. To'
+  echo '      provide  your own,  edit  the very  last command  in'
+  echo '      `./boot-vm.sh`.'
+  echo ''
+};
+
+####################################################
+# SWITCHES                                         #
+####################################################
+
+# https://unix.stackexchange.com/a/204927/85131
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -l|--location)
+      location="$2"
+      ;;
+    -g|--resource-group)
+      resource_group="$2"
+      ;;
+    -i|--image)
+      case "$2" in
+        /*)
+          img_id="$2"
+          ;;
+        *)  # image name
+          img_id="$(az image list             \
+            --query "[?name=='"$2"'].{ID:id}" \
+            --output tsv
+          )"
+       esac
+      ;;
+    -n|--vm-name)
+      vm_name="$2"
+      ;;
+    -s|--vm-size)
+      vm_size="$2"
+      ;;
+    -d|--os-disk-size-gb)
+      os_size="$2"
+      ;;
+    *)
+      printf "***************************\n"
+      printf "* Error: Invalid argument *\n"
+      printf "***************************\n"
+      usage
+      exit 1
+  esac
+  shift
+  shift
+done
+
+if [ -z "${img_id}" ] || [ -z "${resource_group}" ] || [ -z "${vm_name}" ]
+then
+  printf "************************************\n"
+  printf "* Error: Missing required argument *\n"
+  printf "************************************\n"
+  usage
+  exit 1
+fi
+
+####################################################
+# DEFAULTS                                         #
+####################################################
+
+location_d="${location:-"westus2"}"
+os_size_d="${vm_size:-"42"}"
+vm_size_d="${os_size:-"Standard_DS1_v2"}"
+
+# https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+set -euxo pipefail
+
+# Make resource group exists
+if ! az group show --resource-group "${resource_group}" &>/dev/null
+then
+  az group create              \
+    --name "${resource_group}" \
+    --location "${location_d}"
+fi
+
+# (optional) identity
+if ! az identity show --name "${resource_group}-identity" --resource-group "${resource_group}" &>/dev/stderr
+then
+  az identity create                    \
+    --name "${resource_group}-identity" \
+    --resource-group "${resource_group}"
+fi
+
+# (optional) role assignment, to the resource group;
+# bad but not really great alternatives
+principal_id="$(
+  az identity show                       \
+    --name "${resource_group}-identity"  \
+    --resource-group "${resource_group}" \
+    --output tsv --query "[principalId]"
+)"
+
+group_id="$(
+  az group show                \
+    --name "${resource_group}" \
+    --output tsv               \
+    --query "[id]"
+)"
+
+# As long as the `az role assignment` command fails,
+# the loop will continue
+# https://tldp.org/LDP/Bash-Beginners-Guide/html/sect_09_03.html
+# https://linuxize.com/post/bash-until-loop/
+# TODO Is the loop really needed?
+until assign_role;
+do
+  echo "Retrying role assignment..."
+  sleep 1
+done
+
+echo "Role assignment successful"
+
+identity_id="$(
+  az identity show                       \
+    --name "${resource_group}-identity"  \
+    --resource-group "${resource_group}" \
+    --output tsv --query "[id]"
+  )"
 
 # boot vm
-az vm create \
-  --name "${group}-vm" \
-  --resource-group "${group}" \
-  --assign-identity "${identity_id}" \
-  --size "${vm_size}" \
-  --os-disk-size-gb "${os_size}" \
-  --image "${image}" \
-  --admin-username "${USER}" \
-  --location "westus2" \
-  --storage-sku "Premium_LRS" \
-  --ssh-key-values "$(ssh-add -L)"
+az vm create                           \
+  --name "${vm_name}"                  \
+  --resource-group "${resource_group}" \
+  --assign-identity "${identity_id}"   \
+  --size "${vm_size_d}"                \
+  --os-disk-size-gb "${os_size_d}"     \
+  --image "${img_id}"                  \
+  --admin-username "${USER}"           \
+  --location "${location_d}"           \
+  --storage-sku "Premium_LRS"          \
+  --generate-ssh-keys
+  # This only works if `ssh-agent` is running
+  # --ssh-key-values "$(ssh-add -L)"
+  # TODO Add key options to script
 

--- a/nixos/maintainers/scripts/azure-new/examples/basic/image.nix
+++ b/nixos/maintainers/scripts/azure-new/examples/basic/image.nix
@@ -1,6 +1,11 @@
 let
+  # NOTE Messing with this import  will likely result in "The
+  #      option  `virtualisation.azureImage`  defined in  ...
+  #      does not exist.".
+  #      See https://github.com/NixOS/nixpkgs/issues/86005
   pkgs = (import ../../../../../../default.nix {});
   machine = import "${pkgs.path}/nixos/lib/eval-config.nix" {
+    # pkgs = import <nixpkgs> {};
     system = "x86_64-linux";
     modules = [
       ({config, ...}: { imports = [ ./system.nix ]; })

--- a/nixos/maintainers/scripts/azure-new/examples/basic/system.nix
+++ b/nixos/maintainers/scripts/azure-new/examples/basic/system.nix
@@ -1,6 +1,6 @@
 { pkgs, modulesPath, ... }:
 
-let username = "azurenixosuser";
+let username = "freeswitch";
 in
 {
   imports = [
@@ -8,16 +8,21 @@ in
     "${modulesPath}/virtualisation/azure-image.nix"
   ];
 
-  ## NOTE: This is just an example of how to hard-code a user.
-  ## The normal Azure agent IS included and DOES provision a user based
-  ## on the information passed at VM creation time.
+  ## NOTE: This is just an  example of how to hard-code a
+  ##       user.
+  ##
+  ## The  normal Azure  agent  IS included  and
+  ## DOES  provision   a  user  based   on  the
+  ## information passed at VM creation time.
   users.users."${username}" = {
     isNormalUser = true;
     home = "/home/${username}";
-    description = "Azure NixOS Test User";
-    openssh.authorizedKeys.keys = [ (builtins.readFile ~/.ssh/id_ed25519.pub) ];
+    extraGroups = [ "wheel" ]; # Enable ‘sudo’ for the user.
+  # description = "Azure NixOS Test User";
+  # openssh.authorizedKeys.keys = [ (builtins.readFile ~/.ssh/id_ed25519.pub) ];
   };
-  nix.trustedUsers = [ username ];
+  # nix.trustedUsers = [ username ];
+  nix.trustedUsers = [ "@wheel" ];
 
   virtualisation.azureImage.diskSize = 2500;
 
@@ -29,6 +34,8 @@ in
   security.sudo.wheelNeedsPassword = false;
 
   environment.systemPackages = with pkgs; [
-    git file htop wget curl
+    git file htop wget curl vim freeswitch
   ];
+
+  services.freeswitch.enable = true;
 }

--- a/nixos/maintainers/scripts/azure-new/shell.nix
+++ b/nixos/maintainers/scripts/azure-new/shell.nix
@@ -1,13 +1,16 @@
-with (import ../../../../default.nix {});
-stdenv.mkDerivation {
-  name = "nixcfg-azure-devenv";
+{pkgs ? import ../../../../default.nix {} }:
 
-  nativeBuildInputs = [
+pkgs.mkShell {
+  buildInputs = with pkgs; [
     azure-cli
     bash
+    # TODO What is cacert used for?
+    # Probably because Azure CLI needs SSL certs, and
+    # https://gist.github.com/CMCDragonkai/1ae4f4b5edeb021ca7bb1d271caca999
     cacert
     azure-storage-azcopy
   ];
 
   AZURE_CONFIG_DIR="/tmp/azure-cli/.azure";
+  AZURE_NEW_PKGS_PATH=pkgs.path;
 }

--- a/nixos/maintainers/scripts/azure-new/upload-image.sh
+++ b/nixos/maintainers/scripts/azure-new/upload-image.sh
@@ -1,58 +1,220 @@
 #!/usr/bin/env bash
-set -euo pipefail
-set -x
 
-image_nix="${1:-"./examples/basic/image.nix"}"
+####################################################
+# AZ LOGIN CHECK                                   #
+####################################################
 
-nix-build "${image_nix}" --out-link "azure"
-
-group="nixos-images"
-location="westus2"
-img_name="nixos-image"
-img_file="$(readlink -f ./azure/disk.vhd)"
-
-if ! az group show -n "${group}" &>/dev/null; then
-  az group create --name "${group}" --location "${location}"
+# Making  sure  that  one   is  logged  in  (to  avoid
+# surprises down the line).
+# TODO Works flawlessly when  not logged in, but shows
+#      error when do logged in.
+#      > ./upload-image.sh: line 126: [: too many arguments
+if [ $(az account list 2> /dev/null) = [] ]
+then
+  echo
+  echo '********************************************************'
+  echo '* Please log  in to  Azure by  typing "az  login", and *'
+  echo '* repeat the "./upload-image.sh" command.              *'
+  echo '********************************************************'
+  exit 1
 fi
 
-# note: the disk access token song/dance is tedious
-# but allows us to upload direct to a disk image
-# thereby avoid storage accounts (and naming them) entirely!
-if ! az disk show -g "${group}" -n "${img_name}" &>/dev/null; then
+####################################################
+# HELPERS                                          #
+####################################################
+
+show_id() {
+  az $1 show \
+    --resource-group "${resource_group}" \
+    --name "${img_name}"        \
+    --query "[id]"              \
+    --output tsv
+}
+
+# make_boot_sh_opts <image-id> "<opt1>=<val1>;...;<optn>=<valn>"
+make_boot_sh_opts() {
+  # Add `./upload-image.sh`'s resource group if not given
+  # https://stackoverflow.com/a/8811800/1498178 (contains string?)
+  if [ "${2#*g=}" != "$2" ] || [ "${2#*resource-group}" != "$2" ]
+  then
+    opt_string=$2
+  else
+    opt_string="resource-group=${resource_group};$2"
+  fi
+
+  acc=""
+  # https://stackoverflow.com/a/918931/1498178 (parse and loop opt-string)
+  while IFS=';' read -ra opts; do
+    for i in "${opts[@]}"; do
+        # https://stackoverflow.com/a/10520718/1498178 (separate opts and vals)
+        opt=${i%=*}
+        val=${i#*=}
+        # https://stackoverflow.com/a/17750975/1498178 (string length)
+        # https://stackoverflow.com/a/3953712/1498178 (ternary)
+        sep=$([ ${#opt} == 1 ] && echo "-" || echo "--")
+        acc="${acc}${sep}${opt} ${val} "
+    done
+  done <<< "image=$1;$opt_string"
+
+  echo $acc
+}
+
+usage() {
+  echo ''
+  echo 'USAGE: (Every switch requires an argument)'
+  echo ''
+  echo '-g --resource-group REQUIRED Created if does  not exist. Will'
+  echo '                             house a new disk and the created'
+  echo '                             image.'
+  echo ''
+  echo '-n --image-name     REQUIRED The  name of  the image  created'
+  echo '                             (and also of the new disk).'
+  echo ''
+  echo '-i --image-nix      Nix  expression   to  build  the'
+  echo '                    image. Default value:'
+  echo '                    "./examples/basic/image.nix".'
+  echo ''
+  echo '-l --location       Values from `az account list-locations`.'
+  echo '                    Default value: "westus2".'
+  echo ''
+  echo '-b --boot-sh-opts   Once  the image  is created  and uploaded,'
+  echo '                    run `./boot-vm.sh`  with arguments  in the'
+  echo '                    format of "opt1=val1;...;optn=valn".'
+  echo ''
+  echo '                    + "vm-name=..." (or "n=...") is mandatory'
+  echo ''
+  echo '                    + "--image" will  be  pre-populated  with'
+  echo "                      the created image's ID"
+  echo ''
+  echo '                    + if  resource group  is omitted,  the one'
+  echo '                      for `./upload-image.sh` is used'
+}
+
+####################################################
+# SWITCHES                                         #
+####################################################
+
+# https://unix.stackexchange.com/a/204927/85131
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -i|--image-nix)
+      image_nix="$2"
+      ;;
+    -l|--location)
+      location="$2"
+      ;;
+    -g|--resource-group)
+      resource_group="$2"
+      ;;
+    -n|--image-name)
+      img_name="$2"
+      ;;
+    -b|--boot-sh-opts)
+      boot_opts="$2"
+      ;;
+    -h|--help)
+      usage
+      exit 1
+      ;;
+    *)
+      printf "***************************\n"
+      printf "* Error: Invalid argument *\n"
+      printf "***************************\n"
+      usage
+      exit 1
+  esac
+  shift
+  shift
+done
+
+if [ -z "${img_name}" ] || [ -z "${resource_group}" ]
+then
+  printf "************************************\n"
+  printf "* Error: Missing required argument *\n"
+  printf "************************************\n"
+  usage
+  exit 1
+fi
+
+####################################################
+# DEFAULTS                                         #
+####################################################
+
+image_nix_d="${image_nix:-"./examples/basic/image.nix"}"
+location_d="${location:-"westus2"}"
+boot_opts_d="${boot_opts:-"none"}"
+
+####################################################
+# PUT IMAGE INTO AZURE CLOUD                       #
+####################################################
+
+# https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+set -euxo pipefail
+
+nix-build             \
+  --out-link "azure"  \
+  "${image_nix_d}"
+
+# Make resource group exists
+if ! az group show --resource-group "${resource_group}" &>/dev/null
+then
+  az group create     \
+    --name "${resource_group}" \
+    --location "${location_d}"
+fi
+
+# NOTE: The  disk   access  token   song/dance  is
+#       tedious  but allows  us  to upload  direct
+#       to  a  disk  image thereby  avoid  storage
+#       accounts (and naming them) entirely!
+
+if ! show_id "disk" &>/dev/null
+then
+
+  img_file="$(readlink -f ./azure/disk.vhd)"
   bytes="$(stat -c %s ${img_file})"
-  size="30"
-  az disk create \
-    --resource-group "${group}" \
-    --name "${img_name}" \
-    --for-upload true --upload-size-bytes "${bytes}"
+
+  az disk create                \
+    --resource-group "${resource_group}" \
+    --name "${img_name}"        \
+    --for-upload true           \
+    --upload-size-bytes "${bytes}"
 
   timeout=$(( 60 * 60 )) # disk access token timeout
   sasurl="$(\
-    az disk grant-access \
-      --access-level Write \
-      --resource-group "${group}" \
-      --name "${img_name}" \
+    az disk grant-access               \
+      --access-level Write             \
+      --resource-group "${resource_group}"      \
+      --name "${img_name}"             \
       --duration-in-seconds ${timeout} \
-        | jq -r '.accessSas'
+      --query "[accessSas]"            \
+      --output tsv
   )"
 
   azcopy copy "${img_file}" "${sasurl}" \
     --blob-type PageBlob
 
-  az disk revoke-access \
-    --resource-group "${group}" \
+  # https://docs.microsoft.com/en-us/cli/azure/disk?view=azure-cli-latest#az-disk-revoke-access
+  # > Revoking the SAS will  change the state of
+  # > the managed  disk and allow you  to attach
+  # > the disk to a VM.
+  az disk revoke-access         \
+    --resource-group "${resource_group}" \
     --name "${img_name}"
 fi
 
-if ! az image show -g "${group}" -n "${img_name}" &>/dev/null; then
-  diskid="$(az disk show -g "${group}" -n "${img_name}" -o json | jq -r .id)"
+if ! show_id "image" &>/dev/null
+then
 
-  az image create \
-    --resource-group "${group}" \
-    --name "${img_name}" \
-    --source "${diskid}" \
+  az image create                \
+    --resource-group "${resource_group}"  \
+    --name "${img_name}"         \
+    --source "$(show_id "disk")" \
     --os-type "linux" >/dev/null
 fi
 
-imageid="$(az image show -g "${group}" -n "${img_name}" -o json | jq -r .id)"
-echo "${imageid}"
+if [ "${boot_opts_d}" != "none" ]
+then
+  img_id="$(show_id "image")"
+  ./boot-vm.sh $(make_boot_sh_opts $img_id $boot_opts_d)
+fi


### PR DESCRIPTION
###### Motivation for this change

This is mainly a request for review (@colemickens , @jonringer ?) as most of the changes are opinionated but hope that there are parts that could be of use.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
