### PR TITLE
python3Packages.azure*: bump

### DIFF
--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -14,14 +14,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.7.0";
+  version = "1.8.0";
   pname = "azure-core";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "0p6pzpgfxr0c95gqr8ryq779an13x84vlm3zhvwlgx47l90a4vd6";
+    sha256 = "c89bbdcdc13ad45fe57d775ed87b15baf6d0b039a1ecd0a1bc91d2f713cb1f08";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-datalake-store/default.nix
+++ b/pkgs/development/python-modules/azure-datalake-store/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "azure-datalake-store";
-  version = "0.0.48";
+  version = "0.0.49";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d27c335783d4add00b3a5f709341e4a8009857440209e15a739a9a96b52386f7";
+    sha256 = "3fcede6255cc9cd083d498c3a399b422f35f804c561bb369a7150ff1f2f07da9";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-identity/default.nix
+++ b/pkgs/development/python-modules/azure-identity/default.nix
@@ -17,13 +17,13 @@
 
 buildPythonPackage rec {
   pname = "azure-identity";
-  version = "1.3.1";
+  version = "1.4.0";
   disabled = isPy38;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "5a59c36b4b05bdaec455c390feda71b6495fc828246593404351b9a41c2e877a";
+    sha256 = "820e1f3e21f90d36063239c6cb7ca9a6bb644cb120a6b1ead3081cafdf6ceaf8";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-keyvault-certificates/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault-certificates/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure-keyvault-certificates";
-  version = "4.1.0";
+  version = "4.2.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "069l6m80rq4smyqbrmjb2w18wxxg49xi2yrf1wsxpq8r0r45cksl";
+    sha256 = "5e33881f3a9b3080c815fe6a7200c0c8670ec506eff45955432ddb84f3076902";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-keyvault-certificates/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault-certificates/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , python
 , isPy3k
+, azure-common
 , azure-core
 , msrest
 , msrestazure
@@ -19,6 +20,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    azure-common
     azure-core
     msrest
     msrestazure

--- a/pkgs/development/python-modules/azure-keyvault-keys/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault-keys/default.nix
@@ -10,13 +10,13 @@
 
 buildPythonPackage rec {
   pname = "azure-keyvault-keys";
-  version = "4.1.0";
+  version = "4.2.0";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "f9967b4deb48e619f6c40558f69e48978779cc09c8a7fad33d536cfc41cd68f9";
+    sha256 = "e47b76ca5d99b12436c64ce4431271cd6744fba017f282991b84ce303e0b9eaa";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-keyvault-secrets/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault-secrets/default.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "azure-keyvault-secrets";
-  version = "4.1.0";
+  version = "4.2.0";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "4f3bfac60e025e01dd1c1998b73649d45d706975356c0cf147174cf5a6ddf8be";
+    sha256 = "1083ab900da5ec63c518ffef49d9fdca02c81ddffdf80c52c03cd9da479e021f";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-authorization/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-authorization/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure-mgmt-authorization";
-  version = "0.60.0";
+  version = "0.61.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "19yn2ar2y8j4idzf8mxrxplxnawbk83sid3pzvzddif29aipbs1i";
+    sha256 = "f5cceea3add04e9445ea88492f15eecf6c126f0406d967c95f6e48b79be8db75";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-cdn/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-cdn/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure-mgmt-cdn";
-  version = "4.0.0";
+  version = "5.1.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "a53e9e09e2711ce9109329538fe9a8a1a5d0809efb231d7df481e55d09c4f02a";
+    sha256 = "5af79f80e6c5f4766bcb5b8c62273445fb2beaeae85c5b9d2ab9aa369d60ede3";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-compute/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-compute/default.nix
@@ -7,13 +7,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "12.1.0";
+  version = "13.0.0";
   pname = "azure-mgmt-compute";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "54416e6fa4584bb986e8985f510486a36b4fdf47af012a4982a0960c7b11e89c";
+    sha256 = "7f331bafcbedf25d65aa42038f7553747dab18d7f10a5af3297192d31c45339e";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-core/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-core/default.nix
@@ -7,13 +7,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.1.0";
+  version = "1.2.0";
   pname = "azure-mgmt-core";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "049dfb0bcc7961d0d988fee493d1ec4f4480e109e4661e360bad054cc297d43c";
+    sha256 = "8fe3b59446438f27e34f7b24ea692a982034d9e734617ca1320eedeee1939998";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-cosmosdb/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-cosmosdb/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure-mgmt-cosmosdb";
-  version = "0.15.0";
+  version = "0.16.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "03ysr8kx0gavjrxsi9wqrgxpg3g17nvii7z68qfm0k2mv6ryj3z7";
+    sha256 = "308aeabdff61bf35ceb7a3d6dd19f1ab69a041bd92c85ee24d98a624968697f3";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-datafactory/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datafactory/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure-mgmt-datafactory";
-  version = "0.11.0";
+  version = "0.12.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "35d7c737054a7e6fc7c88d8c437fc012904c4568809487cac443eb3b13e6655b";
+    sha256 = "cee5168c8b89cbc673744323cf98f7f22d710914c79d103f84f8f24b780e8214";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-hdinsight/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-hdinsight/default.nix
@@ -5,13 +5,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.5.1";
+  version = "1.6.0";
   pname = "azure-mgmt-hdinsight";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "76b94f3e43fdc6698023d79be731937dc645dc3178dc134854768528ecc0aea3";
+    sha256 = "b1d06279307c41da5e0a5c9722aa6b36ce3b2c212534a54767210639451b9800";
     extension = "zip";
   };
 

--- a/pkgs/development/python-modules/azure-mgmt-kusto/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-kusto/default.nix
@@ -5,13 +5,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.8.0";
+  version = "0.9.0";
   pname = "azure-mgmt-kusto";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b12388df60982265c9f18e7382c5cc0e389c071227865cadc626b9ff9c6e3871";
+    sha256 = "9210db89fa18ee8ed53339cd63bbe6fe1d9624cd793b54b7451ddbda8ae92ef3";
     extension = "zip";
   };
 

