### PR TITLE
kpack: init at 1.1.0

### DIFF
--- a/pkgs/development/tools/misc/kpack/default.nix
+++ b/pkgs/development/tools/misc/kpack/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, cmake, asciidoc, libxslt, docbook_xsl }:
+
+stdenv.mkDerivation rec {
+  pname = "kpack";
+
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "KnightOS";
+    repo = "kpack";
+    rev = version;
+    sha256 = "0kakfbzdvq5ldv1gdzl473j73c9nfdyx4xzfkriglkrqmksqc329";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ asciidoc libxslt.bin docbook_xsl ];
+
+  hardeningDisable = [ "fortify" ];
+
+  meta = with stdenv.lib; {
+    homepage    = "https://knightos.org/";
+    description = "A tool to create or extract KnightOS packages";
+    license     = licenses.lgpl2Only;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10969,6 +10969,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  kpack = callPackage ../development/tools/misc/kpack { };
+
   kustomize = callPackage ../development/tools/kustomize { };
 
   ktlint = callPackage ../development/tools/ktlint { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
