### PR TITLE
pythonPackages.rdflib-jsonld: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4414,6 +4414,12 @@
     githubId = 524268;
     name = "Koral";
   };
+  koslambrou = {
+    email = "koslambrou@gmail.com";
+    github = "koslambrou";
+    githubId = 2037002;
+    name = "Konstantinos";
+  };
   kovirobi = {
     email = "kovirobi@gmail.com";
     github = "kovirobi";

--- a/pkgs/development/python-modules/rdflib-jsonld/default.nix
+++ b/pkgs/development/python-modules/rdflib-jsonld/default.nix
@@ -1,0 +1,21 @@
+{ buildPythonPackage, fetchPypi, lib, rdflib, nose }:
+
+buildPythonPackage rec {
+  pname = "rdflib-jsonld";
+  version = "0.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4f7d55326405071c7bce9acf5484643bcb984eadb84a6503053367da207105ed";
+  };
+
+  nativeBuildInputs = [ nose ];
+  propagatedBuildInputs = [ rdflib ];
+
+  meta = with lib; {
+    homepage = "https://github.com/RDFLib/rdflib-jsonld";
+    license = licenses.bsdOriginal;
+    description = "rdflib extension adding JSON-LD parser and serializer";
+    maintainers = [ maintainers.koslambrou ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5944,6 +5944,8 @@ in {
 
   rdflib = callPackage ../development/python-modules/rdflib { };
 
+  rdflib-jsonld = callPackage ../development/python-modules/rdflib-jsonld { };
+
   isodate = callPackage ../development/python-modules/isodate { };
 
   owslib = callPackage ../development/python-modules/owslib { };


### PR DESCRIPTION
#### Motivation for this change
added rdflib-jsonld python package

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
