### PR TITLE
zstd: fix shebangs when cross-compiling

### DIFF
--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, gnugrep
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, bash, gnugrep
 , fixDarwinDylibNames
 , file
 , legacySupport ? false
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ]
    ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
+  buildInputs = [ bash ];
 
   patches = [
     ./playtests-darwin.patch
@@ -29,11 +30,7 @@ stdenv.mkDerivation rec {
     # work fine, and I'm not sure how to write the condition.
     ++ stdenv.lib.optional stdenv.hostPlatform.isWindows ./mcfgthreads-no-pthread.patch;
 
-  postPatch =
-  # Patch shebangs for playTests
-  ''
-    patchShebangs programs/zstdgrep
-  '' + stdenv.lib.optionalString (!static) ''
+  postPatch = stdenv.lib.optionalString (!static) ''
     substituteInPlace build/cmake/CMakeLists.txt \
       --replace 'message(SEND_ERROR "You need to build static library to build tests")' ""
     substituteInPlace build/cmake/tests/CMakeLists.txt \
@@ -60,6 +57,8 @@ stdenv.mkDerivation rec {
   doCheck = true;
   checkPhase = ''
     runHook preCheck
+    # Patch shebangs for playTests
+    patchShebangs ../programs/zstdgrep
     ctest -R playTests # The only relatively fast test.
     runHook postCheck
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

When cross-compiling, `zstdless` has `/bin/sh` as a shebang, while `zstdgrep` has build-time bash. `zstdgrep` is manually patched for running the tests, and the automatic `patchShebangs` after installation doesn't convert build-time bash to runtime bash.

Since we can't run tests while cross-compiling anyway, I moved the manual `patchShebangs` to `checkPhase`. This prevents it from interfering with the automatic `patchShebangs` fixup when cross-compiling. For native builds, build and runtime bash are the same, so this still works fine.

cc @orivej 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
