### PR TITLE
dwarf-fortress: dfhack and TWBT fixes

### DIFF
--- a/pkgs/games/dwarf-fortress/dfhack/default.nix
+++ b/pkgs/games/dwarf-fortress/dfhack/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildEnv, lib, fetchFromGitHub, cmake, writeScriptBin
-, perl, XMLLibXML, XMLLibXSLT, zlib
+, perl, XMLLibXML, XMLLibXSLT, zlib, ruby
 , enableStoneSense ? false,  allegro5, libGLU, libGL
 , enableTWBT ? true, twbt
 , SDL
@@ -139,6 +139,12 @@ let
 
     cmakeFlags = [ "-DDFHACK_BUILD_ARCH=${arch}" "-DDOWNLOAD_RUBY=OFF" ]
               ++ lib.optionals enableStoneSense [ "-DBUILD_STONESENSE=ON" "-DSTONESENSE_INTERNAL_SO=OFF" ];
+
+    # dfhack expects an unversioned libruby.so to be present in the hack
+    # subdirectory for ruby plugins to function.
+    postInstall = ''
+      ln -s ${ruby}/lib/libruby-*.so $out/hack/libruby.so
+    '';
 
     enableParallelBuilding = true;
   };

--- a/pkgs/games/dwarf-fortress/dfhack/default.nix
+++ b/pkgs/games/dwarf-fortress/dfhack/default.nix
@@ -53,10 +53,10 @@ let
       prerelease = true;
     };
     "0.47.04" = {
-      dfHackRelease = "0.47.04-alpha0";
-      sha256 = "07056k6717mqim9skwjprqplj8jmmli6g4p2c72c8000jwnn2hjy";
-      xmlRev = "23500e4e9bd1885365d0a2ef1746c321c1dd50aa";
-      prerelease = true;
+      dfHackRelease = "0.47.04-r2";
+      sha256 = "18ppn1dqaxi6ahjzsvb9kw70rvca106a1hibhzc4rxmraypnqb89";
+      xmlRev = "036b662a1bbc96b4911f3cbe74dfa1243b6459bc";
+      prerelease = false;
     };
   };
 
@@ -109,6 +109,19 @@ let
     };
 
     patches = [ ./fix-stonesense.patch ];
+
+    # As of
+    # https://github.com/DFHack/dfhack/commit/56e43a0dde023c5a4595a22b29d800153b31e3c4,
+    # dfhack gets its goodies from the directory above the Dwarf_Fortress
+    # executable, which leads to stock Dwarf Fortress and not the built
+    # environment where all the dfhack resources are symlinked to (typically
+    # ~/.local/share/df_linux). This causes errors like `tweak is not a
+    # recognized command` to be reported and dfhack to lose some of its
+    # functionality.
+    postPatch = ''
+      sed -i 's@cached_path = path_string.*@cached_path = getenv("DF_DIR");@' library/Process-linux.cpp
+    '';
+
     nativeBuildInputs = [ cmake perl XMLLibXML XMLLibXSLT fakegit ];
     # We don't use system libraries because dfhack needs old C++ ABI.
     buildInputs = [ zlib SDL ]

--- a/pkgs/games/dwarf-fortress/twbt/default.nix
+++ b/pkgs/games/dwarf-fortress/twbt/default.nix
@@ -42,9 +42,10 @@ let
       prerelease = false;
     };
     "0.47.04" = {
-      twbtRelease = "6.61";
-      sha256 = "07bqy9rkd64h033sxdpigp5zq4xrr0xd36wdr1b21g649mv8j6yw";
-      prerelease = false;
+      twbtRelease = "6.xx";
+      dfhackRelease = "0.47.04-r2";
+      sha256 = "092dgp8fh1j4nqr9wbzn89ib1nhscclr8m91lfxsvg0mgn7j8xlv";
+      prerelease = true;
     };
   };
 
@@ -58,7 +59,11 @@ stdenvNoCC.mkDerivation rec {
   version = release.twbtRelease;
 
   src = fetchurl {
-    url = "https://github.com/mifki/df-twbt/releases/download/v${version}/twbt-${version}-linux.zip";
+    url =
+      if version == "6.xx" then
+        "https://github.com/thurin/df-twbt/releases/download/${release.dfhackRelease}/twbt-${version}-linux64-${release.dfhackRelease}.zip"
+      else
+        "https://github.com/mifki/df-twbt/releases/download/v${version}/twbt-${version}-linux.zip";
     sha256 = release.sha256;
   };
 

--- a/pkgs/games/dwarf-fortress/wrapper/dwarf-fortress-init.in
+++ b/pkgs/games/dwarf-fortress/wrapper/dwarf-fortress-init.in
@@ -1,6 +1,6 @@
 shopt -s extglob
 
-[ -z "$DF_DIR" ] && DF_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/df_linux"
+[ -z "$DF_DIR" ] && export DF_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/df_linux"
 env_dir="@env@"
 exe="$env_dir/@exe@"
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I recently got into Dwarf Fortress, and some things were not working as expected.

* dfhack itself was out of date (there now exists an `r2` release, which is considerably newer  than the `alpha0` release).
  * In this release, some path handling was reworked, so we need to patch the source in order for dfhack to find its utilities (like the tweak plugin). See the commit message for more information: https://github.com/NixOS/nixpkgs/commit/c936f7a197f0fc1cd909b34183767ec2c5060cd4.
* dfhack was complaining about being unable to initialize Ruby plugins, so I fixed it (not that I use Ruby plugins -- please let me know if this actually works). See the commit message for more information: https://github.com/NixOS/nixpkgs/commit/0bf44861ce7d14d2e1c4ca3c4ff783bdaa2c804b.
* TWBT was out of date for dfhack 0.47.04 -- there exists a fork adding support for this, so switch to it when using dfhack 0.47.04. See the commit message for more information: https://github.com/NixOS/nixpkgs/commit/f35ccafff98c8df55040ca8734646fe6f9530069.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Closes https://github.com/NixOS/nixpkgs/pull/88497 (superceded).
Resolves https://github.com/NixOS/nixpkgs/issues/56013 (dfhack doesn't load to a black screen for me; I've also resolved the dfhack + twbt compat issue).
Resolves https://github.com/NixOS/nixpkgs/issues/56485 (dfhack no longer complains about being unable to load the ruby library).

cc @srhb

EDIT: Sorry for the ping, Jon. Clicked on your name by mistake x)