### PR TITLE
nixos-option: use the system's nix package

### DIFF
--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -48,7 +48,7 @@ let
   nixos-option =
     if lib.versionAtLeast (lib.getVersion pkgs.nix) "2.4pre"
     then null
-    else pkgs.callPackage ./nixos-option { };
+    else pkgs.callPackage ./nixos-option { nix = config.nix.package; };
 
   nixos-version = makeProg {
     name = "nixos-version";


### PR DESCRIPTION
This guarantees that 'nixos-option' accepts the same nix expressions as 'nix', 'nixos-rebuild' and 'nixos-install'.

In my specific case I was using a modified version of nix for `nix.package`, which lead to a system where nixos-option couldn't parse my nixos configuration.