### PR TITLE
foot: init at 1.4.4

### DIFF
--- a/pkgs/applications/misc/foot/default.nix
+++ b/pkgs/applications/misc/foot/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchgit
+, fcft, freetype, pixman, libxkbcommon, fontconfig, wayland
+, meson, ninja, ncurses, scdoc, tllist, wayland-protocols, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "foot";
+  version = "1.4.4";
+
+  src = fetchgit {
+    url = "https://codeberg.org/dnkl/foot.git";
+    rev = "${version}";
+    sha256 = "1cr4sz075v18clh8nlvgyxlbvfkhbsg0qrqgnclip5rwa24ry1lg";
+  };
+
+  nativeBuildInputs = [
+    meson ninja ncurses scdoc tllist wayland-protocols pkg-config
+  ];
+  buildInputs = [
+    fontconfig freetype pixman wayland libxkbcommon fcft
+  ];
+
+  # recommended build flags for foot as per INSTALL.md
+  # https://codeberg.org/dnkl/foot/src/branch/master/INSTALL.md#user-content-release-build
+  preConfigure = ''
+    export CFLAGS+="-O3 -fno-plt"
+  '';
+
+  mesonFlags = [ "--buildtype=release" "-Db_lto=true" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://codeberg.org/dnkl/foot/";
+    description = "A fast, lightweight and minimalistic Wayland terminal emulator";
+    license = licenses.mit;
+    maintainers = [ maintainers.sternenseemann ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/fcft/default.nix
+++ b/pkgs/development/libraries/fcft/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchgit, pkg-config, meson, ninja, scdoc
-,freetype, fontconfig, pixman, tllist }:
+,freetype, fontconfig, pixman, tllist, check }:
 
 stdenv.mkDerivation rec {
   pname = "fcft";
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config meson ninja scdoc ];
   buildInputs = [ freetype fontconfig pixman tllist ];
+  checkInputs = [ check ];
+
+  mesonFlags = [ "--buildtype=release" ];
+
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://codeberg.org/dnkl/fcft";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20049,6 +20049,8 @@ in
 
   foo-yc20 = callPackage ../applications/audio/foo-yc20 { };
 
+  foot = callPackage ../applications/misc/foot { };
+
   fossil = callPackage ../applications/version-management/fossil { };
 
   freebayes = callPackage ../applications/science/biology/freebayes { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

add `foot` a simple and fast terminal emulator for wayland based of `fcft` font rendering.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
