### PR TITLE
git-vanity-hash: init at 2020-02-26

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -239,6 +239,8 @@ let
 
   transcrypt = callPackage ./transcrypt { };
 
+  git-vanity-hash = callPackage ./git-vanity-hash { };
+
   ydiff = pkgs.python3.pkgs.toPythonApplication pkgs.python3.pkgs.ydiff;
 
 } // lib.optionalAttrs (config.allowAliases or true) (with self; {

--- a/pkgs/applications/version-management/git-and-tools/git-vanity-hash/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-vanity-hash/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "git-vanity-hash";
+  version = "2020-02-26-unstable";
+
+  src = fetchFromGitHub {
+    owner = "prasmussen";
+    repo = "git-vanity-hash";
+    rev = "000004122124005af8d118a3f379bfc6ecc1e7c7";
+    sha256 = "1wf342zawbphlzvji0yba0qg4f6v67h81nhxqcsir132jv397ma7";
+  };
+
+  cargoSha256 = "0mbdis1kxmgj3wlgznr9bqf5yv0jwlj2f63gr5c99ja0ijccp99h";
+
+  postInstall = ''
+    mkdir -p $out/share/doc/git-vanity-hash
+    cp README.md $out/share/doc/git-vanity-hash
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/prasmussen/git-vanity-hash";
+    description = "Tool for creating commit hashes with a specific prefix";
+    license = [ licenses.mit ];
+    maintainers = [ maintainers.kaction ];
+  };
+}


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Content:

````
├── bin
│   └── git-vanity-hash
└── share
    └── doc
        └── git-vanity-hash
            └── README.md

4 directories, 2 files
````

Closure size:

````
/nix/store/70g14lxdfi420w8mxnqdrwqksnrfdkxi-git-vanity-hash-unstable-2020-02-26	   33510144
````