### PR TITLE
grex: init at 1.1.0

### DIFF
--- a/pkgs/tools/misc/grex/default.nix
+++ b/pkgs/tools/misc/grex/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, fetchpatch, rustPlatform, cmake, perl, pkgconfig, zlib
+, darwin, libiconv, installShellFiles
+}:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  pname = "grex";
+  version = "1.1.0";
+
+  cargoSha256 = "0kf2n2j7kfrfzid1h2gd0qf53fah0hpyrrlh2k5vrhd0panv3bwc";
+
+  src = fetchFromGitHub {
+    owner = "pemistahl";
+    repo = "grex";
+    rev = "v${version}";
+    sha256 = "1viph7ki6f2akc5mpbgycacndmxnv088ybfji2bfdbi5jnpyavvs";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig perl installShellFiles ];
+  buildInputs = [ zlib ]
+  ++ stdenv.lib.optionals stdenv.isDarwin [
+    libiconv darwin.apple_sdk.frameworks.Security ]
+  ;
+
+  # Some tests fail, but Travis ensures a proper build
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A command-line tool for generating regular expressions from user-provided test cases";
+    homepage = "https://github.com/pemistahl/grex";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1051,6 +1051,8 @@ in
 
   gremlin-console = callPackage ../applications/misc/gremlin-console { };
 
+  grex = callPackage ../tools/misc/grex { };
+
   gcsfuse = callPackage ../tools/filesystems/gcsfuse { };
 
   glyr = callPackage ../tools/audio/glyr { };


### PR DESCRIPTION
Fixes #95315.

This introduces `grex` to nixpkgs:

* homepage URL: https://github.com/pemistahl/grex
* source URL: https://github.com/pemistahl/grex
* license: `apl2`
* platforms: `unix`

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
