### PR TITLE
source-han-*: reduce closure size by 2x

### DIFF
--- a/pkgs/data/fonts/source-han/default.nix
+++ b/pkgs/data/fonts/source-han/default.nix
@@ -19,7 +19,8 @@ let
     version = lib.removeSuffix "R" rev;
 
     buildCommand = ''
-      install -m444 -Dt $out/share/fonts/opentype/source-han-${family} ${ttc}
+      mkdir -p $out/share/fonts/opentype/source-han-${family}
+      ln -s ${ttc} $out/share/fonts/opentype/source-han-${family}/SourceHan${Family}.ttc
     '';
 
     meta = {


### PR DESCRIPTION
The file name of the installed font was the path returned by fetchurl:
`xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-SourceHanSans.ttc`

This caused the derivation to reference the downloaded font file,
storing the font twice unless you optimise the store (each file is
~150M).

cc maintainers @taku0 @emilazy 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)


:smile: Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
