### PR TITLE
pythonPackages.coloredlogs: remove obsolete patch

### DIFF
--- a/pkgs/development/python-modules/coloredlogs/default.nix
+++ b/pkgs/development/python-modules/coloredlogs/default.nix
@@ -1,4 +1,13 @@
-{ lib, buildPythonPackage, fetchFromGitHub, stdenv, isPy3k, fetchpatch, humanfriendly, verboselogs, capturer, pytest, mock, utillinux }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, humanfriendly
+, verboselogs
+, capturer
+, pytest
+, mock
+, utillinux
+}:
 
 buildPythonPackage rec {
   pname = "coloredlogs";
@@ -10,13 +19,6 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "0rnmxwrim4razlv4vi3krxk5lc5ksck6h5374j8avqwplika7q2x";
   };
-
-  # patch by risicle
-  patches = lib.optional (stdenv.isDarwin && isPy3k) (fetchpatch {
-    name = "darwin-py3-capture-fix.patch";
-    url = "https://github.com/xolox/python-coloredlogs/pull/74.patch";
-    sha256 = "0pk7k94iz0gdripw623vzdl4hd83vwhsfzshl8pbvh1n6swi0xx9";
-  });
 
   checkPhase = ''
     PATH=$PATH:$out/bin pytest . -k "not test_plain_text_output_format \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
coloredlogs build was broken on darwin since it was updated from 10.0 to 14.0.
The patch from https://github.com/xolox/python-coloredlogs/pull/74 has been merged for 11.0, so it does not apply any more.

Please note that the dependency `capturer` by the same upstream author is also broken on darwin with python38, so this patch can only be tested on python37 at the moment.

Issue for the capturer bug: https://github.com/xolox/python-capturer/issues/10.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
