### PR TITLE
discrete-scroll: init at 0.1.1

### DIFF
--- a/pkgs/os-specific/darwin/discrete-scroll/default.nix
+++ b/pkgs/os-specific/darwin/discrete-scroll/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub, Cocoa }:
+
+## after launching for the first time, grant access for parent application (e.g. Terminal.app)
+## from 'system preferences >> security & privacy >> accessibility'
+## and then launch again
+
+stdenv.mkDerivation rec {
+  pname = "discrete-scroll";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "emreyolcu";
+    repo = "discrete-scroll";
+    rev = "v${version}";
+    sha256 = "0aqkp4kkwjlkll91xbqwf8asjww8ylsdgqvdk8d06bwdvg2cgvhg";
+  };
+
+  buildInputs = [ Cocoa ];
+
+  buildPhase = ''
+    cc -std=c99 -O3 -Wall -framework Cocoa -o dc DiscreteScroll/main.m
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./dc $out/bin/discretescroll
+  '';
+
+  meta = with lib; {
+    description = "Fix for OS X's scroll wheel problem";
+    homepage = "https://github.com/emreyolcu/discrete-scroll";
+    platforms = platforms.darwin;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -88,4 +88,8 @@ in
 
   ios-deploy = callPackage ../os-specific/darwin/ios-deploy {};
 
+  discrete-scroll = callPackage ../os-specific/darwin/discrete-scroll {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
+
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
