### PR TITLE
ocamlPackages.posix-{base,socket,types}: init at 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/posix/base.nix
+++ b/pkgs/development/ocaml-modules/posix/base.nix
@@ -1,0 +1,26 @@
+{ lib, buildDunePackage, fetchFromGitHub
+, ctypes, integers
+}:
+
+buildDunePackage rec {
+  pname = "posix-base";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-posix";
+    rev = "v${version}";
+    sha256 = "18px8hfqcfy2lk8105ki3hrxxigs44gs046ba0fqda6wzd0hr82b";
+  };
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [ ctypes integers ];
+
+  meta = {
+    homepage = "https://www.liquidsoap.info/ocaml-posix/";
+    description = "Base module for the posix bindings";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/posix/socket.nix
+++ b/pkgs/development/ocaml-modules/posix/socket.nix
@@ -1,0 +1,16 @@
+{ lib, buildDunePackage, posix-base }:
+
+buildDunePackage {
+  pname = "posix-socket";
+
+  inherit (posix-base) version src useDune2;
+
+  propagatedBuildInputs = [ posix-base ];
+
+  doCheck = true;
+
+  meta = posix-base.meta // {
+    description = "Bindings for posix sockets";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/posix/types.nix
+++ b/pkgs/development/ocaml-modules/posix/types.nix
@@ -1,0 +1,15 @@
+{ lib, buildDunePackage, posix-base }:
+
+buildDunePackage {
+  pname = "posix-types";
+
+  inherit (posix-base) version src useDune2;
+
+  minimumOCamlVersion = "4.03";
+
+  propagatedBuildInputs = [ posix-base ];
+
+  meta = posix-base.meta // {
+    description = "Bindings for the types defined in <sys/types.h>";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -748,6 +748,8 @@ let
 
     posix-base = callPackage ../development/ocaml-modules/posix/base.nix { };
 
+    posix-socket = callPackage ../development/ocaml-modules/posix/socket.nix { };
+
     ppxfind = callPackage ../development/ocaml-modules/ppxfind { };
 
     ppxlib = callPackage ../development/ocaml-modules/ppxlib { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -750,6 +750,8 @@ let
 
     posix-socket = callPackage ../development/ocaml-modules/posix/socket.nix { };
 
+    posix-types = callPackage ../development/ocaml-modules/posix/types.nix { };
+
     ppxfind = callPackage ../development/ocaml-modules/ppxfind { };
 
     ppxlib = callPackage ../development/ocaml-modules/ppxlib { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -746,6 +746,8 @@ let
 
     piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };
 
+    posix-base = callPackage ../development/ocaml-modules/posix/base.nix { };
+
     ppxfind = callPackage ../development/ocaml-modules/ppxfind { };
 
     ppxlib = callPackage ../development/ocaml-modules/ppxlib { };


### PR DESCRIPTION
###### Motivation for this change

Dependency of recent liquidsoap.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
