### PR TITLE
python3Packages.finalfusion: init at 0.7.1

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -85,6 +85,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = ''Beerware License'';
   };
 
+  blueOak100 = spdx {
+    spdxId = "BlueOak-1.0.0";
+    fullName = "Blue Oak Model License 1.0.0";
+  };
+
   bsd0 = spdx {
     spdxId = "0BSD";
     fullName = "BSD Zero Clause License";

--- a/pkgs/development/python-modules/finalfusion/default.nix
+++ b/pkgs/development/python-modules/finalfusion/default.nix
@@ -1,0 +1,56 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, isPy3k
+, cython
+, numpy
+, toml
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "finalfusion";
+  version = "0.7.1";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "finalfusion";
+    repo = "finalfusion-python";
+    rev = version;
+    sha256 = "0pwzflamxqvpl1wcz0zbhhd6aa4xn18rmza6rggaic3ckidhyrh4";
+  };
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    toml
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  postPatch = ''
+    patchShebangs tests/integration
+  '';
+
+  checkPhase = ''
+    # Regular unit tests.
+    pytest
+
+    # Integration tests for command-line utilities.
+    PATH=$PATH:$out/bin tests/integration/all.sh
+  '';
+
+  meta = with lib; {
+    description = "Python module for using finalfusion, word2vec, and fastText word embeddings";
+    homepage = "https://github.com/finalfusion/finalfusion-python/";
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.all;
+    license = licenses.blueOak100;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -764,6 +764,8 @@ in {
 
   filemagic = callPackage ../development/python-modules/filemagic { };
 
+  finalfusion = callPackage ../development/python-modules/finalfusion { };
+
   fints = callPackage ../development/python-modules/fints { };
 
   fire = callPackage ../development/python-modules/fire { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This is a package for working with many different word embedding formats (word2vec, finalfusion, fastText, etc.). It can read/write these formats, expose embeddings as numpy matrices, and do queries (e.g. similarity).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
