### PR TITLE
stdenv: expose libc/c++ stdlib header at runtime

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -308,11 +308,14 @@ stdenv.mkDerivation {
 
     # We have a libc++ directly, we have one via "smuggled" GCC, or we have one
     # bundled with the C compiler because it is GCC
-    + optionalString (libcxx != null || (isClang && !(stdenv.targetPlatform.useLLVM or false) && gccForLibs.langCC or false) || (isGNU && cc.langCC or false)) ''
+    + optionalString (libcxx != null
+                      || (isClang && !(stdenv.targetPlatform.useLLVM or false) && gccForLibs.langCC or false)
+                      || (isGNU && cc.langCC or false)) ''
       touch "$out/nix-support/libcxx-cxxflags"
       touch "$out/nix-support/libcxx-ldflags"
     ''
-    + optionalString (libcxx == null && (isClang && !(stdenv.targetPlatform.useLLVM or false) && gccForLibs.langCC or false)) ''
+    + optionalString (libcxx == null
+                      && (isClang && !(stdenv.targetPlatform.useLLVM or false) && gccForLibs.langCC or false)) ''
       for dir in ${gccForLibs}/include/c++/*; do
         echo "-isystem $dir" >> $out/nix-support/libcxx-cxxflags
       done

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -331,6 +331,27 @@ stdenv.mkDerivation {
     '')
 
     ##
+    ## Tooling support
+    ##
+
+    # At runtime we need these flags to find libc / c++ stdlib headers with tools such as clangd.
+    # We can read those by accessing $NIX_CC in a nix-shell.
+    # Multiple paths should be seperated by colon.
+    # We don't need this for libc yet, but we should keep the option open and make it consistent with c++.
+    + optionalString (libc != null) ''
+      echo ${libc_dev}${libc.incdir or "/include"} > $out/nix-support/cpath
+    ''
+    # c++ includes come from gcc
+    + optionalString (gccForLibs.langCC or false) ''
+      echo "$(echo ${gccForLibs}/include/c++/*):$(echo ${gccForLibs}/include/c++/*/${targetPlatform.config})" \
+        > $out/nix-support/cxxpath
+    ''
+    # c++ includes come from clang
+    + optionalString (libcxx != null) ''
+      echo "${stdenv.lib.getDev libcxx}/include/c++/v1" > $out/nix-support/cxxpath
+    ''
+
+    ##
     ## Initial CFLAGS
     ##
 

--- a/pkgs/development/tools/clang-tools/default.nix
+++ b/pkgs/development/tools/clang-tools/default.nix
@@ -13,9 +13,6 @@ in stdenv.mkDerivation {
     runHook preInstall
 
     mkdir -p $out/bin
-    export libc_includes="${stdenv.lib.getDev stdenv.cc.libc}/include"
-    export libcpp_includes="${llvmPackages.libcxx}/include/c++/v1"
-
     export clang=${clang}
     substituteAll ${./wrapper} $out/bin/clangd
     chmod +x $out/bin/clangd

--- a/pkgs/development/tools/clang-tools/wrapper
+++ b/pkgs/development/tools/clang-tools/wrapper
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 buildcpath() {
   local path
@@ -13,8 +13,19 @@ buildcpath() {
   echo $path
 }
 
-export CPATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE})
-export CPATH=${CPATH}${CPATH:+':'}@libc_includes@
-export CPLUS_INCLUDE_PATH=${CPATH}${CPATH:+':'}@libcpp_includes@
+setpaths() {
+  local nix_cpath=$(buildcpath ${NIX_CFLAGS_COMPILE})
+  export CPATH=${CPATH}${CPATH:+':'}${nix_cpath}
+
+  if [[ -f "$NIX_CC/nix-support/cpath" ]]; then
+    export CPATH=${CPATH}${CPATH:+':'}$(< "$NIX_CC/nix-support/cpath")
+  fi
+
+  if [[ -f "$NIX_CC/nix-support/cxxpath" ]]; then
+    export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(< "$NIX_CC/nix-support/cxxpath")
+  fi
+}
+
+setpaths
 
 exec -a "$0" @clang@/bin/$(basename $0) "$@"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

It evaluate, but I need to test it actually.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
