### PR TITLE
meson: Add upstream patch to stop failing on skipped tests

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -4,6 +4,7 @@
 , writeTextDir
 , substituteAll
 , pkgsHostHost
+, fetchpatch
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -16,6 +17,13 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   patches = [
+    # Meson 0.55.0 incorrectly considers skipped tests as failures,
+    # which makes some packages like gjs fail to build.
+    (fetchpatch {
+      url = "https://github.com/mesonbuild/meson/commit/7db49db67d4aa7582cf46feb7157235e66aa95b1.diff";
+      sha256 = "1chq52sgk24afdlswssr8n8p6fa2wz8rjlxvkjhpqg1kg3qnqc9p";
+    })
+
     # Upstream insists on not allowing bindir and other dir options
     # outside of prefix for some reason:
     # https://github.com/mesonbuild/meson/issues/2561


### PR DESCRIPTION
###### Motivation for this change

The nixos-unstable channel is currently blocked by a gjs build failure introduced by the Meson 0.55.0 upgrade (d8ac41f86394365f8319d8b37fd25e6a7ba7d904, #93011). Meson now incorrectly treats skipped tests as failed. This is an upstream bug fixed in mesonbuild/meson#7525. Pull in this patch.

See also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=966923.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
