### PR TITLE
oci-seccomp-bpf-hook: new at 1.2.0

### DIFF
--- a/pkgs/applications/virtualization/oci-seccomp-bpf-hook/default.nix
+++ b/pkgs/applications/virtualization/oci-seccomp-bpf-hook/default.nix
@@ -1,0 +1,58 @@
+{ stdenv
+, buildGoModule
+, fetchFromGitHub
+, go-md2man
+, installShellFiles
+, libseccomp
+, linuxPackages
+, pkg-config
+}:
+
+buildGoModule rec {
+  pname = "oci-seccomp-bpf-hook";
+  version = "1.2.0";
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "oci-seccomp-bpf-hook";
+    rev = "v${version}";
+    sha256 = "143x4daixzhhhpli1l14r7dr7dn3q42w8dddr16jzhhwighsirqw";
+  };
+  vendorSha256 = null;
+  doCheck = false;
+
+  outputs = [ "out" "man" ];
+  nativeBuildInputs = [
+    go-md2man
+    installShellFiles
+    pkg-config
+  ];
+  buildInputs = [
+    libseccomp
+    linuxPackages.bcc
+  ];
+
+  buildPhase = ''
+    make
+  '';
+
+  postBuild = ''
+    substituteInPlace oci-seccomp-bpf-hook.json --replace HOOK_BIN_DIR "$out/bin"
+  '';
+
+  installPhase = ''
+    install -Dm755 bin/* -t $out/bin
+    install -Dm644 oci-seccomp-bpf-hook.json -t $out
+    installManPage docs/*.[1-9]
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/containers/oci-seccomp-bpf-hook";
+    description = ''
+      OCI hook to trace syscalls and generate a seccomp profile
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ saschagrunert ];
+    platforms = platforms.linux;
+    badPlatforms = [ "aarch64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24521,6 +24521,8 @@ in
 
   nxengine-evo = callPackage ../games/nxengine-evo { };
 
+  oci-seccomp-bpf-hook = callPackage ../applications/virtualization/oci-seccomp-bpf-hook { };
+
   odamex = callPackage ../games/odamex { };
 
   oilrush = callPackage ../games/oilrush { };


### PR DESCRIPTION

###### Motivation for this change
Add a new package for the OCI seccomp BPF hook package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @NixOS/podman 