### PR TITLE
Add basic support for the ESP32

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -35,6 +35,7 @@ let
     "msp430-none"
     "riscv64-none" "riscv32-none"
     "vc4-none"
+    "xtensa-none"
 
     "js-ghcjs"
 

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -124,6 +124,12 @@ rec {
     platform = {};
   };
 
+  esp32 = {
+    config = "xtensa-esp32-elf";
+    libc = "newlib";
+    platform = {};
+  };
+
   arm-embedded = {
     config = "arm-none-eabi";
     libc = "newlib";

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -22,6 +22,7 @@ rec {
     isWasm         = { cpu = { family = "wasm"; }; };
     isMsp430       = { cpu = { family = "msp430"; }; };
     isVc4          = { cpu = { family = "vc4"; }; };
+    isXtensa       = { cpu = { family = "xtensa"; }; };
     isAvr          = { cpu = { family = "avr"; }; };
     isAlpha        = { cpu = { family = "alpha"; }; };
     isJavaScript   = { cpu = cpuTypes.js; };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -114,6 +114,8 @@ rec {
 
     vc4      = { bits = 32; significantByte = littleEndian; family = "vc4"; };
 
+    xtensa   = { bits = 32; significantByte = littleEndian; family = "xtensa"; };
+
     js       = { bits = 32; significantByte = littleEndian; family = "js"; };
   };
 
@@ -287,6 +289,7 @@ rec {
     watchos = kernels.ios;
     tvos = kernels.ios;
     win32 = kernels.windows;
+    esp32 = kernels.none;
   };
 
   ################################################################################

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -185,6 +185,7 @@ stdenv.mkDerivation {
       else if targetPlatform.isAvr then "avr"
       else if targetPlatform.isAlpha then "alpha"
       else if targetPlatform.isVc4 then "vc4"
+      else if targetPlatform.isXtensa then "xtensa"
       else throw "unknown emulation for platform: ${targetPlatform.config}";
     in if targetPlatform.useLLVM or false then ""
        else targetPlatform.platform.bfdEmulation or (fmt + sep + arch);

--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -1,10 +1,23 @@
-{ stdenv, fetchurl, buildPackages }:
+{ stdenv, fetchurl, fetchFromGitHub, buildPackages }:
 
-let version = "3.3.0";
+let
+  xtensa-overlays = fetchFromGitHub {
+    owner = "espressif";
+    repo = "xtensa-overlays";
+    rev = "e9af7626c8a550eb6a422fa5e7903ee912c90539";
+    sha256 = "14s3jrngj15xdryg6gggrbl1826x6j86ckmnf447ixzmnf39b404";
+  };
+
+  version = if stdenv.targetPlatform.isXtensa then "3.0.0" else "3.3.0";
 in stdenv.mkDerivation {
   pname = "newlib";
   inherit version;
-  src = fetchurl {
+  src = if stdenv.targetPlatform.isXtensa then fetchFromGitHub {
+    owner = "espressif";
+    repo = "newlib-esp32";
+    rev = "1590f7fa92e899e86df4774a7f743af19fe077e7";
+    sha256 = "0pcs2y81i99niic2i78h0xk2fapmyklpwkxzswmg9dbwyyzpkfrk";
+  } else fetchurl {
     url = "ftp://sourceware.org/pub/newlib/newlib-${version}.tar.gz";
     sha256 = "0ricyx792ig2cb2x31b653yb7w7f7mf2111dv5h96lfzmqz9xpaq";
   };
@@ -14,6 +27,8 @@ in stdenv.mkDerivation {
   # newlib expects CC to build for build platform, not host platform
   preConfigure = ''
     export CC=cc
+
+    cp -r ${xtensa-overlays}/xtensa_esp32/newlib/* .
   '';
 
   configurePlatforms = [ "build" "target" ];

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -33,6 +33,12 @@ let
     rev = "708acc851880dbeda1dd18aca4fd0a95b2573b36";
     sha256 = "1kdrz6fki55lm15rwwamn74fnqpy0zlafsida2zymk76n3656c63";
   };
+  xtensa-overlays = fetchFromGitHub {
+    owner = "espressif";
+    repo = "xtensa-overlays";
+    rev = "e9af7626c8a550eb6a422fa5e7903ee912c90539";
+    sha256 = "14s3jrngj15xdryg6gggrbl1826x6j86ckmnf447ixzmnf39b404";
+  };
   # HACK to ensure that we preserve source from bootstrap binutils to not rebuild LLVM
   normal-src = stdenv.__bootPackages.binutils-unwrapped.src or (fetchurl {
     url = "mirror://gnu/binutils/${basename}-${version}.tar.bz2";
@@ -104,6 +110,8 @@ stdenv.mkDerivation {
     for i in binutils/Makefile.in gas/Makefile.in ld/Makefile.in gold/Makefile.in; do
         sed -i "$i" -e 's|ln |ln -s |'
     done
+  '' + lib.optionalString stdenv.targetPlatform.isXtensa ''
+    cp -r ${xtensa-overlays}/xtensa_esp32/binutils/* .
   '';
 
   # As binutils takes part in the stdenv building, we don't want references

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8519,11 +8519,13 @@ in
   gerbil-support = callPackage ../development/compilers/gerbil/gerbil-support.nix { };
   gerbilPackages-unstable = gerbil-support.gerbilPackages-unstable; # NB: don't recurseIntoAttrs for (unstable!) libraries
 
-  gccFun = callPackage (if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
-    then ../development/compilers/gcc/6
+  gccFun = callPackage (
+    if (with stdenv.targetPlatform; isVc4 || libc == "relibc") then ../development/compilers/gcc/6
+    else if (with stdenv.targetPlatform; isXtensa) then ../development/compilers/gcc/8
     else ../development/compilers/gcc/9);
-  gcc = if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
-    then gcc6 else gcc9;
+  gcc = if (with stdenv.targetPlatform; isVc4 || libc == "relibc") then gcc6
+        else if (with stdenv.targetPlatform; isXtensa) then gcc8
+        else gcc9;
 
   gcc-unwrapped = gcc.cc;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Created a basic cross-compilation toolchain for the ESP32 microcontroller.

To test, try running `flash.bash` after cloning https://github.com/taktoa/esp32-baremetal (assuming you have an ESP32 microcontroller connected on `/dev/ttyUSB0` and your current user is in the `dialout` group). Then do:

```
$ stty -F /dev/ttyUSB0 180:4:18b2:8a20:3:1c:7f:15:4:0:1:0:11:13:1a:0:12:f:17:16:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0
$ cat /dev/ttyUSB0
```

and you should see a spam of `"hello, world!"`.

I tested with the [SparkFun ESP32 Thing](https://www.sparkfun.com/products/13907), for other boards YMMV, though I don't know of any reason why it might not work.

CC: @Ericson2314 @cleverca22 @bgamari 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
