### PR TITLE
[haskell-updates] haskellPackages.neuron: Fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1383,23 +1383,11 @@ self: super: {
   reflex-dom-pandoc = super.reflex-dom-pandoc.override {
     pandoc-types = self.pandoc-types_1_21;
   };
-  pandoc_2_10_1 = super.pandoc_2_10_1.override {
+  pandoc_2_10_1 = super.pandoc_2_10_1.overrideScope (self: super: {
     pandoc-types = self.pandoc-types_1_21;
     hslua = self.hslua_1_1_2;
-    texmath = self.texmath.override {
-      pandoc-types = self.pandoc-types_1_21;
-    };
-    tasty-lua = self.tasty-lua.override {
-      hslua = self.hslua_1_1_2;
-    };
-    hslua-module-text = self.hslua-module-text.override {
-      hslua = self.hslua_1_1_2;
-    };
-    hslua-module-system = self.hslua-module-system.override {
-      hslua = self.hslua_1_1_2;
-    };
     jira-wiki-markup = self.jira-wiki-markup_1_3_2;
-  };
+  });
 
   # Apply version-bump patch that is not contained in released version yet.
   # Upstream PR: https://github.com/srid/neuron/pull/304
@@ -1411,14 +1399,10 @@ self: super: {
     extraPrefix = "";
   }))
     # See comment about overrides above commonmark-pandoc
-    .override {
+    .overrideScope (self: super: {
     pandoc = self.pandoc_2_10_1;
     pandoc-types = self.pandoc-types_1_21;
-    rib = super.rib.override {
-      pandoc = self.pandoc_2_10_1;
-      pandoc-types = self.pandoc-types_1_21;
-    };
-  };
+  });
 
   # Testsuite trying to run `which haskeline-examples-Test`
   haskeline_0_8_0_0 = dontCheck super.haskeline_0_8_0_0;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2581,6 +2581,7 @@ extra-packages:
   - hoogle == 5.0.14                    # required by hie-hoogle
   - html-conduit ^>= 1.2                # pre-lts-11.x versions neeed by git-annex 6.20180227
   - http-conduit ^>= 2.2                # pre-lts-11.x versions neeed by git-annex 6.20180227
+  - hslua == 1.1.2                      # required for pandoc 2.10
   - inline-c < 0.6                      # required on GHC 8.0.x
   - inline-c-cpp < 0.2                  # required on GHC 8.0.x
   - lens-labels == 0.1.*                # required for proto-lens-descriptors


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This fixes an evaluation error of haskell-updates.

Also reusing `overrideScope` here, thx for the tip @cdepillabout it's fun!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
