### PR TITLE
lib/modules: Fix nonexistant option error

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -115,8 +115,8 @@ rec {
 
       checkUnmatched =
         if config._module.check && config._module.freeformType == null && merged.unmatchedDefns != [] then
-          let inherit (head merged.unmatchedDefns) file prefix;
-          in throw "The option `${showOption prefix}' defined in `${file}' does not exist."
+          let firstDef = head merged.unmatchedDefns;
+          in throw "The option `${showOption (prefix ++ firstDef.prefix)}' defined in `${firstDef.file}' does not exist."
         else null;
 
       result = builtins.seq checkUnmatched {


### PR DESCRIPTION
###### Motivation for this change
The refactoring in https://github.com/NixOS/nixpkgs/commit/fd75dc876586bde8cdb683a6952a41132e8db166 (#82743)
introduced a mistake in the error message that doesn't show the full
context anymore. E.g. with this module:

    options.foo.bar = lib.mkOption {
      type = lib.types.submodule {
        baz = 10;
      };
      default = {};
    };

You'd get the error

> The option `baz` defined in `/home/infinisil/src/nixpkgs/config.nix` does not exist.

instead of the previous

> The option `foo.bar.baz` defined in `/home/infinisil/src/nixpkgs/config.nix` does not exist.

This commit undoes this regression

Ping @roberth @Ma27 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
