### PR TITLE
nixosTests.hocker-fetchdocker

### DIFF
--- a/nixos/tests/hocker-fetchdocker/default.nix
+++ b/nixos/tests/hocker-fetchdocker/default.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({ pkgs, ...} : {
+import ../make-test-python.nix ({ pkgs, ...} : {
   name = "test-hocker-fetchdocker";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ixmatus ];
@@ -7,9 +7,9 @@ import ../make-test.nix ({ pkgs, ...} : {
   machine = import ./machine.nix;
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $machine->waitForUnit("sockets.target");
-    $machine->waitUntilSucceeds("docker run registry-1.docker.io/v2/library/hello-world:latest");
+    machine.wait_for_unit("sockets.target")
+    machine.wait_until_succeeds("docker run registry-1.docker.io/v2/library/hello-world:latest")
   '';
 })

--- a/nixos/tests/hocker-fetchdocker/default.nix
+++ b/nixos/tests/hocker-fetchdocker/default.nix
@@ -2,6 +2,7 @@ import ../make-test-python.nix ({ pkgs, ...} : {
   name = "test-hocker-fetchdocker";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ixmatus ];
+    broken = true; # tries to download from registry-1.docker.io - how did this ever work?
   };
 
   machine = import ./machine.nix;


### PR DESCRIPTION
This ports over the `hocker-fetchdocker` VM test to the python tooling.
The test itself seems broken without internet access, so I marked it as broken for now.

I opened https://github.com/NixOS/nixpkgs/issues/96075 to unbreak the test.

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
