### PR TITLE
nixos/pulseaudio: Fix ExecStop

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -312,6 +312,7 @@ in {
         serviceConfig = {
           Type = "notify";
           ExecStart = "${binaryNoDaemon} --log-level=${cfg.daemon.logLevel} --system -n --file=${myConfigFile}";
+          ExecStop = "${binaryNoDaemon} --kill";
           Restart = "on-failure";
           RestartSec = "500ms";
         };


### PR DESCRIPTION
###### Motivation for this change
Not sure the root cause, but I will have many pulseaudio daemons running, and unable to get audio.

Current fix was to do `pulseaudio --kill; pulseaudio --start`, obviously, this isn't ideal. However, altering the ExecStop to use the `--kill` command seems to clean up all the zombie daemons.

prior behavior
```
Aug 13 14:54:57 jon-desktop systemd[9664]: Starting Sound Service...
Aug 13 14:54:57 jon-desktop pulseaudio[903]: E: [pulseaudio] pid.c: Daemon already running.
Aug 13 14:54:57 jon-desktop pulseaudio[903]: E: [pulseaudio] main.c: pa_pid_file_create() failed.
Aug 13 14:54:57 jon-desktop systemd[9664]: pulseaudio.service: Main process exited, code=exited, status=1/FAILURE
Aug 13 14:54:57 jon-desktop systemd[9664]: pulseaudio.service: Failed with result 'exit-code'.
Aug 13 14:54:57 jon-desktop systemd[9664]: Failed to start Sound Service.
Aug 13 14:54:58 jon-desktop systemd[9664]: pulseaudio.service: Scheduled restart job, restart counter is at 4.
Aug 13 14:54:58 jon-desktop systemd[9664]: Stopped Sound Service.
Aug 13 14:54:58 jon-desktop systemd[9664]: Starting Sound Service...
Aug 13 14:54:58 jon-desktop pulseaudio[919]: E: [pulseaudio] pid.c: Daemon already running.
Aug 13 14:54:58 jon-desktop pulseaudio[919]: E: [pulseaudio] main.c: pa_pid_file_create() failed.
Aug 13 14:54:58 jon-desktop systemd[9664]: pulseaudio.service: Main process exited, code=exited, status=1/FAILURE
Aug 13 14:54:58 jon-desktop systemd[9664]: pulseaudio.service: Failed with result 'exit-code'.
Aug 13 14:54:58 jon-desktop systemd[9664]: Failed to start Sound Service.
Aug 13 14:54:58 jon-desktop systemd[9664]: pulseaudio.service: Scheduled restart job, restart counter is at 5.
```

current behavior:
```
# systemctl --user restart pulseaudio
Aug 13 15:21:25 jon-desktop systemd[9664]: Starting Sound Service...
Aug 13 15:21:26 jon-desktop systemd[9664]: Started Sound Service.
Aug 13 15:21:26 jon-desktop pulseaudio[25942]: E: [pulseaudio] bluez5-util.c: GetManagedObjects() failed: org.freedesktop.D>
# another `systemctl --user restart pulseaudio` to verify it works
Aug 13 15:22:21 jon-desktop systemd[9664]: Stopping Sound Service...
Aug 13 15:22:21 jon-desktop systemd[9664]: pulseaudio.service: Succeeded.
Aug 13 15:22:21 jon-desktop systemd[9664]: Stopped Sound Service.
Aug 13 15:22:21 jon-desktop systemd[9664]: Starting Sound Service...
Aug 13 15:22:21 jon-desktop systemd[9664]: Started Sound Service.
Aug 13 15:22:21 jon-desktop pulseaudio[26290]: E: [pulseaudio] bluez5-util.c: GetManagedObjects() failed: org.freedesktop.D
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
