### PR TITLE
pdfpc: 4.3.4 → 4.4.0

### DIFF
--- a/pkgs/applications/misc/pdfpc/default.nix
+++ b/pkgs/applications/misc/pdfpc/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "pdfpc";
-  version = "4.3.4";
+  version = "4.4.0";
 
   src = fetchFromGitHub {
     repo = product;
     owner = product;
     rev = "v${version}";
-    sha256 = "07aafsm4jzdgpahz83p0ajv40hry7gviyadqi13ahr8xdhhwy2sd";
+    sha256 = "0vh2r32akvasdrghkaq7ard24r2qncp34jfiyshi3zxabm9bhfaa";
   };
 
   nativeBuildInputs = [
@@ -30,14 +30,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = stdenv.lib.optional stdenv.isDarwin "-DMOVIES=OFF";
-
-  patches = [
-    # Fix build vala 0.46
-    (fetchpatch {
-      url = "https://github.com/pdfpc/pdfpc/commit/bbc16b97ecbdcdd22c2dc827a5c0e8b569073312.patch";
-      sha256 = "0wi1rqcvg65cxnxvmvavcvghqyksnpijq1p91m57jaby3hb0pdcy";
-    })
-  ];
 
   meta = with stdenv.lib; {
     description = "A presenter console with multi-monitor support for PDF files";


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/pdfpc/pdfpc/blob/v4.4.0/CHANGELOG.txt

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
