### PR TITLE
qt: bring back QML import patch in 5.14

### DIFF
--- a/pkgs/development/libraries/qt-5/5.14/qtdeclarative.patch
+++ b/pkgs/development/libraries/qt-5/5.14/qtdeclarative.patch
@@ -1,3 +1,23 @@
+diff --git a/src/qml/qml/qqmlimport.cpp b/src/qml/qml/qqmlimport.cpp
+index 005db4248..685c5b1b2 100644
+--- a/src/qml/qml/qqmlimport.cpp
++++ b/src/qml/qml/qqmlimport.cpp
+@@ -1760,6 +1760,15 @@ QQmlImportDatabase::QQmlImportDatabase(QQmlEngine *e)
+     QString installImportsPath =  QLibraryInfo::location(QLibraryInfo::Qml2ImportsPath);
+     addImportPath(installImportsPath);
+ 
++    // Add import paths derived from PATH
++    const QStringList paths = QFile::decodeName(qgetenv("PATH")).split(':');
++    const QString qmldir = QStringLiteral("../" NIXPKGS_QML2_IMPORT_PREFIX);
++    for (const QString &path: paths) {
++        if (!path.isEmpty()) {
++            addImportPath(QDir::cleanPath(path + QDir::separator() + qmldir));
++        }
++    }
++
+     // env import paths
+     if (Q_UNLIKELY(!qEnvironmentVariableIsEmpty("QML2_IMPORT_PATH"))) {
+         const QString envImportPath = qEnvironmentVariable("QML2_IMPORT_PATH");
 diff --git a/tools/qmlcachegen/qmlcache.prf b/tools/qmlcachegen/qmlcache.prf
 index 537eaf62e..e21de58f6 100644
 --- a/tools/qmlcachegen/qmlcache.prf


### PR DESCRIPTION
###### Motivation for this change

This was missed in the 5.12 -> 5.14 update process.

Resolves #95636

It's a pretty big rebuild, but it's a pretty big bug: not sure whether that means it should be against staging or master?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
