### PR TITLE
xdragon: Init at 1.1.1

### DIFF
--- a/pkgs/applications/misc/xdragon/default.nix
+++ b/pkgs/applications/misc/xdragon/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, pkg-config, gtk3 }:
+
+stdenv.mkDerivation rec {
+  pname = "xdragon";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "mwh";
+    repo = "dragon";
+    rev = "v${version}";
+    sha256 = "0fgzz39007fdjwq72scp0qygp2v3zc5f1xkm0sxaa8zxm25g1bra";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ gtk3 ];
+
+  installFlags = [ "PREFIX=${placeholder "out"}/bin" ];
+  postInstall = ''
+    ln -s $out/bin/dragon $out/bin/xdragon
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple drag-and-drop source/sink for X (called dragon in upstream)";
+    homepage = "https://github.com/mwh/dragon";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26872,6 +26872,8 @@ in
 
   sift = callPackage ../tools/text/sift { };
 
+  xdragon = lowPrio (callPackage ../applications/misc/xdragon { });
+
   xlockmore = callPackage ../misc/screensavers/xlockmore { };
 
   xtrlock-pam = callPackage ../misc/screensavers/xtrlock-pam { };


### PR DESCRIPTION
The package is renamed from `dragon` to prevent name conflicts with the
existing package as recommended in [1].

1: https://github.com/mwh/dragon/issues/17

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I use this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
