### PR TITLE
buildGoModule/vend: use upstream instead of fork

### DIFF
--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
   };
 
   runVend = true;
-  vendorSha256 = "0avdvbhv1jlisiicpi5vshz28a2p2fgnlrag9zngzglcrbhdd1rn";
+  vendorSha256 = "13zs5113ip85yl6sw9hzclxwlnrhy18d39vh9cwbq97dgnh9rz89";
 
   doCheck = false;
 

--- a/pkgs/development/tools/vend/default.nix
+++ b/pkgs/development/tools/vend/default.nix
@@ -1,27 +1,37 @@
 { stdenv, buildGoModule, fetchFromGitHub }:
 
-buildGoModule {
+buildGoModule rec {
   pname = "vend";
-  version = "unstable-2020-06-04";
 
-  patches = [./remove_tidy.patch];
+  /*
+  This package is used to generate vendor folders for
+  packages that use the `runVend` option with `buildGoModule`.
 
-  # A permanent fork from master is maintained to avoid non deterministic go tidy
+  Do not update this package without checking that the vendorSha256
+  hashes of packages using the `runVend` option are unchanged
+  or updating their vendorSha256 hashes if necessary.
+  */
+  version = "1.0.2";
+  # Disable the bot
+  # nixpkgs-update: no auto update
+
+  # Disable `mod tidy`, patch was refused upstream
+  # https://github.com/nomad-software/vend/pull/9
+  patches = [ ./remove_tidy.patch ];
+
   src = fetchFromGitHub {
-    owner = "c00w";
+    owner = "nomad-software";
     repo = "vend";
-    rev = "24fdebfdb2c3cc0516321a9cf33a3fd81c209c04";
-    sha256 = "112p9dz9by2h2m3jha2bv1bvzn2a86bpg1wphgmf9gksjpwy835l";
+    rev = "v${version}";
+    sha256 = "0h9rwwb56nzs46xsvl92af71i8b3wz3pf9ngi8v0i2bpk7p3p89d";
   };
 
   vendorSha256 = null;
 
-  doCheck = false;
-
   meta = with stdenv.lib; {
-    homepage = "https://github.com/c00w/vend";
+    homepage = "https://github.com/nomad-software/vend";
     description = "A utility which vendors go code including c dependencies";
-    maintainers = with maintainers; [ c00w ];
+    maintainers = with maintainers; [ c00w mic92 zowoq ];
     license = licenses.mit;
   };
 }

--- a/pkgs/servers/mautrix-whatsapp/default.nix
+++ b/pkgs/servers/mautrix-whatsapp/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   buildInputs = [ olm ];
 
-  vendorSha256 = "05cqwprd1rcciw27wyz7lj1s3zmz2vq093vw1cx3kkjyf6lq8sk6";
+  vendorSha256 = "1dmlqhhwmc0k9nbab5j8sl20b8d6b5yrmcdf7ibaiqh7i16zrp3s";
 
   doCheck = false;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Closes https://github.com/NixOS/nixpkgs/pull/94574