--- a/pkgs/development/python-modules/azure-mgmt-netapp/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-netapp/default.nix
@@ -5,13 +5,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.10.0";
+  version = "0.12.0";
   pname = "azure-mgmt-netapp";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "380b2153c52a861ae9069fcd601cbaeb9a6f91c49cba823443a9b5fe461c3998";
+    sha256 = "7d773119bc02e3d6f9d7cffb7effc17e85676d5c5b1f656d05abc4489e472c76";
     extension = "zip";
   };
 

--- a/pkgs/development/python-modules/azure-mgmt-resource/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-resource/default.nix
@@ -8,13 +8,13 @@
 
 
 buildPythonPackage rec {
-  version = "10.1.0";
+  version = "10.2.0";
   pname = "azure-mgmt-resource";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "9be7fcdf586f24acb799a799cf5e9363e9323ca0ce54cca63ab505f69fa0fddd";
+    sha256 = "ddfe4c0c55f0e3fd1f66dd82c1d4a3d872ce124639b9a77fcd172daf464438a5";
   };
 
   postInstall = if isPy3k then "" else ''

--- a/pkgs/development/python-modules/azure-mgmt-servicefabric/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-servicefabric/default.nix
@@ -11,12 +11,12 @@
 
 buildPythonPackage rec {
   pname = "azure-mgmt-servicefabric";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "1x18grkjf2p2r1ihlwv607sna9yjvsr2jwnkjc55askrgrwx5jx2";
+    sha256 = "5771f24516c8d4a27f5569f23f3a606f6f106e4ad502eec7f38aedfcd3eadc74";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-sql/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-sql/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure-mgmt-sql";
-  version = "0.19.0";
+  version = "0.20.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "694649d4c9c5f89e543f23ec10e450b6382b2f1bc5843ef266cfc302276038c6";
+    sha256 = "29dde5bb3234be6e4b2bc93ad1d37dc94b3d0536bbb21759e9b24250d2dfdab2";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-storage-file-share/default.nix
+++ b/pkgs/development/python-modules/azure-storage-file-share/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "azure-storage-file-share";
-  version = "12.1.2";
+  version = "12.2.0";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "74422d241454d66fdc3184dbe52334997ebe4f9f9a0d88ec1a2ba6c602f8a332";
+    sha256 = "b649ed8afd67c10c9833f349a7c579d771a6425ad6b88027130a6b8cfa433ffb";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/95528
51 packages built:
azure-cli python27Packages.azure-datalake-store python27Packages.azure-mgmt-authorization python27Packages.azure-mgmt-cdn python27Packages.azure-mgmt-compute python27Packages.azure-mgmt-cosmosdb python27Packages.azure-mgmt-datafactory python27Packages.azure-mgmt-resource python27Packages.azure-mgmt-servicefabric python27Packages.azure-mgmt-sql python37Packages.azure-core python37Packages.azure-datalake-store python37Packages.azure-identity python37Packages.azure-keyvault python37Packages.azure-keyvault-certificates python37Packages.azure-keyvault-keys python37Packages.azure-keyvault-secrets python37Packages.azure-mgmt-authorization python37Packages.azure-mgmt-cdn python37Packages.azure-mgmt-compute python37Packages.azure-mgmt-core python37Packages.azure-mgmt-cosmosdb python37Packages.azure-mgmt-datafactory python37Packages.azure-mgmt-hdinsight python37Packages.azure-mgmt-kusto python37Packages.azure-mgmt-netapp python37Packages.azure-mgmt-resource python37Packages.azure-mgmt-servicefabric python37Packages.azure-mgmt-sql python37Packages.azure-multiapi-storage python37Packages.azure-storage-file-share python38Packages.azure-core python38Packages.azure-datalake-store python38Packages.azure-keyvault python38Packages.azure-keyvault-certificates python38Packages.azure-keyvault-keys python38Packages.azure-keyvault-secrets python38Packages.azure-mgmt-authorization python38Packages.azure-mgmt-cdn python38Packages.azure-mgmt-compute python38Packages.azure-mgmt-core python38Packages.azure-mgmt-cosmosdb python38Packages.azure-mgmt-datafactory python38Packages.azure-mgmt-hdinsight python38Packages.azure-mgmt-kusto python38Packages.azure-mgmt-netapp python38Packages.azure-mgmt-resource python38Packages.azure-mgmt-servicefabric python38Packages.azure-mgmt-sql python38Packages.azure-multiapi-storage python38Packages.azure-storage-file-share
```