### PR TITLE
[haskell-updates] haskellPackages.pango: Bump version (including deps) to fix build 

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1362,14 +1362,28 @@ self: super: {
   # https://github.com/kowainik/policeman/issues/57
   policeman = doJailbreak super.policeman;
 
-  # 2020-06-29: These three packages have bumped their dependencies for haskell-gi and haskell-gi-base beyond stack-lts.
-  # Choosing a jailbreak, because a version override would rebuild most of the glibverse and the packages still build with the older version.
-  gi-javascriptcore =
-    # Remove these jailbreaks, when assert fails.
-    assert (pkgs.lib.versionOlder super.haskell-gi-base.version "0.24");
-    doJailbreak super.gi-javascriptcore;
-  gi-soup = doJailbreak super.gi-soup;
-  gi-webkit2 = doJailbreak super.gi-webkit2;
+  # 2020-08-14: gi-pango from stackage is to old for the C libs it links against in nixpkgs.
+  # That's why we need to bump a ton of dependency versions to unbreak them.
+  gi-pango = assert super.gi-pango.version == "1.0.22"; self.gi-pango_1_0_23;
+  haskell-gi-base = assert super.haskell-gi-base.version == "0.23.0"; addBuildDepends (self.haskell-gi-base_0_24_2) [ pkgs.gobject-introspection ];
+  haskell-gi = assert super.haskell-gi.version == "0.23.1"; self.haskell-gi_0_24_4;
+  gi-cairo = assert super.gi-cairo.version == "1.0.23"; self.gi-cairo_1_0_24;
+  gi-glib = assert super.gi-glib.version == "2.0.23"; self.gi-glib_2_0_24;
+  gi-gobject = assert super.gi-gobject.version == "2.0.22"; self.gi-gobject_2_0_24;
+  gi-atk = assert super.gi-atk.version == "2.0.21"; self.gi-atk_2_0_22;
+  gi-gio = assert super.gi-gio.version == "2.0.26"; self.gi-gio_2_0_27;
+  gi-gdk = assert super.gi-gdk.version == "3.0.22"; self.gi-gdk_3_0_23;
+  gi-gtk = assert super.gi-gtk.version == "3.0.33"; self.gi-gtk_3_0_35;
+  gi-gdkpixbuf = assert super.gi-gdkpixbuf.version == "2.0.23"; self.gi-gdkpixbuf_2_0_24;
+
+  # 2020-08-14: Needs some manual patching to be compatible with haskell-gi-base 0.24
+  # Created upstream PR @ https://github.com/ghcjs/jsaddle/pull/119
+  jsaddle-webkit2gtk = appendPatch super.jsaddle-webkit2gtk (pkgs.fetchpatch {
+    url = "https://github.com/ghcjs/jsaddle/compare/9727365...09f44aa.patch";
+    sha256 = "1bkwgmc04544haycb69fqsd97lg24jc7hc1yrin2sgr4l7hz04pf";
+    stripLen = 2;
+    extraPrefix = "";
+  });
 
   # Missing -Iinclude parameter to doc-tests (pull has been accepted, so should be resolved when 0.5.3 released)
   # https://github.com/lehins/massiv/pull/104

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2560,6 +2560,8 @@ extra-packages:
   - deepseq == 1.3.0.1                  # required to build Cabal with GHC 6.12.3
   - dhall == 1.29.0                     # required for spago 0.14.0.
   - doctemplates == 0.8                 # required by pandoc-2.9.x
+  - gi-gdk == 3.0.23                    # required for gi-pango 1.0.23
+  - gi-gtk == 3.0.35                    # required for gi-pango 1.0.23
   - generic-deriving == 1.10.5.*        # new versions don't compile with GHC 7.10.x
   - ghc-check == 0.3.0.1                # only version compatible with ghcide 0.2.0
   - ghc-tcplugins-extra ==0.3.2         # required for polysemy-plugin 0.2.5.0
@@ -5317,7 +5319,6 @@ broken-packages:
   - gi-gtkosxapplication
   - gi-gtksource
   - gi-handy
-  - gi-harfbuzz
   - gi-ibus
   - gi-notify
   - gi-ostree


### PR DESCRIPTION
This does not fix all haskell-gi dependencies. I have limited myself to
the ones needed to build webkitgtk, because I care about that one and
the issue is hopefully only temporary anyways.

###### Motivation for this change

gi-pango broke because of updates in the C libs it links against.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
