### PR TITLE
python3Packages.web: 0.51 -> 0.61, fix build

### DIFF
--- a/pkgs/development/python-modules/web/default.nix
+++ b/pkgs/development/python-modules/web/default.nix
@@ -1,18 +1,19 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
-, isPy3k
+, cheroot
 }:
 
 buildPythonPackage rec {
-  version = "0.51";
+  version = "0.61";
   pname = "web.py";
-  disabled = isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b50343941360984d37270186453bb897d13630028a739394fedf38f9cde2fd07";
+    sha256 = "1fycbq5v16sdcp3yw9az68fqs63mxr3klmf70gkx6v08xcd0iaf7";
   };
+
+  propagatedBuildInputs = [ cheroot ];
 
   meta = with stdenv.lib; {
     description = "Makes web apps";


### PR DESCRIPTION
###### Motivation for this change
This would fix the build, if `cheroot` was about to build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
