### PR TITLE
khal: 0.10.1 -> 0.10.2

### DIFF
--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -2,21 +2,14 @@
 
 with python3.pkgs; buildPythonApplication rec {
   pname = "khal";
-  version = "0.10.1";
+  version = "0.10.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1r8bkgjwkh7i8ygvsv51h1cnax50sb183vafg66x5snxf3dgjl6l";
+    sha256 = "11qhrga44knlnp88py9p547d4nr5kn041d2nszwa3dqw7mf22ks9";
   };
 
-  # Include a khal.desktop file via upstream commit.
-  # This patch should be removed when updating to the next version, probably.
   patches = [
-    (fetchpatch {
-      name = "add-khal-dot-desktop.patch";
-      url = "https://github.com/pimutils/khal/commit/1f93d238fec7c934dd2f8e48f54925d22130e3aa.patch";
-      sha256 = "06skn3van7zd93348fc6axllx71ckkc7h2zljqlvwa339vca608c";
-    })
     ./skip-broken-test.patch
   ];
 

--- a/pkgs/applications/misc/khal/skip-broken-test.patch
+++ b/pkgs/applications/misc/khal/skip-broken-test.patch
@@ -1,3 +1,15 @@
+diff --git a/tests/cli_test.py b/tests/cli_test.py
+index 5e354a5..d8fbcd5 100644
+--- a/tests/cli_test.py
++++ b/tests/cli_test.py
+@@ -493,6 +493,7 @@ def test_import_invalid_choice_and_prefix(runner):
+     assert result.output == '09.04.-09.04. An Event\n'
+ 
+ 
++@pytest.mark.skip(reason="Mocking breaks in this testcase")
+ def test_import_from_stdin(runner, monkeypatch):
+     ics_data = 'This is some really fake icalendar data'
+ 
 diff --git a/tests/ui/test_editor.py b/tests/ui/test_editor.py
 index 27b7fa5..5978d72 100644
 --- a/tests/ui/test_editor.py


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
