### PR TITLE
 fuzzel: 1.3.0 → 1.4.1; fcft: 0.4.3 → 2.2.6

### DIFF
--- a/pkgs/applications/misc/fuzzel/default.nix
+++ b/pkgs/applications/misc/fuzzel/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "fuzzel";
-  version = "1.3.0";
+  version = "1.4.1";
 
   src = fetchgit {
     url = "https://codeberg.org/dnkl/fuzzel";
     rev = "${version}";
-    sha256 = "12jv5iwmksygw8nfkxbd9rbi03wnpgb30hczq009aqgy7lyi5zmp";
+    sha256 = "18pg46xry7q4i19mpjfz942c6vkqlrj4q18p85zldzv9gdsxnm9c";
   };
 
   nativeBuildInputs = [ pkg-config meson ninja scdoc git ];

--- a/pkgs/development/libraries/fcft/default.nix
+++ b/pkgs/development/libraries/fcft/default.nix
@@ -1,16 +1,17 @@
-{ stdenv, lib, fetchgit, pkg-config, meson, ninja, freetype, fontconfig, pixman, tllist }:
+{ stdenv, lib, fetchgit, pkg-config, meson, ninja, scdoc
+,freetype, fontconfig, pixman, tllist }:
 
 stdenv.mkDerivation rec {
   pname = "fcft";
-  version = "0.4.3";
+  version = "2.2.6";
 
   src = fetchgit {
     url = "https://codeberg.org/dnkl/fcft.git";
     rev = "${version}";
-    sha256 = "1r2k5726k6ps8ml2s1vqmpiggqxzq9pbzs7m0dsxk29mh8vg0psj";
+    sha256 = "06zywvvgrch9k4d07bir2sxddwsli2gzpvlvjfcwbrj3bw5x6j1b";
   };
 
-  nativeBuildInputs = [ pkg-config meson ninja ];
+  nativeBuildInputs = [ pkg-config meson ninja scdoc ];
   buildInputs = [ freetype fontconfig pixman tllist ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update `fuzzel` to the new release which fixes a crash and adds new features. Also update dependency `fcft` which is now required in a higher version.

[Changelog](https://codeberg.org/dnkl/fuzzel/releases/tag/1.4.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @fionera