### PR TITLE
pkgs/data/fonts: merge back the split otb output

### DIFF
--- a/pkgs/data/fonts/clearlyU/default.nix
+++ b/pkgs/data/fonts/clearlyU/default.nix
@@ -20,18 +20,11 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    # install bdf fonts
+    # install otb and bdf fonts
     fontDir="$out/share/fonts"
-    install -m 644 -D *.bdf -t "$fontDir"
-    mkfontdir "$fontDir"
-
-    # install otb fonts
-    fontDir="$otb/share/fonts"
-    install -m 644 -D *.otb -t "$fontDir"
+    install -m 644 -D *.bdf *.otb -t "$fontDir"
     mkfontdir "$fontDir"
   '';
-
-  outputs = [ "out"  "otb" ];
 
   meta = with stdenv.lib; {
     description = "A Unicode font";

--- a/pkgs/data/fonts/creep/default.nix
+++ b/pkgs/data/fonts/creep/default.nix
@@ -20,13 +20,9 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    install -D -m644 creep.bdf "$out/share/fonts/misc/creep.bdf"
+    install -D -m644 creep.otb creep.bdf -t "$out/share/fonts/misc/"
     mkfontdir "$out/share/fonts/misc"
-    install -D -m644 creep.otb "$otb/share/fonts/misc/creep.otb"
-    mkfontdir "$otb/share/fonts/misc"
   '';
-
-  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     description = "A pretty sweet 4px wide pixel font";

--- a/pkgs/data/fonts/dina/default.nix
+++ b/pkgs/data/fonts/dina/default.nix
@@ -41,15 +41,13 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    install -D -m 644 -t "$out/share/fonts/misc" *.pcf.gz
+    install -D -m 644 -t "$out/share/fonts/misc" *.pcf.gz *.otb
     install -D -m 644 -t "$bdf/share/fonts/misc" *.bdf
-    install -D -m 644 -t "$otb/share/fonts/misc" *.otb
     mkfontdir "$out/share/fonts/misc"
     mkfontdir "$bdf/share/fonts/misc"
-    mkfontdir "$otb/share/fonts/misc"
   '';
 
-  outputs = [ "out" "bdf" "otb" ];
+  outputs = [ "out" "bdf" ];
 
   meta = with stdenv.lib; {
     description = "A monospace bitmap font aimed at programmers";

--- a/pkgs/data/fonts/envypn-font/default.nix
+++ b/pkgs/data/fonts/envypn-font/default.nix
@@ -25,13 +25,9 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    install -D -m 644 -t "$out/share/fonts/misc" *.pcf.gz
-    install -D -m 644 -t "$otb/share/fonts/misc" *.otb
+    install -D -m 644 -t "$out/share/fonts/misc" *.otb *.pcf.gz
     mkfontdir "$out/share/fonts/misc"
-    mkfontdir "$otb/share/fonts/misc"
   '';
-
-  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     description = ''

--- a/pkgs/data/fonts/gohufont/default.nix
+++ b/pkgs/data/fonts/gohufont/default.nix
@@ -52,18 +52,11 @@ stdenv.mkDerivation rec {
     fontDir="$out/share/consolefonts"
     install -D -m 644 -t "$fontDir" psf/*.psf
 
-    # install the pcf fonts (for xorg applications)
+    # install the pcf and otb fonts (for X11,GTK applications)
     fontDir="$out/share/fonts/misc"
-    install -D -m 644 -t "$fontDir" *.pcf
-    mkfontdir "$fontDir"
-
-    # install the otb fonts (for gtk applications)
-    fontDir="$otb/share/fonts/misc"
-    install -D -m 644 -t "$fontDir" *.otb
+    install -D -m 644 -t "$fontDir" *.pcf *.otb
     mkfontdir "$fontDir"
   '';
-
-  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     description = ''

--- a/pkgs/data/fonts/profont/default.nix
+++ b/pkgs/data/fonts/profont/default.nix
@@ -28,14 +28,9 @@ stdenv.mkDerivation {
       gzip -n -9 -c "$f" > "$out/share/fonts/misc/$f.gz"
     done
     install -D -m 644 LICENSE -t "$out/share/doc/$pname"
+    install -D -m 644 "$srcOtb/profontn.otb" -t $out/share/fonts/misc
     mkfontdir "$out/share/fonts/misc"
-
-    cd $srcOtb
-    install -D -m 644 profontn.otb -t $otb/share/fonts/misc
-    mkfontdir "$otb/share/fonts/misc"
   '';
-
-  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     homepage = "https://tobiasjung.name/profont/";

--- a/pkgs/data/fonts/siji/default.nix
+++ b/pkgs/data/fonts/siji/default.nix
@@ -24,15 +24,13 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    install -m 644 -D pcf/* -t "$out/share/fonts/misc"
+    install -m 644 -D *.otb pcf/* -t "$out/share/fonts/misc"
     install -m 644 -D bdf/* -t "$bdf/share/fonts/misc"
-    install -m 644 -D *.otb -t "$otb/share/fonts/misc"
     mkfontdir "$out/share/fonts/misc"
     mkfontdir "$bdf/share/fonts/misc"
-    mkfontdir "$otb/share/fonts/misc"
   '';
 
-  outputs = [ "out" "bdf" "otb" ];
+  outputs = [ "out" "bdf" ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/stark/siji";

--- a/pkgs/data/fonts/tamsyn/default.nix
+++ b/pkgs/data/fonts/tamsyn/default.nix
@@ -29,14 +29,10 @@ in stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    install -m 644 -D *.pcf.gz -t "$out/share/fonts/misc"
+    install -m 644 -D *.otb *.pcf.gz -t "$out/share/fonts/misc"
     install -m 644 -D *.psf.gz -t "$out/share/consolefonts"
-    install -m 644 -D *.otb    -t "$otb/share/fonts/misc"
     mkfontdir "$out/share/fonts/misc"
-    mkfontdir "$otb/share/fonts/misc"
   '';
-
-  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     description = "A monospace bitmap font aimed at programmers";

--- a/pkgs/data/fonts/tamzen/default.nix
+++ b/pkgs/data/fonts/tamzen/default.nix
@@ -14,14 +14,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ mkfontscale ];
 
   installPhase = ''
-    install -m 644 -D pcf/*.pcf -t "$out/share/fonts/misc"
+    install -m 644 -D otb/*.otb pcf/*.pcf -t "$out/share/fonts/misc"
     install -m 644 -D psf/*.psf -t "$out/share/consolefonts"
-    install -m 644 -D otb/*.otb -t "$otb/share/fonts/misc"
     mkfontdir "$out/share/fonts/misc"
-    mkfontdir "$otb/share/fonts/misc"
   '';
-
-  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     description = "Bitmapped programming font based on Tamsyn";

--- a/pkgs/data/fonts/terminus-font/default.nix
+++ b/pkgs/data/fonts/terminus-font/default.nix
@@ -35,13 +35,11 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     # install otb fonts (for GTK applications)
-    install -m 644 -D *.otb -t "$otb/share/fonts/misc";
-    mkfontdir "$otb/share/fonts/misc"
+    install -m 644 -D *.otb -t "$out/share/fonts/misc";
+    mkfontdir "$out/share/fonts/misc"
   '';
 
   installTargets = [ "install" "fontdir" ];
-
-  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     description = "A clean fixed width font";

--- a/pkgs/data/fonts/tewi/default.nix
+++ b/pkgs/data/fonts/tewi/default.nix
@@ -38,15 +38,9 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     fontDir="$out/share/fonts/misc"
-    install -m 644 -D out/* -t "$fontDir"
-    mkfontdir "$fontDir"
-
-    fontDir="$otb/share/fonts/misc"
-    install -m 644 -D *.otb -t "$fontDir"
+    install -m 644 -D *.otb out/* -t "$fontDir"
     mkfontdir "$fontDir"
   '';
-
-  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     description = "A nice bitmap font, readable even at small sizes";

--- a/pkgs/data/fonts/ucs-fonts/default.nix
+++ b/pkgs/data/fonts/ucs-fonts/default.nix
@@ -42,16 +42,14 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    install -m 644 -D *.pcf.gz -t "$out/share/fonts/misc"
-    install -m 644 -D *.bdf    -t "$bdf/share/fonts/misc"
-    install -m 644 -D *.otb    -t "$otb/share/fonts/misc"
+    install -m 644 -D *.otb *.pcf.gz -t "$out/share/fonts/misc"
+    install -m 644 -D *.bdf -t "$bdf/share/fonts/misc"
 
     mkfontdir "$out/share/fonts/misc"
     mkfontdir "$bdf/share/fonts/misc"
-    mkfontdir "$otb/share/fonts/misc"
   '';
 
-  outputs = [ "out" "bdf" "otb" ];
+  outputs = [ "out" "bdf" ];
 
   meta = with stdenv.lib; {
     homepage = "https://www.cl.cam.ac.uk/~mgk25/ucs-fonts.html";

--- a/pkgs/data/fonts/uni-vga/default.nix
+++ b/pkgs/data/fonts/uni-vga/default.nix
@@ -34,23 +34,20 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    # install pcf (for X11 applications)
-    install -m 644 -D *.pcf.gz -t "$out/share/fonts"
+    # install pcf and otb (for X11 and GTK applications)
+    install -m 644 -D *.otb *.pcf.gz -t "$out/share/fonts"
     mkfontdir "$out/share/fonts"
 
     # install bdf font
     install -m 644 -D *.bdf -t "$bdf/share/fonts"
     mkfontdir "$bdf/share/fonts"
 
-    # install otb font (for GTK applications)
-    install -m 644 -D *.otb -t "$otb/share/fonts"
-    mkfontdir "$otb/share/fonts"
   '' + optionalString stdenv.isLinux ''
     # install psf (for linux virtual terminal)
     install -m 644 -D *.psf.gz -t "$out/share/consolefonts"
   '';
 
-  outputs = [ "out" "bdf" "otb" ];
+  outputs = [ "out" "bdf" ];
 
   meta = {
     description = "Unicode VGA font";

--- a/pkgs/data/fonts/unifont/default.nix
+++ b/pkgs/data/fonts/unifont/default.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation rec {
   installPhase =
     ''
       # install otb fonts
-      install -m 644 -D unifont.otb "$otb/share/fonts/unifont.otb"
-      mkfontdir "$otb/share/fonts"
+      install -m 644 -D unifont.otb "$out/share/fonts/unifont.otb"
+      mkfontdir "$out/share/fonts"
 
       # install pcf and ttf fonts
       install -m 644 -D ${pcf} $out/share/fonts/unifont.pcf.gz
@@ -40,8 +40,6 @@ stdenv.mkDerivation rec {
       mkfontdir
       mkfontscale
     '';
-
-  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     description = "Unicode font for Base Multilingual Plane";

--- a/pkgs/data/fonts/uw-ttyp0/default.nix
+++ b/pkgs/data/fonts/uw-ttyp0/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     install -m 644 -D psf/*.psf -t "$fontDir"
 
     # install otb fonts
-    fontDir="$otb/share/fonts/X11/misc"
+    fontDir="$out/share/fonts/X11/misc"
     install -m 644 -D otb/*.otb -t "$fontDir"
     mkfontdir "$fontDir"
   '';
@@ -79,8 +79,6 @@ stdenv.mkDerivation rec {
     ./configure --prefix="$out"
     runHook postConfigure
   '';
-
-  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     description = "Monospace bitmap screen fonts for X11";


### PR DESCRIPTION
###### Motivation for this change
Since the Pango issue [457][1] has been fixed and Nixpkgs patched, it's no longer necessary to keep X11 and .otb fonts in separate outputs (previously they would cause application to display broken fonts).
Linked to #75160, also.

[1]: https://gitlab.gnome.org/GNOME/pango/-/issues/457


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change: all good expect already broken ones.
- [x] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
