### PR TITLE
geogebra 6 : init at 6-0-598-0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8717,6 +8717,14 @@
     githubId = 13259982;
     name = "Vanessa McHale";
   };
+
+  voidless = {
+    email = "julius.schmitt@yahoo.de";
+    github = "voidIess";
+    githubId = 45292658;
+    name = "Julius Schmitt";
+  };
+
   volhovm = {
     email = "volhovm.cs@gmail.com";
     github = "volhovm";

--- a/pkgs/applications/science/math/geogebra/geogebra6.nix
+++ b/pkgs/applications/science/math/geogebra/geogebra6.nix
@@ -1,0 +1,46 @@
+{ stdenv, unzip, fetchurl, electron_6, makeWrapper, geogebra }:
+stdenv.mkDerivation rec{
+
+  name = "geogebra-${version}";
+  version = "6-0-598-0";
+
+  src = fetchurl {
+    urls = [
+        "https://download.geogebra.org/installers/6.0/GeoGebra-Linux64-Portable-${version}.zip"
+        "https://web.archive.org/web/20200815132422/https://download.geogebra.org/installers/6.0/GeoGebra-Linux64-Portable-${version}.zip"
+      ];
+    sha256 = "1klazsgrpmfd6vjzpdcfl5x8qhhbh6vx2g6id4vg16ac4sjdrb0c";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    unzip
+    makeWrapper
+  ];
+
+  unpackPhase = ''
+    unzip $src
+  '';
+
+  installPhase = ''
+    mkdir -p $out/libexec/geogebra/ $out/bin
+    cp -r GeoGebra-linux-x64/{resources,locales} "$out/"
+    makeWrapper ${stdenv.lib.getBin electron_6}/bin/electron $out/bin/geogebra --add-flags "$out/resources/app"
+    install -Dm644 "${desktopItem}/share/applications/"* \
+      -t $out/share/applications/
+
+    install -Dm644 "${srcIcon}" \
+      "$out/share/icons/hicolor/scalable/apps/geogebra.svg"
+  '';
+
+  srcIcon = geogebra.srcIcon;
+
+  desktopItem = geogebra.desktopItem;
+  meta = with stdenv.lib; geogebra.meta // {
+    license = licenses.geogebra;
+    maintainers = with maintainers; [ voidless ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25839,7 +25839,7 @@ in
   gap-full = lowPrio (gap.override { packageSet = "full"; });
 
   geogebra = callPackage ../applications/science/math/geogebra { };
-  geogebra-6 = callPackage ../applications/science/math/geogebra/geogebra6.nix { };
+  geogebra6 = callPackage ../applications/science/math/geogebra/geogebra6.nix { };
 
   maxima = callPackage ../applications/science/math/maxima {
     ecl = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25839,6 +25839,7 @@ in
   gap-full = lowPrio (gap.override { packageSet = "full"; });
 
   geogebra = callPackage ../applications/science/math/geogebra { };
+  geogebra-6 = callPackage ../applications/science/math/geogebra/geogebra6.nix { };
 
   maxima = callPackage ../applications/science/math/maxima {
     ecl = null;


### PR DESCRIPTION
since geogebra was ported from java to electron, this is a repacke;
wont want to delete geogebra 5, no darwin package for 6

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Geogebra changed their stack from java to electron, so simple update wouldn't do the job. This happened on the version change from 5.x to 6.x. The update was requested in  #80593.

###### Things done
Added a package for geogebra 6.x and left the old geogebra package as it is. Since my approach didn't work for Darwin, I will not remove the old package.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
