### PR TITLE
python3Packages.test-tube: init at 0.7.5

### DIFF
--- a/pkgs/development/python-modules/test-tube/default.nix
+++ b/pkgs/development/python-modules/test-tube/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, pytestCheckHook
+, future
+, imageio
+, numpy
+, pandas
+, pytorch
+, tensorflow-tensorboard
+}:
+
+buildPythonPackage rec {
+  pname = "test-tube";
+  version = "0.7.5";
+
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "williamFalcon";
+    repo = pname;
+    rev = version;
+    sha256 = "0zpvlp1ybp2dhgap8jsalpfdyg8ycjhlfi3xrdf5dqffqvh2yhp2";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  propagatedBuildInputs = [
+    future
+    imageio
+    numpy
+    pandas
+    pytorch
+    tensorflow-tensorboard
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/williamFalcon/test-tube";
+    description = "Framework-agnostic library to track and parallelize hyperparameter search in machine learning experiments";
+    license = licenses.mit;
+    maintainers = [ maintainers.tbenst ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6737,6 +6737,8 @@ in {
 
   terminaltables = callPackage ../development/python-modules/terminaltables { };
 
+  test-tube = callPackage ../development/python-modules/test-tube { };
+
   testpath = callPackage ../development/python-modules/testpath { };
 
   testrepository = callPackage ../development/python-modules/testrepository { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Optional dependency of `python3Packages.pytorch-lightning` (finishes the refresh of #77155 started with #95827).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @tbenst 
