### PR TITLE
lib: add toApp

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -488,6 +488,31 @@ rec {
   dontRecurseIntoAttrs =
     attrs: attrs // { recurseForDerivations = false; };
 
+  /* Heuristic that maps an 'app' or derivation to a binary path.
+
+     If 'pkg' is of type 'app', it outputs the 'program'
+
+     If 'pkg' is a derivation, it outputs the path to
+     '${drv}/bin/${drv.pname}' (simplified)
+
+     This copies the logic of `nix run` that lives in the nix src/nix/app.cc
+     file.
+
+     Example:
+       toApp pkgs.bash
+       => "/nix/store/vwcxfvl2p0rnw2w6lqa2ax0wbcahlsss-bash-interactive-4.4-p23/bin/bash"
+  */
+  toApp = pkg:
+    let
+      outPath = pkg.outPath;
+      name = pkg.name;
+      type = pkg.type;
+    in
+    if type == "app" then pkg.program
+    else if type == "derivation" then
+      "${outPath}/bin/${(builtins.parseDrvName name).name}"
+    else throw "unsupported type '${type}'";
+
   /*** deprecated stuff ***/
 
   zipWithNames = zipAttrsWithNames;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -78,7 +78,7 @@ let
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting getOutput getBin
       getLib getDev getMan chooseDevOutputs zipWithNames zip
-      recurseIntoAttrs dontRecurseIntoAttrs;
+      recurseIntoAttrs dontRecurseIntoAttrs toApp;
     inherit (lists) singleton forEach foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range partition zipListsWith zipLists


### PR DESCRIPTION
Introduce the same logic as in `nix run`, but accessible as a nix
function.

###### Motivations for this change

1. Since `nix run` will have that logic, I think it's good to also try using it inside of nixpkgs. It will force us to improve `pname` attributes so that they map to the default binary. And also expose weaknesses in the heuristic.

2. There are a lot of times in nixpkgs where we have these patterns:

```nix
'''
  ${pkgs.bash}/bin/bash bla bla bla
'''
```
which can now be replaced with:
```nix
'''
  ${lib.toApp pkgs.bash} bla bla bla
'''
```

Not all of these can be replaced but there are ~5k of those in nixpkgs using this heuristic: `$ rg '}/bin/' | wc -l`

There was a previous attempt with some discussion a long time ago, which this replaces: #67392

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
