### PR TITLE
nixos/hardened: Port test to Python and fix it

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -424,15 +424,18 @@ class Machine:
                 output += out
         return output
 
-    def fail(self, *commands: str) -> None:
+    def fail(self, *commands: str) -> str:
         """Execute each command and check that it fails."""
+        output = ""
         for command in commands:
             with self.nested("must fail: {}".format(command)):
-                status, output = self.execute(command)
+                (status, out) = self.execute(command)
                 if status == 0:
                     raise Exception(
                         "command `{}` unexpectedly succeeded".format(command)
                     )
+                output += out
+        return output
 
     def wait_until_succeeds(self, command: str) -> str:
         """Wait until a command returns success and return its output.

--- a/nixos/tests/hardened.nix
+++ b/nixos/tests/hardened.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, latestKernel ? false, ... } : {
+import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... } : {
   name = "hardened";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ joachifm ];
@@ -47,84 +47,88 @@ import ./make-test.nix ({ pkgs, latestKernel ? false, ... } : {
       };
     in
     ''
-      $machine->waitForUnit("multi-user.target");
+      machine.wait_for_unit("multi-user.target")
 
-      subtest "apparmor-loaded", sub {
-          $machine->succeed("systemctl status apparmor.service");
-      };
+
+      with subtest("AppArmor profiles are loaded"):
+          machine.succeed("systemctl status apparmor.service")
+
 
       # AppArmor securityfs
-      subtest "apparmor-securityfs", sub {
-          $machine->succeed("mountpoint -q /sys/kernel/security");
-          $machine->succeed("cat /sys/kernel/security/apparmor/profiles");
-      };
+      with subtest("AppArmor securityfs is mounted"):
+          machine.succeed("mountpoint -q /sys/kernel/security")
+          machine.succeed("cat /sys/kernel/security/apparmor/profiles")
+
 
       # Test loading out-of-tree modules
-      subtest "extra-module-packages", sub {
-          $machine->succeed("grep -Fq wireguard /proc/modules");
-      };
+      with subtest("Out-of-tree modules can be loaded"):
+          machine.succeed("grep -Fq wireguard /proc/modules")
+
 
       # Test hidepid
-      subtest "hidepid", sub {
-          $machine->succeed("grep -Fq hidepid=2 /proc/mounts");
+      with subtest("hidepid=2 option is applied and works"):
+          machine.succeed("grep -Fq hidepid=2 /proc/mounts")
           # cannot use pgrep -u here, it segfaults when access to process info is denied
-          $machine->succeed("[ `su - sybil -c 'ps --no-headers --user root | wc -l'` = 0 ]");
-          $machine->succeed("[ `su - alice -c 'ps --no-headers --user root | wc -l'` != 0 ]");
-      };
+          machine.succeed("[ `su - sybil -c 'ps --no-headers --user root | wc -l'` = 0 ]")
+          machine.succeed("[ `su - alice -c 'ps --no-headers --user root | wc -l'` != 0 ]")
+
 
       # Test kernel module hardening
-      subtest "lock-modules", sub {
+      with subtest("No more kernel modules can be loaded"):
           # note: this better a be module we normally wouldn't load ...
-          $machine->fail("modprobe dccp");
-      };
+          machine.fail("modprobe dccp")
+
 
       # Test userns
-      subtest "userns", sub {
-          $machine->succeed("unshare --user true");
-          $machine->fail("su -l alice -c 'unshare --user true'");
-      };
+      with subtest("User namespaces are restricted"):
+          machine.succeed("unshare --user true")
+          machine.fail("su -l alice -c 'unshare --user true'")
+
 
       # Test dmesg restriction
-      subtest "dmesg", sub {
-          $machine->fail("su -l alice -c dmesg");
-      };
+      with subtest("Regular users cannot access dmesg"):
+          machine.fail("su -l alice -c dmesg")
+
 
       # Test access to kcore
-      subtest "kcore", sub {
-          $machine->fail("cat /proc/kcore");
-      };
+      with subtest("Kcore is inaccessible as root"):
+          machine.fail("cat /proc/kcore")
+
 
       # Test deferred mount
-      subtest "mount", sub {
-        $machine->fail("mountpoint -q /efi"); # was deferred
-        $machine->execute("mkdir -p /efi");
-        $machine->succeed("mount /dev/disk/by-label/EFISYS /efi");
-        $machine->succeed("mountpoint -q /efi"); # now mounted
-      };
+      with subtest("Deferred mounts work"):
+          machine.fail("mountpoint -q /efi")  # was deferred
+          machine.execute("mkdir -p /efi")
+          machine.succeed("mount /dev/disk/by-label/EFISYS /efi")
+          machine.succeed("mountpoint -q /efi")  # now mounted
+
 
       # Test Nix dæmon usage
-      subtest "nix-daemon", sub {
-        $machine->fail("su -l nobody -s /bin/sh -c 'nix ping-store'");
-        $machine->succeed("su -l alice -c 'nix ping-store'") =~ "OK";
-      };
+      with subtest("nix-daemon cannot be used by all users"):
+          machine.fail("su -l nobody -s /bin/sh -c 'nix ping-store'")
+          machine.succeed("su -l alice -c 'nix ping-store'")
+
 
       # Test kernel image protection
-      subtest "kernelimage", sub {
-        $machine->fail("systemctl hibernate");
-        $machine->fail("systemctl kexec");
-      };
+      with subtest("The kernel image is protected"):
+          machine.fail("systemctl hibernate")
+          machine.fail("systemctl kexec")
+
 
       # Test hardened memory allocator
-      sub runMallocTestProg {
-          my ($progName, $errorText) = @_;
-          my $text = "fatal allocator error: " . $errorText;
-          $machine->fail("${hardened-malloc-tests}/bin/" . $progName) =~ $text;
-      };
+      def runMallocTestProg(prog_name, error_text):
+          text = "fatal allocator error: " + error_text
+          if not text in machine.fail(
+              "${hardened-malloc-tests}/bin/"
+              + prog_name
+              + " 2>&1"
+          ):
+              raise Exception("Hardened malloc does not work for {}".format(error_text))
 
-      subtest "hardenedmalloc", sub {
-        runMallocTestProg("double_free_large", "invalid free");
-        runMallocTestProg("unaligned_free_small", "invalid unaligned free");
-        runMallocTestProg("write_after_free_small", "detected write after free");
-      };
+
+      with subtest("The hardened memory allocator works"):
+          runMallocTestProg("double_free_large", "invalid free")
+          runMallocTestProg("unaligned_free_small", "invalid unaligned free")
+          runMallocTestProg("write_after_free_small", "detected write after free")
     '';
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
