### PR TITLE
python3Packages.portalocker: 1.7.0 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/portalocker/default.nix
+++ b/pkgs/development/python-modules/portalocker/default.nix
@@ -6,23 +6,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.7.0";
+  version = "2.0.0";
   pname = "portalocker";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1p32v16va780mjjdbyp3v702aqg5s618khlila7bdyynis1n84q9";
+    sha256 = "1r165ll4gnsbgvf9cgdkbg04526aqwllwa7hxlkl34dah7npwj0l";
   };
-
-  patches = [
-    # remove pytest-flakes from test dependencies
-    # merged into master, remove > 1.7.0 release
-    (fetchpatch {
-      url = "https://github.com/WoLpH/portalocker/commit/42e4c0a16bbc987c7e33b5cbc7676a63a164ceb5.patch";
-      sha256 = "01mlr41nhh7mh3qhqy5fhp3br4nps745iy4ns9fjcnm5xhabg5rr";
-      excludes = [ "pytest.ini" ];
-    })
-  ];
 
   checkInputs = [
     sphinx


### PR DESCRIPTION

###### Motivation for this change
noticed it was out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
