### PR TITLE
wofi: do not follow symlinks in PATH

### DIFF
--- a/pkgs/applications/misc/wofi/default.nix
+++ b/pkgs/applications/misc/wofi/default.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config meson ninja wrapGAppsHook installShellFiles ];
   buildInputs = [ wayland gtk3 ];
 
+  patches = [
+    # https://todo.sr.ht/~scoopta/wofi/121
+    ./do_not_follow_symlinks.patch
+  ];
+
   postInstall = ''
     installManPage man/wofi*
   '';

--- a/pkgs/applications/misc/wofi/do_not_follow_symlinks.patch
+++ b/pkgs/applications/misc/wofi/do_not_follow_symlinks.patch
@@ -1,0 +1,39 @@
+diff -r 3414ab984249 modes/run.c
+--- a/modes/run.c	Tue Aug 11 19:07:49 2020 -0700
++++ b/modes/run.c	Sat Aug 22 13:39:52 2020 +0200
+@@ -91,23 +91,10 @@
+ 
+ 	char* path = strdup(getenv("PATH"));
+ 
+-	struct map* paths = map_init();
+-
+ 	char* save_ptr;
+ 	char* str = strtok_r(path, ":", &save_ptr);
+ 	do {
+ 
+-		str = realpath(str, NULL);
+-		if(str == NULL) {
+-			continue;
+-		}
+-		if(map_contains(paths, str)) {
+-			free(str);
+-			continue;
+-		}
+-
+-		map_put(paths, str, "true");
+-
+ 		DIR* dir = opendir(str);
+ 		if(dir == NULL) {
+ 			continue;
+@@ -132,11 +119,9 @@
+ 			}
+ 			free(full_path);
+ 		}
+-		free(str);
+ 		closedir(dir);
+ 	} while((str = strtok_r(NULL, ":", &save_ptr)) != NULL);
+ 	free(path);
+-	map_free(paths);
+ 	map_free(cached);
+ 	map_free(entries);
+ }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

wofi resolves the symlink in `/run/current-system/sw/bin` and the resolved binary paths are stored in `~/.cache/wofi-run`:
```
3 /nix/store/i10xnplpxdi9iyydzgkka079n61rvl5m-system-path/bin/firefox
```

This has the (security-related) effect that if you run firefox once, then wofi will always run that version from then on.  Even if you upgraded the system.

Reported upstream:
https://todo.sr.ht/~scoopta/wofi/121


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
