### PR TITLE
thin-provisioning-tools: 0.7.6 -> 0.9.0

### DIFF
--- a/pkgs/tools/misc/thin-provisioning-tools/default.nix
+++ b/pkgs/tools/misc/thin-provisioning-tools/default.nix
@@ -1,33 +1,19 @@
-{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, expat, libaio, boost }:
+{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, expat, libaio, boost, binutils }:
 
 stdenv.mkDerivation rec {
   pname = "thin-provisioning-tools";
-  version = "0.7.6";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "jthornber";
     repo = "thin-provisioning-tools";
     rev = "v${version}";
-    sha256 = "175mk3krfdmn43cjw378s32hs62gq8fmq549rjmyc651sz6jnj0g";
+    sha256 = "1iwg04rhmdhijmlk5hfl8wvv83115lzb65if6cc1glkkfva8jfjp";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  buildInputs = [ expat libaio boost ];
-
-  patches = [
-    (fetchpatch {
-      # a) Fix build if limits.h provides definition for PAGE_SIZE, as musl does w/musl per XSI[1] although it's apparently optional [2].
-      #    This value is only provided when it's known to be a constant, to avoid the need to discover the value dynamically.
-      # b) If not using system-provided (kernel headers, or libc headers, or something) use the POSIX approach of querying the value
-      #    dynamically using sysconf(_SC_PAGE_SIZE) instead of hardcoded value that hopefully is correct.
-      # [1] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html
-      # [2] http://www.openwall.com/lists/musl/2015/09/11/8
-      url = "https://raw.githubusercontent.com/void-linux/void-packages/a0ece13ad7ab2aae760e09e41e0459bd999a3695/srcpkgs/thin-provisioning-tools/patches/musl.patch";
-      sha256 = "1m8r3vhrnsy8drgs0svs3fgpi3mmxzdcqsv6bmvc0j52cvfqvhvy";
-      extraPrefix = ""; # empty means add 'a/' and 'b/'
-    })
-  ];
+  buildInputs = [ expat libaio boost binutils ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

thin-provisinoning-tool 0.9.0 includes some fixes regarding static builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
