### PR TITLE
sogo: 4.3.2 -> 5.0.0

### DIFF
--- a/nixos/modules/services/web-apps/sogo.nix
+++ b/nixos/modules/services/web-apps/sogo.nix
@@ -77,7 +77,6 @@ in {
         // Paths
         WOSendMail = "/run/wrappers/bin/sendmail";
         SOGoMailSpoolPath = "/var/lib/sogo/spool";
-        SOGoZipPath = "${pkgs.zip}/bin/zip";
         // Enable CSRF protection
         SOGoXSRFValidationEnabled = YES;
         // Remove dates from log (jornald does that)

--- a/pkgs/development/libraries/sope/default.nix
+++ b/pkgs/development/libraries/sope/default.nix
@@ -1,13 +1,13 @@
 { gnustep, lib, fetchFromGitHub , libxml2, openssl_1_1
 , openldap, mysql, libmysqlclient, postgresql }: with lib; gnustep.stdenv.mkDerivation rec {
   pname = "sope";
-  version = "4.3.2";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "inverse-inc";
     repo = pname;
     rev = "SOPE-${version}";
-    sha256 = "0ny1ihx38gd25w8f3dfybyswvyjfljvb2fhfmkajgg6hhjrkfar2";
+    sha256 = "sha256-7NM9wcyHDSVmjjqu489Ff3iJgl9VM+UBF3XYWoiHHTg=";
   };
 
   nativeBuildInputs = [ gnustep.make ];

--- a/pkgs/servers/web-apps/sogo/default.nix
+++ b/pkgs/servers/web-apps/sogo/default.nix
@@ -18,8 +18,8 @@ with lib; gnustep.stdenv.mkDerivation rec {
   patches = [
     # TODO: take a closer look at other patches in https://sources.debian.org/patches/sogo/ and https://github.com/Skrupellos/sogo-patches
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/s/sogo/4.3.0-1/debian/patches/0005-Remove-build-date.patch";
-      sha256 = "0lrh3bkfj3r0brahfkyb0g7zx7r2jjd5cxzjl43nqla0fs09wsh8";
+      url = "https://salsa.debian.org/debian/sogo/-/raw/120ac6390602c811908c7fcb212a79acbc7f7f28/debian/patches/0005-Remove-build-date.patch";
+      sha256 = "151i8504kwdlcirgd0pbif7cxnb1q6jsp5j7dbh9p6zw2xgwkp25";
     })
   ];
 

--- a/pkgs/servers/web-apps/sogo/default.nix
+++ b/pkgs/servers/web-apps/sogo/default.nix
@@ -1,17 +1,18 @@
 { gnustep, lib, fetchFromGitHub, fetchpatch, makeWrapper, python2, lndir
-, openssl_1_1, openldap, sope, libmemcached, curl }: with lib; gnustep.stdenv.mkDerivation rec {
+, openssl_1_1, openldap, sope, libmemcached, curl, libsodium, libzip, pkgconfig }:
+with lib; gnustep.stdenv.mkDerivation rec {
   pname = "SOGo";
-  version = "4.3.2";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "inverse-inc";
     repo = pname;
     rev = "SOGo-${version}";
-    sha256 = "1xxad23a8zy6w850x5nrrf54db0x73lc9drmc5kpfk870fk2lmr0";
+    sha256 = "sha256-SEyyHekUCSkb5rOh7Ty8AhtT4S9KicTRbo9iWhijdGE=";
   };
 
   nativeBuildInputs = [ gnustep.make makeWrapper python2 ];
-  buildInputs = [ gnustep.base sope openssl_1_1 libmemcached (curl.override { openssl = openssl_1_1; }) ]
+  buildInputs = [ gnustep.base sope openssl_1_1 libmemcached (curl.override { openssl = openssl_1_1; }) libsodium libzip pkgconfig ]
     ++ optional (openldap != null) openldap;
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change
New upstream release.

cc @herrwiese @dasJ 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
