### PR TITLE
arcanist: copy directly from $PWD to pick up any applied patches

### DIFF
--- a/pkgs/development/tools/misc/arcanist/default.nix
+++ b/pkgs/development/tools/misc/arcanist/default.nix
@@ -1,20 +1,24 @@
-{ stdenv, fetchFromGitHub, php, flex }:
+{ bison
+, fetchFromGitHub
+, flex
+, php
+, stdenv
+}:
 
 # Make a custom wrapper. If `wrapProgram` is used, arcanist thinks .arc-wrapped is being
 # invoked and complains about it being an unknown toolset. We could use `makeWrapper`, but
 # then we’d need to still craft a script that does the `php libexec/arcanist/bin/...` dance
 # anyway... So just do everything at once.
 let makeArcWrapper = toolset: ''
-    cat << WRAPPER > $out/bin/${toolset}
-    #!$shell -e
-    export PATH='${php}/bin/'\''${PATH:+':'}\$PATH
-    exec ${php}/bin/php $out/libexec/arcanist/bin/${toolset} "\$@"
-    WRAPPER
-    chmod +x $out/bin/${toolset}
+  cat << WRAPPER > $out/bin/${toolset}
+  #!$shell -e
+  export PATH='${php}/bin/'\''${PATH:+':'}\$PATH
+  exec ${php}/bin/php $out/libexec/arcanist/bin/${toolset} "\$@"
+  WRAPPER
+  chmod +x $out/bin/${toolset}
 '';
 
 in
-
 stdenv.mkDerivation {
   pname = "arcanist";
   version = "20200711";
@@ -25,7 +29,7 @@ stdenv.mkDerivation {
     rev = "2565cc7b4d1dbce6bc7a5b3c4e72ae94be4712fe";
     sha256 = "0jiv4aj4m5750dqw9r8hizjkwiyxk4cg4grkr63sllsa2dpiibxw";
   };
-  buildInputs = [ php flex ];
+  buildInputs = [ bison flex php ];
 
   postPatch = stdenv.lib.optionalString stdenv.isAarch64 ''
     substituteInPlace support/xhpast/Makefile \
@@ -33,13 +37,15 @@ stdenv.mkDerivation {
   '';
 
   buildPhase = ''
+    make cleanall -C support/xhpast
     make xhpast -C support/xhpast
   '';
 
   installPhase = ''
     mkdir -p $out/bin $out/libexec
     make install -C support/xhpast
-    cp -R $src $out/libexec/arcanist
+    make cleanall -C support/xhpast
+    cp -R . $out/libexec/arcanist
 
     ${makeArcWrapper "arc"}
     ${makeArcWrapper "phage"}
@@ -53,9 +59,9 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Command line interface to Phabricator";
-    homepage    = "http://phabricator.org";
-    license     = stdenv.lib.licenses.asl20;
-    platforms   = stdenv.lib.platforms.unix;
+    homepage = "http://phabricator.org";
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The `arcanist` recipe should copy from `$PWD` instead of `$src`
which appears to not contain the patched sources.

cc @nagisa

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).