### PR TITLE
python3Packages.strictyaml: 1.0.6 -> 1.1.0

### DIFF
--- a/pkgs/development/python-modules/strictyaml/default.nix
+++ b/pkgs/development/python-modules/strictyaml/default.nix
@@ -1,17 +1,19 @@
 { buildPythonPackage
 , lib
 , fetchPypi
+, isPy27
 , ruamel_yaml
 , python-dateutil
 }:
 
 buildPythonPackage rec {
-  version = "1.0.6";
+  version = "1.1.0";
   pname = "strictyaml";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "dd687a32577e0b832619ce0552eac86d6afad5fa7b61ab041bb765881c6a1f36";
+    sha256 = "1jj20fwcpvqzp7rnzk3mc3xm94wz3gy3zi3787nj7c3syzadn1vb";
   };
 
   propagatedBuildInputs = [ ruamel_yaml python-dateutil ];
@@ -19,6 +21,7 @@ buildPythonPackage rec {
   # Library tested with external tool
   # https://hitchdev.com/approach/contributing-to-hitch-libraries/
   doCheck = false;
+  pythonImportsCheck = [ "strictyaml" ];
 
   meta = with lib; {
     description = "Strict, typed YAML parser";


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/95519
5 packages built:
devpi-client devpi-server python27Packages.strictyaml python37Packages.strictyaml python38Packages.strictyaml
```