### PR TITLE
nixos/test-instrumentation: properly import `options` for `qemu`-check

### DIFF
--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -1,21 +1,12 @@
 # This module allows the test driver to connect to the virtual machine
 # via a root shell attached to port 514.
 
-{ config, lib, pkgs, ... }:
+{ options, config, lib, pkgs, ... }:
 
 with lib;
 with import ../../lib/qemu-flags.nix { inherit pkgs; };
 
 {
-
-  # This option is a dummy that if used in conjunction with
-  # modules/virtualisation/qemu-vm.nix gets merged with the same option defined
-  # there and only is declared here because some modules use
-  # test-instrumentation.nix but not qemu-vm.nix.
-  #
-  # One particular example are the boot tests where we want instrumentation
-  # within the images but not other stuff like setting up 9p filesystems.
-  options.virtualisation.qemu = { };
 
   config = {
 


### PR DESCRIPTION
###### Motivation for this change

If `qemu-vm.nix` is imported, the option `virtualisation.qemu.consoles`
should be set to make sure that the machine's output isn't rendered on
the graphical window of QEMU.

This is needed when interactively running a NixOS test or in conjunction
with `nixos-build-vms(8)`.

The patch 257855753073987160c293fdedc9d95a33cbc0e8 tries to only do this
if the option actually exists, however this condition used to be always
false since `options` wasn't imported in the module and pointed to
`lib.options` due to the `with lib;`-clause.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
