### PR TITLE
bubblemail: init at 1.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/bubblemail/default.nix
+++ b/pkgs/applications/networking/mailreaders/bubblemail/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, fetchFromGitLab
+, gettext
+, gtk3
+, python3Packages
+, gdk-pixbuf
+, libnotify
+, gst_all_1
+, libsecret
+, wrapGAppsHook
+, gsettings-desktop-schemas
+, gnome-online-accounts
+, glib
+, gobject-introspection
+, folks
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "bubblemail";
+  version = "1.3";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "razer";
+    repo = "bubblemail";
+    rev = "v${version}";
+    sha256 = "FEIdEoZBlM28F5kSMoln7KACwetb8hp+qix1P+DIE8k=";
+  };
+
+  buildInputs = [
+    gtk3
+    gdk-pixbuf
+    glib
+    libnotify
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    libsecret
+    gnome-online-accounts
+    folks
+  ];
+
+  nativeBuildInputs = [
+    gettext
+    wrapGAppsHook
+    python3Packages.pillow
+    # For setup-hook
+    gobject-introspection
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    gsettings-desktop-schemas
+    pygobject3
+    dbus-python
+    pyxdg
+  ];
+
+  # See https://nixos.org/nixpkgs/manual/#ssec-gnome-common-issues-double-wrapped
+  dontWrapGApps = true;
+
+  # https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = with lib; {
+    description = "An extensible mail notification service.";
+    homepage = "http://bubblemail.free.fr/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5348,6 +5348,7 @@ in
   mailnagWithPlugins = mailnag.withPlugins(
     builtins.attrValues mailnag.availablePlugins
   );
+  bubblemail = callPackage ../applications/networking/mailreaders/bubblemail { };
 
   mailsend = callPackage ../tools/networking/mailsend { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

A fork of mailnag, that just works and looks better.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
