### PR TITLE
semantik: Init at 1.2.5

### DIFF
--- a/pkgs/applications/office/semantik/default.nix
+++ b/pkgs/applications/office/semantik/default.nix
@@ -29,7 +29,7 @@ mkDerivation rec {
   src = fetchFromGitLab {
     owner = "ita1024";
     repo = "semantik";
-    rev = "semantik-${version}"; 
+    rev = "semantik-${version}";
     sha256 = "0dkg6mbnsbvbis17iz8v59wlhld93nc51abnkbyqvvkyyiqb006c";
   };
 
@@ -58,7 +58,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [ (lib.getDev qtsvg) (lib.getLib qtsvg) python3 pkg-config wafHook cmake ];
 
-  buildInputs = [ 
+  buildInputs = [
     qtbase
     qtwebengine
     qtsvg

--- a/pkgs/applications/office/semantik/default.nix
+++ b/pkgs/applications/office/semantik/default.nix
@@ -5,7 +5,6 @@
 , pkg-config
 , cmake
 , qtbase
-, qttools
 , python3
 , qtwebengine
 , qtsvg

--- a/pkgs/applications/office/semantik/default.nix
+++ b/pkgs/applications/office/semantik/default.nix
@@ -22,8 +22,8 @@
 , sonnet
 , kdelibs4support
 }:
-mkDerivation rec {
 
+mkDerivation rec {
   pname = "semantik";
   version = "1.2.5";
 

--- a/pkgs/applications/office/semantik/default.nix
+++ b/pkgs/applications/office/semantik/default.nix
@@ -1,0 +1,91 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, wafHook
+, pkg-config
+, cmake
+, qtbase
+, qttools
+, python3
+, qtwebengine
+, qtsvg
+, ncurses6
+, kio
+, kauth
+, kiconthemes
+, kconfigwidgets
+, kxmlgui
+, kcoreaddons
+, kconfig
+, kwidgetsaddons
+, ki18n
+, sonnet
+, kdelibs4support
+}:
+mkDerivation rec {
+
+  pname = "semantik";
+  version = "1.2.5";
+
+  src = fetchFromGitLab {
+    owner = "ita1024";
+    repo = "semantik";
+    rev = "semantik-${version}"; 
+    sha256 = "0dkg6mbnsbvbis17iz8v59wlhld93nc51abnkbyqvvkyyiqb006c";
+  };
+
+  patches = [ ./qt5.patch ];
+
+  postPatch = ''
+    echo "${lib.getDev qtwebengine}"
+    substituteInPlace wscript \
+      --replace @Qt5Base_dev@ "${lib.getDev qtbase}" \
+      --replace @KF5KIOCore_dev@ "${lib.getDev kio}" \
+      --replace @KF5Auth_dev@ "${lib.getDev kauth}" \
+      --replace @KF5IconThemes_dev@ "${lib.getDev kiconthemes}" \
+      --replace @KF5ConfigWidgets_dev@ "${lib.getDev kconfigwidgets}" \
+      --replace @KF5XmlGui_dev@ "${lib.getDev kxmlgui}" \
+      --replace @KF5CoreAddons_dev@ "${lib.getDev kcoreaddons}" \
+      --replace @KF5Config_dev@ "${lib.getDev kconfig}" \
+      --replace @KF5WidgetsAddons_dev@ "${lib.getDev kwidgetsaddons}" \
+      --replace @KF5I18n_dev@ "${lib.getDev ki18n}" \
+      --replace @KF5SonnetUi_dev@ "${lib.getDev sonnet}" \
+      --replace @Qt5Svg@ "${qtsvg}" \
+      --replace @Qt5Svg_dev@ "${lib.getDev qtsvg}" \
+      --replace @Qt5WebEngine@ "${qtwebengine}" \
+      --replace @Qt5WebEngine_dev@ "${lib.getDev qtwebengine}" \
+      --replace /usr/include/KF5/KDELibs4Support "${lib.getDev kdelibs4support}/include/KF5/KDELibs4Support"
+  '';
+
+  nativeBuildInputs = [ (lib.getDev qtsvg) (lib.getLib qtsvg) python3 pkg-config wafHook cmake ];
+
+  buildInputs = [ 
+    qtbase
+    qtwebengine
+    qtsvg
+    ncurses6
+    kio
+    kauth
+    kiconthemes
+    kconfigwidgets
+    kxmlgui
+    kcoreaddons
+    kconfig
+    kwidgetsaddons
+    ki18n
+    sonnet
+    kdelibs4support
+  ];
+
+  wafConfigureFlags = [
+    "--qtlibs=${lib.getLib qtbase}/lib"
+  ];
+
+  meta = with lib; {
+    description = "A mind-mapping application for KDE";
+    license = licenses.mit;
+    homepage = "https://waf.io/semantik.html";
+    maintainers = [ maintainers.shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/office/semantik/qt5.patch
+++ b/pkgs/applications/office/semantik/qt5.patch
@@ -1,0 +1,78 @@
+diff --color -ur a/wscript b/wscript
+--- a/wscript	2020-08-17 19:49:43.389864343 +0200
++++ b/wscript	2020-08-18 00:22:51.172556519 +0200
+@@ -149,6 +149,26 @@
+ 	if not conf.env.QT_LRELEASE: conf.fatal('Semantik requires the program lrelease (from the Qt linguist package? - compilation only)')
+ 	conf.find_program('python3', var='PYTHON')
+ 	conf.load('python')
++	conf.env.HAVE_QT5SVG = 1
++	conf.env.DEFINES_QT5SVG = [ 'QT_SVG_LIB' ]
++	conf.env.INCLUDES_QT5SVG = [ '@Qt5Svg_dev@/include/QtSvg' ]
++	conf.env.LIBPATH_QT5SVG = '@Qt5Svg@/lib'
++	conf.env.LIB_QT5SVG = [ 'Qt5Svg', 'Qt5Core', 'Qt5Gui', 'Qt5Widgets' ]
++	conf.env.HAVE_QT5WEBENGINEWIDGETS = 1
++	conf.env.DEFINES_QT5WEBENGINEWIDGETS = [ 'QT_WEBENGINEWIDGETS_LIB' ]
++	conf.env.INCLUDES_QT5WEBENGINEWIDGETS = [ '@Qt5WebEngine_dev@/include/QtWebEngineWidgets' ]
++	conf.env.LIBPATH_QT5WEBENGINEWIDGETS = '@Qt5WebEngine@/lib'
++	conf.env.LIB_QT5WEBENGINEWIDGETS = [
++		'Qt5WebEngineWidgets',
++		'Qt5Core',
++		'Qt5Gui',
++		'Qt5WebEngineCore',
++		'Qt5Widgets',
++		'Qt5Network',
++		'Qt5Quick',
++		'Qt5PrintSupport'
++	]
++	print("conf.env.LIB_QT5SVG : ",conf.env)
+ 	if not conf.env.LIB_QT5SVG: conf.fatal('Could not find Qt5Svg - Semantik requires Qt >= 5')
+ 	if not conf.env.LIB_QT5WEBENGINEWIDGETS: conf.fatal('Could not find Qt5WebEngineWidgets - check `pkg-config --libs Qt5WebEngineWidgets`')
+ 	if not conf.env.LIB_QT5DBUS: conf.fatal('Install Qt Dbus')
+@@ -186,7 +206,11 @@
+ 		raise ValueError('Could not find QT_HOST_DATA')
+ 
+ 	specpath = conf.cmd_and_log(conf.env.QMAKE + ['-query', 'QMAKE_SPEC'], quiet=0, stdout=True)
++	path = "@Qt5Base_dev@"
++	print("\n\n[log] specpath = ",specpath,"\n")
++	print("\n\n[log] path = ",path,"\n")
+ 	specpath = os.path.join(path, 'mkspecs', specpath.strip())
++	print("\n\n[log] specpath = ",specpath,"\n")
+ 	if not os.path.exists(specpath):
+ 		raise ValueError('No spec path, cannot build')
+ 
+@@ -196,17 +220,28 @@
+ 
+ 	conf.env.append_value('INCLUDES_KDECORE', specpath)
+ 
+-	libs = ['KF5KIOCore', 'KF5Auth', 'KF5KIOWidgets',
+-		'KF5IconThemes', 'KF5ConfigWidgets', 'KF5XmlGui',
+-		'KF5CoreAddons', 'KF5ConfigGui', 'KF5ConfigCore',
+-		'KF5WidgetsAddons', 'KF5I18n', 'KF5SonnetUi']
++	libs = {
++            'KF5KIOCore': '@KF5KIOCore_dev@',
++            'KF5Auth': '@KF5Auth_dev@',
++            'KF5KIOWidgets': '@KF5KIOCore_dev@',
++            'KF5IconThemes': '@KF5IconThemes_dev@',
++            'KF5ConfigWidgets': '@KF5ConfigWidgets_dev@',
++            'KF5XmlGui': '@KF5XmlGui_dev@',
++            'KF5CoreAddons': '@KF5CoreAddons_dev@',
++            'KF5ConfigGui': '@KF5Config_dev@',
++            'KF5ConfigCore': '@KF5Config_dev@',
++            'KF5WidgetsAddons': '@KF5WidgetsAddons_dev@',
++            'KF5I18n': '@KF5I18n_dev@',
++            'KF5SonnetUi': '@KF5SonnetUi_dev@',
++        }
+ 
+-	for lib in libs:
++	for lib,mkspec_path in libs.items():
++		print("[log] mkspec : ", mkspec_path)
+ 		name = lib[3:]
+ 		if not name.startswith('K') and name != 'SonnetUi':
+ 			name = 'K' + name
+-
+-		p = '%s/qt_%s.pri' % (path, name)
++		p = '%s/qt_%s.pri' % (mkspec_path+"/mkspecs/modules", name)
++		print("[log] path :",path,", name : ",name)
+ 		for line in Utils.readf(p).splitlines():
+ 			lst = line.strip().split(' = ')
+ 			if lst[0].endswith('.name'):

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11256,6 +11256,8 @@ in
 
   semver-tool = callPackage ../development/tools/misc/semver-tool { };
 
+  semantik = libsForQt5.callPackage ../applications/office/semantik { };
+
   sconsPackages = dontRecurseIntoAttrs (callPackage ../development/tools/build-managers/scons { });
   scons = sconsPackages.scons_latest;
 


### PR DESCRIPTION
###### Motivation for this change
@blub asked for this package on #nixos IRC

###### Things done
Patched the wscript and tested execution on release 1.2.5

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
