### PR TITLE
google-chrome-{beta,dev}: fix icons

### DIFF
--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -119,9 +119,13 @@ in stdenv.mkDerivation {
       --replace /opt $out/share \
       --replace $out/share/google/$appname/google-$appname $exe
 
-    for icon_file in $out/share/google/chrome*/product_logo_*[0-9].png; do
+    for icon_file in $out/share/google/chrome*/product_logo_[0-9]*.png; do
       num_and_suffix="''${icon_file##*logo_}"
-      icon_size="''${num_and_suffix%.*}"
+      if [ $dist = "stable" ]; then
+        icon_size="''${num_and_suffix%.*}"
+      else
+        icon_size="''${num_and_suffix%_*}"
+      fi
       logo_output_prefix="$out/share/icons/hicolor"
       logo_output_path="$logo_output_prefix/''${icon_size}x''${icon_size}/apps"
       mkdir -p "$logo_output_path"


### PR DESCRIPTION
The icon naming scheme for Chrome Beta/Dev has changed from `product_logo_{res}.png` to `product_logo_{res}_{branch}.png`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Things done
Checked icon paths of all google-chrome* packages.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
