### PR TITLE
swiftformat: 0.44.9 -> 0.45.6

### DIFF
--- a/pkgs/development/tools/swiftformat/default.nix
+++ b/pkgs/development/tools/swiftformat/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "swiftformat";
-  version = "0.44.9";
+  version = "0.47.10";
 
   src = fetchFromGitHub {
     owner = "nicklockwood";
     repo = "SwiftFormat";
     rev = version;
-    sha256 = "0zajvbaf3r02k53lv5zdxf13apc6chnjmj69zkyac48lpnpbcxq6";
+    sha256 = "1gqxpymbhpmap0i2blg9akarlql4mkzv45l4i212gsxcs991b939";
   };
 
   preConfigure = "LD=$CC";


### PR DESCRIPTION
###### Motivation for this change

Version bump. The changelog is [here](https://github.com/nicklockwood/SwiftFormat/blob/0.45.6/CHANGELOG.md).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @alyssais – thank you for merging my earlier PR, #83113! Unfortunately I had let it get stale and now there’s an even newer version to upgrade to.