### PR TITLE
chrootenv: ignore SIGINT while waiting for child

### DIFF
--- a/pkgs/build-support/build-fhsenv-chroot/chrootenv/src/chrootenv.c
+++ b/pkgs/build-support/build-fhsenv-chroot/chrootenv/src/chrootenv.c
@@ -155,6 +155,8 @@ int main(gint argc, gchar **argv) {
   else {
     int status;
 
+    fail_if(signal(SIGINT, SIG_IGN) == SIG_ERR);
+
     fail_if(waitpid(cpid, &status, 0) != cpid);
     fail_if(rmdir(prefix));
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I was unable to break using ctrl-c in gdb when running under chrootenv.

###### Things done

Ignore SIGINT in chroot after the child process is started.  chrootenv is waiting for the child process, which will still receive the signal.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
