### PR TITLE
mkrom: init at 1.0.1

### DIFF
--- a/pkgs/development/tools/misc/mkrom/default.nix
+++ b/pkgs/development/tools/misc/mkrom/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, cmake, asciidoc }:
+
+stdenv.mkDerivation rec {
+  pname = "mkrom";
+  version = "unstable-2020-06-11";
+
+  src = fetchFromGitHub {
+    owner = "KnightOS";
+    repo = "mkrom";
+    rev = "7a735ecbe09409e74680a9dc1c50dd4db99a409f";
+    sha256 = "18h7a0fb5zb991iy9ljpknmk9qvl9nz3yh1zh5bm399rpxn4nzx3";
+  };
+
+  nativeBuildInputs = [
+    asciidoc
+    cmake
+  ];
+
+  hardeningDisable = [ "format" ];
+
+  meta = with stdenv.lib; {
+    homepage    = "https://knightos.org/";
+    description = "Packages KnightOS distribution files into a ROM";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11039,6 +11039,10 @@ in
 
   mkcert = callPackage ../development/tools/misc/mkcert { };
 
+  mkrom = callPackage ../development/tools/misc/mkrom {
+    asciidoc = asciidoc-full;
+  };
+
   mkdocs = callPackage ../development/tools/documentation/mkdocs { };
 
   mockgen = callPackage ../development/tools/mockgen { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
