### PR TITLE
chromium: prefer VMS with 'big-parallel'

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -214,6 +214,8 @@ in stdenv.mkDerivation {
     done
   '';
 
+  # prefer high core count VMs for hydra
+  requireSystemFeatures = [ "big-parallel" ];
   inherit (chromium.browser) packageName;
   meta = chromium.browser.meta;
   passthru = {


### PR DESCRIPTION
###### Motivation for this change
IIRC, hydra's "big-parallel" machines have 32 cores instead of 2. Should help with ~60 hr build times. Unless this causes timeout/OOm issues

may close: #81081

related: #78347

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
