### PR TITLE
hdt: init at 1.3.3

### DIFF
--- a/pkgs/misc/hdt/default.nix
+++ b/pkgs/misc/hdt/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, libtool, pkgconfig, zlib, serd }:
+
+stdenv.mkDerivation rec {
+  pname = "hdt";
+  version = "1.3.3";
+
+  src = fetchFromGitHub {
+    owner = "rdfhdt";
+    repo = "hdt-cpp";
+    rev = "v${version}";
+    sha256 = "1vsq80jnix6cy78ayag7v8ajyw7h8dqyad1q6xkf2hzz3skvr34z";
+  };
+
+  buildInputs = [ zlib serd ];
+
+  nativeBuildInputs = [ autoreconfHook libtool pkgconfig ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.rdfhdt.org/";
+    description = "Header Dictionary Triples (HDT) is a compression format for RDF data that can also be queried for Triple Patterns.";
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.koslambrou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12659,6 +12659,8 @@ in
 
   haxor-news = callPackage ../applications/misc/haxor-news { };
 
+  hdt = callPackage ../misc/hdt {};
+
   herqq = libsForQt5.callPackage ../development/libraries/herqq { };
 
   heyefi = haskellPackages.heyefi;


### PR DESCRIPTION
Added the hdt package in Nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Closes: #94670