### PR TITLE
prometheus: 2.19.3 -> 2.20.1, fix thanos test

### DIFF
--- a/nixos/tests/prometheus.nix
+++ b/nixos/tests/prometheus.nix
@@ -158,7 +158,10 @@ in import ./make-test-python.nix {
 
     s3 = { pkgs, ... } : {
       # Minio requires at least 1GiB of free disk space to run.
-      virtualisation.diskSize = 2 * 1024;
+      virtualisation = {
+        diskSize = 2 * 1024;
+        memorySize = 1024;
+      };
       networking.firewall.allowedTCPPorts = [ minioPort ];
 
       services.minio = {
@@ -235,7 +238,7 @@ in import ./make-test-python.nix {
     # Test if the Thanos bucket command is able to retrieve blocks from the S3 bucket
     # and check if the blocks have the correct labels:
     store.succeed(
-        "thanos bucket ls "
+        "thanos tools bucket ls "
         + "--objstore.config-file=${nodes.store.config.services.thanos.store.objstore.config-file} "
         + "--output=json | "
         + "jq .thanos.labels.some_label | "

--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -1,13 +1,13 @@
-{ lib, go, buildGoPackage, fetchFromGitHub, mkYarnPackage }:
+{ lib, go, buildGoPackage, fetchFromGitHub, mkYarnPackage, nixosTests }:
 
 let
-  version = "2.19.3";
+  version = "2.20.1";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "prometheus";
     repo = "prometheus";
-    sha256 = "0dlvhbxahdq0x0qa0gv1rc4y5dp6lx44w280rbm9279nv1nplffh";
+    sha256 = "0svhx08pbz55nhn6g9pn79zbhyvr394k5w3ny1mq3wp382h62r5j";
   };
 
   webui = mkYarnPackage {
@@ -60,6 +60,8 @@ in buildGoPackage rec {
   '';
 
   doCheck = true;
+
+  passthru.tests = { inherit (nixosTests) prometheus; };
 
   meta = with lib; {
     description = "Service monitoring system and time series database";

--- a/pkgs/servers/monitoring/prometheus/webui-yarndeps.nix
+++ b/pkgs/servers/monitoring/prometheus/webui-yarndeps.nix
@@ -4122,11 +4122,11 @@
       };
     }
     {
-      name = "elliptic___elliptic_6.5.2.tgz";
+      name = "elliptic___elliptic_6.5.3.tgz";
       path = fetchurl {
-        name = "elliptic___elliptic_6.5.2.tgz";
-        url  = "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz";
-        sha1 = "05c5678d7173c049d8ca433552224a495d0e3762";
+        name = "elliptic___elliptic_6.5.3.tgz";
+        url  = "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz";
+        sha1 = "cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6";
       };
     }
     {
@@ -11698,11 +11698,11 @@
       };
     }
     {
-      name = "websocket_extensions___websocket_extensions_0.1.3.tgz";
+      name = "websocket_extensions___websocket_extensions_0.1.4.tgz";
       path = fetchurl {
-        name = "websocket_extensions___websocket_extensions_0.1.3.tgz";
-        url  = "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz";
-        sha1 = "5d2ff22977003ec687a4b87073dfbbac146ccf29";
+        name = "websocket_extensions___websocket_extensions_0.1.4.tgz";
+        url  = "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz";
+        sha1 = "7f8473bc839dfd87608adb95d7eb075211578a42";
       };
     }
     {


### PR DESCRIPTION
###### Motivation for this change
https://github.com/prometheus/prometheus/releases/tag/v2.20.0
https://github.com/prometheus/prometheus/releases/tag/v2.20.1

> This release changes WAL compression from opt-in to default. WAL compression will prevent a downgrade to v2.10 or earlier without deleting the WAL. Disable WAL compression explicitly by setting the command line flag --no-storage.tsdb.wal-compression if you require downgrading to v2.10 or earlier.

###### Things done
Increased memory of the minio node to avoid OOM panics which happened during local execution.
Also fixed the usage of the thanos command in the test.
The test is now exposed in the package via `passthru.tests`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
