### PR TITLE
python3Packages.userpath: init at 1.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9438,4 +9438,10 @@
     github = "fzakaria";
     githubId = 605070;
   };
+  yevhenshymotiuk = {
+    name = "Yevhen Shymotiuk";
+    email = "yevhenshymotiuk@gmail.com";
+    github = "yevhenshymotiuk";
+    githubId = 44244245;
+  };
 }

--- a/pkgs/development/python-modules/userpath/default.nix
+++ b/pkgs/development/python-modules/userpath/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, click
+, distro
+, tox
+, pytest
+, coverage
+}:
+
+buildPythonPackage rec {
+  pname = "userpath";
+  version = "1.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256="0mfjmvx286z1dmnrc7bm65x8gj8qrmkcyagl0vf5ywfq0bm48591";
+  };
+
+  propagatedBuildInputs = [ click distro ];
+
+  checkInputs = [ tox pytest coverage ];
+
+  # We should skip tox dependencies installation to run tests but
+  # tox doesn't have such an option yet (https://github.com/tox-dev/tox/issues/410)
+  doCheck = false;
+
+  checkPhase = ''
+    tox
+  '';
+
+  meta = with lib; {
+    description = "Cross-platform tool for adding locations to the user PATH";
+    homepage = "https://github.com/ofek/userpath";
+    license = [ licenses.asl20 licenses.mit ];
+    maintainers = with maintainers; [ yevhenshymotiuk ];
+  };
+}

--- a/pkgs/development/python-modules/userpath/default.nix
+++ b/pkgs/development/python-modules/userpath/default.nix
@@ -16,6 +16,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ click distro ];
 
+  # test suite is difficult to emulate in sandbox due to shell manipulation
   doCheck = false;
 
   pythonImportsCheck = [ "click" "userpath" ];

--- a/pkgs/development/python-modules/userpath/default.nix
+++ b/pkgs/development/python-modules/userpath/default.nix
@@ -3,9 +3,6 @@
 , fetchPypi
 , click
 , distro
-, tox
-, pytest
-, coverage
 }:
 
 buildPythonPackage rec {
@@ -19,15 +16,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ click distro ];
 
-  checkInputs = [ tox pytest coverage ];
-
-  # We should skip tox dependencies installation to run tests but
-  # tox doesn't have such an option yet (https://github.com/tox-dev/tox/issues/410)
   doCheck = false;
 
-  checkPhase = ''
-    tox
-  '';
+  pythonImportsCheck = [ "click" "userpath" ];
 
   meta = with lib; {
     description = "Cross-platform tool for adding locations to the user PATH";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7824,6 +7824,8 @@ in {
 
   rxv     = callPackage ../development/python-modules/rxv     { };
 
+  userpath = callPackage ../development/python-modules/userpath { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

[userpath](https://github.com/ofek/userpath) is a cross-platform tool for adding locations to the user PATH. It is required to package a very useful python tool [pipx](https://github.com/pipxproject/pipx), which allows to install and run python applications in isolated environments.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
