### PR TITLE
libnifalcon: init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8779,6 +8779,12 @@
     email = "kirill.wedens@gmail.com";
     name = "wedens";
   };
+  wesliao = {
+    email = "wesliao@iu.edu";
+    github = "wesleysliao";
+    githubId = 6721004;
+    name = "Wesley Liao";
+  };
   WhittlesJr = {
     email = "alex.joseph.whitt@gmail.com";
     github = "WhittlesJr";

--- a/pkgs/development/libraries/libnifalcon/default.nix
+++ b/pkgs/development/libraries/libnifalcon/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, cmake, doxygen, libusb1, pkgconfig, expat }:
+
+stdenv.mkDerivation rec {
+  name = "libnifalcon-1.1";
+
+  src = fetchFromGitHub {
+    owner = "libnifalcon";
+    repo = "libnifalcon";
+    rev = "c1546ec8d9a94b3be7d74f8ba9f1a121a0ebb0c2";
+    sha256 = "1gp2cf56rlnlw785vl90w6scpknajw2mdny26yqlx5yl277x9b9s";
+  };
+
+  buildInputs = [ cmake libusb1 doxygen pkgconfig expat ];
+  outputs = [ "out" "dev" ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://qdot.github.com/libnifalcon/";
+    description = "Open source drivers for the Novint Falcon haptic controller";
+    license = licenses.bsd3;
+
+    longDescription =
+      ''libnifalcon is a development library for the NovInt Falcon,
+        and is an open source, crossplatform alternative to NovInt’s SDK.
+
+        libnifalcon provides basic functionality to connect to the falcon and
+        load firmware to the internal microcontroller. In addition, it comes
+        with sample functionality made available through the firmware available
+        in NovInt’s drivers (the novint.bin file in TestUtilties and the
+        nifalcon_test_fw files for the library source). This firmware is
+        distributed in the firmware directory of the source distribution, and
+        is required for the findfalcons utility to run.
+      '';
+
+    maintainers = with maintainers; [ wesliao ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13636,6 +13636,8 @@ in
 
   libnih = callPackage ../development/libraries/libnih { };
 
+  libnifalcon = callPackage ../development/libraries/libnifalcon { };
+
   libnova = callPackage ../development/libraries/libnova { };
 
   libnxml = callPackage ../development/libraries/libnxml { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
A library for development using the Novint Falcon haptic device. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
