### PR TITLE
python3Packages.elementpath: 1.4.6 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/elementpath/default.nix
+++ b/pkgs/development/python-modules/elementpath/default.nix
@@ -1,7 +1,7 @@
 { lib, buildPythonPackage, fetchFromGitHub, isPy27 }:
 
 buildPythonPackage rec {
-  version = "1.4.6";
+  version = "2.0.0";
   pname = "elementpath";
   disabled = isPy27; # uses incompatible class syntax
 
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     owner = "sissaschool";
     repo = "elementpath";
     rev = "v${version}";
-    sha256 = "0prrqyiw9s9wf91s4f0vhqb9babs43aq24naa66qlirskdm87pav";
+    sha256 = "16kfbiy87qjl07y3iin8jdjhz8j28wlwnkwxq9a0752ipjjg869p";
   };
 
   # avoid circular dependency with xmlschema which directly depends on this

--- a/pkgs/development/python-modules/xmlschema/default.nix
+++ b/pkgs/development/python-modules/xmlschema/default.nix
@@ -5,14 +5,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.2.2";
+  version = "1.2.3";
   pname = "xmlschema";
 
   src = fetchFromGitHub {
     owner = "sissaschool";
     repo = "xmlschema";
     rev = "v${version}";
-    sha256 = "04rlcm5777cv7aw9mf0z1xrj8cn2rljfzs9i2za6sdk6h1ngpj3q";
+    sha256 = "1lasi84d5v66xpd40fbj3lqwc5hfh3izxrr2wbfdbj4a3m996zc9";
   };
 
   propagatedBuildInputs = [ elementpath ];
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "elementpath~=1.4.0" "elementpath~=1.4"
+      --replace "elementpath~=2.0.0" "elementpath~=2.0"
   '';
 
   # Ignore broken fixtures, and tests for files which don't exist.


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/95529
8 packages built:
python37Packages.elementpath python37Packages.fints python37Packages.sepaxml python37Packages.xmlschema python38Packages.elementpath python38Packages.fints python38Packages.sepaxml python38Packages.xmlschema
```