### PR TITLE
recursive: 1.054 -> 1.057

### DIFF
--- a/pkgs/data/fonts/recursive/default.nix
+++ b/pkgs/data/fonts/recursive/default.nix
@@ -1,21 +1,21 @@
 { lib, fetchzip }:
 
 let
-  version = "1.054";
+  version = "1.057";
 in
 fetchzip {
   name = "recursive-${version}";
 
-  url = "https://github.com/arrowtype/recursive/releases/download/${version}/ArrowType-Recursive-${version}.zip";
+  url = "https://github.com/arrowtype/recursive/releases/download/${version}/Recursive-${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.otf -x __MACOSX/\* -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -x __MACOSX/\* -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.woff2 -x __MACOSX/\* -d $out/share/fonts/woff2
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.woff2 -d $out/share/fonts/woff2
   '';
 
-  sha256 = "12ld0w7x5lyvymrnqzfj74a3m6knv7i1795bvnpyljmxxkacscnl";
+  sha256 = "0qsqldnhgl93h1izminjajjymvyxsw91ngdbxlhgbqvadg77325y";
 
   meta = with lib; {
     homepage = "https://recursive.design/";


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/arrowtype/recursive/releases/tag/1.057

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
