### PR TITLE
iniconfig: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/iniconfig/default.nix
+++ b/pkgs/development/python-modules/iniconfig/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, py }:
+
+buildPythonPackage rec {
+  version = "1.0.1";
+  pname = "iniconfig";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0s9z9n4603fdpv2vzh6ddzfgsjmb09n6qalkjl2xwrss6n4jzyg5";
+  };
+
+  buildInputs = [ py ];
+
+  # Do not test with pytest because it creates an infinite loop as pytest depends on iniconfig.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "http://github.com/RonnyPfannschmidt/iniconfig";
+    description = "Simple parsing of ini files";
+    maintainers = with maintainers; [ dasj19 ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3234,6 +3234,8 @@ in {
 
   itypes = callPackage ../development/python-modules/itypes { };
 
+  iniconfig = callPackage ../development/python-modules/iniconfig { };
+
   iniparse = callPackage ../development/python-modules/iniparse { };
 
   intreehooks = callPackage ../development/python-modules/intreehooks { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Added iniconfig package.
This is a dependency for newest pytest library. After this get merged we can update pytest to version 6.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
