### PR TITLE
pythonPackages.*: disable failing python2 builds

### DIFF
--- a/pkgs/development/python-modules/bip_utils/default.nix
+++ b/pkgs/development/python-modules/bip_utils/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , ecdsa
 , pysha3
 }:
@@ -8,6 +9,7 @@
 buildPythonPackage rec {
   pname = "bip_utils";
   version = "1.0.5";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/gspread/default.nix
+++ b/pkgs/development/python-modules/gspread/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , requests
+, google_auth
 }:
 
 buildPythonPackage rec {
@@ -19,6 +20,8 @@ buildPythonPackage rec {
     description = "Google Spreadsheets client library";
     homepage = "https://github.com/burnash/gspread";
     license = licenses.mit;
+    # missing multiple google libraries
+    broken = true; # 2020-08-15
   };
 
   # No tests included

--- a/pkgs/development/python-modules/mox3/default.nix
+++ b/pkgs/development/python-modules/mox3/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , python
 , subunit
 , testrepository
@@ -14,6 +15,7 @@
 buildPythonPackage rec {
   pname = "mox3";
   version = "1.1.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pymystem3/default.nix
+++ b/pkgs/development/python-modules/pymystem3/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchPypi
 , buildPythonPackage
+, isPy3k
 , requests
 , flake8
 , mock
@@ -19,6 +20,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ requests ];
   checkInputs = [ flake8 mock pytest ];
+  doCheck = isPy3k; # fails on linting
 
   postPatch = ''
     sed -i 's#^_mystem_info = .*#_mystem_info = ["${mystem}/bin", "${mystem}/bin/mystem"]#' pymystem3/constants.py

--- a/pkgs/development/python-modules/pytest-quickcheck/default.nix
+++ b/pkgs/development/python-modules/pytest-quickcheck/default.nix
@@ -15,5 +15,6 @@ buildPythonPackage rec {
     license = licenses.asl20;
     homepage = "https://pypi.python.org/pypi/pytest-quickcheck";
     description = "pytest plugin to generate random data inspired by QuickCheck";
+    broken = true; # missing pytest-codestyle
   };
 }

--- a/pkgs/development/python-modules/pytest-testmon/default.nix
+++ b/pkgs/development/python-modules/pytest-testmon/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , coverage
 , pytest
 }:
@@ -8,6 +9,7 @@
 buildPythonPackage rec {
   pname = "pytest-testmon";
   version = "1.0.2";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/python-igraph/default.nix
+++ b/pkgs/development/python-modules/python-igraph/default.nix
@@ -5,6 +5,7 @@
 buildPythonPackage rec {
   pname = "python-igraph";
   version = "0.8.2";
+  disabled = !isPy3k; # fails to build
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ igraph ];

--- a/pkgs/development/python-modules/pyvcd/default.nix
+++ b/pkgs/development/python-modules/pyvcd/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , setuptools_scm
 , six
 , pytest
@@ -9,6 +10,7 @@
 buildPythonPackage rec {
   version = "0.2.3";
   pname = "pyvcd";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/rq/default.nix
+++ b/pkgs/development/python-modules/rq/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, fetchPypi, buildPythonPackage, click, redis }:
+{ stdenv, fetchPypi, buildPythonPackage, isPy27, click, redis }:
 
 buildPythonPackage rec {
   pname = "rq";
   version = "1.4.3";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/sorl_thumbnail/default.nix
+++ b/pkgs/development/python-modules/sorl_thumbnail/default.nix
@@ -1,12 +1,14 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , setuptools_scm
 }:
 
 buildPythonPackage rec {
   pname = "sorl-thumbnail";
   version = "12.6.3";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/sphinxcontrib-applehelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-applehelp/default.nix
@@ -1,11 +1,13 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "sphinxcontrib-applehelp";
   version = "1.0.2";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/sphinxcontrib-htmlhelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-htmlhelp/default.nix
@@ -1,11 +1,13 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "sphinxcontrib-htmlhelp";
   version = "1.0.3";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
@@ -1,11 +1,13 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "sphinxcontrib-qthelp";
   version = "1.0.3";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/sphinxcontrib-serializinghtml/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-serializinghtml/default.nix
@@ -1,11 +1,13 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "sphinxcontrib-serializinghtml";
   version = "1.1.4";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/venusian/default.nix
+++ b/pkgs/development/python-modules/venusian/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , pytest
 , pytestcov
 }:
@@ -8,6 +9,7 @@
 buildPythonPackage rec {
   pname = "venusian";
   version = "3.0.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/wsproto/0.14.nix
+++ b/pkgs/development/python-modules/wsproto/0.14.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "wsproto";
-  version = "0.15.0";
+  version = "0.14.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "614798c30e5dc2b3f65acc03d2d50842b97621487350ce79a80a711229edfa9d";
+    sha256 = "051s127qb5dladxa14n9nqajwq7xki1dz1was5r5v9df5a0jq8pd";
   };
 
   propagatedBuildInputs = [ h11 enum34 ];

--- a/pkgs/development/python-modules/yappi/default.nix
+++ b/pkgs/development/python-modules/yappi/default.nix
@@ -1,8 +1,9 @@
-{ lib, buildPythonPackage, fetchPypi, nose }:
+{ lib, buildPythonPackage, fetchPypi, isPy27, nose }:
 
 buildPythonPackage rec {
   pname = "yappi";
   version = "1.2.5";
+  disabled = isPy27; # invalid syntax
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change
all of these packages no longer build on python2 (determined by upstream). Most commits have related failure message

this in preparation of ZHF, but may as well clean up master anyway

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
