### PR TITLE
openambit: init at 0.5

### DIFF
--- a/pkgs/applications/misc/openambit/default.nix
+++ b/pkgs/applications/misc/openambit/default.nix
@@ -1,0 +1,48 @@
+{ cmake
+, fetchFromGitHub
+, lib
+, libusb1
+, mkDerivation
+, python3
+, qtbase
+, qttools
+, udev
+, zlib
+}:
+
+mkDerivation rec {
+  pname = "openambit";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "openambitproject";
+    repo = pname;
+    rev = version;
+    sha256 = "1074kvkamwnlkwdajsw1799wddcfkjh2ay6l842r0s4cvrxrai85";
+  };
+
+  nativeBuildInputs = [ cmake qttools ];
+  buildInputs = [ libusb1 python3 qtbase udev zlib ];
+
+  cmakeFlags = [ "-DCMAKE_INSTALL_UDEVRULESDIR=${placeholder "out"}/lib/udev/rules.d" ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/openambit --version
+  '';
+
+  postInstall = ''
+    install -m755 -D $src/tools/openambit2gpx.py $out/bin/openambit2gpx
+
+    mv -v $out/lib/udev/rules.d/libambit.rules \
+          $out/lib/udev/rules.d/20-libambit.rules
+  '';
+
+  meta = with lib; {
+    description = "Helps fetch data from Suunto Ambit GPS watches";
+    homepage = "https://github.com/openambitproject/openambit/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ rycee ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22251,6 +22251,8 @@ in
 
   inherit (python3Packages.callPackage ../applications/networking/onionshare { }) onionshare onionshare-gui;
 
+  openambit = qt5.callPackage ../applications/misc/openambit { };
+
   openbox = callPackage ../applications/window-managers/openbox { };
 
   openbox-menu = callPackage ../applications/misc/openbox-menu {


### PR DESCRIPTION
##### Motivation for this change

To package openambit.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
