### PR TITLE
rescuetime: 2.14.5.2 -> 2.16.3.1

### DIFF
--- a/pkgs/applications/misc/rescuetime/default.nix
+++ b/pkgs/applications/misc/rescuetime/default.nix
@@ -1,19 +1,20 @@
 { stdenv, lib, fetchurl, dpkg, patchelf, qt5, libXtst, libXext, libX11, mkDerivation, makeWrapper, libXScrnSaver }:
 
 let
+  version = "2.16.3.1";
   src =
     if stdenv.hostPlatform.system == "i686-linux" then fetchurl {
       name = "rescuetime-installer.deb";
-      url = "https://www.rescuetime.com/installers/rescuetime_current_i386.deb";
-      sha256 = "0mw8dh9z7pqan0yrhycmv39h5c1sc4mbw5l02cfnn17cy75xdiay";
+      url = "https://www.rescuetime.com/installers/rescuetime_${version}_i386.deb";
+      sha256 = "1374nmj6g6w24cv604kzac0v57gcl1pwpw0nxpr7kv2786x1aqg2";
     } else fetchurl {
       name = "rescuetime-installer.deb";
-      url = "https://www.rescuetime.com/installers/rescuetime_current_amd64.deb";
-      sha256 = "1a6pc8vi2ab721kzyhvg6bmw24dr85dgmx2m9j9vbf3jyr85fv10";
+      url = "https://www.rescuetime.com/installers/rescuetime_${version}_amb64.deb";
+      sha256 = "05qs6wbc3705z8w9c3n83m4j8xfmzm673lyh5j95x1ak5czkrphk";
     };
 in mkDerivation {
   # https://www.rescuetime.com/updates/linux_release_notes.html
-  name = "rescuetime-2.14.5.2";
+  name = "rescuetime-${version}";
   inherit src;
   nativeBuildInputs = [ dpkg ];
   # avoid https://github.com/NixOS/patchelf/issues/99


### PR DESCRIPTION
###### Motivation for this change

I am trying to upgrade NixOS but I can't because `rescuetime` is broken. See https://github.com/NixOS/nixpkgs/issues/87226.

```sh-session
$ sudo nixos-rebuild switch --upgrade
```

The shas were broken for 2.14.5.2 because the urls where pointing directly at the current version of rescuetime. e.g.

https://www.rescuetime.com/installers/rescuetime_current_amd64.deb

So, I've upgraded to the latest version, fixed the urls, and changed the sha256s.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] ~macOS~
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`). NOTE: only able to test amd64 platform.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] ~Ensured that relevant documentation is up to date~
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).