### PR TITLE
write_stylus: refactor (sha256)

### DIFF
--- a/pkgs/applications/graphics/write_stylus/default.nix
+++ b/pkgs/applications/graphics/write_stylus/default.nix
@@ -1,29 +1,22 @@
 { mkDerivation, stdenv, lib, qtbase, qtsvg, libglvnd, libX11, libXi, fetchurl, makeDesktopItem }:
 let
-  # taken from: https://www.iconfinder.com/icons/50835/edit_pencil_write_icon
-  # license: Free for commercial use
-  desktopIcon = fetchurl {
-    url = "https://www.iconfinder.com/icons/50835/download/png/256";
-    sha256 = "0abdya42yf9alxbsmc2nf8jwld50zfria6z3d4ncvp1zw2a9jhb8";
+  desktopItem = makeDesktopItem {
+    name = "Write";
+    exec = "Write";
+    comment = "A word processor for handwriting";
+    icon = "write_stylus";
+    desktopName = "Write";
+    genericName = "Write";
+    categories = "Office;Graphics";
   };
 in
 mkDerivation rec {
   pname = "write_stylus";
   version = "300";
 
-  desktopItem = makeDesktopItem {
-    name = "Write";
-    exec = "Write";
-    comment = "A word processor for handwriting";
-    icon = desktopIcon;
-    desktopName = "Write";
-    genericName = "Write";
-    categories = "Office;Graphics";
-  };
-
   src = fetchurl {
     url = "http://www.styluslabs.com/write/write${version}.tar.gz";
-    sha256 = "1kg4qqxgg7iyxl13hkbl3j27dykra56dj67hbv0392mwdcgavihq";
+    sha256 = "0h1wf3af7jzp3f3l8mlnshi83d7a4v4y8nfqfai4lmskyicqlz7c";
   };
 
   sourceRoot = ".";
@@ -36,8 +29,11 @@ mkDerivation rec {
     # symlink the binary to bin/
     ln -s $out/Write/Write $out/bin/Write
 
+    # Create desktop item
     mkdir -p $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications/
+    mkdir -p $out/share/icons
+    ln -s $out/Write/Write144x144.png $out/share/icons/write_stylus.png
   '';
   preFixup = let
     libPath = lib.makeLibraryPath [


### PR DESCRIPTION
###### Motivation for this change
Checksum updated and https://github.com/NixOS/nixpkgs/issues/95963 fixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
