### PR TITLE
cargo-fund: init at 0.2.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-fund/default.nix
+++ b/pkgs/development/tools/rust/cargo-fund/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, pkg-config, rustPlatform, Security, curl, openssl, libiconv }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-fund";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "acfoltzer";
+    repo = pname;
+    rev = version;
+    sha256 = "1jim5bgq3fc33391qpa1q1csbzqf4hk1qyfzwxpcs5pb4ixb6vgk";
+  };
+
+  cargoSha256 = "181gcmaw2w5a6ah8a2ahsnc1zkadpmx1azkwh2a6x8myhzw2dxsj";
+
+  # The tests need a GitHub API token.
+  doCheck = false;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ] ++ stdenv.lib.optionals stdenv.isDarwin [ Security libiconv curl ];
+
+  meta = with stdenv.lib; {
+    description = "Discover funding links for your project's dependencies";
+    homepage = "https://github.com/acfoltzer/cargo-fund";
+    license = with licenses; [ mit /* or */ asl20 ];
+    maintainers = with maintainers; [ johntitor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9448,6 +9448,9 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
   cargo-expand = callPackage ../development/tools/rust/cargo-expand { };
+  cargo-fund = callPackage ../development/tools/rust/cargo-fund {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
   cargo-fuzz = callPackage ../development/tools/rust/cargo-fuzz { };
   cargo-geiger = callPackage ../development/tools/rust/cargo-geiger {
     inherit (darwin) libiconv;


### PR DESCRIPTION
###### Motivation for this change

cargo-fund is a helpful cargo subcommand binary to support FLOSS developers.
https://github.com/acfoltzer/cargo-fund


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
