### PR TITLE
gnomeExtensions.night-theme-switcher: 19 -> 36

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/night-theme-switcher/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/night-theme-switcher/default.nix
@@ -1,26 +1,24 @@
-{ stdenv, fetchFromGitLab }:
+{ stdenv, fetchFromGitLab, glib, gnome3, unzip }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-night-theme-switcher";
-  version = "19";
+  version = "36";
 
   src = fetchFromGitLab {
     owner = "rmnvgr";
     repo = "nightthemeswitcher-gnome-shell-extension";
     rev = "v${version}";
-    sha256 = "1ll0yf1skf51wa10mlrajd1dy459w33kx0i3vhfcx2pdk7mw5a3c";
+    sha256 = "1c88979qprwb5lj0v7va017w7rdr89a648anhw4k5q135jwyskpz";
   };
 
-  # makefile tries to do install in home directory using
-  # `gnome-extensions install`
-  dontBuild = true;
+  buildInputs = [ glib gnome3.gnome-shell unzip ];
 
   uuid = "nightthemeswitcher@romainvigier.fr";
 
   installPhase = ''
     runHook preInstall
     mkdir -p $out/share/gnome-shell/extensions/
-    cp -r src/ $out/share/gnome-shell/extensions/${uuid}
+    unzip build/${uuid}.shell-extension.zip -d $out/share/gnome-shell/extensions/${uuid}
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Motivation for this change

The `night-theme-switcher` GNOME Shell extension is outdated. There are a number of updates and new features in the [changelog](https://gitlab.com/rmnvgr/nightthemeswitcher-gnome-shell-extension/-/releases).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
