### PR TITLE
python3Packages.uvloop: disable test_write_to_closed_transport test on 3.8+

### DIFF
--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -6,6 +6,7 @@
 , libuv
 , psutil
 , isPy27
+, pythonAtLeast
 , CoreServices
 , ApplicationServices
 # Check Inputs
@@ -44,14 +45,11 @@ buildPythonPackage rec {
     "--tb=native"
     # ignore code linting tests
     "--ignore=tests/test_sourcecode.py"
-    # Fails on Python 3.8
-    # https://salsa.debian.org/python-team/modules/uvloop/-/commit/302a7e8f5a2869e13d0550cd37e7a8f480e79869
-    "--ignore=tests/test_tcp.py"
   ];
 
   disabledTests = [
     "test_sock_cancel_add_reader_race"  # asyncio version of test is supposed to be skipped but skip doesn't happen. uvloop version runs fine
-  ];
+  ] ++ lib.optionals (pythonAtLeast "3.8") [ "test_write_to_closed_transport" ];  # https://github.com/MagicStack/uvloop/issues/355
 
   # force using installed/compiled uvloop vs source by moving tests to temp dir
   preCheck = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Reenables the TCP testsuite and only disables the single failing test.

https://github.com/MagicStack/uvloop/issues/355

Noticed the breakage in https://github.com/NixOS/nixpkgs/pull/95518#issuecomment-674522171 and wondered why master was not affected. 

The port to stable blocks #95518.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
