### PR TITLE
nixos/modules/security/rngd: Disable by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -815,6 +815,13 @@ CREATE ROLE postgres LOGIN SUPERUSER;
      the value of <option>services.jellyfin.package</option> to <literal>pkgs.jellyfin_10_5</literal>.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The <literal>security.rngd</literal> service is now disabled by default.
+     This choice was made because there's krngd in the linux kernel space making it (for most usecases)
+     functionally redundent.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/security/rngd.nix
+++ b/nixos/modules/security/rngd.nix
@@ -10,11 +10,10 @@ in
     security.rngd = {
       enable = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description = ''
-          Whether to enable the rng daemon, which adds entropy from
-          hardware sources of randomness to the kernel entropy pool when
-          available.
+          Whether to enable the rng daemon.  Devices that the kernel recognises
+          as entropy sources are handled automatically by krngd.
         '';
       };
       debug = mkOption {
@@ -26,12 +25,6 @@ in
   };
 
   config = mkIf cfg.enable {
-    services.udev.extraRules = ''
-      KERNEL=="random", TAG+="systemd"
-      SUBSYSTEM=="cpu", ENV{MODALIAS}=="cpu:type:x86,*feature:*009E*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="rngd.service"
-      KERNEL=="hw_random", TAG+="systemd", ENV{SYSTEMD_WANTS}+="rngd.service"
-    '';
-
     systemd.services.rngd = {
       bindsTo = [ "dev-random.device" ];
 


### PR DESCRIPTION
###### Motivation for this change

`rngd` seems to be the root cause for slow boot issues, and its functionality is
redundant since kernel v3.17 (2014), which introduced a `krngd` task (in kernel
space) that takes care of pulling in data from hardware RNGs:

> commit be4000bc4644d027c519b6361f5ae3bbfc52c347
> Author: Torsten Duwe <duwe@lst.de>
> Date:   Sat Jun 14 23:46:03 2014 -0400
>
>     hwrng: create filler thread
>
>     This can be viewed as the in-kernel equivalent of hwrngd;
>     like FUSE it is a good thing to have a mechanism in user land,
>     but for some reasons (simplicity, secrecy, integrity, speed)
>     it may be better to have it in kernel space.
>
>     This patch creates a thread once a hwrng registers, and uses
>     the previously established add_hwgenerator_randomness() to feed
>     its data to the input pool as long as needed. A derating factor
>     is used to bias the entropy estimation and to disable this
>     mechanism entirely when set to zero.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).