### PR TITLE
gpac: 0.8.0 -> 1.0.0 addressing numerous CVEs

### DIFF
--- a/pkgs/applications/video/gpac/default.nix
+++ b/pkgs/applications/video/gpac/default.nix
@@ -1,15 +1,19 @@
 { stdenv, fetchFromGitHub, pkgconfig, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.8.0";
+  version = "1.0.0";
   pname = "gpac";
 
   src = fetchFromGitHub {
     owner = "gpac";
     repo = "gpac";
     rev = "v${version}";
-    sha256 = "1w1dyrn6900yi8ngchfzy5hvxr6yc60blvdq8y8mczimmmq8khb5";
+    sha256 = "11jrklaahhdfqhci7f3lzv8wchh9bc91rg6w8ibh6varrk692vsb";
   };
+
+  postPatch = ''
+    substituteInPlace Makefile --replace 'dh_link' 'ln -s'
+  '';
 
   # this is the bare minimum configuration, as I'm only interested in MP4Box
   # For most other functionality, this should probably be extended


### PR DESCRIPTION
###### Motivation for this change
Addresses:

CVE-2019-20159
CVE-2019-20160
CVE-2019-20161
CVE-2019-20162
CVE-2019-20163
CVE-2019-20164
CVE-2019-20165
CVE-2019-20166
CVE-2019-20167
CVE-2019-20168
CVE-2019-20169
CVE-2019-20170
CVE-2019-20171
CVE-2019-20208
CVE-2020-11558
CVE-2020-6630
CVE-2020-6631

of mixed severity but at least a couple of them look pretty serious.

For each of these vulnerabilities, the trail leads to a commit included in 1.0.0.

Hopefully we could get a maintainer (@bluescreen303 ? @mgdelacroix ?) to take a look at this because I don't really know how to test it. The executables behave in a very similar (odd) way to the binaries in the previous 0.8.0 package, anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
