### PR TITLE
sigil: 0.9.14 -> 1.3.0, addressing CVE-2019-14452

### DIFF
--- a/pkgs/applications/editors/sigil/default.nix
+++ b/pkgs/applications/editors/sigil/default.nix
@@ -1,18 +1,18 @@
 { stdenv, mkDerivation, fetchFromGitHub, cmake, pkgconfig, makeWrapper
-, boost, xercesc
-, qtbase, qttools, qtwebkit, qtxmlpatterns
-, python3, python3Packages
+, boost, xercesc, hunspell, zlib, pcre16
+, qtbase, qttools, qtwebengine, qtxmlpatterns
+, python3Packages
 }:
 
 mkDerivation rec {
   pname = "sigil";
-  version = "0.9.14";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
-    sha256 = "0fmfbfpnmhclbbv9cbr1xnv97si6ls7331kk3ix114iqkngqwgl1";
-    rev = version;
     repo = "Sigil";
     owner = "Sigil-Ebook";
+    rev = version;
+    sha256 = "02bkyi9xpaxdcivm075y3praxgvfay9z0189gvr6g8yc3ml1miyr";
   };
 
   pythonPath = with python3Packages; [ lxml ];
@@ -20,8 +20,9 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
 
   buildInputs = [
-    boost xercesc qtbase qttools qtwebkit qtxmlpatterns
-    python3Packages.lxml ];
+    boost xercesc qtbase qttools qtwebengine qtxmlpatterns
+    python3Packages.lxml
+  ];
 
   dontWrapQtApps = true;
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-14452

Bumped this to latest version. Package still needs some proper maintenance love e.g. elimination of vendored libs using `USE_SYSTEM_LIBS` (currently this causes an error involving `minizip` and `crypto.h`. This will have to do for now. Seems to work for me, non-nixos linux x86_64.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
