### PR TITLE
appmenu-gtk-module: init at 0.7.6

### DIFF
--- a/pkgs/development/libraries/appmenu-gtk3-module/default.nix
+++ b/pkgs/development/libraries/appmenu-gtk3-module/default.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, meson
+, cmake
+, pkg-config
+, systemd
+, gtk-doc
+, docbook-xsl-nons
+, ninja
+, glib
+, gtk3
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "appmenu-gtk3-module";
+  version = "0.7.6";
+
+  outputs = [ "out" "devdoc" ];
+
+  src = fetchFromGitLab {
+    owner = "vala-panel-project";
+    repo = "vala-panel-appmenu";
+    rev = version;
+    sha256 = "sha256:1ywpygjwlbli65203ja2f8wwxh5gbavnfwcxwg25v061pcljaqmm";
+  };
+
+  sourceRoot = "source/subprojects/appmenu-gtk-module";
+
+  nativeBuildInputs = [
+    meson
+    cmake
+    pkg-config
+    systemd
+    gtk-doc
+    docbook-xsl-nons
+    ninja
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+  ];
+
+  preConfigure = ''
+    substituteInPlace meson_options.txt --replace "value: ['2','3']" "value: ['3']"
+  '';
+
+  mesonFlags = [
+    "-Dgtk_doc=true"
+    "--prefix=${placeholder "out"}"
+  ];
+
+  PKG_CONFIG_GTK__3_0_LIBDIR = "${placeholder "out"}/lib";
+  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
+
+  postInstall = ''
+    glib-compile-schemas "$out/share/glib-2.0/schemas"
+  '';
+
+  meta = with lib; {
+    description = "Port of the Unity GTK 3 Module";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ louisdk1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -153,6 +153,8 @@ with pkgs;
 
   ### BUILD SUPPORT
 
+  appmenu-gtk3-module = callPackage ../development/libraries/appmenu-gtk3-module {};
+
   auditBlasHook = makeSetupHook
     { name = "auto-blas-hook"; deps = [ blas lapack ]; }
     ../build-support/setup-hooks/audit-blas.sh;


### PR DESCRIPTION
###### Motivation for this change

appmenu-gtk-module is currently not in nix as a separate package despite being compatible with a wide range of DEs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
