### PR TITLE
asterisk-module-sccp: Init at 4.3.2-epsilon

### DIFF
--- a/pkgs/servers/asterisk/sccp/default.nix
+++ b/pkgs/servers/asterisk/sccp/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, binutils-unwrapped, patchelf, asterisk }:
+stdenv.mkDerivation rec {
+  pname = "asterisk-module-sccp";
+  version = "4.3.2-epsilon";
+
+  src = fetchFromGitHub {
+    owner = "chan-sccp";
+    repo = "chan-sccp";
+    rev = "v${version}";
+    sha256 = "0sp74xvb35m32flsrib0983yn1dyz3qk69vp0gqbx620ycbz19gd";
+  };
+
+  nativeBuildInputs = [ patchelf ];
+
+  configureFlags = [ "--with-asterisk=${asterisk}" ];
+
+  installFlags = [ "DESTDIR=/build/dest" "DATAROOTDIR=/build/dest" ];
+
+  postInstall = ''
+    mkdir -p "$out"
+    cp -r /build/dest/${asterisk}/* "$out"
+  '';
+
+  postFixup = ''
+    p="$out/lib/asterisk/modules/chan_sccp.so"
+    patchelf --set-rpath "$p:${stdenv.lib.makeLibraryPath [ binutils-unwrapped ]}" "$p"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Replacement for the SCCP channel driver in Asterisk";
+    license = licenses.gpl1Only;
+    maintainers = with maintainers; [ das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16040,6 +16040,8 @@ in
     asterisk asterisk-stable asterisk-lts
     asterisk_13 asterisk_15 asterisk_16;
 
+  asterisk-module-sccp = callPackage ../servers/asterisk/sccp { };
+
   sabnzbd = callPackage ../servers/sabnzbd { };
 
   bftpd = callPackage ../servers/ftp/bftpd {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
