### PR TITLE
python3Packages.swspotify: init at 1.2.1, swaglyrics: init at 1.2.2

### DIFF
--- a/pkgs/development/python-modules/swspotify/default.nix
+++ b/pkgs/development/python-modules/swspotify/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, buildPythonPackage, fetchFromGitHub, requests, flask-cors, dbus-python, pytestCheckHook, mock, isPy27 }:
+
+buildPythonPackage rec {
+  pname = "SwSpotify";
+  version = "1.2.1";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "SwagLyrics";
+    repo = "SwSpotify";
+    rev = "v${version}";
+    sha256 = "0jxcvy8lw8kpjbl4q6mi11164pvi0w9m9p76bxj2m7i7s5p4dxd4";
+  };
+
+  propagatedBuildInputs = [
+    requests flask-cors dbus-python
+  ];
+
+  preConfigure = ''
+    substituteInPlace setup.py \
+      --replace 'requests>=2.24.0' 'requests~=2.23'
+  '';
+
+  checkPhase = ''
+    pytest tests/test_spotify.py::LinuxTests
+  '';
+
+  checkInputs = [ pytestCheckHook mock ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/SwagLyrics/SwSpotify";
+    description = "Library to get the currently playing song and artist from Spotify";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/swaglyrics/default.nix
+++ b/pkgs/tools/misc/swaglyrics/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, python3, fetchFromGitHub, ncurses }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "swaglyrics";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "SwagLyrics";
+    repo = "SwagLyrics-For-Spotify";
+    rev = "v${version}";
+    sha256 = "1dwj9fpyhqqpm2z3imp8hfribkzxya891shh77yg77rc2xghp7mh";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    unidecode colorama beautifulsoup4 flask requests swspotify
+  ];
+
+  preConfigure = ''
+    substituteInPlace setup.py \
+      --replace 'requests>=2.24.0' 'requests~=2.23'
+  '';
+
+  preBuild = "export HOME=$NIX_BUILD_TOP";
+
+  # disable tests which touch network
+  disabledTests = [
+     "test_database_for_unsupported_song"
+     "test_that_lyrics_works_for_unsupported_songs"
+     "test_that_get_lyrics_works"
+     "test_lyrics_are_shown_in_tab"
+     "test_songchanged_can_raise_songplaying"
+  ];
+
+  checkInputs = with python3.pkgs;
+    [ blinker swspotify pytestCheckHook flask mock flask_testing ]
+    ++ [ ncurses ];
+
+  meta = with stdenv.lib; {
+    description = "Lyrics fetcher for currently playing Spotify song";
+    homepage = "https://github.com/SwagLyrics/SwagLyrics-For-Spotify";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23458,6 +23458,8 @@ in
 
   sunvox = callPackage ../applications/audio/sunvox { };
 
+  swaglyrics = callPackage ../tools/misc/swaglyrics { };
+
   swh_lv2 = callPackage ../applications/audio/swh-lv2 { };
 
   swift-im = libsForQt514.callPackage ../applications/networking/instant-messengers/swift-im {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6876,6 +6876,8 @@ in {
 
   swagger-ui-bundle = callPackage ../development/python-modules/swagger-ui-bundle { };
 
+  swspotify = callPackage ../development/python-modules/swspotify { };
+
   sybil = callPackage ../development/python-modules/sybil { };
 
   symengine = callPackage ../development/python-modules/symengine { symengine = pkgs.symengine; };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
