### PR TITLE
helm: compile with gcc9

### DIFF
--- a/pkgs/applications/audio/helm/default.nix
+++ b/pkgs/applications/audio/helm/default.nix
@@ -1,5 +1,16 @@
-{ stdenv, fetchFromGitHub , xorg, freetype, alsaLib, curl, libjack2
-, lv2, pkgconfig, libGLU, libGL }:
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, xorg
+, freetype
+, alsaLib
+, curl
+, libjack2
+, lv2
+, pkgconfig
+, libGLU
+, libGL
+}:
 
   stdenv.mkDerivation {
   version = "0.9.0";
@@ -20,7 +31,15 @@
 
   CXXFLAGS = "-DHAVE_LROUND";
 
-  patchPhase = ''
+  patches = [
+    # gcc9 compatibility https://github.com/mtytel/helm/pull/233
+    (fetchpatch {
+      url = "https://github.com/mtytel/helm/commit/cb611a80bd5a36d31bfc31212ebbf79aa86c6f08.patch";
+      sha256 = "1i2289srcfz17c3zzab6f51aznzdj62kk53l4afr32bkjh9s4ixk";
+    })
+  ];
+
+  prePatch = ''
     sed -i 's|usr/||g' Makefile
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26299,9 +26299,7 @@ in
 
   hatari = callPackage ../misc/emulators/hatari { };
 
-  helm = callPackage ../applications/audio/helm {
-    stdenv = gcc8Stdenv;
-  };
+  helm = callPackage ../applications/audio/helm { };
 
   helmfile = callPackage ../applications/networking/cluster/helmfile { };
 


### PR DESCRIPTION
###### Motivation for this change

To make using it with recent MESA libraries work, discussed in #95806

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
