### PR TITLE
clpeak: init at 1.1.0

### DIFF
--- a/pkgs/tools/misc/clpeak/default.nix
+++ b/pkgs/tools/misc/clpeak/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, cmake, ocl-icd, opencl-clhpp }:
+
+stdenv.mkDerivation rec {
+  pname = "clpeak";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "krrishnarraj";
+    repo = "clpeak";
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "1wkjpvn4r89c3y06rv7gfpwpqw6ljmqwz0w0mljl9y5hn1r4pkx2";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ ocl-icd opencl-clhpp ];
+
+  meta = with stdenv.lib; {
+    description = "A tool which profiles OpenCL devices to find their peak capacities";
+    homepage = "https://github.com/krrishnarraj/clpeak/";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26194,6 +26194,8 @@ in
 
   clinfo = callPackage ../tools/system/clinfo { };
 
+  clpeak = callPackage ../tools/misc/clpeak { };
+
   cups = callPackage ../misc/cups { };
 
   cups-filters = callPackage ../misc/cups/filters.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

A tool which profiles OpenCL devices to find their peak capacities.

Thanks to @acowley for pointing me to this very useful tool!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
