### PR TITLE
mailnag: Fix pluginDeps usage & comment

### DIFF
--- a/pkgs/applications/networking/mailreaders/mailnag/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailnag/default.nix
@@ -16,7 +16,7 @@
 # Available plugins (can be overriden)
 , availablePlugins
 # Used in the withPlugins interface at passthru, can be overrided directly, or
-# prefarably via e.g: `mailnag.withPlugins(["goa"])`
+# prefarably via e.g: `mailnag.withPlugins([mailnag.availablePlugins.goa])`
 , mailnag
 , userPlugins ? [ ]
 , pluginsDeps ? [ ]
@@ -72,7 +72,10 @@ python3Packages.buildPythonApplication rec {
         pluginsDeps = lib.flatten (lib.catAttrs "buildInputs" plugs);
         self = mailnag;
       in
-        self.override { userPlugins = plugs; };
+        self.override {
+          userPlugins = plugs;
+          inherit pluginsDeps;
+        };
   };
 
   # See https://nixos.org/nixpkgs/manual/#ssec-gnome-common-issues-double-wrapped


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

After doing a fresh NixOS installation, I noticed the goa plugin wasn't even usable, but it worked for me when I wrote https://github.com/NixOS/nixpkgs/pull/94202 due to the proper environment being set never the less. cc @jonringer who reviewed https://github.com/NixOS/nixpkgs/pull/94202 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
