### PR TITLE
ujprog: init at 3.0.92

### DIFF
--- a/pkgs/development/tools/misc/ujprog/default.nix
+++ b/pkgs/development/tools/misc/ujprog/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, fetchFromGitHub
+, pkgconfig
+, libftdi
+, libusb-compat-0_1
+}:
+
+stdenv.mkDerivation {
+  name = "ujprog";
+  version = "3.0.92";
+
+  src = fetchFromGitHub {
+    owner = "f32c";
+    repo = "tools";
+    rev = "0698352b0e912caa9b8371b8f692e19aac547a69";
+    sha256 = "05gqvhg2yydvkfhzfr1kxr89amfzyvrnvx2pgnzi7qb2wljsj21a";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+
+  buildInputs = [
+    libftdi
+    libusb-compat-0_1
+  ];
+
+  # The Mac OS X Makefile is more portable and better suited to NixOS across all platforms because,
+  # unlike the Linux Makefile, it does not rely on explicit /usr/lib* library paths.
+  unpackPhase = ''
+    cp $src/ujprog/Makefile.osx Makefile
+    cp $src/ujprog/ujprog.c .
+  '';
+
+  buildPhase = ''
+    make ujprog
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ujprog $out/bin/ujprog
+  '';
+
+  meta = with stdenv.lib; {
+    description = "JTAG Programmer for the ULX3S and ULX2S open hardware FPGA development boards.";
+    homepage = "https://github.com/f32c/tools";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ trepetti ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11415,6 +11415,8 @@ in
 
   uisp = callPackage ../development/tools/misc/uisp { };
 
+  ujprog = callPackage ../development/tools/misc/ujprog { };
+
   uncrustify = callPackage ../development/tools/misc/uncrustify { };
 
   universal-ctags = callPackage ../development/tools/misc/universal-ctags { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

[ujprog](https://github.com/f32c/tools/tree/master/ujprog) is a JTAG programmer for the ULX3S and ULX2S open source FPGA development boards. The boards use Lattice parts that are capable of being programmed using the reverse engineered prjtrellis and icestorm toolchains, respectively. This addition will allow Nix users to program their devices after generating FPGA bitstreams using the tools described above (both are already packaged in NIx).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
