### PR TITLE
keystore-explorer: init at 5.4.4

### DIFF
--- a/pkgs/applications/misc/keystore-explorer/default.nix
+++ b/pkgs/applications/misc/keystore-explorer/default.nix
@@ -1,0 +1,40 @@
+{ fetchzip, stdenv, jdk8, runtimeShell }:
+
+stdenv.mkDerivation rec {
+  version = "5.4.4";
+  pname = "keystore-explorer";
+  src = fetchzip {
+    url = "https://github.com/kaikramer/keystore-explorer/releases/download/v${version}/kse-544.zip";
+    sha256 = "01kpa8g6p6vcqq9y70w5bm8jbw4kp55pbywj2zrhgjibrhgjqi0b";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share/keystore-explorer
+    cp -R icons licenses lib kse.jar $out/share/keystore-explorer/
+
+    # keystore-explorer's kse.sh tries to detect the path of Java by using
+    # Python on Darwin; just write our own start script to avoid unnecessary dependencies
+    cat > $out/bin/keystore-explorer <<EOF
+    #!${runtimeShell}
+    export JAVA_HOME=${jdk8.home}
+    exec ${jdk8}/bin/java -jar $out/share/keystore-explorer/kse.jar "\$@"
+    EOF
+    chmod +x $out/bin/keystore-explorer
+
+    runHook postInstall
+  '';
+
+  dontStrip = true;
+  dontBuild = true;
+  dontConfigure = true;
+
+  meta = {
+    description = "Open source GUI replacement for the Java command-line utilities keytool and jarsigner";
+    license = stdenv.lib.licenses.gpl3Only;
+    maintainers = [ stdenv.lib.maintainers.numinit ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5091,6 +5091,8 @@ in
 
   keyfuzz = callPackage ../tools/inputmethods/keyfuzz { };
 
+  keystore-explorer = callPackage ../applications/misc/keystore-explorer { };
+
   kibana6 = callPackage ../development/tools/misc/kibana/6.x.nix { };
   kibana6-oss = callPackage ../development/tools/misc/kibana/6.x.nix {
     enableUnfree = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adding piece of fairly widely used software.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
