### PR TITLE
python3Packages.streamz: 0.5.4 -> 0.5.5

### DIFF
--- a/pkgs/development/python-modules/streamz/default.nix
+++ b/pkgs/development/python-modules/streamz/default.nix
@@ -14,11 +14,11 @@
 
 buildPythonPackage rec {
   pname = "streamz";
-  version = "0.5.4";
+  version = "0.5.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1vzmwnj12ij0cqhggys2dqv3b0v935yfzhcjwl5jw206vlla22bw";
+    sha256 = "0r83z3233pfwjw31bkmdldjqlx533f27iimayadfgcn5jr3xwykq";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
also fixes build

noticed it was broken reviewing: #95516
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/95526
2 packages built:
python37Packages.streamz python38Packages.streamz
```