### PR TITLE
pythonPackages.urwid: disable tests for pythons < 3

### DIFF
--- a/pkgs/development/python-modules/urwid/default.nix
+++ b/pkgs/development/python-modules/urwid/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, glibcLocales }:
+{ stdenv, buildPythonPackage, fetchPypi, glibcLocales, pythonAtLeast }:
 
 buildPythonPackage rec {
   pname = "urwid";
@@ -9,6 +9,8 @@ buildPythonPackage rec {
     sha256 = "09nmi2nmvpcmbh3w3fb0dn0c7yp7r20i5pfcr6q722xh6mp8cw3q";
   };
 
+  # tests fail in python2
+  doCheck = pythonAtLeast "3.0";
   # tests need to be able to set locale
   LC_ALL = "en_US.UTF-8";
   checkInputs = [ glibcLocales ];


### PR DESCRIPTION
###### Motivation for this change

python2Packages.urwid fails to build, as per https://github.com/NixOS/nixpkgs/issues/94684

Disabling tests lets it build without apparent breakage on the only package in my system that depends on it (targetcli).

I'm also opening another PR to make targetcli build with python3, which I think is preferable in any case where that's an option

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
