### PR TITLE
ocamlPackages.ocaml-hidapi: init at 1.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/hidapi/default.nix
+++ b/pkgs/development/ocaml-modules/hidapi/default.nix
@@ -1,0 +1,27 @@
+{ pkgs, lib, fetchurl, buildDunePackage, pkg-config
+, bigstring,
+}:
+
+buildDunePackage rec {
+  pname = "hidapi";
+  version = "1.1.1";
+
+  src = fetchurl {
+    url = "https://github.com/vbmithr/ocaml-hidapi/releases/download/${version}/${pname}-${version}.tbz";
+    sha256 = "1j7rd7ajrzla76r3sxljx6fb18f4f4s3jd7vhv59l2ilxyxycai2";
+  };
+
+  minimumOCamlVersion = "4.03";
+
+  buildInputs = [ pkgs.hidapi pkg-config ];
+  propagatedBuildInputs = [ bigstring ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = https://github.com/vbmithr/ocaml-hidapi;
+    description = "Bindings to Signal11's hidapi library";
+    license = licenses.isc;
+    maintainers = [ maintainers.alexfmpe ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -312,6 +312,8 @@ let
 
     herelib = callPackage ../development/ocaml-modules/herelib { };
 
+    hidapi = callPackage ../development/ocaml-modules/hidapi { };
+
     higlo = callPackage ../development/ocaml-modules/higlo { };
 
     hkdf = callPackage ../development/ocaml-modules/hkdf { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
