### PR TITLE
Duplicity fix b2 backend

### DIFF
--- a/pkgs/development/python-modules/b2sdk/default.nix
+++ b/pkgs/development/python-modules/b2sdk/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchPypi, setuptools_scm, isPy27, pytestCheckHook
+, requests, arrow, logfury, tqdm }:
+
+buildPythonPackage rec {
+  pname = "b2sdk";
+  version = "1.1.4";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0g527qdda105r5g9yjh4lxzlmz34m2bdz8dydqqy09igdsmiyi9j";
+  };
+
+  pythonImportsCheck = [ "b2sdk" ];
+
+  nativebuildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ requests arrow logfury tqdm ];
+
+  # requires unpackaged dependencies like liccheck
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Client library and utilities for access to B2 Cloud Storage (backblaze).";
+    homepage = "https://github.com/Backblaze/b2-sdk-python";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -46,9 +46,8 @@ pythonPackages.buildPythonApplication rec {
     librsync
   ];
 
-  propagatedBuildInputs = [
-    backblaze-b2
-  ] ++ (with pythonPackages; [
+  propagatedBuildInputs = with pythonPackages; [
+    b2sdk
     boto
     cffi
     cryptography
@@ -65,7 +64,7 @@ pythonPackages.buildPythonApplication rec {
     future
   ] ++ stdenv.lib.optionals (!isPy3k) [
     enum
-  ]);
+  ];
 
   checkInputs = [
     gnupg # Add 'gpg' to PATH.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -713,6 +713,8 @@ in {
 
   azure-synapse-spark = callPackage ../development/python-modules/azure-synapse-spark { };
 
+  b2sdk = callPackage ../development/python-modules/b2sdk { };
+
   Babel = callPackage ../development/python-modules/Babel { };
 
   babelfish = callPackage ../development/python-modules/babelfish { };


### PR DESCRIPTION

###### Motivation for this change

The backblaze library moved into the b2sdk package.
If it’s not used, duplicity fails loading the b2:// backend.

> BackendException: B2 backend requires B2 Python SDK (pip install b2sdk)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
