### PR TITLE
flam3: fix license (gpl3Only, not cc-by-nc-sa-20)

### DIFF
--- a/pkgs/tools/graphics/flam3/default.nix
+++ b/pkgs/tools/graphics/flam3/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     homepage = "https://flam3.com/";
     maintainers = [ maintainers.nand0p ];
     platforms = platforms.linux;
-    license = licenses.cc-by-nc-sa-20;
+    license = licenses.gpl3Plus;
   };
 }


### PR DESCRIPTION
https://github.com/scottdraves/flam3/blob/v3.1.1/COPYING

###### Motivation for this change

To be able to package qosmic without having to allow nonfree packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).