### PR TITLE
pciutils: fixup musl support

### DIFF
--- a/pkgs/tools/system/pciutils/default.nix
+++ b/pkgs/tools/system/pciutils/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, zlib, kmod, which }:
+{ stdenv
+, fetchurl
+, pkgconfig
+, zlib
+, kmod
+, which
+, shared ? true
+}:
 
 stdenv.mkDerivation rec {
   name = "pciutils-3.7.0"; # with release-date database
@@ -12,7 +19,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ zlib kmod which ];
 
   makeFlags = [
-    "SHARED=yes"
+    "SHARED=${if (shared) then "yes" else "no"}"
     "PREFIX=\${out}"
     "STRIP="
     "HOST=${stdenv.hostPlatform.system}"

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -268,6 +268,8 @@ in {
     if set ? overrideScope' then set.overrideScope' ocamlStaticAdapter else set
   ) super.ocaml-ng;
 
+  pciutils = super.pciutils.override { shared = false; };
+
   python27 = super.python27.override { static = true; };
   python36 = super.python36.override { static = true; };
   python37 = super.python37.override { static = true; };


### PR DESCRIPTION
###### Motivation for this change

fix build on musl

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
