### PR TITLE
lutris: 0.5.6 -> 0.5.7.1

### DIFF
--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -8,7 +8,6 @@
 , gobject-introspection
 , gst_all_1
 , gtk3
-, libgnome-keyring
 , libnotify
 , pango
 , webkitgtk
@@ -22,6 +21,7 @@
 , pygobject3
 , pyyaml
 , requests
+, keyring
 
 # commands that lutris needs
 , xrandr
@@ -71,13 +71,13 @@ let
 
 in buildPythonApplication rec {
   pname = "lutris-original";
-  version = "0.5.6";
+  version = "0.5.7.1";
 
   src = fetchFromGitHub {
     owner = "lutris";
     repo = "lutris";
     rev = "v${version}";
-    sha256 = "1f78qhyy8xqdg0rhxcwkap1bmg5mfxhb8qw1vbpxr6g62ajpwksa";
+    sha256 = "12ispwkbbm5aq263n3bdjmjfkpwplizacnqs2c0wnag4zj4kpm29";
   };
 
   nativeBuildInputs = [ wrapGAppsHook ];
@@ -88,14 +88,13 @@ in buildPythonApplication rec {
     gnome-desktop
     gobject-introspection
     gtk3
-    libgnome-keyring
     libnotify
     pango
     webkitgtk
   ] ++ gstDeps;
 
   propagatedBuildInputs = [
-    evdev distro pyyaml pygobject3 requests pillow dbus-python
+    evdev distro pyyaml pygobject3 requests pillow dbus-python keyring
   ];
 
   # avoid double wrapping

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21351,7 +21351,7 @@ in
   luppp = callPackage ../applications/audio/luppp { };
 
   lutris-unwrapped = python3.pkgs.callPackage ../applications/misc/lutris {
-    inherit (gnome3) gnome-desktop libgnome-keyring;
+    inherit (gnome3) gnome-desktop;
     wine = wineWowPackages.staging;
   };
   lutris = callPackage ../applications/misc/lutris/fhsenv.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Runner configuration dialogue was crashing with new wine versions, which seems fixed in 0.5.7.1
`libgnome-keyring` dependency is replaced with python `keyring` package (last change cc @jonringer )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
