### PR TITLE
pythonPackages.Nikola: fix tests

### DIFF
--- a/pkgs/development/python-modules/Nikola/default.nix
+++ b/pkgs/development/python-modules/Nikola/default.nix
@@ -57,14 +57,11 @@ buildPythonPackage rec {
     sha256 = "2e5c8305ec4423b56af2223336c3309e5c9b8c96df0d6fde46d26cff4c5d6f1a";
   };
 
-  patchPhase = ''
-    # upstream added bound so that requires.io doesn't send mails about update
-    # nikola should work with markdown 3.0: https://github.com/getnikola/nikola/pull/3175#issue-220147596
-    sed -i 's/Markdown>.*/Markdown/' requirements.txt
-  '';
+  # Remove this patch when upgrading to Nikola>=8.1.0
+  patches = [ ./fix_markdown_test.patch ];
 
   checkPhase = ''
-    LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8" py.test .
+    LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8" py.test tests/
   '';
 
   meta = {

--- a/pkgs/development/python-modules/Nikola/fix_markdown_test.patch
+++ b/pkgs/development/python-modules/Nikola/fix_markdown_test.patch
@@ -1,0 +1,25 @@
+From 226e8a726e85525fb22664d9d76f4fe1729cf51d Mon Sep 17 00:00:00 2001
+From: Chris Warrick <kwpolska@gmail.com>
+Date: Fri, 7 Feb 2020 18:00:04 +0100
+Subject: [PATCH] Update tests for Markdown==3.2 output change
+
+This minor change does not affect the appearance of Nikola's output.
+---
+ tests/test_compile_markdown.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/test_compile_markdown.py b/tests/test_compile_markdown.py
+index 4d0e3d89c..88ac290d0 100644
+--- a/tests/test_compile_markdown.py
++++ b/tests/test_compile_markdown.py
+@@ -31,8 +31,8 @@
+ <table class="codehilitetable"><tr><td class="linenos">\
+ <div class="linenodiv"><pre>1</pre></div>\
+ </td><td class="code"><pre class="code literal-block"><span></span>\
+-<span class="kn">from</span> <span class="nn">this</span>
+-</pre>
++<code><span class="kn">from</span> <span class="nn">this</span>
++</code></pre>
+ </td></tr></table>
+ """,
+             id="hilite",


### PR DESCRIPTION
- Use `pytest tests/` instead of `pytest .` to fix a relative import error
- Apply a patch to fix markdown compilation tests
- Remove a patch to requirements.txt not needed anymore

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The build of Nikola was failing.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).