### PR TITLE
cri-o: add pinns path and witch to crio.conf.d config style

### DIFF
--- a/nixos/modules/virtualisation/cri-o.nix
+++ b/nixos/modules/virtualisation/cri-o.nix
@@ -85,7 +85,7 @@ in
 
     environment.etc."crictl.yaml".source = copyFile "${pkgs.cri-o-unwrapped.src}/crictl.yaml";
 
-    environment.etc."crio/crio.conf".text = ''
+    environment.etc."crio/crio.conf.d/00-default.conf".text = ''
       [crio]
       storage_driver = "${cfg.storageDriver}"
 
@@ -100,6 +100,7 @@ in
       cgroup_manager = "systemd"
       log_level = "${cfg.logLevel}"
       manage_ns_lifecycle = true
+      pinns_path = "${cfg.package}/bin/pinns"
 
       ${optionalString (cfg.runtime != null) ''
       default_runtime = "${cfg.runtime}"


### PR DESCRIPTION

###### Motivation for this change
This adds the pinns path to the configuration let CRI-O start properly.
We also change the configuration to the new drop-in syntax.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @NixOS/podman 