### PR TITLE
pythonPackages.aioitertools: init at 0.7.0

### DIFF
--- a/pkgs/development/python-modules/aioitertools/default.nix
+++ b/pkgs/development/python-modules/aioitertools/default.nix
@@ -1,0 +1,32 @@
+{ buildPythonPackage
+, fetchPypi
+, pythonOlder
+, typing-extensions
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "aioitertools";
+  version = "0.7.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xw1gg2c6zpw9s7i7q34qf0qxqdfj8nc2k1xnzqpw5q315db071l";
+  };
+
+  propagatedBuildInputs = [
+    typing-extensions
+  ];
+
+  checkPhase = ''
+    python -m aioitertools.tests
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/omnilib/aioitertools";
+    description = "Implementation of itertools, builtins, and more for AsyncIO and mixed-type iterables.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cmcdragonkai ];
+  };
+}

--- a/pkgs/development/python-modules/aioitertools/default.nix
+++ b/pkgs/development/python-modules/aioitertools/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   ];
 
   checkPhase = ''
-    python -m aioitertools.tests
+    ${python.interpreter} -m aioitertools.tests
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/aioitertools/default.nix
+++ b/pkgs/development/python-modules/aioitertools/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     sha256 = "0xw1gg2c6zpw9s7i7q34qf0qxqdfj8nc2k1xnzqpw5q315db071l";
   };
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = lib.optionals (pythonAtLeast "3.7") [
     typing-extensions
   ];
 

--- a/pkgs/development/python-modules/aioitertools/default.nix
+++ b/pkgs/development/python-modules/aioitertools/default.nix
@@ -1,6 +1,7 @@
 { buildPythonPackage
 , fetchPypi
 , pythonOlder
+, pythonAtLeast
 , typing-extensions
 , lib
 }:

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -180,6 +180,8 @@ in {
 
   agate-sql = callPackage ../development/python-modules/agate-sql { };
 
+  aioitertools = callPackage ../development/python-modules/aioitertools { };
+
   aioamqp = callPackage ../development/python-modules/aioamqp { };
 
   aioconsole = callPackage ../development/python-modules/aioconsole { };


### PR DESCRIPTION
###### Motivation for this change

Added aioitertools for Python asyncio based itertools.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
