### PR TITLE
python: wtf-peewee: 3.0.1 -> 3.0.2

### DIFF
--- a/pkgs/development/python-modules/wtf-peewee/default.nix
+++ b/pkgs/development/python-modules/wtf-peewee/default.nix
@@ -8,11 +8,11 @@
 
 buildPythonPackage rec {
   pname = "wtf-peewee";
-  version = "3.0.1";
+  version = "3.0.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4ac1b457f3255ee2d72915267884a16e5fb502e1e7bb793f2f1301c926e3599a";
+    sha256 = "03qs6np5s9r0nmsryfzll29ajcqk27b18kcbgd9plf80ys3nb6kd";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
v3.0.1 had a test failing, ref https://discourse.nixos.org/t/problem-building-python3-8-wtf-peewee-3-0-1-drv/8618. v3.0.2 fixed that, ref https://github.com/coleifer/wtf-peewee/issues/54.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
