### PR TITLE
pipes: fix dependencies

### DIFF
--- a/pkgs/misc/screensavers/pipes/default.nix
+++ b/pkgs/misc/screensavers/pipes/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgs }:
+{ stdenv, fetchurl, makeWrapper, coreutils, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "pipes";
@@ -9,11 +9,14 @@ stdenv.mkDerivation rec {
     sha256 = "09m4alb3clp3rhnqga5v6070p7n1gmnwp2ssqhq87nf2ipfpcaak";
   };
 
-  buildInputs = with pkgs; [ bash ];
+  buildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir $out -p
     make PREFIX=$out/ install
+
+    wrapProgram $out/bin/pipes.sh \
+      --set PATH "${stdenv.lib.makeBinPath [ coreutils ncurses ]}"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
This change uses `makeWrapper` to set the PATH to include the runtime dependencies of pipes.sh: `coreutils` and `ncurses`.

It also removes some unnecessary code like including `bash` in `buildInputs`.
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes: https://github.com/NixOS/nixpkgs/issues/95902

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md) **(I think)**.
