### PR TITLE
fractal: 4.2.2 → 4.4.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/fractal/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fractal/default.nix
@@ -9,7 +9,7 @@
 , rustc
 , python3
 , rustPlatform
-, pkgconfig
+, pkg-config
 , gtksourceview4
 , glib
 , libhandy
@@ -26,24 +26,24 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "fractal";
-  version = "4.2.2";
+  version = "4.4.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "fractal";
     rev = version;
-    sha256 = "0r98km3c8naj3mdr1wppzj823ir7jnsia7r3cbg3vsq8q52i480r";
+    sha256 = "DSNVd9YvI7Dd3s3+M0+wE594tmL1yPNMnD1W9wLhSuw=";
   };
 
-  cargoSha256 = "10fgw9m6gdazrca73g43sgvsghhac7xc3bg7hr0vpynzqyfigwa9";
+  cargoSha256 = "xim5sOzeXJjRXbTOg2Gk/LHU0LioiyMK5nSr1LwMPjc=";
 
   nativeBuildInputs = [
     cargo
     gettext
     meson
     ninja
-    pkgconfig
+    pkg-config
     python3
     rustc
     wrapGAppsHook


### PR DESCRIPTION
###### Motivation for this change
https://gitlab.gnome.org/GNOME/fractal/-/blob/4.4.0/fractal-gtk/res/org.gnome.Fractal.metainfo.xml.in.in#L21-49

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
