### PR TITLE
[r20.03] sigil: 0.9.14 -> 0.9.16, addressing CVE-2019-14452

### DIFF
--- a/pkgs/applications/editors/sigil/default.nix
+++ b/pkgs/applications/editors/sigil/default.nix
@@ -1,15 +1,15 @@
 { stdenv, mkDerivation, fetchFromGitHub, cmake, pkgconfig, makeWrapper
 , boost, xercesc
-, qtbase, qttools, qtwebkit, qtxmlpatterns
+, qtbase, qttools, qtwebengine, qtxmlpatterns
 , python3, python3Packages
 }:
 
 mkDerivation rec {
   pname = "sigil";
-  version = "0.9.14";
+  version = "0.9.16";
 
   src = fetchFromGitHub {
-    sha256 = "0fmfbfpnmhclbbv9cbr1xnv97si6ls7331kk3ix114iqkngqwgl1";
+    sha256 = "1xxd59j21g31lp9phrf64y9zvg15g8mk6snsp3n4f6bsf44dn4ha";
     rev = version;
     repo = "Sigil";
     owner = "Sigil-Ebook";
@@ -20,7 +20,7 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
 
   buildInputs = [
-    boost xercesc qtbase qttools qtwebkit qtxmlpatterns
+    boost xercesc qtbase qttools qtwebengine qtxmlpatterns
     python3Packages.lxml ];
 
   dontWrapQtApps = true;


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-14452

Seems to work fine, tested non-nixos linux x86_64.

`master` bumped in #95537

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
