### PR TITLE
pythonPackages.javaobj-py3: disable

### DIFF
--- a/pkgs/development/python-modules/javaobj-py3/default.nix
+++ b/pkgs/development/python-modules/javaobj-py3/default.nix
@@ -1,11 +1,13 @@
 { buildPythonPackage
 , fetchPypi
+, isPy27
 , lib
 }:
 
 buildPythonPackage rec {
   pname = "javaobj-py3";
   version = "0.4.1";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change
disabling failing python 2 builds

```
  ERROR: Could not find a version that satisfies the requirement typing; python_version <= "3.4" (from javaobj-py3==0.4.1) (from versions: none)
  ERROR: No matching distribution found for typing; python_version <= "3.4" (from javaobj-py3==0.4.1)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
