### PR TITLE
python37Packages.pelican: 4.2.0 -> 4.5.0

### DIFF
--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub
+{ stdenv, buildPythonPackage, fetchFromGitHub, isPy27
 , glibcLocales, git
 , mock, nose, markdown, lxml, typogrify
 , jinja2, pygments, docutils, pytz, unidecode, six, dateutil, feedgenerator
-, blinker, pillow, beautifulsoup4, markupsafe }:
+, blinker, pillow, beautifulsoup4, markupsafe, pandoc }:
 
 buildPythonPackage rec {
   pname = "pelican";
-  version = "4.2.0";
+  version = "4.5.0";
+
+  disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "getpelican";
     repo = "pelican";
     rev = version;
-    sha256 = "0w9nqdw2jmqc6kqwg4rh6irr5k6j7hk8axg6vgd137rs50v62yv5";
+    sha256 = "0p8p84fcpkr19d54dhxvldd8ijbg334wmrmkr99pnbrdl1gf64qi";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
     extraPostFetch = ''
@@ -24,15 +26,15 @@ buildPythonPackage rec {
 
   # Exclude custom locale test, which files were removed above to fix the source checksum
   checkPhase = ''
-    nosetests -sv --exclude=test_custom_locale_generation_works pelican
+    nosetests -s \
+      --exclude=test_custom_locale_generation_works \
+      --exclude=test_log_filter \
+      pelican
   '';
 
   buildInputs = [
     glibcLocales
-    # Note: Pelican has to adapt to a changed CLI of pandoc before enabling this
-    # again. Compare https://github.com/getpelican/pelican/pull/2252.
-    # Version 4.2.0 is incompatible with our current pandoc version.
-    # pandoc
+    pandoc
     git
     mock
     markdown
@@ -46,20 +48,15 @@ buildPythonPackage rec {
 
   checkInputs = [
     nose
+    pandoc
   ];
 
   postPatch= ''
     substituteInPlace pelican/tests/test_pelican.py \
       --replace "'git'" "'${git}/bin/git'"
-
-    # Markdown-3.1 changed footnote separator to colon
-    # https://github.com/getpelican/pelican/issues/2493#issuecomment-491723744
-    sed -i '/test_article_with_footnote/i\
-        @unittest.skip("")' pelican/tests/test_readers.py
   '';
 
   LC_ALL="en_US.UTF-8";
-
 
   # We only want to patch shebangs in /bin, and not those
   # of the project scripts that are created by Pelican.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Bump to latest version.

This version drops support for Python 2.

See PR #87600 for discussion for backporting to `nixos-20.03`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
