### PR TITLE
[20.03] palemoon: 28.10.0 -> 28.12.0

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchgit, makeDesktopItem
+{ stdenv, lib, fetchFromGitHub, writeScript, desktop-file-utils
 , pkgconfig, autoconf213, alsaLib, bzip2, cairo
 , dbus, dbus-glib, ffmpeg, file, fontconfig, freetype
 , gnome2, gnum4, gtk2, hunspell, libevent, libjpeg
@@ -16,35 +16,33 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "28.10.0";
+  version = "28.12.0";
 
-  src = fetchgit {
-    url = "https://github.com/MoonchildProductions/Pale-Moon.git";
+  src = fetchFromGitHub {
+    owner = "MoonchildProductions";
+    repo = "Pale-Moon";
     rev = "${version}_Release";
-    sha256 = "0c64vmrp46sbl1dgl9dq2vkmpgz9gvgd59dk02jqwyhx4lln1g2l";
+    sha256 = "1cc75972nhmxkkynkky1m2fijbf3qlzvpxsd98mxlx0b7h4d3l5l";
     fetchSubmodules = true;
   };
 
-  desktopItem = makeDesktopItem {
-    name = "palemoon";
-    exec = "palemoon %U";
-    icon = "palemoon";
-    desktopName = "Pale Moon";
-    genericName = "Web Browser";
-    categories = "Application;Network;WebBrowser;";
-    mimeType = lib.concatStringsSep ";" [
-      "text/html"
-      "text/xml"
-      "application/xhtml+xml"
-      "application/vnd.mozilla.xul+xml"
-      "x-scheme-handler/http"
-      "x-scheme-handler/https"
-      "x-scheme-handler/ftp"
-    ];
-  };
+  passthru.updateScript = writeScript "update-${pname}" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p common-updater-scripts curl libxml2
+
+    set -eu -o pipefail
+
+    # Only release note announcement == finalized release
+    version="$(
+      curl -s 'http://www.palemoon.org/releasenotes.shtml' |
+      xmllint --html --xpath 'html/body/table/tbody/tr/td/h3/text()' - 2>/dev/null | head -n1 |
+      sed 's/v\(\S*\).*/\1/'
+    )"
+    update-source-version ${pname} "$version"
+  '';
 
   nativeBuildInputs = [
-    file gnum4 makeWrapper perl pkgconfig python2 wget which
+    desktop-file-utils file gnum4 makeWrapper perl pkgconfig python2 wget which
   ];
 
   buildInputs = [
@@ -106,7 +104,7 @@ in stdenv.mkDerivation rec {
 
     ac_add_options --prefix=$out
 
-    mk_add_options MOZ_MAKE_FLAGS="-j$NIX_BUILD_CORES"
+    mk_add_options MOZ_MAKE_FLAGS="-j${if enableParallelBuilding then "$NIX_BUILD_CORES" else "1"}"
     mk_add_options AUTOCONF=${autoconf213}/bin/autoconf
     '
   '';
@@ -116,14 +114,13 @@ in stdenv.mkDerivation rec {
   installPhase = ''
     $src/mach install
 
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications
+    desktop-file-install --dir=$out/share/applications \
+      $src/palemoon/branding/official/palemoon.desktop
 
-    for n in 16 22 24 32 48 256; do
+    for iconname in default{16,22,24,32,48,256} mozicon128; do
+      n=''${iconname//[^0-9]/}
       size=$n"x"$n
-      mkdir -p $out/share/icons/hicolor/$size/apps
-      cp $src/palemoon/branding/official/default$n.png \
-         $out/share/icons/hicolor/$size/apps/palemoon.png
+      install -Dm644 $src/palemoon/branding/official/$iconname.png $out/share/icons/hicolor/$size/apps/palemoon.png
     done
 
     wrapProgram $out/lib/palemoon-${version}/palemoon \


### PR DESCRIPTION
(cherry picked from commit a5ffb7cf8a0af97bd4302d1ab27fd8cf3a16f6f3)

Backport of #93407
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
