### PR TITLE
chamber: init at 2.8.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4190,6 +4190,12 @@
     githubId = 87115;
     name = "Wael Nasreddine";
   };
+  kalekseev = {
+    email = "mail@kalekseev.com";
+    github = "kalekseev";
+    githubId = 367259;
+    name = "Konstantin Alekseev";
+  };
   kamadorueda = {
     name = "Kevin Amado";
     email = "kamadorueda@gmail.com";

--- a/pkgs/tools/admin/chamber/default.nix
+++ b/pkgs/tools/admin/chamber/default.nix
@@ -1,0 +1,28 @@
+{ buildGoModule, lib, fetchFromGitHub }:
+buildGoModule rec {
+  pname = "chamber";
+  version = "2.8.2";
+
+  src = fetchFromGitHub {
+    owner = "segmentio";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-7L9RaE4LvHRR6MUimze5QpbnfasWJdY4arfS/Usy2q0=";
+  };
+
+  vendorSha256 = null;
+
+  # set the version. see: chamber's Makefile
+  buildFlagsArray = ''
+    -ldflags=
+    -X main.Version=v${version}
+  '';
+
+  meta = with lib; {
+    description =
+      "Chamber is a tool for managing secrets by storing them in AWS SSM Parameter Store.";
+    homepage = "https://github.com/segmentio/chamber";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalekseev ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -821,6 +821,8 @@ in
 
   boxes = callPackage ../tools/text/boxes { };
 
+  chamber = callPackage ../tools/admin/chamber {  };
+
   ec2_api_tools = callPackage ../tools/virtualization/ec2-api-tools { };
 
   ec2_ami_tools = callPackage ../tools/virtualization/ec2-ami-tools { };


### PR DESCRIPTION
###### Motivation for this change

[Chamber](https://github.com/segmentio/chamber) is a tool for managing secrets. Currently it does so by storing secrets in SSM Parameter Store, an AWS service for storing secrets.
Basic use case is that you want to allow some IAM role to run service that require configuration, chamber helps manage config params in AWS SSM so iam user can start service by passing config from SSM, eg: `aws-vault exec development -- chamber exec loadbalancers -- nginx`



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
