### PR TITLE
python3Packages.docker: 4.2.0 -> 4.3.0

### DIFF
--- a/pkgs/development/python-modules/docker/default.nix
+++ b/pkgs/development/python-modules/docker/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "docker";
-  version = "4.2.2";
+  version = "4.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0m4vgk2831yfdjy8vqyvvfnmwv270a44z358frdzb672wzfbmvi6";
+    sha256 = "14xgsvvjj5g0d3cp0zdfigpgcqjc4zd455izc4qam1dg5j7jc6j3";
   };
 
   nativeBuildInputs = lib.optional isPy27 mock;


### PR DESCRIPTION
###### Motivation for this change

noticed it was out of date
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
error: build of '/nix/store/hnbd73jlxawm2fm3agd6gx5qa36hia1w-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/95516
67 packages failed to build:
apache-airflow buildbot buildbot-full buildbot-ui mlflow-server python27Packages.pytrends python27Packages.trackpy python37Packages.arviz python37Packages.buildbot python37Packages.buildbot-full python37Packages.buildbot-ui python37Packages.dask-xgboost python37Packages.datashader python37Packages.fastparquet python37Packages.geopandas python37Packages.google_cloud_bigquery python37Packages.ibis-framework python37Packages.imbalanced-learn python37Packages.intake python37Packages.ipydatawidgets python37Packages.mask-rcnn python37Packages.mlflow python37Packages.optuna python37Packages.osmnx python37Packages.phik python37Packages.pvlib python37Packages.pyarrow python37Packages.pymc3 python37Packages.qasm2image python37Packages.qiskit python37Packages.qiskit-aer python37Packages.qiskit-aqua python37Packages.qiskit-ignis python37Packages.rl-coach python37Packages.rpy2 python37Packages.runway-python python37Packages.streamz python37Packages.sumo python37Packages.tensorboardx python37Packages.trackpy python37Packages.xgboost python38Packages.dask-xgboost python38Packages.datashader python38Packages.fastparquet python38Packages.geopandas python38Packages.google_cloud_bigquery python38Packages.imbalanced-learn python38Packages.intake python38Packages.ipydatawidgets python38Packages.mlflow python38Packages.osmnx python38Packages.phik python38Packages.pvlib python38Packages.pyarrow python38Packages.qasm2image python38Packages.qiskit python38Packages.qiskit-aer python38Packages.qiskit-aqua python38Packages.qiskit-ignis python38Packages.rpy2 python38Packages.runway-python python38Packages.streamz python38Packages.sumo python38Packages.tensorboardx python38Packages.trackpy python38Packages.xgboost streamlit

