### PR TITLE
easyrsa: 3.0.0 -> 3.0.8

### DIFF
--- a/pkgs/tools/networking/easyrsa/default.nix
+++ b/pkgs/tools/networking/easyrsa/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, openssl, runtimeShell }:
 
 let
-  version = "3.0.0";
+  version = "3.0.8";
 in stdenv.mkDerivation {
   pname = "easyrsa";
   inherit version;
@@ -10,14 +10,15 @@ in stdenv.mkDerivation {
     owner = "OpenVPN";
     repo = "easy-rsa";
     rev = "v${version}";
-    sha256 = "0wbdv3wmqwm5680rpb971l56xiw49adpicqshk3vhfmpvqzl4dbs";
+    sha256 = "05q60s343ydh9j6hzj0840qdcq8fkyz06q68yw4pqgqg4w68rbgs";
   };
 
   patches = [ ./fix-paths.patch ];
 
   installPhase = ''
     mkdir -p $out/share/easyrsa
-    cp -r easyrsa3/{openssl*.cnf,x509-types,vars.example} $out/share/easyrsa
+    cp -r easyrsa3/{*.cnf,x509-types,vars.example} $out/share/easyrsa
+    cp easyrsa3/openssl-easyrsa.cnf $out/share/easyrsa/safessl-easyrsa.cnf
     install -D -m755 easyrsa3/easyrsa $out/bin/easyrsa
     substituteInPlace $out/bin/easyrsa \
       --subst-var out \
@@ -35,7 +36,7 @@ in stdenv.mkDerivation {
     description = "Simple shell based CA utility";
     homepage = "https://openvpn.net/";
     license = licenses.gpl2;
-    maintainers = [ maintainers.offline ];
+    maintainers = [ maintainers.offline maintainers.numinit ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/networking/easyrsa/fix-paths.patch
+++ b/pkgs/tools/networking/easyrsa/fix-paths.patch
@@ -1,33 +1,49 @@
 diff --git a/easyrsa3/easyrsa b/easyrsa3/easyrsa
-index 6fec288..210648a 100755
+index 261336f..7b9a79b 100755
 --- a/easyrsa3/easyrsa
 +++ b/easyrsa3/easyrsa
-@@ -1003,7 +1003,7 @@ Note: using Easy-RSA configuration from: $vars"
+@@ -1661,7 +1661,7 @@ Note: using Easy-RSA configuration from: $vars"
  	
  	# Set defaults, preferring existing env-vars if present
- 	set_var EASYRSA		"$PWD"
+ 	set_var EASYRSA		"$prog_dir"
 -	set_var EASYRSA_OPENSSL	openssl
 +	set_var EASYRSA_OPENSSL	"@openssl@"
- 	set_var EASYRSA_PKI	"$EASYRSA/pki"
+ 	set_var EASYRSA_PKI	"$PWD/pki"
  	set_var EASYRSA_DN	cn_only
  	set_var EASYRSA_REQ_COUNTRY	"US"
-@@ -1030,13 +1030,17 @@ Note: using Easy-RSA configuration from: $vars"
- 	# Detect openssl config, preferring EASYRSA_PKI over EASYRSA
- 	if [ -f "$EASYRSA_PKI/openssl-1.0.cnf" ]; then
- 		set_var EASYRSA_SSL_CONF	"$EASYRSA_PKI/openssl-1.0.cnf"
--	else	set_var EASYRSA_SSL_CONF	"$EASYRSA/openssl-1.0.cnf"
-+	elif [ -f "$EASYRSA/openssl-1.0.cnf" ]; then
-+		set_var EASYRSA_SSL_CONF	"$EASYRSA/openssl-1.0.cnf"
-+	else	set_var EASYRSA_SSL_CONF	"@out@/share/easyrsa/openssl-1.0.cnf"
- 	fi
+@@ -1683,16 +1683,31 @@ Note: using Easy-RSA configuration from: $vars"
+ 	set_var EASYRSA_TEMP_DIR	"$EASYRSA_PKI"
+ 	set_var EASYRSA_REQ_CN		ChangeMe
+ 	set_var EASYRSA_DIGEST		sha256
+-	set_var EASYRSA_SSL_CONF	"$EASYRSA_PKI/openssl-easyrsa.cnf"
+-	set_var EASYRSA_SAFE_CONF	"$EASYRSA_PKI/safessl-easyrsa.cnf"
+ 	set_var EASYRSA_KDC_REALM	"CHANGEME.EXAMPLE.COM"
  
++	if [ -f "$EASYRSA_PKI/safessl-easyrsa.conf" ]; then
++		set_var EASYRSA_SAFE_CONF	"$EASYRSA_PKI/safessl-easyrsa.cnf"
++	elif [ -f "$EASYRSA/safessl-easyrsa.conf" ]; then
++		set_var EASYRSA_SAFE_CONF	"$EASYRSA/safessl-easyrsa.cnf"
++	elif [ -f "@out@/share/easyrsa/safessl-easyrsa.cnf" ]; then
++		set_var EASYRSA_SAFE_CONF	"@out@/share/easyrsa/safessl-easyrsa.cnf"
++	fi
++
++	if [ -f "$EASYRSA_PKI/openssl-easyrsa.conf" ]; then
++		set_var EASYRSA_SSL_CONF	"$EASYRSA_PKI/openssl-easyrsa.cnf"
++	elif [ -f "$EASYRSA/openssl-easyrsa.conf" ]; then
++		set_var EASYRSA_SSL_CONF	"$EASYRSA/openssl-easyrsa.cnf"
++	elif [ -f "@out@/share/easyrsa/openssl-easyrsa.cnf" ]; then
++		set_var EASYRSA_SSL_CONF	"@out@/share/easyrsa/openssl-easyrsa.cnf"
++	fi
++
  	# Same as above for the x509-types extensions dir
  	if [ -d "$EASYRSA_PKI/x509-types" ]; then
  		set_var EASYRSA_EXT_DIR		"$EASYRSA_PKI/x509-types"
--	else	set_var EASYRSA_EXT_DIR		"$EASYRSA/x509-types"
+-	else	
+-		#TODO: This should be removed.  Not really suitable for packaging.
 +	elif [ -d "$EASYRSA/x509-types" ]; then
-+		set_var EASYRSA_EXT_DIR		"$EASYRSA/x509-types"
-+	else	set_var EASYRSA_EXT_DIR		"@out@/share/easyrsa/x509-types"
+ 		set_var EASYRSA_EXT_DIR		"$EASYRSA/x509-types"
++	else
++		set_var EASYRSA_EXT_DIR		"@out@/share/easyrsa/x509-types"
  	fi
  
  	# EASYRSA_ALGO_PARAMS must be set depending on selected algo


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Getting latest version of easy-rsa. Slightly different NixOS compatibility patch required.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
