### PR TITLE
fonts.fontconfig-penultimate: remove dependency on fontconfig_210

### DIFF
--- a/nixos/modules/config/fonts/fontconfig-penultimate.nix
+++ b/nixos/modules/config/fonts/fontconfig-penultimate.nix
@@ -7,24 +7,14 @@ let
 
   fcBool = x: "<bool>" + (boolToString x) + "</bool>";
 
-  # back-supported fontconfig version and package
-  # version is used for font cache generation
-  supportVersion = "210";
-  supportPkg     = pkgs."fontconfig_${supportVersion}";
-
   # latest fontconfig version and package
   # version is used for configuration folder name, /etc/fonts/VERSION/
-  # note: format differs from supportVersion and can not be used with makeCacheConf
   latestVersion  = pkgs.fontconfig.configVersion;
   latestPkg      = pkgs.fontconfig;
-
-  # supported version fonts.conf
-  supportFontsConf = pkgs.makeFontsConf { fontconfig = supportPkg; fontDirectories = config.fonts.fonts; };
 
   # configuration file to read fontconfig cache
   # version dependent
   # priority 0
-  cacheConfSupport = makeCacheConf { version = supportVersion; };
   cacheConfLatest  = makeCacheConf {};
 
   # generate the font cache setting file for a fontconfig version
@@ -186,7 +176,6 @@ let
     mkdir -p $latest_folder
 
     # fonts.conf
-    ln -s ${supportFontsConf} $support_folder/../fonts.conf
     ln -s ${latestPkg.out}/etc/fonts/fonts.conf \
           $latest_folder/../fonts.conf
 
@@ -196,7 +185,6 @@ let
     ln -s ${pkgs.fontconfig-penultimate}/etc/fonts/conf.d/*.conf \
           $latest_folder
 
-    ln -s ${cacheConfSupport} $support_folder/00-nixos-cache.conf
     ln -s ${cacheConfLatest}  $latest_folder/00-nixos-cache.conf
 
     rm $support_folder/10-antialias.conf $latest_folder/10-antialias.conf


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Since https://github.com/NixOS/nixpkgs/pull/93562 was merged,
configurations which set `fonts.fontconfig.penultimate.enable` to true
will fail to build, tripping the assertion:

```
fontconfig 2.10.x hasn't had a release in years, is vulnerable to CVE-2016-5384
and has only been used for old fontconfig caches.
```

This rectifies the module, deleting references to fontconfig_210. I just
did the most obvious thing possible to make it build, and didn't really
think properly about the consequences, so I would appreciate some review
on this one from someone who knows the fontconfig stuff a bit better.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).