### PR TITLE
SoftHSM: 2.5.0 -> 2.6.1

### DIFF
--- a/pkgs/tools/security/softhsm/default.nix
+++ b/pkgs/tools/security/softhsm/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchurl, botan, libobjc, Security }:
+{ stdenv, fetchurl, botan2, libobjc, Security }:
 
 stdenv.mkDerivation rec {
 
   pname = "softhsm";
-  version = "2.5.0";
+  version = "2.6.1";
 
   src = fetchurl {
     url = "https://dist.opendnssec.org/source/${pname}-${version}.tar.gz";
-    sha256 = "1cijq78jr3mzg7jj11r0krawijp99p253f4qdqr94n728p7mdalj";
+    hash = "sha256:1wkmyi6n3z2pak1cj5yk6v6bv9w0m24skycya48iikab0mrr8931";
   };
 
   configureFlags = [
     "--with-crypto-backend=botan"
-    "--with-botan=${botan}"
+    "--with-botan=${botan2}"
     "--sysconfdir=$out/etc"
     "--localstatedir=$out/var"
     ];
@@ -20,13 +20,24 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs =
     stdenv.lib.optionals stdenv.isDarwin [ libobjc Security ];
 
-  buildInputs = [ botan ];
+  buildInputs = [ botan2 ];
 
   postInstall = "rm -rf $out/var";
 
   meta = with stdenv.lib; {
     homepage = "https://www.opendnssec.org/softhsm";
     description = "Cryptographic store accessible through a PKCS #11 interface";
+    longDescription = "
+      SoftHSM provides a software implementation of a generic
+      cryptographic device with a PKCS#11 interface, which is of
+      course especially useful in environments where a dedicated hardware
+      implementation of such a device - for instance a Hardware
+      Security Module (HSM) or smartcard - is not available.
+
+      SoftHSM follows the OASIS PKCS#11 standard, meaning it should be
+      able to work with many cryptographic products. SoftHSM is a
+      programme of The Commons Conservancy.
+    ";
     license = licenses.bsd2;
     maintainers = [ maintainers.leenaars ];
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

Simple version bump with update to botan2 and additional longDescription.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
