### PR TITLE
pubs: v0.8.2 -> v0.8.3

### DIFF
--- a/pkgs/tools/misc/pubs/default.nix
+++ b/pkgs/tools/misc/pubs/default.nix
@@ -2,33 +2,28 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pubs";
-  version = "0.8.2";
+  version = "0.8.3";
 
   src = fetchFromGitHub {
     owner = "pubs";
     repo = "pubs";
     rev = "v${version}";
-    sha256 = "16zwdqfbmlla6906g3a57a4nj8wnl11fq78r20qms717bzv211j0";
+    sha256 = "0npgsyxj7kby5laznk5ilkrychs3i68y57gphwk48w8k9fvnl3zc";
   };
 
-  patches = [
-    # Fix for bibtexparser 1.1.0
-    (fetchpatch {
-      url = "https://github.com/pubs/pubs/pull/185/commits/e58ae98b93b8364a07fd5f5f452ba88ad332c948.patch";
-      sha256 = "1n7zrk119v395jj8wqg8wlymc9l9pq3v752yy3kam9kflc0aashp";
-    })
-    # Fix test broken by PyYAML 5.1
-    (fetchpatch {
-      url = "https://github.com/pubs/pubs/pull/194/commits/c3cb713ae76528eeeaaeb948fe319a76ab3934d8.patch";
-      sha256 = "05as418m7wzs65839bb91b2jrs8l68z8ldcjcd9cn4b9fcgsf3rk";
-    })
-  ];
-
   propagatedBuildInputs = with python3Packages; [
-    argcomplete dateutil configobj feedparser bibtexparser pyyaml requests six beautifulsoup4
+    argcomplete dateutil configobj feedparser bibtexparser pyyaml requests six 
+    beautifulsoup4
   ];
 
   checkInputs = with python3Packages; [ pyfakefs mock ddt ];
+
+  # Disabling git tests because they expect git to be preconfigured
+  # with the user's details. See 
+  # https://github.com/NixOS/nixpkgs/issues/94663
+  preCheck = ''
+    rm tests/test_git.py
+    '';
 
   meta = with stdenv.lib; {
     description = "Command-line bibliography manager";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Upgrading to version 0.8.3.

###### Things done

Removed patches applied upstream.
Disabled git tests.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
