### PR TITLE
pylode: init at 2.8.6

### DIFF
--- a/pkgs/misc/pylode/default.nix
+++ b/pkgs/misc/pylode/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "pyLODE";
+  version = "2.8.6";
+
+  src = fetchFromGitHub {
+    owner = "RDFLib";
+    repo = pname;
+    rev = version;
+    sha256 = "0zbk5lj9vlg32rmvw1himlw63kxd7sim7nzglrjs5zm6vpi4x5ch";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    dateutil
+    falcon
+    gunicorn
+    isodate
+    jinja2
+    markdown
+    rdflib
+    rdflib-jsonld
+    requests
+    six
+    beautifulsoup4
+  ];
+
+  meta = with lib; {
+    description = "An OWL ontology documentation tool using Python and templating, based on LODE";
+    homepage = "https://github.com/RDFLib/pyLODE";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ koslambrou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14603,6 +14603,8 @@ in
 
   pybind11 = pythonPackages.pybind11;
 
+  pylode = callPackage ../misc/pylode {};
+
   python-qt = callPackage ../development/libraries/python-qt {
     python = python27;
     inherit (qt5) qmake qttools qtwebengine qtxmlpatterns;


### PR DESCRIPTION
###### Motivation for this change

added new package: pylode at version 2.8.6

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
