### PR TITLE
relibc: build from source

### DIFF
--- a/pkgs/development/libraries/relibc/default.nix
+++ b/pkgs/development/libraries/relibc/default.nix
@@ -1,26 +1,71 @@
-{ stdenvNoCC, buildPackages, fetchurl }:
+{ stdenvNoCC, buildPackages, makeRustPlatform }:
 
-stdenvNoCC.mkDerivation {
-  name = "binary-relibc-latest";
+let
+  rpath = stdenvNoCC.lib.makeLibraryPath [
+    buildPackages.stdenv.cc.libc
+    "$out"
+  ];
+  bootstrapCrossRust = stdenvNoCC.mkDerivation {
+    name = "binary-redox-rust";
+    
+    src = fetchTarball {
+      name = "redox-rust-toolchain-bin.tar.gz";
+      url = "https://www.dropbox.com/s/33r92en0t47l1ei/redox-rust-toolchain-bin.tar.gz?dl=1";
+      sha256 = "1g17qp2q6b88p04yclkw6amm374pqlakrmw9kd86vw8z4g70jkxm";
+    };
 
-  # snapshot of https://static.redox-os.org/toolchain/x86_64-unknown-redox/relibc-install.tar.gz
-  src = fetchurl {
-    name = "relibc-install.tar.gz";
-    url = "https://gateway.pinata.cloud/ipfs/QmNp6fPTjPA6LnCYvW1UmbAHcPpU7tqZhstfSpSXMJCRwp";
-    sha256 = "1hjdzrj67jdag3pm8h2dqh6xipbfxr6f4navdra6q1h83gl7jkd9";
+    dontBuild = true;
+    dontPatchELF = true;
+    dontStrip = true;
+    installPhase = ''
+      mkdir $out/
+      cp -r * $out/
+
+      find $out/ -executable -type f -exec patchelf \
+          --set-interpreter "${buildPackages.stdenv.cc.libc}/lib/ld-linux-x86-64.so.2" \
+          --set-rpath "${rpath}" \
+          "{}" \;
+      find $out/ -name "*.so" -type f -exec patchelf \
+          --set-rpath "${rpath}" \
+          "{}" \;
+    '';
+
+    meta.platforms = with stdenvNoCC.lib; platforms.redox ++ platforms.linux;
   };
 
-  # to avoid "unpacker produced multiple directories"
-  unpackPhase = "unpackFile $src";
+  redoxRustPlatform = buildPackages.makeRustPlatform {
+    rustc = bootstrapCrossRust;
+    cargo = bootstrapCrossRust;
+  };
 
-  dontBuild = true;
-  dontPatchELF = true;
-  dontStrip = true;
-  installPhase = ''
-    mkdir $out/
-    cp -r x86_64-unknown-redox/* $out/
-    rm -rf $out/bin
+in
+redoxRustPlatform.buildRustPackage rec {
+  pname = "relibc";
+  version = "latest";
+
+  LD_LIBRARY_PATH = "${buildPackages.zlib}/lib";
+
+  src = buildPackages.fetchgit {
+    url = "https://gitlab.redox-os.org/redox-os/relibc/";
+    rev = "5af8e3ca35ad401014a867ac1a0cc3b08dee682b";
+    sha256 = "1j4wsga9psl453031izkl3clkvm31d1wg4y8f3yqqvhml2aliws5";
+    fetchSubmodules = true;
+  };
+
+  RUSTC_BOOTSTRAP = 1;
+
+  dontInstall = true;
+  dontFixup = true;
+  doCheck = false;
+
+  postBuild = ''
+    mkdir -p $out
+    DESTDIR=$out make install
   '';
+
+  TARGET = buildPackages.rust.toRustTarget stdenvNoCC.targetPlatform;
+
+  cargoSha256 = "1fzz7ba3ga57x1cbdrcfrdwwjr70nh4skrpxp4j2gak2c3scj6rz";
 
   meta = with stdenvNoCC.lib; {
     homepage = "https://gitlab.redox-os.org/redox-os/relibc";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

For #93661. Building things from source is generally good. I could eventually bootstrap even further from source, but for now, this PR should be a good step forward.

This PR also makes it easier for Nix users to contribute to relibc source code.

P.S. @Ericson2314 I'm close to getting a relibc-based toolchain working for Linux, after which I'll make a PR to add linux to relibc's `meta.platforms` :-)

###### Things done

I tested this by building a full Redox VM from it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
