### PR TITLE
libsepol: fixup static compilation

### DIFF
--- a/pkgs/os-specific/linux/libsepol/default.nix
+++ b/pkgs/os-specific/linux/libsepol/default.nix
@@ -23,9 +23,15 @@ stdenv.mkDerivation rec {
     "MAN3DIR=$(man)/share/man/man3"
     "MAN8DIR=$(man)/share/man/man8"
     "SHLIBDIR=$(out)/lib"
+  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl [
+    "-f" "Makefile.static"
   ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
+
+  patches = stdenv.lib.optional stdenv.hostPlatform.isMusl [
+    ./static.patch
+  ];
 
   passthru = { inherit se_release se_url; };
 

--- a/pkgs/os-specific/linux/libsepol/static.patch
+++ b/pkgs/os-specific/linux/libsepol/static.patch
@@ -1,0 +1,24 @@
+diff -Nur a/Makefile.static b/Makefile.static
+--- a/Makefile.static	1970-01-01 00:00:00.000000000 +0000
++++ b/Makefile.static	2020-04-12 14:32:40.701684751 +0000
+@@ -0,0 +1,9 @@
++all:
++	$(MAKE) -f Makefile.static -C src all-static
++	$(MAKE) -C utils all
++
++install:
++	$(MAKE) -C include install
++	$(MAKE) -f Makefile.static -C src install-static
++	$(MAKE) -C utils install
++	$(MAKE) -C man install
+diff -Nur a/src/Makefile.static b/src/Makefile.static
+--- a/src/Makefile.static	1970-01-01 00:00:00.000000000 +0000
++++ b/src/Makefile.static	2020-04-12 14:30:00.131285362 +0000
+@@ -0,0 +1,7 @@
++include Makefile
++
++all-static: $(LIBA)
++
++install-static: all-static
++	test -d $(DESTDIR)$(LIBDIR) || install -m 755 -d $(DESTDIR)$(LIBDIR)
++	install -m 644 $(LIBA) $(DESTDIR)$(LIBDIR)


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
