### PR TITLE
nixos/awesome: add wrapped awesome to systemPackages

### DIFF
--- a/nixos/modules/services/x11/window-managers/awesome.nix
+++ b/nixos/modules/services/x11/window-managers/awesome.nix
@@ -11,9 +11,13 @@ let
     " --search " + (getLuaPath path "share") +
     " --search " + (getLuaPath path "lib")
   );
-in
-
-{
+  awesomeWrapped = pkgs.buildEnv {
+    name = "awesome-wrapper";
+    paths = [ (writeScriptBin "awesome" ''
+      exec ${awesome}/bin/awesome ${lib.optionalString cfg.noArgb "--no-argb"} ${makeSearchPath cfg.luaModules} "$@"
+    '')];
+  };
+in {
 
   ###### interface
 
@@ -55,12 +59,12 @@ in
       { name = "awesome";
         start =
           ''
-            ${awesome}/bin/awesome ${lib.optionalString cfg.noArgb "--no-argb"} ${makeSearchPath cfg.luaModules} &
+            ${awesomeWrapped}/bin/.awesome-wrapped &
             waitPID=$!
           '';
       };
 
-    environment.systemPackages = [ awesome ];
+    environment.systemPackages = [ awesomeWrapped ];
 
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Lets user start awesome in the same way as the display-manager would do,
including luaPaths.
I prefer not using a display manager at all, and instead starting my wm using `xinit`/`startx`. However, that breaks my awesome setup as I use some the nixos config to add some lua modules to awesomes search path: these search path additions are only made available for the xsession script. This change makes it possible to started a wrapped awesome with the same lua search paths from startx.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
