### PR TITLE
pulumi 2.6.1 -> 2.8.2

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,58 +1,58 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "2.6.1";
+  version = "2.8.2";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.6.1-linux-x64.tar.gz";
-        sha256 = "12f81wj8r3pmxj2l8qhcgnmy2m0a6bfzrvq9avl3444h2w29qpy2";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.8.2-linux-x64.tar.gz";
+        sha256 = "0yr3yv6jr63zr6lcqvri2xys075ljzg0nb47yw7nfzpw4mb7sqib";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.13.0-linux-amd64.tar.gz";
-        sha256 = "03l7ybc9ca63vdm7a2zsvgc8zz8ip973sfxsjqf3bb277r04mnpb";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v3.1.0-linux-amd64.tar.gz";
+        sha256 = "1aw3yvpbha5cccakvvkwlqf0wn7sav2ly6r2388cg7c0bp4jbzzm";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.13.0-linux-amd64.tar.gz";
-        sha256 = "0ivdiib3a1c1r2ppxmj6blgq26s05s3081969j0j9jlscpa79lap";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.18.0-linux-amd64.tar.gz";
+        sha256 = "1zcygr34l8wmbd8czyl0jkd5y2qr6cc5adjyw08547ir4yv3lkw7";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.2.0-linux-amd64.tar.gz";
         sha256 = "0w6ys5bmry1b8ndzj167cz3a8fc6mbl5v9v2almrmd3q6fycm4gj";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.4.0-linux-amd64.tar.gz";
-        sha256 = "0id3mji08hk76kffz46dlbl2r11kgv5jvlmw869dssg2d0wliv82";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.4.3-linux-amd64.tar.gz";
+        sha256 = "125zhfj0sxfhnnln2qm1dw0qih54rlrv8jigrq41x36zmki62l7h";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.2.2-linux-amd64.tar.gz";
-        sha256 = "07asdmmacxazg65d5hphjxzb5j5d2dcc95wjbxx3wwc1swqma4aq";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.3.0-linux-amd64.tar.gz";
+        sha256 = "17p15pvz62s0aslvnkbmp3zcjbhsv8k3bjjb73pfrd6zd4jxgkxy";
       }
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.6.1-darwin-x64.tar.gz";
-        sha256 = "17jf9xwpwpbqk5r20i14j1z4i4rbbx781k0zqyc9yskmv5q4mmwr";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.8.2-darwin-x64.tar.gz";
+        sha256 = "1ifz9iyiqr8s96zhdx3kn5s4k3mzvb18dsxzhq19nv6bcpz0a7gq";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.13.0-darwin-amd64.tar.gz";
-        sha256 = "18mjf9gm8siskg9jh65x4qp4w8p4wnp19bxxk4jfbq27icdk7ws9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v3.1.0-darwin-amd64.tar.gz";
+        sha256 = "0m43h0l3vwjpz19196m4cvjbawckrdcd6kbcr99fy233qg5wd4wd";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.13.0-darwin-amd64.tar.gz";
-        sha256 = "14iwz1gm34irs9jlpwc4ig1wc8k4aaxq8mz3g22yrvwddrsc4rcw";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.18.0-darwin-amd64.tar.gz";
+        sha256 = "15g19gz35wzfg1z3s20wdsqc0h2r65nr3fs4qfa8mzd9hd80cmyy";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.2.0-darwin-amd64.tar.gz";
         sha256 = "0zaxp2n1w5djwyq1afhd3v887dh0yj53jz449riqp19dpyfqf7h7";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.4.0-darwin-amd64.tar.gz";
-        sha256 = "1kzs7k7as9r1vbj746wqz9iph13zfzzw8nsk3waq8aq1hmgh2g1q";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.4.3-darwin-amd64.tar.gz";
+        sha256 = "1ybwd7q37gqvwxkyr99cknjazx53wrhv71h662628bvyr1xfrsan";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.2.2-darwin-amd64.tar.gz";
-        sha256 = "0hwdghij7g9h58nwimfmaz91lz38wibkrdzwqhi7d426m53g6f5c";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.3.0-darwin-amd64.tar.gz";
+        sha256 = "0xmry29j8njvvwygp9q18hirc1s2rqy0vyvmnq9mqbn1dsbkqsbm";
       }
     ];
   };

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 
-VERSION="2.6.1"
+VERSION="2.8.2"
 
 # Bash 3 compatible for Darwin
 plugins=(
     # https://github.com/pulumi/pulumi-aws/releases
-    "aws=2.13.0"
+    "aws=3.1.0"
     # https://github.com/pulumi/pulumi-gcp/releases
-    "gcp=3.13.0"
+    "gcp=3.18.0"
     # https://github.com/pulumi/pulumi-random/releases
     "random=2.2.0"
     # https://github.com/pulumi/pulumi-kubernetes/releases
-    "kubernetes=2.4.0"
+    "kubernetes=2.4.3"
     # https://github.com/pulumi/pulumi-postgresql/releases
-    "postgresql=2.2.2");
+    "postgresql=2.3.0");
 
 function genMainSrc() {
     local url="https://get.pulumi.com/releases/sdk/pulumi-v${VERSION}-$1-x64.tar.gz"


### PR DESCRIPTION
modules
aws:        2.13.0 -> 3.1.0
gcp:        3.13.0 -> 3.18.0
kubernetes: 2.4.0  -> 2.4.3
postgresql: 2.2.2  -> 2.3.0

###### Motivation for this change

update to current latest versions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
