### PR TITLE
undmg: 1.0.5 -> 1.1.0

### DIFF
--- a/pkgs/tools/archivers/undmg/default.nix
+++ b/pkgs/tools/archivers/undmg/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, fetchFromGitHub, zlib, bzip2 }:
+{ stdenv, fetchFromGitHub, zlib, bzip2, lzfse, pkg-config }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.5";
+  version = "1.1.0";
   pname = "undmg";
 
   src = fetchFromGitHub {
     owner = "matthewbauer";
     repo = "undmg";
     rev = "v${version}";
-    sha256 = "0yz5fniaa5z33d8bdzgr263957r1c9l99237y2p8k0hdid207la1";
+    sha256 = "0rb4h89jrl04vwf6p679ipa4mp95hzmc1ca11wqbanv3xd1kcpxm";
   };
 
-  buildInputs = [ zlib bzip2 ];
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ zlib bzip2 lzfse ];
 
   setupHook = ./setup-hook.sh;
 

--- a/pkgs/tools/archivers/undmg/setup-hook.sh
+++ b/pkgs/tools/archivers/undmg/setup-hook.sh
@@ -1,5 +1,5 @@
 unpackCmdHooks+=(_tryUnpackDmg)
 _tryUnpackDmg() {
     if ! [[ "$curSrc" =~ \.dmg$ ]]; then return 1; fi
-    undmg < "$curSrc"
+    undmg "$curSrc"
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
