### PR TITLE
gitstatus: fix zsh integration

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, stdenv, fetchFromGitHub, ...}:
+{ callPackage, stdenv, fetchFromGitHub, git, zsh, ...}:
 
 stdenv.mkDerivation rec {
   pname = "gitstatus";
@@ -13,11 +13,61 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ (callPackage ./romkatv_libgit2.nix {}) ];
   patchPhase = ''
-    sed -i "1i GITSTATUS_DAEMON=$out/bin/gitstatusd" gitstatus.plugin.zsh
+    sed -i '1i GITSTATUS_AUTO_INSTALL=''${GITSTATUS_AUTO_INSTALL-0}' gitstatus.plugin.zsh
+    sed -i "1a GITSTATUS_DAEMON=$out/bin/gitstatusd" install
   '';
   installPhase = ''
     install -Dm755 usrbin/gitstatusd $out/bin/gitstatusd
     install -Dm444 gitstatus.plugin.zsh $out
+    install -Dm555 install $out
+    install -Dm444 build.info $out
+  '';
+  # Don't install the "install" and "build.info" files, which the end user
+  # should not need to worry about.
+  pathsToLink = [
+    "/bin/gitstatusd"
+    "/gitstatus.plugin.zsh"
+  ];
+
+  # The install check sets up an empty Git repository and a minimal zshrc that
+  # invokes gitstatus.plugin.zsh. It runs zsh against this zshrc and verifies
+  # that the script was sourced successfully and that the "gitstatus_query"
+  # command ran successfully. This tests the binary itself and the zsh
+  # integration.
+  installCheckInputs = [ git zsh ];
+  doInstallCheck = true;
+  installCheckPhase = ''
+    TEMP=$(mktemp -d)
+    cd "$TEMP"
+
+    git init
+
+    echo '
+      GITSTATUS_LOG_LEVEL=DEBUG
+      . $out/gitstatus.plugin.zsh || exit 1
+
+      gitstatus_stop NIX_TEST && gitstatus_start NIX_TEST
+      gitstatus_query NIX_TEST
+      if [[ $? -ne 0 ]]; then
+          print -- "Something went wrong with gitstatus"
+          exit 1
+      elif [[ $VCS_STATUS_RESULT != "ok-sync" ]]; then
+          print -- "Not in a Git repo"
+          exit 1
+      else
+          print -- "OK"
+          exit 0
+      fi
+    ' > .zshrc
+
+    # If we try to run zsh like "zsh -i -c true" or "zsh -i > output" then job
+    # control will be disabled in the shell and the gitstatus plugin script
+    # will fail when it tries to set the MONITOR option. As a workaround, we
+    # run zsh as a full-fledged independent process and then wait for it to
+    # exit. (The "exit" statements in the zshrc ensure that zsh will exit
+    # almost immediately after starting.)
+    ZDOTDIR=. zsh -i &
+    wait $!
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

At some point the upstream changed and gitstatus.prompt.zsh stopped working. The issue was that this file expects to be able to run the "install" script in the same directory.

- Install the "install" script and "build.info" file that gitstatus.prompt.zsh expects to be able to find when it runs.
- Patch the install script so that it defaults to not automatically installing gitstatus. This can still be overridden by setting GITSTATUS_AUTO_INSTALL=1, although I'm not sure why anyone would do this if they've already installed gitstatus with Nix.
- Add an install check phase that tests the zsh integration to prevent this derivation from breaking in the same way in the future. (This also ends up testing the binary itself.)

Fixes #96135.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
