### PR TITLE
libpwquality: fixup static build

### DIFF
--- a/pkgs/development/libraries/libpwquality/default.nix
+++ b/pkgs/development/libraries/libpwquality/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, perl, cracklib, python3 }:
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, perl, cracklib, python3, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "libpwquality";
@@ -11,8 +11,21 @@ stdenv.mkDerivation rec {
     sha256 = "0n4pjhm7wfivk0wizggaxq4y4mcxic876wcarjabkp5z9k14y36h";
   };
 
-  nativeBuildInputs = [ autoreconfHook perl ];
-  buildInputs = [ cracklib python3 ];
+  nativeBuildInputs = [ autoreconfHook perl python3 ];
+  buildInputs = [ cracklib ];
+
+  patches = lib.optional stdenv.hostPlatform.isMusl [
+    (fetchpatch {
+      name = "static-build.patch";
+      url = "https://github.com/libpwquality/libpwquality/pull/40.patch";
+      sha256 = "1ypccq437wxwgddd98cvd330jfm7jscdlzlyxgy05g6yzrr68xyk";
+    })
+  ];
+
+  configureFlags = lib.optional stdenv.hostPlatform.isMusl [
+    # Python binding generates a shared library which are unavailable with musl build
+    "--disable-python-bindings"
+  ];
 
   meta = with lib; {
     description = "Password quality checking and random password generation library";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
