### PR TITLE
wxGTK*: Remove abandoned dependencies

### DIFF
--- a/pkgs/development/libraries/wxwidgets/2.8/default.nix
+++ b/pkgs/development/libraries/wxwidgets/2.8/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gtk2, libXinerama, libSM, libXxf86vm, xorgproto
-, gstreamer, gst-plugins-base, GConf, libX11, cairo
+, libX11, cairo
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
 , withMesa ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
 , libGLU ? null, libGL ? null
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "1l1w4i113csv3bd5r8ybyj0qpxdq83lj6jrc5p7cc10mkwyiagqz";
   };
 
-  buildInputs = [ gtk2 libXinerama libSM libXxf86vm xorgproto gstreamer gst-plugins-base GConf libX11 cairo ]
+  buildInputs = [ gtk2 libXinerama libSM libXxf86vm xorgproto libX11 cairo ]
     ++ optional withMesa libGLU;
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/wxwidgets/2.9/default.nix
+++ b/pkgs/development/libraries/wxwidgets/2.9/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gtk2, libXinerama, libSM, libXxf86vm, xorgproto
-, gstreamer, gst-plugins-base, GConf, setfile
+, setfile
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
 , withMesa ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
 , libGLU ? null, libGL ? null
@@ -32,8 +32,7 @@ stdenv.mkDerivation {
   ];
 
   buildInputs =
-    [ gtk2 libXinerama libSM libXxf86vm xorgproto gstreamer
-      gst-plugins-base GConf ]
+    [ gtk2 libXinerama libSM libXxf86vm xorgproto ]
     ++ optional withMesa libGLU
     ++ optionals stdenv.isDarwin [ setfile Carbon Cocoa Kernel QuickTime ];
 
@@ -42,7 +41,7 @@ stdenv.mkDerivation {
   propagatedBuildInputs = optional stdenv.isDarwin AGL;
 
   configureFlags =
-    [ "--enable-gtk2" "--disable-precomp-headers" "--enable-mediactrl"
+    [ "--enable-gtk2" "--disable-precomp-headers"
       (if compat24 then "--enable-compat24" else "--disable-compat24")
       (if compat26 then "--enable-compat26" else "--disable-compat26") ]
     ++ optional unicode "--enable-unicode"

--- a/pkgs/development/libraries/wxwidgets/3.0/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchurl, pkgconfig
 , libXinerama, libSM, libXxf86vm
-, gtk2, GConf ? null, gtk3
+, gtk2, gtk3
 , xorgproto, gst_all_1, setfile
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
 , withMesa ? libGLSupported
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libXinerama libSM libXxf86vm xorgproto gst_all_1.gstreamer gst_all_1.gst-plugins-base
-  ] ++ optionals withGtk2 [ gtk2 GConf ]
+  ] ++ optionals withGtk2 [ gtk2 ]
     ++ optional (!withGtk2) gtk3
     ++ optional withMesa libGLU
     ++ optional withWebKit webkitgtk

--- a/pkgs/development/libraries/wxwidgets/3.1/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.1/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchurl, pkgconfig
 , libXinerama, libSM, libXxf86vm
-, gtk2, GConf ? null, gtk3
+, gtk2, gtk3
 , xorgproto, gst_all_1, setfile
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
 , withMesa ? libGLSupported, libGLU ? null, libGL ? null
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libXinerama libSM libXxf86vm xorgproto gst_all_1.gstreamer gst_all_1.gst-plugins-base
-  ] ++ optionals withGtk2 [ gtk2 GConf ]
+  ] ++ optionals withGtk2 [ gtk2 ]
     ++ optional (!withGtk2) gtk3
     ++ optional withMesa libGLU
     ++ optional withWebKit webkitgtk

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15563,9 +15563,7 @@ in
   wxGTK30 = wxGTK30-gtk2;
   wxGTK31 = wxGTK31-gtk2;
 
-  wxGTK28 = callPackage ../development/libraries/wxwidgets/2.8 {
-    inherit (gnome2) GConf;
-  };
+  wxGTK28 = callPackage ../development/libraries/wxwidgets/2.8 { };
 
   wxGTK29 = callPackage ../development/libraries/wxwidgets/2.9 {
     inherit (gnome2) GConf;
@@ -24400,7 +24398,6 @@ in
   fsg = callPackage ../games/fsg {
     wxGTK = wxGTK28.override {
       unicode = false;
-      gst-plugins-base = null;
     };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15566,7 +15566,6 @@ in
   wxGTK28 = callPackage ../development/libraries/wxwidgets/2.8 { };
 
   wxGTK29 = callPackage ../development/libraries/wxwidgets/2.9 {
-    inherit (gnome2) GConf;
     inherit (darwin.stubs) setfile;
     inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QuickTime;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15584,7 +15584,6 @@ in
 
   wxGTK31-gtk2 = callPackage ../development/libraries/wxwidgets/3.1 {
     withGtk2 = true;
-    inherit (gnome2) GConf;
     inherit (darwin.stubs) setfile;
     inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15572,7 +15572,6 @@ in
 
   wxGTK30-gtk2 = callPackage ../development/libraries/wxwidgets/3.0 {
     withGtk2 = true;
-    inherit (gnome2) GConf;
     inherit (darwin.stubs) setfile;
     inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
   };


### PR DESCRIPTION
###### Motivation for this change
The many-years abandoned GStreamer 0.10 branch no longer builds so let's remove it. Hopefully nothing used it these days.

GConf has been abandoned for years too and would not work without user running the daemon.

cc https://github.com/NixOS/nixpkgs/issues/39975 https://github.com/NixOS/nixpkgs/pull/93540


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
