### PR TITLE
flink: 1.9.0 -> 1.11.1, addressing CVE-2020-1960

### DIFF
--- a/pkgs/applications/networking/cluster/flink/default.nix
+++ b/pkgs/applications/networking/cluster/flink/default.nix
@@ -8,8 +8,8 @@ let
       sha256 = "18wqcqi3gyqd40nspih99gq7ylfs20b35f4dcrspffagwkfp2l4z";
     };
     "1.6" = {
-      flinkVersion = "1.9.0";
-      sha256 = "1dzfcmqz5j4b545wq2q3xb2xkbhqllr04s3av1afv54y61l5y952";
+      flinkVersion = "1.11.1";
+      sha256 = "0338bg2sb427c1rrf2cmsz63sz0yk6gclpli2lskq0mpx72wxpl0";
     };
   };
 in
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ jre ];
 
   installPhase = ''
-    rm bin/*.bat
+    rm bin/*.bat || true
 
     mkdir -p $out/bin $out/opt/flink
     mv * $out/opt/flink/


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2020-1960

This is mainly for the eyes of maintainer @mbode to check whether this works acceptably for them. It would be nice to get a bump of the mainline package to as recent a version as possible before 20.09 branches, because future vulnerabilities are unlikely to see releases for older versions.

Note that upstream's 1.5 _branch_ actually has a fix for this CVE @ https://github.com/apache/flink/commit/f9b4e0dea71abbcd6463c757577c70c45b3e6bbf, but with no _release_ accompanying it and because this is a binary package, we don't have the possibility of using it as a patch. So it looks like our `flink_1_5` will have to remain vulnerable for the time being (this is why binary packages make me sad).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
