### PR TITLE
buildRustPackage: add darwin Security to buildInputs

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -8,6 +8,7 @@
 , rust
 , rustc
 , windows
+, darwin
 }:
 
 { name ? "${args.pname}-${args.version}"
@@ -89,7 +90,9 @@ stdenv.mkDerivation (args // {
   patchRegistryDeps = ./patch-registry-deps;
 
   nativeBuildInputs = nativeBuildInputs ++ [ cacert git cargo rustc ];
-  buildInputs = buildInputs ++ stdenv.lib.optional stdenv.hostPlatform.isMinGW windows.pthreads;
+  buildInputs = buildInputs
+  ++ stdenv.lib.optional stdenv.hostPlatform.isMinGW windows.pthreads
+  ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Security;
 
   patches = cargoPatches ++ patches;
 

--- a/pkgs/tools/misc/shadowenv/default.nix
+++ b/pkgs/tools/misc/shadowenv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform, installShellFiles, Security }:
+{ stdenv, fetchFromGitHub, rustPlatform, installShellFiles }:
 
 rustPlatform.buildRustPackage rec {
   pname = "shadowenv";
@@ -14,8 +14,6 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "1bjkwn57vm3in8lajhm7p9fjwyqhmkrb3fyq1k7lqjvrrh9jysb2";
 
   nativeBuildInputs = [ installShellFiles ];
-
-  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
 
   postInstall = ''
     installManPage man/man1/shadowenv.1

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11251,9 +11251,7 @@ in
 
   scss-lint = callPackage ../development/tools/scss-lint { };
 
-  shadowenv = callPackage ../tools/misc/shadowenv {
-    inherit (darwin.apple_sdk.frameworks) Security;
-  };
+  shadowenv = callPackage ../tools/misc/shadowenv { };
 
   shake = haskell.lib.justStaticExecutables haskellPackages.shake;
 


### PR DESCRIPTION
Same as https://github.com/NixOS/nixpkgs/pull/83472 for rust.

cc @Mic92 I'm not sure if this is the most correct way of doing this?

Starting with `Security` as it is the most commonly needed with `buildRustPackage`.