### PR TITLE
tektoncd-cli: init at 0.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5961,6 +5961,12 @@
     githubId = 788953;
     name = "Matthijs Steen";
   };
+  mstrangfeld = {
+    email = "marvin@strangfeld.io";
+    github = "mstrangfeld";
+    githubId = 36842980;
+    name = "Marvin Strangfeld";
+  };
   mt-caret = {
     email = "mtakeda.enigsol@gmail.com";
     github = "mt-caret";

--- a/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
+++ b/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
@@ -1,0 +1,47 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "tektoncd-cli";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "tektoncd";
+    repo = "cli";
+    rev = "v${version}";
+    sha256 = "01kcz5pj7hl2wfcqj3kcssj1c589vqqh1r4yc0agb67rm6q7xl06";
+  };
+
+  vendorSha256 = null;
+
+  doCheck = false;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildPhase = ''
+    make bin/tkn
+  '';
+
+  installPhase = ''
+    install bin/tkn -Dt $out/bin
+
+    mkdir -p "$out/share/man/man1"
+    cp docs/man/man1/* "$out/share/man/man1"
+
+    # TODO: Move to enhanced installShellCompletion when merged: PR #83630
+    $out/bin/tkn completion bash > tkn.bash
+    $out/bin/tkn completion zsh  > _tkn
+    installShellCompletion tkn.bash --zsh _tkn
+  '';
+
+  meta = with lib; {
+    description = "The Tekton Pipelines cli project provides a CLI for interacting with Tekton";
+    homepage = "https://tekton.dev";
+    longDescription = ''
+      The Tekton Pipelines cli project provides a CLI for interacting with Tekton!
+      For your convenience, it is recommended that you install the Tekton CLI, tkn, together with the core component of Tekton, Tekton Pipelines.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jk mstrangfeld ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23534,6 +23534,8 @@ in
 
   tdesktop = qt5.callPackage ../applications/networking/instant-messengers/telegram/tdesktop { };
 
+  tektoncd-cli = callPackage ../applications/networking/cluster/tektoncd-cli { };
+
   telepathy-gabble = callPackage ../applications/networking/instant-messengers/telepathy/gabble { };
 
   telepathy-haze = callPackage ../applications/networking/instant-messengers/telepathy/haze {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The Tekton CLI is great for interacting with Tekton pipelines and should definitely be in the nixpkgs repository.

Official website: https://tekton.dev/
Git Repository: https://github.com/tektoncd/cli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
