### PR TITLE
bgnet: 3.0.21 -> 3.1.2

### DIFF
--- a/pkgs/data/documentation/bgnet/default.nix
+++ b/pkgs/data/documentation/bgnet/default.nix
@@ -1,26 +1,29 @@
-{ stdenv, lib, fetchurl, python, zip, fop }:
+{ stdenv, lib, fetchFromGitHub, python3, pandoc }:
 
 stdenv.mkDerivation {
   pname = "bgnet";
-  version = "3.0.21";
+  # to be found in the Makefile
+  version = "3.1.2";
 
-  src = fetchurl {
-    url = "https://beej.us/guide/bgnet/bgnet.tgz";
-    sha256 = "00ggr5prc5i3w9gaaw2sadfq6haq7lmh0vdilaxx8xz9z5znxvyv";
+  src = fetchFromGitHub {
+    owner = "beejjorgensen";
+    repo = "bgnet";
+    rev = "782a785a35d43c355951b8151628d7c64e4d0346";
+    sha256 = "19w0r3zr71ydd29amqwn8q3npgrpy5kkshyshyji2hw5hky6iy92";
   };
 
-  buildInputs = [ python zip fop ];
-
-  preBuild = ''
-    sed -i "s/#disable=1/disable=1/" bin/bgvalidate
+  buildPhase = ''
     # build scripts need some love
-    patchShebangs .
+    patchShebangs bin/preproc
+
+    make -C src bgnet.html
   '';
 
   installPhase = ''
-    mkdir -p $out
-    mv * $out/
+    install -Dm644 src/bgnet.html $out/share/doc/bgnet/html/index.html
   '';
+
+  nativeBuildInputs = [ python3 pandoc ];
 
   meta = {
     description = "Beej’s Guide to Network Programming";


### PR DESCRIPTION
Also builds from source now, the old tarball was long gone.

Thanks to @flokli for noticing.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
