### PR TITLE
makeModulesClosure: fixup firmware extraction

### DIFF
--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -78,7 +78,7 @@ for module in $(cat closure); do
     #
     # For now, the workaround is just to filter out the extraneous lines out
     # of its output.
-    for i in $(modinfo -F firmware $module | grep -v '^name:'); do
+    for i in $(modinfo -b $kernel --set-version "$version" -F firmware $module | grep -v '^name:'); do
         mkdir -p "$out/lib/firmware/$(dirname "$i")"
         echo "firmware for $module: $i"
         cp "$firmware/lib/firmware/$i" "$out/lib/firmware/$i" 2>/dev/null || if test -z "$allowMissing"; then exit 1; fi

--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -68,7 +68,17 @@ done
 
 mkdir -p $out/lib/firmware
 for module in $(cat closure); do
-    for i in $(modinfo -F firmware $module); do
+    # for builtin modules, modinfo will reply with a wrong output looking like:
+    #   $ modinfo -F firmware unix
+    #   name:           unix
+    #
+    # There is a pending attempt to fix this:
+    #   https://github.com/NixOS/nixpkgs/pull/96153
+    #   https://lore.kernel.org/linux-modules/20200823215433.j5gc5rnsmahpf43v@blumerang/T/#u
+    #
+    # For now, the workaround is just to filter out the extraneous lines out
+    # of its output.
+    for i in $(modinfo -F firmware $module | grep -v '^name:'); do
         mkdir -p "$out/lib/firmware/$(dirname "$i")"
         echo "firmware for $module: $i"
         cp "$firmware/lib/firmware/$i" "$out/lib/firmware/$i" 2>/dev/null || if test -z "$allowMissing"; then exit 1; fi


### PR DESCRIPTION
###### Motivation for this change
When building on a non nixos platform, I would get error trying to lookup the firmware for unix module. `modinfo -F firmware unix` output looks wrong. This is an attempt  to work around that. Also I'm not sure we were loading module information from the to-be-loaded kernel, but rather the currently running one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
