### PR TITLE
vtk_9: init at 9.0.1

### DIFF
--- a/pkgs/development/libraries/vtk/9.x.nix
+++ b/pkgs/development/libraries/vtk/9.x.nix
@@ -1,0 +1,95 @@
+{ stdenv, mkDerivation, fetchurl, cmake, libGLU, libGL, libX11, xorgproto, libXt, libtiff
+, fetchpatch
+, enableQt ? false, qtbase, qtx11extras, qttools
+, enablePython ? false, python ? null
+# Darwin support
+, Cocoa, CoreServices, DiskArbitration, IOKit, CFNetwork, Security, GLUT, OpenGL
+, ApplicationServices, CoreText, IOSurface, ImageIO, xpc, libobjc }:
+
+with stdenv.lib;
+
+let
+  os = stdenv.lib.optionalString;
+  majorVersion = "9.0";
+  minorVersion = "1";
+  version = "${majorVersion}.${minorVersion}";
+in
+
+mkDerivation rec {
+  name = "vtk-${os enableQt "qvtk-"}${version}";
+  src = fetchurl {
+    url = "${meta.homepage}files/release/${majorVersion}/VTK-${version}.tar.gz";
+    sha256 = "1ir2lq9i45ls374lcmjzw0nrm5l5hnm1w47lg8g8d0n2j7hsaf8v";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ libtiff ]
+    ++ optionals enableQt [ qtbase qtx11extras qttools ]
+    ++ optionals stdenv.isLinux [
+      libGLU
+      libGL
+      libX11
+      xorgproto
+      libXt
+    ] ++ optionals stdenv.isDarwin [
+      xpc
+      Cocoa
+      CoreServices
+      DiskArbitration
+      IOKit
+      CFNetwork
+      Security
+      ApplicationServices
+      CoreText
+      IOSurface
+      ImageIO
+      OpenGL
+      GLUT
+    ]
+    ++ optional enablePython [
+      python
+    ];
+  propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin [ libobjc ];
+
+  preBuild = ''
+    export LD_LIBRARY_PATH="$(pwd)/lib";
+  '';
+
+  # Shared libraries don't work, because of rpath troubles with the current
+  # nixpkgs cmake approach. It wants to call a binary at build time, just
+  # built and requiring one of the shared objects.
+  # At least, we use -fPIC for other packages to be able to use this in shared
+  # objects.
+  cmakeFlags = [
+    "-DCMAKE_C_FLAGS=-fPIC"
+    "-DCMAKE_CXX_FLAGS=-fPIC"
+    "-DVTK_USE_SYSTEM_TIFF=1"
+    "-DOPENGL_INCLUDE_DIR=${libGL}/include"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_BINDIR=bin"
+  ]
+    ++ optionals enableQt [ "-DVTK_Group_Qt:BOOL=ON" ]
+    ++ optionals stdenv.isDarwin [ "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks" ]
+    ++ optionals enablePython [
+      "-DVTK_WRAP_PYTHON:BOOL=ON"
+      "-DVTK_PYTHON_VERSION:STRING=3"
+    ];
+
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    sed -i 's|COMMAND vtkHashSource|COMMAND "DYLD_LIBRARY_PATH=''${VTK_BINARY_DIR}/lib" ''${VTK_BINARY_DIR}/bin/vtkHashSource-${majorVersion}|' ./Parallel/Core/CMakeLists.txt
+    sed -i 's/fprintf(output, shift)/fprintf(output, "%s", shift)/' ./ThirdParty/libxml2/vtklibxml2/xmlschemas.c
+    sed -i 's/fprintf(output, shift)/fprintf(output, "%s", shift)/g' ./ThirdParty/libxml2/vtklibxml2/xpath.c
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Open source libraries for 3D computer graphics, image processing and visualization";
+    homepage = "https://www.vtk.org/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ tfmoraes ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15413,6 +15413,14 @@ in
                                           CoreText IOSurface ImageIO OpenGL GLUT;
   };
 
+  vtk_9 = libsForQt5.callPackage ../development/libraries/vtk/9.x.nix {
+    inherit (darwin) libobjc;
+    inherit (darwin.apple_sdk.libs) xpc;
+    inherit (darwin.apple_sdk.frameworks) Cocoa CoreServices DiskArbitration
+                                          IOKit CFNetwork Security ApplicationServices
+                                          CoreText IOSurface ImageIO OpenGL GLUT;
+  };
+
   vulkan-headers = callPackage ../development/libraries/vulkan-headers { };
   vulkan-loader = callPackage ../development/libraries/vulkan-loader { };
   vulkan-tools = callPackage ../tools/graphics/vulkan-tools { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

This also adds VTK9. It makes VTK9 the default. Adds VTK_8. 

###### Motivation for this change

Add VTK9 and its Python bindings into NixOS.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
