### PR TITLE
initrd: cross compile fix

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -743,6 +743,11 @@ CREATE ROLE postgres LOGIN SUPERUSER;
      See <link xlink:href="https://github.com/NixOS/nixpkgs/pull/82743#issuecomment-674520472">the PR that changed this</link> for more info.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The <literal>makeInitrd</literal> helper package now seperates the <literal>compressor</literal> parameter from the arguments passed to the <literal>compressor</literal> (which will be properly escaped). So if you previously used e.g. <programlisting>makeInitrd { compressor = "xz --check=crc32 --lzma2=dict=512KiB"; }</programlisting>, replace this by: <programlisting>makeInitrd { compressor = "xz"; compressorArgs = [ "--check=crc32" "--lzma2=dict=512KiB" ]; }</programlisting> Similar changes were made to the compressor option of the <literal>boot.initrd</literal> module, which is no longer marked as internal.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -76,7 +76,7 @@ with lib;
 
     # Create the initrd
     system.build.netbootRamdisk = pkgs.makeInitrd {
-      inherit (config.boot.initrd) compressor;
+      inherit (config.boot.initrd) compressor compressorArgs;
       prepend = [ "${config.system.build.initialRamdisk}/initrd" ];
 
       contents =

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -512,7 +512,6 @@ in
     };
 
     boot.initrd.compressor = mkOption {
-      internal = true;
       default = "gzip";
       type = types.enum [ "cat" "gzip" "bzip2" "xz" "lz4" "lzop" "zstd" ];
       description = "The compressor to use on the initrd image.";
@@ -520,7 +519,6 @@ in
     };
 
     boot.initrd.compressorArgs = mkOption {
-      internal = true;
       default = [];
       type = types.listOf types.str;
       description = "Arguments to pass to the compressor for the initrd image.";

--- a/pkgs/build-support/kernel/make-initrd.sh
+++ b/pkgs/build-support/kernel/make-initrd.sh
@@ -40,7 +40,7 @@ for PREP in $prepend; do
   cat $PREP >> $out/initrd
 done
 (cd root && find * -print0 | xargs -0r touch -h -d '@1')
-(cd root && find * -print0 | sort -z | cpio -o -H newc -R +0:+0 --reproducible --null | $compressor >> $out/initrd)
+(cd root && find * -print0 | sort -z | cpio -o -H newc -R +0:+0 --reproducible --null | eval -- $compress >> $out/initrd)
 
 if [ -n "$makeUInitrd" ]; then
     mv $out/initrd $out/initrd.gz


### PR DESCRIPTION
###### Motivation for this change

Make `initrd` building logic cross friendly, see discussion [here](https://github.com/NixOS/nixpkgs/pull/92964).
I hope this is the right way to go about it, I have zero experience with cross.

As a side effect this makes for a somewhat cleaner interface to `initrd` compression options, which also get exposed (the `compressor` option was marked as internal before this).

###### Things done

Did some basic testing on my local machine playing with `xz` compression and compression levels.
Sadly I don't have the setup to quickly test cross compiling though..
