### PR TITLE
osslsigncode: unstable-2019-07-25 -> unstable-2020-08-02

### DIFF
--- a/pkgs/development/tools/osslsigncode/default.nix
+++ b/pkgs/development/tools/osslsigncode/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "osslsigncode";
-  version = "unstable-2019-07-25";
+  version = "unstable-2020-08-02";
 
   src = fetchFromGitHub {
     owner = "mtrojnar";
     repo = pname;
-    rev = "18810b7e0bb1d8e0d25b6c2565a065cf66bce5d7";
-    sha256 = "02jnbr3xdsb5dpll3k65080ryrfr7agawmjavwxd0v40w0an5yq8";
+    rev = "01b3fb5b542ed0b41e3860aeee7a85b735491ff2";
+    sha256 = "03ynm1ycbi86blglma3xiwadck8kc5yb0gawjzlhyv90jidn680l";
   };
 
   nativeBuildInputs = [ autoreconfHook libgsf pkgconfig openssl curl ];
@@ -24,8 +24,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/mtrojnar/osslsigncode";
     description = "OpenSSL based Authenticode signing for PE/MSI/Java CAB files";
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.mmahut ];
+    maintainers = with maintainers; [ mmahut ];
     platforms = platforms.all;
   };
 }
-


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to include timestamp verification fixes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
