### PR TITLE
gitoxide: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7928,6 +7928,12 @@
     githubId = 332289;
     name = "Rafał Łasocha";
   };
+  syberant = {
+    email = "sybrand@neuralcoding.com";
+    github = "syberant";
+    githubId = 20063502;
+    name = "Sybrand Aarnoutse";
+  };
   symphorien = {
     email = "symphorien_nixpkgs@xlumurb.eu";
     github = "symphorien";

--- a/pkgs/applications/version-management/gitoxide/default.nix
+++ b/pkgs/applications/version-management/gitoxide/default.nix
@@ -1,0 +1,24 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gitoxide";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "Byron";
+    repo = "gitoxide";
+    rev = "v${version}";
+    sha256 = "0xpic9jx7nrxi5d8lqch2vxpvipx994d717c4n0kgr3ipyij1347";
+  };
+
+  cargoSha256 = "104lyfni75h1i30s2jlzf66sp1czfd9ywqz78kj4i7lfdf6fc4x9";
+
+  meta = with lib; {
+    description =
+      "A command-line application for interacting with git repositories";
+    homepage = "https://github.com/Byron/gitoxide";
+    # NOTE: the master branch is dual-licensed with APACHE but v0.3.0 is only MIT
+    license = licenses.mit;
+    maintainers = [ maintainers.syberant ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20335,6 +20335,8 @@ in
 
   gitolite = callPackage ../applications/version-management/gitolite { };
 
+  gitoxide = callPackage ../applications/version-management/gitoxide { };
+
   inherit (gnome3) gitg;
 
   gmrun = callPackage ../applications/misc/gmrun {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This PR is intended to fix #95317.

###### Things I'm not too sure about
The project is pretty young at the moment, I've only had 1 PR merged into nixpkgs so far so I'm not entirely sure what is supposed to go in here and what gets rejected. Some feedback would be appreciated.

I got the `meta.description` from the projects [crates.io page](https://crates.io/crates/gitoxide) but there might be a better one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`), **but only the help subcommand**.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
