### PR TITLE
targetcli: build with python3

### DIFF
--- a/pkgs/os-specific/linux/targetcli/default.nix
+++ b/pkgs/os-specific/linux/targetcli/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, python, fetchFromGitHub }:
+{ stdenv, python3, fetchFromGitHub }:
 
-python.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "targetcli";
   version = "2.1.53";
 
@@ -11,7 +11,7 @@ python.pkgs.buildPythonApplication rec {
     sha256 = "1qrq7y5hnghzbxgrxgl153n8jlhw31kqjbr93jsvlvhz5b3ci750";
   };
 
-  propagatedBuildInputs = with python.pkgs; [ configshell rtslib ];
+  propagatedBuildInputs = with python3.pkgs; [ configshell rtslib ];
 
   postInstall = ''
     install -D targetcli.8 -t $out/share/man/man8/


### PR DESCRIPTION
###### Motivation for this change

Mostly to reduce dependency on py2, and particularly on python2Packages.urwid, which fails to build with py2, as per https://github.com/NixOS/nixpkgs/issues/94684

I have not yet played a lot with it, may be very broken, but if it is it's playing along very nicely for now.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
