### PR TITLE
ocaml-ng.ocamlPackages_4_11.ocaml: 4.11.0+β3 → 4.11.0

### DIFF
--- a/pkgs/development/compilers/ocaml/4.11.nix
+++ b/pkgs/development/compilers/ocaml/4.11.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "11";
-  patch_version = "0+beta3";
-  sha256 = "18lpgirxil00pgy805cyi97v6ycmg93sdvbkc60i35ili030v1f7";
+  patch_version = "0";
+  sha256 = "04b13yfismkqh21ag641q9dl0i602khgh4427g1a7pb77c4skr7z";
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1205,7 +1205,7 @@ in let inherit (pkgs) callPackage; in rec
 
   ocamlPackages_4_11 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.11.nix { });
 
-  ocamlPackages_latest = ocamlPackages_4_10;
+  ocamlPackages_latest = ocamlPackages_4_11;
 
   ocamlPackages = ocamlPackages_4_10;
 }


### PR DESCRIPTION
###### Motivation for this change

Major release: https://inbox.ocaml.org/caml-list/e9e7fc73-943a-b6e4-7e98-07e30078c7d4@inria.fr/T/#u

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
