### PR TITLE
util-linux: fixup musl compilation

### DIFF
--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./rtcwake-search-PATH-for-shutdown.patch
+  ] ++ lib.optional stdenv.hostPlatform.isMusl [
+    ./musl.patch
   ];
 
   outputs = [ "bin" "dev" "out" "man" ];

--- a/pkgs/os-specific/linux/util-linux/musl.patch
+++ b/pkgs/os-specific/linux/util-linux/musl.patch
@@ -1,0 +1,33 @@
+Fixup musl compilation
+
+In file included from misc-utils/kill.c:57:
+./include/pidfd-utils.h: In function 'pidfd_open':
+./include/pidfd-utils.h:20:17: error: 'SYS_pidfd_open' undeclared (first use in this function); did you mean 'pidfd_open'?
+   20 |  return syscall(SYS_pidfd_open, pid, flags);
+      |                 ^~~~~~~~~~~~~~
+      |                 pidfd_open
+./include/pidfd-utils.h:20:17: note: each undeclared identifier is reported only once for each function it appears in
+./include/pidfd-utils.h:21:1: warning: control reaches end of non-void function [-Wreturn-type]
+   21 | }
+      | ^
+
+diff -ur util-linux-2.35.2.orig/include/pidfd-utils.h util-linux-2.35.2/include/pidfd-utils.h
+--- util-linux-2.35.2.orig/include/pidfd-utils.h	2020-05-20 05:27:43.451013558 -0700
++++ util-linux-2.35.2/include/pidfd-utils.h	2020-07-18 19:28:01.513860196 -0700
+@@ -3,6 +3,7 @@
+ 
+ #if defined(__linux__)
+ # include <sys/syscall.h>
++# include <asm-generic/unistd.h>
+ # if defined(SYS_pidfd_send_signal)
+ #  include <sys/types.h>
+ 
+@@ -17,7 +18,7 @@
+ #  ifndef HAVE_PIDFD_SEND_SIGNAL
+ static inline int pidfd_open(pid_t pid, unsigned int flags)
+ {
+-	return syscall(SYS_pidfd_open, pid, flags);
++	return syscall(__NR_pidfd_open, pid, flags);
+ }
+ #  endif
+ 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
