### PR TITLE
jxrlib: fix/enable for darwin

### DIFF
--- a/pkgs/development/libraries/jxrlib/default.nix
+++ b/pkgs/development/libraries/jxrlib/default.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
     sha256 = "0rk3hbh00nw0wgbfbqk1szrlfg3yq7w6ar16napww3nrlm9cj65w";
   };
 
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace Makefile \
+      --replace '-shared' '-dynamiclib -undefined dynamic_lookup' \
+      --replace '.so' '.dylib'
+  '';
+
   nativeBuildInputs = [ python ];
 
   makeFlags = [ "DIR_INSTALL=$(out)" "SHARED=1" ];
@@ -21,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "Implementation of the JPEG XR image codec standard";
     homepage = "https://jxrlib.codeplex.com";
     license = licenses.bsd2;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ romildo ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
In #92708 we're looking at unbundling libs from `freeimage`, but doing so means adding `jxrlib` as a dependency of `freeimage`. Without darwin support for `jxrlib` this will result in no `freeimage` for darwin. Fix this.

Builds for me, macos 10.14.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
