### PR TITLE
wxGTK31: 3.1.3 -> 3.1.4

### DIFF
--- a/pkgs/development/libraries/wxwidgets/3.1/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.1/default.nix
@@ -1,13 +1,32 @@
-{ stdenv, fetchFromGitHub, fetchurl, pkgconfig
-, libXinerama, libSM, libXxf86vm
-, gtk2, gtk3
-, xorgproto, gst_all_1, setfile
+{ stdenv
+, fetchFromGitHub
+, fetchurl
+, pkgconfig
+, libXinerama
+, libSM
+, libXxf86vm
+, libXtst
+, gtk2
+, GConf ? null
+, gtk3
+, xorgproto
+, gst_all_1
+, setfile
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
-, withMesa ? libGLSupported, libGLU ? null, libGL ? null
-, compat28 ? false, compat30 ? true, unicode ? true
+, withMesa ? libGLSupported
+, libGLU ? null
+, libGL ? null
+, compat28 ? false
+, compat30 ? true
+, unicode ? true
 , withGtk2 ? true
-, withWebKit ? false, webkitgtk ? null
-, AGL ? null, Carbon ? null, Cocoa ? null, Kernel ? null, QTKit ? null
+, withWebKit ? false
+, webkitgtk ? null
+, AGL ? null
+, Carbon ? null
+, Cocoa ? null
+, Kernel ? null
+, QTKit ? null
 }:
 
 with stdenv.lib;
@@ -18,47 +37,58 @@ assert withWebKit -> webkitgtk != null;
 assert assertMsg (withGtk2 -> withWebKit == false) "wxGTK31: You cannot enable withWebKit when using withGtk2.";
 
 stdenv.mkDerivation rec {
-  version = "3.1.3";
+  version = "3.1.4";
   pname = "wxwidgets";
 
   src = fetchFromGitHub {
     owner = "wxWidgets";
     repo = "wxWidgets";
     rev = "v${version}";
-    sha256 = "022mby78q7n0bhd4mph04hz93c9qamnvzv3h1s26r839k28760f4";
+    sha256 = "1fwzrk6w5k0vs8kqdq5lpzdbp5c09hx740wg6mi6vgmc1r67dv67";
+    fetchSubmodules = true;
   };
 
   buildInputs = [
-    libXinerama libSM libXxf86vm xorgproto gst_all_1.gstreamer gst_all_1.gst-plugins-base
-  ] ++ optionals withGtk2 [ gtk2 ]
-    ++ optional (!withGtk2) gtk3
-    ++ optional withMesa libGLU
-    ++ optional withWebKit webkitgtk
-    ++ optionals stdenv.isDarwin [ setfile Carbon Cocoa Kernel QTKit ];
+    libXinerama
+    libSM
+    libXxf86vm
+    libXtst
+    xorgproto
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+  ] ++ optionals withGtk2 [ gtk2 GConf ]
+  ++ optional (!withGtk2) gtk3
+  ++ optional withMesa libGLU
+  ++ optional withWebKit webkitgtk
+  ++ optionals stdenv.isDarwin [ setfile Carbon Cocoa Kernel QTKit ];
 
   nativeBuildInputs = [ pkgconfig ];
 
   propagatedBuildInputs = optional stdenv.isDarwin AGL;
 
   patches = [
-    (fetchurl { # https://trac.wxwidgets.org/ticket/17942
+    (fetchurl {
+      # https://trac.wxwidgets.org/ticket/17942
       url = "https://trac.wxwidgets.org/raw-attachment/ticket/17942/"
-          + "fix_assertion_using_hide_in_destroy.diff";
+        + "fix_assertion_using_hide_in_destroy.diff";
       sha256 = "009y3dav79wiig789vkkc07g1qdqprg1544lih79199kb1h64lvy";
     })
   ];
 
   configureFlags =
-    [ "--disable-precomp-headers" "--enable-mediactrl"
+    [
+      "--disable-precomp-headers"
+      "--enable-mediactrl"
       (if compat28 then "--enable-compat28" else "--disable-compat28")
-      (if compat30 then "--enable-compat30" else "--disable-compat30") ]
+      (if compat30 then "--enable-compat30" else "--disable-compat30")
+    ]
     ++ optional unicode "--enable-unicode"
     ++ optional withMesa "--with-opengl"
     ++ optionals stdenv.isDarwin
       # allow building on 64-bit
       [ "--with-cocoa" "--enable-universal-binaries" "--with-macosx-version-min=10.7" ]
     ++ optionals withWebKit
-      ["--enable-webview" "--enable-webviewwebkit"];
+      [ "--enable-webview" "--enable-webviewwebkit" ];
 
   SEARCH_LIB = "${libGLU.out}/lib ${libGL.out}/lib ";
 
@@ -90,8 +120,19 @@ stdenv.mkDerivation rec {
     platforms = with platforms; darwin ++ linux;
     license = licenses.wxWindows;
     homepage = "https://www.wxwidgets.org/";
-    description = "a C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base";
-    longDescription = "wxWidgets gives you a single, easy-to-use API for writing GUI applications on multiple platforms that still utilize the native platform's controls and utilities. Link with the appropriate library for your platform and compiler, and your application will adopt the look and feel appropriate to that platform. On top of great GUI functionality, wxWidgets gives you: online help, network programming, streams, clipboard and drag and drop, multithreading, image loading and saving in a variety of popular formats, database support, HTML viewing and printing, and much more.";
+    description = "A C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base";
+    longDescription = ''
+      WxWidgets gives you a single, easy-to-use API for
+      writing GUI applications on multiple platforms that still utilize the
+      native platform's controls and utilities. Link with the appropriate library
+      for your platform and compiler, and your application will adopt the look
+      and feel appropriate to that platform. On top of great GUI functionality,
+      wxWidgets gives you: online help, network programming, streams, clipboard
+      and drag and drop, multithreading, image loading and saving in a variety of
+      popular formats, database support, HTML viewing and printing, and much
+      more.
+    '';
     badPlatforms = [ "x86_64-darwin" ];
+    maintainers = with maintainers; [ tfmoraes ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

```
❯ nixpkgs-review rev e00baf6b52db9f377d1f444ec985f61f53f30c53                                                                                                                                                                                  nixpkgs-review 
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
$ git worktree add /home/thiago/.cache/nixpkgs-review/rev-e00baf6b52db9f377d1f444ec985f61f53f30c53/nixpkgs d22cd376e501df3012f208488b9ff12384efffc6
Preparing worktree (detached HEAD d22cd376e50)
HEAD is now at d22cd376e50 Merge pull request #95161 from lf-/patch-1
$ nix-env -f /home/thiago/.cache/nixpkgs-review/rev-e00baf6b52db9f377d1f444ec985f61f53f30c53/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit e00baf6b52db9f377d1f444ec985f61f53f30c53
Automatic merge went well; stopped before committing as requested
$ nix-env -f /home/thiago/.cache/nixpkgs-review/rev-e00baf6b52db9f377d1f444ec985f61f53f30c53/nixpkgs -qaP --xml --out-path --show-trace --meta
12 packages updated:
cubicsdr diff-pdf grandorgue kicad-unstable kicad-unstable-small prusa-slicer prusa-slicer pwsafe treesheets wxHexEditor wxGTK31-gtk3 (3.1.3 → 3.1.4) wxGTK31 (3.1.3 → 3.1.4)

$ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/thiago/.cache/nixpkgs-review/rev-e00baf6b52db9f377d1f444ec985f61f53f30c53/build.nix
[15 built, 73 copied (1031.3 MiB), 249.2 MiB DL]
11 packages built:
cubicsdr diff-pdf grandorgue kicad-unstable kicad-unstable-small prusa-slicer pwsafe treesheets wxGTK31 wxGTK31-gtk3 wxhexeditor
```

###### Motivation for this change

Update WxWidgets to 3.1.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
