### PR TITLE
cargo-xbuild: 0.5.29 -> 0.6.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-xbuild/default.nix
+++ b/pkgs/development/tools/rust/cargo-xbuild/default.nix
@@ -2,22 +2,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-xbuild";
-  version = "0.5.29";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "rust-osdev";
     repo = pname;
     rev = "v${version}";
-    sha256 = "05wg1xx2mcwb9cplmrpg13jimddlzmv7hf5g3vjppjp8kz2gb7zj";
+    sha256 = "0kmnwx2fg4nq009dzwk840z8n4rayvpk6hjpryczv56sjdcqm2zv";
   };
 
-  cargoSha256 = "1s2xsfld29shvjzyp16y263hnbqxrq8i2557y0g09xmfm5x0jhix";
+  cargoSha256 = "0vnhaf7b2ai151wjadgj7pm5hdcj7rv1ckj5mjn74r3vvds2jdn7";
 
   meta = with stdenv.lib; {
     description = "Automatically cross-compiles the sysroot crates core, compiler_builtins, and alloc";
     homepage = "https://github.com/rust-osdev/cargo-xbuild";
     license = with licenses; [ mit asl20 ];
-    maintainers = with maintainers; [ xrelkd ];
+    maintainers = with maintainers; [ johntitor xrelkd ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

cargo-xbuild v0.6.0 contains a breaking change to use it with new libstd directory structure, see https://github.com/rust-osdev/cargo-xbuild/blob/master/CHANGELOG.md#060--2020-08-02.
Now, Std Aware Cargo is recommended but this is still useful for some environment.
And I'm happy to be a maintainer as one of the rust-osdev org.

https://github.com/rust-osdev/cargo-xbuild/releases/tag/v0.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
