### PR TITLE
ocamlPackages.uunf: re-generate source from the Unicode Character Database

### DIFF
--- a/pkgs/development/ocaml-modules/uunf/default.nix
+++ b/pkgs/development/ocaml-modules/uunf/default.nix
@@ -1,21 +1,50 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, uchar, uutf, cmdliner }:
+{ stdenv, fetchurl, unzip, ocaml, findlib, ocamlbuild, topkg, uchar, uutf, cmdliner, uucd }:
 let
   pname = "uunf";
   webpage = "https://erratique.ch/software/${pname}";
+  version = "13.0.0";
+  ucdxml = fetchurl {
+    url = "http://www.unicode.org/Public/${version}/ucdxml/ucd.all.grouped.zip";
+    sha256 = "04gpl09ggb6fb0kmk6298rd8184dv6vcscn28l1gpdv1yjlw1a8q";
+  };
+  gen = fetchurl {
+    url = "https://raw.githubusercontent.com/dbuenzli/uunf/v12.0.0/support/gen.ml";
+    sha256 = "08j2mpi7j6q3rqc6bcdwspqn1s7pkkphznxfdycqjv4h9yaqsymj";
+  };
+  gen_norm = fetchurl {
+    url = "https://raw.githubusercontent.com/dbuenzli/uunf/v12.0.0/support/gen_norm.ml";
+    sha256 = "11vx5l5bag6bja7qj8jv4s2x9fknj3557n0mj87k2apq5gs5f4m5";
+  };
+  gen_props = fetchurl {
+    url = "https://raw.githubusercontent.com/dbuenzli/uunf/v12.0.0/support/gen_props.ml";
+    sha256 = "0a6lhja498kp9lxql0pbfvkgvajs10wx88wkqc7y5m3lrvw46268";
+  };
 in
 
 assert stdenv.lib.versionAtLeast ocaml.version "4.03";
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   name = "ocaml-${pname}-${version}";
-  version = "13.0.0";
+  inherit version;
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
     sha256 = "1qci04nkp24kdls1z4s8kz5dzgky4nwd5r8345nwdrgwmxhw7ksm";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg uutf cmdliner ];
+  postConfigure = ''
+    rm -f src/uunf_data.ml
+    mkdir -p support/
+    cp ${gen} support/gen.ml
+    cp ${gen_norm} support/gen_norm.ml
+    cp ${gen_props} support/gen_props.ml
+    funzip ${ucdxml} > support/ucd.xml
+    ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib/ pkg/build_support.ml
+  '';
+
+  nativeBuildInputs = [ unzip ];
+
+  buildInputs = [ ocaml findlib ocamlbuild topkg uutf cmdliner uucd ];
 
   propagatedBuildInputs = [ uchar ];
 
@@ -27,6 +56,5 @@ stdenv.mkDerivation rec {
     platforms = ocaml.meta.platforms or [];
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];
-    broken = stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Let’s hope this fixes the build on Aarch

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
