### PR TITLE
nixos/transmission: handle watch-dir

### DIFF
--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -11,6 +11,7 @@ let
   settingsDir = ".config/transmission-daemon";
   downloadsDir = "Downloads";
   incompleteDir = ".incomplete";
+  watchDir = "watchdir";
   # TODO: switch to configGen.json once RFC0042 is implemented
   settingsFile = pkgs.writeText "settings.json" (builtins.toJSON cfg.settings);
 in
@@ -35,6 +36,8 @@ in
             download-dir = "${cfg.home}/${downloadsDir}";
             incomplete-dir = "${cfg.home}/${incompleteDir}";
             incomplete-dir-enabled = true;
+            watch-dir = "${cfg.home}/${watchDir}";
+            watch-dir-enabled = false;
             message-level = 1;
             peer-port = 51413;
             peer-port-random-high = 65535;
@@ -161,6 +164,9 @@ in
       { assertion = types.path.check cfg.settings.incomplete-dir;
         message = "`services.transmission.settings.incomplete-dir' must be an absolute path.";
       }
+      { assertion = types.path.check cfg.settings.watch-dir;
+        message = "`services.transmission.settings.watch-dir' must be an absolute path.";
+      }
       { assertion = cfg.settings.script-torrent-done-filename == "" || types.path.check cfg.settings.script-torrent-done-filename;
         message = "`services.transmission.settings.script-torrent-done-filename' must be an absolute path.";
       }
@@ -220,7 +226,11 @@ in
             cfg.settings.download-dir
           ] ++
           optional cfg.settings.incomplete-dir-enabled
-            cfg.settings.incomplete-dir;
+            cfg.settings.incomplete-dir
+          ++
+          optional cfg.settings.watch-dir-enabled
+            cfg.settings.watch-dir
+          ;
         BindReadOnlyPaths = [
           # No confinement done of /nix/store here like in systemd-confinement.nix,
           # an AppArmor profile is provided to get a confinement based upon paths and rights.
@@ -410,10 +420,16 @@ in
           ${optionalString cfg.settings.incomplete-dir-enabled ''
             rw ${cfg.settings.incomplete-dir}/**,
           ''}
+          ${optionalString cfg.settings.watch-dir-enabled ''
+            rw ${cfg.settings.watch-dir}/**,
+          ''}
           profile dirs {
             rw ${cfg.settings.download-dir}/**,
             ${optionalString cfg.settings.incomplete-dir-enabled ''
               rw ${cfg.settings.incomplete-dir}/**,
+            ''}
+            ${optionalString cfg.settings.watch-dir-enabled ''
+              rw ${cfg.settings.watch-dir}/**,
             ''}
           }
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Noticed I got errors with watch-dir ever since hardening. cc @ju1m / @Lassulus .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
