### PR TITLE
nixos/dovecot: Improve mailboxes type

### DIFF
--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ options, config, lib, pkgs, ... }:
 
 with lib;
 
@@ -83,11 +83,11 @@ let
     )
 
     (
-      optionalString (cfg.mailboxes != []) ''
+      optionalString (cfg.mailboxes != {}) ''
         protocol imap {
           namespace inbox {
             inbox=yes
-            ${concatStringsSep "\n" (map mailboxConfig cfg.mailboxes)}
+            ${concatStringsSep "\n" (map mailboxConfig (attrValues cfg.mailboxes))}
           }
         }
       ''
@@ -131,12 +131,13 @@ let
     special_use = \${toString mailbox.specialUse}
   '' + "}";
 
-  mailboxes = { ... }: {
+  mailboxes = { name, ... }: {
     options = {
       name = mkOption {
-        type = types.nullOr (types.strMatching ''[^"]+'');
+        type = types.strMatching ''[^"]+'';
         example = "Spam";
-        default = null;
+        default = name;
+        readOnly = true;
         description = "The name of the mailbox.";
       };
       auto = mkOption {
@@ -335,19 +336,11 @@ in
     };
 
     mailboxes = mkOption {
-      type = with types; let m = submodule mailboxes; in either (listOf m) (attrsOf m);
+      type = with types; coercedTo
+        (listOf unspecified)
+        (list: listToAttrs (map (entry: { name = entry.name; value = removeAttrs entry ["name"]; }) list))
+        (attrsOf (submodule mailboxes));
       default = {};
-      apply = x:
-        if isList x then warn "Declaring `services.dovecot2.mailboxes' as a list is deprecated and will break eval in 21.03!" x
-        else mapAttrsToList (name: value:
-          if value.name != null
-            then throw ''
-              When specifying dovecot2 mailboxes as attributes, declaring
-              a `name'-attribute is prohibited! The name ${value.name} should
-              be the attribute key!
-            ''
-          else value // { inherit name; }
-        ) x;
       example = literalExample ''
         {
           Spam = { specialUse = "Junk"; auto = "create"; };
@@ -470,6 +463,10 @@ in
     };
 
     environment.systemPackages = [ dovecotPkg ];
+
+    warnings = mkIf (any isList options.services.dovecot2.mailboxes.definitions) [
+      "Declaring `services.dovecot2.mailboxes' as a list is deprecated and will break eval in 21.03! See the release notes for more info for migration."
+    ];
 
     assertions = [
       {


### PR DESCRIPTION
###### Motivation for this change

The previous use of `types.either` disallowed assigning a list at one point and an attrset an another. This fixes this plus some other improvements like:
- Only throwing the deprecation warning once and mentioning the release notes for more info
- Have `config.services.dovecot2.mailboxes` be an attrset instead of a list, by not using `apply`

I couldn't easily keep the informative `name` assignment error, so I removed that in favor of `name` being `readOnly` (meaning it can only be assigned once, which is already done in the module itself).

Ping @Ma27 and @nlewo from the PR that introduced mailboxes as attrsets (nice!) https://github.com/NixOS/nixpkgs/pull/89486

###### Things done

Tested with https://gitlab.com/simple-nixos-mailserver/nixos-mailserver (which uses a list to assign mailboxes) and some custom mailboxes in my own config (which uses an attrset).