### PR TITLE
powerdevil: backport fix for debug log spam

### DIFF
--- a/pkgs/desktops/plasma-5/patches/0001-Add-a-logging-category-config-file.patch
+++ b/pkgs/desktops/plasma-5/patches/0001-Add-a-logging-category-config-file.patch
@@ -1,0 +1,210 @@
+From e63a0dc2a7b185906a93d60e9d5d6deee4950efc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?M=C3=A9ven=20Car?= <meven.car@enioka.com>
+Date: Wed, 20 May 2020 14:02:07 +0200
+Subject: [PATCH] Add a logging category config file
+
+Makes powerdevil default logging level Warning
+---
+ CMakeLists.txt                     |  2 ++
+ daemon/CMakeLists.txt              |  6 ++++++
+ daemon/actions/dpms/CMakeLists.txt |  2 +-
+ daemon/backends/CMakeLists.txt     |  6 +++---
+ daemon/powerdevil_debug.cpp        | 21 ---------------------
+ daemon/powerdevil_debug.h          | 26 --------------------------
+ kcmodule/activities/CMakeLists.txt |  2 +-
+ kcmodule/common/CMakeLists.txt     |  2 +-
+ kcmodule/profiles/CMakeLists.txt   |  2 +-
+ powerdevil.categories              |  1 +
+ 10 files changed, 16 insertions(+), 54 deletions(-)
+ delete mode 100644 daemon/powerdevil_debug.cpp
+ delete mode 100644 daemon/powerdevil_debug.h
+ create mode 100644 powerdevil.categories
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5ded8f5a..52a7318c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,6 +11,7 @@ find_package(ECM ${KF5_MIN_VERSION} REQUIRED NO_MODULE)
+ set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+ 
+ include(ECMSetupVersion)
++include(ECMQtDeclareLoggingCategory)
+ include(FeatureSummary)
+ include(KDEInstallDirs)
+ include(KDECMakeSettings)
+@@ -76,6 +77,7 @@ add_subdirectory(daemon)
+ add_subdirectory(kcmodule)
+ add_subdirectory(doc)
+ 
++install( FILES powerdevil.categories  DESTINATION  ${KDE_INSTALL_LOGGINGCATEGORIESDIR})
+ install( FILES powerdevil.notifyrc DESTINATION ${KDE_INSTALL_KNOTIFY5RCDIR} )
+ 
+ feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES FATAL_ON_MISSING_REQUIRED_PACKAGES)
+diff --git a/daemon/CMakeLists.txt b/daemon/CMakeLists.txt
+index 33ca655b..96cc9b7b 100644
+--- a/daemon/CMakeLists.txt
++++ b/daemon/CMakeLists.txt
+@@ -48,6 +48,12 @@ set(powerdevilcore_SRCS
+     kwinkscreenhelpereffect.cpp
+ )
+ 
++ecm_qt_declare_logging_category(powerdevilcore_SRCS
++   HEADER powerdevil_debug.h
++   IDENTIFIER POWERDEVIL
++   CATEGORY_NAME org.kde.powerdevil
++   DEFAULT_SEVERITY Warning)
++
+ kconfig_add_kcfg_files(powerdevilcore_SRCS ../PowerDevilSettings.kcfgc)
+ 
+ # Action DBus Adaptors
+diff --git a/daemon/actions/dpms/CMakeLists.txt b/daemon/actions/dpms/CMakeLists.txt
+index f8ca4e20..3b8bd95b 100644
+--- a/daemon/actions/dpms/CMakeLists.txt
++++ b/daemon/actions/dpms/CMakeLists.txt
+@@ -3,7 +3,7 @@ include_directories(${PowerDevil_SOURCE_DIR}/daemon
+                     ${CMAKE_CURRENT_BINARY_DIR})
+ 
+ set(powerdevildpmsaction_SRCS
+-    ${PowerDevil_SOURCE_DIR}/daemon/powerdevil_debug.cpp
++    ${CMAKE_CURRENT_BINARY_DIR}/../../powerdevil_debug.cpp
+     powerdevildpmsaction.cpp
+     abstractdpmshelper.cpp
+     xcbdpmshelper.cpp
+diff --git a/daemon/backends/CMakeLists.txt b/daemon/backends/CMakeLists.txt
+index 89400446..05c4263e 100644
+--- a/daemon/backends/CMakeLists.txt
++++ b/daemon/backends/CMakeLists.txt
+@@ -4,7 +4,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/upower
+                     ${X11_Xrandr_INCLUDE_PATH})
+ 
+ set(powerdevilupowerbackend_SRCS
+-    ${PowerDevil_SOURCE_DIR}/daemon/powerdevil_debug.cpp
++    ${CMAKE_CURRENT_BINARY_DIR}/../powerdevil_debug.cpp
+     upower/upowersuspendjob.cpp
+     upower/login1suspendjob.cpp
+     upower/powerdevilupowerbackend.cpp
+@@ -33,14 +33,14 @@ ${CMAKE_CURRENT_SOURCE_DIR}/upower/dbus/org.freedesktop.UPower.KbdBacklight.xml
+ upower_kbdbacklight_interface)
+ 
+ ## backlight helper executable
+-add_executable(backlighthelper upower/backlighthelper.cpp ${PowerDevil_SOURCE_DIR}/daemon/powerdevil_debug.cpp ${backlighthelper_mocs})
++add_executable(backlighthelper upower/backlighthelper.cpp ${CMAKE_CURRENT_BINARY_DIR}/../powerdevil_debug.cpp ${backlighthelper_mocs})
+ target_link_libraries(backlighthelper Qt5::Core KF5::AuthCore KF5::I18n)
+ install(TARGETS backlighthelper DESTINATION ${KAUTH_HELPER_INSTALL_DIR})
+ kauth_install_helper_files(backlighthelper org.kde.powerdevil.backlighthelper root)
+ kauth_install_actions(org.kde.powerdevil.backlighthelper ${CMAKE_CURRENT_SOURCE_DIR}/upower/backlight_helper_actions.actions)
+ 
+ ## discrete gpu helper executable
+-add_executable(discretegpuhelper upower/discretegpuhelper.cpp ${PowerDevil_SOURCE_DIR}/daemon/powerdevil_debug.cpp ${discretegpuhelper_mocs})
++add_executable(discretegpuhelper upower/discretegpuhelper.cpp ${CMAKE_CURRENT_BINARY_DIR}/../powerdevil_debug.cpp ${discretegpuhelper_mocs})
+ target_link_libraries(discretegpuhelper Qt5::Core KF5::AuthCore)
+ install(TARGETS discretegpuhelper DESTINATION ${KAUTH_HELPER_INSTALL_DIR})
+ kauth_install_helper_files(discretegpuhelper org.kde.powerdevil.discretegpuhelper root)
+diff --git a/daemon/powerdevil_debug.cpp b/daemon/powerdevil_debug.cpp
+deleted file mode 100644
+index 86172c1b..00000000
+--- a/daemon/powerdevil_debug.cpp
++++ /dev/null
+@@ -1,21 +0,0 @@
+-/*  This file is part of the KDE project
+-    Copyright (C) 2014 Hrvoje Senjan <hrvoje.senjan@gmail.com>
+-
+-    This library is free software; you can redistribute it and/or
+-    modify it under the terms of the GNU Library General Public
+-    License as published by the Free Software Foundation; either
+-    version 2 of the License, or (at your option) any later version.
+-
+-    This library is distributed in the hope that it will be useful,
+-    but WITHOUT ANY WARRANTY; without even the implied warranty of
+-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-    Library General Public License for more details.
+-
+-    You should have received a copy of the GNU Library General Public License
+-    along with this library; see the file COPYING.LIB.  If not, write to
+-    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+-    Boston, MA 02110-1301, USA.
+-*/
+-
+-#include "powerdevil_debug.h"
+-Q_LOGGING_CATEGORY(POWERDEVIL, "powerdevil")
+diff --git a/daemon/powerdevil_debug.h b/daemon/powerdevil_debug.h
+deleted file mode 100644
+index fcd9c10f..00000000
+--- a/daemon/powerdevil_debug.h
++++ /dev/null
+@@ -1,26 +0,0 @@
+-/*  This file is part of the KDE project
+-    Copyright (C) 2014 Hrvoje Senjan <hrvoje.senjan@gmail.com>
+-
+-    This library is free software; you can redistribute it and/or
+-    modify it under the terms of the GNU Library General Public
+-    License as published by the Free Software Foundation; either
+-    version 2 of the License, or (at your option) any later version.
+-
+-    This library is distributed in the hope that it will be useful,
+-    but WITHOUT ANY WARRANTY; without even the implied warranty of
+-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-    Library General Public License for more details.
+-
+-    You should have received a copy of the GNU Library General Public License
+-    along with this library; see the file COPYING.LIB.  If not, write to
+-    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+-    Boston, MA 02110-1301, USA.
+-*/
+-
+-#ifndef PROCESSCORE_DEBUG_H
+-#define PROCESSCORE_DEBUG_H
+-
+-#include <QLoggingCategory>
+-Q_DECLARE_LOGGING_CATEGORY(POWERDEVIL)
+-
+-#endif
+diff --git a/kcmodule/activities/CMakeLists.txt b/kcmodule/activities/CMakeLists.txt
+index 41a6da48..6e248e91 100644
+--- a/kcmodule/activities/CMakeLists.txt
++++ b/kcmodule/activities/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ add_definitions(-DTRANSLATION_DOMAIN=\"powerdevilactivitiesconfig\")
+ 
+ set( kcm_powerdevil_activities_SRCS
+-     ${PowerDevil_SOURCE_DIR}/daemon/powerdevil_debug.cpp
++     ${CMAKE_CURRENT_BINARY_DIR}/../../daemon/powerdevil_debug.cpp
+      activitypage.cpp
+      activitywidget.cpp
+      ../common/ErrorOverlay.cpp
+diff --git a/kcmodule/common/CMakeLists.txt b/kcmodule/common/CMakeLists.txt
+index ca483fa7..400b7746 100644
+--- a/kcmodule/common/CMakeLists.txt
++++ b/kcmodule/common/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ add_definitions(-DTRANSLATION_DOMAIN=\"libpowerdevilcommonconfig\")
+ 
+ set( powerdevil_config_common_private_SRCS
+-    ${PowerDevil_SOURCE_DIR}/daemon/powerdevil_debug.cpp
++    ${CMAKE_CURRENT_BINARY_DIR}/../../daemon/powerdevil_debug.cpp
+     actionconfigwidget.cpp
+     actioneditwidget.cpp
+     ErrorOverlay.cpp
+diff --git a/kcmodule/profiles/CMakeLists.txt b/kcmodule/profiles/CMakeLists.txt
+index ac5c96e0..32279089 100644
+--- a/kcmodule/profiles/CMakeLists.txt
++++ b/kcmodule/profiles/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ add_definitions(-DTRANSLATION_DOMAIN=\"powerdevilprofilesconfig\")
+ 
+ set( kcm_powerdevil_profiles_SRCS
+-     ${PowerDevil_SOURCE_DIR}/daemon/powerdevil_debug.cpp
++     ${CMAKE_CURRENT_BINARY_DIR}/../../daemon/powerdevil_debug.cpp
+      EditPage.cpp
+      ${PowerDevil_SOURCE_DIR}/daemon/powerdevilprofilegenerator.cpp
+ )
+diff --git a/powerdevil.categories b/powerdevil.categories
+new file mode 100644
+index 00000000..3147de54
+--- /dev/null
++++ b/powerdevil.categories
+@@ -0,0 +1 @@
++org.kde.powerdevil Powerdevil DEFAULT_SEVERITY [WARNING] IDENTIFIER [POWERDEVIL]
+-- 
+2.25.4
+

--- a/pkgs/desktops/plasma-5/powerdevil.nix
+++ b/pkgs/desktops/plasma-5/powerdevil.nix
@@ -27,5 +27,10 @@ mkDerivation {
       url = "https://invent.kde.org/plasma/powerdevil/-/commit/fcb26be2fb279e6ad3b7b814d26a5921d16201eb.patch";
       sha256 = "0gdyaa0nd1c1d6x2h0m933lascm8zm5sikd99wxmkf7hhaby6k2s";
     })
+    # This is a backport of
+    # https://invent.kde.org/plasma/powerdevil/-/commit/c7590f9065ec9547b7fabad77a548bbc0c693113.patch,
+    # which doesn't apply cleanly to 5.17.5.  It should make it into 5.20, so
+    # this patch can be removed when we upgrade to 5.20.
+    ./patches/0001-Add-a-logging-category-config-file.patch
   ];
 }


### PR DESCRIPTION
This is a copy of the botched PR #94301 (sorry about that).

----

The version of powerdevil we're using prints a few debug messages every time an
inhibition is triggered, including some spurious messages about not being able
to contact consolekit.  This can cause a lot of spam in the system journal,
especially when a web browser or other application that plays video is running,
because such applications often trigger such inhibitions very frequently.

A recent upstream commit to powerdevil changes the logging behavior of the
program so that it doesn't print debug messages anymore.  This commit backports
that patch to our version of powerdevil (5.17.5).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
