### PR TITLE
kimg: init at 0.3.0

### DIFF
--- a/pkgs/development/tools/misc/kimg/default.nix
+++ b/pkgs/development/tools/misc/kimg/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, cmake, asciidoc, pkg-config, imagemagick }:
+
+stdenv.mkDerivation rec {
+  pname = "kimg";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "KnightOS";
+    repo = "kimg";
+    rev = version;
+    sha256 = "00gj420m0jvhgm8kkslw8r69nl7r73bxrh6gqs2mx16ymcpkanpk";
+  };
+
+  nativeBuildInputs = [ cmake asciidoc pkg-config ];
+
+  buildInputs = [ imagemagick ];
+
+  hardeningDisable = [ "format" ];
+
+  meta = with stdenv.lib; {
+    homepage    = "https://knightos.org/";
+    description = "Converts image formats supported by ImageMagick to the KnightOS image format";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4828,6 +4828,11 @@ in
 
   kippo = callPackage ../servers/kippo { };
 
+  kimg = callPackage ../development/tools/misc/kimg {
+    asciidoc = asciidoc-full;
+    imagemagick = imagemagick7Big;
+  };
+  
   kristall = libsForQt5.callPackage ../applications/networking/browsers/kristall { };
 
   kzipmix = pkgsi686Linux.callPackage ../tools/compression/kzipmix { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
