### PR TITLE
[20.03] qtwebengine: fix build for darwin

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -87,8 +87,10 @@ let
         url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/qtbug-77037-workaround.patch?h=packages/qt5-webengine&id=fc77d6b3d5ec74e421b58f199efceb2593cbf951";
         sha256 = "1gv733qfdn9746nbqqxzyjx4ijjqkkb7zb71nxax49nna5bri3am";
       })
-    ]
-      ++ optional stdenv.isDarwin ./qtwebengine-darwin-no-platform-check.patch;
+    ] ++ optionals stdenv.isDarwin [
+      ./qtwebengine-darwin-no-platform-check.patch
+      ./qtwebengine-darwin-fix-failed-static-assertion.patch
+    ];
     qtwebkit = [ ./qtwebkit.patch ]
       ++ optionals stdenv.isDarwin [
         ./qtwebkit-darwin-no-readline.patch

--- a/pkgs/development/libraries/qt-5/5.12/qtwebengine-darwin-fix-failed-static-assertion.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtwebengine-darwin-fix-failed-static-assertion.patch
@@ -1,0 +1,31 @@
+Fix a following build error:
+
+In file included from ../../3rdparty/chromium/device/bluetooth/bluetooth_remote_gatt_characteristic_mac.mm:7:
+../../3rdparty/chromium/base/bind.h:59:3: error: static_assert failed "Bound argument |i| of type |Arg| cannot be forwarded as |Unwrapped| to the bound functor, which declares it as |Param|."
+  static_assert(
+  ^
+../../3rdparty/chromium/base/bind.h:91:7: note: in instantiation of template class 'base::internal::AssertConstructible<1, long, long, const long &, NSError *>' requested here
+    : AssertConstructible<Ns, Args, std::decay_t<Args>, Unwrapped, Params>... {
+      ^
+../../3rdparty/chromium/base/bind.h:213:27: note: in instantiation of template class 'base::internal::AssertBindArgsValidity<std::__1::integer_sequence<unsigned long, 0, 1>, base::internal::TypeList<base::WeakPtr<device::BluetoothRemoteGattCharacteristicMac>, long>, base::internal::TypeList<device::BluetoothRemoteGattCharacteristicMac *, const long &>, base::internal::TypeList<device::BluetoothRemoteGattCharacteristicMac *, NSError *> >' requested here
+  static_assert(internal::AssertBindArgsValidity<
+                          ^
+../../3rdparty/chromium/base/bind.h:242:16: note: in instantiation of function template specialization 'base::BindRepeating<void (device::BluetoothRemoteGattCharacteristicMac::*)(NSError *), base::WeakPtr<device::BluetoothRemoteGattCharacteristicMac>, long>' requested here
+  return base::BindRepeating(std::forward<Functor>(functor),
+               ^
+../../3rdparty/chromium/device/bluetooth/bluetooth_remote_gatt_characteristic_mac.mm:211:15: note: in instantiation of function template specialization 'base::Bind<void (device::BluetoothRemoteGattCharacteristicMac::*)(NSError *), base::WeakPtr<device::BluetoothRemoteGattCharacteristicMac>, long>' requested here
+        base::Bind(&BluetoothRemoteGattCharacteristicMac::DidWriteValue,
+              ^
+
+Resurrected from https://github.com/NixOS/nixpkgs/blob/ddcf01bca6c7a7a7f096bec836a1e6a707ad473d/pkgs/development/libraries/qt-5/5.11/qtwebengine-clang-fix.patch because the same problem is present in 5.12 when compiling on macOS.
+
+--- a/src/3rdparty/chromium/device/bluetooth/bluetooth_remote_gatt_characteristic_mac.mm
++++ b/src/3rdparty/chromium/device/bluetooth/bluetooth_remote_gatt_characteristic_mac.mm
+@@ -209,7 +209,7 @@ void BluetoothRemoteGattCharacteristicMac::WriteRemoteCharacteristic(
+     base::ThreadTaskRunnerHandle::Get()->PostTask(
+         FROM_HERE,
+         base::Bind(&BluetoothRemoteGattCharacteristicMac::DidWriteValue,
+-                   weak_ptr_factory_.GetWeakPtr(), nil));
++                   weak_ptr_factory_.GetWeakPtr(), nullptr));
+   }
+ }

--- a/pkgs/development/libraries/qt-5/5.12/qtwebengine-darwin-no-platform-check.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtwebengine-darwin-no-platform-check.patch
@@ -1,4 +1,18 @@
+diff --git a/configure.pri b/configure.pri
+index 897bea54..6f834c20 100644
+--- a/configure.pri
++++ b/configure.pri
+@@ -269,7 +269,7 @@ defineReplace(webEngineGetMacOSVersion) {
+ }
+ 
+ defineReplace(webEngineGetMacOSSDKVersion) {
+-    value = $$system("/usr/bin/xcodebuild -sdk $$QMAKE_MAC_SDK -version ProductVersion 2>/dev/null")
++    value = $$system("xcrun --show-sdk-version")
+     return($$value)
+ }
+ 
 diff --git a/mkspecs/features/platform.prf b/mkspecs/features/platform.prf
+index 35eb6b89..7eed640a 100644
 --- a/mkspecs/features/platform.prf
 +++ b/mkspecs/features/platform.prf
 @@ -40,8 +40,6 @@ defineTest(isPlatformSupported) {
@@ -19,15 +33,39 @@ diff --git a/mkspecs/features/platform.prf b/mkspecs/features/platform.prf
      }
    } else {
      skipBuild("Unknown platform. Qt WebEngine only supports Linux, Windows, and macOS.")
+@@ -111,7 +107,7 @@ defineTest(isMinOSXSDKVersion) {
+     requested_minor = $$2
+     requested_patch = $$3
+     isEmpty(requested_patch): requested_patch = 0
+-    WEBENGINE_OSX_SDK_PRODUCT_VERSION = $$system("/usr/bin/xcodebuild -sdk $$QMAKE_MAC_SDK -version ProductVersion 2>/dev/null")
++    WEBENGINE_OSX_SDK_PRODUCT_VERSION = $$system("xcrun --show-sdk-version")
+     export(WEBENGINE_OSX_SDK_PRODUCT_VERSION)
+     isEmpty(WEBENGINE_OSX_SDK_PRODUCT_VERSION) {
+         skipBuild("Could not resolve SDK product version for \'$$QMAKE_MAC_SDK\'.")
 diff --git a/src/core/config/mac_osx.pri b/src/core/config/mac_osx.pri
+index 4426901c..3aa6057e 100644
 --- a/src/core/config/mac_osx.pri
 +++ b/src/core/config/mac_osx.pri
-@@ -5,8 +5,6 @@ load(functions)
+@@ -5,16 +5,16 @@ load(functions)
  # otherwise query for it.
  QMAKE_MAC_SDK_VERSION = $$eval(QMAKE_MAC_SDK.$${QMAKE_MAC_SDK}.SDKVersion)
  isEmpty(QMAKE_MAC_SDK_VERSION) {
 -     QMAKE_MAC_SDK_VERSION = $$system("/usr/bin/xcodebuild -sdk $${QMAKE_MAC_SDK} -version SDKVersion 2>/dev/null")
--     isEmpty(QMAKE_MAC_SDK_VERSION): error("Could not resolve SDK version for \'$${QMAKE_MAC_SDK}\'")
++     QMAKE_MAC_SDK_VERSION = $$system("xcrun --show-sdk-version")
+      isEmpty(QMAKE_MAC_SDK_VERSION): error("Could not resolve SDK version for \'$${QMAKE_MAC_SDK}\'")
  }
-
+ 
  QMAKE_CLANG_DIR = "/usr"
+-QMAKE_CLANG_PATH = $$eval(QMAKE_MAC_SDK.macx-clang.$${QMAKE_MAC_SDK}.QMAKE_CXX)
+-!isEmpty(QMAKE_CLANG_PATH) {
+-    clang_dir = $$clean_path("$$dirname(QMAKE_CLANG_PATH)/../")
+-    exists($$clang_dir): QMAKE_CLANG_DIR = $$clang_dir
+-}
++# QMAKE_CLANG_PATH = $$eval(QMAKE_MAC_SDK.macx-clang.$${QMAKE_MAC_SDK}.QMAKE_CXX)
++# !isEmpty(QMAKE_CLANG_PATH) {
++#     clang_dir = $$clean_path("$$dirname(QMAKE_CLANG_PATH)/../")
++#     exists($$clang_dir): QMAKE_CLANG_DIR = $$clang_dir
++# }
+ 
+ QMAKE_CLANG_PATH = "$${QMAKE_CLANG_DIR}/bin/clang++"
+ message("Using clang++ from $${QMAKE_CLANG_PATH}")

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -13,7 +13,7 @@
 , systemd
 , enableProprietaryCodecs ? true
 , gn
-, cups, darwin, openbsm, runCommand, xcbuild
+, cups, darwin, openbsm, runCommand, xcbuild, writeScriptBin
 , ffmpeg ? null
 , lib, stdenv
 }:
@@ -51,6 +51,13 @@ qtModule {
       substituteInPlace ./src/3rdparty/chromium/v8/gypfiles/standalone.gypi \
         --replace /bin/echo ${coreutils}/bin/echo
     ''
+    # Prevent Chromium build script from making the path to `clang` relative to
+    # the build directory.  `clang_base_path` is the value of `QMAKE_CLANG_DIR`
+    # from `src/core/config/mac_osx.pri`.
+    + optionalString stdenv.isDarwin ''
+      substituteInPlace ./src/3rdparty/chromium/build/toolchain/mac/BUILD.gn \
+        --replace 'prefix = rebase_path("$clang_base_path/bin/", root_build_dir)' 'prefix = "$clang_base_path/bin/"'
+    ''
     # Patch library paths in Qt sources
     + ''
       sed -i \
@@ -69,32 +76,15 @@ qtModule {
     ''
     + optionalString stdenv.isDarwin (''
       substituteInPlace src/core/config/mac_osx.pri \
-        --replace /usr ${stdenv.cc}
+        --replace 'QMAKE_CLANG_DIR = "/usr"' 'QMAKE_CLANG_DIR = "${stdenv.cc}"'
     ''
+     # Following is required to prevent a build error:
+     # ninja: error: '/nix/store/z8z04p0ph48w22rqzx7ql67gy8cyvidi-SDKs/MacOSX10.12.sdk/usr/include/mach/exc.defs', needed by 'gen/third_party/crashpad/crashpad/util/mach/excUser.c', missing and no known rule to make it
     + (optionalString (lib.versionAtLeast qtCompatVersion "5.11") ''
       substituteInPlace src/3rdparty/chromium/third_party/crashpad/crashpad/util/BUILD.gn \
         --replace '$sysroot/usr' "${darwin.xnu}"
     '')
     + ''
-
-    cat <<EOF > src/3rdparty/chromium/build/mac/find_sdk.py
-#!/usr/bin/env python
-print("${darwin.apple_sdk.sdk}")
-print("10.12.0")
-EOF
-
-    cat <<EOF > src/3rdparty/chromium/build/config/mac/sdk_info.py
-#!/usr/bin/env python
-print('xcode_version="0910"')
-print('xcode_version_int=910')
-print('xcode_build="9B55"')
-print('machine_os_build="17E199"')
-print('sdk_path=""')
-print('sdk_version="10.10"')
-print('sdk_platform_path=""')
-print('sdk_build="17B41"')
-EOF
-
     # Apple has some secret stuff they don't share with OpenBSM
     substituteInPlace src/3rdparty/chromium/base/mac/mach_port_broker.mm \
       --replace "audit_token_to_pid(msg.trailer.msgh_audit)" "msg.trailer.msgh_audit.val[5]"
@@ -111,8 +101,8 @@ EOF
     # TODO: investigate and fix properly
     "-march=westmere"
   ] ++ lib.optionals stdenv.isDarwin [
-    "-DMAC_OS_X_VERSION_MAX_ALLOWED=MAC_OS_X_VERSION_10_10"
-    "-DMAC_OS_X_VERSION_MIN_REQUIRED=MAC_OS_X_VERSION_10_10"
+    "-DMAC_OS_X_VERSION_MAX_ALLOWED=MAC_OS_X_VERSION_10_12"
+    "-DMAC_OS_X_VERSION_MIN_REQUIRED=MAC_OS_X_VERSION_10_12"
 
     #
     # Prevent errors like
@@ -189,6 +179,7 @@ EOF
     CoreWLAN
     Quartz
     Cocoa
+    LocalAuthentication
 
     openbsm
     libunwind
@@ -196,6 +187,21 @@ EOF
 
   buildInputs = optionals stdenv.isDarwin (with darwin; [
     cups
+
+    # `sw_vers` is used by `src/3rdparty/chromium/build/config/mac/sdk_info.py`
+    # to get some information about the host platform.
+    (writeScriptBin "sw_vers" ''
+      #!${stdenv.shell}
+
+      while [ $# -gt 0 ]; do
+        case "$1" in
+          -buildVersion) echo "17E199";;
+        *) break ;;
+
+        esac
+        shift
+      done
+    '')
 
     # For sandbox.h include
     (runCommand "MacOS_SDK_sandbox.h" {} ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Port #95826 to stable.

(cherry picked from commit 68bf9101d7764297466041c67f72b2db4b998c26

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - I'm not sure how tell this command to use the release branch
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - Not directly, but by packages that use it (like Anki)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
