### PR TITLE
python3Packages.azure-storage-blob: 2.1.0 -> 12.4.0

### DIFF
--- a/pkgs/development/python-modules/azure-storage-blob/default.nix
+++ b/pkgs/development/python-modules/azure-storage-blob/default.nix
@@ -2,23 +2,28 @@
 , buildPythonPackage
 , fetchPypi
 , azure-common
+, azure-core
 , azure-storage-common
+, msrest
 , isPy3k
 , futures
 }:
 
 buildPythonPackage rec {
   pname = "azure-storage-blob";
-  version = "2.1.0";
+  version = "12.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b90323aad60f207f9f90a0c4cf94c10acc313c20b39403398dfba51f25f7b454";
+    extension = "zip";
+    sha256 = "1s03daq5mxh9acbv8qpa55c2wmjvdf8jq071cwv65mrly8prp84n";
   };
 
   propagatedBuildInputs = [
     azure-common
+    azure-core
     azure-storage-common
+    msrest
   ] ++ lib.optional (!isPy3k) futures;
 
   # has no tests


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date
was also needed by another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/95647
4 packages failed to build:
python37Packages.snowflake-connector-python python37Packages.snowflake-sqlalchemy python38Packages.snowflake-connector-python python38Packages.snowflake-sqlalchemy

4 packages built:
azure-cli dvc-with-remotes python37Packages.azure-storage-blob python38Packages.azure-storage-blob
```