210 packages built:
arion aws-sam-cli cq-editor csvs-to-sqlite cura docker-compose fdroidserver gns3-gui gns3-server poretools python27Packages.awkward python27Packages.bkcharts python27Packages.docker python27Packages.drms python27Packages.duckdb python27Packages.flammkuchen python27Packages.imbalanced-learn python27Packages.mapsplotlib python27Packages.moto python27Packages.pandas python27Packages.seaborn python27Packages.uproot python27Packages.uproot-methods python27Packages.vega_datasets python27Packages.vidstab python37Packages.Quandl python37Packages.acoustics python37Packages.altair python37Packages.aplpy python37Packages.apptools python37Packages.atomman python37Packages.awkward python37Packages.batchgenerators python37Packages.bkcharts python37Packages.caffe python37Packages.celery python37Packages.cirq python37Packages.cnvkit python37Packages.colorcet python37Packages.csvs-to-sqlite python37Packages.cufflinks python37Packages.dask python37Packages.dask-gateway python37Packages.dask-glm python37Packages.dask-image python37Packages.dask-jobqueue python37Packages.dask-ml python37Packages.dask-mpi python37Packages.dftfit python37Packages.distributed python37Packages.django-raster python37Packages.djmail python37Packages.docker python37Packages.dockerspawner python37Packages.drms python37Packages.duckdb python37Packages.envisage python37Packages.flammkuchen python37Packages.flower python37Packages.glymur python37Packages.google_cloud_automl python37Packages.google_cloud_monitoring python37Packages.graspy python37Packages.heudiconv python37Packages.hickle python37Packages.holoviews python37Packages.hvplot python37Packages.image-match python37Packages.imagecorruptions python37Packages.imgaug python37Packages.jupyter-repo2docker python37Packages.lammps-cython python37Packages.mayavi python37Packages.mesa python37Packages.moto python37Packages.nbsmoke python37Packages.nilearn python37Packages.nipype python37Packages.osmpythontools python37Packages.pandas python37Packages.partd python37Packages.pims python37Packages.pybids python37Packages.pyfftw python37Packages.pymatgen python37Packages.pymatgen-lammps python37Packages.pytrends python37Packages.pywick python37Packages.qiskit-ibmq-provider python37Packages.qiskit-terra python37Packages.scikit-bio python37Packages.scikitimage python37Packages.seaborn python37Packages.sentry-sdk python37Packages.skorch python37Packages.sparse python37Packages.spectral-cube python37Packages.spyder-kernels_0_5 python37Packages.spyder_3 python37Packages.statsmodels python37Packages.stumpy python37Packages.stytra python37Packages.sunpy python37Packages.tablib python37Packages.tensorly python37Packages.traittypes python37Packages.uproot python37Packages.uproot-methods python37Packages.vega python37Packages.vega_datasets python37Packages.vidstab python37Packages.wrf-python python37Packages.xarray python38Packages.Quandl python38Packages.acoustics python38Packages.altair python38Packages.aplpy python38Packages.apptools python38Packages.atomman python38Packages.awkward python38Packages.batchgenerators python38Packages.bkcharts python38Packages.caffe python38Packages.celery python38Packages.cirq python38Packages.cnvkit python38Packages.colorcet python38Packages.cufflinks python38Packages.dask python38Packages.dask-gateway python38Packages.dask-glm python38Packages.dask-image python38Packages.dask-jobqueue python38Packages.dask-ml python38Packages.dask-mpi python38Packages.dftfit python38Packages.distributed python38Packages.django-raster python38Packages.djmail python38Packages.docker python38Packages.dockerspawner python38Packages.drms python38Packages.duckdb python38Packages.envisage python38Packages.flammkuchen python38Packages.flower python38Packages.glymur python38Packages.google_cloud_automl python38Packages.google_cloud_monitoring python38Packages.graspy python38Packages.hickle python38Packages.holoviews python38Packages.hvplot python38Packages.image-match python38Packages.imagecorruptions python38Packages.imgaug python38Packages.jupyter-repo2docker python38Packages.lammps-cython python38Packages.mayavi python38Packages.mesa python38Packages.moto python38Packages.nbsmoke python38Packages.nilearn python38Packages.nipype python38Packages.osmpythontools python38Packages.pandas python38Packages.partd python38Packages.pims python38Packages.pybids python38Packages.pyfftw python38Packages.pymatgen python38Packages.pymatgen-lammps python38Packages.pytrends python38Packages.pywick python38Packages.qiskit-ibmq-provider python38Packages.qiskit-terra python38Packages.scikit-bio python38Packages.scikitimage python38Packages.seaborn python38Packages.sentry-sdk python38Packages.skorch python38Packages.sparse python38Packages.spectral-cube python38Packages.spyder-kernels_0_5 python38Packages.spyder_3 python38Packages.statsmodels python38Packages.stumpy python38Packages.stytra python38Packages.sunpy python38Packages.tablib python38Packages.tensorly python38Packages.traittypes python38Packages.uproot python38Packages.uproot-methods python38Packages.vega python38Packages.vega_datasets python38Packages.vidstab python38Packages.wrf-python python38Packages.xarray sourcehut.buildsrht sourcehut.dispatchsrht sourcehut.gitsrht sourcehut.hgsrht sourcehut.listssrht sourcehut.mansrht sourcehut.metasrht sourcehut.pastesrht sourcehut.todosrht tebreak visidata
```