### PR TITLE
pcre2: Disable JIT on RISC-V

### DIFF
--- a/pkgs/development/libraries/pcre2/default.nix
+++ b/pkgs/development/libraries/pcre2/default.nix
@@ -11,8 +11,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-pcre2-16"
     "--enable-pcre2-32"
-    "--enable-jit"
-  ];
+  ] ++ stdenv.lib.optional (!stdenv.hostPlatform.isRiscV) "--enable-jit";
 
   outputs = [ "bin" "dev" "out" "doc" "man" "devdoc" ];
 


### PR DESCRIPTION
##### Motivation for this change

JIT isn't yet supported on RISC-V. JIT was disabled for pcre on RISC-V
in 158cf6449c58b559a02dccc40096d4171c8a6589

Allows to build pcre2 for RISC-V.
Tested with `nix-build -A pkgsCross.riscv64.pcre2`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
