### PR TITLE
nixpkgs-fmt: 0.9.0 -> 1.0.0

### DIFF
--- a/pkgs/tools/nix/nixpkgs-fmt/default.nix
+++ b/pkgs/tools/nix/nixpkgs-fmt/default.nix
@@ -7,10 +7,10 @@ rustPlatform.buildRustPackage rec {
     owner = "nix-community";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-rO30/B+mH/ZOEH8IF2fF4uHK7XQqyR4zIDueHnmNMHA=";
+    sha256 = "0w1himwix7iv40rixj9afknwmqg2qmkif23z217gc7x63zyg9vdc";
   };
 
-  cargoSha256 = "sha256-fP/8yDg+W7hiWGucbRr338y9PEDTb2bdq71JKE6M8OM=";
+  cargoSha256 = "1qzhii72hjdxmgfncvyk80ybvk6zywd6v73bb1ibhnry734grzvw";
 
   meta = with lib; {
     description = "Nix code formatter for nixpkgs";

--- a/pkgs/tools/nix/nixpkgs-fmt/default.nix
+++ b/pkgs/tools/nix/nixpkgs-fmt/default.nix
@@ -1,16 +1,16 @@
 { lib, rustPlatform, fetchFromGitHub, fetchpatch }:
 rustPlatform.buildRustPackage rec {
   pname = "nixpkgs-fmt";
-  version = "0.9.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1kkw87c63nx5pqsxcwn6iw27k02j9ls21zyhb5dvf0zaqd9sz7ad";
+    sha256 = "sha256-rO30/B+mH/ZOEH8IF2fF4uHK7XQqyR4zIDueHnmNMHA=";
   };
 
-  cargoSha256 = "1wybvm9qckx9cd656gx9zrbszmaj66ihh2kk6qqdb6maixcq5k0x";
+  cargoSha256 = "sha256-fP/8yDg+W7hiWGucbRr338y9PEDTb2bdq71JKE6M8OM=";
 
   meta = with lib; {
     description = "Nix code formatter for nixpkgs";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

update nixpkgs-fmt from 0.9.0 to 1.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
