### PR TITLE
pythonPackages.mocket: 3.8.7 -> 3.8.8

### DIFF
--- a/pkgs/development/python-modules/mocket/default.nix
+++ b/pkgs/development/python-modules/mocket/default.nix
@@ -8,11 +8,11 @@
 
 buildPythonPackage rec {
   pname = "mocket";
-  version = "3.8.7";
+  version = "3.8.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1zj2p20blf4p071kcs86h2c9sc964x6sahff60gg7y4d2c0iq3rs";
+    sha256 = "0yqls2hqmfs6i4p2nb89j5icyrqwabalsmwfixfvbjir4fmgad2l";
   };
 
   patchPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://repology.org/project/python:mocket/versions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
7 packages built:
python27Packages.mocket python37Packages.geoip2 python37Packages.mocket python37Packages.sopel python38Packages.geoip2 python38Packages.mocket python38Packages.sopel
```