### PR TITLE
harfbuzz: 2.6.7 → 2.7.1

### DIFF
--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -1,28 +1,34 @@
-{ stdenv, fetchurl, pkgconfig, glib, freetype, cairo, libintl
+{ stdenv, fetchFromGitHub, pkgconfig, glib, freetype, cairo, libintl
+, meson, ninja
 , gobject-introspection
 , icu, graphite2, harfbuzz # The icu variant uses and propagates the non-icu one.
 , ApplicationServices, CoreText
 , withCoreText ? false
 , withIcu ? false # recommended by upstream as default, but most don't needed and it's big
 , withGraphite2 ? true # it is small and major distros do include it
-, python
+, python3
+, gtk-doc, docbook-xsl-nons, docbook_xml_dtd_43
 }:
 
 let
-  version = "2.6.7";
+  version = "2.7.1";
   inherit (stdenv.lib) optional optionals optionalString;
+  mesonFeatureFlag = opt: b:
+    "-D${opt}=${if b then "enabled" else "disabled"}";
 in
 
 stdenv.mkDerivation {
   name = "harfbuzz${optionalString withIcu "-icu"}-${version}";
 
-  src = fetchurl {
-    url = "https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${version}.tar.xz";
-    sha256 = "065jg6s8xix45s4msj0l2r0iycw5yyyjdylripv7pyfzdk883r29";
+  src = fetchFromGitHub {
+    owner  = "harfbuzz";
+    repo   = "harfbuzz";
+    rev    = version;
+    sha256 = "172jmwp666xbs6yy1pc2495gnkz8xw11b8zkz3j19jxlvvp4mxcs";
   };
 
   postPatch = ''
-    patchShebangs src/gen-def.py
+    patchShebangs src/*.py
     patchShebangs test
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     # ApplicationServices.framework headers have cast-align warnings.
@@ -30,22 +36,25 @@ stdenv.mkDerivation {
       --replace '#pragma GCC diagnostic error   "-Wcast-align"' ""
   '';
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";
 
-  configureFlags = [
-    # not auto-detected by default
-    "--with-graphite2=${if withGraphite2 then "yes" else "no"}"
-    "--with-icu=${if withIcu then "yes" else "no"}"
-    "--with-gobject=yes"
-    "--enable-introspection=yes"
-  ]
-    ++ stdenv.lib.optional withCoreText "--with-coretext=yes";
+  mesonFlags = [
+    (mesonFeatureFlag "graphite" withGraphite2)
+    (mesonFeatureFlag "icu" withIcu)
+    (mesonFeatureFlag "coretext" withCoreText)
+  ];
 
   nativeBuildInputs = [
+    meson
+    ninja
     gobject-introspection
     libintl
     pkgconfig
+    python3
+    gtk-doc
+    docbook-xsl-nons
+    docbook_xml_dtd_43
   ];
 
   buildInputs = [ glib freetype cairo ] # recommended by upstream
@@ -55,11 +64,10 @@ stdenv.mkDerivation {
     ++ optional withGraphite2 graphite2
     ++ optionals withIcu [ icu harfbuzz ];
 
-  checkInputs = [ python ];
-  doInstallCheck = false; # fails, probably a bug
+  doCheck = true;
 
   # Slightly hacky; some pkgs expect them in a single directory.
-  postInstall = optionalString withIcu ''
+  postFixup = optionalString withIcu ''
     rm "$out"/lib/libharfbuzz.* "$dev/lib/pkgconfig/harfbuzz.pc"
     ln -s {'${harfbuzz.out}',"$out"}/lib/libharfbuzz.la
     ln -s {'${harfbuzz.dev}',"$dev"}/lib/pkgconfig/harfbuzz.pc
@@ -71,12 +79,9 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "An OpenType text shaping engine";
-    homepage = "http://www.freedesktop.org/wiki/Software/HarfBuzz";
-    downloadPage = "https://www.freedesktop.org/software/harfbuzz/release/";
+    homepage = "https://harfbuzz.github.io/";
     maintainers = [ maintainers.eelco ];
     license = licenses.mit;
     platforms = with platforms; linux ++ darwin;
-    inherit version;
-    updateWalker = true;
   };
 }


### PR DESCRIPTION
Notable changes:

* Upstream changed from freedesktop.org to GitHub, so updateWalker is disabled and fetchFromGitHub used
* Build system now based on meson/ninja
* python3 instead of python
* postInstall hook moved to postFixup since it depends on some files being moved around in fixupPhase

Help testing this and feedback would be appreciated. I couldn't test it on darwin yet, for example, and I doubt a `nixpkgs-review` on my hardware will finish in a reasonable time.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
