### PR TITLE
[r20.03] pythonPackages.asyncpg: add patch for CVE-2020-17446

### DIFF
--- a/pkgs/development/python-modules/asyncpg/default.nix
+++ b/pkgs/development/python-modules/asyncpg/default.nix
@@ -11,6 +11,14 @@ buildPythonPackage rec {
     sha256 = "1c4mcjrdbvvq5crrfc3b9m221qb6pxp55yynijihgfnvvndz2jrr";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "CVE-2020-17446.patch";
+      url = "https://github.com/MagicStack/asyncpg/commit/69bcdf5bf7696b98ee708be5408fd7d854e910d0.patch";
+      sha256 = "0br5bfzrlhwq7kqmnlgnjlizyyaq31mvgw77p3lwhxn5r0wkpnaj";
+    })
+  ];
+
   checkInputs = [
     uvloop
     postgresql


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-17446

`master` has already been bumped for the fix (#95499)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
