### PR TITLE
python3Packages.pytorch-lightning: init at 0.8.5

### DIFF
--- a/pkgs/development/python-modules/pytorch-lightning/default.nix
+++ b/pkgs/development/python-modules/pytorch-lightning/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, future
+, pytestCheckHook
+, pytorch
+, pyyaml
+, tensorflow-tensorboard
+, tqdm }:
+
+buildPythonPackage rec {
+  pname = "pytorch-lightning";
+  version = "0.8.5";
+
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "PyTorchLightning";
+    repo = pname;
+    rev = version;
+    sha256 = "12zhq4pnfcwbgcx7cs99c751gp3w0ysaf5ykv2lv8f4i360w3r5a";
+  };
+
+  propagatedBuildInputs = [ 
+    future
+    pytorch
+    pyyaml
+    tensorflow-tensorboard
+    tqdm
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+  # Some packages are not in NixPkgs; other tests try to build distributed
+  # models, which doesn't work in the sandbox.
+  doCheck = false;
+
+  pythonImportsCheck = [ "pytorch_lightning" ];
+
+  meta = with lib; {
+    description = "Lightweight PyTorch wrapper for machine learning researchers";
+    homepage = "https://pytorch-lightning.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4083,6 +4083,8 @@ in {
     cudaSupport = false;
   };
 
+  pytorch-lightning = callPackage ../development/python-modules/pytorch-lightning { };
+
   pytorch-metric-learning = callPackage ../development/python-modules/pytorch-metric-learning { };
 
   pythondialog = callPackage ../development/python-modules/pythondialog { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Refresh of #77155 but without adding an expression for the `test-tube` dependency which is now optional except for testing, and we don't run the tests.

Added @tbenst as maintainer but happy to change it to or add myself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
