### PR TITLE
postgresql: 12.3 -> 12.4 and similar updates for earlier versions

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -182,41 +182,41 @@ let
 in self: {
 
   postgresql_9_5 = self.callPackage generic {
-    version = "9.5.22";
+    version = "9.5.23";
     psqlSchema = "9.5";
-    sha256 = "03v4d4nr9f86y0i1j5jmvfan5w8y4ga1mar59lhcnj3jl5q58ma8";
+    sha256 = "0rl31jc3kg2wq6hazyd297gnmx3cibjvivllbsivii2m6dzgl573";
     this = self.postgresql_9_5;
     inherit self;
   };
 
   postgresql_9_6 = self.callPackage generic {
-    version = "9.6.18";
+    version = "9.6.19";
     psqlSchema = "9.6";
-    sha256 = "16crr2a1sl97aiacqzd0bk56yl1abq6blc0c6qpx5rl5ny1c4zji";
+    sha256 = "1c2wnl5bbpjs1s1rpzvlnzsqlpb0p823zw7s38nhpgnxrja3myb1";
     this = self.postgresql_9_6;
     inherit self;
   };
 
   postgresql_10 = self.callPackage generic {
-    version = "10.13";
+    version = "10.14";
     psqlSchema = "10.0"; # should be 10, but changing it is invasive
-    sha256 = "1qal0yp7a90yzya7hl56gsmw5fvacplrdhpn7h9gnbyr1i2iyw2d";
+    sha256 = "0fxj30jvwq5pqpbj97vhlxgmn2ah59a78s9jyjr7vxyqj7sdh71q";
     this = self.postgresql_10;
     inherit self;
   };
 
   postgresql_11 = self.callPackage generic {
-    version = "11.8";
+    version = "11.9";
     psqlSchema = "11.1"; # should be 11, but changing it is invasive
-    sha256 = "1qksqyayxmnccmbapg3ajsw9pjgqva0inxjhx64rqd6ckhrg9wpa";
+    sha256 = "0db6pfphc5rp12abnkvv2l9pbl7bdyf3hhiwj8ghjwh35skqlq9m";
     this = self.postgresql_11;
     inherit self;
   };
 
   postgresql_12 = self.callPackage generic {
-    version = "12.3";
+    version = "12.4";
     psqlSchema = "12";
-    sha256 = "0hfg3n7rlz96579cj3z1dh2idl15rh3wfvn8jl31jj4h2yk69vcl";
+    sha256 = "1k06wryy8p4s1fim9qafcjlak3f58l0wqaqnrccr9x9j5jz3zsdy";
     this = self.postgresql_12;
     inherit self;
   };


### PR DESCRIPTION
###### Motivation for this change
Package [Postgresql updates from 2020-08-13](https://www.postgresql.org/about/news/2060/)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date _- no changes for point releases_
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
