### PR TITLE
python3Packages.pwntools: Allow to use any debugger

### DIFF
--- a/pkgs/development/python-modules/pwntools/default.nix
+++ b/pkgs/development/python-modules/pwntools/default.nix
@@ -1,8 +1,10 @@
 { stdenv
 , buildPythonPackage
+, debugger
 , fetchPypi
 , isPy3k
 , Mako
+, makeWrapper
 , packaging
 , pysocks
 , pygments
@@ -58,10 +60,15 @@ buildPythonPackage rec {
 
   doCheck = false; # no setuptools tests for the package
 
+  postFixup = ''
+    mkdir -p "$out/bin"
+    makeWrapper "${debugger}/bin/${stdenv.lib.strings.getName debugger}" "$out/bin/pwntools-gdb"
+  '';
+
   meta = with stdenv.lib; {
     homepage = "http://pwntools.com";
     description = "CTF framework and exploit development library";
     license = licenses.mit;
-    maintainers = with maintainers; [ bennofs kristoff3r ];
+    maintainers = with maintainers; [ bennofs kristoff3r pamplemousse ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26788,6 +26788,8 @@ in
 
   pyload = callPackage ../applications/networking/pyload {};
 
+  pwntools = with python3Packages; toPythonApplication pwntools;
+
   uae = callPackage ../misc/emulators/uae { };
 
   fsuae = callPackage ../misc/emulators/fs-uae { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7455,7 +7455,7 @@ in {
 
   packet-python = callPackage ../development/python-modules/packet-python { };
 
-  pwntools = callPackage ../development/python-modules/pwntools { };
+  pwntools = callPackage ../development/python-modules/pwntools { debugger = pkgs.gdb; };
 
   ROPGadget = callPackage ../development/python-modules/ROPGadget { };
 


### PR DESCRIPTION
###### Motivation for this change

`pwntools` allow to specify any debuggers by putting a `pwntools-gdb` in the `PATH`.
See https://github.com/Gallopsled/pwntools/blob/eb60b5d6b617d41652ab5525b7033f97e6e4c5ac/pwnlib/gdb.py#L496 .

This PR allows to declaratively specify a debugger to use with `pwntools`, and hooks everything as necessary; Defaults to `gdb`.

And, I kinda had to give `gdb` a `pname` for convenience.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] ~Ensured that relevant documentation is up to date~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Signed-off-by: Pamplemousse <xav.maso@gmail.com>