### PR TITLE
tensorflow-lite: init at 2.5.0

### DIFF
--- a/pkgs/development/libraries/science/math/tensorflow-lite/default.nix
+++ b/pkgs/development/libraries/science/math/tensorflow-lite/default.nix
@@ -1,0 +1,159 @@
+{ stdenv
+, bash
+, abseil-cpp
+, fetchFromGitHub
+, fetchFromGitLab
+, fetchpatch
+, fetchurl
+, flatbuffers
+, hostPlatform
+, lib
+, zlib
+}:
+let
+  tflite-eigen = fetchFromGitLab {
+    owner = "libeigen";
+    repo = "eigen";
+    rev = "3d9051ea84a5089b277c88dac456b3b1576bfa7f";
+    sha256 = "1y3f2jvimb5i904f4n37h23cv2pkdlbz8656s0kga1y7c0p50wif";
+  };
+
+  gemmlowp-src = fetchFromGitHub {
+    owner = "google";
+    repo = "gemmlowp";
+    rev = "fda83bdc38b118cc6b56753bd540caa49e570745";
+    sha256 = "1sbp8kmr2azwlvfbzryy1frxi99jhsh1nc93bdbxdf8zdgpv0kxl";
+  };
+
+  neon-2-sse-src = fetchFromGitHub {
+    owner = "intel";
+    repo = "ARM_NEON_2_x86_SSE";
+    rev = "1200fe90bb174a6224a525ee60148671a786a71f";
+    sha256 = "0fhxch711ck809dpq1myxz63jiiwfcnxvj45ww0kg8s0pqpn5kv6";
+  };
+
+  farmhash-src = fetchFromGitHub {
+    owner = "google";
+    repo = "farmhash";
+    rev = "816a4ae622e964763ca0862d9dbd19324a1eaf45";
+    sha256 = "1mqxsljq476n1hb8ilkrpb39yz3ip2hnc7rhzszz4sri8ma7qzp6";
+  };
+
+  fft2d-src = fetchurl {
+    url = "http://www.kurims.kyoto-u.ac.jp/~ooura/fft2d.tgz";
+    sha256 = "ada7e99087c4ed477bfdf11413f2ba8db8a840ba9bbf8ac94f4f3972e2a7cec9";
+  };
+
+  fp16-src = fetchFromGitHub {
+    owner = "Maratyszcza";
+    repo = "FP16";
+    rev = "4dfe081cf6bcd15db339cf2680b9281b8451eeb3";
+    sha256 = "06a8dfl3a29r93nxpp6hpywsajz5d555n3sqd3i6krybb6swnvh7";
+  };
+
+  ruy-src = fetchFromGitHub {
+    owner = "google";
+    repo = "ruy";
+    rev = "23633b37099b614a2f836ef012cafc8087fdb98c";
+    sha256 = "14k9hz6ss8qy8nsajk6lrq25f6qxrldxky31ijw0dpqnfnnswrx4";
+  };
+
+  cpuinfo-src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "cpuinfo";
+    rev = "5916273f79a21551890fd3d56fc5375a78d1598d";
+    sha256 = "0q6760xdxsg18acdv8vq3yrq7ksr7wsm8zbyan01zf2khnb6fw4x";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "tensorflow-lite";
+  version = "2.5.0";
+
+  src = fetchFromGitHub {
+    owner = "tensorflow";
+    repo = "tensorflow";
+    rev = "v${version}";
+    sha256 = "1jdw2i1rq06zqd6aabh7bbm0avsg4pygnfmd7gviv0blhih9054l";
+  };
+
+  buildInputs = [ zlib flatbuffers ];
+
+  dontConfigure = true;
+
+  postPatch = ''
+    substituteInPlace ./tensorflow/lite/tools/make/Makefile \
+      --replace /bin/bash ${bash}/bin/bash \
+      --replace /bin/sh ${bash}/bin/sh
+  '';
+
+  makefile = "tensorflow/lite/tools/make/Makefile";
+
+  preBuild =
+    let
+      includes =
+        lib.concatMapStringsSep
+          " "
+          (subdir: "-I $PWD/tensorflow/lite/tools/make/downloads/${subdir}")
+          [
+            "neon_2_sse"
+            "gemmlowp"
+            "absl"
+            "fp16/include"
+            "farmhash/src"
+            "ruy"
+            "cpuinfo"
+            "cpuinfo/src"
+            "cpuinfo/include"
+            "cpuinfo/deps/clog/include"
+            "eigen"
+          ];
+    in
+    ''
+      # enter the vendoring lair of doom
+
+      prefix="$PWD/tensorflow/lite/tools/make/downloads"
+
+      mkdir -p "$prefix"
+
+      tar xzf ${fft2d-src} -C "$prefix"
+
+      ln -s ${ruy-src} "$prefix/ruy"
+      ln -s ${gemmlowp-src} "$prefix/gemmlowp"
+      ln -s ${neon-2-sse-src} "$prefix/neon_2_sse"
+      ln -s ${farmhash-src} "$prefix/farmhash"
+      ln -s ${cpuinfo-src} "$prefix/cpuinfo"
+      ln -s ${fp16-src} "$prefix/fp16"
+      ln -s ${tflite-eigen} "$prefix/eigen"
+
+      # tensorflow lite is using the *source* of flatbuffers
+      ln -s ${flatbuffers.src} "$prefix/flatbuffers"
+
+      # tensorflow lite expects to compile abseil into `libtensorflow-lite.a`
+      ln -s ${abseil-cpp.src} "$prefix/absl"
+
+      buildFlagsArray+=(INCLUDES="-I $PWD ${includes}" TARGET_TOOLCHAIN_PREFIX="" -j$NIX_BUILD_CORES all)
+    '';
+
+  installPhase = ''
+    mkdir "$out"
+
+    # copy the static lib and binaries into the output dir
+    cp -r ./tensorflow/lite/tools/make/gen/linux_${hostPlatform.uname.processor}/{bin,lib} "$out"
+
+    find ./tensorflow/lite -type f -name '*.h' | while read f; do
+      path="$out/include/''${f/.\//}"
+      install -D "$f" "$path"
+
+      # remove executable bit from headers
+      chmod -x "$path"
+    done
+  '';
+
+  meta = with lib; {
+    description = "An open source deep learning framework for on-device inference.";
+    homepage = "https://www.tensorflow.org/lite";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ cpcloud ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+  };
+}

