### PR TITLE
pure-ftpd: add patches for CVE-2020-9274, CVE-2020-9365

### DIFF
--- a/pkgs/servers/ftp/pure-ftpd/default.nix
+++ b/pkgs/servers/ftp/pure-ftpd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl }:
+{ stdenv, fetchurl, openssl, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "pure-ftpd-1.0.49";
@@ -7,6 +7,19 @@ stdenv.mkDerivation rec {
     url = "https://download.pureftpd.org/pub/pure-ftpd/releases/${name}.tar.gz";
     sha256 = "19cjr262n6h560fi9nm7l1srwf93k34bp8dp1c6gh90bqxcg8yvn";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2020-9274.patch";
+      url = "https://github.com/jedisct1/pure-ftpd/commit/8d0d42542e2cb7a56d645fbe4d0ef436e38bcefa.patch";
+      sha256 = "1yd84p6bd4rf21hg3kqpi2a02cac6dz5ag4xx3c2dl5vbzhr5a8k";
+    })
+    (fetchpatch {
+      name = "CVE-2020-9365.patch";
+      url = "https://github.com/jedisct1/pure-ftpd/commit/bf6fcd4935e95128cf22af5924cdc8fe5c0579da.patch";
+      sha256 = "003klx7j82qf92qr1dxg32v5r2bhhywplynd3xil1lbcd3s3mqhi";
+    })
+  ];
 
   buildInputs = [ openssl ];
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2020-9274
https://nvd.nist.gov/vuln/detail/CVE-2020-9365

Fixes merged to upstream's master but no release yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
