### PR TITLE
nixos/systemd.tmpfiles.packages: fix an edge case

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1012,18 +1012,18 @@ in
       "sysctl.d/50-coredump.conf".source = "${systemd}/example/sysctl.d/50-coredump.conf";
       "sysctl.d/50-default.conf".source = "${systemd}/example/sysctl.d/50-default.conf";
 
-      "tmpfiles.d".source = (pkgs.symlinkJoin {
+      "tmpfiles.d".source = pkgs.symlinkJoin {
         name = "tmpfiles.d";
-        paths = cfg.tmpfiles.packages;
+        paths = map (p: p + "/lib/tmpfiles.d") cfg.tmpfiles.packages;
         postBuild = ''
           for i in $(cat $pathsPath); do
-            (test -d $i/lib/tmpfiles.d && test $(ls $i/lib/tmpfiles.d/*.conf | wc -l) -ge 1) || (
-              echo "ERROR: The path $i was passed to systemd.tmpfiles.packages but either does not contain the folder lib/tmpfiles.d or if it contains that folder, there are no files ending in .conf in it."
+            (test -d "$i" && test $(ls "$i"/*.conf | wc -l) -ge 1) || (
+              echo "ERROR: The path '$i' from systemd.tmpfiles.packages contains no *.conf files."
               exit 1
             )
           done
         '';
-      }) + "/lib/tmpfiles.d";
+      };
 
       "systemd/system-generators" = { source = hooks "generators" cfg.generators; };
       "systemd/system-shutdown" = { source = hooks "shutdown" cfg.shutdown; };

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -240,6 +240,8 @@ rec {
    * This creates a single derivation that replicates the directory structure
    * of all the input paths.
    *
+   * BEWARE: it may not "work right" when the passed paths contain symlinks to directories.
+   *
    * Examples:
    * # adds symlinks of hello to current build.
    * symlinkJoin { name = "myhello"; paths = [ pkgs.hello ]; }


### PR DESCRIPTION
symlinkJoin can break (silently) when the passed paths contain symlinks
to directories.  This should work now.

Down-side: when lib/tmpfiles.d doesn't exist for some passed package,
the error message is a little less explicit, because we never get
to the postBuild phase (and symlinkJoin doesn't provide a better way):
/nix/store/HASH-NAME/lib/tmpfiles.d: No such file or directory

Also, it seemed pointless to create symlinks for whole package trees
and using only a part of the result (usually very small part).

###### Motivation for this change
Real-life breakage example: https://github.com/NixOS/nixpkgs/pull/95222#issuecomment-674449189

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

_Reviews requested from `systemd.meta.maintainers`._