### PR TITLE
python3Packages.wxpython_4_1: init at 4.1.0

### DIFF
--- a/pkgs/development/python-modules/wxPython/4.1.nix
+++ b/pkgs/development/python-modules/wxPython/4.1.nix
@@ -1,0 +1,124 @@
+{ lib
+, stdenv
+, openglSupport ? true
+
+, fetchPypi
+, buildPythonPackage
+, which
+, pkgconfig
+, gtk3
+, pkg-config
+
+, python
+, isPy27
+, freeglut
+, gst_all_1
+, libpng
+, libtiff
+, libjpeg
+, libnotify
+, SDL2
+, xorg
+
+, libX11
+, pyopengl
+, requests
+, doxygen
+, cairo
+, ncurses
+, pango
+, pathlib2
+
+, libGLU
+}:
+let
+  dynamic-linker = stdenv.cc.bintools.dynamicLinker;
+in
+buildPythonPackage rec {
+  pname = "wxPython";
+  version = "4.1.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12x4ci5q7qni4rkfiq6lnpn1fk8b0sfc6dck5wyxkj2sfp5pa91f";
+  };
+
+  # https://github.com/NixOS/nixpkgs/issues/75759
+  # https://github.com/wxWidgets/Phoenix/issues/1316
+  doCheck = false;
+
+  nativeBuildInputs = [ which doxygen gtk3 pkg-config ];
+
+  buildInputs = [
+    freeglut
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    libpng
+    libtiff
+    libjpeg
+    libnotify
+    SDL2
+    xorg.libSM
+    xorg.libXtst
+    gtk3
+    ncurses
+    requests
+    libX11
+    pathlib2
+    libGLU
+  ]
+  ++ lib.optional openglSupport pyopengl;
+
+  hardeningDisable = [ "format" ];
+
+  DOXYGEN = "${doxygen}/bin/doxygen";
+
+  preConfigure = lib.optionalString (!stdenv.isDarwin) ''
+    substituteInPlace wx/lib/wxcairo/wx_pycairo.py \
+      --replace 'cairoLib = None' 'cairoLib = ctypes.CDLL("${cairo}/lib/libcairo.so")'
+    substituteInPlace wx/lib/wxcairo/wx_pycairo.py \
+      --replace '_dlls = dict()' '_dlls = {k: ctypes.CDLL(v) for k, v in [
+        ("gdk",        "${gtk3}/lib/libgtk-x11-3.0.so"),
+        ("pangocairo", "${pango.out}/lib/libpangocairo-1.0.so"),
+        ("appsvc",     None)
+      ]}'
+
+    # https://github.com/wxWidgets/Phoenix/pull/1584
+    substituteInPlace build.py --replace "os.environ['PYTHONPATH'] = phoenixDir()" \
+      "os.environ['PYTHONPATH'] = os.environ['PYTHONPATH'] + os.pathsep + phoenixDir()"
+  '';
+
+  buildPhase = ''
+    ${python.interpreter} build.py -v build
+  '';
+
+  installPhase = ''
+    ${python.interpreter} setup.py install --skip-build --prefix=$out
+    wrapPythonPrograms
+  '';
+
+  shellHook = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$out/${python.sitePackages}/wx
+  '';
+
+  preFixup = ''
+    for i in $out/${python.sitePackages}/wx/*.so; do
+      patchelf --set-rpath "$out/${python.sitePackages}/wx:$(patchelf --print-rpath $i)" $i
+    done
+
+    for i in $out/${python.sitePackages}/wx/lib/*.so; do
+      patchelf --set-rpath "$out/${python.sitePackages}/wx/lib:$(patchelf --print-rpath $i)" $i
+    done
+  '';
+
+  passthru = { inherit openglSupport; };
+
+  meta = with lib; {
+    description = "Cross platform GUI toolkit for Python, Phoenix version";
+    homepage = "http://wxpython.org/";
+    license = licenses.wxWindows;
+    maintainers = with maintainers; [ tfmoraes ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7530,6 +7530,8 @@ in {
     };
   };
 
+  wxPython_4_1 = callPackage ../development/python-modules/wxPython/4.1.nix { };
+
   wxPython = self.wxPython30;
 
   x11_hash = callPackage ../development/python-modules/x11_hash { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add WXPython-4.1.0 to NixOS. The package is compiling its own wxgtk because wxpython is not compiling with it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`

```
$ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/thiago/.cache/nixpkgs-review/rev-7133bbdbd31696c8a646ea44e85e78f38be3ca2d/build.nix
[2 built, 0.0 MiB DL]
2 packages built:
python37Packages.wxPython_4_1 python38Packages.wxPython_4_1

$ nix-shell /home/thiago/.cache/nixpkgs-review/rev-7133bbdbd31696c8a646ea44e85e78f38be3ca2d/shell.nix

```

- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
