### PR TITLE
wstunnel: unstable-2019-01-28 -> unstable-2020-07-12

### DIFF
--- a/pkgs/tools/networking/wstunnel/default.nix
+++ b/pkgs/tools/networking/wstunnel/default.nix
@@ -2,27 +2,20 @@
 , classy-prelude, cmdargs, connection, hslogger, mtl, network
 , network-conduit-tls, stdenv, streaming-commons, text
 , unordered-containers, websockets
+, hspec, iproute
 , lib, fetchFromGitHub, fetchpatch
 }:
 
 mkDerivation rec {
   pname = "wstunnel";
-  version = "unstable-2019-01-28";
+  version = "unstable-2020-07-12";
 
   src = fetchFromGitHub {
     owner = "erebe";
     repo = pname;
-    rev = "78cc5a5f1aa4dbcb25fa9b0efc9cfef3640672e4";
-    sha256 = "17y3yn7qg1h7jx9xs041sw63g51vyns236f60d2m2mghi49lm9i2";
+    rev = "093a01fa3a34eee5efd8f827900e64eab9d16c05";
+    sha256 = "17p9kq0ssz05qzl6fyi5a5fjbpn4bxkkwibb9si3fhzrxc508b59";
   };
-
-  patches = [
-    # Support GHC 8.6   https://github.com/erebe/wstunnel/pull/18
-    (fetchpatch {
-      url = "https://github.com/erebe/wstunnel/commit/8f348fea4dbf75874d5d930334377843763335ab.patch";
-      sha256 = "0a66jx7k97j3iyr7j5npbyq1lkhzz74r81mkas4nig7z3hny1gn9";
-    })
-  ];
 
   isLibrary = false;
   isExecutable = true;
@@ -31,13 +24,14 @@ mkDerivation rec {
     async base base64-bytestring binary bytestring classy-prelude
     connection hslogger mtl network network-conduit-tls
     streaming-commons text unordered-containers websockets
+    iproute
   ];
 
   executableHaskellDepends = [
     base bytestring classy-prelude cmdargs hslogger text
   ];
 
-  testHaskellDepends = [ base text ];
+  testHaskellDepends = [ base text hspec ];
 
   homepage = "https://github.com/erebe/wstunnel";
   description = "UDP and TCP tunnelling over WebSocket";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream version.  The latest 3.0 version unfortunately doesn't build with the current `network` package, but this has been fixed on master in the meantime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
