### PR TITLE
meson: 0.55.0 → 0.55.1

### DIFF
--- a/pkgs/development/tools/build-managers/meson/allow-dirs-outside-of-prefix.patch
+++ b/pkgs/development/tools/build-managers/meson/allow-dirs-outside-of-prefix.patch
@@ -1,6 +1,6 @@
 --- a/mesonbuild/coredata.py
 +++ b/mesonbuild/coredata.py
-@@ -483,7 +483,6 @@ class CoreData:
+@@ -491,7 +491,6 @@ class CoreData:
              return value
          if option.endswith('dir') and value.is_absolute() and \
             option not in builtin_dir_noprefix_options:
@@ -8,7 +8,7 @@
              # commonpath will always return a path in the native format, so we
              # must use pathlib.PurePath to do the same conversion before
              # comparing.
-@@ -495,7 +494,7 @@ class CoreData:
+@@ -503,7 +502,7 @@ class CoreData:
              try:
                  value = value.relative_to(prefix)
              except ValueError:

--- a/pkgs/development/tools/build-managers/meson/clear-old-rpath.patch
+++ b/pkgs/development/tools/build-managers/meson/clear-old-rpath.patch
@@ -1,8 +1,8 @@
 diff --git a/mesonbuild/scripts/depfixer.py b/mesonbuild/scripts/depfixer.py
-index 77ac03d66..d12f77592 100644
+index 4176b9a03..faaabf616 100644
 --- a/mesonbuild/scripts/depfixer.py
 +++ b/mesonbuild/scripts/depfixer.py
-@@ -337,6 +337,15 @@ class Elf(DataSizes):
+@@ -336,6 +336,15 @@ class Elf(DataSizes):
          if not new_rpath:
              self.remove_rpath_entry(entrynum)
          else:

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -8,11 +8,11 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "meson";
-  version = "0.55.0";
+  version = "0.55.1";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "Chriv+KuFKxHWTU3+TKQ+3npt3XFW0xTwoK8PKN0WzU=";
+    sha256 = "O1dB+ITgSSi9+hlHRn/wavpsmOYjwlzvda33HKOc4IA=";
   };
 
   patches = [
@@ -58,10 +58,6 @@ python3.pkgs.buildPythonApplication rec {
   # Ensure there will always be a native C compiler when meson is used, as a
   # workaround until https://github.com/mesonbuild/meson/pull/6512 lands.
   depsHostHostPropagated = [ pkgsHostHost.stdenv.cc ];
-
-  pythonPath = [
-    python3.pkgs.setuptools # for pkg_resources
-  ];
 
   # 0.45 update enabled tests but they are failing
   doCheck = false;

--- a/pkgs/development/tools/build-managers/meson/fix-rpath.patch
+++ b/pkgs/development/tools/build-managers/meson/fix-rpath.patch
@@ -1,6 +1,6 @@
 --- a/mesonbuild/backend/backends.py
 +++ b/mesonbuild/backend/backends.py
-@@ -453,6 +453,21 @@ class Backend:
+@@ -456,6 +456,21 @@ class Backend:
                  args.extend(self.environment.coredata.get_external_link_args(target.for_machine, lang))
              except Exception:
                  pass
@@ -19,6 +19,6 @@
 +                    dirs.add(flag)
 +                next_is_path = False
 +
-         for arg in args:
-             if arg.startswith('-Wl,-rpath='):
-                 for dir in arg.replace('-Wl,-rpath=','').split(':'):
+         # Match rpath formats:
+         # -Wl,-rpath=
+         # -Wl,-rpath,

--- a/pkgs/development/tools/build-managers/meson/gir-fallback-path.patch
+++ b/pkgs/development/tools/build-managers/meson/gir-fallback-path.patch
@@ -1,8 +1,8 @@
 --- a/mesonbuild/modules/gnome.py
 +++ b/mesonbuild/modules/gnome.py
-@@ -801,6 +801,13 @@ class GnomeModule(ExtensionModule):
-             scan_command += ['--sources-top-dirs', os.path.join(state.environment.get_source_dir(), self.interpreter.subproject_dir, state.subproject)]
-             scan_command += ['--sources-top-dirs', os.path.join(state.environment.get_build_dir(), self.interpreter.subproject_dir, state.subproject)]
+@@ -807,6 +807,13 @@ class GnomeModule(ExtensionModule):
+         if fatal_warnings:
+             scan_command.append('--warn-error')
  
 +        if len(set([girtarget.get_custom_install_dir()[0] for girtarget in girtargets])) > 1:
 +            raise MesonException('generate_gir tries to build multiple libraries with different install_dir at once: {}'.format(','.join([str(girtarget) for girtarget in girtargets])))

--- a/pkgs/development/tools/build-managers/meson/more-env-vars.patch
+++ b/pkgs/development/tools/build-managers/meson/more-env-vars.patch
@@ -1,8 +1,8 @@
 diff --git a/mesonbuild/envconfig.py b/mesonbuild/envconfig.py
-index 17058df6b..7a68b7f15 100644
+index 219b62ec8..e3ceaddbd 100644
 --- a/mesonbuild/envconfig.py
 +++ b/mesonbuild/envconfig.py
-@@ -120,7 +120,7 @@ def get_env_var_pair(for_machine: MachineChoice,
+@@ -94,7 +94,7 @@ def get_env_var_pair(for_machine: MachineChoice,
          # compiling we fall back on the unprefixed host version. This
          # allows native builds to never need to worry about the 'BUILD_*'
          # ones.


### PR DESCRIPTION
###### Motivation for this change
https://github.com/mesonbuild/meson/compare/0.55.0...0.55.1

setuptools have been removed from runtime dependencies:
https://github.com/mesonbuild/meson/pull/7461

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] built systemd
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
