### PR TITLE
postgresqlPackages.age: init at 0.2.0

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/age.nix
+++ b/pkgs/servers/sql/postgresql/ext/age.nix
@@ -1,0 +1,65 @@
+{ stdenv, fetchFromGitHub, bison, flex, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "age";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "bitnine-oss";
+    repo = "AgensGraph-Extension";
+    rev = "v${version}";
+    sha256 = "0way59lj30727jlz2qz6rnw4fsxcd5028xcwgrwk7jxcaqi5fa17";
+  };
+
+  buildInputs = [ postgresql ];
+
+  makeFlags = [
+    "BISON=${bison}/bin/bison"
+    "FLEX=${flex}/bin/flex"
+  ];
+
+  installPhase = ''
+    install -D -t $out/lib *.so
+    install -D -t $out/share/postgresql/extension *.sql
+    install -D -t $out/share/postgresql/extension *.control
+  '';
+
+  passthru.tests = stdenv.mkDerivation {
+    inherit version src;
+
+    pname = "age-regression";
+
+    dontConfigure = true;
+
+    buildPhase = let
+      postgresqlAge = postgresql.withPackages (ps: [ ps.age ]);
+    in ''
+      # The regression tests need to be run in the order specified in the Makefile.
+      echo -e "include Makefile\nfiles:\n\t@echo \$(REGRESS)" > Makefile.regress
+      REGRESS_TESTS=$(make -f Makefile.regress files)
+
+      ${postgresql}/lib/pgxs/src/test/regress/pg_regress \
+        --inputdir=./ \
+        --bindir='${postgresqlAge}/bin' \
+        --encoding=UTF-8 \
+        --load-extension=age \
+        --inputdir=./regress --outputdir=./regress --temp-instance=./regress/instance \
+        --port=61958 --dbname=contrib_regression \
+        $REGRESS_TESTS
+    '';
+
+    installPhase = ''
+      touch $out
+    '';
+  };
+
+  meta = with stdenv.lib; {
+    description = "A graph database extension for PostgreSQL";
+    homepage = "https://github.com/bitnine-oss/AgensGraph-Extension";
+    changelog = "https://github.com/bitnine-oss/AgensGraph-Extension/releases/tag/v${version}";
+    maintainers = with maintainers; [ danieldk ];
+    platforms = postgresql.meta.platforms;
+    license = licenses.asl20;
+    broken = versionOlder postgresql.version "11.0";
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -1,5 +1,7 @@
 self: super: {
 
+    age = super.callPackage ./ext/age.nix { };
+
     periods = super.callPackage ./ext/periods.nix { };
 
     postgis = super.callPackage ./ext/postgis.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Apache AGE is an extension of PostgreSQL that provides an implementation
of the openCypher query language.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
