### PR TITLE
knightos-kcc: init at 4.0.0

### DIFF
--- a/pkgs/development/compilers/kcc/default.nix
+++ b/pkgs/development/compilers/kcc/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, cmake, bison, flex, boost }:
+
+stdenv.mkDerivation rec {
+  pname = "kcc";
+
+  version = "4.0.0";
+
+  src = fetchFromGitHub {
+    owner = "KnightOS";
+    repo = "kcc";
+    rev = version;
+    sha256 = "1cd226nqbxq32mppkljavq1kb74jqfqns9r7fskszr42hbygynk4";
+  };
+
+  nativeBuildInputs = [ cmake bison flex ];
+
+  buildInputs = [ boost ];
+
+  meta = with stdenv.lib; {
+    homepage    = "https://knightos.org/";
+    description = "KnightOS C compiler";
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9170,6 +9170,8 @@ in
 
   jwasm =  callPackage ../development/compilers/jwasm { };
 
+  knightos-kcc = callPackage ../development/compilers/kcc { };
+
   kotlin = callPackage ../development/compilers/kotlin { };
 
   lazarus = callPackage ../development/compilers/fpc/lazarus.nix {


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
