### PR TITLE
idris2: Enable --install, bugfixes

### DIFF
--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -4,7 +4,7 @@
 
 # Uses scheme to bootstrap the build of idris2
 stdenv.mkDerivation rec {
-  name = "idris2";
+  pname = "idris2";
   version = "0.2.1";
 
   src = fetchFromGitHub {
@@ -30,9 +30,42 @@ stdenv.mkDerivation rec {
 
   checkTarget = "bootstrap-test";
 
-  # idris2 needs to find scheme at runtime to compile
-  postInstall = ''
-    wrapProgram "$out/bin/idris2" --set CHEZ "${chez}/bin/scheme"
+  # TODO: Move this into its own derivation, such that this can be changed
+  #       without having to recompile idris2 every time.
+  postInstall = let
+    includedLibs = [ "base" "contrib" "network" "prelude" ];
+    name = "${pname}-${version}";
+    packagePaths = builtins.map (l: "$out/${name}/" + l) includedLibs;
+    additionalIdris2Paths = builtins.concatStringsSep ":" packagePaths;
+  in ''
+    # Remove existing idris2 wrapper that sets incorrect LD_LIBRARY_PATH
+    rm $out/bin/idris2
+    # Move actual idris2 binary
+    mv $out/bin/idris2_app/idris2.so $out/bin/idris2
+
+    # After moving the binary, there is nothing left in idris2_app that isn't
+    # either contained in lib/ or is useless to us.
+    rm $out/bin/idris2_app/*
+    rmdir $out/bin/idris2_app
+
+    # idris2 needs to find scheme at runtime to compile
+    # idris2 installs packages with --install into the path given by PREFIX.
+    # Since PREFIX is in nix-store, it is immutable so --install does not work.
+    # If the user redefines PREFIX to be able to install packages, idris2 will
+    # not find the libraries and packages since all paths are relative to
+    # PREFIX by default.
+    # We explicitly make all paths to point to nix-store, such that they are
+    # independent of what IDRIS2_PREFIX is. This allows the user to redefine
+    # IDRIS2_PREFIX and use --install as expected.
+    # TODO: Make support libraries their own derivation such that
+    #       overriding LD_LIBRARY_PATH is unnecessary
+    # TODO: Maybe set IDRIS2_PREFIX to the users home directory
+    wrapProgram "$out/bin/idris2" \
+      --set-default CHEZ "${chez}/bin/scheme" \
+      --suffix IDRIS2_LIBS ':' "$out/${name}/lib" \
+      --suffix IDRIS2_DATA ':' "$out/${name}/support" \
+      --suffix IDRIS2_PATH ':' "${additionalIdris2Paths}" \
+      --suffix LD_LIBRARY_PATH ':' "$out/${name}/lib"
   '';
 
   meta = {


### PR DESCRIPTION

###### Motivation for this change

This removes the need of the `bin/idris2_app` folder
and replaces it with proper links to the nix-storage folders
This also allows the user to override `IDRIS2_PREFIX` which
will allow them to use `--install` to install packages.


Example of how directories are created by the wrapper when user changes the prefix:
```
$ IDRIS2_PREFIX=~/.idris2 idris2 --paths
+ Working Directory      :: "/home/wchresta/src/nixpkgs"
+ Source Directory       :: Nothing
+ Build Directory        :: "build"
+ Output Directory       :: "build/exec"
+ Installation Prefix    :: "/home/wchresta/.idris2"
+ Extra Directories      :: [".", "/nix/store/h4851cakq6w4cw3hcy2c65b87l80br96-idris2/idris2-0.2.1/base", "/nix/store/h4851cakq6w4cw3hcy2c65b87l80br96-idris2/idris2-0.2.1/contrib", "/nix/store/h4851cakq6w4cw3hcy2c65b87l80br96-idris2/idris2-0.2.1/network", "/nix/store/h4851cakq6w4cw3hcy2c65b87l80br96-idris2/idris2-0.2.1/prelude", "/home/wchresta/.idris2/idris2-0.2.1/prelude", "/home/wchresta/.idris2/idris2-0.2.1/base"]
+ CG Library Directories :: ["/nix/store/h4851cakq6w4cw3hcy2c65b87l80br96-idris2/idris2-0.2.1/lib", "/home/wchresta/.idris2/idris2-0.2.1/lib", "/home/wchresta/src/nixpkgs"]
+ Data Directories       :: ["/nix/store/h4851cakq6w4cw3hcy2c65b87l80br96-idris2/idris2-0.2.1/support", "/home/wchresta/.idris2/idris2-0.2.1/support"]

```

###### Things done


* Fix: idris2_app/ was exposed in bin/
* Remove native Idris2 wrapper that set LD_LIBRARY_PATH
* Improve new Idris2 wrapper to set Idris2 paths to out folders

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
