### PR TITLE
Bump a few packages related to the Matrix ecosystem

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "element-desktop",
   "productName": "Element",
   "main": "src/electron-main.js",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "A feature-rich client for Matrix.org",
   "author": "Element",
   "repository": {
@@ -61,7 +61,7 @@
   },
   "build": {
     "appId": "im.riot.app",
-    "electronVersion": "9.0.5",
+    "electronVersion": "9.1.2",
     "files": [
       "package.json",
       {

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -8,12 +8,12 @@
 
 let
   executableName = "element-desktop";
-  version = "1.7.3";
+  version = "1.7.4";
   src = fetchFromGitHub {
     owner = "vector-im";
     repo = "riot-desktop";
     rev = "v${version}";
-    sha256 = "1qr00g2a8dibnkxn4pv9qkv09wwalfbgi2jq4wkq66anbgj9f39g";
+    sha256 = "16ilkf5b8mz74x1r9fym5xjb4plxzhg3g5njj1sl4qvsbrkk6r9a";
   };
   electron = electron_9;
 

--- a/pkgs/applications/networking/instant-messengers/element/element-web.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-web.nix
@@ -12,11 +12,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "element-web";
-  version = "1.7.3";
+  version = "1.7.4";
 
   src = fetchurl {
     url = "https://github.com/vector-im/riot-web/releases/download/v${version}/riot-v${version}.tar.gz";
-    sha256 = "0vlh89kilnpg90kdxlikfak03zdwhwj754xskgb27jal0iaw0r8s";
+    sha256 = "0ssyd5b9yrxidivr3rcjsd8ixkmppsmmr7a8k0sv16yk7hjnvz5b";
   };
 
   installPhase = ''

--- a/pkgs/development/python-modules/canonicaljson/default.nix
+++ b/pkgs/development/python-modules/canonicaljson/default.nix
@@ -1,14 +1,15 @@
 { stdenv, buildPythonPackage, fetchPypi
-, frozendict, simplejson, six
+, frozendict, simplejson, six, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "canonicaljson";
-  version = "1.1.4";
+  version = "1.3.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "45bce530ff5fd0ca93703f71bfb66de740a894a3b5dd6122398c6d8f18539725";
+    sha256 = "0v2b72n28fi763xxv9vrf4qc61anl2ys9njy7hlm719fdaq3sxml";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -9,11 +9,11 @@ let
 in
 buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "1.18.0";
+  version = "1.19.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0bqacma2ip0l053rfvxznbixs2rmb2dawqi2jq2zbqk5jqxhpaxi";
+    sha256 = "1fl9p0cb442271hx7zjz8vp111xgvdpn4khk8bk3kl8z9hjs2l1p";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

* Updated `element-{web,desktop}` to `1.7.4` (https://github.com/vector-im/element-web/releases/tag/v1.7.4, https://github.com/vector-im/element-desktop/releases/tag/v1.7.4).
* Updated `matrix-synapse` to [`1.19.0`](https://github.com/matrix-org/synapse/releases/tag/v1.19.0).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
