### PR TITLE
buildPerlPackage: fix patchShebangs when cross-compiling

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -28,7 +28,7 @@ let
 
     # TODO: Add a "dev" output containing the header files.
     outputs = [ "out" "man" "devdoc" ] ++
-      optional crossCompiling "dev";
+      optional crossCompiling "mini";
     setOutputFlags = false;
 
     disallowedReferences = [ stdenv.cc ];
@@ -144,13 +144,13 @@ let
           --replace "$man" /no-such-path
       '' + optionalString crossCompiling
       ''
-        mkdir -p $dev/lib/perl5/cross_perl/${version}
+        mkdir -p $mini/lib/perl5/cross_perl/${version}
         for dir in cnf/{stub,cpan}; do
-          cp -r $dir/* $dev/lib/perl5/cross_perl/${version}
+          cp -r $dir/* $mini/lib/perl5/cross_perl/${version}
         done
 
-        mkdir -p $dev/bin
-        install -m755 miniperl $dev/bin/perl
+        mkdir -p $mini/bin
+        install -m755 miniperl $mini/bin/perl
 
         export runtimeArch="$(ls $out/lib/perl5/site_perl/${version})"
         # wrapProgram should use a runtime-native SHELL by default, but
@@ -161,9 +161,9 @@ let
         # miniperl can't load the native modules there. However, it can
         # (and sometimes needs to) load and run some of the pure perl
         # code there, so we add it anyway. When needed, stubs can be put
-        # into $dev/lib/perl5/cross_perl/${version}.
-        wrapProgram $dev/bin/perl --prefix PERL5LIB : \
-          "$dev/lib/perl5/cross_perl/${version}:$out/lib/perl5/${version}:$out/lib/perl5/${version}/$runtimeArch"
+        # into $mini/lib/perl5/cross_perl/${version}.
+        wrapProgram $mini/bin/perl --prefix PERL5LIB : \
+          "$mini/lib/perl5/cross_perl/${version}:$out/lib/perl5/${version}:$out/lib/perl5/${version}/$runtimeArch"
       ''; # */
 
     meta = {

--- a/pkgs/development/interpreters/perl/setup-hook-cross.sh
+++ b/pkgs/development/interpreters/perl/setup-hook-cross.sh
@@ -9,4 +9,4 @@ addPerlLibPath () {
     addToSearchPath PERL5LIB $1/lib/perl5/site_perl/@version@/@runtimeArch@
 }
 
-addEnvHooks "$targetOffset" addPerlLibPath
+addEnvHooks "$hostOffset" addPerlLibPath

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -42,7 +42,7 @@ toPerlModule(stdenv.mkDerivation (
     version = lib.getVersion attrs;                     # TODO: phase-out `attrs.name`
     builder = ./builder.sh;
     buildInputs = buildInputs ++ [ perl ];
-    nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];
+    nativeBuildInputs = nativeBuildInputs ++ [ (perl.mini or perl) ];
     fullperl = buildPerl;
   }
 ))


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Cross-compiled `perl.dev` contains miniperl compiled for the build arch. When perl is added to `buildInputs`, `perl.dev` ends up in `$HOST_PATH`, causing `patchShebangs` to use `${perl.dev}/bin/perl` as the shebang. A fix is to explicitly only include `perl.out` in `buildInputs`. This bug only occurs with Perl packages with executable scripts, for example `XMLTwig`.

This PR does not affect native builds, because native Perl does not have a `dev` output. I have only tested this PR with cross-compiled `XMLTwig`. I attempted to test git and hydra, but they both depend on ModuleBuild, which [currently cannot be cross-compiled](https://github.com/NixOS/nixpkgs/issues/66741).

cc @alyssais @volth @worldofpeace 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
