### PR TITLE
nvidia_x11_beta: 450.66 -> 440.66.14

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -31,11 +31,10 @@ rec {
 
   beta = if stdenv.hostPlatform.system == "x86_64-linux"
     then generic {
-      version = "440.66.14";
-      sha256_64bit = "0zqn552fya4wakjj6ql6xgkk39apn5sa01sdh58dyz05x7fpzdmv";
-      settingsSha256 = "15psxvd65wi6hmxmd2vvsp2v0m07axw613hb355nh15r1dpkr3ma";
-      persistencedSha256 = "13izz9p2kg9g38gf57g3s2sw7wshp1i9m5pzljh9v82c4c22x1fw";
-      url = https://developer.nvidia.com/vulkan-beta-4406614-linux;
+      version = "450.51";
+      sha256_64bit = "17pam9737jx9vvczma5rafa0rihprccmfz84clb1y4nhbay5alf2";
+      settingsSha256 = "09hc1mjh7s94hy37rslxrxr30kx9a4yfnkmv35wn86b2p9zk3w6n";
+      persistencedSha256 = "0jmri8kj6gffqn8pm8nijhq2airvgid11vj2ffc037l7z4w0s6ar";
     }
     else stable;
 

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -29,8 +29,15 @@ rec {
     }
     else legacy_390;
 
-  # No active beta right now
-  beta = stable;
+  beta = if stdenv.hostPlatform.system == "x86_64-linux"
+    then generic {
+      version = "440.66.14";
+      sha256_64bit = "0zqn552fya4wakjj6ql6xgkk39apn5sa01sdh58dyz05x7fpzdmv";
+      settingsSha256 = "15psxvd65wi6hmxmd2vvsp2v0m07axw613hb355nh15r1dpkr3ma";
+      persistencedSha256 = "13izz9p2kg9g38gf57g3s2sw7wshp1i9m5pzljh9v82c4c22x1fw";
+      url = https://developer.nvidia.com/vulkan-beta-4406614-linux;
+    }
+    else stable;
 
   # Last one supporting x86
   legacy_390 = generic {

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -1,4 +1,5 @@
 { version
+, url ? null
 , sha256_32bit ? null
 , sha256_64bit
 , settingsSha256
@@ -41,7 +42,12 @@ let
     builder = ./builder.sh;
 
     src =
-      if stdenv.hostPlatform.system == "x86_64-linux" then
+      if url != null then
+        fetchurl {
+          inherit url;
+          sha256 = if stdenv.hostPlatform.is64bit then sha256_64bit else sha256_32bit;
+        }
+      else if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run";
           sha256 = sha256_64bit;


### PR DESCRIPTION
This is fetched from a different URL, so allow passing that explicitly.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).