### PR TITLE
rippled: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/servers/rippled/default.nix
+++ b/pkgs/servers/rippled/default.nix
@@ -31,8 +31,8 @@ let
 
   nudb = fetchgit rec {
     url = "https://github.com/CPPAlliance/NuDB.git";
-    rev = "2.0.1";
-    sha256 = "10hlp2k7pc0c705f8sk0qw6mjfky0k08cjhh262bbjvp9fbdc7r4";
+    rev = "2.0.3";
+    sha256 = "0imd9sh6knydwa3pxa5bbvjs3bmb8650dnsvj04qgns6bynwlqh1";
     leaveDotGit = true;
     fetchSubmodules = true;
     postFetch = "cd $out && git tag ${rev}";
@@ -49,8 +49,8 @@ let
 
   lz4 = fetchgit rec {
     url = "https://github.com/lz4/lz4.git";
-    rev = "v1.8.2";
-    sha256 = "1niv553q60hwn95yflzmrqkp1046hrid13h0yr36lm4fjza21h9w";
+    rev = "v1.9.2";
+    sha256 = "0322xy2vfhxkb8akas7vwajjgcigq1q8l9f5fnfmavcsd6kmxmgg";
     leaveDotGit = true;
     fetchSubmodules = false;
     postFetch = "cd $out && git tag ${rev}";
@@ -58,8 +58,8 @@ let
 
   libarchive = fetchgit rec {
     url = "https://github.com/libarchive/libarchive.git";
-    rev = "v3.3.3";
-    sha256 = "165imgfmizpi4ffpiwfs8gxysn6lw3y1fxj5rga98filkl7hxs31";
+    rev = "v3.4.3";
+    sha256 = "00yrzy2129vr4nfhigd91651984sl447dyfjfz26dmzvna5hwzp1";
     leaveDotGit = true;
     fetchSubmodules = false;
     postFetch = "cd $out && git tag ${rev}";
@@ -116,12 +116,12 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "rippled";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchgit {
     url = "https://github.com/ripple/rippled.git";
     rev = version;
-    sha256 = "0nh0x1ygrj3fw558vxbcp0md80qh27yrp3xhdlasrir7h1l2nplv";
+    sha256 = "176i3dm98zp5jllslpzfhh52bd2lapq9i8r7m45v8sg9icvsmyz7";
     leaveDotGit = true;
     fetchSubmodules = true;
   };
@@ -146,6 +146,9 @@ in stdenv.mkDerivation rec {
     git config --global url."file://${google-test}".insteadOf "${google-test.url}"
     git config --global url."file://${date}".insteadOf "${date.url}"
 
+    substituteInPlace Builds/CMake/deps/Sqlite.cmake --replace "http://www.sqlite.org/2018/sqlite-amalgamation-3260000.zip" "" 
+    substituteInPlace Builds/CMake/deps/Sqlite.cmake --replace "https://www2.sqlite.org/2018/sqlite-amalgamation-3260000.zip" "" 
+    substituteInPlace Builds/CMake/deps/Sqlite.cmake --replace "http://www2.sqlite.org/2018/sqlite-amalgamation-3260000.zip" "" 
     substituteInPlace Builds/CMake/deps/Sqlite.cmake --replace "URL ${sqlite3.url}" "URL ${sqlite3}"
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
