### PR TITLE
 python3Packages.svglib: init at 1.0.0 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8416,6 +8416,12 @@
     githubId = 207457;
     name = "Matthieu Chevrier";
   };
+  trepetti = {
+    email = "trepetti@cs.columbia.edu";
+    github = "trepetti";
+    githubId = 25440339;
+    name = "Tom Repetti";
+  };
   trevorj = {
     email = "nix@trevor.joynson.io";
     github = "akatrevorjay";

--- a/pkgs/development/python-modules/svglib/default.nix
+++ b/pkgs/development/python-modules/svglib/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, cssselect2
+, lxml
+, pillow
+, pytest
+, reportlab
+, tinycss2
+}:
+
+buildPythonPackage rec {
+  pname = "svglib";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b17d4a6352f6c25ca3718d2b66a2f1ecfcdf558b1f6646c37f5c191b655979f1";
+  };
+
+  disabled = !isPy3k;
+
+  propagatedBuildInputs = [
+    cssselect2
+    lxml
+    pillow
+    reportlab
+    tinycss2
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  # Ignore tests that require network access (TestWikipediaFlags and TestW3CSVG), and tests that
+  # require files missing in the 1.0.0 PyPI release (TestOtherFiles).
+  checkPhase = ''
+    py.test svglib tests -k 'not TestWikipediaFlags and not TestW3CSVG and not TestOtherFiles'
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/deeplook/svglib";
+    description = "A pure-Python library for reading and converting SVG";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ trepetti ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6550,6 +6550,8 @@ in {
 
   stevedore = callPackage ../development/python-modules/stevedore {};
 
+  svglib = callPackage ../development/python-modules/svglib { };
+
   text-unidecode = callPackage ../development/python-modules/text-unidecode { };
 
   Theano = callPackage ../development/python-modules/Theano rec {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

[svglib](https://github.com/deeplook/svglib) is a pure Python package for manipulating and exporting SVGs. Due to its focus on portability, it has already seen use in [an academic molecular dynamics package](https://github.com/gayverjr/pyemap) and a tool for generating gcode from PCB Gerber files for CNC fabrication. The latter of which, [FlatCAM](https://bitbucket.org/jpcgt/flatcam/src/master/), I am in the process of packaging, and for which I am submitting this last remaining requirement as a stepping stone.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
