### PR TITLE
xxe-pe: init at 9.4.0

### DIFF
--- a/pkgs/applications/editors/xxe-pe/default.nix
+++ b/pkgs/applications/editors/xxe-pe/default.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, fetchurl
+, lib
+, unzip
+, makeWrapper
+, openjdk11
+, makeDesktopItem
+, icoutils
+, config
+, acceptLicense ? config.xxe-pe.acceptLicense or false
+}:
+
+let
+  pkg_path = "$out/lib/xxe";
+
+  desktopItem = makeDesktopItem {
+    name = "XMLmind XML Editor Personal Edition";
+    exec = "xxe";
+    icon = "xxe";
+    desktopName = "xxe";
+    genericName = "XML Editor";
+    categories = "Development;IDE;TextEditor;Java";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "xxe-pe";
+  version = "9.4.0";
+
+  src =
+    assert !acceptLicense -> throw ''
+      You must accept the XMLmind XML Editor Personal Edition License at
+      https://www.xmlmind.com/xmleditor/license_xxe_perso.html
+      by setting nixpkgs config option `xxe-pe.acceptLicense = true;`
+      or by using `xxe-pe.override { acceptLicense = true; }` package.
+    '';
+      fetchurl {
+        url = "https://www.xmlmind.com/xmleditor/_download/xxe-perso-${builtins.replaceStrings [ "." ] [ "_" ] version}.zip";
+        sha256 = "FKPdf9cOpgm/WG2i8bFnR6MmEifpiq5ykw2zHA8HnT8=";
+      };
+
+  nativeBuildInputs = [
+    unzip
+    makeWrapper
+    icoutils
+  ];
+
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p "${pkg_path}"
+    mkdir -p "${pkg_path}" "$out/share/applications"
+    cp -a * "${pkg_path}"
+    ln -s ${desktopItem}/share/applications/* $out/share/applications
+
+    icotool -x "${pkg_path}/bin/icon/xxe.ico"
+    ls
+    for f in xxe_*.png; do
+      res=$(basename "$f" ".png" | cut -d"_" -f3 | cut -d"x" -f1-2)
+      mkdir -pv "$out/share/icons/hicolor/$res/apps"
+      mv "$f" "$out/share/icons/hicolor/$res/apps/xxe.png"
+    done;
+  '';
+
+  postFixup = ''
+    mkdir -p "$out/bin"
+    makeWrapper "${pkg_path}/bin/xxe" "$out/bin/xxe" \
+      --prefix PATH : ${lib.makeBinPath [ openjdk11 ]}
+  '';
+
+  meta = with lib; {
+    description = "Strictly validating, near WYSIWYG, XML editor with DocBook support";
+    homepage = "https://www.xmlmind.com/xmleditor/";
+    license = licenses.unfree;
+    maintainers = [ maintainers.jtojnar ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11433,6 +11433,8 @@ in
 
   xxdiff = libsForQt5.callPackage ../development/tools/misc/xxdiff { };
 
+  xxe-pe = callPackage ../applications/editors/xxe-pe { };
+
   xxdiff-tip = xxdiff;
 
   yaml2json = callPackage ../development/tools/yaml2json { };


### PR DESCRIPTION
###### Motivation for this change
Add a proprietary DocBook editor free for personal use.

https://www.xmlmind.com/xmleditor/

Based on ghidra derivation. Would prefer to use `openjdk14` as that is what the [installation guide](https://www.xmlmind.com/xmleditor/_distrib/doc/help/installing_xxe.html) shows but that seems to need to be built from scratch (including webkit:exclamation:), the guide also says Java 8+ is needed so `openjdk11` should be fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
