### PR TITLE
[haskell-updates] haskellPackages.hls-ghcide: Fix hydra-build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1323,23 +1323,6 @@ self: super: {
   # https://github.com/ennocramer/monad-dijkstra/issues/4
   monad-dijkstra = dontCheck (doJailbreak super.monad-dijkstra);
 
-  fourmolu = super.fourmolu.overrideScope (self: super: {
-    aeson = dontCheck self.aeson_1_5_2_0;
-  });
-  # Tests disabled because they access /home
-  haskell-language-server = (dontCheck super.haskell-language-server).overrideScope (self: super: {
-    # haskell-language-server uses its own fork of ghcide
-    # Test disabled: it seems to freeze (is it just that it takes a long time ?)
-    ghcide = dontCheck super.hls-ghcide;
-    # we are faster than stack here
-    hie-bios = dontCheck self.hie-bios_0_6_2;
-    lsp-test = dontCheck self.lsp-test_0_11_0_4;
-    # fourmolu can‘t compile with an older aeson
-    aeson = dontCheck super.aeson_1_5_2_0;
-    # brittany has an aeson upper bound of 1.5
-    brittany = doJailbreak super.brittany;
-  });
-
   # https://github.com/kowainik/policeman/issues/57
   policeman = doJailbreak super.policeman;
 
@@ -1450,4 +1433,24 @@ self: super: {
   # https://github.com/bos/statistics/issues/170
   statistics = dontCheck super.statistics;
 
-} // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super
+  # INSERT NEW OVERRIDES ABOVE THIS LINE
+
+} // (let
+  hlsScopeOverride = self: super: {
+    # haskell-language-server uses its own fork of ghcide
+    # Test disabled: it seems to freeze (is it just that it takes a long time ?)
+    ghcide = dontCheck self.hls-ghcide;
+    # we are faster than stack here
+    hie-bios = dontCheck self.hie-bios_0_6_2;
+    lsp-test = dontCheck self.lsp-test_0_11_0_4;
+    # fourmolu can‘t compile with an older aeson
+    aeson = dontCheck super.aeson_1_5_2_0;
+    # brittany has an aeson upper bound of 1.5
+    brittany = doJailbreak super.brittany;
+  };
+in {
+  haskell-language-server = dontCheck (super.haskell-language-server.overrideScope hlsScopeOverride);
+  hls-ghcide = dontCheck (super.hls-ghcide.overrideScope hlsScopeOverride);
+  fourmolu = super.fourmolu.overrideScope hlsScopeOverride;
+}
+)  // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super


### PR DESCRIPTION
Rearrange the scope override of the haskell-language-server in a way
that intermediate packages don‘t cause build fails on hydra.

My last pr broke the hls-ghcide build on hydra. Which I didn‘t think of because no one uses it other than in hls.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
