### PR TITLE
mozwire: init at 0.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5951,6 +5951,12 @@
     githubId = 1224006;
     name = "Roberto Abdelkader Martínez Pérez";
   };
+  nilsirl = {
+    email = "nils@nilsand.re";
+    github = "NilsIrl";
+    githubId = 26231126;
+    name = "Nils ANDRÉ-CHANG";
+  };
   ninjatrappeur = {
     email = "felix@alternativebit.fr";
     github = "ninjatrappeur";

--- a/pkgs/tools/networking/mozwire/default.nix
+++ b/pkgs/tools/networking/mozwire/default.nix
@@ -1,0 +1,23 @@
+{ rustPlatform, stdenv, fetchFromGitHub, Security }:
+rustPlatform.buildRustPackage rec {
+  pname = "MozWire";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "NilsIrl";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1slfb6m22vzglnrxahlhdcwzwpf3b817mskdx628s92mjzngzyih";
+  };
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
+  
+  cargoSha256 = "0b00j8vn1vvvphcyv8li7i73pq66sq6dr4wc1w4s3pppa151xr55";
+
+  meta = with stdenv.lib; {
+    description = "MozillaVPN configuration manager giving Linux, macOS users (among others), access to MozillaVPN";
+    homepage = "https://github.com/NilsIrl/MozWire";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ siraben nilsirl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3212,6 +3212,10 @@ in
 
   mcrcon = callPackage ../tools/networking/mcrcon {};
 
+  mozwire = callPackage ../tools/networking/mozwire {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   rage = callPackage ../tools/security/rage {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change
Add mozwire.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
