### PR TITLE
python3Packages.behave: 1.2.6 -> 1.2.7.dev1, python3Packages.cucumber-tag-expressions: init at 3.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5206,6 +5206,12 @@
     githubId = 35892750;
     name = "Maxine Aubrey";
   };
+  maxxk = {
+    email = "maxim.krivchikov@gmail.com";
+    github = "maxxk";
+    githubId = 1191859;
+    name = "Maxim Krivchikov";
+  };
   mbakke = {
     email = "mbakke@fastmail.com";
     github = "mbakke";

--- a/pkgs/development/python-modules/behave/default.nix
+++ b/pkgs/development/python-modules/behave/default.nix
@@ -1,30 +1,24 @@
-{ stdenv, fetchPypi, fetchpatch
-, buildPythonApplication, python, pythonOlder
-, mock, nose, pathpy, pyhamcrest, pytest_4
-, glibcLocales, parse, parse-type, six
-, traceback2
+{ stdenv, fetchFromGitHub
+, buildPythonApplication, python
+, mock, pathpy, pyhamcrest, pytest, pytest-html
+, glibcLocales
+, colorama, cucumber-tag-expressions, parse, parse-type, six
 }:
 
 buildPythonApplication rec {
   pname = "behave";
-  version = "1.2.6";
+  version = "1.2.7.dev1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "11hsz365qglvpp1m1w16239c3kiw15lw7adha49lqaakm8kj6rmr";
+  src = fetchFromGitHub {
+    owner = "behave";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1ssgixmqlg8sxsyalr83a1970njc2wg3zl8idsmxnsljwacv7qwv";
   };
 
-  patches = [
-    # Fix tests on Python 2.7
-    (fetchpatch {
-      url = "https://github.com/behave/behave/commit/0a9430a94881cd18437deb03d2ae23afea0f009c.patch";
-      sha256 = "1nrh9ii6ik6gw2kjh8a6jk4mg5yqw3jfjfllbyxardclsab62ydy";
-    })
-  ];
-
-  checkInputs = [ mock nose pathpy pyhamcrest pytest_4 ];
+  checkInputs = [ mock pathpy pyhamcrest pytest pytest-html ];
   buildInputs = [ glibcLocales ];
-  propagatedBuildInputs = [ parse parse-type six ] ++ stdenv.lib.optional (pythonOlder "3.0") traceback2;
+  propagatedBuildInputs = [ colorama cucumber-tag-expressions parse parse-type six ];
 
   postPatch = ''
     patchShebangs bin
@@ -36,7 +30,7 @@ buildPythonApplication rec {
     export LANG="en_US.UTF-8"
     export LC_ALL="en_US.UTF-8"
 
-    pytest test tests
+    pytest tests
 
     ${python.interpreter} bin/behave -f progress3 --stop --tags='~@xfail' features/
     ${python.interpreter} bin/behave -f progress3 --stop --tags='~@xfail' tools/test-features/
@@ -47,6 +41,6 @@ buildPythonApplication rec {
     homepage = "https://github.com/behave/behave";
     description = "behaviour-driven development, Python style";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ alunduil ];
+    maintainers = with maintainers; [ alunduil maxxk ];
   };
 }

--- a/pkgs/development/python-modules/cucumber-tag-expressions/default.nix
+++ b/pkgs/development/python-modules/cucumber-tag-expressions/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchPypi, buildPythonPackage, pytest, pytest-html }:
+
+buildPythonPackage rec {
+  pname = "cucumber-tag-expressions";
+  version = "3.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0kb8dq458sflwl2agb2v9hp04qwygslrhdps819vq27wc44jabxw";
+  };
+
+  checkInputs = [ pytest pytest-html ];
+  checkPhase = "pytest tests/*/*.py";
+
+  meta = with lib; {
+    homepage = "https://github.com/cucumber/tag-expressions-python";
+    description = "Provides tag-expression parser for cucumber/behave";
+    license = licenses.mit;
+    maintainers = with maintainers; [ maxxk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7637,6 +7637,8 @@ in {
 
   pure-pcapy3 = callPackage ../development/python-modules/pure-pcapy3 { };
 
+  cucumber-tag-expressions = callPackage ../development/python-modules/cucumber-tag-expressions { };
+
   behave = callPackage ../development/python-modules/behave { };
 
   bellows = callPackage ../development/python-modules/bellows { };


### PR DESCRIPTION
###### Motivation for this change

`python3Packages.python-docx` is broken in current master because behave 1.2.6 doesn't work in Python 3.8. Updated version is published as GitHub tag "1.2.7.dev1". However, there is no information about future release: https://github.com/behave/behave/issues/855 .

This PR updates `behave` to version "1.2.7.dev1" and introduces its new dependency `cucumber-tag-expressions`. 
Due to both `behave` and `cucumber-tag-expressions` dependency on `pytest-html` it is currently incompatible with Python 2.7, so I removed the compatibility code (patch and dependency) from `behave` package. If it is not desirable, I can rollback these changes, but recent version of `pytest-html` definitely is incompatible with Python 2.7.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
