### PR TITLE
rescuetime: 2.16.2.1 -> 2.16.3.1

### DIFF
--- a/pkgs/applications/misc/rescuetime/default.nix
+++ b/pkgs/applications/misc/rescuetime/default.nix
@@ -1,19 +1,21 @@
 { stdenv, lib, fetchurl, dpkg, patchelf, qt5, libXtst, libXext, libX11, mkDerivation, makeWrapper, libXScrnSaver }:
 
 let
+  version = "2.16.3.1";
   src =
     if stdenv.hostPlatform.system == "i686-linux" then fetchurl {
       name = "rescuetime-installer.deb";
-      url = "https://www.rescuetime.com/installers/rescuetime_current_i386.deb";
-      sha256 = "157yg4n5ppgnrd5wrz06qfx391vggp3wifla39rvcaaysvvisl8v";
+      url = "https://www.rescuetime.com/installers/rescuetime_${version}_i386.deb";
+      sha256 = "1374nmj6g6w24cv604kzac0v57gcl1pwpw0nxpr7kv2786x1aqg2";
     } else fetchurl {
       name = "rescuetime-installer.deb";
-      url = "https://www.rescuetime.com/installers/rescuetime_current_amd64.deb";
-      sha256 = "17gjiwf0qbh1zbrxxsilnpg0qxy5kdpqxlnl28namp671rv0aic8";
+      url = "https://www.rescuetime.com/installers/rescuetime_${version}_amd64.deb";
+      sha256 = "05qs6wbc3705z8w9c3n83m4j8xfmzm673lyh5j95x1ak5czkrphk";
     };
 in mkDerivation {
   # https://www.rescuetime.com/updates/linux_release_notes.html
-  name = "rescuetime-2.16.2.1";
+  inherit version;
+  pname = "rescuetime";
   inherit src;
   nativeBuildInputs = [ dpkg ];
   # avoid https://github.com/NixOS/patchelf/issues/99


### PR DESCRIPTION
###### Motivation for this change

I am trying to upgrade NixOS 20.03 but I can't because `rescuetime` is broken. See https://github.com/NixOS/nixpkgs/issues/87226. i.e. the following fails with a sha256 error:

```sh-session
$ sudo nixos-rebuild switch --upgrade
```

I previously raised the PR https://github.com/NixOS/nixpkgs/pull/95860 to patch `nixos-20.03` but I think the process is to patch `master` first and then cherry-pick to backport.

The shas were broken for 2.14.5.2 on `nixos-20.03` because the urls where pointing directly at the current version of rescuetime. The same is the case on `master` which has shas for the 2.16.2.1 `.deb` files. e.g.

https://www.rescuetime.com/installers/rescuetime_current_amd64.deb

So, I've upgraded to the latest version, fixed the urls, and changed the sha256s.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] ~macOS~
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`).
  NOTE: only able to test amd64 platform.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] ~Ensured that relevant documentation is up to date~
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).