### PR TITLE
claws-mail: patch mailto handling

### DIFF
--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -1,4 +1,4 @@
-{ config, fetchurl, stdenv, wrapGAppsHook, autoreconfHook
+{ config, fetchurl, fetchpatch, stdenv, wrapGAppsHook, autoreconfHook
 , curl, dbus, dbus-glib, enchant, gtk2, gnutls, gnupg, gpgme
 , libarchive, libcanberra-gtk2, libetpan, libnotify, libsoup, libxml2, networkmanager
 , openldap, perl, pkgconfig, poppler, python, shared-mime-info
@@ -39,7 +39,17 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  patches = [ ./mime.patch ];
+  patches = [
+    ./mime.patch
+
+    # Backports a mitigation to the "mailto vulnerability". This patch is
+    # included in the next release and must therefore be removed.
+    (fetchpatch {
+      name = "fix-4373-4374.patch";
+      url = "https://git.claws-mail.org/?p=claws.git;a=patch;h=4c9d15b4b37cdc57edfa16df550a0a881a156153";
+      sha256 = "0sp0vxr6pk2fv5ydpcakb50rmn2w2nma98apgfsgcgan82qmwk7n";
+    })
+  ];
 
   preConfigure = ''
     # autotools check tries to dlopen libpython as a requirement for the python plugin


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The ["Mailto: Me Your Secrets"][0] paper describes vulnerabilities in
multiple email clients regarding the undocumented "attach" field of a
mailto URI. This might allow the inclusion of sensitive data in an
outgoing email.

Pull request #95758 addresses this issue on a more general level.

Claws Mail unfortunately also has problems with mailto URIs ([bug 4373][1], [bug 4374][2]).
Referring to the paper, problems for "attach" and "insert" were found
and fixed. These patches, which are not included in a release yet, are
hereby added.

[0]:https://www.nds.ruhr-uni-bochum.de/media/nds/veroeffentlichungen/2020/08/15/mailto-paper.pdf
[1]:https://www.thewildbeast.co.uk/claws-mail/bugzilla/show_bug.cgi?id=4373
[2]:https://www.thewildbeast.co.uk/claws-mail/bugzilla/show_bug.cgi?id=4374

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
