### PR TITLE
osu-lazer: add unfreeRedistributable license

### DIFF
--- a/pkgs/games/osu-lazer/default.nix
+++ b/pkgs/games/osu-lazer/default.nix
@@ -99,7 +99,11 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Rhythm is just a *click* away";
     homepage = "https://osu.ppy.sh";
-    license = with licenses; [ mit cc-by-nc-40 ];
+    license = with licenses; [
+      mit
+      cc-by-nc-40
+      unfreeRedistributable # osu-framework contains libbass.so in repository
+    ];
     maintainers = with maintainers; [ oxalica ];
     platforms = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
The [unfree BASS library](http://www.un4seen.com/bass.html#license) is a dependency of the osu framework, which [includes the shared library](https://github.com/ppy/osu-framework/tree/master/osu.Framework.NativeLibs/runtimes) in its repository. The library for the system runtime is included in the build output.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Accurately reflecting the package’s license.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
