### PR TITLE
python3Packages.recommonmark: disable tests

### DIFF
--- a/pkgs/development/python-modules/recommonmark/default.nix
+++ b/pkgs/development/python-modules/recommonmark/default.nix
@@ -31,7 +31,8 @@ buildPythonPackage rec {
     "test_integration"
   ];
 
-  disabled = isPy3k; # Not yet compatible with latest Sphinx.
+  doCheck = !isPy3k; # Not yet compatible with latest Sphinx.
+  pythonImportsCheck = [ "recommonmark" ];
 
   meta = {
     description = "A docutils-compatibility bridge to CommonMark";


### PR DESCRIPTION
###### Motivation for this change
upstream appears to support python3

tests fail against latest sphinx, but errors suggest
session needs to be cleaned

related: #94591

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
