### PR TITLE
Adding alias for git tool "git brunch"

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -63,6 +63,8 @@ let
 
   git-annex-utils = callPackage ./git-annex-utils { };
 
+  git-brunch = pkgs.haskellPackages.git-brunch;
+
   git-appraise = callPackage ./git-appraise {};
 
   git-bug = callPackage ./git-bug { };
@@ -235,6 +237,7 @@ let
   # aliases
   darcsToGit = darcs-to-git;
   gitAnnex = git-annex;
+  gitBrunch = git-brunch;
   gitFastExport = git-fast-export;
   gitRemoteGcrypt = git-remote-gcrypt;
   svn_all_fast_export = svn-all-fast-export;


### PR DESCRIPTION
###### Motivation for this change

I'm maintaining a git tool called git-brunch and want to add it to the category of git tools. Because it is written with Haskell and published on Hackage, adding an alias (similar to `git-annex`) is enough.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).