### PR TITLE
flashfocus: init at 2.2.2 & pythonPackages.xpybutil: init at 0.0.6

### DIFF
--- a/pkgs/development/python-modules/xpybutil/default.nix
+++ b/pkgs/development/python-modules/xpybutil/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchFromGitHub, xcffib, pillow }:
+
+buildPythonPackage rec {
+  pname = "xpybutil";
+  version = "0.0.6";
+
+  # Pypi only offers a wheel
+  src = fetchFromGitHub {
+    owner = "BurntSushi";
+    repo = pname;
+    rev = version;
+    sha256 = "17gbqq955fcl29aayn8l0x14azc60cxgkvdxblz9q8x3l50w0xpg";
+  };
+
+  # pillow is a dependency in image.py which is not listed in setup.py
+  propagatedBuildInputs = [ xcffib pillow ];
+
+  meta = with lib; {
+    homepage = "https://github.com/BurntSushi/xpybutil";
+    description = "An incomplete xcb-util port plus some extras";
+    license = licenses.wtfpl;
+    maintainers = with maintainers; [ artturin ];
+  };
+}

--- a/pkgs/misc/flashfocus/default.nix
+++ b/pkgs/misc/flashfocus/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonApplication, fetchPypi, xcffib, pyyaml, click, i3ipc, marshmallow, cffi, xpybutil, pytestrunner }:
+
+
+buildPythonApplication rec {
+  pname = "flashfocus";
+  version = "2.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1z20d596rnc7cs0rrd221gjn14dmbr11djv94y9p4v7rr788sswv";
+  };
+
+  nativeBuildInputs = [ pytestrunner ];
+  propagatedBuildInputs = [ i3ipc xcffib click cffi xpybutil marshmallow pyyaml ];
+
+  # Tests require access to a X session
+  doCheck = false;
+
+  pythonImportsCheck = [ "flashfocus" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/fennerm/flashfocus";
+    description = "Simple focus animations for tiling window managers";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ artturin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1917,6 +1917,8 @@ in
 
   fuzzel = callPackage ../applications/misc/fuzzel { };
 
+  flashfocus = python3Packages.callPackage ../misc/flashfocus { };
+
   qt-video-wlr = libsForQt5.callPackage ../applications/misc/qt-video-wlr { };
 
   fwup = callPackage ../tools/misc/fwup { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7161,6 +7161,8 @@ in {
 
   xcffib = callPackage ../development/python-modules/xcffib {};
 
+  xpybutil = callPackage ../development/python-modules/xpybutil {};
+
   pafy = callPackage ../development/python-modules/pafy { };
 
   suds = callPackage ../development/python-modules/suds { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->
Add flashfocus and a not yet packaged dependency
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
