### PR TITLE
binwalk-full: enable visual entropy graphing (needs matplotlib)

### DIFF
--- a/pkgs/development/python-modules/binwalk/default.nix
+++ b/pkgs/development/python-modules/binwalk/default.nix
@@ -12,12 +12,13 @@
 , cramfsprogs
 , cramfsswap
 , lzma
+, matplotlib
 , nose
 , pycrypto
 , pyqtgraph ? null }:
 
 let
-  visualizationSupport = (pyqtgraph != null);
+  visualizationSupport = (pyqtgraph != null) && (matplotlib != null);
   version = "2.2.0";
 in
 buildPythonPackage {
@@ -32,7 +33,7 @@ buildPythonPackage {
   };
 
   propagatedBuildInputs = [ zlib xz ncompress gzip bzip2 gnutar p7zip cabextract cramfsswap cramfsprogs lzma pycrypto ]
-  ++ stdenv.lib.optional visualizationSupport pyqtgraph;
+  ++ stdenv.lib.optionals visualizationSupport [ matplotlib pyqtgraph ];
 
   # setup.py only installs version.py during install, not test
   postPatch = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2050,10 +2050,12 @@ in {
 
   binwalk = callPackage ../development/python-modules/binwalk {
     pyqtgraph = null;
+    matplotlib = null;
   };
 
   binwalk-full = appendToName "full" (self.binwalk.override {
     pyqtgraph = self.pyqtgraph;
+    matplotlib = self.matplotlib;
   });
 
   bitmath = callPackage ../development/python-modules/bitmath { };


### PR DESCRIPTION
This is used for visual entropy graphing (`-E` argument)

Fixes https://github.com/NixOS/nixpkgs/issues/95578.

![image](https://user-images.githubusercontent.com/183879/90333108-2de7bc80-dfc3-11ea-8230-fc957573ac00.png)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @asbachb