### PR TITLE
fet-sh: init at 1.5

### DIFF
--- a/pkgs/tools/misc/fet-sh/default.nix
+++ b/pkgs/tools/misc/fet-sh/default.nix
@@ -1,0 +1,28 @@
+{ stdenvNoCC, lib, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "fet-sh";
+  version = "1.5";
+
+  src = fetchFromGitHub {
+    owner = "6gk";
+    repo = "fet.sh";
+    rev = "v${version}";
+    sha256 = "15336cayv3rb79y7f0v0qvn6nhr5aqr8479ayp0r0sihn5mkfg35";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -m755 -D ./fet.sh $out/bin/fet.sh
+  '';
+
+  meta = with lib; {
+    description = "A fetch written in posix shell without any external commands (linux only)";
+    homepage = "https://github.com/6gk/fet.sh";
+    license = licenses.isc;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ elkowar ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -269,6 +269,8 @@ in
 
   etBook = callPackage ../data/fonts/et-book { };
 
+  fet-sh = callPackage ../tools/misc/fet-sh { };
+
   fetchbower = callPackage ../build-support/fetchbower {
     inherit (nodePackages) bower2nix;
   };


### PR DESCRIPTION
###### Motivation for this change

[fet.sh](https://github.com/6gk/fet.sh) is a simple, pure sh fetch script for Linux.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
