### PR TITLE
melpaBuild: Update package-build

### DIFF
--- a/pkgs/build-support/emacs/melpa.nix
+++ b/pkgs/build-support/emacs/melpa.nix
@@ -38,8 +38,8 @@ import ./generic.nix { inherit lib stdenv emacs texinfo; } ({
   packageBuild = fetchFromGitHub {
     owner = "melpa";
     repo = "package-build";
-    rev = "0a22c3fbbf661822ec1791739953b937a12fa623";
-    sha256 = "0dpy5p34il600sc8ic5jdgb3glya9si3lrvhxab0swks8fdydjgs";
+    rev = "4cb0f98a21729f9ef0189f095384555c9d2b6fe4";
+    sha256 = "0ij6p7i5x0fs0yn8zxcx7gf9ldanflh7mj7mblr8snpgbzx3jwnz";
   };
 
   elpa2nix = ./elpa2nix.el;

--- a/pkgs/build-support/emacs/melpa.nix
+++ b/pkgs/build-support/emacs/melpa.nix
@@ -38,8 +38,9 @@ import ./generic.nix { inherit lib stdenv emacs texinfo; } ({
   packageBuild = fetchFromGitHub {
     owner = "melpa";
     repo = "package-build";
-    rev = "4cb0f98a21729f9ef0189f095384555c9d2b6fe4";
-    sha256 = "0ij6p7i5x0fs0yn8zxcx7gf9ldanflh7mj7mblr8snpgbzx3jwnz";
+    rev = "c40adc46ee1a29e8d7e2aa296bef335a1e4ea100";
+    sha256 = "06x20z69242i32bqjmmnjy8q4x5f0g3yyfkazkh5cm09zayri00c";
+    # date = 2020-12-27T19:45:05+01:00;
   };
 
   elpa2nix = ./elpa2nix.el;


### PR DESCRIPTION
###### Motivation for this change

The current version of package-build used to build MELPA packages is from [2018](https://github.com/melpa/package-build/commit/0a22c3fbbf661822ec1791739953b937a12fa623), and there have been [a number of changes](https://github.com/melpa/package-build/commits/master) since then. I think it's better to update it, and this can potentially resolve various issues related to the Emacs infrastructure.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
