### PR TITLE
statping: init at 0.90.63

### DIFF
--- a/pkgs/servers/monitoring/statping/default.nix
+++ b/pkgs/servers/monitoring/statping/default.nix
@@ -1,0 +1,56 @@
+{ buildGoModule, mkYarnPackage, fetchFromGitHub, lib, tree }:
+
+let
+  version = "0.90.63";
+
+  src = fetchFromGitHub {
+    owner = "statping";
+    repo = "statping";
+    rev = "v${version}";
+    sha256 = "01cvl7xg8xfdqn5yvnllcg7ippdch9yi60vnvhlxam4dpfqvc1xi";
+  };
+
+  frontend = mkYarnPackage {
+    name = "statping-frontend";
+    src = "${src}/frontend";
+    packageJSON = "${src}/frontend/package.json";
+    yarnLock = "${src}/frontend/yarn.lock";
+    #yarnNix = ./yarndeps.nix;
+  };
+in buildGoModule rec {
+  pname = "statping";
+  inherit src version;
+
+  vendorSha256 = "1p45ld6r0iy7gbxbpwis78ygqi0h8cslgb4xcskygkc4aq9ksxr3";
+
+  postPatch = ''
+${tree}/bin/tree -L 4 ${frontend}
+echo XXXXXXXXXXXXXXXXXXXX
+    cp -r ${frontend}/libexec/statping/deps/statping source/dist
+    ls -la source/dist
+    cp -r ${src}/frontend/src/assets/scss source/dist/
+    cp ${src}/frontend/public/favicon.ico source/dist/
+    cp ${src}/frontend/public/robots.txt source/dist/
+    cp ${src}/frontend/public/banner.png source/dist/
+    cp -r ${src}/frontend/public/favicon source/dist/
+  '';
+
+  subPackages = [ "cmd" ];
+
+  # has no effect. binary still named cmd and `cmd version` empty
+  buildFlagsArray = [
+  "-tags=netgo"
+  "-o statping"
+  ''
+    -ldflags='-X main.VERSION=${version} -X main.COMMIT=${version}'
+  ''
+  ];
+
+  meta = with lib; {
+    description = "An open source server to monitor your web applications and all other HTTP, TCP, UDP and gRPC services";
+    homepage = "https://statping.com/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ davidak ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16816,6 +16816,8 @@ in
 
   slurm-spank-x11 = callPackage ../servers/computing/slurm-spank-x11 { };
 
+  statping = callPackage ../servers/monitoring/statping { };
+
   systemd-journal2gelf = callPackage ../tools/system/systemd-journal2gelf { };
 
   syncserver = callPackage ../servers/syncserver { };


### PR DESCRIPTION
##### Motivation for this change

Closes #95253

NixOS module will follow in separate PR

##### TODO

- [ ] binary name should be _statping_
- [ ] `statping version` should display version number
- [ ] statping should actually start
- [ ] assets should be included

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
