### PR TITLE
secp256k1: 2017-12-18 -> 2020-08-16

### DIFF
--- a/pkgs/tools/security/secp256k1/default.nix
+++ b/pkgs/tools/security/secp256k1/default.nix
@@ -20,13 +20,13 @@ stdenv.mkDerivation {
 
   # I can't find any version numbers, so we're just using the date of the
   # last commit.
-  version = "2017-12-18";
+  version = "2020-08-16";
 
   src = fetchFromGitHub {
     owner = "bitcoin-core";
     repo = "secp256k1";
-    rev = "f54c6c5083307b18224c953cf5870ea7ffce070b";
-    sha256 = "0bxqmimm627g9klalg1vdbspmn52588v4a6cli3p8bn84ibsnzbm";
+    rev = "670cdd3f8be25f81472b2d16dcd228b0d24a5c45";
+    sha256 = "0ak2hrr0wznl5d9s905qwn5yds7k22i28d2jp957l4a8yf8cqv3s";
   };
 
   buildInputs = optionals enableJNI [ jdk ];
@@ -34,10 +34,13 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook ];
 
   configureFlags =
-    [ "--enable-benchmark=no" "--enable-tests=no" "--enable-exhaustive-tests=no" ] ++
+    [ "--enable-benchmark=no" "--enable-tests=yes" "--enable-exhaustive-tests=no" ] ++
     optionals enableECDH [ "--enable-module-ecdh" "--enable-experimental" ] ++
     optionals enableRecovery [ "--enable-module-recovery" ] ++
     optionals enableJNI [ "--enable-jni" ];
+
+  doCheck = true;
+  checkPhase = "./tests";
 
   meta = with stdenv.lib; {
     description = "Optimized C library for EC operations on curve secp256k1";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bump version, enable tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
