### PR TITLE
 pythonPackages.librosa: fix required package pooch

### DIFF
--- a/pkgs/development/python-modules/librosa/default.nix
+++ b/pkgs/development/python-modules/librosa/default.nix
@@ -9,6 +9,7 @@
 , audioread
 , resampy
 , soundfile
+, pooch
 }:
 
 buildPythonPackage rec {
@@ -20,15 +21,21 @@ buildPythonPackage rec {
     sha256 = "af0b9f2ed4bbf6aecbc448a4cd27c16453c397cb6bef0f0cfba0e63afea2b839";
   };
 
-  propagatedBuildInputs = [ joblib matplotlib six scikitlearn decorator audioread resampy soundfile ];
+  propagatedBuildInputs = [ joblib matplotlib six scikitlearn decorator audioread resampy soundfile pooch ];
 
   # No tests
+  # 1. Internet connection is required
+  # 2. Got error "module 'librosa' has no attribute 'version'"
   doCheck = false;
+
+  # check that import works, this allows to capture errors like https://github.com/librosa/librosa/issues/1160
+  pythonImportsCheck = [ "librosa" ];
 
   meta = with stdenv.lib; {
     description = "Python module for audio and music processing";
     homepage = "http://librosa.github.io/";
     license = licenses.isc;
+    maintainers = with maintainers; [ GuillaumeDesforges ];
   };
 
 }

--- a/pkgs/development/python-modules/pooch/default.nix
+++ b/pkgs/development/python-modules/pooch/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, buildPythonPackage
+, isPy27
+, fetchPypi
+, pytestCheckHook
+, packaging
+, appdirs
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pooch";
+  version = "1.0.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1k2vinlhkzl7lzhvbz20x3a2r2zqqila0yxg3a3fax2r6qxbxxzi";
+  };
+
+  propagatedBuildInputs = [ packaging appdirs requests ];
+
+  checkInputs = [ pytestCheckHook ];
+  disabledTests = [
+    "pooch_custom_url"
+    "pooch_download"
+    "pooch_logging_level"
+    "pooch_update"
+    "pooch_corrupted"
+    "check_availability"
+    "downloader"
+    "test_fetch"
+    "decompress"
+    "extractprocessor_fails"
+    "processor"
+    "integration"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A friend to fetch your data files.";
+    homepage = "https://github.com/fatiando/pooch";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ GuillaumeDesforges ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7851,6 +7851,8 @@ in {
   rxv     = callPackage ../development/python-modules/rxv     { };
 
   userpath = callPackage ../development/python-modules/userpath { };
+  
+  pooch = callPackage ../development/python-modules/pooch {};
 
 });
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Librosa 0.7.2 fails to load after update of numba to 0.50
https://github.com/librosa/librosa/issues/1160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
