### PR TITLE
coqPackages.gappalib: 1.4.3 → 1.4.4

### DIFF
--- a/pkgs/development/coq-modules/gappalib/default.nix
+++ b/pkgs/development/coq-modules/gappalib/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, which, coq, flocq }:
 
 stdenv.mkDerivation {
-  name = "coq${coq.coq-version}-gappalib-1.4.3";
+  name = "coq${coq.coq-version}-gappalib-1.4.4";
   src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/file/38302/gappalib-coq-1.4.3.tar.gz";
-    sha256 = "108k9dks04wbcqz38pf0zz11hz5imbzimpnkgjrk5gp1hifih370";
+    url = "https://gforge.inria.fr/frs/download.php/file/38338/gappalib-coq-1.4.4.tar.gz";
+    sha256 = "1ds9qp3ml07w5ali0rsczlwgdx4xcgasgbcnpi2lssgj1xpxgfpn";
   };
 
   nativeBuildInputs = [ which ];
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    compatibleCoqVersions = stdenv.lib.flip builtins.elem [ "8.8" "8.9" "8.10" "8.11" ];
+    compatibleCoqVersions = stdenv.lib.flip builtins.elem [ "8.8" "8.9" "8.10" "8.11" "8.12" ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Support for Coq 8.12

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
