### PR TITLE
odafileconverter: init at 21.7.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9474,6 +9474,12 @@
     github = "fzakaria";
     githubId = 605070;
   };
+  nagisa = {
+    name = "Simonas Kazlauskas";
+    email = "nixpkgs@kazlauskas.me";
+    github = "nagisa";
+    githubId = 679122;
+  };
   yevhenshymotiuk = {
     name = "Yevhen Shymotiuk";
     email = "yevhenshymotiuk@gmail.com";

--- a/pkgs/applications/graphics/odafileconverter/default.nix
+++ b/pkgs/applications/graphics/odafileconverter/default.nix
@@ -1,0 +1,53 @@
+{ lib, stdenv, mkDerivation, dpkg, fetchurl, qtbase }:
+
+let
+  # To obtain the version you will need to run the following command:
+  #
+  # dpkg-deb -I ${odafileconverter.src} | grep Version
+  version = "21.7.0.0";
+  rpath = "$ORIGIN:${lib.makeLibraryPath [ stdenv.cc.cc qtbase ]}";
+
+in mkDerivation {
+  pname = "oda-file-converter";
+  inherit version;
+  nativeBuildInputs = [ dpkg ];
+
+  src = fetchurl {
+    # NB: this URL is not stable (i.e. the underlying file and the corresponding version will change over time)
+    url = "https://download.opendesign.com/guestfiles/ODAFileConverter/ODAFileConverter_QT5_lnxX64_7.2dll.deb";
+    sha256 = "0sa21nnwzqb6g7gl0z43smqgcd9h3xipj3cq2cl7ybfh3cvcxfi9";
+  };
+
+  unpackPhase = ''
+    dpkg -x $src oda_unpacked
+    sourceRoot=$PWD/oda_unpacked
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib
+    cp -vr $sourceRoot/usr/bin/ODAFileConverter_${version} $out/libexec
+    cp -vr $sourceRoot/usr/share $out/share
+  '';
+
+  dontWrapQtApps = true;
+  fixupPhase = ''
+    echo "setting interpreter"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/libexec/ODAFileConverter
+    patchelf --set-rpath '${rpath}' $out/libexec/ODAFileConverter
+    wrapQtApp $out/libexec/ODAFileConverter
+    mv $out/libexec/ODAFileConverter $out/bin
+
+    find $out/libexec -type f -executable | while read file; do
+      echo "patching $file"
+      patchelf --set-rpath '${rpath}' $file
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "For converting between different versions of .dwg and .dxf";
+    homepage = "https://www.opendesign.com/guestfiles/oda_file_converter";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ nagisa ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2265,6 +2265,8 @@ in
 
   obinskit = callPackage ../applications/misc/obinskit {};
 
+  odafileconverter = libsForQt5.callPackage ../applications/graphics/odafileconverter {};
+
   pastel = callPackage ../applications/misc/pastel {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change

This is _the_ way to convert AutoCAD DWG files to something more open on Linux. It can work both as a stand-alone tool as well as used transparently by freecad and similar tooling to enable DWG support in them.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
