### PR TITLE
openrct2: 0.2.6 -> 0.3.0

### DIFF
--- a/pkgs/games/openrct2/default.nix
+++ b/pkgs/games/openrct2/default.nix
@@ -1,23 +1,23 @@
-{ stdenv, fetchFromGitHub,
-  SDL2, cmake, curl, fontconfig, freetype, icu, jansson, libiconv, libpng,
-  libpthreadstubs, libzip, libGLU, openssl, pkgconfig, speexdsp, zlib
+{ stdenv, fetchFromGitHub
+, SDL2, cmake, curl, duktape, fontconfig, freetype, icu, jansson, libGLU
+, libiconv, libpng, libpthreadstubs, libzip, openssl, pkgconfig, speexdsp, zlib
 }:
 
 let
-  version = "0.2.6";
+  version = "0.3.0";
 
   openrct2-src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "OpenRCT2";
     rev = "v${version}";
-    sha256 = "1vikbkg3wh5ngzdfilb6irbh6nqinf138qpdz8wz9izlvl8s36k4";
+    sha256 = "0xs8pnn3lq30iy76pv42hywsrabapcrrkl597dhjafwh1xaxxj91";
   };
 
   objects-src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "objects";
-    rev = "v1.0.14";
-    sha256 = "1bqbia5y73v4r0sv5cvi5729jh2ns7cxn557blh715yxswk91590";
+    rev = "v1.0.16";
+    sha256 = "1xz50ghiqj9rm0m6d65j09ich6dlhyj36zah6zvmmzr4kg6svnk5";
   };
 
   title-sequences-src = fetchFromGitHub {
@@ -41,15 +41,16 @@ stdenv.mkDerivation {
   buildInputs = [
     SDL2
     curl
+    duktape
     fontconfig
     freetype
     icu
     jansson
+    libGLU
     libiconv
     libpng
     libpthreadstubs
     libzip
-    libGLU
     openssl
     speexdsp
     zlib
@@ -57,7 +58,7 @@ stdenv.mkDerivation {
 
   postUnpack = ''
     cp -r ${objects-src}         $sourceRoot/data/object
-    cp -r ${title-sequences-src} $sourceRoot/data/title
+    cp -r ${title-sequences-src} $sourceRoot/data/sequence
   '';
 
   cmakeFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update OpenRCT2 to its latest, just released version [0.3.0](https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.3.0).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
