### PR TITLE
mkDerivation: Introduce .inputDerivation for shell.nix build convenience

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -337,6 +337,32 @@ in rec {
         validity.handled
         ({
            overrideAttrs = f: mkDerivation (attrs // (f attrs));
+
+           # A derivation that always builds successfully and whose runtime
+           # dependencies are the original derivations build time dependencies
+           # This allows easy building and distributing of all derivations
+           # needed to enter a nix-shell with
+           #   nix-build shell.nix -A inputDerivation
+           inputDerivation = derivation (derivationArg // {
+             # Add a name in case the original drv didn't have one
+             name = derivationArg.name or "inputDerivation";
+             # This always only has one output
+             outputs = [ "out" ];
+
+             # Propagate the original builder and arguments, since we override
+             # them and they might contain references to build inputs
+             _derivation_original_builder = derivationArg.builder;
+             _derivation_original_args = derivationArg.args;
+
+             builder = stdenv.shell;
+             # The bash builtin `export` dumps all current environment variables,
+             # which is where all build input references end up (e.g. $PATH for
+             # binaries). By writing this to $out, Nix can find and register
+             # them as runtime dependencies (since Nix greps for store paths
+             # through $out to find them)
+             args = [ "-c" "export > $out" ];
+           });
+
            inherit meta passthru;
          } //
          # Pass through extra attributes that are not inputs, but


### PR DESCRIPTION
This allows easy building and distributing of all derivations needed to
enter a nix-shell with

    nix-build shell.nix -A inputDerivation

Or with cachix:

    nix-build shell.nix -A inputDerivation | cachix push $name

In more technical terms: This introduces the `.inputDerivation` attribute on all derivations created with `mkDerivation`. This is another derivation that can always build successfully and whose runtime dependencies are the build time dependencies of the original derivation.

### Motivation for this change
The recent blog post by @fzakaria (https://fzakaria.com/2020/08/11/caching-your-nix-shell.html) mentions:

> **tl;dr;** you can use the following invocation to cache your *nix-shell*
>
>     $ nix-store --query --references $(nix-instantiate shell.nix) | \
>        xargs nix-store --realise | \
>        xargs nix-store --query --requisites | \
>        cachix push your_cache

However after testing this I noticed that this caches more than needed due to multiple outputs not being handled separately. Since I had such an `inputDerivation` in the repo, I was able to compare it directly: Above command resulted in 653 paths, whereas `inputDerivation` only needed 475.

So I'm now upstreaming this such that it can be used by everybody. During my couple years in the #nixos IRC channel this kind of functionality was requested more than once, and with this PR there's finally a good builtin solution for it.

Ping @grahamc who once shared an original version of this
Ping @Ericson2314 @matthewbauer as people who are often involved with `make-derivation.nix`

And ping @zupo from [Niteo](https://niteo.co/), who sponsored this PR :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
