### PR TITLE
openexr: 2.5.2 → 2.5.3

### DIFF
--- a/pkgs/development/libraries/ilmbase/default.nix
+++ b/pkgs/development/libraries/ilmbase/default.nix
@@ -2,7 +2,6 @@
 , lib
 , buildPackages
 , cmake
-, libtool
 , openexr
 }:
 
@@ -16,7 +15,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ cmake libtool ];
+  nativeBuildInputs = [ cmake ];
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   # fails 1 out of 1 tests with

--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -6,12 +6,11 @@
 , ilmbase
 , fetchpatch
 , cmake
-, libtool
 }:
 
 stdenv.mkDerivation rec {
   pname = "openexr";
-  version = "2.5.2";
+  version = "2.5.3";
 
   outputs = [ "bin" "dev" "out" "doc" ];
 
@@ -19,7 +18,7 @@ stdenv.mkDerivation rec {
     owner = "AcademySoftwareFoundation";
     repo = "openexr";
     rev = "v${version}";
-    sha256 = "dtVoXA3JdmNs1iqu7cZlAdxt/CAgL5lSbOwu0SheyO0=";
+    sha256 = "xyYdRrwAYdnRZmErIK0tZspguqtrXvixO5+6nMDoOh8=";
   };
 
   patches = [
@@ -28,23 +27,10 @@ stdenv.mkDerivation rec {
       url = "https://github.com/AcademySoftwareFoundation/openexr/commit/6442fb71a86c09fb0a8118b6dbd93bcec4883a3c.patch";
       sha256 = "bwD5WTKPT4DjOJDnPXIvT5hJJkH0b71Vo7qupWO9nPA=";
     })
-  ] ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.libc != "glibc") [
-    # Fix ilmbase/openexr using glibc-only fpstate.
-    # Found via https://git.alpinelinux.org/aports/tree/community/openexr/10-musl-_fpstate.patch?id=80d9611b7b8e406a554c6f511137e03ff26acbae,
-    # TODO Remove when https://github.com/AcademySoftwareFoundation/openexr/pull/798 is merged and available.
-    (fetchpatch {
-      name = "ilmbase-musl-_fpstate.patch.patch";
-      url = "https://raw.githubusercontent.com/void-linux/void-packages/80bbc168faa25448bd3399f4df331b836e74b85c/srcpkgs/ilmbase/patches/musl-_fpstate.patch";
-      sha256 = "1bmyg4qfbz2p5iflrakbj8jzs85s1cf4cpfyclycnnqqi45j8m8d";
-      # The patch's files are written as `IlmBase/...`, this turns it into
-      # `a/IlmBase/...`, so that the `patch -p1` that `patches` does works.
-      extraPrefix = ""; # Changing this requires changing the `sha256` (fixed-output)!
-    })
   ];
-  nativeBuildInputs = [ cmake libtool ];
-  propagatedBuildInputs = [ ilmbase zlib ];
 
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [ ilmbase zlib ];
 
   meta = with stdenv.lib; {
     description = "A high dynamic-range (HDR) image file format";


### PR DESCRIPTION
###### Motivation for this change
https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v2.5.3

* Includes the musl patch.
* Also clean up a bit while at it:
    * libtool not necessary since CMake port
    * enableParallelBuilding is on by default with cmake

cc @nh2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
