### PR TITLE
pythonPackages.urwid: disable tests

### DIFF
--- a/pkgs/development/python-modules/urwid/default.nix
+++ b/pkgs/development/python-modules/urwid/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, glibcLocales }:
+{ stdenv, buildPythonPackage, isPy3k, fetchPypi, glibcLocales }:
 
 buildPythonPackage rec {
   pname = "urwid";
@@ -12,6 +12,11 @@ buildPythonPackage rec {
   # tests need to be able to set locale
   LC_ALL = "en_US.UTF-8";
   checkInputs = [ glibcLocales ];
+
+  # tests which assert on strings don't decode results correctly
+  doCheck = isPy3k;
+
+  pythonImportsCheck = [ "urwid" ];
 
   meta = with stdenv.lib; {
     description = "A full-featured console (xterm et al.) user interface library";


### PR DESCRIPTION
###### Motivation for this change
the tests which involve decoding responses seems to fail within the testsuite

closes #94684

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
