### PR TITLE
[haskell-updates]: haskellPackages.haskell-language-server: Fix evalution errors

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1335,7 +1335,7 @@ self: super: {
           '';
         })).override {
           # we are faster than stack here
-          hie-bios = dontCheck self.hie-bios_0_6_1;
+          hie-bios = dontCheck self.hie-bios_0_6_2;
           lsp-test = dontCheck self.lsp-test_0_11_0_4;
         });
 
@@ -1355,7 +1355,7 @@ self: super: {
       # use a fork of ghcide
       ghcide = self.hls-ghcide;
       # we are faster than stack here
-      hie-bios = dontCheck self.hie-bios_0_6_1;
+      hie-bios = dontCheck self.hie-bios_0_6_2;
       lsp-test = dontCheck self.lsp-test_0_11_0_4;
     };
 


### PR DESCRIPTION
###### Motivation for this change

Fix an evalution error. hie-bios had released a new version to hackage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
