### PR TITLE
[20.03] sigil: add patches for CVE-2019-14452

### DIFF
--- a/pkgs/applications/editors/sigil/default.nix
+++ b/pkgs/applications/editors/sigil/default.nix
@@ -1,5 +1,5 @@
 { stdenv, mkDerivation, fetchFromGitHub, cmake, pkgconfig, makeWrapper
-, boost, xercesc
+, boost, xercesc, fetchpatch
 , qtbase, qttools, qtwebkit, qtxmlpatterns
 , python3, python3Packages
 }:
@@ -14,6 +14,24 @@ mkDerivation rec {
     repo = "Sigil";
     owner = "Sigil-Ebook";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-14452.part-1.patch";
+      url = "https://github.com/Sigil-Ebook/Sigil/commit/369eebe936e4a8c83cc54662a3412ce8bef189e4.patch";
+      sha256 = "07pgy89lsp7332zgdraji4xbiy0yri00nfdd311nxi2scmf55izv";
+    })
+    (fetchpatch {
+      name = "CVE-2019-14452.part-2.patch";
+      url = "https://github.com/Sigil-Ebook/Sigil/commit/0979ba8d10c96ebca330715bfd4494ea0e019a8f.patch";
+      sha256 = "1fsqcgh6y3137fw5989gxv5wryvklcfdcqyk4pgi0nq7m6ydbj30";
+    })
+    (fetchpatch {
+      name = "CVE-2019-14452.part-3.patch";
+      url = "https://github.com/Sigil-Ebook/Sigil/commit/04e2f280cc4a0766bedcc7b9eb56449ceecc2ad4.patch";
+      sha256 = "1mza8kj9gyp25m0in4fdzad2w5cm2wy18ds0308qdx24bdlmr4j5";
+    })
+  ];
 
   pythonPath = with python3Packages; [ lxml ];
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-14452

Probably simpler than figuring out misbehaviour on someone else's machine in #95583 is just adding the patches to the existing release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
