### PR TITLE
eolie: 0.9.63 -> 0.9.99, fix build

### DIFF
--- a/pkgs/applications/networking/browsers/eolie/default.nix
+++ b/pkgs/applications/networking/browsers/eolie/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchgit, meson, ninja, pkgconfig, nix-update-script
-, python3, gtk3, libsecret, gst_all_1, webkitgtk
+, python3, gtk3, libsecret, gst_all_1, webkitgtk, glib
 , glib-networking, gtkspell3, hunspell, desktop-file-utils
-, gobject-introspection, wrapGAppsHook }:
+, gobject-introspection, wrapGAppsHook, gnome3 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "eolie";
-  version = "0.9.63";
+  version = "0.9.99";
 
   format = "other";
   doCheck = false;
@@ -14,7 +14,7 @@ python3.pkgs.buildPythonApplication rec {
     url = "https://gitlab.gnome.org/World/eolie";
     rev = "refs/tags/${version}";
     fetchSubmodules = true;
-    sha256 = "0z8gcfg7i842rr5p8r3vqa31kf7nnj1yv3afax3jzf4zbnhb8wm0";
+    sha256 = "077jww5mqg6bbqbj0j1gss2j3dxlfr2xw8bc43k8vg52drqg6g8w";
   };
 
   nativeBuildInputs = [
@@ -33,18 +33,23 @@ python3.pkgs.buildPythonApplication rec {
     gst-plugins-base
     gst-plugins-ugly
     gstreamer
+    gnome3.gnome-settings-daemon
     gtk3
     gtkspell3
     hunspell
     libsecret
     webkitgtk
+    glib
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
+    pyfxa
     beautifulsoup4
+    cryptography
     pycairo
     pygobject3
     python-dateutil
+    pycrypto
   ];
 
   postPatch = ''
@@ -52,9 +57,11 @@ python3.pkgs.buildPythonApplication rec {
     patchShebangs meson_post_install.py
   '';
 
+  dontWrapGApps = true;
   preFixup = ''
     buildPythonPath "$out $propagatedBuildInputs"
     patchPythonScript "$out/libexec/eolie-sp"
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
   passthru = {
@@ -63,6 +70,7 @@ python3.pkgs.buildPythonApplication rec {
     };
   };
 
+  strictDeps = false;
 
   meta = with stdenv.lib; {
     description = "A new GNOME web browser";

--- a/pkgs/applications/networking/browsers/eolie/default.nix
+++ b/pkgs/applications/networking/browsers/eolie/default.nix
@@ -38,7 +38,7 @@ python3.pkgs.buildPythonApplication rec {
     gtkspell3
     hunspell
     libsecret
-    webkitgtk
+    (webkitgtk.override {enableGLES = false;})
     glib
   ];
 

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -43,6 +43,7 @@
 , sqlite
 , enableGtk2Plugins ? false
 , gtk2 ? null
+, enableGLES ? true
 , gst-plugins-base
 , gst-plugins-bad
 , woff2
@@ -167,7 +168,7 @@ stdenv.mkDerivation rec {
     "-DUSE_ACCELERATE=0"
     "-DUSE_SYSTEM_MALLOC=ON"
   ] ++ optional (!enableGtk2Plugins) "-DENABLE_PLUGIN_PROCESS_GTK2=OFF"
-    ++ optional stdenv.isLinux "-DENABLE_GLES2=ON";
+    ++ optional (stdenv.isLinux && enableGLES) "-DENABLE_GLES2=ON";
 
   postPatch = ''
     patchShebangs .

--- a/pkgs/development/python-modules/pyfxa/default.nix
+++ b/pkgs/development/python-modules/pyfxa/default.nix
@@ -1,6 +1,6 @@
 { lib, buildPythonPackage, fetchPypi
 , requests, cryptography, pybrowserid, hawkauthlib, six
-, grequests, mock, responses, pytest }:
+, grequests, mock, responses, pytest, pyjwt }:
 
 buildPythonPackage rec {
   pname = "PyFxA";
@@ -17,15 +17,16 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
-    requests cryptography pybrowserid hawkauthlib six
+    pyjwt requests cryptography pybrowserid hawkauthlib six
   ];
 
   checkInputs = [
     grequests mock responses pytest
   ];
 
+  # test_oath is mostly network calls
   checkPhase = ''
-    pytest
+    pytest --ignore=fxa/tests/test_oauth.py
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing another package

one issue is that it needs to be ran like `WEBKIT_DISABLE_COMPOSITING_MODE=1 ./result/bin/eolie` currently because webkitgtk is built with `-DENABLE_GLES2=ON`. Further information can be found https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=229491

example GLES error:
```
Cannot create EGL window surface: EGL_BAD_MATCH
```
The program would launch, but fail to render a web page

I added some additional switches to webkitgtk to disable this option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
