### PR TITLE
python3Packages.cvxpy: 1.1.3 -> 1.1.4

### DIFF
--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -16,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "cvxpy";
-  version = "1.1.3";
+  version = "1.1.4";
 
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6ce061bd431b05b8c47faa5044cdd5ad5654da4a4bd5c4360bd3c786ee4c64eb";
+    sha256 = "1f37da2f891508ebc2bbb2b75c46a2076be39a60a45c8a88261e000e8aabeef2";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/osqp/default.nix
+++ b/pkgs/development/python-modules/osqp/default.nix
@@ -30,7 +30,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "osqp" ];
   checkInputs = [ pytestCheckHook ];
   dontUseSetuptoolsCheck = true;  # don't run checks twice
-  disabledTests = [ "mkl_" ];
+  disabledTests = [
+    "mkl_"
+    "update_matrices_tests" # broken w/ scipy >= 1.5.0. Remove next release. See https://github.com/oxfordcontrol/osqp-python/issues/44
+  ];
 
   meta = with lib; {
     description = "The Operator Splitting QP Solver";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Unbreaks ``python3Packages.[osqp, cvxpy]`` on master, and updates cvxpy to latest version. https://github.com/cvxgrp/cvxpy/releases/tag/v1.1.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
