### PR TITLE
androidenv: fix convert files not quoting urls

### DIFF
--- a/pkgs/development/mobile/androidenv/convertaddons.xsl
+++ b/pkgs/development/mobile/androidenv/convertaddons.xsl
@@ -36,13 +36,13 @@
       archives = {
       <xsl:for-each select="archives/archive[not(host-os)]">
         all = fetchurl {
-          url = <xsl:call-template name="repository-url"/>;
+          url = "<xsl:call-template name="repository-url"/>";
           sha1 = "<xsl:value-of select="complete/checksum" />";
         };
       </xsl:for-each>
       <xsl:for-each select="archives/archive[host-os and not(host-os = 'windows')]">
         <xsl:value-of select="host-os" /> = fetchurl {
-          url = <xsl:call-template name="repository-url"/>;
+          url = "<xsl:call-template name="repository-url"/>";
           sha1 = "<xsl:value-of select="complete/checksum" />";
         };
       </xsl:for-each>
@@ -60,13 +60,13 @@
       archives = {
       <xsl:for-each select="archives/archive[not(host-os)]">
         all = fetchurl {
-          url = <xsl:call-template name="repository-url"/>;
+          url = "<xsl:call-template name="repository-url"/>";
           sha1 = "<xsl:value-of select="complete/checksum" />";
         };
       </xsl:for-each>
       <xsl:for-each select="archives/archive[host-os and not(host-os = 'windows')]">
         <xsl:value-of select="host-os" /> = fetchurl {
-          url = <xsl:call-template name="repository-url"/>;
+          url = "<xsl:call-template name="repository-url"/>";
           sha1 = "<xsl:value-of select="complete/checksum" />";
         };
       </xsl:for-each>
@@ -108,13 +108,13 @@
       archives = {
       <xsl:for-each select="archives/archive[not(host-os)]">
         all = fetchurl {
-          url = <xsl:call-template name="repository-url"/>;
+          url = "<xsl:call-template name="repository-url"/>";
           sha1 = "<xsl:value-of select="complete/checksum" />";
         };
       </xsl:for-each>
       <xsl:for-each select="archives/archive[host-os and not(host-os = 'windows')]">
         <xsl:value-of select="host-os" /> = fetchurl {
-          url = <xsl:call-template name="repository-url"/>;
+          url = "<xsl:call-template name="repository-url"/>";
           sha1 = "<xsl:value-of select="complete/checksum" />";
         };
       </xsl:for-each>

--- a/pkgs/development/mobile/androidenv/convertpackages.xsl
+++ b/pkgs/development/mobile/androidenv/convertpackages.xsl
@@ -98,13 +98,13 @@
     archives = {
       <xsl:for-each select="archives/archive[not(host-os)]">
         all = fetchurl {
-          url = <xsl:call-template name="repository-url"/>;
+          url = !<xsl:call-template name="repository-url"/>";
           sha1 = "<xsl:value-of select="complete/checksum" />";
         };
       </xsl:for-each>
       <xsl:for-each select="archives/archive[host-os and not(host-os = 'windows')]">
         <xsl:value-of select="host-os" /> = fetchurl {
-        url = <xsl:call-template name="repository-url"/>;
+        url = "<xsl:call-template name="repository-url"/>";
         sha1 = "<xsl:value-of select="complete/checksum" />";
       };
       </xsl:for-each>

--- a/pkgs/development/mobile/androidenv/convertsystemimages.xsl
+++ b/pkgs/development/mobile/androidenv/convertsystemimages.xsl
@@ -64,7 +64,7 @@
     displayName = "</xsl:text><xsl:value-of select="display-name" /><xsl:text>";
     archives.all = fetchurl {</xsl:text>
     <xsl:for-each select="archives/archive"><xsl:text>
-      url = </xsl:text><xsl:call-template name="repository-url"/><xsl:text>;
+      url = "</xsl:text><xsl:call-template name="repository-url"/><xsl:text>";
       sha1 = "</xsl:text><xsl:value-of select="complete/checksum" /><xsl:text>";</xsl:text>
     </xsl:for-each><xsl:text>
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
When running the `./generate.sh` script, it would not quote the URLs for src.
This is fixed here, as it is a requirement.
Seems like the previous generated files have been manually tampered with, outside of the generate script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
