### PR TITLE
pythonPackages.exchangelib: 1.12.2 -> 3.2.1

### DIFF
--- a/pkgs/development/python-modules/exchangelib/default.nix
+++ b/pkgs/development/python-modules/exchangelib/default.nix
@@ -1,33 +1,38 @@
 { stdenv, fetchFromGitHub, buildPythonPackage,
-  lxml, tzlocal, python-dateutil, pygments, future, requests-kerberos,
+  pythonOlder,
+  lxml, tzlocal, python-dateutil, pygments, requests-kerberos,
   defusedxml, cached-property, isodate, requests_ntlm, dnspython,
-  psutil, requests-mock, pyyaml
+  psutil, requests-mock, pyyaml,
+  oauthlib, requests_oauthlib,
+  flake8,
 }:
 
 buildPythonPackage rec {
   pname = "exchangelib";
-  version = "1.12.2";
+  version = "3.2.1";
+  disabled = pythonOlder "3.5";
 
   # tests are not present in the PyPI version
   src = fetchFromGitHub {
     owner = "ecederstrand";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1p24fq6f46j0qd0ccb64mncxbnm2n9w0sqpl4zk113caaaxkpjil";
+    sha256 = "1sh780q2iwdm3bnlnfdacracf0n7jhbv0g39cdx65v3d510zp4jv";
   };
 
-  # one test is failing due to it trying to send a request to example.com
-  patches = [ ./skip_failing_test.patch ];
-  checkInputs = [ psutil requests-mock pyyaml ];
+  checkInputs = [ psutil requests-mock pyyaml
+    flake8
+  ];
   propagatedBuildInputs = [
     lxml tzlocal python-dateutil pygments requests-kerberos
-    future defusedxml cached-property isodate requests_ntlm dnspython ];
+    defusedxml cached-property isodate requests_ntlm dnspython
+    oauthlib requests_oauthlib
+  ];
 
   meta = with stdenv.lib; {
     description = "Client for Microsoft Exchange Web Services (EWS)";
     homepage    = "https://github.com/ecederstrand/exchangelib";
     license     = licenses.bsd2;
     maintainers = with maintainers; [ catern ];
-    broken = true;
   };
 }


### PR DESCRIPTION
Also marks the package as no longer broken.

Obsoletes PR #95313

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
