### PR TITLE
python3Packages.pipx: init at 0.15.5.0

### DIFF
--- a/pkgs/development/python-modules/pipx/default.nix
+++ b/pkgs/development/python-modules/pipx/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, userpath
+, argcomplete
+, packaging
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pipx";
+  version = "0.15.5.0";
+
+  disabled = pythonOlder "3.6";
+
+  # no tests in the pypi tarball, so we directly fetch from github
+  src = fetchFromGitHub {
+    owner = "pipxproject";
+    repo = pname;
+    rev = version;
+    sha256 = "13z032i8r9f6d09hssvyjpxjacb4wgms5bh2i37da2ili9bh72m6";
+  };
+
+  propagatedBuildInputs = [ userpath argcomplete packaging ];
+
+  # avoid inconclusive venv assertion, see https://github.com/pipxproject/pipx/pull/477
+  # remove after PR is merged
+  postPatch = ''
+    substituteInPlace tests/helpers.py \
+      --replace 'assert getattr(sys, "base_prefix", sys.prefix) != sys.prefix, "Tests require venv"' ""
+  '';
+
+  checkInputs = [ pytestCheckHook ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # disable tests, which require internet connection
+  disabledTests = [
+    "install"
+    "inject"
+    "ensure_null_pythonpath"
+    "missing_interpreter"
+    "cache"
+    "internet"
+    "runpip"
+    "upgrade"
+  ];
+
+  meta = with lib; {
+    description =
+      "Install and Run Python Applications in Isolated Environments";
+    homepage = "https://github.com/pipxproject/pipx";
+    license = licenses.mit;
+    maintainers = with maintainers; [ yevhenshymotiuk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5344,6 +5344,8 @@ in {
 
   pip = callPackage ../development/python-modules/pip { };
 
+  pipx = callPackage ../development/python-modules/pipx { };
+
   pip-tools = callPackage ../development/python-modules/pip-tools {
     git = pkgs.gitMinimal;
     glibcLocales = pkgs.glibcLocales;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

[pipx](https://github.com/pipxproject/pipx) is a tool which allows to install and run python applications in isolated environments

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
