### PR TITLE
[haskell-updates] haskellPackages.haskell-language-server: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1323,41 +1323,22 @@ self: super: {
   # https://github.com/ennocramer/monad-dijkstra/issues/4
   monad-dijkstra = dontCheck (doJailbreak super.monad-dijkstra);
 
-  # haskell-language-server uses its own fork of ghcide
-  # Test disabled: it seems to freeze (is it just that it takes a long time ?)
-  hls-ghcide =
-    dontCheck ((
-      overrideCabal super.hls-ghcide
-        (old: {
-          # The integration test run by lsp-test requires the executable to be in the PATH
-          preCheck = ''
-            export PATH=$PATH:dist/build/ghcide
-          '';
-        })).override {
-          # we are faster than stack here
-          hie-bios = dontCheck self.hie-bios_0_6_2;
-          lsp-test = dontCheck self.lsp-test_0_11_0_4;
-        });
-
-  haskell-language-server = (overrideCabal super.haskell-language-server
-    (old: {
-      # The integration test run by lsp-test requires the executable to be in the PATH
-      preCheck = ''
-        export PATH=$PATH:dist/build/haskell-language-server
-      '';
-      # The wrapper test does not work for now.
-      testTarget = "func-test";
-
-      # test needs the git tool
-      testToolDepends = old.testToolDepends
-        ++ [ pkgs.git ];
-    })).override {
-      # use a fork of ghcide
-      ghcide = self.hls-ghcide;
-      # we are faster than stack here
-      hie-bios = dontCheck self.hie-bios_0_6_2;
-      lsp-test = dontCheck self.lsp-test_0_11_0_4;
-    };
+  fourmolu = super.fourmolu.overrideScope (self: super: {
+    aeson = dontCheck self.aeson_1_5_2_0;
+  });
+  # Tests disabled because they access /home
+  haskell-language-server = (dontCheck super.haskell-language-server).overrideScope (self: super: {
+    # haskell-language-server uses its own fork of ghcide
+    # Test disabled: it seems to freeze (is it just that it takes a long time ?)
+    ghcide = dontCheck super.hls-ghcide;
+    # we are faster than stack here
+    hie-bios = dontCheck self.hie-bios_0_6_2;
+    lsp-test = dontCheck self.lsp-test_0_11_0_4;
+    # fourmolu can‘t compile with an older aeson
+    aeson = dontCheck super.aeson_1_5_2_0;
+    # brittany has an aeson upper bound of 1.5
+    brittany = doJailbreak super.brittany;
+  });
 
   # https://github.com/kowainik/policeman/issues/57
   policeman = doJailbreak super.policeman;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2540,6 +2540,7 @@ default-package-overrides:
 
 extra-packages:
   - aeson < 0.8                         # newer versions don't work with GHC 7.6.x or earlier
+  - aeson == 1.5.2.0                    # needed for fourmolu 0.1.0.0, but 1.5.3 is to new for our purpose
   - aeson-pretty < 0.8                  # required by elm compiler
   - Agda == 2.6.1                       # allows the agdaPackage set to be fixed to this version so that it won't break when another agda version is released.
   - ansi-terminal == 0.10.3             # required by cabal-plan, and policeman in ghc-8.8.x
@@ -5074,7 +5075,6 @@ broken-packages:
   - foscam-filename
   - foscam-sort
   - Foster
-  - fourmolu
   - fpco-api
   - fplll
   - fpnla-examples
@@ -9165,7 +9165,6 @@ broken-packages:
   - rethinkdb-client-driver
   - rethinkdb-model
   - rethinkdb-wereHamster
-  - retrie
   - retryer
   - reverse-geocoding
   - reversi

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -767,4 +767,8 @@ self: super: builtins.intersectAttrs super {
   postgresql-libpq-notify = dontCheck super.postgresql-libpq-notify;
   postgresql-pure = dontCheck super.postgresql-pure;
 
+  retrie = overrideCabal super.retrie (drv: {
+    testToolDepends = [ pkgs.git pkgs.mercurial ];
+  });
+
 }

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -105,8 +105,9 @@ symlinkJoin {
         --set "NIX_${ghcCommandCaps}_LIBDIR" "${libDir}"
     fi
 
-    # ghcide and haskell-language-server do package discovery without calling our ghc wrapper.
-    for prg in ghcide haskell-language-server; do
+    # ghcide 0.2.0 does package discovery without calling our ghc wrapper.
+    # 2020-08-16 We can most likely remove this workaround as soon as we build ghcide with a newer hie-bios (currently we use 0.5.1 from stack)
+    for prg in ghcide; do
       if [[ -x "$out/bin/$prg" ]]; then
         wrapProgram $out/bin/$prg  \
           --set "NIX_${ghcCommandCaps}"        "$out/bin/${ghcCommand}"     \

--- a/pkgs/development/tools/haskell/haskell-language-server/default.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/default.nix
@@ -1,30 +1,31 @@
 { mkDerivation, aeson, base, binary, blaze-markup, brittany
 , bytestring, containers, data-default, deepseq, Diff, directory
-, extra, fetchgit, filepath, floskell, ghc, ghc-paths, ghcide
-, gitrev, hashable, haskell-lsp, haskell-lsp-types, hie-bios
-, hslogger, hspec, hspec-core, hspec-expectations, lens, lsp-test
-, optparse-applicative, optparse-simple, ormolu, process
-, regex-tdfa, safe-exceptions, shake, stdenv, stm, stylish-haskell
-, tasty, tasty-ant-xml, tasty-expected-failure, tasty-golden
-, tasty-hunit, tasty-rerun, temporary, text, time, transformers
-, unix, unordered-containers, yaml
+, extra, fetchgit, filepath, floskell, fourmolu, ghc, ghc-boot-th
+, ghc-paths, ghcide, gitrev, hashable, haskell-lsp
+, haskell-lsp-types, hie-bios, hslogger, hspec, hspec-core, lens
+, lsp-test, optparse-applicative, optparse-simple, ormolu, process
+, regex-tdfa, retrie, safe-exceptions, shake, stdenv, stm
+, stylish-haskell, tasty, tasty-ant-xml, tasty-expected-failure
+, tasty-golden, tasty-hunit, tasty-rerun, temporary, text, time
+, transformers, unix, unordered-containers, yaml
 }:
 mkDerivation {
   pname = "haskell-language-server";
-  version = "0.2.2.0";
+  version = "0.3.0.0";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "0g9g2gyb0fidx16l741ky12djxh4cid9akvxa48105iq1gdihd8l";
-    rev = "12c0e4423263140e3d16e76681927ec69fe4929f";
+    sha256 = "0gh3sgy6a08d8d3q6r2qn5r817ilzka2qkp0g0y6wsx7rjwag0yx";
+    rev = "23dda97f583e8ff39993b89c01bbd1ac24187605";
     fetchSubmodules = true;
   };
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
     aeson base binary brittany bytestring containers data-default
-    deepseq Diff directory extra filepath floskell ghc ghcide gitrev
-    hashable haskell-lsp hie-bios hslogger lens optparse-simple ormolu
-    process regex-tdfa shake stylish-haskell temporary text time
+    deepseq Diff directory extra filepath floskell fourmolu ghc
+    ghc-boot-th ghcide gitrev hashable haskell-lsp hie-bios hslogger
+    lens optparse-simple ormolu process regex-tdfa retrie
+    safe-exceptions shake stylish-haskell temporary text time
     transformers unix unordered-containers
   ];
   executableHaskellDepends = [
@@ -36,9 +37,9 @@ mkDerivation {
   testHaskellDepends = [
     aeson base blaze-markup bytestring containers data-default
     directory filepath haskell-lsp haskell-lsp-types hie-bios hslogger
-    hspec hspec-core hspec-expectations lens lsp-test process stm tasty
-    tasty-ant-xml tasty-expected-failure tasty-golden tasty-hunit
-    tasty-rerun temporary text transformers unordered-containers yaml
+    hspec hspec-core lens lsp-test process stm tasty tasty-ant-xml
+    tasty-expected-failure tasty-golden tasty-hunit tasty-rerun
+    temporary text transformers unordered-containers yaml
   ];
   testToolDepends = [ ghcide ];
   homepage = "https://github.com/haskell/haskell-language-server#readme";

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-ghcide.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-ghcide.nix
@@ -7,7 +7,7 @@
 , hie-bios, hslogger, lens, lsp-test, mtl, network-uri
 , opentelemetry, optparse-applicative, prettyprinter
 , prettyprinter-ansi-terminal, process, QuickCheck
-, quickcheck-instances, regex-tdfa, rope-utf16-splay
+, quickcheck-instances, regex-tdfa, rope-utf16-splay, safe
 , safe-exceptions, shake, sorted-list, stdenv, stm, syb, tasty
 , tasty-expected-failure, tasty-hunit, tasty-quickcheck
 , tasty-rerun, text, time, transformers, unix, unordered-containers
@@ -17,9 +17,9 @@ mkDerivation {
   pname = "ghcide";
   version = "0.2.0";
   src = fetchgit {
-    url = "https://github.com/bubba/ghcide";
-    sha256 = "1kj2i86mkaxgxlrbmv2d24mch7hywgcy2n61z8paj21chncs1j5w";
-    rev = "7e895cfa53260b41996df707baec496a8f2c75dc";
+    url = "https://github.com/wz1000/ghcide";
+    sha256 = "1zq7ngaak8il91a309rl51dghzasnk4m2sm3av6d93cyqyra1hfc";
+    rev = "078e3d3c0d319f83841ccbcdc60ff5f0e243f6be";
     fetchSubmodules = true;
   };
   isLibrary = true;
@@ -30,23 +30,23 @@ mkDerivation {
     filepath fuzzy ghc ghc-boot ghc-boot-th ghc-check ghc-paths
     haddock-library hashable haskell-lsp haskell-lsp-types hie-bios
     hslogger mtl network-uri opentelemetry prettyprinter
-    prettyprinter-ansi-terminal regex-tdfa rope-utf16-splay
+    prettyprinter-ansi-terminal regex-tdfa rope-utf16-splay safe
     safe-exceptions shake sorted-list stm syb text time transformers
     unix unordered-containers utf8-string
   ];
   executableHaskellDepends = [
     aeson base bytestring containers data-default directory extra
     filepath gitrev hashable haskell-lsp haskell-lsp-types hie-bios
-    lsp-test optparse-applicative process safe-exceptions text
+    lens lsp-test optparse-applicative process safe-exceptions text
     unordered-containers
   ];
   testHaskellDepends = [
-    aeson base bytestring containers directory extra filepath ghc
-    ghc-typelits-knownnat haddock-library haskell-lsp haskell-lsp-types
-    lens lsp-test network-uri optparse-applicative process QuickCheck
-    quickcheck-instances rope-utf16-splay safe-exceptions shake tasty
-    tasty-expected-failure tasty-hunit tasty-quickcheck tasty-rerun
-    text
+    aeson base binary bytestring containers directory extra filepath
+    ghc ghc-typelits-knownnat haddock-library haskell-lsp
+    haskell-lsp-types lens lsp-test network-uri optparse-applicative
+    process QuickCheck quickcheck-instances rope-utf16-splay safe
+    safe-exceptions shake tasty tasty-expected-failure tasty-hunit
+    tasty-quickcheck tasty-rerun text
   ];
   benchmarkHaskellDepends = [
     aeson base Chart Chart-diagrams diagrams diagrams-svg directory

--- a/pkgs/development/tools/haskell/haskell-language-server/update.sh
+++ b/pkgs/development/tools/haskell/haskell-language-server/update.sh
@@ -29,7 +29,7 @@ ghcide_new_version=$(curl --silent "https://api.github.com/repos/haskell/haskell
 echo "Updating haskell-language-server from old version $ghcide_old_version to new version $ghcide_new_version."
 echo "Running cabal2nix and outputting to ${ghcide_derivation_file}..."
 
-cabal2nix --revision "$ghcide_new_version" "https://github.com/bubba/ghcide" > "$ghcide_derivation_file"
+cabal2nix --revision "$ghcide_new_version" "https://github.com/wz1000/ghcide" > "$ghcide_derivation_file"
 
 
 # ===========================


### PR DESCRIPTION
While we are at it I:
* Disable tests, because I can‘t keep up with the speed hls introduces
more tests that cause trouble in nixpkgs.
* Fix builds of fourmolu and retrie
* Remove the wrapper for hls which is obsolete because of improved
package detection in hie-bios. And added a note that this can be removed
for ghcide soon, too.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
