### PR TITLE
python3Packages.phik: fix deps

### DIFF
--- a/pkgs/development/python-modules/phik/default.nix
+++ b/pkgs/development/python-modules/phik/default.nix
@@ -5,6 +5,7 @@
 , pytest
 , pytest-pylint
 , nbconvert
+, joblib
 , jupyter_client
 , numpy
 , scipy
@@ -33,6 +34,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    joblib
     numpy
     scipy
     pandas


### PR DESCRIPTION
###### Motivation for this change

noticed it was broken reviewing: #95516

```
  ERROR: Could not find a version that satisfies the requirement joblib>=0.14.1 (from phik==0.10.0) (from versions: none)
  ERROR: No matching distribution found for joblib>=0.14.1 (from phik==0.10.0)
  builder for '/nix/store/jl1bkb8m9dhq6kpz6bak2jlvmra34mi7-python3.8-phik-0.10.0.drv' failed with exit code 1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/95521
2 packages built:
python37Packages.phik python38Packages.phik
```