### PR TITLE
coolreader: init at 3.2.45

### DIFF
--- a/pkgs/applications/misc/coolreader/default.nix
+++ b/pkgs/applications/misc/coolreader/default.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, fetchFromGitHub, cmake, pkg-config, lib,
+  qttools, fribidi, libunibreak }:
+
+mkDerivation rec {
+  pname = "coolreader";
+  version = "3.2.45";
+
+  src = fetchFromGitHub {
+    owner = "buggins";
+    repo = pname;
+    rev = "cr${version}";
+    sha256 = "0nkk4d0j04yjwanjszq8h8hvx87rnwax2k6akm4bpjxwpcs4icws";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ qttools fribidi libunibreak ];
+
+  meta = with lib; {
+    homepage = "https://github.com/buggins/coolreader";
+    description = "Cross platform open source e-book reader";
+    license = licenses.gpl2Plus; # see https://github.com/buggins/coolreader/issues/80
+    maintainers = with maintainers; [ gebner ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/libunibreak/default.nix
+++ b/pkgs/development/libraries/libunibreak/default.nix
@@ -1,17 +1,23 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "libunibreak";
-  version = "1.1";
+  version = "4.3";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/vimgadgets/libunibreak/${version}/${pname}-${version}.tar.gz";
-    sha256 = "02657l426bk5d8h42b9ixxy1clc50mx4bzwg02nkdhs09wqw32wn";
+  src = let
+      rev_version = stdenv.lib.replaceStrings ["-"] ["_"] version;
+  in fetchFromGitHub {
+    owner = "adah1972";
+    repo = pname;
+    rev = "libunibreak_${rev_version}";
+    sha256 = "19g3ixs1ycisfdnzd8v7j5r49h0x0hshchk9qwlz4i0mjv825plx";
   };
 
+  nativeBuildInputs = [ autoreconfHook ];
+
   meta = with stdenv.lib; {
-    homepage = "http://vimgadgets.sourceforge.net/libunibreak/";
-    description = "A library implementing a line breaking algorithm as described in Unicode 6.0.0 Standard";
+    homepage = "https://github.com/adah1972/libunibreak";
+    description = "Implementation of line breaking and word breaking algorithms as in the Unicode standard";
     license = licenses.zlib;
     platforms = platforms.unix;
     maintainers = [ maintainers.coroa ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -935,6 +935,8 @@ in
 
   codespell = with python3Packages; toPythonApplication codespell;
 
+  coolreader = libsForQt5.callPackage ../applications/misc/coolreader {};
+
   cozy = callPackage ../applications/audio/cozy-audiobooks { };
 
   ctrtool = callPackage ../tools/archivers/ctrtool { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New package.  Coolreader is an e-book reader.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
