### PR TITLE
sabnzbd: 2.3.9 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/sabyenc3/default.nix
+++ b/pkgs/development/python-modules/sabyenc3/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchPypi, python3Packages }:
+
+python3Packages.buildPythonPackage rec {
+  pname = "sabyenc3";
+  version = "4.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zfj1k4zij8ph8jwkq4d6i6axym8cil16yijxshqla5163d1031z";
+  };
+
+  # tests are not included in pypi distribution
+  doCheck = false;
+
+  meta = {
+    description = "yEnc Decoding for Python 3";
+    homepage = "https://github.com/sabnzbd/sabyenc/";
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.lovek323 ];
+  };
+
+}

--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -1,17 +1,33 @@
-{stdenv, fetchFromGitHub, python2, par2cmdline, unzip, unrar, p7zip, makeWrapper}:
+{ stdenv
+, fetchFromGitHub
+, python3
+, par2cmdline
+, unzip
+, unrar
+, p7zip
+, makeWrapper
+}:
 
 let
-  pythonEnv = python2.withPackages(ps: with ps; [ cryptography cheetah yenc sabyenc ]);
+  pythonEnv = python3.withPackages(ps: with ps; [
+    chardet
+    cheetah3
+    cherrypy
+    cryptography
+    configobj
+    feedparser
+    sabyenc3
+  ]);
   path = stdenv.lib.makeBinPath [ par2cmdline unrar unzip p7zip ];
 in stdenv.mkDerivation rec {
-  version = "2.3.9";
+  version = "3.0.1";
   pname = "sabnzbd";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "06ln00rqz4xpsqhq0f495893xq1w5dfjawb8dgfyjjfds8627p16";
+    sha256 = "1zp8cxz56qmai1z6xcscnq85gxhv64dv1s5zqsqdn0zpbxyqqdlr";
   };
 
   buildInputs = [ pythonEnv makeWrapper ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1560,6 +1560,8 @@ in {
 
   sabyenc = callPackage ../development/python-modules/sabyenc { };
 
+  sabyenc3 = callPackage ../development/python-modules/sabyenc3 { };
+
   salmon-mail = callPackage ../development/python-modules/salmon-mail { };
 
   sanic-auth = callPackage ../development/python-modules/sanic-auth { };


### PR DESCRIPTION
##### Motivation for this change

A new major version of SABnzbd was released.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).