### PR TITLE
buildGo{Module,Package}: remove platform.all from packages

### DIFF
--- a/pkgs/applications/graphics/pdfcpu/default.nix
+++ b/pkgs/applications/graphics/pdfcpu/default.nix
@@ -22,6 +22,5 @@ buildGoModule rec {
     homepage = "https://pdfcpu.io";
     license = licenses.asl20;
     maintainers = with maintainers; [ doronbehar ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/graphics/yeetgif/default.nix
+++ b/pkgs/applications/graphics/yeetgif/default.nix
@@ -18,6 +18,5 @@ buildGoPackage rec {
     homepage = "https://github.com/sgreben/yeetgif";
     license = with licenses; [ mit asl20 cc-by-nc-sa-40 ];
     maintainers = with maintainers; [ ajs124 ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/misc/archiver/default.nix
+++ b/pkgs/applications/misc/archiver/default.nix
@@ -23,6 +23,5 @@ buildGoModule rec {
     homepage = "https://github.com/mholt/archiver";
     license = licenses.mit;
     maintainers = with maintainers; [ kalbasit ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/misc/geoipupdate/default.nix
+++ b/pkgs/applications/misc/geoipupdate/default.nix
@@ -19,7 +19,6 @@ buildGoModule rec {
     description = "Automatic GeoIP database updater";
     homepage = "https://github.com/maxmind/geoipupdate";
     license = with licenses; [ asl20 ];
-    platforms = platforms.all;
     maintainers = with maintainers; [ das_j ];
   };
 }

--- a/pkgs/applications/misc/mop/default.nix
+++ b/pkgs/applications/misc/mop/default.nix
@@ -26,6 +26,5 @@ buildGoPackage rec {
     description = "Simple stock tracker implemented in go";
     homepage =  "https://github.com/mop-tracker/mop";
     license = licenses.mit;
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/misc/remarkable/rmapi/default.nix
+++ b/pkgs/applications/misc/remarkable/rmapi/default.nix
@@ -21,6 +21,5 @@ buildGoModule rec {
     changelog = "https://github.com/juruen/rmapi/blob/v${version}/CHANGELOG.md";
     license = licenses.agpl3;
     maintainers = [ maintainers.nickhu ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/misc/syncthing-tray/default.nix
+++ b/pkgs/applications/misc/syncthing-tray/default.nix
@@ -23,6 +23,5 @@ buildGoPackage rec {
     homepage = "https://github.com/alex2108/syncthing-tray";
     license = licenses.mit;
     maintainers = with maintainers; [ nickhu ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/misc/terminal-parrot/default.nix
+++ b/pkgs/applications/misc/terminal-parrot/default.nix
@@ -19,7 +19,6 @@ buildGoModule rec {
     description = "Shows colorful, animated party parrot in your terminial";
     homepage = "https://github.com/jmhobbs/terminal-parrot";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = [ maintainers.heel ];
   };
 }

--- a/pkgs/applications/networking/browsers/captive-browser/default.nix
+++ b/pkgs/applications/networking/browsers/captive-browser/default.nix
@@ -16,7 +16,6 @@ buildGoPackage rec {
     description = "Dedicated Chrome instance to log into captive portals without messing with DNS settings";
     homepage = "https://blog.filippo.io/captive-browser";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = with maintainers; [ volth ];
   };
 }

--- a/pkgs/applications/networking/cluster/atlantis/default.nix
+++ b/pkgs/applications/networking/cluster/atlantis/default.nix
@@ -20,7 +20,6 @@ buildGoModule rec {
   meta = with stdenv.lib; {
     homepage = "https://github.com/runatlantis/atlantis";
     description = "Terraform Pull Request Automation";
-    platforms = platforms.all;
     license = licenses.asl20;
     maintainers = with maintainers; [ jpotier ];
   };

--- a/pkgs/applications/networking/cluster/kubeval/default.nix
+++ b/pkgs/applications/networking/cluster/kubeval/default.nix
@@ -20,6 +20,5 @@ buildGoModule rec {
     homepage = "https://github.com/instrumenta/kubeval";
     license = licenses.asl20;
     maintainers = with maintainers; [ johanot nicknovitski ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/networking/cluster/terraform-inventory/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-inventory/default.nix
@@ -21,7 +21,6 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     homepage = "https://github.com/adammck/terraform-inventory";
     description = "Terraform state to ansible inventory adapter";
-    platforms = platforms.all;
     license = licenses.mit;
     maintainers = with maintainers; [ htr ];
   };

--- a/pkgs/applications/networking/instant-messengers/ssh-chat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ssh-chat/default.nix
@@ -20,6 +20,5 @@ buildGoPackage rec {
     homepage = "https://github.com/shazow/ssh-chat";
     license = licenses.mit;
     maintainers = with maintainers; [ luc65r ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/networking/mailreaders/hasmail/default.nix
+++ b/pkgs/applications/networking/mailreaders/hasmail/default.nix
@@ -38,6 +38,5 @@ buildGoModule rec {
     homepage = "https://github.com/jonhoo/hasmail";
     license = licenses.unlicense;
     maintainers = with maintainers; [ doronbehar ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/networking/sync/rclone/default.nix
+++ b/pkgs/applications/networking/sync/rclone/default.nix
@@ -39,6 +39,5 @@ buildGoPackage rec {
     homepage = "https://rclone.org";
     license = licenses.mit;
     maintainers = with maintainers; [ danielfullmer marsam ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/version-management/git-and-tools/git-appraise/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-appraise/default.nix
@@ -18,7 +18,6 @@ buildGoPackage rec {
     description = "Distributed code review system for Git repos";
     homepage = "https://github.com/google/git-appraise";
     license = stdenv.lib.licenses.asl20;
-    platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.vdemeester ];
   };
 }

--- a/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
@@ -33,7 +33,6 @@ buildGoModule rec {
     description = "Distributed bug tracker embedded in Git";
     homepage = "https://github.com/MichaelMure/git-bug";
     license = licenses.gpl3;
-    platforms = platforms.all;
     maintainers = with maintainers; [ royneary ];
   };
 }

--- a/pkgs/applications/version-management/git-and-tools/gitin/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitin/default.nix
@@ -26,7 +26,6 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     homepage = "https://github.com/isacikgoz/gitin";
     description = "Text-based user interface for git";
-    platforms = platforms.all;
     license = licenses.bsd3;
     maintainers = with maintainers; [ kimat ];
   };

--- a/pkgs/applications/version-management/git-and-tools/lab/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/lab/default.nix
@@ -31,6 +31,5 @@ buildGoModule rec {
     homepage = "https://zaquestion.github.io/lab";
     license = licenses.cc0;
     maintainers = with maintainers; [ marsam dtzWill ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/version-management/git-sizer/default.nix
+++ b/pkgs/applications/version-management/git-sizer/default.nix
@@ -17,6 +17,5 @@ buildGoPackage rec {
     description = "Compute various size metrics for a Git repository";
     license = licenses.mit;
     maintainers = with maintainers; [ matthewbauer ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/compilers/tinygo/default.nix
+++ b/pkgs/development/compilers/tinygo/default.nix
@@ -47,6 +47,5 @@ buildGoModule rec {
     description = "Go compiler for small places";
     license = licenses.bsd3;
     maintainers = with maintainers; [ chiiruno ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/interpreters/joker/default.nix
+++ b/pkgs/development/interpreters/joker/default.nix
@@ -25,7 +25,6 @@ buildGoModule rec {
     homepage = "https://github.com/candid82/joker";
     description = "A small Clojure interpreter and linter written in Go";
     license = licenses.epl10;
-    platforms = platforms.all;
     maintainers = with maintainers; [ andrestylianos ];
   };
 }

--- a/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
@@ -24,6 +24,5 @@ buildGoPackage rec {
     homepage = "https://github.com/bazelbuild/buildtools";
     license = licenses.asl20;
     maintainers = with maintainers; [ elasticdog uri-canva marsam ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/build-managers/mage/default.nix
+++ b/pkgs/development/tools/build-managers/mage/default.nix
@@ -27,6 +27,5 @@ buildGoModule rec {
     homepage = "https://magefile.org/";
     license = licenses.asl20;
     maintainers = with maintainers; [ swdunlop ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/conftest/default.nix
+++ b/pkgs/development/tools/conftest/default.nix
@@ -25,6 +25,5 @@ buildGoModule rec {
     inherit (src.meta) homepage;
     license = licenses.asl20;
     maintainers = with maintainers; [ yurrriq ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/corgi/default.nix
+++ b/pkgs/development/tools/corgi/default.nix
@@ -23,7 +23,6 @@ buildGoPackage rec {
     '';
     homepage = "https://github.com/DrakeW/corgi";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = with maintainers; [ kalbasit ];
   };
 }

--- a/pkgs/development/tools/dep/default.nix
+++ b/pkgs/development/tools/dep/default.nix
@@ -21,7 +21,6 @@ buildGoPackage rec {
     homepage = "https://github.com/golang/dep";
     description = "Go dependency management tool";
     license = licenses.bsd3;
-    platforms = platforms.all;
     maintainers = with maintainers; [ carlsverre rvolosatovs ];
   };
 }

--- a/pkgs/development/tools/devd/default.nix
+++ b/pkgs/development/tools/devd/default.nix
@@ -17,6 +17,5 @@ buildGoPackage rec {
     homepage = "https://github.com/cortesi/devd";
     license = licenses.mit;
     maintainers = with maintainers; [ brianhicks ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/doctl/default.nix
+++ b/pkgs/development/tools/doctl/default.nix
@@ -39,7 +39,6 @@ buildGoModule rec {
     description = "A command line tool for DigitalOcean services";
     homepage = "https://github.com/digitalocean/doctl";
     license = licenses.asl20;
-    platforms = platforms.all;
     maintainers = [ maintainers.siddharthist ];
   };
 }

--- a/pkgs/development/tools/easyjson/default.nix
+++ b/pkgs/development/tools/easyjson/default.nix
@@ -20,6 +20,5 @@ buildGoPackage {
     description = "Fast JSON serializer for golang";
     license = licenses.mit;
     maintainers = with maintainers; [ chiiruno ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/gdm/default.nix
+++ b/pkgs/development/tools/gdm/default.nix
@@ -19,7 +19,6 @@ buildGoPackage rec {
     description = "Minimalist dependency manager for Go written in Go.";
     homepage = "https://github.com/sparrc/gdm";
     license = licenses.unlicense;
-    platforms = platforms.all;
     maintainers = [ maintainers.mic92 ];
   };
 }

--- a/pkgs/development/tools/gllvm/default.nix
+++ b/pkgs/development/tools/gllvm/default.nix
@@ -18,6 +18,5 @@ buildGoPackage rec {
     description = "Whole Program LLVM: wllvm ported to go";
     license = licenses.bsd3;
     maintainers = with maintainers; [ dtzWill ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/go-bindata-assetfs/default.nix
+++ b/pkgs/development/tools/go-bindata-assetfs/default.nix
@@ -16,7 +16,6 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     description = "Serve embedded files from jteeuwen/go-bindata";
     license = licenses.bsd2;
-    platforms = platforms.all;
     maintainers = with maintainers; [ avnik ];
   };
 }

--- a/pkgs/development/tools/go-bindata/default.nix
+++ b/pkgs/development/tools/go-bindata/default.nix
@@ -20,6 +20,5 @@ buildGoPackage {
     description = "A small utility which generates Go code from any file, useful for embedding binary data in a Go program";
     maintainers = with maintainers; [ cstrahan ];
     license = licenses.cc0;
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/go-junit-report/default.nix
+++ b/pkgs/development/tools/go-junit-report/default.nix
@@ -19,6 +19,5 @@ buildGoPackage rec {
     homepage    = "https://${goPackagePath}";
     maintainers = with maintainers; [ cryptix ];
     license     = licenses.mit;
-    platforms   = platforms.all;
   };
 }

--- a/pkgs/development/tools/go-task/default.nix
+++ b/pkgs/development/tools/go-task/default.nix
@@ -29,7 +29,6 @@ buildGoModule rec {
     homepage = "https://taskfile.dev/";
     description = "A task runner / simpler Make alternative written in Go";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = with maintainers; [ parasrah ];
   };
 }

--- a/pkgs/development/tools/gocode-gomod/default.nix
+++ b/pkgs/development/tools/gocode-gomod/default.nix
@@ -44,7 +44,6 @@ buildGoPackage rec {
     '';
     homepage = "https://github.com/stamblerre/gocode";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = with maintainers; [ kalbasit rvolosatovs ];
   };
 }

--- a/pkgs/development/tools/gocode/default.nix
+++ b/pkgs/development/tools/gocode/default.nix
@@ -39,7 +39,6 @@ buildGoPackage rec {
     '';
     homepage = "https://github.com/mdempsky/gocode";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = with maintainers; [ kalbasit ];
   };
 }

--- a/pkgs/development/tools/golint/default.nix
+++ b/pkgs/development/tools/golint/default.nix
@@ -25,6 +25,5 @@ buildGoPackage rec {
     description = "Linter for Go source code";
     license = licenses.bsd3;
     maintainers = with maintainers; [ jhillyerd ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/gox/default.nix
+++ b/pkgs/development/tools/gox/default.nix
@@ -16,7 +16,6 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     homepage = "https://github.com/mitchellh/gox";
     description = "A dead simple, no frills Go cross compile tool";
-    platforms = platforms.all;
     license = licenses.mpl20;
   };
 }

--- a/pkgs/development/tools/hcloud/default.nix
+++ b/pkgs/development/tools/hcloud/default.nix
@@ -30,7 +30,6 @@ buildGoModule rec {
     description = "A command-line interface for Hetzner Cloud, a provider for cloud virtual private servers";
     homepage = "https://github.com/hetznercloud/cli";
     license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.zauberpony ];
   };
 }

--- a/pkgs/development/tools/jid/default.nix
+++ b/pkgs/development/tools/jid/default.nix
@@ -19,7 +19,6 @@ buildGoPackage rec {
     description = "A command-line tool to incrementally drill down JSON";
     homepage = "https://github.com/simeji/jid";
     license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.all;
     maintainers = with stdenv.lib.maintainers; [ stesie ];
   };
 }

--- a/pkgs/development/tools/kubeprompt/default.nix
+++ b/pkgs/development/tools/kubeprompt/default.nix
@@ -27,6 +27,5 @@ buildGoModule rec {
     homepage = "https://github.com/jlesquembre/kubeprompt";
     license = licenses.epl20;
     maintainers = with maintainers; [ jlesquembre ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/modd/default.nix
+++ b/pkgs/development/tools/modd/default.nix
@@ -17,6 +17,5 @@ buildGoPackage rec {
     homepage = "https://github.com/cortesi/modd";
     license = licenses.mit;
     maintainers = with maintainers; [ kierdavis ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/open-policy-agent/default.nix
+++ b/pkgs/development/tools/open-policy-agent/default.nix
@@ -23,6 +23,5 @@ buildGoPackage rec {
     homepage = "https://www.openpolicyagent.org";
     license = licenses.asl20;
     maintainers = with maintainers; [ lewo ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/packet-cli/default.nix
+++ b/pkgs/development/tools/packet-cli/default.nix
@@ -24,6 +24,5 @@ buildGoModule rec {
     homepage = "https://github.com/packethost/packet-cli";
     license = licenses.mit;
     maintainers = with maintainers; [ filalex77 ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/quicktemplate/default.nix
+++ b/pkgs/development/tools/quicktemplate/default.nix
@@ -20,6 +20,5 @@ buildGoPackage {
     description = "Fast, powerful, yet easy to use template engine for Go";
     license = licenses.mit;
     maintainers = with maintainers; [ chiiruno ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/statik/default.nix
+++ b/pkgs/development/tools/statik/default.nix
@@ -20,6 +20,5 @@ buildGoPackage {
     description = "Embed files into a Go executable ";
     license = licenses.asl20;
     maintainers = with maintainers; [ chiiruno ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/tychus/default.nix
+++ b/pkgs/development/tools/tychus/default.nix
@@ -23,6 +23,5 @@ buildGoPackage rec {
     description = "Command line utility to live-reload your application.";
     homepage = "https://github.com/devlocker/tychus";
     license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/tools/vend/default.nix
+++ b/pkgs/development/tools/vend/default.nix
@@ -23,6 +23,5 @@ buildGoModule {
     description = "A utility which vendors go code including c dependencies";
     maintainers = with maintainers; [ c00w ];
     license = licenses.mit;
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/vultr/default.nix
+++ b/pkgs/development/tools/vultr/default.nix
@@ -16,7 +16,6 @@ buildGoPackage rec {
     description = "A command line tool for Vultr services, a provider for cloud virtual private servers";
     homepage = "https://github.com/JamesClonk/vultr";
     license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.zauberpony ];
   };
 }

--- a/pkgs/development/tools/yj/default.nix
+++ b/pkgs/development/tools/yj/default.nix
@@ -20,7 +20,6 @@ buildGoPackage rec {
     description = ''Convert YAML <=> TOML <=> JSON <=> HCL'';
     license = licenses.asl20;
     maintainers = with maintainers; [ Profpatsch ];
-    platforms = platforms.all;
     downloadPage = "https://github.com/sclevine/yj";
     updateWalker = true;
     inherit version;

--- a/pkgs/development/web/shopify-themekit/default.nix
+++ b/pkgs/development/web/shopify-themekit/default.nix
@@ -20,6 +20,5 @@ buildGoPackage rec {
     homepage = "https://shopify.github.io/themekit/";
     license = licenses.mit;
     maintainers = with maintainers; [ maintainers."1000101" ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/dns/ncdns/default.nix
+++ b/pkgs/servers/dns/ncdns/default.nix
@@ -32,7 +32,6 @@ buildGoPackage rec {
     description = "Namecoin to DNS bridge daemon";
     homepage = "https://github.com/namecoin/ncdns";
     license = licenses.gpl3Plus;
-    platforms = platforms.all;
     maintainers = with maintainers; [ rnhmjoj ];
   };
 

--- a/pkgs/servers/gortr/default.nix
+++ b/pkgs/servers/gortr/default.nix
@@ -19,6 +19,5 @@ buildGoModule rec {
     homepage = "https://github.com/cloudflare/gortr/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ petabyteboy ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/gotify/default.nix
+++ b/pkgs/servers/gotify/default.nix
@@ -57,7 +57,6 @@ buildGoModule rec {
     homepage = "https://gotify.net";
     license = licenses.mit;
     maintainers = with maintainers; [ doronbehar ];
-    platforms = platforms.all;
   };
 
 }

--- a/pkgs/servers/hydron/default.nix
+++ b/pkgs/servers/hydron/default.nix
@@ -25,6 +25,5 @@ buildGoPackage {
     description = "High performance media tagger and organizer";
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ chiiruno ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/meguca/default.nix
+++ b/pkgs/servers/meguca/default.nix
@@ -45,7 +45,6 @@ buildGoPackage {
     description = "High performance anonymous realtime imageboard";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ chiiruno ];
-    platforms = platforms.all;
     broken = true; # Broken on Hydra since 2019-04-18:
     # https://hydra.nixos.org/build/98885902
   };

--- a/pkgs/servers/monitoring/alertmanager-bot/default.nix
+++ b/pkgs/servers/monitoring/alertmanager-bot/default.nix
@@ -19,7 +19,6 @@ buildGoPackage rec {
     description = "Bot for Prometheus' Alertmanager";
     homepage = "https://github.com/metalmatze/alertmanager-bot";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = with maintainers; [ mmahut ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/apcupsd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/apcupsd-exporter.nix
@@ -22,6 +22,5 @@ buildGoModule rec {
     homepage = "https://github.com/mdlayher/apcupsd_exporter";
     license = licenses.mit;
     maintainers = with maintainers; [ maintainers."1000101" mdlayher ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/aws-s3-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/aws-s3-exporter.nix
@@ -22,6 +22,5 @@ buildGoPackage rec {
     homepage = "https://github.com/ribbybibby/s3_exporter";
     license = licenses.asl20;
     maintainers = [ maintainers.mmahut ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/gitlab-ci-pipelines-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/gitlab-ci-pipelines-exporter.nix
@@ -22,6 +22,5 @@ buildGoPackage rec {
     homepage = "https://github.com/mvisonneau/gitlab-ci-pipelines-exporter";
     license = licenses.asl20;
     maintainers = [ maintainers.mmahut ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/nginxlog-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/nginxlog-exporter.nix
@@ -22,6 +22,5 @@ buildGoPackage rec {
     homepage = "https://github.com/martin-helmich/prometheus-nginxlog-exporter";
     license = licenses.asl20;
     maintainers = with maintainers; [ mmahut ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/nats-server/default.nix
+++ b/pkgs/servers/nats-server/default.nix
@@ -20,6 +20,5 @@ buildGoPackage rec {
     license = licenses.asl20;
     maintainers = [ maintainers.swdunlop ];
     homepage = "https://nats.io/";
-    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/nats-streaming-server/default.nix
+++ b/pkgs/servers/nats-streaming-server/default.nix
@@ -19,6 +19,5 @@ buildGoPackage rec {
     license = licenses.asl20;
     maintainers = [ maintainers.swdunlop ];
     homepage = "https://nats.io/";
-    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/trickster/trickster.nix
+++ b/pkgs/servers/trickster/trickster.nix
@@ -22,6 +22,5 @@ buildGoPackage rec {
     homepage = "https://github.com/Comcast/trickster";
     license = licenses.asl20;
     maintainers = with maintainers; [ maintainers."1000101" ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/admin/eksctl/default.nix
+++ b/pkgs/tools/admin/eksctl/default.nix
@@ -36,7 +36,6 @@ buildGoModule rec {
     description = "A CLI for Amazon EKS";
     homepage = "https://github.com/weaveworks/eksctl";
     license = licenses.asl20;
-    platforms = platforms.all;
     maintainers = with maintainers; [ xrelkd ];
   };
 }

--- a/pkgs/tools/admin/scaleway-cli/default.nix
+++ b/pkgs/tools/admin/scaleway-cli/default.nix
@@ -18,6 +18,5 @@ buildGoPackage rec {
     homepage = "https://github.com/scaleway/scaleway-cli";
     license = licenses.mit;
     maintainers = with maintainers; [ nickhu ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/backup/diskrsync/default.nix
+++ b/pkgs/tools/backup/diskrsync/default.nix
@@ -24,7 +24,6 @@ buildGoPackage rec {
     description = "Rsync for block devices and disk images";
     homepage = "https://github.com/dop251/diskrsync";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = with maintainers; [ jluttine ];
   };
 

--- a/pkgs/tools/backup/kopia/default.nix
+++ b/pkgs/tools/backup/kopia/default.nix
@@ -31,7 +31,6 @@ buildGoModule rec {
   meta = with lib; {
     homepage = "https://kopia.io";
     description = "Cross-platform backup tool with fast, incremental backups, client-side end-to-end encryption, compression and data deduplication";
-    platforms = platforms.all;
     license = licenses.asl20;
     maintainers = [ maintainers.bbigras ];
   };

--- a/pkgs/tools/misc/chezmoi/default.nix
+++ b/pkgs/tools/misc/chezmoi/default.nix
@@ -34,6 +34,5 @@ buildGoModule rec {
     description = "Manage your dotfiles across multiple machines, securely";
     license = licenses.mit;
     maintainers = with maintainers; [ jhillyerd ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/misc/cloud-sql-proxy/default.nix
+++ b/pkgs/tools/misc/cloud-sql-proxy/default.nix
@@ -23,6 +23,5 @@ buildGoPackage rec {
     homepage = "https://${goPackagePath}";
     license = licenses.asl20;
     maintainers = [ maintainers.nicknovitski ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/misc/dashing/default.nix
+++ b/pkgs/tools/misc/dashing/default.nix
@@ -22,6 +22,5 @@ buildGoPackage rec {
     homepage    = "https://github.com/technosophos/dashing";
     license     = licenses.mit;
     maintainers = [ ];
-    platforms   = platforms.all;
   };
 }

--- a/pkgs/tools/misc/envsubst/default.nix
+++ b/pkgs/tools/misc/envsubst/default.nix
@@ -16,7 +16,6 @@ buildGoPackage rec {
     description = "Environment variables substitution for Go";
     homepage = "https://github.com/a8m/envsubst";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = with maintainers; [ nicknovitski ];
   };
 }

--- a/pkgs/tools/misc/libgen-cli/default.nix
+++ b/pkgs/tools/misc/libgen-cli/default.nix
@@ -35,7 +35,6 @@ buildGoModule rec {
       contents.
     '';
     license = licenses.asl20;
-    platforms = platforms.all;
     maintainers = with maintainers; [ zaninime ];
   };
 }

--- a/pkgs/tools/misc/lnch/default.nix
+++ b/pkgs/tools/misc/lnch/default.nix
@@ -16,7 +16,6 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     homepage = "https://github.com/oem/lnch";
     description = "A small go app that launches a process and moves it out of the process group";
-    platforms = platforms.all;
     license = licenses.publicDomain; # really I don't know
   };
 }

--- a/pkgs/tools/misc/mmake/default.nix
+++ b/pkgs/tools/misc/mmake/default.nix
@@ -25,7 +25,6 @@ buildGoPackage rec {
       pass-through to standard make.
       '';
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = [ maintainers.gabesoft ];
   };
 }

--- a/pkgs/tools/misc/noti/default.nix
+++ b/pkgs/tools/misc/noti/default.nix
@@ -35,6 +35,5 @@ buildGoPackage rec {
     homepage = "https://github.com/variadico/noti";
     license = licenses.mit;
     maintainers = with maintainers; [ stites marsam ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/misc/phraseapp-client/default.nix
+++ b/pkgs/tools/misc/phraseapp-client/default.nix
@@ -21,7 +21,6 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     homepage = "http://docs.phraseapp.com";
     description = "PhraseApp API v2 Command Line Client";
-    platforms = platforms.all;
     license = licenses.mit;
     maintainers = with maintainers; [ manveru ];
   };

--- a/pkgs/tools/misc/systrayhelper/default.nix
+++ b/pkgs/tools/misc/systrayhelper/default.nix
@@ -36,6 +36,5 @@ buildGoPackage rec {
     license     = licenses.mit;
     # It depends on the inputs, i guess? not sure about solaris, for instance. go supports it though
     # I hope nix can figure this out?! ¯\\_(ツ)_/¯
-    platforms   = platforms.all;
   };
 }

--- a/pkgs/tools/misc/teleconsole/default.nix
+++ b/pkgs/tools/misc/teleconsole/default.nix
@@ -22,7 +22,6 @@ buildGoPackage rec {
     homepage = "https://www.teleconsole.com/";
     description = "Share your terminal session with people you trust";
     license = licenses.asl20;
-    platforms = platforms.all;
     # Builds for Aarch64 not possible in the current release due to
     # incompatibilities further up the dependency chain.
     # See:

--- a/pkgs/tools/misc/tewisay/default.nix
+++ b/pkgs/tools/misc/tewisay/default.nix
@@ -31,6 +31,5 @@ buildGoPackage rec {
     description = "Cowsay replacement with unicode and partial ansi escape support";
     license = stdenv.lib.licenses.cc0;
     maintainers = [ stdenv.lib.maintainers.chiiruno ];
-    platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/tools/misc/zabbixctl/default.nix
+++ b/pkgs/tools/misc/zabbixctl/default.nix
@@ -19,7 +19,6 @@ buildGoPackage rec {
     description = "Most effective way for operating in Zabbix Server";
     homepage = "https://github.com/kovetskiy/zabbixctl";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = with maintainers; [ mmahut ];
   };
 }

--- a/pkgs/tools/networking/clash/default.nix
+++ b/pkgs/tools/networking/clash/default.nix
@@ -25,6 +25,5 @@ buildGoModule rec {
     homepage = "https://github.com/Dreamacro/clash";
     license = licenses.gpl3;
     maintainers = with maintainers; [ contrun filalex77 ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -75,7 +75,6 @@ in buildGoPackage rec {
     '';
     homepage    = "https://www.datadoghq.com";
     license     = licenses.bsd3;
-    platforms   = platforms.all;
     maintainers = with maintainers; [ thoughtpolice domenkozar rvl ];
   };
 }

--- a/pkgs/tools/networking/dd-agent/datadog-process-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-process-agent.nix
@@ -19,7 +19,6 @@ buildGoPackage rec {
     description = "Live process collector for the DataDog Agent v6";
     homepage    = "https://www.datadoghq.com";
     license     = licenses.bsd3;
-    platforms   = platforms.all;
     maintainers = with maintainers; [ domenkozar rvl ];
   };
 }

--- a/pkgs/tools/networking/dnsproxy/default.nix
+++ b/pkgs/tools/networking/dnsproxy/default.nix
@@ -20,6 +20,5 @@ buildGoModule rec {
     homepage = "https://github.com/AdguardTeam/dnsproxy";
     license = licenses.gpl3;
     maintainers = with maintainers; [ contrun ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/networking/frp/default.nix
+++ b/pkgs/tools/networking/frp/default.nix
@@ -28,6 +28,5 @@ buildGoModule rec {
     homepage = "https://github.com/fatedier/frp";
     license = licenses.asl20;
     maintainers = with maintainers; [ filalex77 ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/networking/nebula/default.nix
+++ b/pkgs/tools/networking/nebula/default.nix
@@ -39,7 +39,6 @@ buildGoModule rec {
     homepage = "https://github.com/slackhq/nebula";
     license = licenses.mit;
     maintainers = with maintainers; [ filalex77 ];
-    platforms = platforms.all;
   };
 
 }

--- a/pkgs/tools/networking/oneshot/default.nix
+++ b/pkgs/tools/networking/oneshot/default.nix
@@ -22,6 +22,5 @@ buildGoModule rec {
     homepage = "https://github.com/raphaelreyna/oneshot";
     license = licenses.mit;
     maintainers = with maintainers; [ edibopp ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/networking/shadowfox/default.nix
+++ b/pkgs/tools/networking/shadowfox/default.nix
@@ -24,7 +24,6 @@ buildGoModule rec {
     '';
     homepage = "https://overdodactyl.github.io/ShadowFox/";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = with maintainers; [ infinisil ];
   };
 }

--- a/pkgs/tools/networking/yggdrasil/default.nix
+++ b/pkgs/tools/networking/yggdrasil/default.nix
@@ -36,7 +36,6 @@ buildGoModule rec {
       "An experiment in scalable routing as an encrypted IPv6 overlay network";
     homepage = "https://yggdrasil-network.github.io/";
     license = licenses.lgpl3;
-    platforms = platforms.all;
     maintainers = with maintainers; [ ehmry gazally lassulus ];
   };
 }

--- a/pkgs/tools/security/2fa/default.nix
+++ b/pkgs/tools/security/2fa/default.nix
@@ -16,7 +16,6 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     homepage = "https://rsc.io/2fa";
     description = "Two-factor authentication on the command line";
-    platforms = platforms.all;
     maintainers = with maintainers; [ rvolosatovs ];
     license = licenses.bsd3;
   };

--- a/pkgs/tools/security/aws-okta/default.nix
+++ b/pkgs/tools/security/aws-okta/default.nix
@@ -25,7 +25,6 @@ buildGoPackage rec {
     description = "aws-vault like tool for Okta authentication";
     license = licenses.mit;
     maintainers = [maintainers.imalsogreg];
-    platforms = platforms.all;
     homepage = "https://github.com/segmentio/aws-okta";
     downloadPage = "https://github.com/segmentio/aws-okta";
   };

--- a/pkgs/tools/security/bettercap/default.nix
+++ b/pkgs/tools/security/bettercap/default.nix
@@ -34,6 +34,5 @@ buildGoModule rec {
     homepage = "https://www.bettercap.org/";
     license = with licenses; gpl3;
     maintainers = with maintainers; [ y0no ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/security/browserpass/default.nix
+++ b/pkgs/tools/security/browserpass/default.nix
@@ -50,7 +50,6 @@ buildGoModule rec {
     description = "Browserpass native client app";
     homepage = "https://github.com/browserpass/browserpass-native";
     license = licenses.isc;
-    platforms = platforms.all;
     maintainers = with maintainers; [ rvolosatovs infinisil ];
   };
 }

--- a/pkgs/tools/security/certstrap/default.nix
+++ b/pkgs/tools/security/certstrap/default.nix
@@ -16,7 +16,6 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;
     description = "Tools to bootstrap CAs, certificate requests, and signed certificates";
-    platforms = platforms.all;
     license = licenses.asl20;
     maintainers = with maintainers; [ volth ];
   };

--- a/pkgs/tools/security/hologram/default.nix
+++ b/pkgs/tools/security/hologram/default.nix
@@ -23,7 +23,6 @@ buildGoPackage rec {
     homepage = "https://github.com/AdRoll/hologram/";
     description = "Easy, painless AWS credentials on developer laptops.";
     maintainers = with maintainers; [ nand0p ];
-    platforms = platforms.all;
     license = licenses.asl20;
   };
 }

--- a/pkgs/tools/system/jump/default.nix
+++ b/pkgs/tools/system/jump/default.nix
@@ -36,7 +36,6 @@ buildGoModule rec {
     '';
     homepage = "https://github.com/gsamokovarov/jump";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = with maintainers; [ sondr3 ];
   };
 }

--- a/pkgs/tools/text/platinum-searcher/default.nix
+++ b/pkgs/tools/text/platinum-searcher/default.nix
@@ -19,7 +19,6 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     homepage = "https://github.com/monochromegane/the_platinum_searcher";
     description = "A code search tool similar to ack and the_silver_searcher(ag).";
-    platforms = platforms.all;
     license = licenses.mit;
   };
 }

--- a/pkgs/tools/text/sift/default.nix
+++ b/pkgs/tools/text/sift/default.nix
@@ -21,6 +21,5 @@ buildGoPackage rec {
     homepage = "https://sift-tool.org";
     maintainers = [ maintainers.carlsverre ];
     license = licenses.gpl3;
-    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/virtualization/marathonctl/default.nix
+++ b/pkgs/tools/virtualization/marathonctl/default.nix
@@ -18,7 +18,6 @@ buildGoPackage {
   meta = with stdenv.lib; {
     homepage = "https://github.com/shoenig/marathonctl";
     description = "CLI tool for Marathon";
-    platforms = platforms.all;
     license = licenses.mit;
     maintainers = with maintainers; [ manveru ];
   };


### PR DESCRIPTION
`buildGo{Module,Package}` already sets `meta.platforms`.