### PR TITLE
python38Packages.coloredlogs: disable tests on darwin

### DIFF
--- a/pkgs/development/python-modules/coloredlogs/default.nix
+++ b/pkgs/development/python-modules/coloredlogs/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchFromGitHub
 , humanfriendly
@@ -7,6 +8,7 @@
 , pytest
 , mock
 , util-linux
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -20,13 +22,18 @@ buildPythonPackage rec {
     sha256 = "0rnmxwrim4razlv4vi3krxk5lc5ksck6h5374j8avqwplika7q2x";
   };
 
+  # capturer is broken on darwin / py38, so we skip the test until a fix for
+  # https://github.com/xolox/python-capturer/issues/10 is released.
+  doCheck = !(isPy38 && stdenv.isDarwin);
   checkPhase = ''
     PATH=$PATH:$out/bin pytest . -k "not test_plain_text_output_format \
                                      and not test_auto_install"
   '';
-  checkInputs = [ pytest mock util-linux ];
+  checkInputs = [ pytest mock util-linux verboselogs capturer ];
 
-  propagatedBuildInputs = [ humanfriendly verboselogs capturer ];
+  pythonImportsCheck = [ "coloredlogs" ];
+
+  propagatedBuildInputs = [ humanfriendly ];
 
   meta = with lib; {
     description = "Colored stream handler for Python's logging module";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

Fixing the build on darwin / py38 by turning `capturer` and `verboselogs` into `checkInputs` and disabling the test for this combo.
This can be reverted after https://github.com/xolox/python-capturer/issues/10 is fixed.

See 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
