### PR TITLE
mozwire: 0.4.1 -> 0.5.1

### DIFF
--- a/pkgs/tools/networking/mozwire/default.nix
+++ b/pkgs/tools/networking/mozwire/default.nix
@@ -1,18 +1,19 @@
 { rustPlatform, stdenv, fetchFromGitHub, Security }:
+
 rustPlatform.buildRustPackage rec {
   pname = "MozWire";
-  version = "0.4.1";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "NilsIrl";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1slfb6m22vzglnrxahlhdcwzwpf3b817mskdx628s92mjzngzyih";
+    sha256 = "07icgswmfvrvlm3mkm78pbbk6m2hb73j7ffj7r77whzb11v027v1";
   };
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
   
-  cargoSha256 = "0b00j8vn1vvvphcyv8li7i73pq66sq6dr4wc1w4s3pppa151xr55";
+  cargoSha256 = "10lhz7bdlfqj7wgsqnsxdfskms33pvj176fhf4kwci7nb8vgai4b";
 
   meta = with stdenv.lib; {
     description = "MozillaVPN configuration manager giving Linux, macOS users (among others), access to MozillaVPN";


### PR DESCRIPTION
###### Motivation for this change

Change hashes.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
