### PR TITLE
fzf: Make sure that perl path is valid

### DIFF
--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, writeText, runtimeShell, ncurses }:
+{ lib, buildGoModule, fetchFromGitHub, writeText, runtimeShell, ncurses, perl }:
 
 buildGoModule rec {
   pname = "fzf";
@@ -27,6 +27,13 @@ buildGoModule rec {
         echo "Failed to replace vim base_dir path with $out"
         exit 1
     fi
+
+    # Has a sneaky dependency on perl
+    # Include first args to make sure we're patching the right thing
+    substituteInPlace shell/key-bindings.zsh \
+      --replace " perl -ne " " ${perl}/bin/perl -ne "
+    substituteInPlace shell/key-bindings.bash \
+      --replace " perl -n " " ${perl}/bin/perl -n "
   '';
 
   preInstall = ''


### PR DESCRIPTION
###### Motivation for this change
Since https://github.com/NixOS/nixpkgs/pull/91213, fzf's history widget complains about a missing perl. This fixes it by having fzf depend on perl

Ping @zowoq @filalex77 @Ma27 

###### Things done

- [x] Made sure this builds on Linux
- [x] Made sure the `Ctrl-R` command in zsh works again