### PR TITLE
nixos/services.imwheel: sleep 3s before restarting

### DIFF
--- a/nixos/modules/services/x11/imwheel.nix
+++ b/nixos/modules/services/x11/imwheel.nix
@@ -61,7 +61,8 @@ in
             "--kill"
           ] ++ cfg.extraOptions);
           ExecStop = "${pkgs.procps}/bin/pkill imwheel";
-          Restart = "on-failure";
+          RestartSec = 3;
+          Restart = "always";
         };
       };
     };


### PR DESCRIPTION
###### Motivation for this change
Imwheel service required restarting (`systemctl; --user restart imwheel.service`) in order to start working. Probably because it was racing with some other services initialization.

###### Things done
Delay imwheel start by 3s (value taken from redshift) to prevent the issue.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
