### PR TITLE
nixos/fontconfig: fix 50-user.conf handling

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -204,8 +204,10 @@ let
     ln -s ${renderConf}       $dst/10-nixos-rendering.conf
 
     # 50-user.conf
-    ${optionalString (!cfg.includeUserConf) ''
-    rm $dst/50-user.conf
+    # Since latest fontconfig looks for default files inside the package,
+    # we had to move this one elsewhere to be able to exclude it here.
+    ${optionalString cfg.includeUserConf ''
+    ln -s ${pkg.out}/etc/fonts/conf.d.bak/50-user.conf $dst/50-user.conf
     ''}
 
     # local.conf (indirect priority 51)


### PR DESCRIPTION
Apparently, edf2541f02c6b24ea791710d5cadeae36f9b1a3a was missed while
rebasing https://github.com/NixOS/nixpkgs/pull/93562.

Provide 50-user.conf in fontconfig if includeUserConf is true (the
default), and don't try removing the non-existent one if it's disabled

Fixes #95685
Fixes #95712

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
