### PR TITLE
xdg-utils: add missing dependencies

### DIFF
--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -36,17 +36,15 @@ stdenv.mkDerivation rec {
     cp ${mimisrc}/xdg-open $out/bin/xdg-open
   '' + ''
     sed  '2s#.#\
-    cut()   { ${coreutils}/bin/cut  "$@"; }\
     sed()   { ${gnused}/bin/sed     "$@"; }\
     grep()  { ${gnugrep}/bin/grep   "$@"; }\
     egrep() { ${gnugrep}/bin/egrep  "$@"; }\
     file()  { ${file}/bin/file      "$@"; }\
     awk()   { ${gawk}/bin/awk       "$@"; }\
-    sort()  { ${coreutils}/bin/sort "$@"; }\
     xset()  { ${xset}/bin/xset      "$@"; }\
     perl()  { PERL5LIB=${perlPath} ${perlPackages.perl}/bin/perl "$@"; }\
     mimetype() { ${perlPackages.FileMimeInfo}/bin/mimetype "$@"; }\
-    PATH=$PATH:'"$out"'/bin\
+    PATH=$PATH:'$out'/bin:${coreutils}/bin\
     &#' -i "$out"/bin/*
 
     substituteInPlace $out/bin/xdg-open \
@@ -58,7 +56,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/bin/xdg-email \
       --replace "/bin/echo" "${coreutils}/bin/echo"
 
-    sed 's# which # type -P #g' -i "$out"/bin/*
+    sed 's|\bwhich\b|type -P|g' -i "$out"/bin/*
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
- Add coreutils to PATH, because the xdg scripts use other not yet provided coreutils like head.
  This makes the custom 'cut' and 'sort' functions obsolete.
  Remove double quotes around $out because $out contains no Bash field separators.
- Replace all instances of 'which' with 'type -P'.
  The previous sed command only replaced instances with a leading space.

#### Reproduce

```bash
firefox=$(nix-build --no-out-link '<nixpkgs>' -A firefox)
xdgUtils=$(nix-build --no-out-link '<nixpkgs>' -A xdg_utils)
env -i XDG_DATA_DIRS=$firefox/share PATH=$firefox/bin $xdgUtils/bin/xdg-mime query default x-scheme-handler/http
## Output before this patch:
# /nix/store/.../bin/xdg-mime: line 1031: head: command not found
# /nix/store/.../bin/xdg-mime: line 1031: head: command not found
# /nix/store/.../bin/xdg-mime: line 1031: head: command not found
# /nix/store/.../bin/xdg-mime: line 1031: head: command not found
# /nix/store/.../bin/xdg-mime: line 947: basename: command not found
## Output after this patch:
# firefox.desktop
```