### PR TITLE
switcheroo-control: init at 2.3

### DIFF
--- a/nixos/modules/hardware/video/switcheroo-control.nix
+++ b/nixos/modules/hardware/video/switcheroo-control.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+let
+  pkg = [ pkgs.switcheroo-control ];
+  cfg = config.services.switcherooControl;
+in {
+  options.services.switcherooControl = {
+    enable = mkEnableOption "switcheroo-control, a D-Bus service to check the availability of dual-GPU";
+  };
+
+  config = mkIf cfg.enable {
+    services.dbus.packages = pkg;
+    environment.systemPackages = pkg;
+    systemd.packages = pkg;
+    systemd.targets.multi-user.wants = [ "switcheroo-control.service" ];
+  };
+}

--- a/pkgs/os-specific/linux/switcheroo-control/default.nix
+++ b/pkgs/os-specific/linux/switcheroo-control/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, ninja
+, meson
+, fetchFromGitLab
+, systemd
+, libgudev
+, pkg-config
+, glib
+, python3
+, gobject-introspection
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "switcheroo-control";
+  version = "2.3";
+
+  format = "other";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "hadess";
+    repo = pname;
+    rev = version;
+    hash = "sha256-1Pze2TJ9mggfcpiLFwJ7/9WhsdJx4G3GoA7+Z47shuc=";
+  };
+
+  nativeBuildInputs = [
+    ninja
+    meson
+    pkg-config
+
+    # needed for glib-compile-resources
+    glib
+  ];
+
+  buildInputs = [
+    systemd
+    libgudev
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.pygobject3
+  ];
+
+  mesonFlags = [
+    "-Dsystemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
+    "-Dhwdbdir=${placeholder "out"}/etc/udev/hwdb.d"
+  ];
+
+  meta = with lib; {
+    description = "D-Bus service to check the availability of dual-GPU";
+    homepage = "https://gitlab.freedesktop.org/hadess/switcheroo-control/";
+    changelog = "https://gitlab.freedesktop.org/hadess/switcheroo-control/-/blob/${version}/NEWS";
+    license = licenses.gpl3Plus;
+    maintainers = [ ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18432,6 +18432,8 @@ in
 
   storm = callPackage ../servers/computing/storm { };
 
+  switcheroo-control = callPackage ../os-specific/linux/switcheroo-control { };
+
   slurm = callPackage ../servers/computing/slurm { gtk2 = null; };
 
   slurm-spank-x11 = callPackage ../servers/computing/slurm-spank-x11 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
A service used by GNOME and other desktop environment to offload GPU intensve processes to a secondary GPU.
Fixes https://github.com/NixOS/nixpkgs/issues/87005 .
Thanks to @jtojnar for their guidance on packaging it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
