### PR TITLE
gitAndTools.diff-so-fancy: Fix shebang patching and clean up

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/diff-so-fancy/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/diff-so-fancy/default.nix
@@ -11,12 +11,19 @@ stdenv.mkDerivation rec {
     sha256 = "0aavxahzha2mms4vdwysk79pa6wzswpfwgsq2hwaxnaf66maahfl";
   };
 
-  # Perl is needed here for patchShebangs
-  nativeBuildInputs = [ perl makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+  ];
 
-  buildPhase = null;
+  buildInputs = [
+    perl # needed for patchShebangs
+  ];
+
+  dontBuild = true;
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin $out/lib/diff-so-fancy
 
     # diff-so-fancy executable searches for it's library relative to
@@ -32,6 +39,8 @@ stdenv.mkDerivation rec {
       --prefix PATH : "${git}/bin" \
       --prefix PATH : "${coreutils}/bin" \
       --prefix PATH : "${ncurses.out}/bin"
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
perl is a runtime dependency so it needs to be in buildInputs, otherwise patchShebangs hook will not see it. This impurity was revealed by #91213 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
