### PR TITLE
apparmor: add apparmor_parser config file

### DIFF
--- a/nixos/modules/security/apparmor.nix
+++ b/nixos/modules/security/apparmor.nix
@@ -23,11 +23,17 @@ in
          default = [];
          description = "List of packages to be added to apparmor's include path";
        };
+       parserConfig = mkOption {
+         type = types.str;
+         default = "";
+         description = "AppArmor parser configuration file content";
+       };
      };
    };
 
    config = mkIf cfg.enable {
      environment.systemPackages = [ pkgs.apparmor-utils ];
+     environment.etc."apparmor/parser.conf".text = cfg.parserConfig;
 
      boot.kernelParams = [ "apparmor=1" "security=apparmor" ];
 


### PR DESCRIPTION

###### Motivation for this change
If the config does not exist, then apparmor_parser will throw a warning.
To avoid that and make the parser configurable, we now add a new option
to it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
