### PR TITLE
utf8proc: enable tests

### DIFF
--- a/pkgs/development/libraries/utf8proc/default.nix
+++ b/pkgs/development/libraries/utf8proc/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
+    "-DUTF8PROC_ENABLE_TESTING=ON"
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
   ];
 
   # the pkg-config file is not created in the cmake installation
@@ -22,6 +24,8 @@ stdenv.mkDerivation rec {
   # see https://github.com/JuliaStrings/utf8proc/issues/198
   preConfigure = "make libutf8proc.pc prefix=$out";
   postInstall = "install -Dm644 ../libutf8proc.pc -t $out/lib/pkgconfig/";
+
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "A clean C library for processing UTF-8 Unicode data";


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Enable test suite of `utf8proc`.

For the current version normtest and graphemetest are disabled. This
will probably change in the future. Those tests are problematic because
they depend on unicode data files which are downloaded by cmake at build
time:

    file(MAKE_DIRECTORY data)
    set(UNICODE_VERSION 13.0.0)
    file(DOWNLOAD https://www.unicode.org/Public/${UNICODE_VERSION}/ucd/NormalizationTest.txt data/NormalizationTest.txt SHOW_PROGRESS)
    file(DOWNLOAD https://www.unicode.org/Public/${UNICODE_VERSION}/ucd/auxiliary/GraphemeBreakTest.txt data/GraphemeBreakTest.txt SHOW_PROGRESS)

For the next update, we'll probably need to patch out this section of
CMakeLists.txt and download the files in question with fetchurl
ourselves. It's trivial, but a little more maintenance work because
you have two more hashes to update.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
