### PR TITLE
Improve spaCy checks

### DIFF
--- a/pkgs/development/python-modules/spacy/annotation-test/annotate.py
+++ b/pkgs/development/python-modules/spacy/annotation-test/annotate.py
@@ -1,0 +1,69 @@
+import pytest
+import spacy
+
+en_text = (
+    "When Sebastian Thrun started working on self-driving cars at "
+    "Google in 2007, few people outside of the company took him "
+    "seriously. “I can tell you very senior CEOs of major American "
+    "car companies would shake my hand and turn away because I wasn’t "
+    "worth talking to,” said Thrun, in an interview with Recode earlier "
+    "this week.")
+
+
+@pytest.fixture
+def en_core_web_sm():
+    return spacy.load("en_core_web_sm")
+
+
+@pytest.fixture
+def doc_en_core_web_sm(en_core_web_sm):
+    return en_core_web_sm(en_text)
+
+
+def test_entities(doc_en_core_web_sm):
+    entities = list(map(lambda e: (e.text, e.label_),
+                        doc_en_core_web_sm.ents))
+
+    assert entities == [
+        ('Sebastian Thrun', 'PERSON'),
+        ('Google', 'ORG'), ('2007', 'DATE'),
+        ('American', 'NORP'),
+        ('Thrun', 'ORG'),
+        ('earlier this week', 'DATE')
+    ]
+
+
+def test_nouns(doc_en_core_web_sm):
+    assert [
+        chunk.text for chunk in doc_en_core_web_sm.noun_chunks] == [
+        'Sebastian Thrun',
+        'self-driving cars',
+        'Google',
+        'few people',
+        'the company',
+        'him',
+        'I',
+        'you',
+        'very senior CEOs',
+        'major American car companies',
+        'my hand',
+        'I',
+        'Thrun',
+        'an interview',
+        'Recode']
+
+
+def test_verbs(doc_en_core_web_sm):
+    assert [
+        token.lemma_ for token in doc_en_core_web_sm if token.pos_ == "VERB"] == [
+        'start',
+        'work',
+        'drive',
+        'take',
+        'can',
+        'tell',
+        'would',
+        'shake',
+        'turn',
+        'talk',
+        'say']

--- a/pkgs/development/python-modules/spacy/annotation-test/default.nix
+++ b/pkgs/development/python-modules/spacy/annotation-test/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, pytest, spacy_models }:
+
+stdenv.mkDerivation {
+  name = "spacy-annotation-test";
+
+  src = ./.;
+
+  dontConfigure = true;
+  dontBuild = true;
+  doCheck = true;
+
+  checkInputs = [ pytest spacy_models.en_core_web_sm ];
+
+  checkPhase = ''
+    pytest annotate.py
+  '';
+
+  installPhase = ''
+    touch $out
+  '';
+
+  meta.timeout = 60;
+}

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, callPackage
 , fetchPypi
 , pythonOlder
 , pytest
@@ -63,6 +64,8 @@ buildPythonPackage rec {
   '';
 
   pythonImportsCheck = [ "spacy" ];
+
+  passthru.tests = callPackage ./annotation-test {};
 
   meta = with lib; {
     description = "Industrial-strength Natural Language Processing (NLP) with Python and Cython";

--- a/pkgs/development/python-modules/spacy/models.nix
+++ b/pkgs/development/python-modules/spacy/models.nix
@@ -14,6 +14,8 @@ let
     propagatedBuildInputs = [ spacy ]
       ++ lib.optionals (lang == "zh") [ jieba pkuseg ];
 
+    pythonImportsCheck = [ pname ];
+
     meta = with stdenv.lib; {
       description = "Models for the spaCy NLP library";
       homepage    = "https://github.com/explosion/spacy-models";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This PR combines two commits:

1. Add `pythonImportsCheck` to the spaCy models, for an extra sanity check (with the absense of upstream model tests).
2. Add a test to `passthru.tests` of the spaCy derivation that loads a model and verifies that it outputs the expected annotations. This should be able to catch regressions better than the import check of spaCy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
