### PR TITLE
picamera: init at 1.13

### DIFF
--- a/pkgs/development/python-modules/picamera/default.nix
+++ b/pkgs/development/python-modules/picamera/default.nix
@@ -2,10 +2,15 @@
 , buildPythonPackage
 , numpy
 , fetchPypi
+, fetchpatch
 }:
 let
   pname = "picamera";
   version = "1.13";
+  removeCustomInstallCommandPatch = fetchpatch {
+    url = "https://github.com/waveform80/picamera/commit/c145015837caf512cdef777894b8c203998c1359.patch";
+    sha256 = "0m9s3nrrqkalpywl8zjbcji1nbgf97c4biigil4v2gmpg4gc94b5";
+  };
 in
 buildPythonPackage rec {
   inherit pname version;
@@ -16,7 +21,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    https://github.com/waveform80/picamera/commit/c145015837caf512cdef777894b8c203998c1359.patch
+    removeCustomInstallCommandPatch
   ];
   propagatedBuildInputs = [ numpy ];
 

--- a/pkgs/development/python-modules/picamera/default.nix
+++ b/pkgs/development/python-modules/picamera/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, numpy
+, fetchPypi
+}:
+let
+  pname = "picamera";
+  version = "1.13";
+in
+buildPythonPackage rec {
+  inherit pname version;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0l1y2qda7ighgm00c8cqajwscwmqac4svlsxm6k5bn7406m1a249";
+  };
+
+  propagatedBuildInputs = [ numpy ];
+
+  meta = with lib; {
+    description = "A pure Python interface to the Raspberry Pi camera module for Python 2.7 (or above) or Python 3.2 (or above).";
+    homepage = "https://github.com/waveform80/picamera";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ cpcloud ];
+    platforms = [ "aarch64-linux" ];
+  };
+}

--- a/pkgs/development/python-modules/picamera/default.nix
+++ b/pkgs/development/python-modules/picamera/default.nix
@@ -3,6 +3,7 @@
 , numpy
 , fetchPypi
 , fetchpatch
+, raspberrypi-tools
 }:
 let
   pname = "picamera";
@@ -23,6 +24,8 @@ buildPythonPackage rec {
   patches = [
     removeCustomInstallCommandPatch
   ];
+
+  buildInputs = [ raspberrypi-tools ];
   propagatedBuildInputs = [ numpy ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/picamera/default.nix
+++ b/pkgs/development/python-modules/picamera/default.nix
@@ -15,6 +15,9 @@ buildPythonPackage rec {
     sha256 = "0l1y2qda7ighgm00c8cqajwscwmqac4svlsxm6k5bn7406m1a249";
   };
 
+  patches = [
+    https://github.com/waveform80/picamera/commit/c145015837caf512cdef777894b8c203998c1359.patch
+  ];
   propagatedBuildInputs = [ numpy ];
 
   meta = with lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1124,6 +1124,8 @@ in {
 
   pdfx = callPackage ../development/python-modules/pdfx { };
 
+  picamera = callPackage ../development/python-modules/picamera { };
+
   pushover-complete = callPackage ../development/python-modules/pushover-complete { };
 
   pyicloud = callPackage ../development/python-modules/pyicloud { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This PR introduces `picamera`, the pure Python interface to the Raspberry Pi camera.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).