### PR TITLE
python3Packages.qiskit: 0.19.6 -> 0.20.0 & update components

### DIFF
--- a/pkgs/development/libraries/muparserx/default.nix
+++ b/pkgs/development/libraries/muparserx/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "muparserx";
+  version = "4.0.8";
+
+  src = fetchFromGitHub {
+    owner = "beltoforion";
+    repo = "muparserx";
+    rev = "v${version}";
+    sha256 = "097pkdffv0phr0345hy06mjm5pfy259z13plsvbxvcmds80wl48v";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
+  doCheck = true;
+  checkPhase = ''
+    echo "***Muparserx self-test***"
+    echo "quit" | ./example > test_result.log
+    cat test_result.log
+    if grep -Fqi "failed" test_result.log; then
+      echo ">=1 muparserx tests failed"
+      exit 1
+    else
+      echo -e "\nmuparserx tests succeeded"
+    fi
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A C++ Library for Parsing Expressions with Strings, Complex Numbers, Vectors, Matrices and more.";
+    homepage = "https://beltoforion.de/en/muparserx/";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/development/python-modules/multitasking/default.nix
+++ b/pkgs/development/python-modules/multitasking/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "multitasking";
+  version = "0.0.9";
+
+  # GitHub source releases aren't tagged
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b59d99f709d2e17d60ccaa2be09771b6e9ed9391c63f083c0701e724f624d2e0";
+  };
+
+  doCheck = false;  # No tests included
+  pythonImportsCheck = [ "multitasking" ];
+
+  meta = with lib; {
+    description = "Non-blocking Python methods using decorators";
+    homepage = "https://github.com/ranaroussi/multitasking";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/development/python-modules/pylatexenc/default.nix
+++ b/pkgs/development/python-modules/pylatexenc/default.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "pylatexenc";
-  version = "2.4";
+  version = "2.7";
 
   src = fetchFromGitHub {
     owner = "phfaist";
     repo = "pylatexenc";
     rev = "v${version}";
-    sha256 = "0i4frypbv90mjir8bkp03cwkvwhgvc9p3fw6q2jz1dn7fw94v2rv";
+    sha256 = "1hpcwbknfah3mky2m4asw15b9qdvv4k5ni0js764n1jpi83m1zgk";
   };
 
   pythonImportsCheck = [ "pylatexenc" ];

--- a/pkgs/development/python-modules/qiskit-aer/remove-conan-install.patch
+++ b/pkgs/development/python-modules/qiskit-aer/remove-conan-install.patch
@@ -1,0 +1,63 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index efeacfc..77bd6bd 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -121,7 +121,11 @@ endif()
+ # Looking for external libraries
+ #
+ 
+-setup_conan()
++find_package(muparserx REQUIRED)
++find_package(nlohmann_json REQUIRED)
++find_package(spdlog REQUIRED)
++# for tests only
++find_package(catch2)
+ 
+ # If we do not set them with a space CMake fails afterwards if nothing is set for this vars!
+ set(AER_LINKER_FLAGS " ")
+@@ -269,16 +273,16 @@ endif()
+ set(AER_LIBRARIES
+ 	${AER_LIBRARIES}
+ 	${BLAS_LIBRARIES}
+-	CONAN_PKG::nlohmann_json
++	nlohmann_json
+ 	Threads::Threads
+-	CONAN_PKG::spdlog
++	spdlog
+ 	${DL_LIB}
+ 	${THRUST_DEPENDANT_LIBS})
+ 
+ set(AER_COMPILER_DEFINITIONS ${AER_COMPILER_DEFINITIONS} ${CONAN_DEFINES})
+ # Cython build is only enabled if building through scikit-build.
+ if(SKBUILD) # Terra Addon build
+-	set(AER_LIBRARIES ${AER_LIBRARIES} CONAN_PKG::muparserx)
++	set(AER_LIBRARIES ${AER_LIBRARIES} muparserx)
+ 	add_subdirectory(qiskit/providers/aer/pulse/qutip_extra_lite/cy)
+ 	add_subdirectory(qiskit/providers/aer/backends/wrappers)
+ 	add_subdirectory(src/open_pulse)
+diff --git a/setup.py b/setup.py
+index fd71e9f..1561cc4 100644
+--- a/setup.py
++++ b/setup.py
+@@ -11,12 +11,6 @@ import inspect
+ 
+ PACKAGE_NAME = os.getenv('QISKIT_AER_PACKAGE_NAME', 'qiskit-aer')
+ 
+-try:
+-    from conans import client
+-except ImportError:
+-    subprocess.call([sys.executable, '-m', 'pip', 'install', 'conan'])
+-    from conans import client
+-
+ try:
+     from skbuild import setup
+ except ImportError:
+@@ -46,8 +40,6 @@ common_requirements = [
+ 
+ setup_requirements = common_requirements + [
+     'scikit-build',
+-    'cmake!=3.17,!=3.17.0',
+-    'conan>=1.22.2'
+ ]
+ 
+ requirements = common_requirements + ['qiskit-terra>=0.12.0']

--- a/pkgs/development/python-modules/qiskit-aqua/default.nix
+++ b/pkgs/development/python-modules/qiskit-aqua/default.nix
@@ -2,6 +2,7 @@
 , pythonOlder
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 # , cplex
 , cvxpy
 , dlx
@@ -16,6 +17,7 @@
 , qiskit-terra
 , quandl
 , scikitlearn
+, yfinance
   # Check Inputs
 , ddt
 , pytestCheckHook
@@ -24,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-aqua";
-  version = "0.7.3";
+  version = "0.7.5";
 
   disabled = pythonOlder "3.5";
 
@@ -33,8 +35,17 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-aqua";
     rev = version;
-    sha256 = "04zcnrc0vi6dfjahp1019h2ngdgi7l7jvfs9aw0y306nd9g6qgjc";
+    sha256 = "19sdv7lnc4b1c86rd1dv7pjpi8cmrpzbv7nav0fb899ki8ldqdwq";
   };
+
+  # TODO: remove in next release
+  patches = [
+    (fetchpatch {
+      name = "qiskit-aqua-fix-test-issue-1214.patch";
+      url = "https://github.com/Qiskit/qiskit-aqua/commit/284a4323192ac85787b22cbe5f344996fae16f7d.patch";
+      sha256 = "0zl8hqa2fq9ng793x4dhh0ny67nnbjcd8l1cdsaaab4ca1y0xcfr";
+    })
+  ];
 
   # Optional packages: pyscf (see below NOTE) & pytorch. Can install via pip/nix if needed.
   propagatedBuildInputs = [
@@ -51,6 +62,7 @@ buildPythonPackage rec {
     qiskit-ignis
     quandl
     scikitlearn
+    yfinance
   ];
 
   # *** NOTE ***
@@ -105,8 +117,9 @@ buildPythonPackage rec {
     # Disabled due to missing pyscf
     "test_validate" # test/chemistry/test_inputparser.py
 
-    "test_binary" # in SklearnSVM, seems to have trouble with eigenvectors converging
-    "test_pauli_expect_single"  # fails for unknown reason, 3e-3 out of tolerance
+    # Online tests
+    "test_exchangedata"
+    "test_yahoo"
 
     # Disabling slow tests > 10 seconds
     "TestVQE"
@@ -119,7 +132,6 @@ buildPythonPackage rec {
     "TestQGAN"
     "test_evaluate_qasm_mode"
     "test_measurement_error_mitigation_auto_refresh"
-    "test_exchangedata"
     "test_wikipedia"
     "test_shor_factoring_1__15___qasm_simulator____3__5__"
     "test_readme_sample"
@@ -138,11 +150,13 @@ buildPythonPackage rec {
     "test_oh"
     "test_confidence_intervals_00001"
     "test_eoh"
+    "test_qasm_5"
   ];
 
   meta = with lib; {
     description = "An extensible library of quantum computing algorithms";
     homepage = "https://github.com/QISKit/qiskit-aqua";
+    changelog = "https://qiskit.org/documentation/release_notes.html";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
   };

--- a/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
+++ b/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-ibmq-provider";
-  version = "0.7.2";
+  version = "0.8.0";
 
   disabled = pythonOlder "3.6";
 
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "11h1ca4v11pajzn1cxqhim1hfziqzj27xzakwln13g8zmiqx3csp";
+    sha256 = "0rrpwr4a82j69j5ibl2g0nw8wbpg201cfz6f234k2v6pj500x9nl";
   };
 
   propagatedBuildInputs = [
@@ -85,6 +85,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Qiskit provider for accessing the quantum devices and simulators at IBMQ";
     homepage = "https://github.com/Qiskit/qiskit-ibmq-provider";
+    changelog = "https://qiskit.org/documentation/release_notes.html";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
   };

--- a/pkgs/development/python-modules/qiskit-ignis/default.nix
+++ b/pkgs/development/python-modules/qiskit-ignis/default.nix
@@ -9,14 +9,15 @@
 , scikitlearn
 , scipy
   # Check Inputs
-, ddt
 , pytestCheckHook
+, ddt
+, pyfakefs
 , qiskit-aer
 }:
 
 buildPythonPackage rec {
   pname = "qiskit-ignis";
-  version = "0.3.3";
+  version = "0.4.0";
 
   disabled = pythonOlder "3.6";
 
@@ -25,7 +26,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-ignis";
     rev = version;
-    sha256 = "0sy9qpw0jqirsk9y61j5kr18jrw1wa812n7y98fjj6w668rrv560";
+    sha256 = "07mxhaknkp121xm6mgrpcrbj9qw6j924ra3k0s6vr8qgvfcxvh0y";
   };
 
   propagatedBuildInputs = [
@@ -41,18 +42,21 @@ buildPythonPackage rec {
   dontUseSetuptoolsCheck = true;
   preCheck = "export HOME=$TMPDIR";
   checkInputs = [
-    ddt
     pytestCheckHook
+    ddt
+    pyfakefs
     qiskit-aer
   ];
-  # Test is in test/verification/test_entanglemet.py. test fails due to out-of-date calls & bad logic with this file since qiskit-ignis#328
-  # see qiskit-ignis#386 for all issues. Should be able to re-enable in future.
-  disabledTests = [ "TestEntanglement" ];
+  disabledTests = [
+    "test_tensored_meas_cal_on_circuit" # Flaky test, occasionally returns result outside bounds
+    "test_qv_fitter"  # execution hangs, ran for several minutes
+  ];
 
   meta = with lib; {
     description = "Qiskit tools for quantum hardware verification, noise characterization, and error correction";
     homepage = "https://qiskit.org/ignis";
     downloadPage = "https://github.com/QISKit/qiskit-ignis/releases";
+    changelog = "https://qiskit.org/documentation/release_notes.html";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
   };

--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -8,12 +8,11 @@
 , fastjsonschema
 , jsonschema
 , numpy
-, marshmallow
-, marshmallow-polyfield
 , networkx
 , ply
 , psutil
 , python-constraint
+, python-dateutil
 , retworkx
 , scipy
 , sympy
@@ -36,7 +35,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-terra";
-  version = "0.14.2";
+  version = "0.15.1";
 
   disabled = pythonOlder "3.5";
 
@@ -44,7 +43,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "0p5wapjvy81pnks100xbb23kbs2wyys9ykyc8z4968wl487lq4g5";
+    sha256 = "1p7y36gj3675dmp05nwi0m9nc7h0bwyimir3ncf9wbkx3crrh99c";
   };
 
   nativeBuildInputs = [ cython ];
@@ -54,13 +53,12 @@ buildPythonPackage rec {
     fastjsonschema
     jsonschema
     numpy
-    marshmallow
-    marshmallow-polyfield
     matplotlib
     networkx
     ply
     psutil
     python-constraint
+    python-dateutil
     retworkx
     scipy
     sympy
@@ -74,10 +72,6 @@ buildPythonPackage rec {
     seaborn
   ];
 
-  postPatch = ''
-    # Fix relative imports in tests
-    touch test/python/dagcircuit/__init__.py
-  '';
 
   # *** Tests ***
   checkInputs = [
@@ -94,9 +88,6 @@ buildPythonPackage rec {
     "qiskit.transpiler.passes.routing.cython.stochastic_swap.swap_trial"
   ];
 
-  disabledTests = [
-    "test_random_clifford_valid"  # random test, fails at least once when testing locally.
-  ];
   pytestFlagsArray = [
     "--ignore=test/randomized/test_transpiler_equivalence.py" # collection requires qiskit-aer, which would cause circular dependency
   ];
@@ -106,9 +97,9 @@ buildPythonPackage rec {
   preCheck = ''
     export PACKAGEDIR=$out/${python.sitePackages}
     echo "Moving Qiskit test files to package directory"
-    cp -r $TMP/source/test $PACKAGEDIR
-    cp -r $TMP/source/examples $PACKAGEDIR
-    cp -r $TMP/source/qiskit/schemas/examples $PACKAGEDIR/qiskit/schemas/
+    cp -r $TMP/$sourceRoot/test $PACKAGEDIR
+    cp -r $TMP/$sourceRoot/examples $PACKAGEDIR
+    cp -r $TMP/$sourceRoot/qiskit/schemas/examples $PACKAGEDIR/qiskit/schemas/
 
     # run pytest from Nix's $out path
     pushd $PACKAGEDIR
@@ -127,6 +118,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://qiskit.org/terra";
     downloadPage = "https://github.com/QISKit/qiskit-terra/releases";
+    changelog = "https://qiskit.org/documentation/release_notes.html";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
   };

--- a/pkgs/development/python-modules/qiskit/default.nix
+++ b/pkgs/development/python-modules/qiskit/default.nix
@@ -15,7 +15,7 @@
 buildPythonPackage rec {
   pname = "qiskit";
   # NOTE: This version denotes a specific set of subpackages. See https://qiskit.org/documentation/release_notes.html#version-history
-  version = "0.19.6";
+  version = "0.20.0";
 
   disabled = pythonOlder "3.5";
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit";
     rev = version;
-    sha256 = "0liby6ffgrla6wr4k742qkg8m80im372p6hmr4gkz47nmc76zy1i";
+    sha256 = "1r23pjnql49gczf4k4m6ir5rr95gqdxjrks60p8a93d243mxx3c9";
   };
 
   propagatedBuildInputs = [
@@ -36,14 +36,21 @@ buildPythonPackage rec {
 
   checkInputs = [ pytestCheckHook ];
   dontUseSetuptoolsCheck = true;
-  # following doesn't work b/c they are distributed across different nix sitePackages dirs. Tested with pytest though.
-  pythonImportsCheck = [ "qiskit" "qiskit.circuit" "qiskit.ignis" "qiskit.providers.aer" "qiskit.aqua" ];
 
-  meta = {
+  pythonImportsCheck = [
+    "qiskit"
+    "qiskit.aqua"
+    "qiskit.circuit"
+    "qiskit.ignis"
+    "qiskit.providers.aer"
+  ];
+
+  meta = with lib; {
     description = "Software for developing quantum computing programs";
     homepage = "https://qiskit.org";
     downloadPage = "https://github.com/QISKit/qiskit/releases";
-    license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ drewrisinger pandaman ];
+    changelog = "https://qiskit.org/documentation/release_notes.html";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger pandaman ];
   };
 }

--- a/pkgs/development/python-modules/yfinance/default.nix
+++ b/pkgs/development/python-modules/yfinance/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, multitasking
+, numpy
+, pandas
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "yfinance";
+  version = "0.1.54";
+
+  # GitHub source releases aren't tagged
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "cee223cbd31e14955869f7978bcf83776d644345c7dea31ba5d41c309bfb0d3d";
+  };
+
+  propagatedBuildInputs = [
+    multitasking
+    numpy
+    pandas
+    requests
+  ];
+
+  doCheck = false;  # Tests require internet access
+  pythonImportsCheck = [ "yfinance" ];
+
+  meta = with lib; {
+    description = "Yahoo! Finance market data downloader (+faster Pandas Datareader)";
+    homepage = "https://aroussi.com/post/python-yahoo-finance";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14234,6 +14234,8 @@ in
     inherit (darwin.stubs) setfile;
   };
 
+  muparserx = callPackage ../development/libraries/muparserx { };
+
   mutest = callPackage ../development/libraries/mutest { };
 
   mygpoclient = pythonPackages.mygpoclient;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7724,6 +7724,8 @@ in {
 
   yattag = callPackage ../development/python-modules/yattag { };
 
+  yfinance = callPackage ../development/python-modules/yfinance { };
+
   xenomapper = disabledIf (!isPy3k) (callPackage ../applications/science/biology/xenomapper { });
 
   z3 = (toPythonModule (pkgs.z3.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5930,7 +5930,8 @@ in {
 
   readchar = callPackage ../development/python-modules/readchar { };
 
-  retworkx = callPackage ../development/python-modules/retworkx { };
+  retworkx = disabledIf (pythonOlder "3.5")
+    (toPythonModule (callPackage ../development/python-modules/retworkx { } ));
 
   rivet = disabledIf (!isPy3k) (toPythonModule (pkgs.rivet.override {
     python3 = python;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4897,6 +4897,8 @@ in {
 
   multiprocess = callPackage ../development/python-modules/multiprocess { };
 
+  multitasking = callPackage ../development/python-modules/multitasking { };
+
   munkres = callPackage ../development/python-modules/munkres { };
 
   musicbrainzngs = callPackage ../development/python-modules/musicbrainzngs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Updates ``python3Packages.qiskit`` to v0.20.0, as well as updates all components.
Some components require new packages, which were added (``muparserx, pythonPackages.yfinance (which requires pythonPackages.multitasking)``).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