--- a/pkgs/development/libraries/science/math/tensorflow-lite/eigen_include_dir.patch
+++ b/pkgs/development/libraries/science/math/tensorflow-lite/eigen_include_dir.patch
@@ -1,0 +1,45 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 28103856e..a36909c0e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -449,13 +449,6 @@ install(FILES
+   DESTINATION ${INCLUDE_INSTALL_DIR} COMPONENT Devel
+   )
+ 
+-if(EIGEN_BUILD_PKGCONFIG)
+-    configure_file(eigen3.pc.in eigen3.pc @ONLY)
+-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/eigen3.pc
+-        DESTINATION ${PKGCONFIG_INSTALL_DIR}
+-        )
+-endif()
+-
+ install(DIRECTORY Eigen DESTINATION ${INCLUDE_INSTALL_DIR} COMPONENT Devel)
+ 
+ add_subdirectory(doc EXCLUDE_FROM_ALL)
+@@ -570,8 +563,15 @@ set ( EIGEN_VERSION_MAJOR  ${EIGEN_WORLD_VERSION} )
+ set ( EIGEN_VERSION_MINOR  ${EIGEN_MAJOR_VERSION} )
+ set ( EIGEN_VERSION_PATCH  ${EIGEN_MINOR_VERSION} )
+ set ( EIGEN_DEFINITIONS "")
+-set ( EIGEN_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/${INCLUDE_INSTALL_DIR}" )
+ set ( EIGEN_ROOT_DIR ${CMAKE_INSTALL_PREFIX} )
++GNUInstallDirs_get_absolute_install_dir(EIGEN_INCLUDE_DIR INCLUDE_INSTALL_DIR)
++
++if(EIGEN_BUILD_PKGCONFIG)
++    configure_file(eigen3.pc.in eigen3.pc @ONLY)
++    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/eigen3.pc
++        DESTINATION ${PKGCONFIG_INSTALL_DIR}
++        )
++endif()
+ 
+ # Interface libraries require at least CMake 3.0
+ if (NOT CMAKE_VERSION VERSION_LESS 3.0)
+diff --git a/eigen3.pc.in b/eigen3.pc.in
+index 3368a3aa1..d6778bf06 100644
+--- a/eigen3.pc.in
++++ b/eigen3.pc.in
+@@ -6,4 +6,4 @@ Description: A C++ template library for linear algebra: vectors, matrices, and r
+ Requires:
+ Version: @EIGEN_VERSION_NUMBER@
+ Libs:
+-Cflags: -I${prefix}/@INCLUDE_INSTALL_DIR@
++Cflags: -I@EIGEN_INCLUDE_DIR@

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1950,6 +1950,8 @@ in
     cudaSupport = config.cudaSupport or false;
   };
 
+  tensorflow-lite = callPackage ../development/libraries/science/math/tensorflow-lite { };
+
   behdad-fonts = callPackage ../data/fonts/behdad-fonts { };
 
   bfetch = callPackage ../tools/misc/bfetch { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This change introduces `tensorflow-lite`, including associated headers, libraries and binaries
at the `v2.5.0` tag for tensorflow.

I have a follow-up patch ready to go to introduce the Coral libraries and headers for
development against Coral edge devices, initially supporting only the USB-C accelerator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).