### PR TITLE
ocamlPackages.camlpdf: 2.3 → 2.3.1

### DIFF
--- a/pkgs/development/ocaml-modules/camlpdf/default.nix
+++ b/pkgs/development/ocaml-modules/camlpdf/default.nix
@@ -5,13 +5,13 @@ then throw "camlpdf is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  version = "2.3";
+  version = "2.3.1";
   name = "ocaml${ocaml.version}-camlpdf-${version}";
   src = fetchFromGitHub {
     owner = "johnwhitington";
     repo = "camlpdf";
     rev = "v${version}";
-    sha256 = "1z8h6bjzmlscr6h6kdvzj8kspifb4n9dg7zi54z1cv2qi03kr8dk";
+    sha256 = "1q69hhk63z836jbkv4wsng27w35w0qpz01c7ax0mqm8d8kmnr0v4";
   };
 
   buildInputs = [ which ocaml findlib ];

--- a/pkgs/development/ocaml-modules/camlpdf/default.nix
+++ b/pkgs/development/ocaml-modules/camlpdf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib }:
+{ stdenv, fetchFromGitHub, which, ocaml, findlib }:
 
 if !stdenv.lib.versionAtLeast ocaml.version "4.02"
 then throw "camlpdf is not available for OCaml ${ocaml.version}"
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "1z8h6bjzmlscr6h6kdvzj8kspifb4n9dg7zi54z1cv2qi03kr8dk";
   };
 
-  buildInputs = [ ocaml findlib ];
+  buildInputs = [ which ocaml findlib ];
 
   # Version number in META file is wrong
   patchPhase = ''
@@ -26,7 +26,9 @@ stdenv.mkDerivation rec {
     EOF
   '';
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs
+  '';
 
   meta = with stdenv.lib; {
     description = "An OCaml library for reading, writing and modifying PDF files";

--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, ocaml, findlib, camlpdf, ncurses }:
 
-let version = "2.3"; in
+let version = "2.3.1"; in
 
 stdenv.mkDerivation {
   name = "ocaml${ocaml.version}-cpdf-${version}";
@@ -9,8 +9,12 @@ stdenv.mkDerivation {
     owner = "johnwhitington";
     repo = "cpdf-source";
     rev = "v${version}";
-    sha256 = "0i976y1v0l7x7k2n8k6v0h4bw9zlxsv04y4fdxss6dzpsfz49w23";
+    sha256 = "1gwz0iy28f67kbqap2q10nf98dalwbi03vv5j893z2an7pb4w68z";
   };
+
+  prePatch = ''
+    substituteInPlace META --replace 'version="1.7"' 'version="${version}"'
+  '';
 
   buildInputs = [ ocaml findlib ncurses ];
   propagatedBuildInputs = [ camlpdf ];


### PR DESCRIPTION
###### Motivation for this change

Minor update.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
