### PR TITLE
timescale-prometheus: 0.1.0-beta.1 -> 0.1.0-beta.2

### DIFF
--- a/pkgs/servers/monitoring/timescale-prometheus/default.nix
+++ b/pkgs/servers/monitoring/timescale-prometheus/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "timescale-prometheus";
-  version = "0.1.0-beta.1";
+  version = "0.1.0-beta.2";
 
   src = fetchFromGitHub {
     owner = "timescale";
     repo = pname;
     rev = "${version}";
-    sha256 = "1q6xky4h9x4j2f0f6ajxwlnqq1pgd2n0z1ldrcifyamd90qkwcm5";
+    sha256 = "1rrr0qb27hh3kcmmxapr1j39dhfxf02vihpjf4b7zpwdf1mpvrbc";
   };
 
-  vendorSha256 = "sha256:1vp30y59w8mksqxy9ic37vj1jw4lbq24ahhb08a72rysylw94r57";
+  vendorSha256 = "sha256:0y5rq2y48kf2z1z3a8ags6rqzfvjs54klk2679fk8x0yjamj5x04";
 
   doCheck = false;
 

--- a/pkgs/servers/monitoring/timescale-prometheus/default.nix
+++ b/pkgs/servers/monitoring/timescale-prometheus/default.nix
@@ -16,6 +16,8 @@ buildGoModule rec {
 
   vendorSha256 = "sha256:0y5rq2y48kf2z1z3a8ags6rqzfvjs54klk2679fk8x0yjamj5x04";
 
+  buildFlagsArray = [ "-ldflags=-s -w -X github.com/timescale/timescale-prometheus/pkg/version.Version=${version} -X github.com/timescale/timescale-prometheus/pkg/version.CommitHash=${src.rev}" ];
+
   doCheck = false;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Upgrade to [0.1.0-beta.2](https://github.com/timescale/timescale-prometheus/releases/tag/0.1.0-beta.2)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
