### PR TITLE
pythonPackages.argparse: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4414,6 +4414,12 @@
     githubId = 524268;
     name = "Koral";
   };
+  koslambrou = {
+    email = "koslambrou@gmail.com";
+    github = "koslambrou";
+    githubId = 2037002;
+    name = "Konstantinos";
+  };
   kovirobi = {
     email = "kovirobi@gmail.com";
     github = "kovirobi";

--- a/pkgs/development/python-modules/argparse/default.nix
+++ b/pkgs/development/python-modules/argparse/default.nix
@@ -1,0 +1,19 @@
+{ buildPythonPackage
+, fetchurl
+, lib
+}:
+buildPythonPackage rec {
+  name = "argparse";
+  version = "1.4.0";
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/18/dd/e617cfc3f6210ae183374cd9f6a26b20514bbb5a792af97949c5aacddf0f/${name}-${version}.tar.gz";
+    sha256 = "62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4";
+};
+  format = "setuptools";
+  meta = with lib; {
+    homepage = "https://github.com/ThomasWaldmann/argparse/";
+    license = licenses.psfl;
+    description = "Python command-line parsing library";
+    maintainers = [ maintainers.koslambrou ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -208,6 +208,8 @@ in {
 
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };
 
+  argparse = callPackage ../development/python-modules/argparse { };
+
   aria2p = callPackage ../development/python-modules/aria2p { inherit (pkgs) aria2; };
 
   arviz = callPackage ../development/python-modules/arviz { };


### PR DESCRIPTION
###### Motivation for this change
pythonPackages.argparse: init at 1.4.0

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
