### PR TITLE
fujprog: init at 4.6

### DIFF
--- a/pkgs/development/tools/misc/fujprog/default.nix
+++ b/pkgs/development/tools/misc/fujprog/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkgconfig
+, libftdi1
+, libusb-compat-0_1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fujprog";
+  version = "4.6";
+
+  src = fetchFromGitHub {
+    owner = "kost";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "04l5rrfrp3pflwz5ncwvb4ibbsqib2259m23bzfi8m80aj216shd";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+  ];
+
+  buildInputs = [
+    libftdi1
+    libusb-compat-0_1
+  ];
+
+  meta = with stdenv.lib; {
+    description = "JTAG programmer for the ULX3S and ULX2S open hardware FPGA development boards.";
+    homepage = "https://github.com/kost/fujprog";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ trepetti ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10745,6 +10745,8 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
+  fujprog = callPackage ../development/tools/misc/fujprog { };
+
   funnelweb = callPackage ../development/tools/literate-programming/funnelweb { };
 
   gede = libsForQt5.callPackage ../development/tools/misc/gede { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

[fujprog](https://github.com/kost/fujprog) is a JTAG programmer for the ULX3S and ULX2S open source FPGA development boards. The boards use Lattice parts that are capable of being programmed using the reverse engineered prjtrellis and icestorm toolchains, respectively. This addition will allow Nix users to program their devices after generating FPGA bitstreams using the tools described above (both are already packaged in NIx).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
