### PR TITLE
ocamlPackages.containers: 2.7 → 3.0

### DIFF
--- a/pkgs/development/ocaml-modules/containers/data.nix
+++ b/pkgs/development/ocaml-modules/containers/data.nix
@@ -1,0 +1,18 @@
+{ buildDunePackage, containers
+, gen, iter, mdx, ounit, qcheck
+}:
+
+buildDunePackage {
+  pname = "containers-data";
+
+  inherit (containers) src version;
+
+  doCheck = true;
+  checkInputs = [ gen iter mdx.bin ounit qcheck ];
+
+  propagatedBuildInputs = [ containers ];
+
+  meta = containers.meta // {
+    description = "A set of advanced datatypes for containers";
+  };
+}

--- a/pkgs/development/ocaml-modules/containers/default.nix
+++ b/pkgs/development/ocaml-modules/containers/default.nix
@@ -1,24 +1,22 @@
 { lib, fetchFromGitHub, buildDunePackage, ocaml
-, iter, result, uchar
-, gen, mdx, ounit, qcheck, uutf
+, seq
+, gen, iter, ounit, qcheck, uutf
 }:
 
 buildDunePackage rec {
-  version = "2.7";
+  version = "3.0";
   pname = "containers";
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "ocaml-containers";
     rev = "v${version}";
-    sha256 = "1nsxfgn1g1vpqihb9gd6gsab0bcm70nf9z84cp441c8wsc57hi6a";
+    sha256 = "0c75d5csgc68qqbsdz4279nlin111zrjbg4d47k32ska28myvpqn";
   };
 
-  buildInputs = [ iter ];
+  propagatedBuildInputs = [ seq ];
 
-  checkInputs = lib.optionals doCheck [ gen mdx.bin ounit qcheck uutf ];
-
-  propagatedBuildInputs = [ result uchar ];
+  checkInputs = [ gen iter ounit qcheck uutf ];
 
   doCheck = true;
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -151,6 +151,8 @@ let
 
     containers = callPackage ../development/ocaml-modules/containers { };
 
+    containers-data = callPackage ../development/ocaml-modules/containers/data.nix { };
+
     cow = callPackage ../development/ocaml-modules/cow { };
 
     cpdf = callPackage ../development/ocaml-modules/cpdf { };


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/c-cube/ocaml-containers/blob/v3.0/CHANGELOG.md

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
