### PR TITLE
ckan 1.16.1 -> 1.29.2

### DIFF
--- a/pkgs/games/ckan/default.nix
+++ b/pkgs/games/ckan/default.nix
@@ -1,44 +1,34 @@
-{ stdenv, fetchFromGitHub, makeWrapper, perl, mono, gtk2, curl }:
+{ stdenv, fetchurl, makeWrapper, mono, gtk2, curl }:
 
 stdenv.mkDerivation rec {
   pname = "ckan";
-  version = "1.16.1";
+  version = "1.29.2";
 
-  src = fetchFromGitHub {
-    owner = "KSP-CKAN";
-    repo = "CKAN";
-    rev = "v${version}";
-    sha256 = "0lfvl8w09lakz35szp5grfvhq8xx486f5igvj1m6azsql4n929lg";
+  src = fetchurl {
+    url = "https://github.com/KSP-CKAN/CKAN/releases/download/v${version}/ckan.exe";
+    sha256 = "10vd61mw2y7vmbnp6nd7b2sq22ixqd7zmd278z210w4njmvqn97h";
   };
 
-  buildInputs = [ makeWrapper perl mono ];
+  dontUnpack = true;
 
-  postPatch = ''
-    substituteInPlace bin/build \
-      --replace /usr/bin/perl ${perl}/bin/perl
-  '';
-
-  # Tests don't currently work, as they try to write into /var/empty.
-  doCheck = false;
-  checkTarget = "test";
+  buildInputs = [ makeWrapper mono ];
 
   libraries = stdenv.lib.makeLibraryPath [ gtk2 curl ];
 
+  buildPhase = "true";
+
   installPhase = ''
-    mkdir -p $out/bin
-    for exe in *.exe; do
-      install -m 0644 $exe $out/bin
-      makeWrapper ${mono}/bin/mono $out/bin/$(basename $exe .exe) \
-        --add-flags $out/bin/$exe \
-        --set LD_LIBRARY_PATH $libraries
-    done
+    install -m 644 -D $src $out/bin/ckan.exe
+    makeWrapper ${mono}/bin/mono $out/bin/ckan \
+      --add-flags $out/bin/ckan.exe \
+      --set LD_LIBRARY_PATH $libraries
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Mod manager for Kerbal Space Program";
     homepage = "https://github.com/KSP-CKAN/CKAN";
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.Baughn ];
-    platforms = stdenv.lib.platforms.all;
-  };    
+    license = licenses.mit;
+    maintainers = with maintainers; [ Baughn ymarkus ];
+    platforms = platforms.all;
+  };
 }


### PR DESCRIPTION
Please review this for MacOS, I'm not sure if my change breaks that.

###### Motivation for this change
CKAN is heavily out-of-date


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
