### PR TITLE
Use src instead of srcs in Python packages

### DIFF
--- a/pkgs/development/python-modules/jq/default.nix
+++ b/pkgs/development/python-modules/jq/default.nix
@@ -4,7 +4,7 @@ buildPythonPackage rec {
   pname = "jq";
   version = "0.1.6";
 
-  srcs = fetchPypi {
+  src = fetchPypi {
     inherit pname version;
     sha256 = "34bdf9f9e49e522e1790afc03f3584c6b57329215ea0567fb2157867d6d6f602";
   };

--- a/pkgs/development/python-modules/openwrt-luci-rpc/default.nix
+++ b/pkgs/development/python-modules/openwrt-luci-rpc/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   pname = "openwrt-luci-rpc";
   version = "1.1.2";
 
-  srcs = fetchPypi {
+  src = fetchPypi {
     inherit pname version;
     sha256 = "144bw7w1xvpdkad5phflpkl15ih5pvi19799wmvfv8mj1dn1yjhp";
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This change addresses an issue mapping nixpkgs Python packages to PyPI names in pynixify: https://github.com/cript0nauta/pynixify/issues/40.

From what I understand, using `srcs` in derivations should only be done when you need two or more different sources. In the case of jq and openwrt-luci-rpc, they only have one source so I see no reason for not using `src`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
