### PR TITLE
pythonPackages.django-widget-tweaks: init at 1.4.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5181,6 +5181,12 @@
     githubId = 35892750;
     name = "Maxine Aubrey";
   };
+  maxxk = {
+    email = "maxim.krivchikov@gmail.com";
+    github = "maxxk";
+    githubId = 1191859;
+    name = "Maxim Krivchikov";
+  };
   mbakke = {
     email = "mbakke@fastmail.com";
     github = "mbakke";

--- a/pkgs/development/python-modules/django-widget-tweaks/default.nix
+++ b/pkgs/development/python-modules/django-widget-tweaks/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage, fetchFromGitHub, python, stdenv, django }:
+
+buildPythonPackage rec {
+  pname = "django-widget-tweaks";
+  version = "1.4.8";
+
+  src = fetchFromGitHub { # package from Pypi missing runtests.py
+    owner = "jazzband";
+    repo = pname;
+    rev = version;
+    sha256 = "00w1ja56dc7cyw7a3mph69ax6mkch1lsh4p98ijdhzfpjdy36rbg";
+  };
+
+  checkPhase = "${python.interpreter} runtests.py";
+  propagatedBuildInputs = [ django ];
+
+  meta = with stdenv.lib; {
+      description = "Tweak the form field rendering in templates, not in python-level form definitions.";
+      homepage = "https://github.com/jazzband/django-widget-tweaks";
+      license = licenses.mit;
+      maintainers = with maintainers; [
+          maxxk
+      ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3820,6 +3820,8 @@ in {
 
   django-webpack-loader = callPackage ../development/python-modules/django-webpack-loader { };
 
+  django-widget-tweaks = callPackage ../development/python-modules/django-widget-tweaks { };
+
   django_tagging = callPackage ../development/python-modules/django_tagging { };
 
   django_classytags = callPackage ../development/python-modules/django_classytags { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
