### PR TITLE
psftools: init at 1.0.13

### DIFF
--- a/pkgs/os-specific/linux/psftools/default.nix
+++ b/pkgs/os-specific/linux/psftools/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl }:
+stdenv.mkDerivation rec {
+  pname = "psftools";
+  version = "1.0.13";
+  src = fetchurl {
+    url = "https://www.seasip.info/Unix/PSF/${pname}-${version}.tar.gz";
+    sha256 = "0rgg1lhryqi6sgm4afhw0z6pjivdw4hyhpxanj8rabyabn4fcqcw";
+  };
+  outputs = ["out" "man" "dev" "lib"];
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.seasip.info/Unix/PSF";
+    description = "Conversion tools for .PSF fonts";
+    longDescription = ''
+      The PSFTOOLS are designed to manipulate fixed-width bitmap fonts,
+      such as DOS or Linux console fonts. Both the PSF1 (8 pixels wide)
+      and PSF2 (any width) formats are supported; the default output
+      format is PSF2.
+    '';
+    platforms = platforms.linux;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28308,4 +28308,5 @@ in
 
   cagebreak = callPackage ../applications/window-managers/cagebreak/default.nix {};
 
+  psftools = callPackage ../os-specific/linux/psftools {};
 }


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).