### PR TITLE
gitpert: init at 0.0.7

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitpert/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitpert/default.nix
@@ -1,0 +1,22 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "gitpert";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    owner = "augmentable-dev";
+    repo = "gitpert";
+    rev = "v${version}";
+    sha256 = "11fs74j8ibq9zqmp87j91l7m34iwgh9bwlf7rb68liq6x9d4kj28";
+  };
+
+  vendorSha256 = "1n7j3wjbls8xlavv0p9116g4bj0phdicywnk4z2s8zl180m3zqhn";
+
+  meta = with lib; {
+    description = "Identify the most relevant git contributors based on commit recency, frequency and impact";
+    homepage = "https://github.com/augmentable-dev/gitpert";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+  };
+}

--- a/pkgs/development/tools/pet/default.nix
+++ b/pkgs/development/tools/pet/default.nix
@@ -13,15 +13,10 @@ buildGoModule rec {
 
   vendorSha256 = "0pnd89iqdj3f719xf4iy5r04n51d0rrrf0qb2zjirpw7vh7g82i9";
 
-  doCheck = false;
-
-  subPackages = [ "." ];
-
   meta = with lib; {
     description = "Simple command-line snippet manager, written in Go";
     homepage = "https://github.com/knqyf263/pet";
     license = licenses.mit;
     maintainers = with maintainers; [ kalbasit ];
-    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3806,6 +3806,8 @@ in
 
   git-big-picture = callPackage ../applications/version-management/git-and-tools/git-big-picture { };
 
+  gitpert = callPackage ../applications/version-management/git-and-tools/gitpert { };
+
   git-crecord = callPackage ../applications/version-management/git-crecord { };
 
   git-lfs = lowPrio (callPackage ../applications/version-management/git-lfs { });


### PR DESCRIPTION
###### Motivation for this change

https://github.com/augmentable-dev/gitpert/tree/v0.0.7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
