### PR TITLE
pythonPackages.avro: 1.9.2 -> 1.10.0

### DIFF
--- a/pkgs/development/python-modules/avro/default.nix
+++ b/pkgs/development/python-modules/avro/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "A serialization and RPC framework";
     homepage = "https://pypi.python.org/pypi/avro/";
-    license = licenses.apache2;
+    license = licenses.asl20;
     maintainers = [ maintainers.zimbatm ];
   };
 }

--- a/pkgs/development/python-modules/avro/default.nix
+++ b/pkgs/development/python-modules/avro/default.nix
@@ -24,5 +24,7 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "A serialization and RPC framework";
     homepage = "https://pypi.python.org/pypi/avro/";
+    license = licenses.apache2;
+    maintainers = [ maintainers.zimbatm ];
   };
 }

--- a/pkgs/development/python-modules/avro/default.nix
+++ b/pkgs/development/python-modules/avro/default.nix
@@ -1,14 +1,22 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy3k, pycodestyle, isort }:
+{ stdenv, buildPythonPackage, isPy3k, fetchPypi, pycodestyle, isort }:
 
 buildPythonPackage rec {
   pname = "avro";
-  version = "1.9.2";
-  disabled = isPy3k;
+  version = "1.10.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4487f0e91d0d44142bd08b3c6da57073b720c3effb02eeb4e2e822804964c56b";
+    sha256 = "00rg1nn9szwm0p1lcda0w3iyqy9mx2y9zv0hdwaz6k0bsagziydv";
   };
+
+  patchPhase = ''
+    # this test requires network access
+    sed -i 's/test_server_with_path/noop/' avro/test/test_ipc.py
+  '' + (stdenv.lib.optionalString isPy3k ''
+    # these files require twisted, which is not python3 compatible
+    rm avro/txipc.py
+    rm avro/test/txsample*
+  '');
 
   nativeBuildInputs = [ pycodestyle ];
   propagatedBuildInputs = [ isort ];


### PR DESCRIPTION
###### Motivation for this change

That package is now Python 3 compatible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).