### PR TITLE
nextcloud-client: 2.6.5 -> 3.0.0

### DIFF
--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -12,18 +12,20 @@
 , qtkeychain
 , qttools
 , qtwebengine
+, qtquickcontrols2
+, qtgraphicaleffects
 , sqlite
 }:
 
 mkDerivation rec {
   pname = "nextcloud-client";
-  version = "2.6.5";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "nextcloud";
     repo = "desktop";
     rev = "v${version}";
-    sha256 = "0r2n9l383drnnzbyywnbqljh9kxm3kz4g0mv7bnrp6b10b2ma3pg";
+    sha256 = "0ikya1s3zrh16hm2cmrqvd2vsxcllyg0grl37k6n9v5lygz3li4h";
   };
 
   patches = [
@@ -44,6 +46,8 @@ mkDerivation rec {
     qtkeychain
     qttools
     qtwebengine
+    qtquickcontrols2
+    qtgraphicaleffects
     sqlite
   ];
 


### PR DESCRIPTION
###### Motivation for this change

New version of nextcloud-client was released recently ([v3.0.0](https://github.com/nextcloud/desktop/releases/tag/v3.0.0)).
There is currently a bug https://github.com/nextcloud/desktop/issues/2279 that requires several restarts of nextlocud-client to load all synced folders. I think it's best to wait until this is resolved before merging.
I have not tested any file manager integration!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
 