### PR TITLE
nixos/fontconfig: fix local.conf regression

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -190,13 +190,6 @@ let
     ln -s ${pkg.out}/etc/fonts/conf.d/*.conf \
           $dst/
 
-    # update 51-local.conf path to look at local.conf
-    rm  $dst/51-local.conf
-
-    substitute ${pkg.out}/etc/fonts/conf.d/51-local.conf \
-               $dst/51-local.conf \
-               --replace local.conf /etc/fonts/${pkg.configVersion}/local.conf
-
     # 00-nixos-cache.conf
     ln -s ${cacheConf}  $dst/00-nixos-cache.conf
 


### PR DESCRIPTION
###### Motivation for this change
Another part of edf2541f02c6b24ea791710d5cadeae36f9b1a3a was missed while
rebasing https://github.com/NixOS/nixpkgs/pull/93562, resulting in incorrect path
as described by https://github.com/NixOS/nixpkgs/issues/86601#issuecomment-675462227

cc @flokli @isaacwhanson

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
