### PR TITLE
cmake: Add a patch to fix a regression since CMake 3.18

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, pkgconfig
+{ stdenv, lib, fetchurl, pkgconfig, fetchpatch
 , bzip2, curl, expat, libarchive, xz, zlib, libuv, rhash
 , buildPackages
 # darwin attributes
@@ -36,6 +36,12 @@ stdenv.mkDerivation rec {
 
     # Derived from https://github.com/libuv/libuv/commit/1a5d4f08238dd532c3718e210078de1186a5920d
     ./libuv-application-services.patch
+
+    # TODO: Remove this patch for a regression once CMake 3.18.2 is out:
+    (fetchpatch { # PCH: Avoid Apple-specific architecture flags on other platforms
+      url = "https://gitlab.kitware.com/cmake/cmake/-/commit/70ce1ad64a04a244bb1c03753da0752c61fc3a37.patch";
+      sha256 = "0jcdgv48j0dd4nlhyy3j0s3h6bcbrq2yg1mdhpgfqrb2y3p91fky";
+    })
 
   ] ++ lib.optional stdenv.isCygwin ./3.2.2-cygwin.patch;
 


### PR DESCRIPTION
This fixes all CMake builds that use target_precompile_headers() and
as a result fail since CMake 3.18 with e.g.:
g++: error: unrecognized command line option '-Xarch_x86_64'; did you mean '-march=x86-64'?

Fix #94905.

CMake references:
- https://gitlab.kitware.com/cmake/cmake/-/issues/21072
- https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5118

---

cc @ttuegel @lnl7 (maintainers)
cc @orivej (found the regression)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
