### PR TITLE
gnome-shell: 3.36.4 -> 3.36.5

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -67,13 +67,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "gnome-shell";
-  version = "3.36.4";
+  version = "3.36.5";
 
   outputs = [ "out" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-shell/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1nyibrr98ijn65z9ki0k7xzcwcliwy2jqssz0l0jalpbkhnr751d";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1hj7gmjmy92xndlgw7pzk5m6j2fbzcgfd1pxc32k38gml8qg19d4";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump.
Release news:

> 3.36.5
> ======
> * Fix extension updates when many extensions are installed [Jeremias; [!1363](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1363)]
> * Fix missing icons in on-screen keyboard [Emre; [#2631](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2631), [#3007](https://gitlab.gnome.org/GNOME/gnome-shell/issues/3007)]
> * Fix delay when showing calendar events [Sebastian; [#2992](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2992)]
> * Fix app picker regressions on small displays [Sebastian; [#2234](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2234), [!1375](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1375), [!1378](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1378)]
> * Fix top bar navigation when NumLock is active [Olivier; [#550](https://gitlab.gnome.org/GNOME/gnome-shell/issues/550)]
> * Delay login animation until wallpaper has loaded [Michael; [#734996](https://gitlab.gnome.org/GNOME/gnome-shell/issues/734996)]
> * Revert changes that caused mispositioning in overview in multi-monitor setups
>   [Robert; [#2971](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2971)]
> * Reset auth prompt on login screen on VT switch before fade in [Ray; [#2997](https://gitlab.gnome.org/GNOME/gnome-shell/issues/2997)]
> * Fix stuck grab when destroying open popup menu [Florian; [#3022](https://gitlab.gnome.org/GNOME/gnome-shell/issues/3022)]
> * Misc. bug fixes and cleanups [Florian, Carlos, Andre, Jonas; [!1357](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1357), [!1371](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1371),
>   [!1381](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1381), [#3037](https://gitlab.gnome.org/GNOME/gnome-shell/issues/3037), [#3005](https://gitlab.gnome.org/GNOME/gnome-shell/issues/3005), [!1386](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1386), [!1390](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1390)]
> 
> Contributors:
>   Michael Catanzaro, Jonas Dreßler, Olivier Fourdan, Carlos Garnacho,
>   Sebastian Keller, Robert Mader, Andre Moreira Magalhaes, Florian Müllner,
>   Jeremias Ortega, Ray Strode, Emre Uyguroglu
> 
> Translators:
>   Boyuan Yang [zh_CN], Rafael Fontenelle [pt_BR]


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
