### PR TITLE
stabber: 2016-11-09 -> 2020-06-08

### DIFF
--- a/pkgs/misc/stabber/default.nix
+++ b/pkgs/misc/stabber/default.nix
@@ -6,13 +6,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation {
   pname = "stabber-unstable";
-  version = "2016-11-09";
+  version = "2020-06-08";
 
   src = fetchFromGitHub {
     owner = "boothj5";
     repo = "stabber";
-    rev = "ed75087e4483233eb2cc5472dbd85ddfb7a1d4d4";
-    sha256 = "1l6cibggi9rx6d26j1g92r1m8zm1g899f6z7n4pfqp84mrfqgz0p";
+    rev = "3e5c2200715666aad403d0076e8ab584b329965e";
+    sha256 = "0042nbgagl4gcxa5fj7bikjdi1gbk0jwyqnzc5lswpb0l5y0i1ql";
   };
 
   preAutoreconf = ''
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Stubbed XMPP Server";
-    homepage = "https://github.com/boothj5/stabber";
+    homepage = "https://github.com/profanity-im/stabber";
     license = licenses.gpl3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ hschaeidt ];


### PR DESCRIPTION
##### Motivation for this change

I originally wanted to fix `profanity` build, but then realised that it does not depend on `stabber` anymore since #95054 

Anyway this fixes the build for stabber. I also updated `meta.homepage`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
